### PR TITLE
Revert "force http1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct 0.6.1",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,17 +1425,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls 0.19.1",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "log",
  "rustls 0.20.4",
- "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2968,7 +2992,6 @@ dependencies = [
  "bytes",
  "ec2_instance_metadata",
  "futures",
- "hyper-rustls",
  "lru",
  "md5",
  "mockall",
@@ -3208,7 +3231,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.0",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -3217,12 +3240,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.4",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3258,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.48.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
+checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
 dependencies = [
  "async-trait",
  "base64",
@@ -3269,7 +3292,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "lazy_static",
  "log",
  "rusoto_credential",
@@ -3283,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.48.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
+checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3301,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_kinesis"
-version = "0.48.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d7b335ca0c3423eeeade6815f709c05a44b4a078362f29232bfbd88093fb4"
+checksum = "9060c90faec6784573af8379107ff26de934206231f4431dfa878382e5584e1b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3315,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_s3"
-version = "0.48.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aae4677183411f6b0b412d66194ef5403293917d66e70ab118f07cc24c5b14d"
+checksum = "048c2fe811a823ad5a9acc976e8bf4f1d910df719dcf44b15c3e96c5b7a51027"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3328,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_signature"
-version = "0.48.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
+checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
 dependencies = [
  "base64",
  "bytes",
@@ -3447,12 +3470,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.0",
+ "rustls 0.19.1",
  "schannel",
  "security-framework",
 ]
@@ -3462,15 +3485,6 @@ name = "rustls-pemfile"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
  "base64",
 ]
@@ -4269,6 +4283,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
 ]
 
 [[package]]

--- a/quickwit-aws/Cargo.toml
+++ b/quickwit-aws/Cargo.toml
@@ -13,9 +13,9 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 futures = "0.3"
 rand = "0.8"
-rusoto_core = {version = "0.48", default-features = false, features = ["rustls"]}
-rusoto_kinesis = { version = "0.48", default-features = false, features = ["rustls"], optional = true }
-rusoto_s3 = { version = "0.48", default-features = false, features = ["rustls"] }
+rusoto_core = {version = "0.47", default-features = false, features = ["rustls"]}
+rusoto_kinesis = { version = "0.47", default-features = false, features = ["rustls"], optional = true }
+rusoto_s3 = { version = "0.47", default-features = false, features = ["rustls"] }
 tokio = "1.19"
 tracing = "0.1"
 

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -32,8 +32,8 @@ quickwit-proto = { path="../quickwit-proto", version ="0.3.0"}
 rdkafka = { version = "0.28", default-features = false, features = ["tokio", "libz", "ssl", "cmake-build"], optional = true }
 openssl = { version = "0.10.36", default-features = false, optional = true}
 libz-sys = {version = "1.1.3", optional = true}
-rusoto_core = { version = "0.48", default-features = false, features = ["rustls"], optional = true }
-rusoto_kinesis = { version = "0.48", default-features = false, features = ["rustls"], optional = true }
+rusoto_core = { version = "0.47", default-features = false, features = ["rustls"], optional = true }
+rusoto_kinesis = { version = "0.47", default-features = false, features = ["rustls"], optional = true }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -30,15 +30,14 @@ lru = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 ec2_instance_metadata = "0.3"
 tempfile = '3'
-hyper-rustls = "0.23"
 
 [dependencies.rusoto_core]
-version = '0.48'
+version = '0.47'
 default-features = false
 features = ['rustls']
 
 [dependencies.rusoto_s3]
-version = '0.48'
+version = '0.47'
 default-features = false
 features = ['rustls']
 


### PR DESCRIPTION
Reverts quickwit-oss/quickwit#1612

The new version of rusoto does not support http (only https).
Our CI tests using localstack ends up being broken. 

The regression is none by the rusoto team and a fix is on the way.
https://github.com/rusoto/rusoto/pull/1981