### PR TITLE
Name child temp directories

### DIFF
--- a/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit-indexing/src/actors/merge_executor.rs
@@ -270,7 +270,8 @@ mod tests {
             .collect();
         assert_eq!(splits.len(), 4);
         let merge_scratch_directory = ScratchDirectory::for_test()?;
-        let downloaded_splits_directory = merge_scratch_directory.temp_child()?;
+        let downloaded_splits_directory =
+            merge_scratch_directory.named_temp_child("downloaded-splits-")?;
         let storage = test_index_builder.index_storage(index_id)?;
         for split in &splits {
             let split_filename = split_file(&split.split_id);

--- a/quickwit-indexing/src/actors/merge_split_downloader.rs
+++ b/quickwit-indexing/src/actors/merge_split_downloader.rs
@@ -63,8 +63,9 @@ impl MergeSplitDownloader {
         ctx: &ActorContext<MergeOperation>,
     ) -> anyhow::Result<()> {
         info!(merge_operation=?merge_operation, "download-merge-splits");
-        let merge_scratch_directory = self.scratch_directory.temp_child()?;
-        let downloaded_splits_directory = merge_scratch_directory.temp_child()?;
+        let merge_scratch_directory = self.scratch_directory.named_temp_child("merge-")?;
+        let downloaded_splits_directory =
+            merge_scratch_directory.named_temp_child("downloaded-splits-")?;
         self.download_splits(
             merge_operation.splits(),
             downloaded_splits_directory.path(),

--- a/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit-indexing/src/models/indexed_split.rs
@@ -79,15 +79,16 @@ impl IndexedSplit {
         // We avoid intermediary merge, and instead merge all segments in the packager.
         // The benefit is that we don't have to wait for potentially existing merges,
         // and avoid possible race conditions.
+        let split_id = new_split_id();
+        let split_scratch_directory_prefix = format!("split-{}-", split_id);
         let split_scratch_directory = indexer_params
             .indexing_directory
             .scratch_directory
-            .temp_child()?;
+            .named_temp_child(split_scratch_directory_prefix)?;
         let index = index_builder.create_in_dir(split_scratch_directory.path())?;
         let index_writer =
             index.writer_with_num_threads(1, indexer_params.heap_size.get_bytes() as usize)?;
         index_writer.set_merge_policy(Box::new(NoMergePolicy));
-        let split_id = new_split_id();
         Ok(IndexedSplit {
             split_id,
             index_id,


### PR DESCRIPTION
### Description
Name child temp directories. For instance, the merge scratch directories will be named `merge-123456`. Fixes #660.

### How was this PR tested?
cargo test -p quickwit-indexing
