### PR TITLE
Release Quickwit 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
- - Support for Boolean Field
+ - Support for boolean field
 
 ### Fixed
 
@@ -15,20 +15,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.3.1] - 2022-06-22
+
+### Added
+- Add support for Google Cloud Storage
+- Sort hits by timestamp desc by default in search UI
+- Add `description` attribute to field mappings
+- Display split state in output of `quickwit split list` command
+
+### Fixed
+- Clean up local split cache after index deletion
+- Fix API URLs displayed for copy and paste in UI
+- Fix custom S3 endpoint with trailing `/`
+- Fix `quickwit index create` command with `--overwrite` option
+
 ## [0.3.0] - 2022-05-31
 
 ### Added
-- Search and cluster overview web UI
-- Ingestion API
+- Embedded UI for displaying search hits and cluster state
+- Schemaless indexing with JSON field
+- Ingest API (Elasticsearch-compatible)
 - Aggregation queries
-- Kinesis data source
-- Support for Json Field
+- Support for Amazon Kinesis
 
 ### Fixed
-- Switched from S.W.I.M to Chitchat
+- Switched cluster membership algorithm from S.W.I.M. to Chitchat
 
 ### Removed
-- u64 as Date Field
+- u64 as date field
 
 ## [0.2.1] - 2022-02-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "arc-swap"
@@ -134,9 +134,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc47084705629d09d15060d70a8dbfce479c842303d05929ce29c74c995916ae"
+checksum = "33d590cacd53140ff87cc2e192eb22fc3dc23c5b3f93b0d4f020677f98e8c629"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2efed1c501becea07ce48118786ebcf229531d0d3b28edf224a720020d9e106"
+checksum = "cf4d047478b986f14a13edad31a009e2e05cb241f9805d0d75e4cba4e129ad4d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
 dependencies = [
  "os_str_bytes",
 ]
@@ -891,9 +891,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+checksum = "140206b78fb2bc3edbcfc9b5ccbd0b30699cfe8d348b8b31b330e47df5291a5a"
 
 [[package]]
 name = "ec2_instance_metadata"
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
+checksum = "81d013529d5574a60caeda29e179e695125448e5de52e3874f7b4c1d7360e18e"
 dependencies = [
  "serde",
 ]
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.1",
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -2038,9 +2038,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.20.0+1.1.1o"
+version = "111.21.0+1.1.1p"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
+checksum = "6d0a8313729211913936f1b95ca47a5fc7f2e04cd658c115388287f8a8361008"
 dependencies = [
  "cc",
 ]
@@ -2147,37 +2147,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2340,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5355b9d4fc0cc607db0c2e93c7a035a32226bfa770e0c6fec504f0018015bad"
+checksum = "9e1516508b396cefe095485fdce673007422f5e48e82934b7b423dc26aa5e6a4"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2390,9 +2365,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2421,7 +2396,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot",
  "procfs",
  "protobuf",
  "thiserror",
@@ -2541,7 +2516,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quickwit-actors"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2556,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-aws"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -2572,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2613,7 +2588,7 @@ dependencies = [
  "tabled",
  "tempfile",
  "thousands",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tokio-util 0.7.3",
  "toml",
@@ -2624,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-cluster"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2646,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -2667,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "byte-unit",
@@ -2686,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2718,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-directories"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2732,7 +2707,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tracing",
  "uuid 1.1.2",
@@ -2740,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-doc-mapper"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2764,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-indexing"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2801,7 +2776,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2810,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-ingest-api"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2833,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-metastore"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2858,14 +2833,14 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quickwit-proto"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -2876,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-search"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2917,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-serve"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2962,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-storage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2994,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "quickwit-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "encoding_rs",
@@ -3011,21 +2986,21 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r2d2"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -3470,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
 
 [[package]]
 name = "rusty-fork"
@@ -3523,7 +3498,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
 dependencies = [
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3689,7 +3664,7 @@ checksum = "d19dbfb999a147cedbfe82f042eb9555f5b0fa4ef95ee4570b74349103d9c9f4"
 dependencies = [
  "lazy_static",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "serial_test_derive",
 ]
 
@@ -3897,9 +3872,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3979,7 +3954,7 @@ dependencies = [
  "tantivy-query-grammar",
  "tempfile",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "uuid 1.1.2",
  "winapi 0.3.9",
  "zstd",
@@ -4149,9 +4124,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa 1.0.2",
  "libc",
@@ -4226,7 +4201,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4380,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4425,9 +4400,9 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -4511,7 +4486,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.9",
+ "time 0.3.11",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4588,7 +4563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be932d774bfad49722da2c4915ac7cc77b77dd223890739a0240de2b2a15957"
 dependencies = [
  "rand",
- "time 0.3.9",
+ "time 0.3.11",
 ]
 
 [[package]]

--- a/quickwit-actors/Cargo.toml
+++ b/quickwit-actors/Cargo.toml
@@ -3,24 +3,22 @@ name = "quickwit-actors"
 version = "0.3.0"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
-license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
+license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Actor framework used in quickwit"
 repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-tokio = { version = "^1.19", features = ["full"] }
-async-trait = "0.1"
 anyhow = "1"
-thiserror = "1"
+async-trait = "0.1"
 flume = "0.10"
 futures = "0.3"
-tracing = "0.1.29"
 quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
+thiserror = "1"
+tokio = { version = "^1.19", features = ["full"] }
+tracing = "0.1.29"
 
 [dev-dependencies]
 rand = "0.8"

--- a/quickwit-actors/Cargo.toml
+++ b/quickwit-actors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-actors"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -15,7 +15,7 @@ anyhow = "1"
 async-trait = "0.1"
 flume = "0.10"
 futures = "0.3"
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
 thiserror = "1"
 tokio = { version = "^1.19", features = ["full"] }
 tracing = "0.1.29"

--- a/quickwit-aws/Cargo.toml
+++ b/quickwit-aws/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quickwit-aws"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Utilities for working with AWS."
@@ -9,18 +9,23 @@ repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
-
 [dependencies]
 anyhow = "1"
 futures = "0.3"
+hyper-rustls = "0.23"
 once_cell = "1"
 rand = "0.8"
-rusoto_core = {version = "0.48", default-features = false, features = ["rustls"]}
-rusoto_kinesis = { version = "0.48", default-features = false, features = ["rustls"], optional = true }
-rusoto_s3 = { version = "0.48", default-features = false, features = ["rustls"] }
+rusoto_core = { version = "0.48", default-features = false, features = [
+  "rustls"
+] }
+rusoto_kinesis = { version = "0.48", default-features = false, features = [
+  "rustls"
+], optional = true }
+rusoto_s3 = { version = "0.48", default-features = false, features = [
+  "rustls"
+] }
 tokio = "1.19"
 tracing = "0.1"
-hyper-rustls = "0.23"
 
 [features]
 kinesis = ["rusoto_kinesis"]

--- a/quickwit-aws/Cargo.toml
+++ b/quickwit-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-aws"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-cli"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -34,21 +34,21 @@ once_cell = "1"
 openssl-probe = { version = "0.1.4", optional = true }
 opentelemetry = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
-quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-cluster = { version = "0.3.0", path = "../quickwit-cluster" }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-core = { version = "0.3.0", path = "../quickwit-core" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
-quickwit-ingest-api = { version = "0.3.0", path = "../quickwit-ingest-api" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
-quickwit-search = { version = "0.3.0", path = "../quickwit-search" }
-quickwit-serve = { version = "0.3.0", path = "../quickwit-serve" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
-quickwit-telemetry = { version = "0.3.0", path = "../quickwit-telemetry" }
+quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
+quickwit-cluster = { version = "0.3.1", path = "../quickwit-cluster" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-core = { version = "0.3.1", path = "../quickwit-core" }
+quickwit-directories = { version = "0.3.1", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
+quickwit-indexing = { version = "0.3.1", path = "../quickwit-indexing" }
+quickwit-ingest-api = { version = "0.3.1", path = "../quickwit-ingest-api" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.1", path = "../quickwit-proto" }
+quickwit-search = { version = "0.3.1", path = "../quickwit-search" }
+quickwit-serve = { version = "0.3.1", path = "../quickwit-serve" }
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
+quickwit-telemetry = { version = "0.3.1", path = "../quickwit-telemetry" }
 regex = "1.5.4"
 serde_json = "1.0"
 tabled = "0.7"

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -19,58 +19,75 @@ name = "generate_markdown"
 path = "src/generate_markdown.rs"
 
 [dependencies]
-async-trait = "0.1"
 anyhow = "1"
+async-trait = "0.1"
+atty = "0.2"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
 clap = { version = "= 3.1", features = ["yaml", "env"] }
+colored = "2.0.0"
+console-subscriber = { version = "0.1.0", optional = true }
+futures = "0.3"
+humansize = "1.1.1"
+humantime = "2.1.0"
+itertools = "0.10.3"
+once_cell = "1"
+openssl-probe = { version = "0.1.4", optional = true }
+opentelemetry = { version = "0.17", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
 quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-core = { version = "0.3.0", path = "../quickwit-core" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
+quickwit-cluster = { version = "0.3.0", path = "../quickwit-cluster" }
 quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
 quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+quickwit-core = { version = "0.3.0", path = "../quickwit-core" }
+quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
 quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
 quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
 quickwit-ingest-api = { version = "0.3.0", path = "../quickwit-ingest-api" }
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
 quickwit-search = { version = "0.3.0", path = "../quickwit-search" }
 quickwit-serve = { version = "0.3.0", path = "../quickwit-serve" }
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
 quickwit-telemetry = { version = "0.3.0", path = "../quickwit-telemetry" }
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
-quickwit-cluster = { version = "0.3.0", path = "../quickwit-cluster" }
+regex = "1.5.4"
+serde_json = "1.0"
 tabled = "0.7"
-tracing = "0.1.29"
-tracing-subscriber = {version = "0.3", features = ["time", "std", "env-filter"] }
-tracing-opentelemetry = "0.17"
-opentelemetry = { version = "0.17", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
+tempfile = "3"
+thousands = "0.2.0"
+time = { version = "0.3.5", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
-atty = "0.2"
-once_cell = "1"
-serde_json = "1.0"
-tempfile = "3"
-humansize = "1.1.1"
-openssl-probe = { version = "0.1.4", optional = true }
-itertools = "0.10.3"
-colored = "2.0.0"
-futures = "0.3"
-regex = "1.5.4"
-time = { version = "0.3.5", features = ["macros"] }
-console-subscriber = { version = "0.1.0", optional = true }
 toml = "0.5.8"
-humantime = "2.1.0"
-thousands = "0.2.0"
+tracing = "0.1.29"
+tracing-opentelemetry = "0.17"
+tracing-subscriber = { version = "0.3", features = [
+  "time",
+  "std",
+  "env-filter"
+] }
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "2"
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "json",
+  "rustls-tls"
+] }
 serial_test = "0.7.0"
 
 [features]
 ci-test = []
-tokio-console = ["console-subscriber"]
 openssl-support = ["openssl-probe"]
-release-feature-set = ["quickwit-metastore/postgres", "quickwit-indexing/kafka", "quickwit-indexing/kinesis", "openssl-support"]
-release-feature-vendored-set = ["quickwit-metastore/postgres", "quickwit-indexing/vendored-kafka", "quickwit-indexing/kinesis", "openssl-support"]
+tokio-console = ["console-subscriber"]
+release-feature-set = [
+  "quickwit-metastore/postgres",
+  "quickwit-indexing/kafka",
+  "quickwit-indexing/kinesis",
+  "openssl-support"
+]
+release-feature-vendored-set = [
+  "quickwit-metastore/postgres",
+  "quickwit-indexing/vendored-kafka",
+  "quickwit-indexing/kinesis",
+  "openssl-support"
+]

--- a/quickwit-cluster/Cargo.toml
+++ b/quickwit-cluster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quickwit-cluster"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's cluster membership"
@@ -12,19 +12,19 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+chitchat = "0.4"
 flume = "0.10"
-quickwit-common = { version = "0.3.0", path = "../quickwit-common"}
-quickwit-config = { version = "0.3.0", path = "../quickwit-config"}
+itertools = "0.10"
+quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
+quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.19", features = [ "full" ] }
-tokio-stream = { version = "0.1", features = [ "sync" ] }
+tokio = { version = "1.19", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1.29"
 uuid = { version = "1.1", features = ["v4", "serde"] }
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto"}
-chitchat = "0.4"
-itertools = '0.10'
 
 [dev-dependencies]
 tempfile = "3"

--- a/quickwit-cluster/Cargo.toml
+++ b/quickwit-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-cluster"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -15,9 +15,9 @@ async-trait = "0.1"
 chitchat = "0.4"
 flume = "0.10"
 itertools = "0.10"
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-proto = { version = "0.3.1", path = "../quickwit-proto" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/quickwit-common/Cargo.toml
+++ b/quickwit-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quickwit-common"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Util crate of quickwit"
@@ -22,7 +22,7 @@ regex = "1"
 serde = "1.0"
 tokio = { version = "1", features = ["fs", "macros", "rt"] }
 tracing = "0.1.29"
-warp = '0.3'
+warp = "0.3"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/quickwit-common/Cargo.toml
+++ b/quickwit-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-common"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io

--- a/quickwit-config/Cargo.toml
+++ b/quickwit-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-config"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial license, contact hello@quickwit.io
@@ -14,8 +14,8 @@ anyhow = "1"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
 json_comments = "0.2"
 once_cell = "1.12.0"
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -15,14 +15,14 @@ async-trait = "0.1"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
 futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false }
-quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-directories = { version = "0.3.1", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
+quickwit-indexing = { version = "0.3.1", path = "../quickwit-indexing" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore" }
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -9,32 +9,36 @@ repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
-
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
-quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["full"] }
-rand = "0.8"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features=false, features = ["mmap", "lz4-compression", "zstd-compression", "quickwit"] }
 futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false }
-uuid = { version = "1.1", features = ["v4", "serde"] }
+quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
+quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
+quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
+quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tracing = "0.1.29"
-tokio-stream = "0.1"
-tempfile = '3'
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features = false, features = [
+  "mmap",
+  "lz4-compression",
+  "zstd-compression",
+  "quickwit"
+] }
+tempfile = "3"
 thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["full"] }
+tracing = "0.1.29"
+uuid = { version = "1.1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 mockall = "0.11"

--- a/quickwit-directories/Cargo.toml
+++ b/quickwit-directories/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-directories"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -15,7 +15,7 @@ async-trait = "0.1"
 crossbeam = "0.8"
 futures = "0.3"
 once_cell = "1"
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 serde = "1"
 serde_cbor = "0.11"
 serde_json = "1"

--- a/quickwit-directories/Cargo.toml
+++ b/quickwit-directories/Cargo.toml
@@ -1,31 +1,35 @@
 [package]
-name = 'quickwit-directories'
+name = "quickwit-directories"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2021'
-license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
+license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Crate containing all of the custom tantivy Directory used in quickwit"
 repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
-
 [dependencies]
+anyhow = "1"
+async-trait = "0.1"
 crossbeam = "0.8"
 futures = "0.3"
+once_cell = "1"
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
 serde = "1"
 serde_cbor = "0.11"
 serde_json = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features=false, features = ["mmap", "lz4-compression", "zstd-compression", "quickwit"] }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
-uuid = { version = "1.1", features = ["v4", "serde"] }
-once_cell = "1"
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features = false, features = [
+  "mmap",
+  "lz4-compression",
+  "zstd-compression",
+  "quickwit"
+] }
+thiserror = "1"
+time = { version = "0.3.9", features = ["std"] }
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1.29"
-thiserror = "1"
-anyhow = "1"
-async-trait = "0.1"
-time = { version = "0.3.9", features = ["std"] }
+uuid = { version = "1.1", features = ["v4", "serde"] }
 
 [dev-dependencies]
-tempfile = '3'
+tempfile = "3"

--- a/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit-doc-mapper/Cargo.toml
@@ -3,7 +3,7 @@ name = "quickwit-doc-mapper"
 version = "0.3.0"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
-license = "AGPL-3.0-or-later"                           # For a commercial, license, contact hello@quickwit.io
+license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit index configuration"
 repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
@@ -13,32 +13,29 @@ documentation = "https://quickwit.io/docs/"
 anyhow = "1"
 base64 = "0.13"
 dyn-clone = "1.0.4"
-itertools = '0.10'
+fnv = "1"
+itertools = "0.10"
 once_cell = "1.12"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features=false, features = ["mmap", "lz4-compression", "zstd-compression", "quickwit"] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa"}
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features = false, features = [
+  "mmap",
+  "lz4-compression",
+  "zstd-compression",
+  "quickwit"
+] }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa" }
 thiserror = "1.0"
 tracing = "0.1.29"
 typetag = "0.1"
-fnv = "1"
-
-[dependencies.quickwit-proto]
-version = "0.3"
-path = '../quickwit-proto'
-
-[dependencies.mockall]
-version = "0.11"
-optional = true
+quickwit-proto = { version = "0.3", path = "../quickwit-proto" }
+mockall = { version = "0.11", optional = true }
 
 [dev-dependencies]
-mockall = "0.11"
 criterion = "0.3"
-
-[dev-dependencies.matches]
-version = "0.1.8"
+matches = "0.1.8"
+mockall = "0.11"
 
 [features]
 testsuite = ["mockall"]

--- a/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit-doc-mapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-doc-mapper"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = 'quickwit-indexing'
+name = "quickwit-indexing"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2021'
-license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
+license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit indexing"
 repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
@@ -11,6 +11,7 @@ documentation = "https://quickwit.io/docs/"
 
 [dependencies]
 anyhow = "1"
+arc-swap = "1.4"
 async-trait = "0.1"
 backoff = { version = "0.4", features = ["tokio"] }
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
@@ -18,40 +19,55 @@ fail = "0.5"
 flume = "0.10"
 futures = "0.3"
 itertools = "0.10.3"
+libz-sys = { version = "1.1.3", optional = true }
 once_cell = "1"
+openssl = { version = "0.10.36", default-features = false, optional = true }
 quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-aws = {version = "0.3.0", path = "../quickwit-aws"}
+quickwit-aws = { version = "0.3.0", path = "../quickwit-aws" }
 quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
 quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories"}
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper", features = ["testsuite"] }
+quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper", features = [
+  "testsuite"
+] }
+quickwit-ingest-api = { path = "../quickwit-ingest-api", version = "0.3.0" }
 quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
+quickwit-proto = { path = "../quickwit-proto", version = "0.3.0" }
 quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
-quickwit-ingest-api = { path="../quickwit-ingest-api", version = "0.3.0"}
-quickwit-proto = { path="../quickwit-proto", version ="0.3.0"}
-rdkafka = { version = "0.28", default-features = false, features = ["tokio", "libz", "ssl", "cmake-build"], optional = true }
-openssl = { version = "0.10.36", default-features = false, optional = true}
-libz-sys = {version = "1.1.3", optional = true}
-rusoto_core = { version = "0.48", default-features = false, features = ["rustls"], optional = true }
-rusoto_kinesis = { version = "0.48", default-features = false, features = ["rustls"], optional = true }
+rdkafka = { version = "0.28", default-features = false, features = [
+  "tokio",
+  "libz",
+  "ssl",
+  "cmake-build"
+], optional = true }
+rusoto_core = { version = "0.48", default-features = false, features = [
+  "rustls"
+], optional = true }
+rusoto_kinesis = { version = "0.48", default-features = false, features = [
+  "rustls"
+], optional = true }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features=false, features = ["mmap", "lz4-compression", "zstd-compression", "quickwit"] }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features = false, features = [
+  "mmap",
+  "lz4-compression",
+  "zstd-compression",
+  "quickwit"
+] }
 tempfile = "3.3"
 thiserror = "1"
+time = { version = "0.3.9", features = ["std"] }
 tokio = { version = "1", features = ["sync"] }
+tokio-stream = "0.1"
 tracing = "0.1.29"
 ulid = "0.6"
-tokio-stream = "0.1"
-arc-swap = "1.4"
-time = { version = "0.3.9", features = ["std"] }
 
 [features]
 kafka = ["rdkafka"]
 kafka-broker-tests = []
 vendored-kafka = ["kafka", "libz-sys/static", "openssl/vendored"]
-kinesis = ["rusoto_core", "rusoto_kinesis","quickwit-aws/kinesis"]
+kinesis = ["rusoto_core", "rusoto_kinesis", "quickwit-aws/kinesis"]
 kinesis-localstack-tests = []
 
 [dev-dependencies]
@@ -59,9 +75,13 @@ bytes = "1"
 mockall = "0.11"
 proptest = "1"
 quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = ["testsuite"] }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = ["testsuite"] }
-rand = '0.8'
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = [
+  "testsuite"
+] }
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = [
+  "testsuite"
+] }
+rand = "0.8"
 tempfile = "3"
 
 [[test]]

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-indexing"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -22,18 +22,18 @@ itertools = "0.10.3"
 libz-sys = { version = "1.1.3", optional = true }
 once_cell = "1"
 openssl = { version = "0.10.36", default-features = false, optional = true }
-quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-aws = { version = "0.3.0", path = "../quickwit-aws" }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper", features = [
+quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
+quickwit-aws = { version = "0.3.1", path = "../quickwit-aws" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-directories = { version = "0.3.1", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper", features = [
   "testsuite"
 ] }
 quickwit-ingest-api = { path = "../quickwit-ingest-api", version = "0.3.0" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore" }
 quickwit-proto = { path = "../quickwit-proto", version = "0.3.0" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 rdkafka = { version = "0.28", default-features = false, features = [
   "tokio",
   "libz",
@@ -74,11 +74,11 @@ kinesis-localstack-tests = []
 bytes = "1"
 mockall = "0.11"
 proptest = "1"
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = [
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore", features = [
   "testsuite"
 ] }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = [
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage", features = [
   "testsuite"
 ] }
 rand = "0.8"

--- a/quickwit-ingest-api/Cargo.toml
+++ b/quickwit-ingest-api/Cargo.toml
@@ -6,22 +6,22 @@ license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwi
 description = "Quickwit is a cost-efficient search engine."
 
 [dependencies]
-tokio = {version = "1", features = ["full"] }
-async-trait = "0.1"
-quickwit-actors = {path="../quickwit-actors", version ="0.3.0"}
-quickwit-metastore = {path="../quickwit-metastore", version = "0.3.0"}
-quickwit-proto = {path="../quickwit-proto", version ="0.3.0"}
-rocksdb = {version = "0.18", features = [], default-features= false}
 anyhow = "1"
-thiserror = "1"
-tracing = "0.1"
+async-trait = "0.1"
 flume = "0.10"
+futures = "0.3.17"
 once_cell = "1"
+quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
+rocksdb = { version = "0.18", features = [], default-features = false }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1"
-futures = "0.3.17"
+thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
 
 [dev-dependencies]
-tempfile = "3"
 rand = "0.8"
 rand_distr = "0.4"
+tempfile = "3"

--- a/quickwit-ingest-api/Cargo.toml
+++ b/quickwit-ingest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-ingest-api"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit is a cost-efficient search engine."
@@ -11,9 +11,9 @@ async-trait = "0.1"
 flume = "0.10"
 futures = "0.3.17"
 once_cell = "1"
-quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
+quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.1", path = "../quickwit-proto" }
 rocksdb = { version = "0.18", features = [], default-features = false }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1"

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-metastore"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -25,10 +25,10 @@ itertools = "0.10.3"
 mockall = { version = "0.11", optional = true }
 once_cell = "1"
 openssl = { version = "0.10.36", optional = true }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 regex = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -43,10 +43,10 @@ dotenv = "0.15"
 futures = "0.3"
 md5 = "0.7"
 mockall = "0.11"
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper", features = [
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper", features = [
   "testsuite"
 ] }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = [
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage", features = [
   "testsuite"
 ] }
 rand = "0.8"

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quickwit-metastore"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's metastore"
@@ -9,50 +9,50 @@ repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
-
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
-time = { version = "0.3.9", features = ["std"] }
 chrono = { version = "0.4" }
-diesel = { version = "1.4", features = ["postgres", "chrono", "extras"], optional = true }
-diesel_migrations =  { version = "1.4", optional = true }
+diesel = { version = "1.4", features = [
+  "postgres",
+  "chrono",
+  "extras"
+], optional = true }
+diesel_migrations = { version = "1.4", optional = true }
 futures = "0.3.17"
 itertools = "0.10.3"
+mockall = { version = "0.11", optional = true }
 once_cell = "1"
 openssl = { version = "0.10.36", optional = true }
-regex = "1"
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = "1.0"
-thiserror = "1.0"
-tokio = { version = "1.19", features = ["full"] }
-tracing = "0.1.29"
-
 quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
 quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
 quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
 quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
-
-[dependencies.mockall]
-version = "0.11"
-optional = true
-
-[dependencies.tempfile]
-version = "3"
-optional = true
+regex = "1"
+serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json = "1.0"
+tempfile = { version = "3", optional = true }
+thiserror = "1.0"
+time = { version = "0.3.9", features = ["std"] }
+tokio = { version = "1.19", features = ["full"] }
+tracing = "0.1.29"
 
 [dev-dependencies]
 dotenv = "0.15"
-mockall = "0.11"
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = ["testsuite"] }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper", features = ["testsuite"] }
-tempfile = '3'
-futures = '0.3'
-rand = "0.8"
+futures = "0.3"
 md5 = "0.7"
+mockall = "0.11"
+quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper", features = [
+  "testsuite"
+] }
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = [
+  "testsuite"
+] }
+rand = "0.8"
+tempfile = "3"
 
 [features]
 testsuite = ["mockall", "tempfile"]
 ci-test = []
-postgres = [ "diesel", "diesel_migrations", "openssl"]
+postgres = ["diesel", "diesel_migrations", "openssl"]

--- a/quickwit-proto/Cargo.toml
+++ b/quickwit-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-proto"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io

--- a/quickwit-proto/Cargo.toml
+++ b/quickwit-proto/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
-name = 'quickwit-proto'
+name = "quickwit-proto"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2021'
-license = 'AGPL-3.0-or-later'  # For a commercial, license, contact hello@quickwit.io
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
+license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's protos"
 repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
 [dependencies]
-prost = { version = "0.10.0", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.10.0", default-features = false, features = [
+  "prost-derive"
+] }
 serde = { version = "1.0", features = ["derive"] }
 tonic = "0.7"
 
 [build-dependencies]
-tonic-build = "0.7.0"
 prost-build = "0.10.0"
-
+tonic-build = "0.7.0"

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -1,77 +1,65 @@
 [package]
-name = 'quickwit-search'
+name = "quickwit-search"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2021'
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's search logic"
 repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
-
 [dependencies]
-anyhow = '1'
+anyhow = "1"
 async-trait = "0.1"
-base64 = '0.13'
-futures = '0.3'
-http = "0.2"
-mockall = "0.11"
-itertools = '0.10'
-thiserror = "1"
-tokio-stream = "0.1"
-tracing = "0.1.29"
-tracing-futures = "0.2.5"
-serde_json = "1"
-serde = { version = "1.0", features = ["derive"] }
-hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
+base64 = "0.13"
 bytes = "1"
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
+futures = "0.3"
+http = "0.2"
+hyper = { version = "0.14", features = [
+  "stream",
+  "server",
+  "http1",
+  "http2",
+  "tcp",
+  "client"
+] }
+itertools = "0.10"
 lru = "0.7"
+mockall = "0.11"
 once_cell = "1"
 opentelemetry = "0.17"
-tracing-opentelemetry = "0.17"
+quickwit-cluster = { version = "0.3.0", path = "../quickwit-cluster" }
+quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
+quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
 rayon = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features=false, features = ["mmap", "lz4-compression", "zstd-compression", "quickwit"] }
-
-[dependencies.quickwit-cluster]
-path = '../quickwit-cluster'
-version = "0.3.0"
-
-[dependencies.quickwit-doc-mapper]
-path = '../quickwit-doc-mapper'
-version = "0.3.0"
-
-[dependencies.tokio]
-version = '1'
-features = ['full']
-
-[dependencies.tokio-util]
-version = '0.7'
-features = ['full']
-
-[dependencies.quickwit-directories]
-path = '../quickwit-directories'
-version = "0.3.0"
-
-[dependencies.quickwit-proto]
-path = '../quickwit-proto'
-version = "0.3.0"
-
-[dependencies.quickwit-metastore]
-path = '../quickwit-metastore'
-version = "0.3.0"
-
-[dependencies.quickwit-storage]
-path = '../quickwit-storage'
-version = "0.3.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features = false, features = [
+  "mmap",
+  "lz4-compression",
+  "zstd-compression",
+  "quickwit"
+] }
+thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["full"] }
+tracing = "0.1.29"
+tracing-futures = "0.2.5"
+tracing-opentelemetry = "0.17"
 
 [dev-dependencies]
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
-quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = ["testsuite"] }
-serde_json = "1"
 assert-json-diff = "2"
-tempfile = "3.3"
 chitchat = "0.4"
+quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = [
+  "testsuite"
+] }
+serde_json = "1"
+tempfile = "3.3"

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-search"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -29,14 +29,14 @@ lru = "0.7"
 mockall = "0.11"
 once_cell = "1"
 opentelemetry = "0.17"
-quickwit-cluster = { version = "0.3.0", path = "../quickwit-cluster" }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+quickwit-cluster = { version = "0.3.1", path = "../quickwit-cluster" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-directories = { version = "0.3.1", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.1", path = "../quickwit-proto" }
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 rayon = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
@@ -57,8 +57,8 @@ tracing-opentelemetry = "0.17"
 [dev-dependencies]
 assert-json-diff = "2"
 chitchat = "0.4"
-quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = [
+quickwit-indexing = { version = "0.3.1", path = "../quickwit-indexing" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore", features = [
   "testsuite"
 ] }
 serde_json = "1"

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = 'quickwit-serve'
+name = "quickwit-serve"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2021'
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's search service"
 repository = "https://github.com/quickwit-oss/quickwit"
@@ -10,62 +10,58 @@ homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
 [dependencies]
-anyhow = '1'
-warp = '0.3'
-hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
+anyhow = "1"
+async-trait = "0.1"
+bytes = "1"
 futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false }
-tracing = "0.1.29"
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
-serde_json = "1"
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+hyper = { version = "0.14", features = [
+  "stream",
+  "server",
+  "http1",
+  "http2",
+  "tcp",
+  "client"
+] }
+mime_guess = { version = "2.0.4" }
+once_cell = "1"
+opentelemetry = "0.17"
+prometheus = "0.13"
+quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
+quickwit-cluster = { version = "0.3.0", path = "../quickwit-cluster" }
 quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-telemetry = { version = "0.3.0", path = "../quickwit-telemetry" }
+quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
+quickwit-core = { version = "0.3.0", path = "../quickwit-core" }
 quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
 quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
 quickwit-ingest-api = { version = "0.3.0", path = "../quickwit-ingest-api" }
-quickwit-core = { version = "0.3.0", path = "../quickwit-core" }
-thiserror = "1"
-async-trait = "0.1"
-termcolor = "1"
-bytes = "1"
-tokio = { version = "1.19", features = [ "full" ] }
-tokio-stream = "0.1"
-opentelemetry = "0.17"
-tracing-opentelemetry = "0.17"
-prometheus = "0.13"
-once_cell = '1'
-quickwit-actors = {version = "0.3.0", path="../quickwit-actors"}
-rust-embed="6.4.0"
-mime_guess = { version = "2.0.4" }
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
+quickwit-search = { version = "0.3.0", path = "../quickwit-search" }
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
+quickwit-telemetry = { version = "0.3.0", path = "../quickwit-telemetry" }
 regex = "1"
+rust-embed = "6.4.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+serde_qs = { version = "0.9", features = ["warp"] }
+termcolor = "1"
+thiserror = "1"
+tokio = { version = "1.19", features = ["full"] }
+tokio-stream = "0.1"
+tracing = "0.1.29"
+tracing-opentelemetry = "0.17"
+warp = "0.3"
 
 [dev-dependencies]
-mockall = "0.11"
 assert-json-diff = "2.0.1"
-tokio = { version = "1", features = ["full"] }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = ["testsuite"] }
-quickwit-core = { version = "0.3.0", path = "../quickwit-core" }
-quickwit-indexing= { version = "0.3.0", path = "../quickwit-indexing" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = ["testsuite"] }
+mockall = "0.11"
+quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = [
+  "testsuite"
+] }
+quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = [
+  "testsuite"
+] }
 rand = "0.8"
-
-[dependencies.quickwit-cluster]
-path = '../quickwit-cluster'
-version = "0.3"
-
-[dependencies.quickwit-search]
-path = '../quickwit-search'
-version = "0.3"
-
-[dependencies.serde]
-version = '1.0'
-features = ['derive']
-
-[dependencies.serde_qs]
-version = '0.9'
-features = ['warp']
+tokio = { version = "1", features = ["full"] }

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-serve"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -27,20 +27,20 @@ mime_guess = { version = "2.0.4" }
 once_cell = "1"
 opentelemetry = "0.17"
 prometheus = "0.13"
-quickwit-actors = { version = "0.3.0", path = "../quickwit-actors" }
-quickwit-cluster = { version = "0.3.0", path = "../quickwit-cluster" }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-core = { version = "0.3.0", path = "../quickwit-core" }
-quickwit-directories = { version = "0.3.0", path = "../quickwit-directories" }
-quickwit-doc-mapper = { version = "0.3.0", path = "../quickwit-doc-mapper" }
-quickwit-indexing = { version = "0.3.0", path = "../quickwit-indexing" }
-quickwit-ingest-api = { version = "0.3.0", path = "../quickwit-ingest-api" }
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore" }
-quickwit-proto = { version = "0.3.0", path = "../quickwit-proto" }
-quickwit-search = { version = "0.3.0", path = "../quickwit-search" }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage" }
-quickwit-telemetry = { version = "0.3.0", path = "../quickwit-telemetry" }
+quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
+quickwit-cluster = { version = "0.3.1", path = "../quickwit-cluster" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-core = { version = "0.3.1", path = "../quickwit-core" }
+quickwit-directories = { version = "0.3.1", path = "../quickwit-directories" }
+quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
+quickwit-indexing = { version = "0.3.1", path = "../quickwit-indexing" }
+quickwit-ingest-api = { version = "0.3.1", path = "../quickwit-ingest-api" }
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore" }
+quickwit-proto = { version = "0.3.1", path = "../quickwit-proto" }
+quickwit-search = { version = "0.3.1", path = "../quickwit-search" }
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
+quickwit-telemetry = { version = "0.3.1", path = "../quickwit-telemetry" }
 regex = "1"
 rust-embed = "6.4.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -57,10 +57,10 @@ warp = "0.3"
 [dev-dependencies]
 assert-json-diff = "2.0.1"
 mockall = "0.11"
-quickwit-metastore = { version = "0.3.0", path = "../quickwit-metastore", features = [
+quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore", features = [
   "testsuite"
 ] }
-quickwit-storage = { version = "0.3.0", path = "../quickwit-storage", features = [
+quickwit-storage = { version = "0.3.1", path = "../quickwit-storage", features = [
   "testsuite"
 ] }
 rand = "0.8"

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-storage"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
@@ -20,9 +20,9 @@ lru = "0.7"
 md5 = "0.7"
 mockall = { version = "0.11", optional = true }
 once_cell = "1"
-quickwit-aws = { version = "0.3.0", path = "../quickwit-aws" }
-quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
+quickwit-aws = { version = "0.3.1", path = "../quickwit-aws" }
+quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
 rand = "0.8"
 regex = "1"
 rusoto_core = { version = "0.48", default-features = false, features = [

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = 'quickwit-storage'
+name = "quickwit-storage"
 version = "0.3.0"
-authors = ['Quickwit, Inc. <hello@quickwit.io>']
-edition = '2021'
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 description = "Quickwit's storage abstraction"
 repository = "https://github.com/quickwit-oss/quickwit"
@@ -10,52 +10,44 @@ homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
 [dependencies]
+anyhow = "1"
+async-trait = "0.1"
+base64 = "0.13"
+bytes = "1"
+ec2_instance_metadata = "0.3"
+futures = "0.3"
+lru = "0.7"
+md5 = "0.7"
+mockall = { version = "0.11", optional = true }
+once_cell = "1"
+quickwit-aws = { version = "0.3.0", path = "../quickwit-aws" }
 quickwit-common = { version = "0.3.0", path = "../quickwit-common" }
 quickwit-config = { version = "0.3.0", path = "../quickwit-config" }
-quickwit-aws = {version = "0.3.0", path = "../quickwit-aws"}
-async-trait = '0.1'
-md5 = '0.7'
-anyhow = '1'
-bytes = '1'
-futures = '0.3'
-serde_json = "1"
-base64 = '0.13'
-tracing = "0.1.29"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features=false, features = ["mmap", "lz4-compression", "zstd-compression", "quickwit"] }
-once_cell = '1'
-regex = '1'
-thiserror = '1'
-rand = '0.8'
-lru = "0.7"
+rand = "0.8"
+regex = "1"
+rusoto_core = { version = "0.48", default-features = false, features = [
+  "rustls"
+] }
+rusoto_s3 = { version = "0.48", default-features = false, features = [
+  "rustls"
+] }
 serde = { version = "1.0", features = ["derive"] }
-ec2_instance_metadata = "0.3"
-tempfile = '3'
-
-[dependencies.rusoto_core]
-version = '0.48'
-default-features = false
-features = ['rustls']
-
-[dependencies.rusoto_s3]
-version = '0.48'
-default-features = false
-features = ['rustls']
-
-[dependencies.tokio]
-version = '1'
-features = ['full']
-
-[dependencies.tokio-util]
-version = '0.7'
-features = ['full']
-
-[dependencies.mockall]
-version = "0.11"
-optional = true
+serde_json = "1"
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "88054aa", default-features = false, features = [
+  "mmap",
+  "lz4-compression",
+  "zstd-compression",
+  "quickwit"
+] }
+tempfile = "3"
+thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["full"] }
+tracing = "0.1.29"
 
 [dev-dependencies]
-tracing-subscriber = "0.3"
 mockall = "0.11"
+tracing-subscriber = "0.3"
 
 [features]
 testsuite = ["mockall"]

--- a/quickwit-telemetry/Cargo.toml
+++ b/quickwit-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickwit-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2021"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io

--- a/quickwit-telemetry/Cargo.toml
+++ b/quickwit-telemetry/Cargo.toml
@@ -9,19 +9,20 @@ repository = "https://github.com/quickwit-oss/quickwit"
 homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
-
 [dependencies]
-
+async-trait = "0.1"
+hostname = "0.3"
+md5 = "0.7"
 once_cell = "1.12.0"
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1.29"
+username = "0.2"
+uuid = { version = "1.1", features = ["v4", "serde"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "json",
+  "rustls-tls"
+] }
 # It is actually not used directly the goal is to fix the version
 # used by reqwest. 0.8.30 has an unclear license.
 encoding_rs = "=0.8.29"
-tokio = {version = "1", features = ["full"] }
-serde = {version = "1", features = ["derive"] }
-uuid = { version= "1.1", features = ["v4", "serde"] }
-tracing = "0.1.29"
-async-trait = "0.1"
-hostname = "0.3"
-username = "0.2"
-md5 = "0.7"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x
+
+# npm install prettier prettier-plugin-toml
+find . -maxdepth 4 -name "Cargo.toml" | xargs -P 4 npx prettier --write
+
+find . -type f -name 'Cargo.toml' -exec sed -i '1,5 s/^version\ =\ "'"$1"'"/version\ =\ "'"$2"'"/g' {} +
+find . -type f -name 'Cargo.toml' -exec sed -i 's/^quickwit-\(.*\)\ =\ {\ version\ =\ "'"$1"'"/quickwit-\1\ =\ {\ version\ =\ "'"$2"'"/g' {} +


### PR DESCRIPTION
### Description
Release Quickwit 0.3.1:
- updated CHANGELOG
- cleaned up Cargo.toml files
- added release script for bumping Quickwit version
- bumped Quickwit from 0.3.0 to 0.3.1

### How was this PR tested?
- `make test-all`
- GH Archive tuto
