### PR TITLE
Display target in `quickwit --version` command output

### DIFF
--- a/quickwit-cli/build.rs
+++ b/quickwit-cli/build.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::env;
 use std::process::Command;
 
 const NONE: &str = "none";
@@ -25,6 +26,10 @@ const UNKNOWN: &str = "unknown";
 
 fn main() {
     commit_info();
+    println!(
+        "cargo:rustc-env=CARGO_BUILD_TARGET={}",
+        env::var("TARGET").unwrap()
+    );
 }
 
 fn commit_info() {

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -91,9 +91,10 @@ async fn main() -> anyhow::Result<()> {
         ""
     };
     let version_text = format!(
-        "{}{} ({} {})",
+        "{}{} ({} {} {})",
         env!("CARGO_PKG_VERSION"),
         nightly,
+        env!("CARGO_BUILD_TARGET"),
         env!("QW_COMMIT_SHORT_HASH"),
         env!("QW_COMMIT_DATE"),
     );


### PR DESCRIPTION
### Description
Display target in `quickwit --version` command output. Fixes #1588.

### How was this PR tested?
```bash
$ cargo run -- --version
Quickwit 0.3.0-nightly (x86_64-unknown-linux-gnu 8c554bd9d 2022-06-01)
```
