### PR TITLE
Remove camelCase from Rust structs/enums generated from protobuf.

### DIFF
--- a/quickwit-proto/build.rs
+++ b/quickwit-proto/build.rs
@@ -26,10 +26,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // prost_config.type_attribute("LeafSearchResponse", "#[derive(Default)]");
     prost_config.protoc_arg("--experimental_allow_proto3_optional");
     tonic_build::configure()
-        .type_attribute(
-            ".",
-            "#[derive(Serialize, Deserialize)]\n#[serde(rename_all = \"camelCase\")]",
-        )
+        .type_attribute(".", "#[derive(Serialize, Deserialize)]")
+        .type_attribute("OutputFormat", "#[serde(rename_all = \"snake_case\")]")
         .out_dir("src/")
         .compile_with_config(
             prost_config,

--- a/quickwit-proto/src/cluster.rs
+++ b/quickwit-proto/src/cluster.rs
@@ -1,6 +1,5 @@
 //// The member information.
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Member {
     //// Member ID.　A string of the UUID.
@@ -18,34 +17,28 @@ pub struct Member {
     pub generation: u64,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListMembersRequest {
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListMembersResponse {
     #[prost(message, repeated, tag="1")]
     pub members: ::prost::alloc::vec::Vec<Member>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeaveClusterRequest {
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeaveClusterResponse {
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClusterStateRequest {
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClusterStateResponse {
     #[prost(string, tag="1")]

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -1,7 +1,6 @@
 // -- Search -------------------
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchRequest {
     /// Index ID
@@ -39,7 +38,6 @@ pub struct SearchRequest {
     pub aggregation_request: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchResponse {
     /// Number of hits matching the query.
@@ -60,7 +58,6 @@ pub struct SearchResponse {
     pub aggregation: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SplitSearchError {
     /// The searcherror that occured formatted as string.
@@ -74,7 +71,6 @@ pub struct SplitSearchError {
     pub retryable_error: bool,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafSearchRequest {
     /// Search request. This is a perfect copy of the original search request,
@@ -94,7 +90,6 @@ pub struct LeafSearchRequest {
     pub index_uri: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SplitIdAndFooterOffsets {
     /// Index split id to apply the query on.
@@ -122,7 +117,6 @@ pub struct SplitIdAndFooterOffsets {
 ////
 //// See  `quickwit_search::convert_leaf_hit`
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafHit {
     /// The actual content of the hit/
@@ -133,7 +127,6 @@ pub struct LeafHit {
     pub partial_hit: ::core::option::Option<PartialHit>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Hit {
     /// The actual content of the hit/
@@ -148,7 +141,6 @@ pub struct Hit {
 /// go and fetch the actual document data, by performing a `get_doc(...)`
 /// request.
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartialHit {
     /// Sorting field value. (e.g. timestamp)
@@ -174,7 +166,6 @@ pub struct PartialHit {
     pub doc_id: u32,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafSearchResponse {
     /// Total number of documents matched by the query.
@@ -195,7 +186,6 @@ pub struct LeafSearchResponse {
     pub intermediate_aggregation_result: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchDocsRequest {
     /// Request fetching the content of a given list of partial_hits.
@@ -215,7 +205,6 @@ pub struct FetchDocsRequest {
     pub index_uri: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchDocsResponse {
     /// List of complete hits.
@@ -223,7 +212,6 @@ pub struct FetchDocsResponse {
     pub hits: ::prost::alloc::vec::Vec<LeafHit>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SearchStreamRequest {
     /// Index ID
@@ -251,7 +239,6 @@ pub struct SearchStreamRequest {
     pub partition_by_field: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafSearchStreamRequest {
     /// Stream request. This is a perfect copy of the original stream request,
@@ -271,7 +258,6 @@ pub struct LeafSearchStreamRequest {
     pub index_uri: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafSearchStreamResponse {
     /// Row of data serialized in bytes.
@@ -282,7 +268,6 @@ pub struct LeafSearchStreamResponse {
     pub split_id: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SortOrder {
@@ -296,7 +281,7 @@ pub enum SortOrder {
 // -- Stream -------------------
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum OutputFormat {

--- a/quickwit-proto/src/quickwit_ingest_api.rs
+++ b/quickwit-proto/src/quickwit_ingest_api.rs
@@ -1,47 +1,40 @@
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueueExistsRequest {
     #[prost(string, tag="1")]
     pub queue_id: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateQueueRequest {
     #[prost(string, tag="1")]
     pub queue_id: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateQueueIfNotExistsRequest {
     #[prost(string, tag="1")]
     pub queue_id: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DropQueueRequest {
     #[prost(string, tag="1")]
     pub queue_id: ::prost::alloc::string::String,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngestRequest {
     #[prost(message, repeated, tag="1")]
     pub doc_batches: ::prost::alloc::vec::Vec<DocBatch>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngestResponse {
     #[prost(uint64, tag="1")]
     pub num_ingested_docs: u64,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchRequest {
     #[prost(string, tag="1")]
@@ -52,7 +45,6 @@ pub struct FetchRequest {
     pub num_bytes_limit: ::core::option::Option<u64>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchResponse {
     #[prost(uint64, optional, tag="1")]
@@ -61,7 +53,6 @@ pub struct FetchResponse {
     pub doc_batch: ::core::option::Option<DocBatch>,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DocBatch {
     #[prost(string, tag="1")]
@@ -85,7 +76,6 @@ pub struct DocBatch {
 //// earlier than this position can yield undefined result:
 //// the truncated records may or may not be returned.
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuggestTruncateRequest {
     #[prost(string, tag="1")]
@@ -94,7 +84,6 @@ pub struct SuggestTruncateRequest {
     pub up_to_position_included: u64,
 }
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TailRequest {
     #[prost(string, tag="1")]

--- a/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit-serve/src/search_api/rest_handler.rs
@@ -716,7 +716,7 @@ mod tests {
         let (index, req) = warp::test::request()
             .path(
                 "/my-index/search/stream?query=obama&fast_field=external_id&\
-                 output_format=clickHouseRowBinary",
+                 output_format=click_house_row_binary",
             )
             .filter(&super::search_stream_filter())
             .await
@@ -741,7 +741,7 @@ mod tests {
         let rejection = warp::test::request()
             .path(
                 "/my-index/search/stream?query=obama&fast_field=external_id&\
-                 output_format=click_house_row_binary",
+                 output_format=ClickHouseRowBinary",
             )
             .filter(&super::search_stream_filter())
             .await
@@ -749,7 +749,7 @@ mod tests {
         let parse_error = rejection.find::<serde_qs::Error>().unwrap();
         assert_eq!(
             parse_error.to_string(),
-            "unknown variant `click_house_row_binary`, expected `csv` or `clickHouseRowBinary`"
+            "unknown variant `ClickHouseRowBinary`, expected `csv` or `click_house_row_binary`"
         );
     }
 
@@ -757,7 +757,7 @@ mod tests {
     async fn test_rest_search_stream_api_error_empty_fastfield() {
         let rejection = warp::test::request()
             .path(
-                "/my-index/search/stream?query=obama&fast_field=&output_format=clickHouseRowBinary",
+                "/my-index/search/stream?query=obama&fast_field=&output_format=click_house_row_binary",
             )
             .filter(&super::search_stream_filter())
             .await

--- a/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit-serve/src/search_api/rest_handler.rs
@@ -757,7 +757,8 @@ mod tests {
     async fn test_rest_search_stream_api_error_empty_fastfield() {
         let rejection = warp::test::request()
             .path(
-                "/my-index/search/stream?query=obama&fast_field=&output_format=click_house_row_binary",
+                "/my-index/search/stream?query=obama&fast_field=&\
+                 output_format=click_house_row_binary",
             )
             .filter(&super::search_stream_filter())
             .await


### PR DESCRIPTION
`make test-all` is passing.