### PR TITLE
Display nightly in `quickwit version` command

### DIFF
--- a/quickwit-cli/src/generate_markdown.rs
+++ b/quickwit-cli/src/generate_markdown.rs
@@ -24,9 +24,10 @@ use toml::Value;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let version_text = format!(
-        "{} (commit-hash: {})",
+        "{} ({} {})",
         env!("CARGO_PKG_VERSION"),
-        env!("GIT_COMMIT_HASH")
+        env!("QW_COMMIT_SHORT_HASH"),
+        env!("QW_COMMIT_DATE"),
     );
 
     let app = build_cli()

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -85,15 +85,22 @@ async fn main() -> anyhow::Result<()> {
 
     let telemetry_handle = quickwit_telemetry::start_telemetry_loop();
     let about_text = about_text();
+    let nightly = if env!("QW_COMMIT_VERSION_TAG") == "none" {
+        "-nightly"
+    } else {
+        ""
+    };
     let version_text = format!(
-        "{} (commit-hash: {})",
+        "{}{} ({} {})",
         env!("CARGO_PKG_VERSION"),
-        env!("GIT_COMMIT_HASH")
+        nightly,
+        env!("QW_COMMIT_SHORT_HASH"),
+        env!("QW_COMMIT_DATE"),
     );
 
     let app = build_cli()
-        .version(version_text.as_str())
-        .about(about_text.as_str());
+        .about(about_text.as_str())
+        .version(version_text.as_str());
     let matches = app.get_matches();
 
     let command = match CliCommand::parse_cli_args(&matches) {
@@ -107,7 +114,7 @@ async fn main() -> anyhow::Result<()> {
     setup_logging_and_tracing(command.default_log_level())?;
     info!(
         version = env!("CARGO_PKG_VERSION"),
-        commit = env!("GIT_COMMIT_HASH"),
+        commit = env!("QW_COMMIT_SHORT_HASH"),
     );
 
     let return_code: i32 = if let Err(err) = command.execute().await {


### PR DESCRIPTION
### Description
Display nightly in `quickwit version` command. Fixes #1531.

### How was this PR tested?
Without tag:
```sh
> cargo build
> ./target/debug/quickwit --version
Quickwit 0.3.0-nightly (54be83d03 2022-05-31)
```

With tag:
```sh
> git tag v0.3.0
> cargo build
> ./target/debug/quickwit --version
Quickwit 0.3.0 (54be83d03 2022-05-31)
```

Without git:
```sh
> mv .git .gitt
> cargo build
> ./target/debug/quickwit --version
Quickwit 0.3.0-nightly (unknown unknown)
```