### PR TITLE
Unify naming convention in REST API

### DIFF
--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -322,7 +322,7 @@ fn test_cmd_search() -> Result<()> {
     .stdout(predicate::function(|output: &[u8]| {
         println!("{}", from_utf8(output).unwrap());
         let result: Value = serde_json::from_slice(output).unwrap();
-        result["numHits"] == Value::Number(Number::from(2i64))
+        result["num_hits"] == Value::Number(Number::from(2i64))
     }));
 
     // search with tag pruning
@@ -340,7 +340,7 @@ fn test_cmd_search() -> Result<()> {
     .success()
     .stdout(predicate::function(|output: &[u8]| {
         let result: Value = serde_json::from_slice(output).unwrap();
-        result["numHits"] == Value::Number(Number::from(1i64))
+        result["num_hits"] == Value::Number(Number::from(1i64))
     }));
 
     // search with tag pruning
@@ -358,7 +358,7 @@ fn test_cmd_search() -> Result<()> {
     .success()
     .stdout(predicate::function(|output: &[u8]| {
         let result: Value = serde_json::from_slice(output).unwrap();
-        result["numHits"] == Value::Number(Number::from(0i64))
+        result["num_hits"] == Value::Number(Number::from(0i64))
     }));
 
     Ok(())
@@ -755,10 +755,10 @@ async fn test_all_local_index() -> Result<()> {
 
     let result: Value =
         serde_json::from_str(&query_response).expect("Couldn't deserialize response.");
-    assert_eq!(result["numHits"], Value::Number(Number::from(2i64)));
+    assert_eq!(result["num_hits"], Value::Number(Number::from(2i64)));
 
     let search_stream_response = reqwest::get(format!(
-        "http://127.0.0.1:{}/api/v1/{}/search/stream?query=level:info&outputFormat=csv&fastField=ts",
+        "http://127.0.0.1:{}/api/v1/{}/search/stream?query=level:info&output_format=csv&fast_field=ts",
         test_env.rest_listen_port,
         test_env.index_id
     ))

--- a/quickwit-search/src/search_response_rest.rs
+++ b/quickwit-search/src/search_response_rest.rs
@@ -26,7 +26,7 @@ use crate::error::SearchError;
 /// SearchResponseRest represents the response returned by the REST search API
 /// and is meant to be serialized into JSON.
 #[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct SearchResponseRest {
     /// Overall number of documents matching the query.
     pub num_hits: u64,

--- a/quickwit-search/src/search_response_rest.rs
+++ b/quickwit-search/src/search_response_rest.rs
@@ -26,7 +26,6 @@ use crate::error::SearchError;
 /// SearchResponseRest represents the response returned by the REST search API
 /// and is meant to be serialized into JSON.
 #[derive(Serialize)]
-#[serde(rename_all = "snake_case")]
 pub struct SearchResponseRest {
     /// Overall number of documents matching the query.
     pub num_hits: u64,

--- a/quickwit-serve/src/cluster_api/rest_handler.rs
+++ b/quickwit-serve/src/cluster_api/rest_handler.rs
@@ -40,7 +40,7 @@ pub fn cluster_handler<TClusterService: ClusterService>(
 /// the rest API.
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 struct ListMembersRequestQueryString {
     /// The output format requested.
     #[serde(default)]

--- a/quickwit-serve/src/cluster_api/rest_handler.rs
+++ b/quickwit-serve/src/cluster_api/rest_handler.rs
@@ -40,7 +40,6 @@ pub fn cluster_handler<TClusterService: ClusterService>(
 /// the rest API.
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
 struct ListMembersRequestQueryString {
     /// The output format requested.
     #[serde(default)]

--- a/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit-serve/src/search_api/rest_handler.rs
@@ -36,9 +36,7 @@ use crate::error::ApiError;
 use crate::format::Format;
 
 fn sort_by_field_mini_dsl<'de, D>(deserializer: D) -> Result<Option<SortByField>, D::Error>
-where
-    D: Deserializer<'de>,
-{
+where D: Deserializer<'de> {
     let string = String::deserialize(deserializer)?;
     Ok(Some(string.into()))
 }
@@ -58,9 +56,7 @@ fn default_max_hits() -> u64 {
 // Conclusion: the best way I found to reject a user query that contains an empty
 // string on an mandatory field is this serializer.
 fn deserialize_not_empty_string<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: Deserializer<'de>,
-{
+where D: Deserializer<'de> {
     let value = String::deserialize(deserializer)?;
     if value.is_empty() {
         return Err(de::Error::custom("Expected a non empty string field."));
@@ -69,9 +65,7 @@ where
 }
 
 fn from_simple_list<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
+where D: Deserializer<'de> {
     let str_sequence = String::deserialize(deserializer)?;
     Ok(Some(
         str_sequence

--- a/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit-serve/src/search_api/rest_handler.rs
@@ -80,7 +80,6 @@ where D: Deserializer<'de> {
 /// the rest API.
 #[derive(Deserialize, Debug, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
 pub struct SearchRequestQueryString {
     /// Query text. The query language is that of tantivy.
     pub query: String,
@@ -211,7 +210,6 @@ pub fn search_stream_handler<TSearchService: SearchService>(
 /// the REST API.
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
 struct SearchStreamRequestQueryString {
     /// Query text. The query language is that of tantivy.
     pub query: String,


### PR DESCRIPTION
Closes #1197
 
This PR will make query params, json payload and json response fields in *snake_case* naming convention.

Note: This is a BREAKING CHANGE.