### PR TITLE
Updating chitchat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chitchat"
-version = "0.2.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0246dc851629cdb02cd36924285daea20e25a07db811f5c89a1af0aabbbbf1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2887,6 +2889,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
+ "chitchat",
  "futures",
  "http",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,10 +388,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chitchat"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41474c726dd5fe2e90b4653fb0fb932b5469986e7f8da76a304df6ea7f9e1a9c"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "rand",
  "serde",

--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -1,7 +1,7 @@
 # ============================ Quickwit Configuration ==============================
 #
 # Website: https://quickwit.io
-# Docs: https://quickwit.io/docs/reference/quickwit-config
+# Docs: https://quickwit.io/docs/configuration/node-config
 #
 # Configure AWS credentials: https://quickwit.io/docs/guides/configure-aws-env
 #
@@ -29,8 +29,8 @@ version: 0
 #
 # By default, peer_seeds is empty.
 # In order to connect to a cluster, one needs to specify a list of
-# seed to connect to. If no port is specified, Quickwit will assume
-# the seeds are using as the current node gossip port.
+# seeds to connect to. If no port is specified, Quickwit will assume
+# the seeds are using the same port as the current node gossip port.
 #
 #peer_seeds:
 #  - quickwit-searcher-0.local:10000

--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -1,7 +1,7 @@
 # ============================ Quickwit Configuration ==============================
 #
 # Website: https://quickwit.io
-# Docs: https://quickwit.io/docs/
+# Docs: https://quickwit.io/docs/reference/quickwit-config
 #
 # Configure AWS credentials: https://quickwit.io/docs/guides/configure-aws-env
 #
@@ -15,15 +15,26 @@ version: 0
 #
 #node_id: node-1
 #
-# Default REST server host is `127.0.0.1`
-# and default HTTP port is 7280.
+# Quickwit opens three sockets.
+# - for its HTTP server, hosting the UI and the REST API (TCP)
+# - for its gRPC service (TCP)
+# - for its Gossip cluster membership service (UDP)
+#
+# All three services are bound to the same host and different port.
+
+# Default server host is `127.0.0.1` and default HTTP port is 7280.
 #
 #listen_address: 127.0.0.1
 #rest_listen_port: 7280
-#peer_seeds:
-#  - quickwit-searcher-0.local
-#  - quickwit-searcher-1.local
 #
+# By default, peer_seeds is empty.
+# In order to connect to a cluster, one needs to specify a list of
+# seed to connect to. If no port is specified, Quickwit will assume
+# the seeds are using as the current node gossip port.
+#
+#peer_seeds:
+#  - quickwit-searcher-0.local:10000
+#  - quickwit-searcher-1.local:10000
 #
 # Path to directory where data is persisted. Default to `./qwdata`.
 #

--- a/quickwit-cli/tests/helpers.rs
+++ b/quickwit-cli/tests/helpers.rs
@@ -26,7 +26,7 @@ use std::{fs, io};
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
 use predicates::str;
-use quickwit_common::net::find_available_port;
+use quickwit_common::net::find_available_tcp_port;
 use quickwit_common::uri::Uri;
 use quickwit_metastore::{FileBackedMetastore, MetastoreResult};
 use quickwit_storage::{LocalFileStorage, S3CompatibleObjectStorage, Storage};
@@ -195,7 +195,7 @@ pub fn create_test_env(index_id: String, storage_type: TestStorageType) -> anyho
             .replace("index_uri: #index_uri\n", ""),
     )?;
     let quickwit_config_path = resources_dir_path.join("config.yaml");
-    let rest_listen_port = find_available_port()?;
+    let rest_listen_port = find_available_tcp_port()?;
     fs::write(
         &quickwit_config_path,
         // A poor's man templating engine reloaded...

--- a/quickwit-cluster/Cargo.toml
+++ b/quickwit-cluster/Cargo.toml
@@ -23,7 +23,7 @@ tokio-stream = { version = "0.1", features = [ "sync" ] }
 tracing = "0.1.29"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 quickwit-proto = { version = "0.2.1", path = "../quickwit-proto"}
-chitchat = {path="../../chitchat/chitchat"}
+chitchat = "0.3"
 itertools = '0.10'
 
 [dev-dependencies]

--- a/quickwit-cluster/Cargo.toml
+++ b/quickwit-cluster/Cargo.toml
@@ -23,7 +23,7 @@ tokio-stream = { version = "0.1", features = [ "sync" ] }
 tracing = "0.1.29"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 quickwit-proto = { version = "0.2.1", path = "../quickwit-proto"}
-chitchat = "0.2"
+chitchat = {path="../../chitchat/chitchat"}
 itertools = '0.10'
 
 [dev-dependencies]

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -87,11 +87,10 @@ impl TryFrom<NodeId> for Member {
             )
         })?;
 
-        let gossip_public_address: SocketAddr = node_id.gossip_public_address;
         Ok(Self {
             node_unique_id: node_unique_id_str.to_string(),
             generation: generation_str.parse()?,
-            gossip_public_address,
+            gossip_public_address: node_id.gossip_public_address,
             is_self: false,
         })
     }

--- a/quickwit-cluster/src/error.rs
+++ b/quickwit-cluster/src/error.rs
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::net::SocketAddr;
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -31,12 +33,15 @@ pub enum ClusterError {
     },
 
     /// Port binding error.
-    #[error("Failed to bind to UDP port `{port}` for the gossip membership protocol: `{message}`")]
+    #[error(
+        "Failed to bind to UDP socket addr `{listen_addr}` for the gossip membership protocol: \
+         `{cause}`"
+    )]
     UDPPortBindingError {
         /// Port number.
-        port: u16,
+        listen_addr: SocketAddr,
         /// Underlying error message.
-        message: String,
+        cause: String,
     },
 
     /// Read host ID error.

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -86,15 +86,16 @@ pub async fn start_cluster_service(
         quickwit_config.gossip_public_addr()?,
     );
 
-    let cluster = Arc::new(Cluster::new(
+    let cluster = Cluster::join(
         member,
         services,
         quickwit_config.gossip_socket_addr()?,
         quickwit_config.cluster_id.clone(),
         quickwit_config.grpc_socket_addr()?,
-        &seed_nodes,
+        seed_nodes,
         FailureDetectorConfig::default(),
-    )?);
+    )
+    .await?;
 
-    Ok(cluster)
+    Ok(Arc::new(cluster))
 }

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -25,6 +25,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::bail;
+use chitchat::transport::UdpTransport;
 use chitchat::FailureDetectorConfig;
 use quickwit_config::QuickwitConfig;
 
@@ -94,6 +95,7 @@ pub async fn start_cluster_service(
         quickwit_config.grpc_socket_addr()?,
         seed_nodes,
         FailureDetectorConfig::default(),
+        &UdpTransport,
     )
     .await?;
 

--- a/quickwit-common/src/net.rs
+++ b/quickwit-common/src/net.rs
@@ -17,11 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, ToSocketAddrs};
+use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 
-/// Finds a random available port.
-pub fn find_available_port() -> anyhow::Result<u16> {
-    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+/// Finds a random available TCP port.
+pub fn find_available_tcp_port() -> anyhow::Result<u16> {
+    let socket: SocketAddr = ([127, 0, 0, 1], 0u16).into();
     let listener = TcpListener::bind(socket)?;
     let port = listener.local_addr()?.port();
     Ok(port)

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -347,10 +347,10 @@ impl QuickwitConfig {
 
     #[doc(hidden)]
     pub fn for_test() -> anyhow::Result<Self> {
-        use quickwit_common::net::find_available_port;
+        use quickwit_common::net::find_available_tcp_port;
 
         let indexer_config = Self {
-            rest_listen_port: find_available_port()?,
+            rest_listen_port: find_available_tcp_port()?,
             ..Default::default()
         };
         Ok(indexer_config)

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -68,3 +68,4 @@ quickwit-metastore = { version = "0.2.1", path = "../quickwit-metastore", featur
 serde_json = "1"
 assert-json-diff = "2"
 tempfile = "3.3"
+chitchat = "0.3"

--- a/quickwit-search/src/rendezvous_hasher.rs
+++ b/quickwit-search/src/rendezvous_hasher.rs
@@ -39,13 +39,12 @@ pub(crate) fn sort_by_rendez_vous_hash<T: Hash>(nodes: &mut [T], split_id: &str)
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::net::SocketAddr;
 
     use super::*;
 
     fn test_socket_addr(last_byte: u8) -> SocketAddr {
-        let ip_addr = Ipv4Addr::new(127, 0, 0, last_byte);
-        SocketAddr::new(IpAddr::V4(ip_addr), 10000)
+        ([127, 0, 0, last_byte], 10_000u16).into()
     }
 
     #[test]

--- a/quickwit-search/src/search_client_pool.rs
+++ b/quickwit-search/src/search_client_pool.rs
@@ -327,32 +327,35 @@ mod tests {
 
     #[tokio::test]
     async fn test_search_client_pool_single_node() -> anyhow::Result<()> {
-        let cluster = Arc::new(create_cluster_for_test(&[], &["searcher"])?);
-        let client_pool = SearchClientPool::create_and_keep_updated(cluster.clone()).await?;
+        let cluster = create_cluster_for_test(Vec::new(), &["searcher"]).await?;
+        let cluster_arc = Arc::new(cluster);
+        let client_pool = SearchClientPool::create_and_keep_updated(cluster_arc.clone()).await?;
         let clients = client_pool.clients();
         let addrs: Vec<SocketAddr> = clients.into_keys().collect();
-        let expected_addrs = vec![grpc_addr_from_listen_addr_for_test(cluster.listen_addr)];
+        let expected_addrs = vec![grpc_addr_from_listen_addr_for_test(cluster_arc.listen_addr)];
         assert_eq!(addrs, expected_addrs);
         Ok(())
     }
 
     #[tokio::test]
     async fn test_search_client_pool_multiple_nodes() -> anyhow::Result<()> {
-        let cluster1 = Arc::new(create_cluster_for_test(&[], &["searcher"])?);
-        let node_1 = cluster1.listen_addr.to_string();
-        let cluster2 = Arc::new(create_cluster_for_test(&[node_1], &["searcher"])?);
+        let cluster1 = create_cluster_for_test(vec![], &["searcher"]).await?;
+        let cluster1_arc= Arc::new(cluster1);
+        let node_1 = cluster1_arc.listen_addr.to_string();
+        let cluster2 = create_cluster_for_test(vec![node_1], &["searcher"]).await?;
+        let cluster2_arc = Arc::new(cluster2);
 
-        cluster1
+        cluster1_arc
             .wait_for_members(|members| members.len() == 2, Duration::from_secs(5))
             .await?;
 
-        let client_pool = SearchClientPool::create_and_keep_updated(cluster1.clone()).await?;
+        let client_pool = SearchClientPool::create_and_keep_updated(cluster1_arc.clone()).await?;
         let clients = client_pool.clients();
 
         let addrs: Vec<SocketAddr> = clients.into_keys().sorted().collect();
         let mut expected_addrs = vec![
-            grpc_addr_from_listen_addr_for_test(cluster1.listen_addr),
-            grpc_addr_from_listen_addr_for_test(cluster2.listen_addr),
+            grpc_addr_from_listen_addr_for_test(cluster1_arc.listen_addr),
+            grpc_addr_from_listen_addr_for_test(cluster2_arc.listen_addr),
         ];
         expected_addrs.sort();
         assert_eq!(addrs, expected_addrs);
@@ -361,8 +364,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_search_client_pool_single_node_assign_jobs() -> anyhow::Result<()> {
-        let cluster = Arc::new(create_cluster_for_test(&[], &["searcher"])?);
-        let client_pool = SearchClientPool::create_and_keep_updated(cluster.clone()).await?;
+        let cluster = create_cluster_for_test(vec![], &["searcher"]).await?;
+        let cluster_arc = Arc::new(cluster);
+        let client_pool = SearchClientPool::create_and_keep_updated(cluster_arc.clone()).await?;
         let jobs = vec![
             SearchJob::for_test("split1", 1),
             SearchJob::for_test("split2", 2),
@@ -372,7 +376,7 @@ mod tests {
 
         let assigned_jobs = client_pool.assign_jobs(jobs, &HashSet::default())?;
         let expected_assigned_jobs = vec![(
-            create_search_service_client(grpc_addr_from_listen_addr_for_test(cluster.listen_addr))
+            create_search_service_client(grpc_addr_from_listen_addr_for_test(cluster_arc.listen_addr))
                 .await?,
             vec![
                 SearchJob::for_test("split4", 4),

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -38,7 +38,7 @@ opentelemetry = "0.17"
 tracing-opentelemetry = "0.17"
 prometheus = "0.13"
 once_cell = '1'
-chitchat = {path="../../chitchat/chitchat"}
+chitchat = "0.3"
 quickwit-actors = {version = "0.2.1", path="../quickwit-actors"}
 rust-embed="6.4.0"
 mime_guess = { version = "2.0.4" }

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -38,7 +38,7 @@ opentelemetry = "0.17"
 tracing-opentelemetry = "0.17"
 prometheus = "0.13"
 once_cell = '1'
-chitchat = "0.2"
+chitchat = {path="../../chitchat/chitchat"}
 quickwit-actors = {version = "0.2.1", path="../quickwit-actors"}
 rust-embed="6.4.0"
 mime_guess = { version = "2.0.4" }


### PR DESCRIPTION
Updating chitchat.

Unit test are now for the most part using the mock transport, removing the need for port allocation.
The address resolution logic is also simplified.
Finally the gossip interval is shortened.
 
`cargo test test_cluster` now finishes in 4s. (17s before)