### PR TITLE
Doc on avoiding `.` in field names

### DIFF
--- a/docs/reference/index-config.md
+++ b/docs/reference/index-config.md
@@ -361,6 +361,10 @@ In plain language:
 - it should only contain latin letter `[a-zA-Z]` digits `[0-9]` or (`.`, `-`, `_`).
 - the first character needs to be a letter.
 
+:::caution
+For field names containing the `.` character, you will need to escape it when referencing them. Otherwise the `.` character will be interpreted as a JSON object property access. Because of this, it is recommended to avoid using field names containing the `.` character.
+:::
+
 ### Behavior with fields not defined in the config
 
 Fields in your JSON document that are not defined in the `index config` will be ignored.


### PR DESCRIPTION
Update docs to recommend avoiding `.` in field names