### PR TITLE
skip long tokens in raw tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.17.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
 dependencies = [
  "async-trait",
  "base64",
@@ -4001,12 +4001,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.1.1"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
 
 [[package]]
 name = "tantivy-common"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.15.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=ed26552#ed26552296e4e380c7a286bfe52d994f8211d04e"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -25,7 +25,7 @@ quickwit-config = { version = "0.2.1", path = "../quickwit-config" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 rand = "0.8"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "ed26552", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "7f45a6a", default-features = false, features = [
     "mmap",
     "lz4-compression",
     "quickwit",

--- a/quickwit-directories/Cargo.toml
+++ b/quickwit-directories/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 serde = "1"
 serde_cbor = "0.11"
 serde_json = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "ed26552", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "7f45a6a", default-features = false, features = [
     "mmap",
     "lz4-compression",
     "quickwit",

--- a/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit-doc-mapper/Cargo.toml
@@ -18,8 +18,8 @@ once_cell = "1.10"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "ed26552", default-features = false, features = ["mmap", "lz4-compression", "quickwit"] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ed26552" }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "7f45a6a", default-features = false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "7f45a6a" }
 thiserror = "1.0"
 tracing = "0.1.29"
 typetag = "0.1"

--- a/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -28,6 +28,7 @@ use tantivy::schema::{Cardinality, Field, FieldType, Schema, STORED};
 use tantivy::Document;
 use tracing::info;
 
+use super::field_mapping_entry::QuickwitTextTokenizer;
 use super::DefaultDocMapperBuilder;
 use crate::default_doc_mapper::mapping_tree::{build_mapping_tree, MappingNode, MappingTree};
 pub use crate::default_doc_mapper::QuickwitJsonOptions;
@@ -130,9 +131,6 @@ impl DefaultDocMapper {
     }
 }
 
-/// Name of the raw tokenizer.
-const RAW_TOKENIZER_NAME: &str = "raw";
-
 fn validate_tag_fields(tag_fields: &[String], schema: &Schema) -> anyhow::Result<()> {
     for tag_field in tag_fields {
         let field = schema
@@ -145,7 +143,7 @@ fn validate_tag_fields(tag_fields: &[String], schema: &Schema) -> anyhow::Result
                     .get_indexing_options()
                     .map(|text_options| text_options.tokenizer());
 
-                if tokenizer_opt != Some(RAW_TOKENIZER_NAME) {
+                if tokenizer_opt != Some(QuickwitTextTokenizer::Raw.get_name()) {
                     bail!(
                         "Tags collection is only allowed on text fields with the `raw` tokenizer."
                     );

--- a/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -98,7 +98,7 @@ pub enum QuickwitTextTokenizer {
 }
 
 impl QuickwitTextTokenizer {
-    fn get_name(&self) -> &str {
+    pub fn get_name(&self) -> &str {
         match self {
             QuickwitTextTokenizer::Raw => "raw",
             QuickwitTextTokenizer::Default => "default",
@@ -161,7 +161,7 @@ impl From<QuickwitTextOptions> for TextOptions {
 }
 
 fn default_json_tokenizer() -> QuickwitTextTokenizer {
-    QuickwitTextTokenizer::Raw
+    QuickwitTextTokenizer::Default
 }
 
 /// Options associated to a json field.
@@ -936,7 +936,7 @@ mod tests {
         .unwrap();
         let expected_json_options = QuickwitJsonOptions {
             indexed: true,
-            tokenizer: QuickwitTextTokenizer::Raw,
+            tokenizer: QuickwitTextTokenizer::Default,
             record: IndexRecordOption::Basic,
             stored: true,
         };
@@ -960,6 +960,7 @@ mod tests {
             {
                 "type": "array<json>",
                 "name": "my_json_field_multi",
+                "tokenizer": "raw",
                 "stored": false
             }
             "#,

--- a/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit-doc-mapper/src/lib.rs
@@ -29,6 +29,7 @@ mod doc_mapper;
 mod error;
 mod query_builder;
 mod sort_by;
+mod tokenizers;
 
 /// Pruning tags manipulation.
 pub mod tag_pruning;
@@ -40,6 +41,7 @@ pub use default_doc_mapper::{
 pub use doc_mapper::DocMapper;
 pub use error::{DocParsingError, QueryParserError};
 pub use sort_by::{SortBy, SortByField, SortOrder};
+pub use tokenizers::QUICKWIT_TOKENIZER_MANAGER;
 
 /// Field name reserved for storing the source document.
 pub const SOURCE_FIELD_NAME: &str = "_source";

--- a/quickwit-doc-mapper/src/query_builder.rs
+++ b/quickwit-doc-mapper/src/query_builder.rs
@@ -20,10 +20,9 @@
 use quickwit_proto::SearchRequest;
 use tantivy::query::{Query, QueryParser, QueryParserError as TantivyQueryParserError};
 use tantivy::schema::{Field, Schema};
-use tantivy::tokenizer::TokenizerManager;
 use tantivy_query_grammar::{UserInputAst, UserInputLeaf};
 
-use crate::QueryParserError;
+use crate::{QueryParserError, QUICKWIT_TOKENIZER_MANAGER};
 
 /// Build a `Query` with field resolution & forbidding range clauses.
 pub(crate) fn build_query(
@@ -44,7 +43,8 @@ pub(crate) fn build_query(
         resolve_fields(&schema, &request.search_fields)?
     };
 
-    let mut query_parser = QueryParser::new(schema, search_fields, TokenizerManager::default());
+    let mut query_parser =
+        QueryParser::new(schema, search_fields, QUICKWIT_TOKENIZER_MANAGER.clone());
     query_parser.set_conjunction_by_default();
     let query = query_parser.parse_query(&request.query)?;
     Ok(query)

--- a/quickwit-doc-mapper/src/tokenizers.rs
+++ b/quickwit-doc-mapper/src/tokenizers.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use once_cell::sync::Lazy;
+use tantivy::tokenizer::{RawTokenizer, RemoveLongFilter, TextAnalyzer, TokenizerManager};
+
+fn get_quickwit_tokenizer_manager() -> TokenizerManager {
+    let raw_tokenizer = TextAnalyzer::from(RawTokenizer).filter(RemoveLongFilter::limit(100));
+
+    let tokenizer_manager = TokenizerManager::default();
+    tokenizer_manager.register("raw", raw_tokenizer);
+    tokenizer_manager
+}
+
+/// Quickwits default tokenizer
+pub static QUICKWIT_TOKENIZER_MANAGER: Lazy<TokenizerManager> =
+    Lazy::new(get_quickwit_tokenizer_manager);
+
+#[test]
+fn raw_tokenizer_test() {
+    let my_haiku = r#"
+        white sandy beach
+        a strong wind is coming 
+        sand in my face
+        "#;
+    let my_long_text = "a text, that is just too long, no one will type it, no one will like it, \
+                        no one shall find it. I just need some more chars, now you may not pass.";
+
+    let tokenizer = get_quickwit_tokenizer_manager().get("raw").unwrap();
+    assert!(tokenizer.token_stream(my_haiku).advance());
+    assert!(!tokenizer.token_stream(my_long_text).advance());
+}

--- a/quickwit-doc-mapper/src/tokenizers.rs
+++ b/quickwit-doc-mapper/src/tokenizers.rs
@@ -43,6 +43,8 @@ fn raw_tokenizer_test() {
                         no one shall find it. I just need some more chars, now you may not pass.";
 
     let tokenizer = get_quickwit_tokenizer_manager().get("raw").unwrap();
-    assert!(tokenizer.token_stream(my_haiku).advance());
+    let mut haiku_stream = tokenizer.token_stream(my_haiku);
+    assert!(haiku_stream.advance());
+    assert!(!haiku_stream.advance());
     assert!(!tokenizer.token_stream(my_long_text).advance());
 }

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -36,7 +36,7 @@ rusoto_kinesis = { version = "0.47", default-features = false, features = ["rust
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="ed26552", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="7f45a6a", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 tempfile = "3.3"
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -27,7 +27,7 @@ use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorRunner, Handler, Mailbox, QueueCapacity, SendError,
 };
 use quickwit_config::IndexingSettings;
-use quickwit_doc_mapper::{DocMapper, DocParsingError, SortBy};
+use quickwit_doc_mapper::{DocMapper, DocParsingError, SortBy, QUICKWIT_TOKENIZER_MANAGER};
 use tantivy::schema::{Field, Value};
 use tantivy::{Document, IndexBuilder, IndexSettings, IndexSortByField};
 use tracing::{info, warn};
@@ -105,7 +105,10 @@ impl IndexerState {
             sort_by_field: self.sort_by_field_opt.clone(),
             ..Default::default()
         };
-        let index_builder = IndexBuilder::new().settings(index_settings).schema(schema);
+        let index_builder = IndexBuilder::new()
+            .settings(index_settings)
+            .schema(schema)
+            .tokenizers(QUICKWIT_TOKENIZER_MANAGER.clone());
         let indexed_split = IndexedSplit::new_in_dir(
             self.index_id.clone(),
             self.indexing_directory.scratch_directory.clone(),

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -366,6 +366,7 @@ mod tests {
     use std::time::Instant;
 
     use quickwit_actors::{create_test_mailbox, ObservationType, Universe};
+    use quickwit_doc_mapper::QUICKWIT_TOKENIZER_MANAGER;
     use quickwit_metastore::checkpoint::CheckpointDelta;
     use tantivy::schema::{NumericOptions, Schema, FAST, STRING, TEXT};
     use tantivy::{doc, Index};
@@ -387,7 +388,8 @@ mod tests {
         let tag_f64 =
             schema_builder.add_f64_field("tag_f64", NumericOptions::default().set_indexed());
         let schema = schema_builder.build();
-        let index = Index::create_in_dir(split_scratch_directory.path(), schema)?;
+        let mut index = Index::create_in_dir(split_scratch_directory.path(), schema)?;
+        index.set_tokenizers(QUICKWIT_TOKENIZER_MANAGER.clone());
         let mut index_writer = index.writer_with_num_threads(1, 10_000_000)?;
         let mut timerange_opt: Option<RangeInclusive<i64>> = None;
         let mut num_docs = 0;

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1"
 opentelemetry = "0.17"
 tracing-opentelemetry = "0.17"
 rayon = "1"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="ed26552", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="7f45a6a", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 
 [dependencies.quickwit-cluster]
 path = '../quickwit-cluster'

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -29,7 +29,7 @@ use itertools::{Either, Itertools};
 use once_cell::sync::OnceCell;
 use quickwit_config::get_searcher_config_instance;
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
-use quickwit_doc_mapper::DocMapper;
+use quickwit_doc_mapper::{DocMapper, QUICKWIT_TOKENIZER_MANAGER};
 use quickwit_proto::{
     LeafSearchResponse, SearchRequest, SplitIdAndFooterOffsets, SplitSearchError,
 };
@@ -113,7 +113,8 @@ pub(crate) async fn open_index(
     let directory = StorageDirectory::new(bundle_storage_with_cache);
     let caching_directory = CachingDirectory::new_with_unlimited_capacity(Arc::new(directory));
     let hot_directory = HotDirectory::open(caching_directory, hotcache_bytes.read_bytes()?)?;
-    let index = Index::open(hot_directory)?;
+    let mut index = Index::open(hot_directory)?;
+    index.set_tokenizers(QUICKWIT_TOKENIZER_MANAGER.clone());
     Ok(index)
 }
 

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -20,7 +20,7 @@ futures = '0.3'
 serde_json = "1"
 base64 = '0.13'
 tracing = "0.1.29"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="ed26552", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="7f45a6a", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 once_cell = '1'
 regex = '1'
 thiserror = '1'


### PR DESCRIPTION
update tantivy

skip tokens longer than 100 for raw tokenizer, set tokenizer when opening Index and in query_parser
change default tokenizer for JSON to the 'default' tokenizer

Fixes https://github.com/quickwit-oss/quickwit/issues/1392
Fixes https://github.com/quickwit-oss/quickwit/issues/1370
