### PR TITLE
set max value for start_offset

### DIFF
--- a/quickwit-search/src/error.rs
+++ b/quickwit-search/src/error.rs
@@ -38,6 +38,8 @@ pub enum SearchError {
     StorageResolverError(#[from] StorageResolverError),
     #[error("Invalid aggregation request: {0}")]
     InvalidAggregationRequest(String),
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
     #[error("Invalid query: {0}")]
     InvalidQuery(String),
 }

--- a/quickwit-serve/src/error.rs
+++ b/quickwit-serve/src/error.rs
@@ -67,6 +67,7 @@ impl ServiceError for SearchError {
             SearchError::InternalError(_) => ServiceErrorCode::Internal,
             SearchError::StorageResolverError(_) => ServiceErrorCode::BadRequest,
             SearchError::InvalidQuery(_) => ServiceErrorCode::BadRequest,
+            SearchError::InvalidArgument(_) => ServiceErrorCode::BadRequest,
             SearchError::InvalidAggregationRequest(_) => ServiceErrorCode::BadRequest,
         }
     }


### PR DESCRIPTION
```
➜  quickwit-indices curl -sS 'http://localhost:7280/api/v1/hdfs/search?query=*&max_hits=0&start_offset=40000000'
{
  "InvalidArgument": "max value for start_offset is 10_000, but got 40000000"
}⏎
```
