### PR TITLE
Validate config URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,8 @@ dependencies = [
  "prometheus",
  "rand",
  "regex",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -513,14 +513,12 @@ pub async fn list_index_cli(args: ListIndexesArgs) -> anyhow::Result<()> {
     debug!(args = ?args, "list");
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
-    let metastore_uri = if let Some(uri) = args.metastore_uri {
-        uri.to_string()
-    } else {
-        quickwit_config.metastore_uri()
-    };
+    let metastore_uri = args
+        .metastore_uri
+        .unwrap_or_else(|| quickwit_config.metastore_uri());
     let metastore = metastore_uri_resolver.resolve(&metastore_uri).await?;
-    let res = metastore.list_indexes_metadatas().await?;
-    let index_table = make_list_indexes_table(res);
+    let indexes = metastore.list_indexes_metadatas().await?;
+    let index_table = make_list_indexes_table(indexes);
 
     println!();
     println!("{}", index_table);

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -83,7 +83,7 @@ async fn load_quickwit_config(
 /// Optionaly, it takes a `SourceConfig` that will be checked instead
 /// of the index's sources.
 pub async fn run_index_checklist(
-    metastore_uri: &str,
+    metastore_uri: &Uri,
     index_id: &str,
     source_to_check: Option<&SourceConfig>,
 ) -> anyhow::Result<()> {

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -367,7 +367,7 @@ fn flatten_json(value: Value) -> Vec<(String, Value)> {
     acc
 }
 
-async fn resolve_index(metastore_uri: &str, index_id: &str) -> anyhow::Result<IndexMetadata> {
+async fn resolve_index(metastore_uri: &Uri, index_id: &str) -> anyhow::Result<IndexMetadata> {
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(metastore_uri).await?;
     let index_metadata = metastore.index_metadata(index_id).await?;

--- a/quickwit-common/Cargo.toml
+++ b/quickwit-common/Cargo.toml
@@ -13,15 +13,17 @@ documentation = "https://quickwit.io/docs/"
 anyhow = "1"
 colored = "2"
 env_logger = "0.9"
+futures = "0.3"
+home = "0.5.3"
 once_cell = "1"
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
 regex = "1"
+serde = "1.0"
 tokio = { version = "1", features = ["fs", "macros", "rt"] }
-warp = '0.3'
 tracing = "0.1.29"
-home = "0.5.3"
-futures = "0.3"
+warp = '0.3'
 
 [dev-dependencies]
+serde_json = "1.0"
 tempfile = "3"

--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -23,9 +23,14 @@ use std::fmt::Display;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{bail, Context};
+use serde::{Serialize, Serializer};
 
 /// Default file protocol `file://`
-const FILE_PROTOCOL: &str = "file";
+pub const FILE_PROTOCOL: &str = "file";
+
+const POSTGRES_PROTOCOL: &str = "postgres";
+
+const POSTGRESQL_PROTOCOL: &str = "postgresql";
 
 const PROTOCOL_SEPARATOR: &str = "://";
 
@@ -57,23 +62,25 @@ pub struct Uri {
 }
 
 impl Uri {
-    /// Tries to to construct a Uri from the raw string.
+    /// Attempts to construct a [`Uri`] from a raw string slice.
     /// A `file://` protocol is assumed if not specified.
-    /// File URIs are resolved (normalised) relative to the current working directory
+    /// File URIs are resolved (normalized) relative to the current working directory
     /// unless an absolute path is specified.
-    /// Handles special characters like (~, ., ..)
+    /// Handles special characters like `~`, `.`, `..`.
     pub fn try_new(uri: &str) -> anyhow::Result<Self> {
+        if uri.is_empty() {
+            bail!("URI is empty.");
+        }
         let (protocol, mut path) = match uri.split_once(PROTOCOL_SEPARATOR) {
             None => (FILE_PROTOCOL, uri.to_string()),
             Some((protocol, path)) => (protocol, path.to_string()),
         };
-
         if protocol == FILE_PROTOCOL {
             if path.starts_with('~') {
                 // We only accept `~` (alias to the home directory) and `~/path/to/something`.
                 // If there is something following the `~` that is not `/`, we bail out.
                 if path.len() > 1 && !path.starts_with("~/") {
-                    bail!("This path syntax `{}` is not supported.", uri);
+                    bail!("Path syntax `{}` is not supported.", uri);
                 }
 
                 let home_dir_path = home::home_dir()
@@ -83,27 +90,33 @@ impl Uri {
 
                 path.replace_range(0..1, &home_dir_path);
             }
-
-            if !path.starts_with('/') {
+            if Path::new(&path).is_relative() {
                 let current_dir = env::current_dir().context(
                     "Failed to resolve current working directory: dir does not exist or \
                      insufficient permissions.",
                 )?;
                 path = current_dir.join(path).to_string_lossy().to_string();
             }
-
             path = normalize_path(Path::new(&path))
                 .to_string_lossy()
                 .to_string();
         }
-
         Ok(Self {
             uri: format!("{}{}{}", protocol, PROTOCOL_SEPARATOR, path),
             protocol_idx: protocol.len(),
         })
     }
 
-    /// Returns the URI extension.
+    /// Constructs a [`Uri`] from a properly formatted string `<protocol>://<path>` where `path` is
+    /// normalized. Use this method exclusively for trusted input.
+    pub fn new(uri: String) -> Self {
+        let protocol_idx = uri
+            .find(PROTOCOL_SEPARATOR)
+            .expect("URI lacks protocol separator. Use `Uri::new` exclusively for trusted input.");
+        Self { uri, protocol_idx }
+    }
+
+    /// Returns the extension of the URI.
     pub fn extension(&self) -> Option<Extension> {
         Path::new(&self.uri)
             .extension()
@@ -111,19 +124,68 @@ impl Uri {
             .and_then(Extension::maybe_new)
     }
 
-    /// Returns the uri protocol.
+    /// Returns the URI as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.uri
+    }
+
+    /// Returns the protocol of the URI.
     pub fn protocol(&self) -> &str {
         &self.uri[..self.protocol_idx]
     }
 
-    /// Returns the file path from the uri.
-    /// Useful only for `file://` protocol Uri.
+    /// Returns the file path of the URI.
+    /// Applies only to `file://` URIs.
     pub fn filepath(&self) -> Option<&Path> {
-        if self.protocol() == "file" {
+        if self.protocol() == FILE_PROTOCOL {
             self.uri.strip_prefix("file://").map(Path::new)
         } else {
             None
         }
+    }
+
+    /// Consumes the [`Uri`] struct and returns the normalized URI as a string.
+    pub fn into_string(self) -> String {
+        self.uri
+    }
+
+    /// Creates a new [`Uri`] with `path` adjoined to `self`.
+    /// Fails if `path` is absolute.
+    pub fn join(&self, path: &str) -> anyhow::Result<Self> {
+        if Path::new(path).is_absolute() {
+            bail!(
+                "Cannot join URI `{}` with absolute path `{}`.",
+                self.uri,
+                path
+            );
+        }
+        let joined = match self.protocol() {
+            FILE_PROTOCOL => Path::new(&self.uri)
+                .join(path)
+                .to_string_lossy()
+                .to_string(),
+            POSTGRES_PROTOCOL | POSTGRESQL_PROTOCOL => bail!(
+                "Cannot join PostgreSQL URI `{}` with path `{}`.",
+                self.uri,
+                path
+            ),
+            _ => format!(
+                "{}{}{}",
+                self.uri,
+                if self.uri.ends_with('/') { "" } else { "/" },
+                path
+            ),
+        };
+        Ok(Self {
+            uri: joined,
+            protocol_idx: self.protocol_idx,
+        })
+    }
+}
+
+impl AsRef<str> for Uri {
+    fn as_ref(&self) -> &str {
+        &self.uri
     }
 }
 
@@ -133,9 +195,21 @@ impl Display for Uri {
     }
 }
 
-impl AsRef<str> for Uri {
-    fn as_ref(&self) -> &str {
-        &self.uri
+impl PartialEq<&str> for Uri {
+    fn eq(&self, other: &&str) -> bool {
+        &self.uri == other
+    }
+}
+impl PartialEq<String> for Uri {
+    fn eq(&self, other: &String) -> bool {
+        &self.uri == other
+    }
+}
+
+impl Serialize for Uri {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        serializer.serialize_str(&self.uri)
     }
 }
 
@@ -177,83 +251,79 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_uri() -> anyhow::Result<()> {
+    fn test_try_new_uri() {
+        Uri::try_new("").unwrap_err();
+
         let home_dir = home::home_dir().unwrap();
         let current_dir = env::current_dir().unwrap();
 
-        let uri = Uri::try_new("file:///home/foo/bar")?;
+        let uri = Uri::try_new("file:///home/foo/bar").unwrap();
         assert_eq!(uri.protocol(), "file");
         assert_eq!(uri.filepath(), Some(Path::new("/home/foo/bar")));
-        assert_eq!(uri.as_ref(), "file:///home/foo/bar");
+        assert_eq!(uri, "file:///home/foo/bar");
+        assert_eq!(uri, "file:///home/foo/bar".to_string());
 
         assert_eq!(
-            Uri::try_new("home/homer/docs/dognuts")?.to_string(),
+            Uri::try_new("home/homer/docs/dognuts").unwrap(),
             format!("file://{}/home/homer/docs/dognuts", current_dir.display())
         );
-
         assert_eq!(
-            Uri::try_new("home/homer/docs/../dognuts")?.to_string(),
+            Uri::try_new("home/homer/docs/../dognuts").unwrap(),
             format!("file://{}/home/homer/dognuts", current_dir.display())
         );
-
         assert_eq!(
-            Uri::try_new("home/homer/docs/../../dognuts")?.to_string(),
+            Uri::try_new("home/homer/docs/../../dognuts").unwrap(),
             format!("file://{}/home/dognuts", current_dir.display())
         );
-
         assert_eq!(
-            Uri::try_new("/home/homer/docs/dognuts")?.to_string(),
+            Uri::try_new("/home/homer/docs/dognuts").unwrap(),
             "file:///home/homer/docs/dognuts"
         );
-
         assert_eq!(
-            Uri::try_new("~")?.to_string(),
+            Uri::try_new("~").unwrap(),
             format!("file://{}", home_dir.display())
         );
         assert_eq!(
-            Uri::try_new("~/")?.to_string(),
+            Uri::try_new("~/").unwrap(),
             format!("file://{}", home_dir.display())
         );
-
         assert_eq!(
             Uri::try_new("~anything/bar").unwrap_err().to_string(),
-            "This path syntax `~anything/bar` is not supported."
+            "Path syntax `~anything/bar` is not supported."
         );
-
         assert_eq!(
-            Uri::try_new("~/.")?.to_string(),
+            Uri::try_new("~/.").unwrap(),
             format!("file://{}", home_dir.display())
         );
         assert_eq!(
-            Uri::try_new("~/..")?.to_string(),
+            Uri::try_new("~/..").unwrap(),
             format!("file://{}", home_dir.parent().unwrap().display())
         );
-
         assert_eq!(
-            Uri::try_new("file://")?.to_string(),
+            Uri::try_new("file://").unwrap(),
             format!("file://{}", current_dir.display())
         );
-
+        assert_eq!(Uri::try_new("file:///").unwrap(), "file:///");
         assert_eq!(
-            Uri::try_new("file://.")?.to_string(),
+            Uri::try_new("file://.").unwrap(),
             format!("file://{}", current_dir.display())
         );
-
         assert_eq!(
-            Uri::try_new("file://..")?.to_string(),
+            Uri::try_new("file://..").unwrap(),
             format!("file://{}", current_dir.parent().unwrap().display())
         );
-
         assert_eq!(
-            Uri::try_new("s3://home/homer/docs/dognuts")?.to_string(),
+            Uri::try_new("s3://home/homer/docs/dognuts").unwrap(),
             "s3://home/homer/docs/dognuts"
         );
-
         assert_eq!(
-            Uri::try_new("s3://home/homer/docs/../dognuts")?.to_string(),
+            Uri::try_new("s3://home/homer/docs/../dognuts").unwrap(),
             "s3://home/homer/docs/../dognuts"
         );
+    }
 
+    #[test]
+    fn test_uri_extension() {
         assert!(Uri::try_new("s3://").unwrap().extension().is_none());
 
         assert_eq!(
@@ -263,7 +333,6 @@ mod tests {
                 .unwrap(),
             Extension::Json
         );
-
         assert_eq!(
             Uri::try_new("s3://config.foo")
                 .unwrap()
@@ -271,7 +340,44 @@ mod tests {
                 .unwrap(),
             Extension::Unknown("foo".to_string())
         );
+    }
 
-        Ok(())
+    #[test]
+    fn test_uri_join() {
+        assert_eq!(
+            Uri::new("file:///".to_string()).join("foo").unwrap(),
+            "file:///foo"
+        );
+        assert_eq!(
+            Uri::new("file:///foo".to_string()).join("bar").unwrap(),
+            "file:///foo/bar"
+        );
+        assert_eq!(
+            Uri::new("file:///foo/".to_string()).join("bar").unwrap(),
+            "file:///foo/bar"
+        );
+        assert_eq!(
+            Uri::new("ram://foo".to_string()).join("bar").unwrap(),
+            "ram://foo/bar"
+        );
+        assert_eq!(
+            Uri::new("s3://bucket/".to_string()).join("key").unwrap(),
+            "s3://bucket/key"
+        );
+        Uri::new("s3://bucket/".to_string())
+            .join("/key")
+            .unwrap_err();
+        Uri::new("postgres://username:password@localhost:5432/metastore".to_string())
+            .join("table")
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_uri_serialize() {
+        let uri = Uri::try_new("s3://bucket/key").unwrap();
+        assert_eq!(
+            serde_json::to_value(&uri).unwrap(),
+            serde_json::Value::String("s3://bucket/key".to_string())
+        );
     }
 }

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -27,8 +27,9 @@ use json_comments::StripComments;
 use once_cell::sync::OnceCell;
 use quickwit_common::net::{get_socket_addr, parse_socket_addr_with_default_port};
 use quickwit_common::new_coolid;
-use quickwit_common::uri::{Extension, Uri};
-use serde::{Deserialize, Serialize};
+use quickwit_common::uri::{Extension, Uri, FILE_PROTOCOL};
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize};
 use tracing::{info, warn};
 
 pub const DEFAULT_QW_CONFIG_PATH: &str = "./config/quickwit.yaml";
@@ -47,11 +48,9 @@ fn default_data_dir_path() -> PathBuf {
 // For a given index `index-id`, it means that we have the metastore file
 // in  `./qwdata/indexes/{index-id}/metastore.json` and splits in
 // dir `./qwdata/indexes/{index-id}/splits`.
-fn default_metastore_and_index_root_uri(data_dir_path: &Path) -> String {
+fn default_metastore_and_index_root_uri(data_dir_path: &Path) -> Uri {
     Uri::try_new(&data_dir_path.join("indexes").to_string_lossy())
-        .expect("Default data dir `./qwdata` value is invalid.")
-        .as_ref()
-        .to_string()
+        .expect("Failed to create default metastore URI. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.")
 }
 
 fn default_cluster_id() -> String {
@@ -174,8 +173,12 @@ pub struct QuickwitConfig {
     pub grpc_listen_port: Option<u16>,
     #[serde(default)]
     pub peer_seeds: Vec<String>,
-    metastore_uri: Option<String>,
-    default_index_root_uri: Option<String>,
+    #[serde(default)]
+    #[serde(deserialize_with = "deser_valid_uri")]
+    metastore_uri: Option<Uri>,
+    #[serde(default)]
+    #[serde(deserialize_with = "deser_valid_uri")]
+    default_index_root_uri: Option<Uri>,
     #[serde(default = "default_data_dir_path")]
     #[serde(rename = "data_dir")]
     pub data_dir_path: PathBuf,
@@ -231,15 +234,15 @@ impl QuickwitConfig {
 
     fn from_json(bytes: &[u8]) -> anyhow::Result<Self> {
         serde_json::from_reader(StripComments::new(bytes))
-            .context("Failed to parse JSON server config file.")
+            .context("Failed to parse JSON config file.")
     }
 
     fn from_toml(bytes: &[u8]) -> anyhow::Result<Self> {
-        toml::from_slice(bytes).context("Failed to parse TOML server config file.")
+        toml::from_slice(bytes).context("Failed to parse TOML config file.")
     }
 
     fn from_yaml(bytes: &[u8]) -> anyhow::Result<Self> {
-        serde_yaml::from_slice(bytes).context("Failed to parse YAML server config file.")
+        serde_yaml::from_slice(bytes).context("Failed to parse YAML config file.")
     }
 
     pub fn validate(&self) -> anyhow::Result<()> {
@@ -251,6 +254,11 @@ impl QuickwitConfig {
         }
         if self.peer_seeds.is_empty() {
             warn!("Seed list is empty.");
+        }
+        let data_dir_uri = Uri::try_new(&self.data_dir_path.to_string_lossy())?;
+
+        if data_dir_uri.protocol() != FILE_PROTOCOL {
+            bail!("Data dir must be located on local file system")
         }
         if !self.data_dir_path.exists() {
             bail!(
@@ -339,17 +347,18 @@ impl QuickwitConfig {
 }
 
 impl QuickwitConfig {
-    pub fn metastore_uri(&self) -> String {
+    pub fn metastore_uri(&self) -> Uri {
         self.metastore_uri
             .as_ref()
-            .unwrap_or(&default_metastore_and_index_root_uri(&self.data_dir_path))
-            .to_string()
+            .cloned()
+            .unwrap_or_else(|| default_metastore_and_index_root_uri(&self.data_dir_path))
     }
-    pub fn default_index_root_uri(&self) -> String {
+
+    pub fn default_index_root_uri(&self) -> Uri {
         self.default_index_root_uri
             .as_ref()
-            .unwrap_or(&default_metastore_and_index_root_uri(&self.data_dir_path))
-            .to_string()
+            .cloned()
+            .unwrap_or_else(|| default_metastore_and_index_root_uri(&self.data_dir_path))
     }
 }
 
@@ -396,10 +405,19 @@ impl std::fmt::Debug for QuickwitConfig {
     }
 }
 
+/// Deserializes and validates a [`Uri`].
+pub(super) fn deser_valid_uri<'de, D>(deserializer: D) -> Result<Option<Uri>, D::Error>
+where D: Deserializer<'de> {
+    let uri_opt: Option<String> = Deserialize::deserialize(deserializer)?;
+    uri_opt
+        .map(|uri| Uri::try_new(&uri))
+        .transpose()
+        .map_err(D::Error::custom)
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;
-    use std::path::PathBuf;
 
     use super::*;
 
@@ -409,10 +427,6 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             config_filename
         )
-    }
-
-    fn set_data_dir_path(config: &mut QuickwitConfig, path: PathBuf) {
-        config.data_dir_path = path;
     }
 
     macro_rules! test_parser {
@@ -553,7 +567,7 @@ mod tests {
         let mut quickwit_config = QuickwitConfig::from_uri(&config_uri, file_content.as_bytes())
             .await
             .unwrap();
-        set_data_dir_path(&mut quickwit_config, env::current_dir().unwrap());
+        quickwit_config.data_dir_path = env::current_dir().unwrap();
         assert!(quickwit_config.validate().is_ok());
     }
 
@@ -658,5 +672,26 @@ mod tests {
             .await
             .unwrap_err();
         assert!(config.to_string().contains("Data dir"));
+    }
+
+    #[test]
+    fn test_config_validates_uris() {
+        {
+            let config_yaml = r#"
+            version: 0
+            node_id: 1
+            metastore_uri: ''
+        "#;
+            serde_yaml::from_str::<QuickwitConfig>(config_yaml).unwrap_err();
+        }
+        {
+            let config_yaml = r#"
+            version: 0
+            node_id: 1
+            metastore_uri: postgres://username:password@host:port/db
+            default_index_root_uri: ''
+        "#;
+            serde_yaml::from_str::<QuickwitConfig>(config_yaml).unwrap_err();
+        }
     }
 }

--- a/quickwit-core/src/lib.rs
+++ b/quickwit-core/src/lib.rs
@@ -35,6 +35,7 @@ pub use index::{clear_cache_directory, get_cache_directory_path, IndexService, I
 mod tests {
     use std::path::Path;
 
+    use quickwit_common::uri::Uri;
     use quickwit_config::{IndexConfig, IndexingSettings, SearchSettings};
     use quickwit_indexing::{FileEntry, TestSandbox};
     use quickwit_metastore::quickwit_metastore_uri_resolver;
@@ -82,7 +83,7 @@ mod tests {
         let index_service = IndexService::new(
             test_sandbox.metastore(),
             StorageUriResolver::for_test(),
-            "".to_string(),
+            Uri::new("file:///quickwit".to_string()),
         );
         let deleted_file_entries = index_service.delete_index(index_id, false).await?;
         assert_eq!(deleted_file_entries.len(), 1);
@@ -114,7 +115,7 @@ mod tests {
         let index_service = IndexService::new(
             metastore,
             storage_resolver,
-            "ram://test-storage-indexes".to_string(),
+            Uri::new("ram://test-storage-indexes".to_string()),
         );
         let index_metadata = index_service.create_index(index_config).await?;
         assert_eq!(index_metadata.index_id, index_id);

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -140,7 +140,7 @@ impl IndexerState {
             *current_split_opt = Some(new_indexed_split);
         }
         let current_index_split = current_split_opt.as_mut().with_context(|| {
-            "No index writer available. Please report: this should never happen."
+            "No index writer available. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues."
         })?;
         Ok(current_index_split)
     }

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -126,11 +126,14 @@ impl MetastoreUriResolver {
     }
 
     /// Resolves the given URI.
-    pub async fn resolve(&self, uri: &str) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {
-        let protocol = uri.split("://").next().ok_or_else(|| {
+    pub async fn resolve<S: AsRef<str>>(
+        &self,
+        uri: S,
+    ) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {
+        let protocol = uri.as_ref().split("://").next().ok_or_else(|| {
             MetastoreResolverError::InvalidUri(format!(
                 "Protocol not found in metastore URI: {}",
-                uri
+                uri.as_ref()
             ))
         })?;
 
@@ -139,7 +142,7 @@ impl MetastoreUriResolver {
             .get(protocol)
             .ok_or_else(|| MetastoreResolverError::ProtocolUnsupported(protocol.to_string()))?;
 
-        let metastore = resolver.resolve(uri).await?;
+        let metastore = resolver.resolve(uri.as_ref()).await?;
         Ok(metastore)
     }
 }

--- a/quickwit-search/src/search_client_pool.rs
+++ b/quickwit-search/src/search_client_pool.rs
@@ -280,7 +280,7 @@ impl SearchClientPool {
             if let Some(client) = socket_to_client.remove(&socket_addr) {
                 client_to_jobs.push((client, jobs));
             } else {
-                error!("Missing client. This should never happen! Please report");
+                error!("Client is missing. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
             }
         }
 

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -58,7 +58,7 @@ async fn get_split_stream_semaphore() -> SemaphorePermit<'static> {
         })
         .acquire()
         .await
-        .expect("Failed to acquire permit. This should never happen. Please report.")
+        .expect("Failed to acquire permit. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.")
 }
 
 /// `leaf` step of search stream.
@@ -284,7 +284,7 @@ fn collect_partitioned_values<TFastValue: FastValue, TPartitionValue: FastValue 
         fast_field_to_collect: request_fields.fast_field_name().to_string(),
         partition_by_fast_field: request_fields
             .partition_by_fast_field_name()
-            .expect("Please report a bug here, the partition_by_fast_field should be defined")
+            .expect("`partition_by_fast_field` is not defined. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.")
             .to_string(),
         timestamp_field_opt: request_fields.timestamp_field,
         start_timestamp_opt,

--- a/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit-serve/src/index_api/rest_handler.rs
@@ -120,6 +120,7 @@ mod tests {
     use std::ops::Range;
 
     use assert_json_diff::assert_json_include;
+    use quickwit_common::uri::Uri;
     use quickwit_indexing::mock_split;
     use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
     use quickwit_storage::StorageUriResolver;
@@ -141,7 +142,7 @@ mod tests {
         let index_service = IndexService::new(
             Arc::new(metastore),
             StorageUriResolver::for_test(),
-            "file:///default-index-uri".to_string(),
+            Uri::new("file:///default-index-uri".to_string()),
         );
         let index_management_handler =
             super::index_management_handlers(Arc::new(index_service)).recover(recover_fn);
@@ -187,7 +188,7 @@ mod tests {
         let index_service = IndexService::new(
             Arc::new(metastore),
             StorageUriResolver::for_test(),
-            "file:///default-index-uri".to_string(),
+            Uri::new("file:///default-index-uri".to_string()),
         );
         let index_management_handler =
             super::index_management_handlers(Arc::new(index_service)).recover(recover_fn);
@@ -218,7 +219,7 @@ mod tests {
         let index_service = IndexService::new(
             Arc::new(metastore),
             StorageUriResolver::for_test(),
-            "file:///default-index-uri".to_string(),
+            Uri::new("file:///default-index-uri".to_string()),
         );
         let index_management_handler =
             super::index_management_handlers(Arc::new(index_service)).recover(recover_fn);
@@ -253,7 +254,7 @@ mod tests {
         let index_service = IndexService::new(
             Arc::new(metastore),
             StorageUriResolver::for_test(),
-            "file:///default-index-uri".to_string(),
+            Uri::new("file:///default-index-uri".to_string()),
         );
         let index_management_handler = super::index_management_handlers(Arc::new(index_service));
         let resp = warp::test::request()
@@ -279,7 +280,7 @@ mod tests {
         let index_service = IndexService::new(
             Arc::new(metastore),
             StorageUriResolver::for_test(),
-            "file:///default-index-uri".to_string(),
+            Uri::new("file:///default-index-uri".to_string()),
         );
         let index_management_handler =
             super::index_management_handlers(Arc::new(index_service)).recover(recover_fn);


### PR DESCRIPTION
### Description
- Validate config URIs (metastore URI, index URI, index root URI), fixes #1061

### How was this PR tested?
- Added unit tests
- Ran `make test-all`
