### PR TITLE
Using rust stable in CI coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy, llvm-tools-preview, rustfmt
 
       - name: Install cargo-llvm-cov
@@ -125,10 +125,10 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo +nightly llvm-cov clean --workspace
-          cargo +nightly llvm-cov --test failpoints --no-report --features fail/failpoints
-          cargo +nightly llvm-cov --no-report --all-features
-          cargo +nightly llvm-cov --no-run --lcov --output-path lcov.info
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --test failpoints --no-report --features fail/failpoints
+          cargo llvm-cov --no-report --all-features
+          cargo llvm-cov --no-run --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -114,6 +114,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          default: true
           components: clippy, llvm-tools-preview, rustfmt
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -111,12 +111,6 @@ jobs:
       - name: Prepare LocalStack S3
         run: ./quickwit-cli/tests/prepare_tests.sh
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          components: clippy, llvm-tools-preview, rustfmt
-
       - name: Install cargo-llvm-cov
         run: |
           curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59"
+channel = "1.60"
 


### PR DESCRIPTION
With rust 1.6, we can now do coverage with stable.
