### PR TITLE
Updates tantivy for bugfix in json value serializaton.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=cbd06ab1#cbd06ab1899c56260568ca914b58767f984cf486"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=cbd06ab1#cbd06ab1899c56260568ca914b58767f984cf486"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.17.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=cbd06ab1#cbd06ab1899c56260568ca914b58767f984cf486"
 dependencies = [
  "async-trait",
  "base64",
@@ -4001,12 +4001,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.1.1"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=cbd06ab1#cbd06ab1899c56260568ca914b58767f984cf486"
 
 [[package]]
 name = "tantivy-common"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=cbd06ab1#cbd06ab1899c56260568ca914b58767f984cf486"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.15.0"
-source = "git+https://github.com/quickwit-oss/tantivy?rev=7f45a6a#7f45a6ac9626edae99a5be4924ca7bfd20e66c53"
+source = "git+https://github.com/quickwit-oss/tantivy?rev=cbd06ab1#cbd06ab1899c56260568ca914b58767f984cf486"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -25,7 +25,7 @@ quickwit-config = { version = "0.2.1", path = "../quickwit-config" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 rand = "0.8"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "7f45a6a", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "cbd06ab1", default-features = false, features = [
     "mmap",
     "lz4-compression",
     "quickwit",

--- a/quickwit-directories/Cargo.toml
+++ b/quickwit-directories/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 serde = "1"
 serde_cbor = "0.11"
 serde_json = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "7f45a6a", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "cbd06ab1", default-features = false, features = [
     "mmap",
     "lz4-compression",
     "quickwit",

--- a/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit-doc-mapper/Cargo.toml
@@ -18,8 +18,8 @@ once_cell = "1.10"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "7f45a6a", default-features = false, features = ["mmap", "lz4-compression", "quickwit"] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "7f45a6a" }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy", rev = "cbd06ab1", default-features = false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "cbd06ab1" }
 thiserror = "1.0"
 tracing = "0.1.29"
 typetag = "0.1"

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -36,7 +36,7 @@ rusoto_kinesis = { version = "0.47", default-features = false, features = ["rust
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="7f45a6a", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="cbd06ab1", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 tempfile = "3.3"
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1"
 opentelemetry = "0.17"
 tracing-opentelemetry = "0.17"
 rayon = "1"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="7f45a6a", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="cbd06ab1", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 
 [dependencies.quickwit-cluster]
 path = '../quickwit-cluster'

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -20,7 +20,7 @@ futures = '0.3'
 serde_json = "1"
 base64 = '0.13'
 tracing = "0.1.29"
-tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="7f45a6a", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
+tantivy = { git= "https://github.com/quickwit-oss/tantivy", rev="cbd06ab1", default-features=false, features = ["mmap", "lz4-compression", "quickwit"] }
 once_cell = '1'
 regex = '1'
 thiserror = '1'


### PR DESCRIPTION
The target PR in tantivy is https://github.com/quickwit-oss/tantivy/pull/1367

Closes #1411

### How was this PR tested?

A unit test was added on tantivy side and the ticket example has been tested and yielded the following result.

```json
{
  "num_hits": 3,
  "hits": [
    {
      "attributes": {
        "syslog": {
          "facility": "daemon",
          "procid": 7816,
          "version": 2
        }
      },
      "body": "<26>2 2022-05-10T17:59:56.706Z for.us benefritz 7816 ID715 - A bug was encountered but not in Vector, which doesn't have bugs",
      "name": "ID715",
      "severity": "ERROR",
      "timestamp": 1652205596
    },
    {
      "attributes": {
        "syslog": {
          "facility": "daemon",
          "procid": 7816,
          "version": 2
        }
      },
      "body": "<26>2 2022-05-10T17:59:56.706Z for.us benefritz 7816 ID715 - A bug was encountered but not in Vector, which doesn't have bugs",
      "name": "ID715",
      "severity": "ERROR",
      "timestamp": 1652205596
    },
    {
      "attributes": {
        "syslog": {
          "facility": "daemon",
          "procid": 7816,
          "version": 2
        }
      },
      "body": "<26>2 2022-05-10T17:59:56.706Z for.us benefritz 7816 ID715 - A bug was encountered but not in Vector, which doesn't have bugs",
      "name": "ID715",
      "severity": "ERROR",
      "timestamp": 1652205596
    }
  ],
  "elapsed_time_micros": 25257,
  "errors": []
}
```