### PR TITLE
small fix setting filename in "quickstart.md "

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -49,7 +49,7 @@ The index config defines three text fields: `title`, `body` and `url`. It also s
 
 And here is the complete config:
 
-```yaml title="wikipedia_index_config.yaml"
+```yaml title="wikipedia-index-config.yaml"
 version: 0
 index_id: wikipedia
 doc_mapping:


### PR DESCRIPTION
### Description
When performing "Create your first index" on quickstart, I noticed that the config file name specified in the CLI command was different from the config file name displayed.
