### PR TITLE
Fix path on windows [W.I.P]

### DIFF
--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -22,7 +22,7 @@
 
 use std::collections::HashMap;
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -40,7 +40,7 @@ const META_FILENAME: &str = "quickwit.json";
 
 /// Creates a path to the metadata file from the given index ID.
 fn meta_path(index_id: &str) -> PathBuf {
-    Path::new(index_id).join(Path::new(META_FILENAME))
+    PathBuf::from(format!("{}/{}", index_id, META_FILENAME))
 }
 
 /// Takes 2 semi-open intervals and returns true iff their intersection is empty

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -202,8 +202,7 @@ impl S3CompatibleObjectStorage {
     }
 
     fn key(&self, relative_path: &Path) -> String {
-        let key_path = self.prefix.join(relative_path);
-        key_path.to_string_lossy().to_string()
+        format!("{}/{}", self.prefix.display(), relative_path.display())
     }
 
     async fn put_single_part_single_try(

--- a/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit-storage/src/prefix_storage.rs
@@ -36,39 +36,46 @@ struct PrefixStorage {
     pub prefix: PathBuf,
 }
 
+impl PrefixStorage {
+    fn key(&self, relative_path: &Path) -> PathBuf {
+        PathBuf::from(format!(
+            "{}/{}",
+            self.prefix.display(),
+            relative_path.display()
+        ))
+    }
+}
+
 #[async_trait]
 impl Storage for PrefixStorage {
     async fn put(&self, path: &Path, payload: crate::PutPayload) -> crate::StorageResult<()> {
-        self.storage.put(&self.prefix.join(path), payload).await
+        self.storage.put(&self.key(path), payload).await
     }
 
     async fn copy_to_file(&self, path: &Path, output_path: &Path) -> crate::StorageResult<()> {
         self.storage
-            .copy_to_file(&self.prefix.join(path), output_path)
+            .copy_to_file(&self.key(path), output_path)
             .await
     }
 
     async fn get_slice(&self, path: &Path, range: Range<usize>) -> crate::StorageResult<Vec<u8>> {
-        self.storage.get_slice(&self.prefix.join(path), range).await
+        self.storage.get_slice(&self.key(path), range).await
     }
 
     async fn get_all(&self, path: &Path) -> crate::StorageResult<Vec<u8>> {
-        self.storage.get_all(&self.prefix.join(path)).await
+        self.storage.get_all(&self.key(path)).await
     }
 
     async fn delete(&self, path: &Path) -> crate::StorageResult<()> {
-        self.storage.delete(&self.prefix.join(path)).await
+        self.storage.delete(&self.key(path)).await
     }
 
     async fn exists(&self, path: &Path) -> crate::StorageResult<bool> {
-        self.storage.exists(&self.prefix.join(path)).await
+        self.storage.exists(&self.key(path)).await
     }
 
     fn uri(&self) -> String {
-        Path::new(&self.storage.uri())
-            .join(&self.prefix)
-            .to_string_lossy()
-            .to_string()
+        format!("{}/{}", self.storage.uri(), self.prefix.display())
     }
 }
 


### PR DESCRIPTION
### Context / purpose
[See](https://github.com/quickwit-inc/quickwit/issues/118)

### Description
Changed `Path.join` usage in the metastore implementations. 
We could get rid of `Path` in PrefixStorage but let's agree on that since this is its public API.

### How was this PR tested?
tested by running instance on windows, macOS and ubuntu as well as all the integration tests

### Checklist
- [x] tested locally
