### PR TITLE
Auto-generate Kafka group ID

### DIFF
--- a/docs/reference/source-config.md
+++ b/docs/reference/source-config.md
@@ -64,7 +64,7 @@ A Kafka source reads data from a Kafka stream. Each message in the stream must h
 
 ### Kafka source parameters
 
-The Kafka source consumes a `topic` using the client library [librdkafka](https://github.com/edenhill/librdkafka) and forwards the key-value pairs carried by the parameter `client_params` to the underlying librdkafka consumer. Common `client_params` options are bootstrap servers (`bootstrap.servers`), consumer group ID (`group.id`), or security protocol (`security.protocol`). Please, refer to [Kafka](https://kafka.apache.org/documentation/#consumerconfigs) and [librdkafka](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) documentation pages for more advanced options.
+The Kafka source consumes a `topic` using the client library [librdkafka](https://github.com/edenhill/librdkafka) and forwards the key-value pairs carried by the parameter `client_params` to the underlying librdkafka consumer. Common `client_params` options are bootstrap servers (`bootstrap.servers`), or security protocol (`security.protocol`). Please, refer to [Kafka](https://kafka.apache.org/documentation/#consumerconfigs) and [librdkafka](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) documentation pages for more advanced options.
 
 | Property | Description | Default value |
 | --- | --- | --- |
@@ -89,7 +89,6 @@ sources:
       topic: my-topic
       client_params:
         bootstrap.servers: localhost:9092
-        group.id: my-group-id
         security.protocol: SSL
 
 # The rest of your index config here
@@ -104,7 +103,6 @@ cat << EOF > my-kafka-source.json
   "topic": "my-topic",
   "client_params": {
     "bootstrap.servers": "localhost:9092",
-    "group.id": "my-group-id",
     "security.protocol": "SSL"
   }
 }

--- a/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -51,10 +51,11 @@ impl TypedSourceFactory for KinesisSourceFactory {
     type Params = KinesisSourceParams;
 
     async fn typed_create_source(
+        source_id: String,
         params: KinesisSourceParams,
         checkpoint: SourceCheckpoint,
     ) -> anyhow::Result<Self::Source> {
-        KinesisSource::try_new(params, checkpoint).await
+        KinesisSource::try_new(source_id, params, checkpoint).await
     }
 }
 
@@ -78,6 +79,8 @@ pub struct KinesisSourceState {
 }
 
 pub struct KinesisSource {
+    // Source ID
+    source_id: String,
     // Target stream to consume.
     stream_name: String,
     // Initialization checkpoint.
@@ -93,13 +96,18 @@ pub struct KinesisSource {
 
 impl fmt::Debug for KinesisSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "KinesisSource {{ stream_name: {} }}", self.stream_name)
+        write!(
+            f,
+            "KinesisSource {{ source_id: {}, stream_name: {} }}",
+            self.source_id, self.stream_name
+        )
     }
 }
 
 impl KinesisSource {
     /// Instantiates a new `KinesisSource`.
     pub async fn try_new(
+        source_id: String,
         params: KinesisSourceParams,
         checkpoint: SourceCheckpoint,
     ) -> anyhow::Result<Self> {
@@ -110,6 +118,7 @@ impl KinesisSource {
         let (shard_consumers_tx, shard_consumers_rx) = mpsc::channel(1_000);
         let state = KinesisSourceState::default();
         Ok(KinesisSource {
+            source_id,
             stream_name,
             checkpoint,
             kinesis_client,
@@ -365,9 +374,10 @@ mod tests {
         };
         {
             let checkpoint = SourceCheckpoint::default();
-            let kinesis_source = KinesisSource::try_new(params.clone(), checkpoint)
-                .await
-                .unwrap();
+            let kinesis_source =
+                KinesisSource::try_new("my-kinesis-source".to_string(), params.clone(), checkpoint)
+                    .await
+                    .unwrap();
             let actor = SourceActor {
                 source: Box::new(kinesis_source),
                 batch_sink: mailbox.clone(),
@@ -418,9 +428,10 @@ mod tests {
             .collect();
         {
             let checkpoint = SourceCheckpoint::default();
-            let kinesis_source = KinesisSource::try_new(params.clone(), checkpoint)
-                .await
-                .unwrap();
+            let kinesis_source =
+                KinesisSource::try_new("my-kinesis-source".to_string(), params.clone(), checkpoint)
+                    .await
+                    .unwrap();
             let actor = SourceActor {
                 source: Box::new(kinesis_source),
                 batch_sink: mailbox.clone(),
@@ -488,9 +499,10 @@ mod tests {
             .into_iter()
             .map(|(partition_id, offset)| (PartitionId::from(partition_id), Position::from(offset)))
             .collect();
-            let kinesis_source = KinesisSource::try_new(params.clone(), checkpoint)
-                .await
-                .unwrap();
+            let kinesis_source =
+                KinesisSource::try_new("my-kinesis-source".to_string(), params.clone(), checkpoint)
+                    .await
+                    .unwrap();
             let actor = SourceActor {
                 source: Box::new(kinesis_source),
                 batch_sink: mailbox,

--- a/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit-indexing/src/source/void_source.rs
@@ -55,8 +55,9 @@ impl TypedSourceFactory for VoidSourceFactory {
     type Params = VoidSourceParams;
 
     async fn typed_create_source(
-        _: VoidSourceParams,
-        _: quickwit_metastore::checkpoint::SourceCheckpoint,
+        _source_id: String,
+        _params: VoidSourceParams,
+        _checkpoint: quickwit_metastore::checkpoint::SourceCheckpoint,
     ) -> anyhow::Result<VoidSource> {
         Ok(VoidSource)
     }
@@ -91,6 +92,7 @@ mod tests {
         let universe = Universe::new();
         let (mailbox, _) = create_test_mailbox();
         let void_source = VoidSourceFactory::typed_create_source(
+            "my-void-source".to_string(),
             VoidSourceParams {},
             SourceCheckpoint::default(),
         )


### PR DESCRIPTION
### Description
Auto-generate a group ID derived from the source ID for debugging purposes.

Fixes #1069.

### How was this PR tested?
`make test-all`
