### PR TITLE
Bugfix: tokenizer for default `QuickwitJsonOption` should be default.

### DIFF
--- a/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -193,7 +193,7 @@ impl Default for QuickwitJsonOptions {
     fn default() -> Self {
         QuickwitJsonOptions {
             indexed: true,
-            tokenizer: QuickwitTextTokenizer::Raw,
+            tokenizer: default_json_tokenizer(),
             record: IndexRecordOption::Basic,
             stored: true,
         }
@@ -971,9 +971,15 @@ mod tests {
     }
 
     #[test]
-    fn test_quickwit_json_options_default_tokenizer_is_raw() {
+    fn test_quickwit_json_options_default_tokenizer_is_default() {
         let quickwit_json_options = QuickwitJsonOptions::default();
-        assert_eq!(quickwit_json_options.tokenizer, QuickwitTextTokenizer::Raw);
+        assert_eq!(quickwit_json_options.tokenizer, QuickwitTextTokenizer::Default);
+    }
+
+    #[test]
+    fn test_quickwit_json_options_default_consistent_with_default() {
+        let quickwit_json_options: QuickwitJsonOptions = serde_json::from_str("{}").unwrap();
+        assert_eq!(quickwit_json_options, QuickwitJsonOptions::default());
     }
 
     #[test]

--- a/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -973,7 +973,10 @@ mod tests {
     #[test]
     fn test_quickwit_json_options_default_tokenizer_is_default() {
         let quickwit_json_options = QuickwitJsonOptions::default();
-        assert_eq!(quickwit_json_options.tokenizer, QuickwitTextTokenizer::Default);
+        assert_eq!(
+            quickwit_json_options.tokenizer,
+            QuickwitTextTokenizer::Default
+        );
     }
 
     #[test]

--- a/quickwit-doc-mapper/src/doc_mapper.rs
+++ b/quickwit-doc-mapper/src/doc_mapper.rs
@@ -136,7 +136,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_minimal_doc_mapper() -> anyhow::Result<()> {
-        let deserialized_default_doc_mapper = serde_json::from_str::<Box<dyn DocMapper>>(r#"{"type": "default"}"#)?;
+        let deserialized_default_doc_mapper =
+            serde_json::from_str::<Box<dyn DocMapper>>(r#"{"type": "default"}"#)?;
         let expected_default_doc_mapper = DefaultDocMapperBuilder::default().try_build()?;
         assert_eq!(
             format!("{:?}", deserialized_default_doc_mapper),
@@ -147,10 +148,14 @@ mod tests {
 
     #[test]
     fn test_deserialize_doc_mapper_default_dynamic_tokenizer() {
-        let expected_default_doc_mapper = DefaultDocMapperBuilder::default().try_build().unwrap();
-        let tantivy_schema = expected_default_doc_mapper.schema();
+        let doc_mapper =
+            serde_json::from_str::<Box<dyn DocMapper>>(r#"{"type": "default", "mode": "dynamic"}"#)
+                .unwrap();
+        let tantivy_schema = doc_mapper.schema();
         let dynamic_field = tantivy_schema.get_field(DYNAMIC_FIELD_NAME).unwrap();
-        if let FieldType::JsonObject(json_options) = tantivy_schema.get_field_entry(dynamic_field).field_type() {
+        if let FieldType::JsonObject(json_options) =
+            tantivy_schema.get_field_entry(dynamic_field).field_type()
+        {
             let text_opt = json_options.get_text_indexing_options().unwrap();
             assert_eq!(text_opt.tokenizer(), "default");
         } else {


### PR DESCRIPTION
Following #1393, the default tokenizer given when deserializing
JsonOptions (the tokenizer property is missing), and the
Default::default implementation are inconsistent.

This is a problem because Default::default is used when deserializing
the doc mapping if the entire `QuickwitJsonOption` is missing.
