### PR TITLE
Fix sed in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CAR
 # Change the default configuration file in order to make the rest,
 # grpc servers and gossip accessible from outside of docker.
 COPY ./config/quickwit.yaml ./config/quickwit.yaml
-RUN sed -i 's/#listen_address: 127.0.0.1/listen_address: 0.0.0.0/g' ./config/quickwit.yaml
+RUN sed -i 's/#[ ]*listen_address: 127.0.0.1/listen_address: 0.0.0.0/g' ./config/quickwit.yaml
 
 FROM debian:bullseye-slim AS quickwit
 


### PR DESCRIPTION
We knew this sed can break :)

We added one space in the config file so currently quickwit starts on 127.0.0.1 in the container.

I built the docker image and tested it.