### PR TITLE
Display source ID in logs

### DIFF
--- a/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit-indexing/src/source/file_source.rs
@@ -115,7 +115,7 @@ impl Source for FileSource {
     }
 
     fn name(&self) -> String {
-        "FileSource".to_string()
+        format!("FileSource{{source_id={}}}", self.source_id)
     }
 
     fn observable_state(&self) -> serde_json::Value {

--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -259,7 +259,7 @@ impl Source for KafkaSource {
     }
 
     fn name(&self) -> String {
-        "KafkaSource".to_string()
+        format!("KafkaSource{{source_id={}}}", self.source_id)
     }
 
     fn observable_state(&self) -> serde_json::Value {

--- a/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -299,7 +299,7 @@ impl Source for KinesisSource {
     }
 
     fn name(&self) -> String {
-        "KinesisSource".to_string()
+        format!("KinesisSource{{source_id={}}}", self.source_id)
     }
 
     fn observable_state(&self) -> serde_json::Value {

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -108,7 +108,7 @@ impl Source for VecSource {
     }
 
     fn name(&self) -> String {
-        "VecSource".to_string()
+        format!("VecSource{{source_id={}}}", self.source_id)
     }
 
     fn observable_state(&self) -> serde_json::Value {
@@ -149,7 +149,10 @@ mod tests {
             source: Box::new(vec_source),
             batch_sink: mailbox,
         };
-        assert_eq!(vec_source_actor.name(), "VecSource");
+        assert_eq!(
+            vec_source_actor.name(),
+            "VecSource{source_id=my-vec-source}"
+        );
         let (_vec_source_mailbox, vec_source_handle) =
             universe.spawn_actor(vec_source_actor).spawn();
         let (actor_termination, last_observation) = vec_source_handle.join().await;


### PR DESCRIPTION
### Description
Display source ID in logs:
```
2022-04-11T16:13:07.739Z  INFO {actor=quickwit_indexing::actors::indexing_server::IndexingServer}:{msg_id=1}::{index=wikipedia gen=0}:{actor=FileSource{source_id=.cli-ingest-source}}: quickwit_actors::runner: actor-exit actor_id=SourceActor-empty-R0Ps exit_status=Success
```

The output is quite ugly in my option. I'm open to suggestions.

### How was this PR tested?
- `make test-all`
- ran `quickwit index` and displayed logs
