### PR TITLE
Added a `doc_to_json` in the DocMapper.

### DIFF
--- a/docs/guides/tutorial-hdfs-logs-distributed-search-aws-s3.md
+++ b/docs/guides/tutorial-hdfs-logs-distributed-search-aws-s3.md
@@ -231,21 +231,11 @@ which returns the json
   "num_hits": 364,
   "hits": [
     {
-      "attributes.class": [
-        "org.apache.hadoop.hdfs.server.datanode.DataNode"
-      ],
-      "body": [
-        "RECEIVED SIGNAL 15: SIGTERM"
-      ],
-      "resource.service": [
-        "datanode/02"
-      ],
-      "severity_text": [
-        "ERROR"
-      ],
-      "timestamp": [
-        1442629246
-      ]
+      "attributes.class": "org.apache.hadoop.hdfs.server.datanode.DataNode",
+      "body": "RECEIVED SIGNAL 15: SIGTERM",
+      "resource": {"service": "datanode/02"},
+      "severity_text": "ERROR",
+      "timestamp": 1442629246
     }
     ...
   ],

--- a/docs/guides/tutorial-hdfs-logs.md
+++ b/docs/guides/tutorial-hdfs-logs.md
@@ -141,21 +141,11 @@ which returns the json
   "num_hits": 364,
   "hits": [
     {
-      "attributes.class": [
-        "org.apache.hadoop.hdfs.server.datanode.DataNode"
-      ],
-      "body": [
-        "RECEIVED SIGNAL 15: SIGTERM"
-      ],
-      "resource.service": [
-        "datanode/02"
-      ],
-      "severity_text": [
-        "ERROR"
-      ],
-      "timestamp": [
-        1442629246
-      ]
+      "attributes.class": "org.apache.hadoop.hdfs.server.datanode.DataNode",
+      "body": "RECEIVED SIGNAL 15: SIGTERM",
+      "resource": { "service": "datanode/02" },
+      "severity_text": "ERROR",
+      "timestamp": 1442629246
     }
     ...
   ],

--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -151,6 +151,26 @@ message SplitIdAndFooterOffsets {
 
 }
 
+/// Hits returned by a FetchDocRequest.
+///
+/// The json that is joined is the raw tantivy json doc.
+/// It is very different from a quickwit json doc.
+///
+/// For instance:
+/// - it may contain a _source and a _dynamic field.
+/// - since tantivy has no notion of cardinality,
+/// all fields is  are arrays.
+/// - since tantivy has no notion of object, the object is
+/// flattened by concatenating the path to the root.
+///
+/// See  `quickwit_search::convert_leaf_hit`
+message LeafHit {
+  // The actual content of the hit/
+  string leaf_json = 1;
+  // The partial hit (ie: the sorting field + the document address)
+  PartialHit partial_hit = 2;
+}
+
 message Hit {
   // The actual content of the hit/
   string json = 1;
@@ -222,7 +242,7 @@ message FetchDocsRequest {
 
 message FetchDocsResponse {
   // List of complete hits.
-  repeated Hit hits = 1;
+  repeated LeafHit hits = 1;
 }
 
 

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -108,6 +108,30 @@ pub struct SplitIdAndFooterOffsets {
     #[prost(uint64, tag="3")]
     pub split_footer_end: u64,
 }
+//// Hits returned by a FetchDocRequest.
+////
+//// The json that is joined is the raw tantivy json doc.
+//// It is very different from a quickwit json doc.
+////
+//// For instance:
+//// - it may contain a _source and a _dynamic field.
+//// - since tantivy has no notion of cardinality,
+//// all fields is  are arrays.
+//// - since tantivy has no notion of object, the object is
+//// flattened by concatenating the path to the root.
+////
+//// See  `quickwit_search::convert_leaf_hit`
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LeafHit {
+    /// The actual content of the hit/
+    #[prost(string, tag="1")]
+    pub leaf_json: ::prost::alloc::string::String,
+    /// The partial hit (ie: the sorting field + the document address)
+    #[prost(message, optional, tag="2")]
+    pub partial_hit: ::core::option::Option<PartialHit>,
+}
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -196,7 +220,7 @@ pub struct FetchDocsRequest {
 pub struct FetchDocsResponse {
     /// List of complete hits.
     #[prost(message, repeated, tag="1")]
-    pub hits: ::prost::alloc::vec::Vec<Hit>,
+    pub hits: ::prost::alloc::vec::Vec<LeafHit>,
 }
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/quickwit-search/src/fetch_docs.rs
+++ b/quickwit-search/src/fetch_docs.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use itertools::Itertools;
-use quickwit_proto::{FetchDocsResponse, Hit, PartialHit, SplitIdAndFooterOffsets};
+use quickwit_proto::{FetchDocsResponse, PartialHit, SplitIdAndFooterOffsets};
 use quickwit_storage::Storage;
 use tantivy::{IndexReader, ReloadPolicy};
 use tracing::error;
@@ -107,13 +107,14 @@ pub async fn fetch_docs(
     let mut global_doc_addr_to_doc_json =
         fetch_docs_to_map(global_doc_addrs, index_storage, splits).await?;
 
-    let hits: Vec<Hit> = partial_hits
+    let hits: Vec<quickwit_proto::LeafHit> = partial_hits
         .iter()
         .flat_map(|partial_hit| {
             let global_doc_addr = GlobalDocAddress::from_partial_hit(partial_hit);
-            if let Some((_, json)) = global_doc_addr_to_doc_json.remove_entry(&global_doc_addr) {
-                Some(Hit {
-                    json,
+            if let Some((_, leaf_json)) = global_doc_addr_to_doc_json.remove_entry(&global_doc_addr)
+            {
+                Some(quickwit_proto::LeafHit {
+                    leaf_json,
                     partial_hit: Some(partial_hit.clone()),
                 })
             } else {


### PR DESCRIPTION
    Formatting returned documents.
    
    Before this PR, documents are just json serialized
    by tantivy.
    
    This is bad because:
    - object fields are not constructed,
    - cardinality is ignored, and all fields are wrapped in arrays,
    - the dynamically mapped fields are added in `_dynamic`,
    
    This PR adds a method to the `DocMapper` in
    order to format JSON Object for documents.
    
    This formatting happens at the root level, in order
    to use the same DocMapper (output format) for all hits.
    
    In addition, the _source field used to be stored in
    text field. After this change, the _source field is stored in a
    JSON field, and returned as a JSON Object (it used to be a JSON
    serialized string within the json document).
    
    Closes #1325
    Closes #1293
