### PR TITLE
Add `test-all` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,13 @@ help:
 # `make docker-compose-up DOCKER_SERVICES='jaeger,localstack'` starts the subset of services matching the profiles.
 docker-compose-up:
 	@echo "Launching ${DOCKER_SERVICES} Docker service(s)"
-	COMPOSE_PROFILES=$(DOCKER_SERVICES) docker-compose -f docker-compose.yml up --remove-orphans
+	COMPOSE_PROFILES=$(DOCKER_SERVICES) docker-compose -f docker-compose.yml up -d --remove-orphans
 
 docker-compose-down:
-	docker-compose -f docker-compose.yml down
+	docker-compose -f docker-compose.yml down --remove-orphans
+
+docker-compose-logs:
+	docker-compose logs -f -t
 
 license-check:
 	docker run -it --rm -v $(shell pwd):/github/workspace ghcr.io/apache/skywalking-eyes/license-eye header check
@@ -22,3 +25,9 @@ license-fix:
 fmt:
 	@echo "Formatting Rust files"
 	@(rustup toolchain list | ( ! grep -q nightly && echo "Toolchain 'nightly' is not installed. Please install using 'rustup toolchain install nightly'.") ) || cargo +nightly fmt
+
+# Usage:
+# `make test-all` starts the Docker services and runs all the tests.
+# `make -k test-all docker-compose-down`, tears down the Docker services after running all the tests.
+test-all: docker-compose-up
+	QUICKWIT_ENV=local cargo test --all-features


### PR DESCRIPTION
### Description
Add `test-all` target to Makefile. `docker-compose-up` now runs in detached mode. Use `docker-compose-logs` to view the logs.

### How was this PR tested?
Ran added and modified targets.
