### PR TITLE
Fix Kinesis source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,8 @@ dependencies = [
  "futures",
  "rand",
  "rusoto_core",
+ "rusoto_kinesis",
+ "rusoto_s3",
  "tokio",
  "tracing",
 ]

--- a/quickwit-aws/Cargo.toml
+++ b/quickwit-aws/Cargo.toml
@@ -14,5 +14,10 @@ documentation = "https://quickwit.io/docs/"
 futures = "0.3"
 rand = "0.8"
 rusoto_core = {version = "0.47", default-features = false, features = ["rustls"]}
+rusoto_kinesis = { version = "0.47", default-features = false, features = ["rustls"], optional = true }
+rusoto_s3 = { version = "0.47", default-features = false, features = ["rustls"] }
 tokio = "1.18"
 tracing = "0.1"
+
+[features]
+kinesis = ["rusoto_kinesis"]

--- a/quickwit-aws/src/error.rs
+++ b/quickwit-aws/src/error.rs
@@ -21,48 +21,175 @@ use std::error::Error as StdError;
 use std::{fmt, io};
 
 use rusoto_core::RusotoError;
+#[cfg(feature = "kinesis")]
+use rusoto_kinesis::{
+    CreateStreamError, DeleteStreamError, DescribeStreamError, GetRecordsError,
+    GetShardIteratorError, ListShardsError, ListStreamsError, MergeShardsError, SplitShardError,
+};
+use rusoto_s3::{
+    AbortMultipartUploadError, CompleteMultipartUploadError, CreateMultipartUploadError,
+    DeleteObjectError, GetObjectError, HeadObjectError, PutObjectError, UploadPartError,
+};
 
-use crate::retry::IsRetryable;
+use crate::retry::Retryable;
 
-pub struct RusotoErrorWrapper<T: StdError>(pub RusotoError<T>);
+pub struct RusotoErrorWrapper<T: Retryable + StdError>(pub RusotoError<T>);
 
-impl<T: StdError> From<RusotoError<T>> for RusotoErrorWrapper<T> {
+impl<T: Retryable + StdError> From<RusotoError<T>> for RusotoErrorWrapper<T> {
     fn from(err: RusotoError<T>) -> Self {
         RusotoErrorWrapper(err)
     }
 }
 
-impl<T: StdError + 'static> StdError for RusotoErrorWrapper<T> {
+impl<T: Retryable + StdError + 'static> StdError for RusotoErrorWrapper<T> {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         Some(&self.0)
     }
 }
 
-impl<T: StdError> fmt::Debug for RusotoErrorWrapper<T> {
+impl<T: Retryable + StdError> fmt::Debug for RusotoErrorWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
     }
 }
 
-impl<T: StdError + 'static> fmt::Display for RusotoErrorWrapper<T> {
+impl<T: Retryable + StdError + 'static> fmt::Display for RusotoErrorWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl<T: StdError> From<io::Error> for RusotoErrorWrapper<T> {
+impl<T: Retryable + StdError> From<io::Error> for RusotoErrorWrapper<T> {
     fn from(err: io::Error) -> Self {
         RusotoErrorWrapper::from(RusotoError::from(err))
     }
 }
 
-impl<T: StdError> IsRetryable for RusotoErrorWrapper<T> {
+impl<T: Retryable + StdError> Retryable for RusotoErrorWrapper<T> {
     fn is_retryable(&self) -> bool {
         match &self.0 {
             RusotoError::HttpDispatch(_) => true,
-            RusotoError::Service(_) => false,
+            RusotoError::Service(service_error) => service_error.is_retryable(),
             RusotoError::Unknown(http_resp) => http_resp.status.is_server_error(),
             _ => false,
         }
+    }
+}
+
+impl Retryable for GetObjectError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl Retryable for DeleteObjectError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl Retryable for UploadPartError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl Retryable for CompleteMultipartUploadError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl Retryable for AbortMultipartUploadError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl Retryable for CreateMultipartUploadError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl Retryable for PutObjectError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl Retryable for HeadObjectError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for GetRecordsError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            GetRecordsError::KMSThrottling(_) => true,
+            GetRecordsError::ProvisionedThroughputExceeded(_) => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for GetShardIteratorError {
+    fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            GetShardIteratorError::ProvisionedThroughputExceeded(_)
+        )
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for ListShardsError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for CreateStreamError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for DeleteStreamError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for DescribeStreamError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for ListStreamsError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for MergeShardsError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "kinesis")]
+impl Retryable for SplitShardError {
+    fn is_retryable(&self) -> bool {
+        false
     }
 }

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -33,7 +33,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::deser_valid_uri;
 use crate::source_config::SourceConfig;
-use crate::validate_identifier;
+use crate::{is_false, validate_identifier};
 
 // Note(fmassot): `DocMapping` is a struct only used for
 // serialization/deserialization of `DocMapper` parameters.
@@ -123,10 +123,6 @@ impl Default for MergePolicy {
             max_merge_factor: Self::default_max_merge_factor(),
         }
     }
-}
-
-fn is_false(val: &bool) -> bool {
-    !*val
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -39,6 +39,10 @@ pub use source_config::{
     CLI_INGEST_SOURCE_ID,
 };
 
+fn is_false(val: &bool) -> bool {
+    !*val
+}
+
 fn validate_identifier(label: &str, value: &str) -> anyhow::Result<()> {
     static IDENTIFIER_REGEX: OnceCell<Regex> = OnceCell::new();
 

--- a/quickwit-config/src/source_config.rs
+++ b/quickwit-config/src/source_config.rs
@@ -229,6 +229,7 @@ pub struct KinesisSourceParams {
     pub stream_name: String,
     #[serde(flatten)]
     pub region_or_endpoint: Option<RegionOrEndpoint>,
+    #[doc(hidden)]
     #[serde(skip_serializing_if = "is_false")]
     pub shutdown_at_stream_eof: bool,
 }

--- a/quickwit-config/src/source_config.rs
+++ b/quickwit-config/src/source_config.rs
@@ -25,7 +25,7 @@ use quickwit_common::uri::{Extension, Uri};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::validate_identifier;
+use crate::{is_false, validate_identifier};
 
 /// Reserved source ID for the `quickwit index ingest` CLI command.
 pub const CLI_INGEST_SOURCE_ID: &str = ".cli-ingest-source";
@@ -227,7 +227,9 @@ pub enum RegionOrEndpoint {
 #[serde(try_from = "KinesisSourceParamsInner")]
 pub struct KinesisSourceParams {
     pub stream_name: String,
+    #[serde(flatten)]
     pub region_or_endpoint: Option<RegionOrEndpoint>,
+    #[serde(skip_serializing_if = "is_false")]
     pub shutdown_at_stream_eof: bool,
 }
 
@@ -356,6 +358,51 @@ mod tests {
 
     #[test]
     fn test_kinesis_source_params_serialization() {
+        {
+            let params = KinesisSourceParams {
+                stream_name: "my-stream".to_string(),
+                region_or_endpoint: None,
+                shutdown_at_stream_eof: false,
+            };
+            let params_yaml = serde_yaml::to_string(&params).unwrap();
+
+            assert_eq!(
+                serde_yaml::from_str::<KinesisSourceParams>(&params_yaml).unwrap(),
+                params,
+            )
+        }
+        {
+            let params = KinesisSourceParams {
+                stream_name: "my-stream".to_string(),
+                region_or_endpoint: Some(RegionOrEndpoint::Region("us-west-1".to_string())),
+                shutdown_at_stream_eof: false,
+            };
+            let params_yaml = serde_yaml::to_string(&params).unwrap();
+
+            assert_eq!(
+                serde_yaml::from_str::<KinesisSourceParams>(&params_yaml).unwrap(),
+                params,
+            )
+        }
+        {
+            let params = KinesisSourceParams {
+                stream_name: "my-stream".to_string(),
+                region_or_endpoint: Some(RegionOrEndpoint::Endpoint(
+                    "https://localhost:4566".to_string(),
+                )),
+                shutdown_at_stream_eof: false,
+            };
+            let params_yaml = serde_yaml::to_string(&params).unwrap();
+
+            assert_eq!(
+                serde_yaml::from_str::<KinesisSourceParams>(&params_yaml).unwrap(),
+                params,
+            )
+        }
+    }
+
+    #[test]
+    fn test_kinesis_source_params_deserialization() {
         {
             {
                 let yaml = r#"

--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -299,7 +299,7 @@ fn previous_position_for_offset(offset: i64) -> Position {
     }
 }
 
-/// Checks if connecting with the given parameters works.
+/// Checks whether we can establish a connection to the Kafka broker.
 pub(super) async fn check_connectivity(params: KafkaSourceParams) -> anyhow::Result<()> {
     let source_id = "quickwit-connectivity-check";
     let consumer = create_consumer(source_id, params.client_log_level, params.client_params)?;

--- a/quickwit-indexing/src/source/kinesis/api.rs
+++ b/quickwit-indexing/src/source/kinesis/api.rs
@@ -17,9 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-// TODO: Remove when `KinesisSource` is fully implemented.
-#![allow(dead_code)]
-
 use quickwit_aws::error::RusotoErrorWrapper;
 use quickwit_aws::retry::{retry, RetryParams};
 use rusoto_kinesis::{

--- a/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -88,13 +88,14 @@ pub struct KinesisSource {
     // Initialization checkpoint.
     checkpoint: SourceCheckpoint,
     kinesis_client: KinesisClient,
+    // Retry parameters (max attempts, max delay, ...).
+    retry_params: RetryParams,
     // Sender for the communication channel between the source and the shard consumers.
     shard_consumers_tx: mpsc::Sender<ShardConsumerMessage>,
     // Receiver for the communication channel between the source and the shard consumers.
     shard_consumers_rx: mpsc::Receiver<ShardConsumerMessage>,
     state: KinesisSourceState,
     shutdown_at_stream_eof: bool,
-    retry_params: RetryParams,
 }
 
 impl fmt::Debug for KinesisSource {
@@ -334,7 +335,7 @@ impl Source for KinesisSource {
     }
 }
 
-fn get_region(region_or_endpoint: Option<RegionOrEndpoint>) -> anyhow::Result<Region> {
+pub(super) fn get_region(region_or_endpoint: Option<RegionOrEndpoint>) -> anyhow::Result<Region> {
     match region_or_endpoint {
         Some(RegionOrEndpoint::Endpoint(endpoint)) => Ok(Region::Custom {
             name: "Custom".to_string(),

--- a/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -199,7 +199,7 @@ impl Source for KinesisSource {
         let mut docs = Vec::new();
         let mut checkpoint_delta = CheckpointDelta::default();
 
-        let deadline = time::sleep(quickwit_actors::HEARTBEAT);
+        let deadline = time::sleep(quickwit_actors::HEARTBEAT / 2);
         tokio::pin!(deadline);
 
         loop {

--- a/quickwit-indexing/src/source/kinesis/shard_consumer.rs
+++ b/quickwit-indexing/src/source/kinesis/shard_consumer.rs
@@ -17,9 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-// TODO: Remove when `KinesisSource` is fully implemented.
-#![allow(dead_code)]
-
 use std::fmt;
 use std::time::Duration;
 
@@ -112,12 +109,10 @@ impl ShardConsumer {
     }
 
     pub fn spawn(self, ctx: &SourceContext) -> ShardConsumerHandle {
-        let shard_id = self.shard_id.clone();
-        let (mailbox, actor_handle) = ctx.spawn_actor(self).spawn();
+        let (_mailbox, _actor_handle) = ctx.spawn_actor(self).spawn();
         ShardConsumerHandle {
-            shard_id,
-            mailbox,
-            actor_handle,
+            _mailbox,
+            _actor_handle,
         }
     }
 
@@ -133,9 +128,8 @@ impl ShardConsumer {
 }
 
 pub(super) struct ShardConsumerHandle {
-    shard_id: String,
-    mailbox: Mailbox<ShardConsumer>,
-    actor_handle: ActorHandle<ShardConsumer>,
+    _mailbox: Mailbox<ShardConsumer>,
+    _actor_handle: ActorHandle<ShardConsumer>,
 }
 
 #[derive(Debug)]

--- a/quickwit-indexing/src/source/kinesis/shard_consumer.rs
+++ b/quickwit-indexing/src/source/kinesis/shard_consumer.rs
@@ -225,8 +225,8 @@ impl Handler<Loop> for ShardConsumer {
                 self.send_message(ctx, message).await?;
                 return Err(ActorExitStatus::Success);
             };
-            // The `GetRecords` API has a limit of 5 transactions per second. 1s / 5 + ε = 205ms.
-            let interval = Duration::from_millis(205);
+            // The `GetRecords` API has a limit of 5 transactions per second. 1s / 5 + ε = 210ms.
+            let interval = Duration::from_millis(210);
             ctx.schedule_self_msg(interval, Loop).await;
             return Ok(());
         }

--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -266,6 +266,17 @@ pub async fn check_source_connectivity(source_config: &SourceConfig) -> anyhow::
                 Ok(())
             }
         }
+        #[allow(unused_variables)]
+        SourceParams::Kinesis(params) => {
+            #[cfg(not(feature = "kinesis"))]
+            bail!("Quickwit binary was not compiled with the `kinesis` feature.");
+
+            #[cfg(feature = "kinesis")]
+            {
+                kinesis::check_connectivity(params.clone()).await?;
+                Ok(())
+            }
+        }
         _ => Ok(()),
     }
 }

--- a/quickwit-storage/src/object_storage/error.rs
+++ b/quickwit-storage/src/object_storage/error.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use quickwit_aws::error::RusotoErrorWrapper;
+use quickwit_aws::retry::Retryable;
 use rusoto_core::RusotoError;
 use rusoto_s3::{
     AbortMultipartUploadError, CompleteMultipartUploadError, CreateMultipartUploadError,
@@ -27,7 +28,7 @@ use rusoto_s3::{
 use crate::{StorageError, StorageErrorKind};
 
 impl<T> From<RusotoErrorWrapper<T>> for StorageError
-where T: Send + Sync + std::error::Error + 'static + ToStorageErrorKind
+where T: Send + Sync + std::error::Error + 'static + ToStorageErrorKind + Retryable
 {
     fn from(err: RusotoErrorWrapper<T>) -> StorageError {
         let error_kind = match &err.0 {


### PR DESCRIPTION
### Description
This PR brings various fixes and improvements to the Kinesis source:
- Fix `RegionOrEndpoint` enum serialization
- Fix Kinesis source actor timeout
- Increase (slightly) Kinesis shard consumer polling interval
- Retry on Kinesis `ProvisionedThroughputExceeded` errors
- Implement connectivity check for the Kinesis source
- Remove dead code

### How was this PR tested?
- Ran `make test-all` command
- Tested manually on empty stream, then stream loaded with malformed data, then stream loaded with GH Archive data