### PR TITLE
Add a search service to address REST requests on indexer only nodes.

### DIFF
--- a/quickwit-search/src/search_client_pool.rs
+++ b/quickwit-search/src/search_client_pool.rs
@@ -24,6 +24,7 @@ use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 
+use anyhow::bail;
 use http::Uri;
 use quickwit_cluster::{Cluster, QuickwitService};
 use quickwit_proto::tonic;
@@ -247,6 +248,10 @@ impl SearchClientPool {
                 });
                 socket_to_client.insert(grpc_addr, client);
             }
+        }
+
+        if nodes.is_empty() {
+            bail!("No search node available.");
         }
 
         // Sort job

--- a/quickwit-serve/src/grpc.rs
+++ b/quickwit-serve/src/grpc.rs
@@ -42,7 +42,7 @@ pub(crate) async fn start_grpc_server(
     let grpc_cluster_service = GrpcClusterAdapter::from(quickwit_services.cluster_service.clone());
     let mut server_router = server.add_service(ClusterServiceServer::new(grpc_cluster_service));
 
-    // We only mount the gRPC servcice if the searcher is enabled on this node.
+    // We only mount the gRPC service if the searcher is enabled on this node.
     if quickwit_services
         .services
         .contains(&QuickwitService::Searcher)

--- a/quickwit-serve/src/grpc.rs
+++ b/quickwit-serve/src/grpc.rs
@@ -19,6 +19,7 @@
 
 use std::net::SocketAddr;
 
+use quickwit_cluster::QuickwitService;
 use quickwit_proto::cluster_service_server::ClusterServiceServer;
 use quickwit_proto::search_service_server::SearchServiceServer;
 use quickwit_proto::tonic;
@@ -41,7 +42,12 @@ pub(crate) async fn start_grpc_server(
     let grpc_cluster_service = GrpcClusterAdapter::from(quickwit_services.cluster_service.clone());
     let mut server_router = server.add_service(ClusterServiceServer::new(grpc_cluster_service));
 
-    if let Some(search_service) = quickwit_services.search_service.clone() {
+    // We only mount the gRPC servcice if the searcher is enabled on this node.
+    if quickwit_services
+        .services
+        .contains(&QuickwitService::Searcher)
+    {
+        let search_service = quickwit_services.search_service.clone();
         let grpc_search_service = GrpcSearchAdapter::from(search_service);
         server_router = server_router.add_service(SearchServiceServer::new(grpc_search_service));
     }

--- a/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit-serve/src/index_api/rest_handler.rs
@@ -28,6 +28,7 @@ use tracing::info;
 use warp::{Filter, Rejection};
 
 use crate::format::Format;
+use crate::with_arg;
 
 pub fn index_management_handlers(
     index_service: Arc<IndexService>,
@@ -44,7 +45,7 @@ fn get_index_metadata_handler(
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!("indexes" / String)
         .and(warp::get())
-        .and(warp::any().map(move || index_service.clone()))
+        .and(with_arg(index_service))
         .and_then(get_index_metadata)
 }
 

--- a/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit-serve/src/search_api/rest_handler.rs
@@ -33,7 +33,7 @@ use warp::hyper::StatusCode;
 use warp::{reply, Filter, Rejection, Reply};
 
 use crate::error::ServiceError;
-use crate::{require, Format};
+use crate::{with_arg, Format};
 
 fn sort_by_field_mini_dsl<'de, D>(deserializer: D) -> Result<Option<SortByField>, D::Error>
 where D: Deserializer<'de> {
@@ -180,10 +180,10 @@ async fn search(
 ///
 /// Parses the search request from the
 pub fn search_get_handler(
-    search_service_opt: Option<Arc<dyn SearchService>>,
+    search_service: Arc<dyn SearchService>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     search_get_filter()
-        .and(require(search_service_opt))
+        .and(with_arg(search_service))
         .and_then(search)
 }
 
@@ -191,18 +191,18 @@ pub fn search_get_handler(
 ///
 /// Parses the search request from the
 pub fn search_post_handler(
-    search_service_opt: Option<Arc<dyn SearchService>>,
+    search_service: Arc<dyn SearchService>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     search_post_filter()
-        .and(require(search_service_opt))
+        .and(with_arg(search_service))
         .and_then(search)
 }
 
 pub fn search_stream_handler(
-    search_service_opt: Option<Arc<dyn SearchService>>,
+    search_service: Arc<dyn SearchService>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     search_stream_filter()
-        .and(require(search_service_opt))
+        .and(with_arg(search_service))
         .and_then(search_stream)
 }
 
@@ -540,7 +540,7 @@ mod tests {
     async fn test_rest_search_api_route_invalid_key() -> anyhow::Result<()> {
         let mock_search_service = MockSearchService::new();
         let rest_search_api_handler =
-            super::search_get_handler(Some(Arc::new(mock_search_service))).recover(recover_fn);
+            super::search_get_handler(Arc::new(mock_search_service)).recover(recover_fn);
         let resp = warp::test::request()
             .path("/quickwit-demo-index/search?query=*&end_unix_timestamp=1450720000")
             .reply(&rest_search_api_handler)
@@ -567,7 +567,7 @@ mod tests {
             })
         });
         let rest_search_api_handler =
-            super::search_get_handler(Some(Arc::new(mock_search_service))).recover(recover_fn);
+            super::search_get_handler(Arc::new(mock_search_service)).recover(recover_fn);
         let resp = warp::test::request()
             .path("/quickwit-demo-index/search?query=*")
             .reply(&rest_search_api_handler)
@@ -595,7 +595,7 @@ mod tests {
             ))
             .returning(|_| Ok(Default::default()));
         let rest_search_api_handler =
-            super::search_get_handler(Some(Arc::new(mock_search_service))).recover(recover_fn);
+            super::search_get_handler(Arc::new(mock_search_service)).recover(recover_fn);
         assert_eq!(
             warp::test::request()
                 .path("/quickwit-demo-index/search?query=*&start_offset=5&max_hits=30")
@@ -616,7 +616,7 @@ mod tests {
             })
         });
         let rest_search_api_handler =
-            super::search_get_handler(Some(Arc::new(mock_search_service))).recover(recover_fn);
+            super::search_get_handler(Arc::new(mock_search_service)).recover(recover_fn);
         assert_eq!(
             warp::test::request()
                 .path("/index-does-not-exist/search?query=myfield:test")
@@ -635,7 +635,7 @@ mod tests {
             .expect_root_search()
             .returning(|_| Err(SearchError::InternalError("ty".to_string())));
         let rest_search_api_handler =
-            super::search_get_handler(Some(Arc::new(mock_search_service))).recover(recover_fn);
+            super::search_get_handler(Arc::new(mock_search_service)).recover(recover_fn);
         assert_eq!(
             warp::test::request()
                 .path("/index-does-not-exist/search?query=myfield:test")
@@ -654,7 +654,7 @@ mod tests {
             .expect_root_search()
             .returning(|_| Err(SearchError::InvalidQuery("invalid query".to_string())));
         let rest_search_api_handler =
-            super::search_get_handler(Some(Arc::new(mock_search_service))).recover(recover_fn);
+            super::search_get_handler(Arc::new(mock_search_service)).recover(recover_fn);
         assert_eq!(
             warp::test::request()
                 .path("/my-index/search?query=myfield:test")
@@ -678,7 +678,7 @@ mod tests {
                 ])))
             });
         let rest_search_stream_api_handler =
-            super::search_stream_handler(Some(Arc::new(mock_search_service))).recover(recover_fn);
+            super::search_stream_handler(Arc::new(mock_search_service)).recover(recover_fn);
         let response = warp::test::request()
             .path("/my-index/search/stream?query=obama&fast_field=external_id&output_format=csv")
             .reply(&rest_search_stream_api_handler)


### PR DESCRIPTION
We add a search service to address REST requests in the UI of index-only
nodes as quickfix for #1482.
It will only address the root part of the requests.

That search service is not mounted as a gRPC service and hence will not address
leaf requests.

We also return an explicit error if there are no search nodes in the cluster.
(before we were panicking).

Closes #1482
