### PR TITLE
disallow unknown fields for json options

### DIFF
--- a/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -169,6 +169,7 @@ fn default_json_tokenizer() -> QuickwitTextTokenizer {
 /// `QuickwitJsonOptions` is also used to configure
 /// the dynamic mapping.
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct QuickwitJsonOptions {
     /// If true, all of the element in the json object will be indexed.
     #[serde(default = "default_as_true")]
@@ -378,6 +379,14 @@ mod tests {
         }
     "#;
 
+    const JSON_MAPPING_ENTRY_UNKNOWN_FIELD: &str = r#"
+        {
+            "name": "my_field_name",
+            "type": "json",
+            "blub": true
+        }
+    "#;
+
     const OBJECT_MAPPING_ENTRY_VALUE: &str = r#"
         {
             "name": "my_field_name",
@@ -400,6 +409,20 @@ mod tests {
             mapping_entry.unwrap_err().to_string(),
             "Error while parsing field `my_field_name`: unknown variant `notexist`, expected one \
              of `raw`, `default`, `en_stem`"
+                .to_string()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_invalid_json_mapping_entry() -> anyhow::Result<()> {
+        let mapping_entry =
+            serde_json::from_str::<FieldMappingEntry>(JSON_MAPPING_ENTRY_UNKNOWN_FIELD);
+        assert!(mapping_entry.is_err());
+        assert_eq!(
+            mapping_entry.unwrap_err().to_string(),
+            "Error while parsing field `my_field_name`: unknown field `blub`, expected one of \
+             `indexed`, `tokenizer`, `record`, `stored`"
                 .to_string()
         );
         Ok(())


### PR DESCRIPTION
dissallow unknown fields for json options, same behaviour as other option types
