### PR TITLE
Clean indexing directory

### DIFF
--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -34,7 +34,7 @@ use quickwit_common::GREEN_COLOR;
 use quickwit_config::{
     IndexConfig, IndexerConfig, SourceConfig, SourceParams, CLI_INGEST_SOURCE_ID,
 };
-use quickwit_core::{clear_cache_directory, IndexService};
+use quickwit_core::{clear_cache_directory, remove_indexing_directory, IndexService};
 use quickwit_doc_mapper::tag_pruning::match_tag_field_name;
 use quickwit_indexing::actors::{IndexingPipeline, IndexingService};
 use quickwit_indexing::models::{
@@ -47,7 +47,7 @@ use quickwit_storage::{load_file, quickwit_storage_uri_resolver};
 use quickwit_telemetry::payload::TelemetryEvent;
 use tabled::{Table, Tabled};
 use thousands::Separable;
-use tracing::{debug, Level};
+use tracing::{debug, warn, Level};
 
 use crate::stats::{mean, percentile, std_deviation};
 use crate::{
@@ -984,6 +984,13 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
         }
         return Ok(());
     }
+
+    if let Err(error) =
+        remove_indexing_directory(&quickwit_config.data_dir_path, args.index_id.clone()).await
+    {
+        warn!(error= ?error, "Could not remove indexing directory.");
+    }
+
     println!("Index `{}` successfully deleted.", args.index_id);
     Ok(())
 }

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -988,7 +988,7 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
     if let Err(error) =
         remove_indexing_directory(&quickwit_config.data_dir_path, args.index_id.clone()).await
     {
-        warn!(error= ?error, "Could not remove indexing directory.");
+        warn!(error= ?error, "Failed to remove indexing directory.");
     }
 
     println!("Index `{}` successfully deleted.", args.index_id);

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -32,6 +32,7 @@ use quickwit_common::rand::append_random_suffix;
 use quickwit_common::uri::Uri;
 use quickwit_config::CLI_INGEST_SOURCE_ID;
 use quickwit_core::get_cache_directory_path;
+use quickwit_indexing::actors::INDEXING;
 use quickwit_metastore::{quickwit_metastore_uri_resolver, Metastore};
 use serde_json::{json, Number, Value};
 use serial_test::serial;
@@ -479,6 +480,12 @@ async fn test_cmd_delete() -> Result<()> {
         .index_metadata(&test_env.index_id)
         .await
         .is_err(),);
+    assert!(!test_env
+        .data_dir_path
+        .join(INDEXING)
+        .join(test_env.index_id)
+        .as_path()
+        .exists());
     Ok(())
 }
 

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -32,7 +32,7 @@ use quickwit_common::rand::append_random_suffix;
 use quickwit_common::uri::Uri;
 use quickwit_config::CLI_INGEST_SOURCE_ID;
 use quickwit_core::get_cache_directory_path;
-use quickwit_indexing::actors::INDEXING;
+use quickwit_indexing::actors::INDEXING_DIR_NAME;
 use quickwit_metastore::{quickwit_metastore_uri_resolver, Metastore};
 use serde_json::{json, Number, Value};
 use serial_test::serial;
@@ -482,7 +482,7 @@ async fn test_cmd_delete() -> Result<()> {
         .is_err(),);
     assert!(!test_env
         .data_dir_path
-        .join(INDEXING)
+        .join(INDEXING_DIR_NAME)
         .join(test_env.index_id)
         .as_path()
         .exists());

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -295,7 +295,7 @@ pub async fn clear_cache_directory(
 ///
 /// * `data_dir_path` - Path to directory where data (tmp data, splits kept for caching purpose) is
 ///   persisted.
-/// * `index_id` - The target index Id.
+/// * `index_id` - The target index ID.
 pub async fn remove_indexing_directory(
     data_dir_path: &Path,
     index_id: String,

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -290,3 +290,18 @@ pub async fn clear_cache_directory(
     empty_dir(&cache_directory_path).await?;
     Ok(())
 }
+
+/// Removes the indexing directory of a given index.
+///
+/// * `data_dir_path` - Path to directory where data (tmp data, splits kept for caching purpose) is
+///   persisted.
+/// * `index_id` - The target index Id.
+pub async fn remove_indexing_directory(
+    data_dir_path: &Path,
+    index_id: String,
+) -> anyhow::Result<()> {
+    let indexing_directory_path = data_dir_path.join(INDEXING).join(index_id);
+    info!(path = %indexing_directory_path.display(), "Clearing indexing directory.");
+    tokio::fs::remove_dir_all(indexing_directory_path.as_path()).await?;
+    Ok(())
+}

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use quickwit_common::fs::empty_dir;
 use quickwit_common::uri::Uri;
 use quickwit_config::IndexConfig;
-use quickwit_indexing::actors::INDEXING;
+use quickwit_indexing::actors::INDEXING_DIR_NAME;
 use quickwit_indexing::models::CACHE;
 use quickwit_indexing::{
     delete_splits_with_files, run_garbage_collect, FileEntry, IndexingSplitStore,
@@ -268,7 +268,7 @@ impl IndexService {
 /// Helper function to get the cache path.
 pub fn get_cache_directory_path(data_dir_path: &Path, index_id: &str, source_id: &str) -> PathBuf {
     data_dir_path
-        .join(INDEXING)
+        .join(INDEXING_DIR_NAME)
         .join(index_id)
         .join(source_id)
         .join(CACHE)
@@ -300,7 +300,7 @@ pub async fn remove_indexing_directory(
     data_dir_path: &Path,
     index_id: String,
 ) -> anyhow::Result<()> {
-    let indexing_directory_path = data_dir_path.join(INDEXING).join(index_id);
+    let indexing_directory_path = data_dir_path.join(INDEXING_DIR_NAME).join(index_id);
     info!(path = %indexing_directory_path.display(), "Clearing indexing directory.");
     tokio::fs::remove_dir_all(indexing_directory_path.as_path()).await?;
     Ok(())

--- a/quickwit-core/src/lib.rs
+++ b/quickwit-core/src/lib.rs
@@ -29,7 +29,10 @@
 
 mod index;
 
-pub use index::{clear_cache_directory, get_cache_directory_path, IndexService, IndexServiceError};
+pub use index::{
+    clear_cache_directory, get_cache_directory_path, remove_indexing_directory, IndexService,
+    IndexServiceError,
+};
 
 #[cfg(test)]
 mod tests {

--- a/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit-indexing/src/actors/indexing_service.rs
@@ -43,7 +43,7 @@ use crate::models::{
 };
 use crate::{IndexingPipeline, IndexingPipelineParams, IndexingStatistics};
 
-pub const INDEXING: &str = "indexing";
+pub const INDEXING_DIR_NAME: &str = "indexing";
 
 /// Reserved source ID used for the ingest API.
 pub const INGEST_API_SOURCE_ID: &str = ".ingest-api";
@@ -94,7 +94,7 @@ impl IndexingService {
         ingest_api_service: Option<Mailbox<IngestApiService>>,
     ) -> IndexingService {
         Self {
-            indexing_dir_path: data_dir_path.join(INDEXING),
+            indexing_dir_path: data_dir_path.join(INDEXING_DIR_NAME),
             split_store_max_num_bytes: indexer_config.split_store_max_num_bytes.get_bytes()
                 as usize,
             split_store_max_num_splits: indexer_config.split_store_max_num_splits,

--- a/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit-indexing/src/actors/mod.rs
@@ -28,7 +28,7 @@ mod publisher;
 mod uploader;
 
 pub use indexing_pipeline::{IndexingPipeline, IndexingPipelineHandler, IndexingPipelineParams};
-pub use indexing_service::{IndexingService, IndexingServiceError, INDEXING};
+pub use indexing_service::{IndexingService, IndexingServiceError, INDEXING_DIR_NAME};
 use tantivy::schema::{Field, FieldType};
 mod merge_executor;
 mod merge_planner;


### PR DESCRIPTION
Deletes the local indexing directory for an index when the index is removed.

Closes https://github.com/quickwit-oss/quickwit/issues/1569