### PR TITLE
docs: fix a format error

### DIFF
--- a/docs/reference/query-language.md
+++ b/docs/reference/query-language.md
@@ -39,4 +39,4 @@ title:(obama OR president)
 
 ### Escaping Special Characters
 
-Special reserved characters are: `+` , `^`, ```, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `*`, `SPACE`. Such characters can still appear in query terms, but they need to be escaped by an antislash `\` .
+Special reserved characters are: `+` , `^`, `` ` ``, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `*`, `SPACE`. Such characters can still appear in query terms, but they need to be escaped by an antislash `\` .


### PR DESCRIPTION
If we want to include a literal backtick character within a code span, we should use multiple backticks as the delimiter.

Before the fix:

![image](https://user-images.githubusercontent.com/3402811/158047231-49cee521-42f3-48f1-bd6c-a6da6dfcf8cc.png)

After:

![image](https://user-images.githubusercontent.com/3402811/158047321-0085dbdb-4840-4ade-84ff-43e587a73fa6.png)

