### PR TITLE
Display cluster ID in logs and UI

### DIFF
--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -104,6 +104,9 @@ impl From<Member> for NodeId {
 
 /// This is an implementation of a cluster using Chitchat.
 pub struct Cluster {
+    /// ID of the cluster joined.
+    pub cluster_id: String,
+    /// Node ID.
     pub node_id: String,
     /// A socket address that represents itself.
     pub listen_addr: SocketAddr,
@@ -112,7 +115,7 @@ pub struct Cluster {
     /// If it is dropped, the chitchat server will stop.
     chitchat_handle: ChitchatHandle,
 
-    /// A receiver(channel) for exchanging members in a cluster.
+    /// A receiver (channel) for exchanging information about the nodes in the cluster.
     members: watch::Receiver<Vec<Member>>,
 
     /// A stop flag of cluster monitoring task.
@@ -140,7 +143,7 @@ impl Cluster {
         info!(member=?me, listen_addr=?listen_addr, "Create new cluster.");
         let chitchat_config = ChitchatConfig {
             node_id: NodeId::from(me.clone()),
-            cluster_id,
+            cluster_id: cluster_id.clone(),
             gossip_interval: GOSSIP_INTERVAL,
             listen_addr,
             seed_nodes,
@@ -168,6 +171,7 @@ impl Cluster {
 
         // Create cluster.
         let cluster = Cluster {
+            cluster_id,
             node_id: me.internal_id(),
             listen_addr,
             chitchat_handle,

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -140,7 +140,13 @@ impl Cluster {
         failure_detector_config: FailureDetectorConfig,
         transport: &dyn Transport,
     ) -> ClusterResult<Self> {
-        info!(member=?me, listen_addr=?listen_addr, "Create new cluster.");
+        info!(
+            cluster_id=%cluster_id,
+            node_id=%me.node_unique_id,
+            listen_address=%listen_addr,
+            gossip_address=%me.gossip_public_address,
+            "Joining cluster."
+        );
         let chitchat_config = ChitchatConfig {
             node_id: NodeId::from(me.clone()),
             cluster_id: cluster_id.clone(),

--- a/quickwit-cluster/src/service.rs
+++ b/quickwit-cluster/src/service.rs
@@ -61,8 +61,12 @@ impl ClusterService for Cluster {
         &self,
         _request: ListMembersRequest,
     ) -> Result<ListMembersResponse, ClusterError> {
+        let cluster_id = self.cluster_id.clone();
         let members = self.members().into_iter().map(PMember::from).collect();
-        Ok(ListMembersResponse { members })
+        Ok(ListMembersResponse {
+            cluster_id,
+            members,
+        })
     }
 
     /// This is the API to leave the member from the cluster.

--- a/quickwit-proto/proto/cluster.proto
+++ b/quickwit-proto/proto/cluster.proto
@@ -53,6 +53,9 @@ message ListMembersRequest {
 }
 
 message ListMembersResponse {
+  /// Cluster ID
+  string cluster_id = 2;
+  /// All nodes belonging to the cluster.
   repeated Member members = 1;
 }
 

--- a/quickwit-proto/src/cluster.rs
+++ b/quickwit-proto/src/cluster.rs
@@ -23,6 +23,10 @@ pub struct ListMembersRequest {
 #[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListMembersResponse {
+    //// Cluster ID
+    #[prost(string, tag="2")]
+    pub cluster_id: ::prost::alloc::string::String,
+    //// All nodes belonging to the cluster.
     #[prost(message, repeated, tag="1")]
     pub members: ::prost::alloc::vec::Vec<Member>,
 }

--- a/quickwit-ui/cypress/integration/homepage.spec.js
+++ b/quickwit-ui/cypress/integration/homepage.spec.js
@@ -26,10 +26,10 @@ describe('Home navigation', () => {
         .should('contain.text', 'Indexes')
         .should('contain.text', 'Cluster');
   });
-  it('Should navigate to cluster members', () => {
+  it('Should navigate to cluster state', () => {
     cy.visit('http://127.0.0.1:7280/ui');
     cy.get('a').contains('Cluster').click();
-    cy.get('p').should('contain.text', 'Cluster members');
+    cy.get('p').should('contain.text', 'Cluster state');
     cy.get('span').should('contain.text', 'listen_address');
   });
 })

--- a/quickwit-ui/src/utils/models.ts
+++ b/quickwit-ui/src/utils/models.ts
@@ -205,5 +205,6 @@ export type Member = {
 }
 
 export type MemberList = {
+  cluster_id: string;
   members: Member[];
 }

--- a/quickwit-ui/src/views/ClusterMembersView.tsx
+++ b/quickwit-ui/src/views/ClusterMembersView.tsx
@@ -25,12 +25,12 @@ import { ViewUnderAppBarBox, FullBoxContainer, QBreadcrumbs } from '../component
 import Loader from '../components/Loader';
 import ErrorResponseDisplay from '../components/ResponseErrorDisplay';
 import { Client } from '../services/client';
-import { Member, ResponseError } from '../utils/models';
+import { MemberList, ResponseError } from '../utils/models';
 
 
 function ClusterView() {
   const [loading, setLoading] = useState(false);
-  const [members, setMembers] = useState<null | Member[]>(null);
+  const [members, setMembers] = useState<null | MemberList>(null);
   const [responseError, setResponseError] = useState<ResponseError | null>(null);
   const quickwitClient = useMemo(() => new Client(), []);
 
@@ -40,7 +40,7 @@ function ClusterView() {
       (clusterMembers) => {
         setResponseError(null);
         setLoading(false);
-        setMembers(clusterMembers.members);
+        setMembers(clusterMembers);
       },
       (error) => {
         setLoading(false);
@@ -63,7 +63,7 @@ function ClusterView() {
     <ViewUnderAppBarBox>
       <FullBoxContainer>
         <QBreadcrumbs aria-label="breadcrumb">
-          <Typography color="text.primary">Cluster members</Typography>
+          <Typography color="text.primary">Cluster state</Typography>
         </QBreadcrumbs>
         <FullBoxContainer sx={{ px: 0 }}>
           { renderResult() }


### PR DESCRIPTION
### Description
Display cluster ID in logs and UI. Fixes #1315.

### How was this PR tested?

#### Logs
Before:
```
2022-06-01T21:35:04.479Z  INFO quickwit_cluster::cluster: Create new cluster. member=Member { node_unique_id: "node-green-PJji", generation: 1654119304, gossip_public_address: 127.0.0.1:7280, is_self: true } listen_addr=127.0.0.1:7280
2022-06-01T21:35:04.480Z
```

After:
```
2022-06-01T22:03:25.197Z  INFO quickwit_cluster::cluster: Joining cluster. cluster_id=quickwit-default-cluster node_id=node-nameless-HM3k listen_address=127.0.0.1:7280 gossip_address=127.0.0.1:7280
```

#### UI
![Screenshot_20220601_173646](https://user-images.githubusercontent.com/3011588/171509901-54d4b942-d820-4a0d-9edb-8b7fc83415a6.png)
