### PR TITLE
Fixing how we handle "."

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=8c1e1cf#8c1e1cf1adaa4c84551ce4ffa797e0684408474a"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=8c1e1cf#8c1e1cf1adaa4c84551ce4ffa797e0684408474a"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.17.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=8c1e1cf#8c1e1cf1adaa4c84551ce4ffa797e0684408474a"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
 dependencies = [
  "async-trait",
  "base64",
@@ -3963,12 +3963,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.1.1"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=8c1e1cf#8c1e1cf1adaa4c84551ce4ffa797e0684408474a"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
 
 [[package]]
 name = "tantivy-common"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=8c1e1cf#8c1e1cf1adaa4c84551ce4ffa797e0684408474a"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.15.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=8c1e1cf#8c1e1cf1adaa4c84551ce4ffa797e0684408474a"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -25,7 +25,7 @@ quickwit-config = { version = "0.2.1", path = "../quickwit-config" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 rand = "0.8"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "8c1e1cf", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "ed26552", default-features = false, features = [
     "mmap",
     "lz4-compression",
     "quickwit",

--- a/quickwit-directories/Cargo.toml
+++ b/quickwit-directories/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 serde = "1"
 serde_cbor = "0.11"
 serde_json = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "8c1e1cf", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "ed26552", default-features = false, features = [
     "mmap",
     "lz4-compression",
     "quickwit",

--- a/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit-doc-mapper/Cargo.toml
@@ -18,8 +18,8 @@ once_cell = "1.10"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "8c1e1cf", default-features = false, features = ["mmap", "lz4-compression", "quickwit"] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "8c1e1cf" }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "ed26552", default-features = false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ed26552" }
 thiserror = "1.0"
 tracing = "0.1.29"
 typetag = "0.1"

--- a/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit-doc-mapper/src/lib.rs
@@ -54,7 +54,7 @@ pub fn default_doc_mapper_for_tests() -> DefaultDocMapper {
         {
             "store_source": true,
             "default_search_fields": [
-                "body", "attributes.server", "attributes.server.status"
+                "body", "attributes.server", "attributes.server\\.status"
             ],
             "timestamp_field": "timestamp",
             "sort_by": {

--- a/quickwit-doc-mapper/src/query_builder.rs
+++ b/quickwit-doc-mapper/src/query_builder.rs
@@ -98,6 +98,7 @@ mod test {
         schema_builder.build()
     }
 
+    #[track_caller]
     fn check_build_query(
         query_str: &str,
         search_fields: Vec<String>,
@@ -152,54 +153,60 @@ mod test {
     }
 
     #[test]
-    fn test_build_query() -> anyhow::Result<()> {
+    fn test_build_query() {
         check_build_query(
             "foo:bar",
             vec![],
-            TestExpectation::Err("Field does not exists: '\"foo\"'"),
-        )?;
-
+            TestExpectation::Err("Field does not exists: 'foo'"),
+        )
+        .unwrap();
         check_build_query(
             "server.type:hpc server.mem:4GB",
             vec![],
-            TestExpectation::Err("Field does not exists: '\"server.type\"'"),
-        )?;
-
+            TestExpectation::Err("Field does not exists: 'server.type'"),
+        )
+        .unwrap();
         check_build_query(
             "title:[a TO b]",
             vec![],
             TestExpectation::Err("Range queries are not currently allowed."),
-        )?;
+        )
+        .unwrap();
         check_build_query(
             "title:{a TO b} desc:foo",
             vec![],
             TestExpectation::Err("Range queries are not currently allowed."),
-        )?;
+        )
+        .unwrap();
         check_build_query(
             "title:>foo",
             vec![],
             TestExpectation::Err("Range queries are not currently allowed."),
-        )?;
+        )
+        .unwrap();
         check_build_query(
             "title:foo desc:bar _source:baz",
             vec![],
             TestExpectation::Ok("TermQuery"),
-        )?;
+        )
+        .unwrap();
         check_build_query(
             "title:foo desc:bar",
             vec!["url".to_string()],
-            TestExpectation::Err("Field does not exists: '\"url\"'"),
-        )?;
+            TestExpectation::Err("Field does not exists: 'url'"),
+        )
+        .unwrap();
         check_build_query(
             "server.name:\".bar:\" server.mem:4GB",
             vec!["server.name".to_string()],
             TestExpectation::Ok("TermQuery"),
-        )?;
+        )
+        .unwrap();
         check_build_query(
             "server.name:\"for.bar:b\" server.mem:4GB",
             vec![],
             TestExpectation::Ok("TermQuery"),
-        )?;
-        Ok(())
+        )
+        .unwrap();
     }
 }

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -36,7 +36,7 @@ rusoto_kinesis = { version = "0.47", default-features = false, features = ["rust
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="8c1e1cf", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="ed26552", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 tempfile = "3.3"
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }

--- a/quickwit-metastore/src/metastore/index_metadata.rs
+++ b/quickwit-metastore/src/metastore/index_metadata.rs
@@ -131,8 +131,8 @@ impl IndexMetadata {
         let search_settings = SearchSettings {
             default_search_fields: vec![
                 "body".to_string(),
-                "attributes.server".to_string(),
-                "attributes.server.status".to_string(),
+                r#"attributes.server"#.to_string(),
+                r#"attributes.server\.status"#.to_string(),
             ],
         };
         let now_timestamp = utc_now_timestamp();

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1"
 opentelemetry = "0.17"
 tracing-opentelemetry = "0.17"
 rayon = "1"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="8c1e1cf", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="ed26552", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 
 [dependencies.quickwit-cluster]
 path = '../quickwit-cluster'

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -20,7 +20,7 @@ futures = '0.3'
 serde_json = "1"
 base64 = '0.13'
 tracing = "0.1.29"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="8c1e1cf", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="ed26552", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 once_cell = '1'
 regex = '1'
 thiserror = '1'


### PR DESCRIPTION
```
    Fix how quickwit handles "." in field names.
    
    After this PR we still accept field names with a ".".
    On the query side this dot then needs to be escaped with a backslash
    to disambiguate it from the "." of Json fields, and the "." of
    object fields.
    
    Under the hood, we still rely on tantivy's query parser.
    The hack consists in escaping the tantivy field name itself.
    
    This PR updates tantivy in order to include
    https://github.com/quickwit-oss/tantivy/pull/1356.
    
    Closes #1338
    Closes #1334
```