### PR TITLE
return correct error status to http client

### DIFF
--- a/quickwit-serve/src/error.rs
+++ b/quickwit-serve/src/error.rs
@@ -37,6 +37,8 @@ use warp::http;
 pub enum ServiceErrorCode {
     NotFound,
     Internal,
+    MethodNotAllowed,
+    UnsupportedMediaType,
     BadRequest,
     PermissionDenied,
 }
@@ -47,6 +49,8 @@ impl ServiceErrorCode {
             ServiceErrorCode::NotFound => tonic::Code::NotFound,
             ServiceErrorCode::Internal => tonic::Code::Internal,
             ServiceErrorCode::BadRequest => tonic::Code::InvalidArgument,
+            ServiceErrorCode::MethodNotAllowed => tonic::Code::InvalidArgument,
+            ServiceErrorCode::UnsupportedMediaType => tonic::Code::InvalidArgument,
             ServiceErrorCode::PermissionDenied => tonic::Code::PermissionDenied,
         }
     }
@@ -55,6 +59,8 @@ impl ServiceErrorCode {
             ServiceErrorCode::NotFound => http::StatusCode::NOT_FOUND,
             ServiceErrorCode::Internal => http::StatusCode::INTERNAL_SERVER_ERROR,
             ServiceErrorCode::BadRequest => http::StatusCode::BAD_REQUEST,
+            ServiceErrorCode::MethodNotAllowed => http::StatusCode::METHOD_NOT_ALLOWED,
+            ServiceErrorCode::UnsupportedMediaType => http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
             ServiceErrorCode::PermissionDenied => http::StatusCode::FORBIDDEN,
         }
     }

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -85,38 +85,72 @@ pub(crate) async fn start_rest_server(
 
 /// This function returns a formatted error based on the given rejection reason.
 pub async fn recover_fn(rejection: Rejection) -> Result<impl Reply, Rejection> {
+    let err = get_status_with_error(rejection);
+    Ok(Format::PrettyJson.make_reply_for_err(err))
+}
+
+fn get_status_with_error(rejection: Rejection) -> FormatError {
     if rejection.is_not_found() {
-        Ok(Format::PrettyJson.make_reply_for_err(FormatError {
+        FormatError {
             code: ServiceErrorCode::NotFound,
             error: "Route not found".to_string(),
-        }))
+        }
+    } else if let Some(error) = rejection.find::<warp::reject::UnsupportedMediaType>() {
+        FormatError {
+            code: ServiceErrorCode::UnsupportedMediaType,
+            error: error.to_string(),
+        }
+    } else if let Some(error) = rejection.find::<warp::reject::InvalidQuery>() {
+        FormatError {
+            code: ServiceErrorCode::BadRequest,
+            error: error.to_string(),
+        }
+    } else if let Some(error) = rejection.find::<warp::reject::LengthRequired>() {
+        FormatError {
+            code: ServiceErrorCode::BadRequest,
+            error: error.to_string(),
+        }
+    } else if let Some(error) = rejection.find::<warp::reject::MissingHeader>() {
+        FormatError {
+            code: ServiceErrorCode::BadRequest,
+            error: error.to_string(),
+        }
+    } else if let Some(error) = rejection.find::<warp::reject::InvalidHeader>() {
+        FormatError {
+            code: ServiceErrorCode::BadRequest,
+            error: error.to_string(),
+        }
+    } else if let Some(error) = rejection.find::<warp::reject::MethodNotAllowed>() {
+        FormatError {
+            code: ServiceErrorCode::MethodNotAllowed,
+            error: error.to_string(),
+        }
+    } else if let Some(error) = rejection.find::<warp::reject::PayloadTooLarge>() {
+        FormatError {
+            code: ServiceErrorCode::BadRequest,
+            error: error.to_string(),
+        }
     } else if let Some(error) = rejection.find::<warp::filters::body::BodyDeserializeError>() {
         // Happens when the request body could not be deserialized correctly.
-        Ok(Format::PrettyJson.make_reply_for_err(FormatError {
+        FormatError {
             code: ServiceErrorCode::BadRequest,
             error: error.to_string(),
-        }))
-    } else if let Some(error) = rejection.find::<warp::reject::PayloadTooLarge>() {
-        Ok(Format::PrettyJson.make_reply_for_err(FormatError {
-            code: ServiceErrorCode::BadRequest,
-            error: error.to_string(),
-        }))
+        }
     } else if let Some(error) = rejection.find::<serde_qs::Error>() {
-        Ok(Format::PrettyJson.make_reply_for_err(FormatError {
+        FormatError {
             code: ServiceErrorCode::BadRequest,
             error: error.to_string(),
-        }))
+        }
     } else if let Some(error) = rejection.find::<crate::ingest_api::BulkApiError>() {
-        Ok(Format::PrettyJson.make_reply_for_err(FormatError {
+        FormatError {
             code: ServiceErrorCode::BadRequest,
             error: error.to_string(),
-        }))
+        }
     } else {
         error!("REST server error: {:?}", rejection);
-        Ok(Format::PrettyJson.make_reply_for_err(FormatError {
+        FormatError {
             code: ServiceErrorCode::Internal,
             error: "Internal server error.".to_string(),
-        }))
+        }
     }
-    // TODO: handle more error types like Rejection([UnsupportedMediaType, MethodNotAllowed])
 }


### PR DESCRIPTION
fixes #1564

### How was this PR tested?
```
➜  quickwit-indices curl -X POST http://127.0.0.1:7280/api/v1/hdfs/ingest --data-binary @./wiki-articles_number_small.json
{
  "error": "Internal server error."
}⏎
➜  quickwit-indices curl -X POST http://127.0.0.1:7280/api/v1/hdfs/ingest --data-binary @./wiki-articles_number_small.json
{
  "error": "The request payload is too large"
}⏎
```
