### PR TITLE
Add unit tests for union directory

### DIFF
--- a/quickwit-directories/src/union_directory.rs
+++ b/quickwit-directories/src/union_directory.rs
@@ -170,10 +170,75 @@ mod tests {
         let dir1 = RamDirectory::create();
         let dir2 = RamDirectory::create();
         dir1.atomic_write(Path::new("shadowed_path"), &b"shadower"[..])?;
-        dir2.atomic_write(Path::new("shadowed_path"), &b"shadowed"[..])?;
+        dir2.atomic_write(Path::new("shadowed_path"), &b"shadowee"[..])?;
         let union_directory = UnionDirectory::union_of(vec![Box::new(dir1), Box::new(dir2)]);
         let payload = union_directory.atomic_read(Path::new("shadowed_path"))?;
         assert_eq!(payload, b"shadower");
+        Ok(())
+    }
+
+    #[test]
+    fn test_union_directory_exists() -> anyhow::Result<()> {
+        let dir1 = RamDirectory::create();
+        dir1.atomic_write(Path::new("path1"), &b"data1"[..])?;
+        dir1.atomic_write(Path::new("shadowed_path"), &b"shadower"[..])?;
+
+        let dir2 = RamDirectory::create();
+        dir2.atomic_write(Path::new("path2"), &b"data2"[..])?;
+        dir2.atomic_write(Path::new("shadowed_path"), &b"shadowee"[..])?;
+
+        let union_directory = UnionDirectory::union_of(vec![Box::new(dir1), Box::new(dir2)]);
+        assert!(union_directory.exists(Path::new("path1"))?);
+        assert!(union_directory.exists(Path::new("path2"))?);
+        assert!(union_directory.exists(Path::new("shadowed_path"))?);
+
+        assert!(!union_directory.exists(Path::new("path3"))?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_union_directory_delete() -> anyhow::Result<()> {
+        let dir1 = RamDirectory::create();
+        dir1.atomic_write(Path::new("path1"), &b"data1"[..])?;
+        dir1.atomic_write(Path::new("shadowed_path"), &b"shadower"[..])?;
+
+        let dir2 = RamDirectory::create();
+        dir2.atomic_write(Path::new("path2"), &b"data2"[..])?;
+        dir2.atomic_write(Path::new("shadowed_path"), &b"shadowee"[..])?;
+
+        let union_directory = UnionDirectory::union_of(vec![Box::new(dir1), Box::new(dir2)]);
+
+        union_directory.delete(Path::new("path1"))?;
+        assert!(!union_directory.exists(Path::new("path1"))?);
+
+        union_directory.delete(Path::new("path2"))?;
+        assert!(!union_directory.exists(Path::new("path2"))?);
+
+        union_directory.delete(Path::new("shadowed_path"))?;
+        assert!(!union_directory.exists(Path::new("shadowed_path"))?);
+
+        union_directory.delete(Path::new("path3")).unwrap_err();
+        Ok(())
+    }
+    #[test]
+    fn test_union_directory_write() -> anyhow::Result<()> {
+        let dir1 = RamDirectory::create();
+        dir1.atomic_write(Path::new("path1"), &b"data1"[..])?;
+
+        let dir2 = RamDirectory::create();
+        dir2.atomic_write(Path::new("path2"), &b"data2"[..])?;
+
+        let union_directory = UnionDirectory::union_of(vec![Box::new(dir1), Box::new(dir2)]);
+        union_directory.atomic_write(Path::new("path1"), &b"data1 data1"[..])?;
+        union_directory.atomic_write(Path::new("path3"), &b"data3"[..])?;
+        {
+            let payload = union_directory.atomic_read(Path::new("path1"))?;
+            assert_eq!(payload, b"data1 data1");
+        }
+        {
+            let payload = union_directory.atomic_read(Path::new("path3"))?;
+            assert_eq!(payload, b"data3");
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
### Description
Per title. Fixes #543.

### How was this PR tested?
`RUST_BACKTRACE=full cargo test -p quickwit-directories`