### PR TITLE
Introducing a sequencer actor.

### DIFF
--- a/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit-indexing/src/actors/mod.rs
@@ -25,6 +25,7 @@ mod indexing_service;
 mod ingest_api_garbage_collector;
 mod packager;
 mod publisher;
+mod sequencer;
 mod uploader;
 
 pub use indexing_pipeline::{IndexingPipeline, IndexingPipelineHandler, IndexingPipelineParams};

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -262,7 +262,6 @@ mod tests {
         let universe = Universe::new();
         let (publisher_mailbox, publisher_handle) = universe.spawn_actor(publisher).spawn();
 
-        // note the future is resolved in the inverse of the expected order.
         assert!(publisher_mailbox
             .send_message(PublisherMessage {
                 index_id: "index".to_string(),

--- a/quickwit-indexing/src/actors/sequencer.rs
+++ b/quickwit-indexing/src/actors/sequencer.rs
@@ -1,0 +1,120 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::Context;
+use async_trait::async_trait;
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox};
+use tokio::sync::oneshot;
+
+pub struct Sequencer<A: Actor> {
+    mailbox: Mailbox<A>,
+}
+
+impl<A: Actor> Sequencer<A> {
+    pub fn new(mailbox: Mailbox<A>) -> Self {
+        Sequencer { mailbox }
+    }
+}
+
+#[async_trait]
+impl<A: Actor> Actor for Sequencer<A> {
+    type ObservableState = ();
+
+    fn observable_state(&self) {}
+}
+
+#[async_trait]
+impl<A, M> Handler<oneshot::Receiver<M>> for Sequencer<A>
+where
+    A: Actor,
+    A: Handler<M>,
+    M: Send + Sync + 'static + std::fmt::Debug,
+{
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        message: oneshot::Receiver<M>,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        let msg = message.await.context("Message future failed.")?;
+        ctx.send_message(&self.mailbox, msg)
+            .await
+            .context("Failed to send message to publisher")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quickwit_actors::Universe;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct SequencerTestActor {
+        messages: Vec<usize>,
+    }
+
+    impl Actor for SequencerTestActor {
+        type ObservableState = Vec<usize>;
+
+        fn observable_state(&self) -> Self::ObservableState {
+            self.messages.clone()
+        }
+    }
+
+    #[async_trait]
+    impl Handler<usize> for SequencerTestActor {
+        type Reply = ();
+
+        async fn handle(
+            &mut self,
+            message: usize,
+            _ctx: &ActorContext<Self>,
+        ) -> Result<(), ActorExitStatus> {
+            self.messages.push(message);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sequencer() {
+        let universe = Universe::new();
+        let test_actor = SequencerTestActor::default();
+        let (test_mailbox, test_handle) = universe.spawn_actor(test_actor).spawn();
+        let sequencer = Sequencer::new(test_mailbox);
+        let (sequencer_mailbox, sequencer_handle) = universe.spawn_actor(sequencer).spawn();
+        let (fut_tx_1, fut_rx_1) = oneshot::channel();
+        let (fut_tx_2, fut_rx_2) = oneshot::channel();
+        let (fut_tx_3, fut_rx_3) = oneshot::channel();
+        sequencer_mailbox.send_message(fut_rx_1).await.unwrap();
+        sequencer_mailbox.send_message(fut_rx_2).await.unwrap();
+        fut_tx_3.send(3).unwrap();
+        fut_tx_1.send(1).unwrap();
+        sequencer_mailbox.send_message(fut_rx_3).await.unwrap();
+        fut_tx_2.send(2).unwrap();
+        std::mem::drop(sequencer_mailbox);
+        let (exit_status, last_state) = test_handle.join().await;
+        assert!(matches!(exit_status, ActorExitStatus::Success));
+        assert_eq!(&last_state, &[1, 2, 3]);
+        let (sequencer_exit_status, _) = sequencer_handle.join().await;
+        assert!(matches!(sequencer_exit_status, ActorExitStatus::Success));
+    }
+}

--- a/quickwit-indexing/src/actors/sequencer.rs
+++ b/quickwit-indexing/src/actors/sequencer.rs
@@ -22,6 +22,17 @@ use async_trait::async_trait;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox};
 use tokio::sync::oneshot;
 
+/// The sequencer serves as a proxy to another actor,
+/// delivering message in a specific order.
+///
+/// Producers of message first "reserve" a position in the
+/// queue of message by sending `oneshot::Receiver<Message>` to the `Sequencer`.
+///
+/// The Sequencer then simply resolves these messages and forwards them to the
+/// targetted actor.
+///
+/// It is used by the uploader actor, to run uploads concurrently and yet
+/// ensures that publish message are send in the right order.
 pub struct Sequencer<A: Actor> {
     mailbox: Mailbox<A>,
 }

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -119,9 +119,10 @@ impl Handler<PackagedSplitBatch> for Uploader {
         fail_point!("uploader:before");
         let (split_uploaded_tx, split_uploaded_rx) = oneshot::channel::<PublisherMessage>();
 
-        // We send the future to the publisher right away.
-        // That way the publisher will process the uploaded split in order as opposed to
-        // publishing in the order splits finish their uploading.
+        // We send the future to the sequencer right away.
+
+        // The sequencer will then resolve the future in their arrival order and ensure that the
+        // publisher publishes splits in order.
         ctx.send_message(&self.sequencer_mailbox, split_uploaded_rx)
             .await?;
 


### PR DESCRIPTION
File uploads are done concurrently.
They may end in a different order than they started.

Before this PR, maintaining the ordering was the job of the publisher.
After this PR, this sequencing logic is done by a dedicated actor
called Sequencer.

The purpose of this PR is to pave the way to make the Publisher a
singleton Service/Actor (as opposed to one actor per index).

We do not want to observe orders for all indices.
One slow upload on one index does not need to delay the publication of
split for all indices. It was therefore necessary to keep the sequencing
within the per-index indexing pipeline.

Besides, it separate the concern, and makes the unit test & logic much
cleaner.

### Description
Describe the proposed changes made in this PR.

### How was this PR tested?
Describe how you tested this PR.
