### PR TITLE
Factorized the http client and the credential provider used in rusoto.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,10 @@ dependencies = [
 name = "quickwit-aws"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "futures",
+ "hyper-rustls",
+ "once_cell",
  "rand",
  "rusoto_core",
  "rusoto_kinesis",
@@ -2968,7 +2971,6 @@ dependencies = [
  "bytes",
  "ec2_instance_metadata",
  "futures",
- "hyper-rustls",
  "lru",
  "md5",
  "mockall",

--- a/quickwit-aws/Cargo.toml
+++ b/quickwit-aws/Cargo.toml
@@ -11,13 +11,16 @@ documentation = "https://quickwit.io/docs/"
 
 
 [dependencies]
+anyhow = "1"
 futures = "0.3"
+once_cell = "1"
 rand = "0.8"
 rusoto_core = {version = "0.48", default-features = false, features = ["rustls"]}
 rusoto_kinesis = { version = "0.48", default-features = false, features = ["rustls"], optional = true }
 rusoto_s3 = { version = "0.48", default-features = false, features = ["rustls"] }
 tokio = "1.19"
 tracing = "0.1"
+hyper-rustls = "0.23"
 
 [features]
 kinesis = ["rusoto_kinesis"]

--- a/quickwit-aws/src/lib.rs
+++ b/quickwit-aws/src/lib.rs
@@ -17,5 +17,55 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::time::Duration;
+
+use anyhow::Context;
+use hyper_rustls::HttpsConnectorBuilder;
+use once_cell::sync::OnceCell;
+use rusoto_core::credential::{AutoRefreshingProvider, ChainProvider, ProvideAwsCredentials};
+use rusoto_core::{HttpClient, HttpConfig};
+
 pub mod error;
 pub mod retry;
+
+/// An timeout for idle sockets being kept-alive.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A credential timeout.
+const CREDENTIAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Returns a singleton hyper http client.
+pub fn get_http_client() -> HttpClient {
+    let mut http_config: HttpConfig = HttpConfig::default();
+    // We experience an issue similar to https://github.com/hyperium/hyper/issues/2312.
+    // It seems like the setting below solved it.
+    http_config.pool_idle_timeout(POOL_IDLE_TIMEOUT);
+    let builder = HttpsConnectorBuilder::new();
+    let builder = builder.with_native_roots();
+    let connector = builder
+        .https_or_http()
+        // We do not enable HTTP2.
+        // It is not enabled on S3 and it does not seem to work with Google Cloud Storage at
+        // this point. https://github.com/quickwit-oss/quickwit/issues/1584
+        //
+        // (Besides, HTTP2 would be awesome but rusoto does not leverage
+        // multiplexing anyway.)
+        .enable_http1()
+        .build();
+    HttpClient::from_connector_with_config(connector, http_config)
+}
+
+/// Returns a singleton credential provider.
+pub fn get_credentials_provider() -> anyhow::Result<impl ProvideAwsCredentials + Send + Sync> {
+    static CREDENTIALS_PROVIDER_SINGLETON: OnceCell<AutoRefreshingProvider<ChainProvider>> =
+        OnceCell::new();
+    CREDENTIALS_PROVIDER_SINGLETON
+        .get_or_try_init(move || {
+            let mut chain_provider = ChainProvider::new();
+            chain_provider.set_timeout(CREDENTIAL_TIMEOUT);
+            let credentials_provider = AutoRefreshingProvider::new(chain_provider)
+                .with_context(|| "Failed to fetch credentials for the object storage.")?;
+            Ok(credentials_provider)
+        })
+        .cloned()
+}

--- a/quickwit-aws/src/lib.rs
+++ b/quickwit-aws/src/lib.rs
@@ -28,7 +28,7 @@ use rusoto_core::{HttpClient, HttpConfig};
 pub mod error;
 pub mod retry;
 
-/// An timeout for idle sockets being kept-alive.
+/// A timeout for idle sockets being kept-alive.
 const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A credential timeout.
@@ -55,7 +55,7 @@ pub fn get_http_client() -> HttpClient {
     HttpClient::from_connector_with_config(connector, http_config)
 }
 
-/// Returns a singleton credential provider.
+/// Returns a singleton credentials provider.
 pub fn get_credentials_provider() -> anyhow::Result<impl ProvideAwsCredentials + Send + Sync> {
     static CREDENTIALS_PROVIDER_SINGLETON: OnceCell<AutoRefreshingProvider<ChainProvider>> =
         OnceCell::new();
@@ -64,7 +64,7 @@ pub fn get_credentials_provider() -> anyhow::Result<impl ProvideAwsCredentials +
             let mut chain_provider = ChainProvider::new();
             chain_provider.set_timeout(CREDENTIAL_TIMEOUT);
             let credentials_provider = AutoRefreshingProvider::new(chain_provider)
-                .with_context(|| "Failed to fetch credentials for the object storage.")?;
+                .with_context(|| "Failed to instantiate AWS credentials provider.")?;
             Ok(credentials_provider)
         })
         .cloned()

--- a/quickwit-indexing/src/source/kinesis/api.rs
+++ b/quickwit-indexing/src/source/kinesis/api.rs
@@ -328,8 +328,9 @@ mod kinesis_localstack_tests {
 
     #[tokio::test]
     async fn test_create_stream() -> anyhow::Result<()> {
+        quickwit_common::setup_logging_for_tests();
         let stream_name = append_random_suffix("test-create-stream");
-        let kinesis_client = get_localstack_client();
+        let kinesis_client = get_localstack_client()?;
         create_stream(&kinesis_client, &stream_name, 1).await?;
         wait_for_active_stream(&kinesis_client, &stream_name).await??;
         let description_summary = describe_stream(&kinesis_client, &stream_name).await?;
@@ -466,7 +467,7 @@ mod kinesis_localstack_tests {
 
     #[tokio::test]
     async fn test_list_streams() -> anyhow::Result<()> {
-        let kinesis_client = get_localstack_client();
+        let kinesis_client = get_localstack_client()?;
         let mut stream_names = Vec::new();
 
         for stream_name_suffix in ["foo", "bar"] {

--- a/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -38,6 +38,7 @@ use tracing::{info, warn};
 use super::api::list_shards;
 use super::shard_consumer::{ShardConsumer, ShardConsumerHandle, ShardConsumerMessage};
 use crate::models::RawDocBatch;
+use crate::source::kinesis::helpers::get_kinesis_client;
 use crate::source::{Indexer, Source, SourceContext, TypedSourceFactory};
 
 const TARGET_BATCH_NUM_BYTES: u64 = 5_000_000;
@@ -118,7 +119,7 @@ impl KinesisSource {
         let stream_name = params.stream_name;
         let shutdown_at_stream_eof = params.shutdown_at_stream_eof;
         let region = get_region(params.region_or_endpoint)?;
-        let kinesis_client = KinesisClient::new(region);
+        let kinesis_client = get_kinesis_client(region)?;
         let (shard_consumers_tx, shard_consumers_rx) = mpsc::channel(1_000);
         let state = KinesisSourceState::default();
         let retry_params = RetryParams::default();

--- a/quickwit-indexing/src/source/kinesis/mod.rs
+++ b/quickwit-indexing/src/source/kinesis/mod.rs
@@ -24,15 +24,15 @@ mod shard_consumer;
 
 use quickwit_aws::retry::RetryParams;
 use quickwit_config::KinesisSourceParams;
-use rusoto_kinesis::KinesisClient;
 
 use crate::source::kinesis::api::{get_records, get_shard_iterator, list_shards};
+use crate::source::kinesis::helpers::get_kinesis_client;
 use crate::source::kinesis::kinesis_source::get_region;
 
 /// Checks whether we can establish a connection to the Kinesis service and read some records.
 pub(super) async fn check_connectivity(params: KinesisSourceParams) -> anyhow::Result<()> {
     let region = get_region(params.region_or_endpoint)?;
-    let kinesis_client = KinesisClient::new(region);
+    let kinesis_client = get_kinesis_client(region)?;
     let retry_params = RetryParams {
         max_attempts: 3,
         ..Default::default()

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -30,7 +30,6 @@ lru = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 ec2_instance_metadata = "0.3"
 tempfile = '3'
-hyper-rustls = "0.23"
 
 [dependencies.rusoto_core]
 version = '0.48'


### PR DESCRIPTION
This solve a bug observed in CI.
Since we upgrade rusoto, by default, its http client does not allow
http (as opposed to https) connections.

This was spotted and fixed for the S3 storage unix test, but the problem
is still there for Kinesis.

This PR makes sure that both kinesis and s3 actually use the same code
to create their http client.

It also shares the logic used to get credentials.

### How was this PR tested?
`make test-all`

