### PR TITLE
Add 'num_docs' info when login a store split remote succes.

### DIFF
--- a/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -154,6 +154,7 @@ impl IndexingSplitStore {
 
         info!(
             split_size_in_megabytes = %split_size_in_megabytes,
+            num_docs = %split.num_docs,
             elapsed_secs = %elapsed_secs,
             throughput_mb_s = %throughput_mb_s,
             is_mature = is_mature,


### PR DESCRIPTION
New logging info:
`2022-06-01T09:05:28.622Z  INFO {actor=quickwit_indexing::actors::indexing_service::IndexingService}:{msg_id=1}::{index=hdfs-logs gen=0}:{actor=Uploader}:{msg_id=5 num_splits=1}: quickwit_indexing::split_store::indexing_split_store: store-split-remote-success split_size_in_megabytes=1 num_docs=10000 elapsed_secs=0.013303875 throughput_mb_s=75.16607 is_mature=false`