### PR TITLE
Upgrade to Rust 2021 edition

### DIFF
--- a/quickwit-actors/Cargo.toml
+++ b/quickwit-actors/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-actors"
 version = "0.1.0"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
-edition = "2018"
+edition = "2021"
 license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
 description = "Actor framework used in quickwit"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-cli"
 version = "0.1.0"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit is a cost-efficient search engine."
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-cluster/Cargo.toml
+++ b/quickwit-cluster/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-cluster"
 version = "0.1.0"
 authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's cluster membership"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-common/Cargo.toml
+++ b/quickwit-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-common"
 version = "0.1.0"
 authors = ['Quickwit, inc <hello@quickwit.io>']
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Util crate of quickwit"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-core"
 version = "0.1.0"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Core crate of quickwit"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-directories/Cargo.toml
+++ b/quickwit-directories/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'quickwit-directories'
 version = '0.1.0'
 authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2018'
+edition = '2021'
 license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
 description = "Crate containing all of the custom tantivy Directory used in quickwit"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-index-config/Cargo.toml
+++ b/quickwit-index-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-index-config"
 version = "0.1.0"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit index configuration"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'quickwit-indexing'
 version = '0.1.0'
 authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2018'
+edition = '2021'
 license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit indexing"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-metastore"
 version = "0.1.0"
 authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's metastore"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-proto/Cargo.toml
+++ b/quickwit-proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'quickwit-proto'
 version = '0.1.0'
 authors = ['Quickwit, inc <hello@quickwit.io>']
-edition = '2018'
+edition = '2021'
 license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's protos"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'quickwit-search'
 version = '0.1.0'
 authors = ['Quickwit, inc <hello@quickwit.io>']
-edition = '2018'
+edition = '2021'
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's search logic"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'quickwit-serve'
 version = '0.1.0'
 authors = ['Quickwit <hello@quickwit.io>']
-edition = '2018'
+edition = '2021'
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's search service"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'quickwit-storage'
 version = '0.1.0'
 authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2018'
+edition = '2021'
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's storage abstraction"
 repository = "https://github.com/quickwit-inc/quickwit"

--- a/quickwit-swim/Cargo.toml
+++ b/quickwit-swim/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-swim"
 version = "0.1.2"
 authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2018'
+edition = '2021'
 description = "Fork of artillery-core SWIM implementation"
 repository = "https://github.com/quickwit-inc/quickwit"
 homepage = "https://quickwit.io/"

--- a/quickwit-telemetry/Cargo.toml
+++ b/quickwit-telemetry/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quickwit-telemetry"
 version = "0.1.0"
 authors = ["Quickwit <hello@quickwit.io>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's telemetry"
 repository = "https://github.com/quickwit-inc/quickwit"


### PR DESCRIPTION
### Description
Upgrade to Rust 2021 edition. Upgrade your compiler toolchain with `rustup update`.

https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html

### How was this PR tested?
Describe how you tested this PR.
