### PR TITLE
Rework command for adding a new source to an indexing

### DIFF
--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::env;
+use std::ffi::OsStr;
 use std::fmt::Display;
 use std::path::{Component, Path, PathBuf};
 
@@ -27,6 +28,26 @@ use anyhow::{bail, Context};
 const FILE_PROTOCOL: &str = "file";
 
 const PROTOCOL_SEPARATOR: &str = "://";
+
+#[derive(Debug, PartialEq)]
+pub enum Extension {
+    Json,
+    Toml,
+    Unknown(String),
+    Yaml,
+}
+
+impl Extension {
+    fn maybe_new(extension: &str) -> Option<Self> {
+        match extension {
+            "json" => Some(Self::Json),
+            "toml" => Some(Self::Toml),
+            "yaml" | "yml" => Some(Self::Yaml),
+            "" => None,
+            unknown => Some(Self::Unknown(unknown.to_string())),
+        }
+    }
+}
 
 /// Encapsulates the URI type.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -80,6 +101,14 @@ impl Uri {
             uri: format!("{}{}{}", protocol, PROTOCOL_SEPARATOR, path),
             protocol_idx: protocol.len(),
         })
+    }
+
+    /// Returns the URI extension.
+    pub fn extension(&self) -> Option<Extension> {
+        Path::new(&self.uri)
+            .extension()
+            .and_then(OsStr::to_str)
+            .and_then(Extension::maybe_new)
     }
 
     /// Returns the uri protocol.
@@ -223,6 +252,24 @@ mod tests {
         assert_eq!(
             Uri::try_new("s3://home/homer/docs/../dognuts")?.to_string(),
             "s3://home/homer/docs/../dognuts"
+        );
+
+        assert!(Uri::try_new("s3://").unwrap().extension().is_none());
+
+        assert_eq!(
+            Uri::try_new("s3://config.json")
+                .unwrap()
+                .extension()
+                .unwrap(),
+            Extension::Json
+        );
+
+        assert_eq!(
+            Uri::try_new("s3://config.foo")
+                .unwrap()
+                .extension()
+                .unwrap(),
+            Extension::Unknown("foo".to_string())
         );
 
         Ok(())

--- a/quickwit-config/resources/tests/source_config/kafka-source.json
+++ b/quickwit-config/resources/tests/source_config/kafka-source.json
@@ -1,0 +1,10 @@
+{
+    "source_id": "hdfs-logs-kafka-source",
+    "source_type": "kafka",
+    "params": {
+        "topic": "cloudera-cluster-logs",
+        "client_params": {
+            "bootstrap.servers": "host:9092"
+        }
+    }
+}

--- a/quickwit-config/resources/tests/source_config/kinesis-source.yaml
+++ b/quickwit-config/resources/tests/source_config/kinesis-source.yaml
@@ -1,0 +1,4 @@
+source_id: hdfs-logs-kinesis-source
+source_type: kinesis
+params:
+  stream_name: emr-cluster-logs

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::env;
-use std::ffi::OsStr;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
@@ -28,7 +27,7 @@ use json_comments::StripComments;
 use once_cell::sync::OnceCell;
 use quickwit_common::net::{get_socket_addr, parse_socket_addr_with_default_port};
 use quickwit_common::new_coolid;
-use quickwit_common::uri::Uri;
+use quickwit_common::uri::{Extension, Uri};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
@@ -181,7 +180,7 @@ pub struct QuickwitConfig {
 }
 
 impl QuickwitConfig {
-    // Parses quickwit config from the given config content and validates.
+    /// Parses and validates a [`QuickwitConfig`] from a given URI and config content.
     pub async fn load(
         uri: &Uri,
         config_content: &[u8],
@@ -200,11 +199,11 @@ impl QuickwitConfig {
     }
 
     async fn from_uri(uri: &Uri, config_content: &[u8]) -> anyhow::Result<Self> {
-        let parser_fn = match Path::new(uri.as_ref()).extension().and_then(OsStr::to_str) {
-            Some("json") => Self::from_json,
-            Some("toml") => Self::from_toml,
-            Some("yaml") | Some("yml") => Self::from_yaml,
-            Some(extension) => bail!(
+        let parser_fn = match uri.extension() {
+            Some(Extension::Json) => Self::from_json,
+            Some(Extension::Toml) => Self::from_toml,
+            Some(Extension::Yaml) => Self::from_yaml,
+            Some(Extension::Unknown(extension)) => bail!(
                 "Failed to read quickwit config file `{}`: file extension `.{}` is not supported. \
                  Supported file formats and extensions are JSON (.json), TOML (.toml), and YAML \
                  (.yaml or .yml).",
@@ -387,11 +386,11 @@ mod tests {
 
     use super::*;
 
-    fn get_resource_path(resource_filename: &str) -> String {
+    fn get_config_filepath(config_filename: &str) -> String {
         format!(
             "{}/resources/tests/config/{}",
             env!("CARGO_MANIFEST_DIR"),
-            resource_filename
+            config_filename
         )
     }
 
@@ -404,7 +403,7 @@ mod tests {
             #[tokio::test]
             async fn $test_function_name() -> anyhow::Result<()> {
                 let config_filepath =
-                    get_resource_path(&format!("quickwit.{}", stringify!($file_extension)));
+                    get_config_filepath(&format!("quickwit.{}", stringify!($file_extension)));
                 let config_uri = Uri::try_new(&config_filepath)?;
                 let file = std::fs::read_to_string(&config_filepath).unwrap();
                 let config = QuickwitConfig::from_uri(&config_uri, file.as_bytes()).await?;
@@ -528,7 +527,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_quickwit_config_validate() {
-        let config_filepath = get_resource_path("quickwit.toml");
+        let config_filepath = get_config_filepath("quickwit.toml");
         let file_content = std::fs::read_to_string(&config_filepath).unwrap();
 
         let config_uri = Uri::try_new(&config_filepath).unwrap();
@@ -633,9 +632,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_config_with_validation_error() {
-        let config_path = get_resource_path("quickwit.yaml");
-        let config_uri = Uri::try_new(&config_path).unwrap();
-        let file = std::fs::read_to_string(&config_path).unwrap();
+        let config_filepath = get_config_filepath("quickwit.yaml");
+        let config_uri = Uri::try_new(&config_filepath).unwrap();
+        let file = std::fs::read_to_string(&config_filepath).unwrap();
         let config = QuickwitConfig::load(&config_uri, file.as_bytes(), None)
             .await
             .unwrap_err();


### PR DESCRIPTION
### Description
The new command is `quickwit source create --index my-index --source-config my-source-config.yaml`. As we may revisit how me manage objects in a near future (#1024), I chose to leave the index out of the config so I did not have to write some custom parsing logic.

Fixes #1071

### How was this PR tested?
`make test-all`
