### PR TITLE
Fix Copy ApiURL to clipboard

### DIFF
--- a/quickwit-ui/src/components/ApiUrlFooter.tsx
+++ b/quickwit-ui/src/components/ApiUrlFooter.tsx
@@ -43,7 +43,13 @@ export default function ApiUrlFooter(url: string) {
     </Typography>
     <Button
       sx={{ fontSize: '0.93em', textTransform: 'inherit', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'clip' }}
-      onClick={() => {navigator.clipboard.writeText(completeUrl)}}
+      onClick={() => {
+        if(window.isSecureContext){
+          navigator.clipboard.writeText(completeUrl);
+        } else {
+          window.open(completeUrl, '_blank');
+        }
+      }}
       endIcon={<ContentCopyIcon />}
       size="small">
         {completeUrl.substring(0, urlMaxLength)}{isTooLong && "..."}


### PR DESCRIPTION
implemented a fallback when the user is not in a secure context to be able to copy the API Url to clipboard.

Closes https://github.com/quickwit-oss/quickwit/issues/1628