### PR TITLE
Docker image build 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,6 @@
 **/target
 docs
 examples
-Makefile
 !.git/
+!quickwit-ui/build/.gitignore
+!quickwit-ui/.gitignore_for_build_directory

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,0 +1,47 @@
+name: 'Build Quickwit docker image'
+description: 'Build & push docker image'
+inputs:
+  version:
+    description: 'Version'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - run: echo "IMAGE_ID=quickwit/quickwit-${{ inputs.version }}" >> $GITHUB_ENV
+      shell: bash
+    - run: echo "IMAGE_DATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+      shell: bash
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'yarn'
+        cache-dependency-path: quickwit-ui/yarn.lock
+    - run: make build-ui
+      shell: bash
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.IMAGE_ID }}
+        labels: |
+          org.opencontainers.image.title=Quickwit
+          maintainer=Quickwit, Inc. <hello@quickwit.io>
+          org.opencontainers.image.vendor=Quickwit, Inc.
+          org.opencontainers.image.licenses=AGPL-3.0
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: ./
+        platforms: linux/amd64
+        push: true
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ env.IMAGE_ID }}:latest, ${{ env.IMAGE_ID }}:${{ env.IMAGE_DATE }}

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,8 +1,14 @@
 name: 'Build Quickwit docker image'
 description: 'Build & push docker image'
 inputs:
+  username:
+    description: 'Dockerhub username'
+    required: true
+  token:
+    description: 'Dockerhub access token'
+    required: true
   version:
-    description: 'Version'
+    description: 'Image version suffix'
     required: false
 runs:
   using: "composite"
@@ -24,8 +30,8 @@ runs:
     - name: Login to DockerHub
       uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.token }}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@v4

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -7,7 +7,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: echo "IMAGE_ID=quickwit/quickwit-${{ inputs.version }}" >> $GITHUB_ENV
+    - name: Image name when version is not empty
+      if: "${{ inputs.version != '' }}"
+      run: echo "IMAGE_ID=quickwit/quickwit-${{ inputs.version }}" >> $GITHUB_ENV
+      shell: bash
+    - name: Image name when version is empty
+      if: "${{ inputs.version == '' }}"
+      run: echo "IMAGE_ID=quickwit/quickwit" >> $GITHUB_ENV
       shell: bash
     - run: echo "IMAGE_DATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -17,13 +17,6 @@ runs:
       shell: bash
     - run: echo "IMAGE_DATE=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
-        cache: 'yarn'
-        cache-dependency-path: quickwit-ui/yarn.lock
-    - run: make build-ui
-      shell: bash
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/publish_nightly_packages.yml
+++ b/.github/workflows/publish_nightly_packages.yml
@@ -19,6 +19,17 @@ jobs:
           target: ${{ matrix.target }}
           version: nightly
 
+  build-and-push-docker-image:
+    name: Build & push docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Build and push nightly docker image
+        uses: ./.github/actions/build-docker
+        with:
+          version: nightly
+          
   # build-x86_64-unknown-linux-musl-package:
   #   name: Build x86_64-unknown-linux-musl
   #   runs-on: ubuntu-latest
@@ -122,13 +133,3 @@ jobs:
   #         push: true
   #         labels: ${{ steps.meta.outputs.labels }}
   #         tags: quickwit/quickwit-nightly:latest, quickwit/quickwit-nightly:${{ env.NIGHTLY_DATE }}
-
-  build-and-push-docker-image:
-    name: Build & push docker images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
-      - uses: ./.github/actions/build-docker
-        with:
-          version: nightly

--- a/.github/workflows/publish_nightly_packages.yml
+++ b/.github/workflows/publish_nightly_packages.yml
@@ -122,3 +122,13 @@ jobs:
   #         push: true
   #         labels: ${{ steps.meta.outputs.labels }}
   #         tags: quickwit/quickwit-nightly:latest, quickwit/quickwit-nightly:${{ env.NIGHTLY_DATE }}
+
+  build-and-push-docker-image:
+    name: Build & push docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/build-docker
+        with:
+          version: nightly

--- a/.github/workflows/publish_nightly_packages.yml
+++ b/.github/workflows/publish_nightly_packages.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Build and push nightly docker image
         uses: ./.github/actions/build-docker
         with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           version: nightly
           
   # build-x86_64-unknown-linux-musl-package:

--- a/.github/workflows/publish_release_packages.yml
+++ b/.github/workflows/publish_release_packages.yml
@@ -262,3 +262,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Build and push main docker image
         uses: ./.github/actions/build-docker
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}

--- a/.github/workflows/publish_release_packages.yml
+++ b/.github/workflows/publish_release_packages.yml
@@ -260,6 +260,5 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      - uses: ./.github/actions/build-docker
-        with:
-          version: nightly
+      - name: Build and push main docker image
+        uses: ./.github/actions/build-docker

--- a/.github/workflows/publish_release_packages.yml
+++ b/.github/workflows/publish_release_packages.yml
@@ -253,3 +253,13 @@ jobs:
   #         push: true
   #         labels: ${{ steps.meta.outputs.labels }}
   #         tags: quickwit/quickwit:latest, quickwit/quickwit:${{ env.ASSET_VERSION }}
+
+  build-and-push-docker-image:
+    name: Build & push docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/build-docker
+        with:
+          version: nightly

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ LABEL maintainer="Quickwit, Inc. <hello@quickwit.io>"
 LABEL org.opencontainers.image.vendor="Quickwit, Inc."
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
+RUN echo "Add nodejs ppa" \
+    && curl -s https://deb.nodesource.com/setup_16.x | bash
+
 RUN apt-get -y update \
     && apt-get -y install ca-certificates \
                           clang \
@@ -17,6 +20,7 @@ RUN apt-get -y update \
                           libpq5  \
                           libssl-dev \
                           llvm \
+                          nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Required by tonic
@@ -25,6 +29,10 @@ RUN rustup component add rustfmt
 COPY . /quickwit
 
 WORKDIR /quickwit
+
+RUN echo "Building quickwit ui" \
+    && npm install --global yarn \
+    && make build-ui
 
 RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CARGO_PROFILE'" \
     && cargo build \


### PR DESCRIPTION
Adds docker image build to ci 
Part of https://github.com/quickwit-oss/quickwit/issues/1219

@fmassot  I think what we are missing is having the binaries build for `.github/workflows/publish_release_packages.yml`
Should I add it here?