### PR TITLE
Clear cache unless instructed otherwise

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -116,7 +116,7 @@ quickwit index ingest
     [--data-dir <data-dir>]
     [--input-path <input-path>]
     [--overwrite]
-    [--clear-cache]
+    [--keep-cache]
 ```
 
 *Options*
@@ -126,7 +126,7 @@ quickwit index ingest
 `--data-dir` Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
 `--input-path` Location of the input file.
 `--overwrite` Overwrites pre-existing index.
-`--clear-cache` Clear local cache directory upon completion.
+`--keep-cache` Does not clear local cache directory upon completion.
 
 *Examples*
 

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -81,7 +81,7 @@ pub fn build_index_command<'a>() -> Command<'a> {
                         .required(false),
                     arg!(--overwrite "Overwrites pre-existing index.")
                         .required(false),
-                    arg!(--"clear-cache" "Clear local cache directory upon completion.")
+                    arg!(--"keep-cache" "Does not clear local cache directory upon completion.")
                         .required(false),
                 ])
             )
@@ -332,7 +332,7 @@ impl IndexCliCommand {
             .expect("`config` is a required arg.")?;
         let data_dir = matches.value_of("data-dir").map(PathBuf::from);
         let overwrite = matches.is_present("overwrite");
-        let clear_cache = matches.is_present("clear-cache");
+        let clear_cache = !matches.is_present("keep-cache");
 
         Ok(Self::Ingest(IngestDocsArgs {
             index_id,

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -223,7 +223,7 @@ mod tests {
                     input_path_opt: None,
                     overwrite: false,
                     data_dir: None,
-                    clear_cache: false,
+                    clear_cache: true,
                 })) if &index_id == "wikipedia"
                        && config_uri == Uri::try_new("file:///config.yaml").unwrap()
         ));
@@ -236,6 +236,7 @@ mod tests {
             "wikipedia",
             "--config",
             "/config.yaml",
+            "--keep-cache",
             "--overwrite",
         ])?;
         let command = CliCommand::parse_cli_args(&matches)?;

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -195,24 +195,24 @@ fn test_cmd_ingest_on_non_existing_file() -> Result<()> {
 }
 
 #[test]
-fn test_cmd_ingest_clear_cache() -> Result<()> {
-    let index_id = append_random_suffix("test-index-clear-cache");
+fn test_cmd_ingest_keep_cache() -> Result<()> {
+    let index_id = append_random_suffix("test-index-keep-cache");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
 
     ingest_docs_with_options(
         test_env.resource_files["logs"].as_path(),
         &test_env,
-        "--clear-cache",
+        "--keep-cache",
     );
 
-    // Ensure cache directory is empty.
+    // Ensure cache directory is not empty.
     let cache_directory_path = get_cache_directory_path(
         &test_env.data_dir_path,
         &test_env.index_id,
         INGEST_SOURCE_ID,
     );
-    assert!(cache_directory_path.read_dir()?.next().is_none());
+    assert!(cache_directory_path.read_dir()?.next().is_some());
     Ok(())
 }
 
@@ -239,7 +239,15 @@ fn test_cmd_ingest_simple() -> Result<()> {
     .stdout(predicate::str::contains("Indexed"))
     .stdout(predicate::str::contains("documents in"))
     .stdout(predicate::str::contains("Now, you can query the index"));
-    println!("piped input");
+
+    // Ensure cache directory is empty.
+    let cache_directory_path = get_cache_directory_path(
+        &test_env.data_dir_path,
+        &test_env.index_id,
+        INGEST_SOURCE_ID,
+    );
+    assert!(cache_directory_path.read_dir()?.next().is_none());
+
     Ok(())
 }
 


### PR DESCRIPTION
### Description
Clear the cache by default. Use `keep-cache` option to preserve the cache.

### How was this PR tested?
`make test-all`
