### PR TITLE
Update dockerfile with new native dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
 RUN apt-get -y update \
     && apt-get -y install ca-certificates \
+                          clang \
                           cmake \
                           libpq-dev \
                           libpq5  \
                           libssl-dev \
+                          llvm \
     && rm -rf /var/lib/apt/lists/*
 
 # Required by tonic


### PR DESCRIPTION
### Description

`docker build .` fails on `main` due to the new native dependencies for `librocksdb-sys`. This PR adds them to fix the build.

### How was this PR tested?

`docker build -t qw . && docker run -it qw run` locally.
