### PR TITLE
Fix Kafka source timeout

### DIFF
--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -184,7 +184,7 @@ impl Source for KafkaSource {
         let mut docs = Vec::new();
         let mut checkpoint_delta = CheckpointDelta::default();
 
-        let deadline = tokio::time::sleep(quickwit_actors::HEARTBEAT);
+        let deadline = tokio::time::sleep(quickwit_actors::HEARTBEAT / 2);
         let mut message_stream = Box::pin(self.consumer.stream().take_until(deadline));
 
         let mut batch_num_bytes = 0;


### PR DESCRIPTION
### Description
Fix Kafka source timeout. Currently, the actor times out when the topic is empty.

### How was this PR tested?
Tested manually on empty topic :/
