### PR TITLE
Set default config location to `./config/quickwit.yaml`

### DIFF
--- a/quickwit-cli/src/cli.rs
+++ b/quickwit-cli/src/cli.rs
@@ -18,7 +18,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::bail;
-use clap::{ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command};
+use quickwit_config::DEFAULT_QW_CONFIG_PATH;
 use tracing::Level;
 
 use crate::index::{build_index_command, IndexCliCommand};
@@ -28,6 +29,15 @@ use crate::split::{build_split_command, SplitCliCommand};
 
 pub fn build_cli<'a>() -> Command<'a> {
     Command::new("Quickwit")
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .help("Config file location")
+                .env("QW_CONFIG")
+                .default_value(DEFAULT_QW_CONFIG_PATH)
+                .global(true)
+                .required(false),
+        )
         .subcommand(build_run_command().display_order(1))
         .subcommand(build_index_command().display_order(2))
         .subcommand(build_source_command().display_order(3))

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -62,8 +62,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
                 .about("List indexes.")
                 .alias("ls")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file")
-                        .env("QW_CONFIG"),
                     arg!(--"metastore-uri" <METASTORE_URI> "Metastore URI. Override the `metastore_uri` parameter defined in the config file. Default to file-backed, but could be Amazon S3 or PostgreSQL.")
                         .required(false)
                 ])
@@ -72,7 +70,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("create")
                 .about("Creates an index from an index config file.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--"index-config" <INDEX_CONFIG> "Location of the index config file."),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -85,7 +82,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("ingest")
                 .about("Indexes JSON documents read from a file or streamed from stdin.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -102,7 +98,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("describe")
                 .about("Displays descriptive statistics of an index: number of published splits, number of documents, splits min/max timestamps, size of splits.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -113,7 +108,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("search")
                 .about("Searches an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -140,7 +134,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("merge")
                 .about("Merges an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -151,7 +144,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("demux")
                 .about("Demuxes an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -162,7 +154,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("gc")
                 .about("Garbage collects stale staged splits and splits marked for deletion.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -178,7 +169,6 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("delete")
                 .about("Delete an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -94,7 +94,6 @@ async fn main() -> anyhow::Result<()> {
     let app = build_cli()
         .version(version_text.as_str())
         .about(about_text.as_str());
-
     let matches = app.get_matches();
 
     let command = match CliCommand::parse_cli_args(&matches) {

--- a/quickwit-cli/src/service.rs
+++ b/quickwit-cli/src/service.rs
@@ -34,7 +34,6 @@ pub fn build_run_command<'a>() -> Command<'a> {
     Command::new("run")
         .about("Runs quickwit services. By default, `indexer` and `searcher` are started.")
         .args(&[
-            arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG").required(true),
             arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.").env("QW_DATA_DIR").required(false),
             arg!(--"service" <SERVICE> "Services (searcher|indexer) to run. If unspecified run both `searcher` and `indexer`.").required(false)
         ])

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -38,7 +38,6 @@ pub fn build_source_command<'a>() -> Command<'a> {
             Command::new("create")
                 .about("Adds a new source to an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Path to Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX_ID> "ID of the target index"),
                     arg!(--"source-config" <SOURCE_CONFIG> "Path to source config file. Please, refer to the documentation for more details."),
                 ])
@@ -47,7 +46,6 @@ pub fn build_source_command<'a>() -> Command<'a> {
             Command::new("delete")
                 .about("Deletes a source from an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX_ID> "ID of the target index"),
                     arg!(--source <SOURCE_ID> "ID of the source."),
                 ])
@@ -56,7 +54,6 @@ pub fn build_source_command<'a>() -> Command<'a> {
             Command::new("describe")
                 .about("Describes a source.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX_ID> "ID of the target index"),
                     arg!(--source <SOURCE_ID> "ID of the source."),
                 ])
@@ -65,7 +62,6 @@ pub fn build_source_command<'a>() -> Command<'a> {
             Command::new("list")
                 .about("Lists the sources of an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX_ID> "ID of the target index"),
                 ])
             )

--- a/quickwit-cli/src/split.rs
+++ b/quickwit-cli/src/split.rs
@@ -43,33 +43,29 @@ pub fn build_split_command<'a>() -> Command<'a> {
             Command::new("list")
                 .about("Lists the splits of an index.")
                 .args(&[
-                    arg!(--config <CONFIG> "Config file location")
-                        .display_order(1)
-                        .required(true)
-                        .env("QW_CONFIG"),
                     arg!(--index <INDEX> "Target index ID")
-                        .display_order(2)
+                        .display_order(1)
                         .required(true),
                     arg!(--states <SPLIT_STATES> "Selects the splits whose states are included in this comma-separated list of states. Possible values are `staged`, `published`, and `marked`.")
-                        .display_order(3)
+                        .display_order(2)
                         .required(false)
                         .use_value_delimiter(true),
                     arg!(--"create-date" <CREATE_DATE> "Selects the splits whose creation dates are before this date.")
-                        .display_order(4)
+                        .display_order(3)
                         .required(false),
                     arg!(--"start-date" <START_DATE> "Selects the splits that contain documents after this date (time-series indexes only).")
-                        .display_order(5)
+                        .display_order(4)
                         .required(false),
                     arg!(--"end-date" <END_DATE> "Selects the splits that contain documents before this date (time-series indexes only).")
-                        .display_order(6)
+                        .display_order(5)
                         .required(false),
                     arg!(--tags <TAGS> "Selects the splits whose tags are all included in this comma-separated list of tags.")
-                        .display_order(7)
+                        .display_order(6)
                         .required(false)
                         .use_value_delimiter(true),
                     Arg::new("mark-for-deletion")
                         .alias("mark")
-                        .display_order(8)
+                        .display_order(7)
                         .long("mark-for-deletion")
                         .help("Marks the selected splits for deletion.")
                 ])
@@ -78,7 +74,6 @@ pub fn build_split_command<'a>() -> Command<'a> {
             Command::new("extract")
                 .about("Downloads and extracts a split to a directory.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--split <SPLIT> "ID of the target split"),
                     arg!(--"target-dir" <TARGET_DIR> "Directory to extract the split to."),
@@ -91,7 +86,6 @@ pub fn build_split_command<'a>() -> Command<'a> {
             Command::new("describe")
                 .about("Displays metadata about a split.")
                 .args(&[
-                    arg!(--config <CONFIG> "Quickwit config file").env("QW_CONFIG"),
                     arg!(--index <INDEX> "ID of the target index"),
                     arg!(--split <SPLIT> "ID of the target split"),
                     arg!(--verbose "Displays additional metadata about the hotcache."),
@@ -105,10 +99,6 @@ pub fn build_split_command<'a>() -> Command<'a> {
                 .about("Marks one or multiple splits of an index for deletion.")
                 .alias("mark")
                 .args(&[
-                    arg!(--config <CONFIG> "Config file location")
-                        .display_order(1)
-                        .env("QW_CONFIG")
-                        .required(true),
                     arg!(--index <INDEX_ID> "Target index ID")
                         .display_order(2)
                         .required(true),

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -31,7 +31,9 @@ use quickwit_common::uri::{Extension, Uri};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-static DEFAULT_DATA_DIR_PATH: &str = "./qwdata";
+pub const DEFAULT_QW_CONFIG_PATH: &str = "./config/quickwit.yaml";
+
+const DEFAULT_DATA_DIR_PATH: &str = "./qwdata";
 
 fn default_data_dir_path() -> PathBuf {
     PathBuf::from(DEFAULT_DATA_DIR_PATH)

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -35,6 +35,8 @@ pub const DEFAULT_QW_CONFIG_PATH: &str = "./config/quickwit.yaml";
 
 const DEFAULT_DATA_DIR_PATH: &str = "./qwdata";
 
+const DEFAULT_CLUSTER_ID: &str = "quickwit-default-cluster";
+
 fn default_data_dir_path() -> PathBuf {
     PathBuf::from(DEFAULT_DATA_DIR_PATH)
 }
@@ -53,7 +55,7 @@ fn default_metastore_and_index_root_uri(data_dir_path: &Path) -> String {
 }
 
 fn default_cluster_id() -> String {
-    "quickwit-test-cluster".to_string()
+    DEFAULT_CLUSTER_ID.to_string()
 }
 
 fn default_node_id() -> String {
@@ -241,10 +243,15 @@ impl QuickwitConfig {
     }
 
     pub fn validate(&self) -> anyhow::Result<()> {
-        if self.peer_seeds.is_empty() {
-            warn!("Seed list is empty.")
+        if self.cluster_id == DEFAULT_CLUSTER_ID {
+            warn!(
+                cluster_id = DEFAULT_CLUSTER_ID,
+                "Cluster ID is not set, falling back to default value."
+            );
         }
-
+        if self.peer_seeds.is_empty() {
+            warn!("Seed list is empty.");
+        }
         if !self.data_dir_path.exists() {
             bail!(
                 "Data dir `{}` does not exist.",
@@ -488,7 +495,7 @@ mod tests {
         "#;
             let config = serde_yaml::from_str::<QuickwitConfig>(config_yaml).unwrap();
             assert_eq!(config.version, 0);
-            assert_eq!(config.cluster_id, "quickwit-test-cluster");
+            assert_eq!(config.cluster_id, DEFAULT_CLUSTER_ID);
             assert_eq!(config.node_id, "1");
             assert_eq!(
                 config.metastore_uri(),

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -23,7 +23,7 @@ mod source_config;
 
 pub use config::{
     get_searcher_config_instance, IndexerConfig, QuickwitConfig, SearcherConfig,
-    SEARCHER_CONFIG_INSTANCE,
+    DEFAULT_QW_CONFIG_PATH, SEARCHER_CONFIG_INSTANCE,
 };
 pub use index_config::{
     build_doc_mapper, DocMapping, IndexConfig, IndexingResources, IndexingSettings, MergePolicy,


### PR DESCRIPTION
### Description
- Set default config location to `./config/quickwit.yaml`; fixes #1339
- Warn user when default cluster ID is used; fixes #1314

### How was this PR tested?
- `make test-all`
- ran a bunch of commands with `--config` at various positions.