### PR TITLE
use tabled for split describe

### DIFF
--- a/quickwit-cli/src/split.rs
+++ b/quickwit-cli/src/split.rs
@@ -19,7 +19,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{anyhow, bail};
+use anyhow::{bail, Context};
 use clap::{arg, Arg, ArgMatches, Command};
 use humansize::{file_size_opts, FileSize};
 use itertools::Itertools;
@@ -392,8 +392,8 @@ async fn describe_split_cli(args: DescribeSplitArgs) -> anyhow::Result<()> {
         .iter()
         .find(|split| split.split_id() == args.split_id)
         .cloned()
-        .ok_or_else(|| {
-            anyhow!(
+        .with_context(|| {
+            format!(
                 "Could not find split metadata in metastore {}",
                 args.split_id
             )


### PR DESCRIPTION
```
 quickwit-indices quickwit split describe --index air_quality --config=quickwit.yaml --split 01G380H2WYF5H0PGX52HYW89TD --verbose
                                                               Split
+----------------------------+----------+-----------+--------------------------------+--------------------------------+------------+
|             ID             | Num docs | Size (MB) |           Created at           |           Updated at           | Time range |
+----------------------------+----------+-----------+--------------------------------+--------------------------------+------------+
| 01G380H2WYF5H0PGX52HYW89TD | 1000062  | 388       | 2022-05-17 3:21:12.0 +00:00:00 | 2022-05-17 3:21:12.0 +00:00:00 | [*]        |
+----------------------------+----------+-----------+--------------------------------+--------------------------------+------------+

                     Files in Split
+--------------------------------------------+----------+
|                 File Name                  |   Size   |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.fast      | 17.84 MB |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.fieldnorm | 13.00 MB |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.idx       | 25.11 MB |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.pos       | 237 B    |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.store     | 90.57 MB |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.term      | 47.24 KB |
+--------------------------------------------+----------+
| hotcache                                   | 93.44 KB |
+--------------------------------------------+----------+
| meta.json                                  | 5.56 KB  |
+--------------------------------------------+----------+

                    Files in Hotcache
+--------------------------------------------+----------+
|                 File Name                  |   Size   |
+--------------------------------------------+----------+
| .managed.json                              | 258 B    |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.fast      | 190 B    |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.fieldnorm | 201 B    |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.idx       | 465 B    |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.pos       | 237 B    |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.store     | 80.37 KB |
+--------------------------------------------+----------+
| 867c45b4aa2a44e883e73c97fa8d48e2.term      | 2.82 KB  |
+--------------------------------------------+----------+
| meta.json                                  | 5.56 KB  |
+--------------------------------------------+----------+

```