### PR TITLE
Rename `clean_cache` option to `clear-cache` and document

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -116,6 +116,7 @@ quickwit index ingest
     [--data-dir <data-dir>]
     [--input-path <input-path>]
     [--overwrite]
+    [--clear-cache]
 ```
 
 *Options*
@@ -125,6 +126,7 @@ quickwit index ingest
 `--data-dir` Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
 `--input-path` Location of the input file.
 `--overwrite` Overwrites pre-existing index.
+`--clear-cache` Clear local cache directory upon completion.
 
 *Examples*
 

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -32,7 +32,7 @@ use quickwit_actors::{ActorHandle, ObservationType, Universe};
 use quickwit_common::uri::Uri;
 use quickwit_common::GREEN_COLOR;
 use quickwit_config::{IndexConfig, IndexerConfig, SourceConfig, SourceParams};
-use quickwit_core::{clean_split_cache, IndexService};
+use quickwit_core::{clear_cache_directory, IndexService};
 use quickwit_doc_mapper::tag_pruning::match_tag_field_name;
 use quickwit_indexing::actors::{IndexingPipeline, IndexingServer};
 use quickwit_indexing::models::{
@@ -81,7 +81,7 @@ pub fn build_index_command<'a>() -> Command<'a> {
                         .required(false),
                     arg!(--overwrite "Overwrites pre-existing index.")
                         .required(false),
-                    arg!(--clean_cache "Clean up local cache splits after indexing.")
+                    arg!(--"clear-cache" "Clear local cache directory upon completion.")
                         .required(false),
                 ])
             )
@@ -199,7 +199,7 @@ pub struct IngestDocsArgs {
     pub config_uri: Uri,
     pub data_dir: Option<PathBuf>,
     pub overwrite: bool,
-    pub clean_cache: bool,
+    pub clear_cache: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -332,7 +332,7 @@ impl IndexCliCommand {
             .expect("`config` is a required arg.")?;
         let data_dir = matches.value_of("data-dir").map(PathBuf::from);
         let overwrite = matches.is_present("overwrite");
-        let clean_cache = matches.is_present("clean_cache");
+        let clear_cache = matches.is_present("clear-cache");
 
         Ok(Self::Ingest(IngestDocsArgs {
             index_id,
@@ -340,7 +340,7 @@ impl IndexCliCommand {
             overwrite,
             config_uri,
             data_dir,
-            clean_cache,
+            clear_cache,
         }))
     }
 
@@ -798,9 +798,9 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
         );
     }
 
-    if args.clean_cache {
-        println!("Cleaning up split cache ...");
-        clean_split_cache(
+    if args.clear_cache {
+        println!("Clearing local cache directory...");
+        clear_cache_directory(
             &config.data_dir_path,
             args.index_id.clone(),
             INGEST_SOURCE_ID.to_string(),

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -223,7 +223,7 @@ mod tests {
                     input_path_opt: None,
                     overwrite: false,
                     data_dir: None,
-                    clean_cache: false,
+                    clear_cache: false,
                 })) if &index_id == "wikipedia"
                        && config_uri == Uri::try_new("file:///config.yaml").unwrap()
         ));
@@ -248,7 +248,7 @@ mod tests {
                     input_path_opt: None,
                     overwrite: true,
                     data_dir: None,
-                    clean_cache: false
+                    clear_cache: false
                 })) if &index_id == "wikipedia"
                         && config_uri == Uri::try_new("file:///config.yaml").unwrap()
         ));

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -30,7 +30,7 @@ use predicates::prelude::*;
 use quickwit_cli::index::{create_index_cli, search_index, CreateIndexArgs, SearchIndexArgs};
 use quickwit_common::rand::append_random_suffix;
 use quickwit_common::uri::Uri;
-use quickwit_core::get_cache_path;
+use quickwit_core::get_cache_directory_path;
 use quickwit_indexing::source::INGEST_SOURCE_ID;
 use quickwit_metastore::{quickwit_metastore_uri_resolver, Metastore};
 use serde_json::{json, Number, Value};
@@ -195,25 +195,24 @@ fn test_cmd_ingest_on_non_existing_file() -> Result<()> {
 }
 
 #[test]
-fn test_cmd_ingest_clean_cache() -> Result<()> {
-    let index_id = append_random_suffix("test-index-clean-cache");
+fn test_cmd_ingest_clear_cache() -> Result<()> {
+    let index_id = append_random_suffix("test-index-clear-cache");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
 
     ingest_docs_with_options(
         test_env.resource_files["logs"].as_path(),
         &test_env,
-        "--clean_cache",
+        "--clear-cache",
     );
 
-    // check cache path
-    let cache_path = get_cache_path(
+    // Ensure cache directory is empty.
+    let cache_directory_path = get_cache_directory_path(
         &test_env.data_dir_path,
         &test_env.index_id,
         INGEST_SOURCE_ID,
     );
-    assert_eq!(false, cache_path.exists());
-
+    assert!(cache_directory_path.read_dir()?.next().is_none());
     Ok(())
 }
 
@@ -223,14 +222,6 @@ fn test_cmd_ingest_simple() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
     ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
-
-    // check cache path
-    let cache_path = get_cache_path(
-        &test_env.data_dir_path,
-        &test_env.index_id,
-        INGEST_SOURCE_ID,
-    );
-    assert_eq!(true, cache_path.exists());
 
     // Using piped input
     let log_path = test_env.resource_files["logs"].clone();

--- a/quickwit-core/src/lib.rs
+++ b/quickwit-core/src/lib.rs
@@ -29,7 +29,7 @@
 
 mod index;
 
-pub use index::{clean_split_cache, get_cache_path, IndexService, IndexServiceError};
+pub use index::{clear_cache_directory, get_cache_directory_path, IndexService, IndexServiceError};
 
 #[cfg(test)]
 mod tests {

--- a/quickwit-indexing/src/models/indexing_directory.rs
+++ b/quickwit-indexing/src/models/indexing_directory.rs
@@ -39,7 +39,7 @@ enum Root {
 }
 
 /// An indexing directory is created in the data directory on the local file system for each index
-/// at the following location: `<data dir>/<index name>`.
+/// at the following location: `<data dir>/indexing/<index ID>/<source ID>`.
 /// The indexing directory consists of two directories:
 /// - a scratch directory that stores temporary intermediate files
 /// - a cache directory that stores frequently accessed data structures


### PR DESCRIPTION
### Description
As per title. I wonder whether this option should be enabled by default, though.

### How was this PR tested?
`make test-all`
