### PR TITLE
Ensure cluster is not miss-configured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,6 +2952,7 @@ dependencies = [
  "quickwit-search",
  "quickwit-storage",
  "quickwit-telemetry",
+ "rand",
  "regex",
  "rust-embed",
  "serde",

--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -28,6 +28,9 @@ use serde::{Serialize, Serializer};
 /// Default file protocol `file://`
 pub const FILE_PROTOCOL: &str = "file";
 
+/// S3 protocol `s3://`
+pub const S3_PROTOCOL: &str = "s3";
+
 const POSTGRES_PROTOCOL: &str = "postgres";
 
 const POSTGRESQL_PROTOCOL: &str = "postgresql";

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -53,6 +53,7 @@ quickwit-core = { version = "0.2.1", path = "../quickwit-core" }
 quickwit-indexing= { version = "0.2.1", path = "../quickwit-indexing" }
 quickwit-doc-mapper = { version = "0.2.1", path = "../quickwit-doc-mapper" }
 quickwit-metastore = { version = "0.2.1", path = "../quickwit-metastore", features = ["testsuite"] }
+rand = "0.8"
 
 [dependencies.quickwit-cluster]
 path = '../quickwit-cluster'


### PR DESCRIPTION
Implements ensuring Quickwit cluster is only run when certain conditions are met.

Closes https://github.com/quickwit-oss/quickwit/issues/1233