### PR TITLE
Add misc. fixes for Kubernetes support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 **/*.md
 **/*.txt
 **/.*
+**/build
 **/Dockerfile
+**/node_modules
+**/qwdata
 **/target
 docs
 examples

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -2,10 +2,10 @@ name: 'Build Quickwit docker image'
 description: 'Build & push docker image'
 inputs:
   username:
-    description: 'Dockerhub username'
+    description: 'Docker Hub username'
     required: true
   token:
-    description: 'Dockerhub access token'
+    description: 'Docker Hub access token'
     required: true
   version:
     description: 'Image version suffix'

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ WORKDIR /quickwit/quickwit-ui
 
 RUN echo "Building Quickwit UI" \
     && npm install --location=global yarn \
-    && yarn install \
-    && yarn build
+    && make install build
 
 # Build workspace
 COPY . /quickwit

--- a/Makefile
+++ b/Makefile
@@ -78,5 +78,4 @@ build-docs:
 
 .PHONY: build-ui
 build-ui:
-	@yarn --cwd quickwit-ui install
-	@yarn --cwd quickwit-ui build
+	@cd quickwit-ui && $(MAKE) install build

--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -27,7 +27,7 @@ version: 0
 # listen_address: 127.0.0.1
 # rest_listen_port: 7280
 #
-# In order to connect to a cluster, one needs to specify a list of
+# In order to join a cluster, one needs to specify a list of
 # seeds to connect to. If no port is specified, Quickwit will assume
 # the seeds are using the same port as the current node gossip port.
 # By default, the peer seed list is empty.

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -1,15 +1,17 @@
-FROM alpine:3.15 AS builder
+FROM alpine:3 AS builder
 
 COPY quickwit-*-unknown-linux-musl.tar.gz ./
 RUN tar -xzf quickwit-*-$(cat /etc/apk/arch)-unknown-linux-musl.tar.gz
 RUN mv ./quickwit-*/* ./
 RUN chmod 744 ./quickwit
 
-# Change the default configuration file in order to make the rest,
-# grpc servers and gossip accessible from outside of docker.
+# Change the default configuration file in order to make the REST,
+# gRPC and gossip services accessible outside of Docker.
 RUN sed -i 's/#listen_address: 127.0.0.1/listen_address: 0.0.0.0/g' ./config/quickwit.yaml
 
-FROM alpine:3.15
+
+FROM alpine:3
+
 LABEL org.opencontainers.image.title="Quickwit"
 LABEL maintainer="Quickwit, Inc. <hello@quickwit.io>"
 LABEL org.opencontainers.image.vendor="Quickwit, Inc."

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -63,7 +63,7 @@ pub fn build_index_command<'a>() -> Command<'a> {
                 .about("List indexes.")
                 .alias("ls")
                 .args(&[
-                    arg!(--"metastore-uri" <METASTORE_URI> "Metastore URI. Override the `metastore_uri` parameter defined in the config file. Default to file-backed, but could be Amazon S3 or PostgreSQL.")
+                    arg!(--"metastore-uri" <METASTORE_URI> "Metastore URI. Override the `metastore_uri` parameter defined in the config file. Defaults to file-backed, but could be Amazon S3 or PostgreSQL.")
                         .required(false)
                 ])
             )
@@ -982,13 +982,11 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
         }
         return Ok(());
     }
-
     if let Err(error) =
         remove_indexing_directory(&quickwit_config.data_dir_path, args.index_id.clone()).await
     {
         warn!(error= ?error, "Failed to remove indexing directory.");
     }
-
     println!("Index `{}` successfully deleted.", args.index_id);
     Ok(())
 }

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -75,25 +75,19 @@ pub async fn start_cluster_service(
     quickwit_config: &QuickwitConfig,
     services: &HashSet<QuickwitService>,
 ) -> anyhow::Result<Arc<Cluster>> {
-    let seed_nodes = quickwit_config
-        .seed_socket_addrs()?
-        .iter()
-        .map(|addr| addr.to_string())
-        .collect::<Vec<_>>();
-
     let member = Member::new(
         quickwit_config.node_id.clone(),
         unix_timestamp(),
-        quickwit_config.gossip_public_addr()?,
+        quickwit_config.gossip_public_addr().await?,
     );
 
     let cluster = Cluster::join(
         member,
         services,
-        quickwit_config.gossip_socket_addr()?,
+        quickwit_config.gossip_listen_addr().await?,
         quickwit_config.cluster_id.clone(),
-        quickwit_config.grpc_socket_addr()?,
-        seed_nodes,
+        quickwit_config.grpc_public_addr().await?,
+        quickwit_config.peer_seed_addrs().await?,
         FailureDetectorConfig::default(),
         &UdpTransport,
     )

--- a/quickwit-common/src/net.rs
+++ b/quickwit-common/src/net.rs
@@ -17,7 +17,96 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
+use std::fmt::Display;
+use std::net::{IpAddr, SocketAddr, TcpListener};
+
+use anyhow::{bail, Context};
+use tokio::net::{lookup_host, ToSocketAddrs};
+
+/// Represents a host, i.e. an IP address (`127.0.0.1`) or a hostname (`localhost`).
+#[derive(Clone, Debug)]
+pub enum Host {
+    Hostname(String),
+    IpAddr(IpAddr),
+}
+
+impl Display for Host {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Host::Hostname(hostname) => hostname.fmt(formatter),
+            Host::IpAddr(ip_addr) => ip_addr.fmt(formatter),
+        }
+    }
+}
+
+/// Represents an address `<host>:<port>` where `host` can be an IP address or a hostname.
+#[derive(Clone, Debug)]
+pub struct HostAddr {
+    host: Host,
+    port: u16,
+}
+
+impl HostAddr {
+    /// Attempts to parse a `host_addr`.
+    /// If no port is defined, it just accepts the host and uses the given default port.
+    ///
+    /// This function supports:
+    /// - IPv4
+    /// - IPv4:port
+    /// - IPv6
+    /// - \[IPv6\]:port -- IpV6 contains colon. It is customary to require bracket for this reason.
+    /// - hostname
+    /// - hostname:port
+    pub fn parse_with_default_port(host_addr: &str, default_port: u16) -> anyhow::Result<Self> {
+        if let Ok(socket_addr) = host_addr.parse::<SocketAddr>() {
+            return Ok(Self {
+                host: Host::IpAddr(socket_addr.ip()),
+                port: socket_addr.port(),
+            });
+        }
+        if let Ok(ip_addr) = host_addr.parse::<IpAddr>() {
+            return Ok(Self {
+                host: Host::IpAddr(ip_addr),
+                port: default_port,
+            });
+        }
+        let (hostname, port) = if let Some((hostname_str, port_str)) = host_addr.split_once(':') {
+            let port_u16 = port_str.parse::<u16>().with_context(|| {
+                format!("Failed to parse address `{}`: port is invalid.", host_addr)
+            })?;
+            (hostname_str, port_u16)
+        } else {
+            (host_addr, default_port)
+        };
+        if !is_valid_hostname(hostname) {
+            bail!(
+                "Failed to parse address `{}`: hostname is invalid.",
+                host_addr
+            )
+        }
+        Ok(Self {
+            host: Host::Hostname(hostname.to_string()),
+            port,
+        })
+    }
+
+    /// Resolves the host if necessary and returns a `SocketAddr`.
+    pub async fn to_socket_addr(&self) -> anyhow::Result<SocketAddr> {
+        match &self.host {
+            Host::IpAddr(ip_addr) => Ok(SocketAddr::new(*ip_addr, self.port)),
+            Host::Hostname(hostname) => get_socket_addr(&(hostname.as_str(), self.port)).await,
+        }
+    }
+}
+
+impl Display for HostAddr {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.host {
+            Host::IpAddr(IpAddr::V6(_)) => write!(formatter, "[{}]:{}", self.host, self.port),
+            _ => write!(formatter, "{}:{}", self.host, self.port),
+        }
+    }
+}
 
 /// Finds a random available TCP port.
 pub fn find_available_tcp_port() -> anyhow::Result<u16> {
@@ -28,100 +117,133 @@ pub fn find_available_tcp_port() -> anyhow::Result<u16> {
 }
 
 /// Converts an object into a resolved `SocketAddr`.
-pub fn get_socket_addr<T: ToSocketAddrs + std::fmt::Debug>(addr: &T) -> anyhow::Result<SocketAddr> {
-    addr.to_socket_addrs()?
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("Failed to resolve address `{:?}`.", addr))
-}
-
-/// Returns true if the socket addr is a valid socket address containing a port.
-///
-/// If the socket adddress looks invalid to begin with, we may return false or true.
-fn contains_port(addr: &str) -> bool {
-    // [IPv6]:port
-    if let Some((_, colon_port)) = addr[1..].rsplit_once(']') {
-        return colon_port.starts_with(':');
-    }
-    if let Some((host, _port)) = addr[1..].rsplit_once(':') {
-        // if host contains a ":" then is thi is probably a IPv6 address.
-        return !host.contains(':');
-    }
-    false
-}
-
-/// Attempts to parse a `socket_addr`.
-/// If no port is defined, it just accepts the address and uses the given default port.
-///
-/// This function supports
-/// - IPv4
-/// - IPv4:port
-/// - IPv6
-/// - \[IPv6\]:port -- IpV6 contains colon. It is customary to require bracket for this reason.
-/// - hostname
-/// - hostname:port
-/// with or without a port.
-///
-/// Note that this function returns a SocketAddr, so that if a hostname
-/// is given, DNS resolution will happen once and for all.
-pub fn parse_socket_addr_with_default_port(
-    addr: &str,
-    default_port: u16,
+pub async fn get_socket_addr<T: ToSocketAddrs + std::fmt::Debug>(
+    addr: &T,
 ) -> anyhow::Result<SocketAddr> {
-    if contains_port(addr) {
-        get_socket_addr(&addr)
-    } else {
-        get_socket_addr(&(addr, default_port))
+    lookup_host(addr)
+        .await
+        .with_context(|| format!("Failed to parse address or resolve hostname `{:?}`.", addr))?
+        .next()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "DNS resolution did not yield any record for hostname `{:?}`.",
+                addr
+            )
+        })
+}
+
+/// Returns whether a hostname is valid according to [IETF RFC 1123](https://tools.ietf.org/html/rfc1123).
+///
+/// A hostname is valid if the following conditions are met:
+///
+/// - It does not start or end with `-` or `.`.
+/// - It does not contain any characters outside of the alphanumeric range, except for `-` and `.`.
+/// - It is not empty.
+/// - It is 253 or fewer characters.
+/// - Its labels (characters separated by `.`) are not empty.
+/// - Its labels are 63 or fewer characters.
+/// - Its labels do not start or end with '-' or '.'.
+fn is_valid_hostname(hostname: &str) -> bool {
+    if hostname.is_empty() || hostname.len() > 253 {
+        return false;
     }
+    if !hostname
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '.')
+    {
+        return false;
+    }
+    if hostname.split('.').any(|label| {
+        label.is_empty() || label.len() > 63 || label.starts_with('-') || label.ends_with('-')
+    }) {
+        return false;
+    }
+    true
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn test_parse_socket_addr_helper(addr: &str, expected_opt: Option<&str>) {
-        let socket_addr_res = parse_socket_addr_with_default_port(addr, 1337);
-        if let Some(expected) = expected_opt {
+    fn test_parse_addr_helper(addr: &str, expected_addr_opt: Option<&str>) {
+        let addr_res = HostAddr::parse_with_default_port(addr, 1337);
+        if let Some(expected_addr) = expected_addr_opt {
             assert!(
-                socket_addr_res.is_ok(),
-                "Parsing `{}` was expected to succeed",
+                addr_res.is_ok(),
+                "Parsing `{}` was expected to succeed.",
                 addr
             );
-            let socket_addr = socket_addr_res.unwrap();
-            let expected_socket_addr: SocketAddr = expected.parse().unwrap();
-            assert_eq!(socket_addr, expected_socket_addr);
+            assert_eq!(addr_res.unwrap().to_string(), expected_addr);
         } else {
             assert!(
-                socket_addr_res.is_err(),
-                "Parsing `{}` was expected to fail",
-                addr
+                addr_res.is_err(),
+                "Parsing `{}` was expected to fail, got `{}`",
+                addr,
+                addr_res.unwrap()
             );
         }
     }
 
-    #[test]
-    fn test_parse_socket_addr_with_ips() {
-        test_parse_socket_addr_helper("127.0.0.1", Some("127.0.0.1:1337"));
-        test_parse_socket_addr_helper("127.0.0.1:100", Some("127.0.0.1:100"));
-        test_parse_socket_addr_helper("127.0..1:100", None);
-        test_parse_socket_addr_helper(
+    #[tokio::test]
+    async fn test_parse_addr_with_ips() {
+        // IPv4
+        test_parse_addr_helper("127.0.0.1", Some("127.0.0.1:1337"));
+        test_parse_addr_helper("127.0.0.1:100", Some("127.0.0.1:100"));
+        test_parse_addr_helper("127.0..1:100", None);
+
+        // IPv6
+        test_parse_addr_helper(
             "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-            Some("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1337"),
+            Some("[2001:db8:85a3::8a2e:370:7334]:1337"),
         );
-        test_parse_socket_addr_helper("2001:0db8:85a3:0000:0000:8a2e:0370:7334:1000", None);
-        test_parse_socket_addr_helper(
+        test_parse_addr_helper("2001:0db8:85a3:0000:0000:8a2e:0370:7334:1000", None);
+        test_parse_addr_helper(
             "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1000",
-            Some("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1000"),
+            Some("[2001:db8:85a3::8a2e:370:7334]:1000"),
         );
-        test_parse_socket_addr_helper("[2001:0db8:1000", None);
-        test_parse_socket_addr_helper("2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1000", None);
+        test_parse_addr_helper("[2001:0db8:1000", None);
+        test_parse_addr_helper("2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1000", None);
+
+        // Hostname
+        test_parse_addr_helper("google.com", Some("google.com:1337"));
+        test_parse_addr_helper("google.com:1000", Some("google.com:1000"));
     }
 
-    // This test require DNS.
     #[test]
-    fn test_parse_socket_addr_with_resolution() {
-        let socket_addr = parse_socket_addr_with_default_port("google.com:1000", 1337).unwrap();
-        assert_eq!(socket_addr.port(), 1000);
-        let socket_addr = parse_socket_addr_with_default_port("google.com", 1337).unwrap();
-        assert_eq!(socket_addr.port(), 1337);
+    fn test_is_valid_hostname() {
+        for hostname in &[
+            "VaLiD-HoStNaMe",
+            "50-name",
+            "235235",
+            "example.com",
+            "VaLid.HoStNaMe",
+            "123.456",
+        ] {
+            assert!(
+                is_valid_hostname(hostname),
+                "Hostname `{}` is valid.",
+                hostname
+            );
+        }
+
+        for hostname in &[
+            "-invalid-name",
+            "also-invalid-",
+            "asdf@fasd",
+            "@asdfl",
+            "asd f@",
+            ".invalid",
+            "invalid.name.",
+            "foo.label-is-way-to-longgggggggggggggggggggggggggggggggggggggggggggg.org",
+            "invalid.-starting.char",
+            "invalid.ending-.char",
+            "empty..label",
+        ] {
+            assert!(
+                !is_valid_hostname(hostname),
+                "Hostname `{}` is invalid.",
+                hostname
+            );
+        }
     }
 }

--- a/quickwit-common/src/net.rs
+++ b/quickwit-common/src/net.rs
@@ -122,13 +122,10 @@ pub async fn get_socket_addr<T: ToSocketAddrs + std::fmt::Debug>(
 ) -> anyhow::Result<SocketAddr> {
     lookup_host(addr)
         .await
-        .with_context(|| format!("Failed to parse address or resolve hostname `{:?}`.", addr))?
+        .with_context(|| format!("Failed to parse address or resolve hostname {addr:?}."))?
         .next()
         .ok_or_else(|| {
-            anyhow::anyhow!(
-                "DNS resolution did not yield any record for hostname `{:?}`.",
-                addr
-            )
+            anyhow::anyhow!("DNS resolution did not yield any record for hostname {addr:?}.")
         })
 }
 
@@ -221,8 +218,7 @@ mod tests {
         ] {
             assert!(
                 is_valid_hostname(hostname),
-                "Hostname `{}` is valid.",
-                hostname
+                "Hostname `{hostname}` is valid.",
             );
         }
 
@@ -241,8 +237,7 @@ mod tests {
         ] {
             assert!(
                 !is_valid_hostname(hostname),
-                "Hostname `{}` is invalid.",
-                hostname
+                "Hostname `{hostname}` is invalid."
             );
         }
     }

--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -203,6 +203,7 @@ impl PartialEq<&str> for Uri {
         &self.uri == other
     }
 }
+
 impl PartialEq<String> for Uri {
     fn eq(&self, other: &String) -> bool {
         &self.uri == other

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -335,6 +335,10 @@ impl QuickwitConfig {
         let mut peer_seed_addrs = Vec::new();
         let default_gossip_port = self.gossip_listen_port();
 
+        // We want to pass non-resolved addresses to Chitchat but still want to resolve them for
+        // validation purposes. Additionally, we need to append a default port if necessary and
+        // finally return the addresses as strings, which is tricky for IPv6. We let the logic baked
+        // in `HostAddr` handle this complexity.
         for peer_seed in &self.peer_seeds {
             let peer_seed_addr =
                 HostAddr::parse_with_default_port(peer_seed.as_str(), default_gossip_port)?;

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -311,12 +312,12 @@ pub async fn clear_cache_directory(
 /// * `data_dir_path` - Path to directory where data (tmp data, splits kept for caching purpose) is
 ///   persisted.
 /// * `index_id` - The target index ID.
-pub async fn remove_indexing_directory(
-    data_dir_path: &Path,
-    index_id: String,
-) -> anyhow::Result<()> {
+pub async fn remove_indexing_directory(data_dir_path: &Path, index_id: String) -> io::Result<()> {
     let indexing_directory_path = data_dir_path.join(INDEXING_DIR_NAME).join(index_id);
     info!(path = %indexing_directory_path.display(), "Clearing indexing directory.");
-    tokio::fs::remove_dir_all(indexing_directory_path.as_path()).await?;
-    Ok(())
+    match tokio::fs::remove_dir_all(indexing_directory_path.as_path()).await {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -190,7 +190,7 @@ pub async fn single_node_search(
 ) -> crate::Result<SearchResponse> {
     let start_instant = tokio::time::Instant::now();
     let index_metadata = metastore.index_metadata(&search_request.index_id).await?;
-    let index_storage = storage_resolver.resolve(&index_metadata.index_uri)?;
+    let index_storage = storage_resolver.resolve(index_metadata.index_uri.as_ref())?;
     let metas = list_relevant_splits(search_request, metastore).await?;
     let split_metadata: Vec<SplitIdAndFooterOffsets> =
         metas.iter().map(extract_split_and_footer_offsets).collect();

--- a/quickwit-serve/src/grpc.rs
+++ b/quickwit-serve/src/grpc.rs
@@ -30,12 +30,12 @@ use crate::cluster_api::GrpcClusterAdapter;
 use crate::search_api::GrpcSearchAdapter;
 use crate::QuickwitServices;
 
-/// Start gRPC service given a gRPC address and a search service and cluster service.
+/// Starts gRPC service given a gRPC address and a search service and cluster service.
 pub(crate) async fn start_grpc_server(
-    grpc_addr: SocketAddr,
+    grpc_listen_addr: SocketAddr,
     quickwit_services: &QuickwitServices,
 ) -> anyhow::Result<()> {
-    info!(grpc_addr=?grpc_addr, "Start gRPC service.");
+    info!(grpc_listen_addr = ?grpc_listen_addr, "Starting gRPC server.");
 
     let mut server = Server::builder();
 
@@ -52,6 +52,6 @@ pub(crate) async fn start_grpc_server(
         server_router = server_router.add_service(SearchServiceServer::new(grpc_search_service));
     }
 
-    server_router.serve(grpc_addr).await?;
+    server_router.serve(grpc_listen_addr).await?;
     Ok(())
 }

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -40,7 +40,7 @@ pub(crate) async fn start_rest_server(
     rest_listen_addr: SocketAddr,
     quickwit_services: &QuickwitServices,
 ) -> anyhow::Result<()> {
-    info!(rest_listen_addr = ?rest_listen_addr, "Starting REST server.");
+    info!(rest_listen_addr = %rest_listen_addr, "Starting REST server.");
     let request_counter = warp::log::custom(|_| {
         crate::COUNTERS.num_requests.inc();
     });

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -35,12 +35,12 @@ use crate::search_api::{search_get_handler, search_post_handler, search_stream_h
 use crate::ui_handler::ui_handler;
 use crate::{Format, QuickwitServices};
 
-/// Start REST service given a HTTP address and a search service.
+/// Starts REST service given a HTTP address and a search service.
 pub(crate) async fn start_rest_server(
-    rest_addr: SocketAddr,
+    rest_listen_addr: SocketAddr,
     quickwit_services: &QuickwitServices,
 ) -> anyhow::Result<()> {
-    info!(rest_addr=?rest_addr, "Starting REST service.");
+    info!(rest_listen_addr = ?rest_listen_addr, "Starting REST server.");
     let request_counter = warp::log::custom(|_| {
         crate::COUNTERS.num_requests.inc();
     });
@@ -78,8 +78,8 @@ pub(crate) async fn start_rest_server(
         .with(request_counter)
         .recover(recover_fn);
 
-    info!("Searcher ready to accept requests at http://{rest_addr}/");
-    warp::serve(rest_routes).run(rest_addr).await;
+    info!("Searcher ready to accept requests at http://{rest_listen_addr}/");
+    warp::serve(rest_routes).run(rest_listen_addr).await;
     Ok(())
 }
 

--- a/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit-storage/src/storage_resolver.rs
@@ -113,7 +113,7 @@ impl StorageUriResolver {
                 kind: storage_error.kind(),
                 message: storage_error
                     .source()
-                    .map(|err| format!("{}", err))
+                    .map(|err| format!("{:?}", err))
                     .unwrap_or_else(String::new),
             }
         })?;

--- a/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit-storage/src/storage_resolver.rs
@@ -113,7 +113,7 @@ impl StorageUriResolver {
                 kind: storage_error.kind(),
                 message: storage_error
                     .source()
-                    .map(|err| format!("{:?}", err))
+                    .map(|err| format!("{err:?}"))
                     .unwrap_or_else(String::new),
             }
         })?;

--- a/quickwit-ui/Makefile
+++ b/quickwit-ui/Makefile
@@ -1,5 +1,8 @@
 build: src/*
-	yarn run build
+	yarn build
+
+install:
+	yarn install
 
 start:
 	yarn start


### PR DESCRIPTION
### Description
Add misc. fixes for Kubernetes support;
- pass non-resolved peer seed addresses to Chitchat
- pass public gRPC address to Chitchat
- add overrides for cluster ID, node ID, ... to `quickwit run` command
- misc. cleanups

### How was this PR tested?
- Ran `make test-all`
- Ran on local Minikube cluster
