### PR TITLE
Allow for an empty field_mappings.

### DIFF
--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -42,6 +42,7 @@ use crate::source_config::SourceConfig;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DocMapping {
+    #[serde(default)]
     pub field_mappings: Vec<FieldMappingEntry>,
     #[serde(default)]
     pub tag_fields: BTreeSet<String>,
@@ -600,8 +601,20 @@ mod tests {
         let config_yaml = r#"
             version: 0
             index_id: hdfs-logs
-            index_uri: ''
+            index_uri: '',
+            doc_mapping: {}
         "#;
         serde_yaml::from_str::<IndexConfig>(config_yaml).unwrap_err();
+    }
+
+    #[test]
+    fn test_minimal_index_config() {
+        let config_yaml = r#"
+            version: 0
+            index_id: hdfs-logs
+            doc_mapping: {}
+        "#;
+        let minimal_config = serde_yaml::from_str::<IndexConfig>(config_yaml).unwrap();
+        assert_eq!(minimal_config.doc_mapping.mode, ModeType::Lenient);
     }
 }


### PR DESCRIPTION
Allowing an empty field mappings. (makes sense in dynamic mode)