### PR TITLE
Fixed main docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 docs
 examples
 Makefile
+!.git/


### PR DESCRIPTION
### Description
Whitelisted `.git` folder as the repo metadata is needed during the docker image build