### PR TITLE
Bump tabled from 0.5 to 0.6 and left rotate source table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2b5b9ea36abb56e4f8a29889e67f878ebc4ab43c918abe32e85a012d27b819"
+checksum = "63709d10e2c2ec58f7bd91d8258d27ce80de090064b0ddf3a4bf38b907b61b8a"
 dependencies = [
  "unicode-width",
 ]
@@ -3808,9 +3808,9 @@ checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "tabled"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fda0a52a50c85604747c6584cc79cfe6c7b6ee2349ffed082f965bdbef77ef"
+checksum = "97353139cc8a4e3f726e54f78081883d1c133b8e1834f55f168122f99f989717"
 dependencies = [
  "papergrid",
  "tabled_derive",
@@ -3818,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "tabled_derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a224735cbc8c30f06e52dc3891dc4b8eed07e5d4c8fb6f4cb6a839458e5a6465"
+checksum = "278ea3921cee8c5a69e0542998a089f7a14fa43c9c4e4f9951295da89bd0c943"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -37,7 +37,7 @@ quickwit-serve = { version = "0.2.1", path = "../quickwit-serve" }
 quickwit-telemetry = { version = "0.2.1", path = "../quickwit-telemetry" }
 quickwit-pushapi = {version="0.2.1", path = "../quickwit-pushapi" }
 quickwit-proto = { version = "0.2.1", path = "../quickwit-proto" }
-tabled = "0.5"
+tabled = "0.6"
 tracing = "0.1.29"
 tracing-subscriber = {version="0.3", features=["time", "std", "env-filter"]}
 tracing-opentelemetry = "0.17"

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -29,7 +29,7 @@ use quickwit_indexing::check_source_connectivity;
 use quickwit_metastore::quickwit_metastore_uri_resolver;
 use quickwit_storage::{load_file, quickwit_storage_uri_resolver};
 use regex::Regex;
-use tabled::{Alignment, Header, Modify, Row, Style, Table, Tabled};
+use tabled::{Alignment, Header, Modify, Rotate, Rows, Style, Table, Tabled};
 use tracing::info;
 
 pub mod cli;
@@ -110,10 +110,25 @@ pub async fn run_index_checklist(
             ));
         }
     }
-
     run_checklist(checks);
-
     Ok(())
+}
+
+/// Constructs a table for display.
+pub fn make_table<T: Tabled>(
+    header: &str,
+    rows: impl IntoIterator<Item = T>,
+    rotate: bool,
+) -> Table {
+    let mut table = Table::new(rows)
+        .with(Modify::new(Rows::new(1..)).with(Alignment::left()))
+        .with(Style::ascii());
+    if rotate {
+        table = table.with(Rotate::Left)
+    }
+    table
+        .with(Header(header))
+        .with(Modify::new(Rows::single(0)).with(Alignment::center()))
 }
 
 #[cfg(test)]
@@ -142,12 +157,4 @@ mod tests {
         assert!(parse_duration_with_unit("1h30").is_err());
         Ok(())
     }
-}
-
-/// Construct a table for display.
-pub fn make_table<T: Tabled>(header: &str, rows: impl IntoIterator<Item = T>) -> Table {
-    Table::new(rows)
-        .with(Header(header))
-        .with(Modify::new(Row(2..)).with(Alignment::left()))
-        .with(Style::psql())
 }

--- a/quickwit-cli/src/split.rs
+++ b/quickwit-cli/src/split.rs
@@ -430,7 +430,7 @@ fn make_list_splits_table(splits: Vec<Split>) -> Table {
                 id: split.split_metadata.split_id,
                 num_docs: split.split_metadata.num_docs,
                 size_mega_bytes: split.split_metadata.original_size_in_bytes / 1_000_000,
-                create_at: OffsetDateTime::from_unix_timestamp(
+                created_at: OffsetDateTime::from_unix_timestamp(
                     split.split_metadata.create_timestamp,
                 )
                 .expect("could not create OffsetDateTime from timestamp"),
@@ -440,7 +440,7 @@ fn make_list_splits_table(splits: Vec<Split>) -> Table {
             }
         })
         .sorted_by(|left, right| left.id.cmp(&right.id));
-    make_table("Splits", rows)
+    make_table("Splits", rows, false)
 }
 
 fn split_state_from_input_str(input: &str) -> anyhow::Result<SplitState> {
@@ -457,17 +457,17 @@ fn split_state_from_input_str(input: &str) -> anyhow::Result<SplitState> {
 
 #[derive(Tabled)]
 struct SplitRow {
-    #[header("Id")]
+    #[tabled(rename = "ID")]
     id: String,
-    #[header("Num Docs")]
+    #[tabled(rename = "Num docs")]
     num_docs: usize,
-    #[header("Size (MB)")]
+    #[tabled(rename = "Size (MB)")]
     size_mega_bytes: u64,
-    #[header("Created At")]
-    create_at: OffsetDateTime,
-    #[header("Updated At")]
+    #[tabled(rename = "Created at")]
+    created_at: OffsetDateTime,
+    #[tabled(rename = "Updated at")]
     updated_at: OffsetDateTime,
-    #[header("Time Range")]
+    #[tabled(rename = "Time range")]
     time_range: String,
 }
 


### PR DESCRIPTION
### Description
- Bump tabled from 0.5.0 to 0.6.0
- Rotate source table (cf. `quickwit source describe` command)

Fixes #914

### How was this PR tested?
![Screenshot_20220405_181459](https://user-images.githubusercontent.com/3011588/161860477-d031d15b-d14f-4169-a10d-d50418048408.png)

