### PR TITLE
Make advertise IP configurable and sniff it when necessary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,12 +614,12 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
- "cast",
+ "cast 0.3.0",
  "clap 2.34.0",
  "criterion-plot",
  "csv",
@@ -638,7 +644,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
- "cast",
+ "cast 0.2.7",
  "itertools",
 ]
 
@@ -1432,9 +1438,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1535,6 +1541,15 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "ipnetwork"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -1906,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,9 +2286,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2278,17 +2299,108 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "pnet"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caaf5b11fd907ff15cf14a4477bfabca4b37ab9e447a4f8dead969a59cdafad"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
+name = "pnet_base"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d3a993d49e5fd5d4d854d6999d4addca1f72d86c65adf224a36757161c02b6"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e466faf03a98ad27f6e15cd27a2b7cc89e73e640a43527742977bc503c37f8aa"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd52a5211fac27e7acb14cfc9f30ae16ae0e956b7b779c8214c74559cef4c3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89de095dc7739349559913aed1ef6a11e73ceade4897dadc77c5e09de6740750"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc3b5111e697c39c8b9795b9fdccbc301ab696699e88b9ea5a4e4628978f495f"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328e231f0add6d247d82421bf3790b4b33b39c8930637f428eef24c4c6a90805"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff597185e6f1f5671b3122e4dba892a1c73e17c17e723d7669bd9299cbe7f124"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
 ]
 
 [[package]]
@@ -2655,8 +2767,10 @@ dependencies = [
  "env_logger",
  "futures",
  "home",
+ "itertools",
  "num_cpus",
  "once_cell",
+ "pnet",
  "prometheus",
  "rand",
  "regex",

--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -20,12 +20,25 @@ version: 0
 # - for its gRPC service (TCP)
 # - for its Gossip cluster membership service (UDP)
 #
-# All three services are bound to the same host and different port.
+# All three services are bound to the same host and a different port. The host can be an IP address or a hostname.
 #
 # Default HTTP server host is `127.0.0.1` and default HTTP port is 7280.
+# The default host value was chosen to avoid exposing the node to the open-world without users' explicit consent.
+# This allows for testing Quickwit in single-node mode or with multiple nodes running on the same host and listening
+# on different ports. However, in cluster mode, using this value is never appropriate because it causes the node to
+# ignore incoming traffic.
+# There are two options to set up a node in cluster mode:
+#   1. specify the node's hostname or IP
+#   2. pass `0.0.0.0` and let Quickwit do its best to discover the node's IP (see `advertise_address`)
 #
 # listen_address: 127.0.0.1
 # rest_listen_port: 7280
+#
+# IP address advertised by the node, i.e. the IP address that peer nodes should use to connect to the node for RPCs.
+# The environment variable `QW_ADVERTISE_ADDRESS` can also be used to configure this value.
+# The default advertise address is `listen_address`. If `listen_address` is unspecified (`0.0.0.0`),
+# Quickwit attempts to sniff the node's IP by scanning the available network interfaces.
+# advertise_address: 192.168.0.42
 #
 # In order to join a cluster, one needs to specify a list of
 # seeds to connect to. If no port is specified, Quickwit will assume
@@ -33,7 +46,7 @@ version: 0
 # By default, the peer seed list is empty.
 #
 # peer_seeds:
-#   - quickwit-searcher-0.local:10000
+#   - quickwit-searcher-0.local
 #   - quickwit-searcher-1.local:10000
 #
 # Path to directory where temporary data (caches, intermediate indexing data structures)

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -76,7 +76,7 @@ pub async fn start_cluster_service(
     let member = Member::new(
         quickwit_config.node_id.clone(),
         unix_timestamp(),
-        quickwit_config.gossip_public_addr().await?,
+        quickwit_config.gossip_advertise_addr().await?,
     );
 
     let cluster = Cluster::join(
@@ -84,7 +84,7 @@ pub async fn start_cluster_service(
         services,
         quickwit_config.gossip_listen_addr().await?,
         quickwit_config.cluster_id.clone(),
-        quickwit_config.grpc_public_addr().await?,
+        quickwit_config.grpc_advertise_addr().await?,
         quickwit_config.peer_seed_addrs().await?,
         FailureDetectorConfig::default(),
         &UdpTransport,

--- a/quickwit-common/Cargo.toml
+++ b/quickwit-common/Cargo.toml
@@ -15,7 +15,9 @@ colored = "2"
 env_logger = "0.9"
 futures = "0.3"
 home = "0.5.3"
+itertools = "0.10.3"
 once_cell = "1"
+pnet = { version = "0.31.0", features = [ "std" ] }
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
 regex = "1"

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -18,14 +18,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::env;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context};
 use byte_unit::Byte;
 use json_comments::StripComments;
 use once_cell::sync::OnceCell;
-use quickwit_common::net::{get_socket_addr, HostAddr};
+use quickwit_common::net::{find_private_ip, Host, HostAddr};
 use quickwit_common::new_coolid;
 use quickwit_common::uri::{Extension, Uri, FILE_PROTOCOL};
 use serde::de::Error;
@@ -69,8 +69,8 @@ fn default_node_id() -> String {
     new_coolid("node")
 }
 
-fn default_listen_address() -> String {
-    "127.0.0.1".to_string()
+fn default_listen_address() -> Host {
+    Host::from(Ipv4Addr::LOCALHOST)
 }
 
 fn default_rest_listen_port() -> u16 {
@@ -185,7 +185,8 @@ pub struct QuickwitConfig {
     #[serde(default = "default_node_id")]
     pub node_id: String,
     #[serde(default = "default_listen_address")]
-    pub listen_address: String,
+    pub listen_address: Host,
+    advertise_address: Option<Host>,
     #[serde(default = "default_rest_listen_port")]
     pub rest_listen_port: u16,
     pub gossip_listen_port: Option<u16>,
@@ -294,7 +295,10 @@ impl QuickwitConfig {
     /// Returns the REST listen address of the node, i.e. the socket address on which the REST API
     /// service listens for TCP connections.
     pub async fn rest_listen_addr(&self) -> anyhow::Result<SocketAddr> {
-        get_socket_addr(&(self.listen_address.as_str(), self.rest_listen_port)).await
+        self.listen_address
+            .with_port(self.rest_listen_port)
+            .to_socket_addr()
+            .await
     }
 
     /// Returns the gRPC listen port of the node.
@@ -306,16 +310,52 @@ impl QuickwitConfig {
     /// Returns the gRPC listen address of the node, i.e. the socket address on which the gRPC
     /// service listens for TCP connections.
     pub async fn grpc_listen_addr(&self) -> anyhow::Result<SocketAddr> {
-        get_socket_addr(&(self.listen_address.as_str(), self.grpc_listen_port())).await
+        self.listen_address
+            .with_port(self.grpc_listen_port())
+            .to_socket_addr()
+            .await
+    }
+
+    /// Returns the advertise
+    pub fn advertise_addr(&self) -> anyhow::Result<Host> {
+        static ADVERTISE_ADDR: OnceCell<Host> = OnceCell::new();
+        ADVERTISE_ADDR.get_or_try_init(|| {
+        if let Ok(advertise_address) = env::var("QW_ADVERTISE_ADDRESS") {
+            return advertise_address.parse().map(|addr| {
+                info!(advertise_address=%advertise_address, "Using advertise address from environment variable `QW_ADVERTISE_ADDRESS`.");
+                addr
+            }).with_context(|| {
+                format!(
+                    "Failed to parse advertise address `{advertise_address}` read from \
+                     environment variable `QW_ADVERTISE_ADDRESS`."
+                )
+            });
+        }
+        if let Some(advertise_addr) = &self.advertise_address {
+            return Ok(advertise_addr.clone());
+        }
+        if self.listen_address.is_unspecified() {
+            if let Some((interface_name, private_ip)) = find_private_ip() {
+                info!(advertise_address=%private_ip, interface_name=%interface_name, "Using sniffed advertise address.");
+                return Ok(Host::from(private_ip));
+            }
+            bail!(
+                "Listen address `{}` is unspecified and advertise address is not set.",
+                self.listen_address
+            );
+        }
+        info!(advertise_address=%self.listen_address, "Using listen address as advertise address.");
+        Ok(self.listen_address.clone())
+        }).cloned()
     }
 
     /// Returns the gRPC public address of the node, i.e. the socket address to connect to in order
     /// to send gRPC requests to the node.
-    pub async fn grpc_public_addr(&self) -> anyhow::Result<SocketAddr> {
-        match env::var("QW_PUBLIC_IP") {
-            Ok(ip_addr) => get_socket_addr(&(ip_addr, self.grpc_listen_port())).await,
-            Err(_) => self.grpc_listen_addr().await,
-        }
+    pub async fn grpc_advertise_addr(&self) -> anyhow::Result<SocketAddr> {
+        self.advertise_addr()?
+            .with_port(self.grpc_listen_port())
+            .to_socket_addr()
+            .await
     }
 
     /// Returns the gossip listen port of the node (UDP).
@@ -328,16 +368,19 @@ impl QuickwitConfig {
     /// Returns the gossip listen address of the node, i.e. the UDP socket address on which the node
     /// receives gossip messages.
     pub async fn gossip_listen_addr(&self) -> anyhow::Result<SocketAddr> {
-        get_socket_addr(&(self.listen_address.as_str(), self.gossip_listen_port())).await
+        self.listen_address
+            .with_port(self.gossip_listen_port())
+            .to_socket_addr()
+            .await
     }
 
     /// Returns the gossip public address of the node, i.e. the socket address to send UDP packets
     /// to in order to gossip with the node.
-    pub async fn gossip_public_addr(&self) -> anyhow::Result<SocketAddr> {
-        match env::var("QW_PUBLIC_IP") {
-            Ok(ip_addr) => get_socket_addr(&(ip_addr, self.gossip_listen_port())).await,
-            Err(_) => self.gossip_listen_addr().await,
-        }
+    pub async fn gossip_advertise_addr(&self) -> anyhow::Result<SocketAddr> {
+        self.advertise_addr()?
+            .with_port(self.gossip_listen_port())
+            .to_socket_addr()
+            .await
     }
 
     /// Returns the list of peer seed addresses. The addresses MUST NOT be resolved. Otherwise, the
@@ -401,6 +444,7 @@ impl Default for QuickwitConfig {
         Self {
             version: 0,
             listen_address: default_listen_address(),
+            advertise_address: None,
             rest_listen_port: default_rest_listen_port(),
             gossip_listen_port: None,
             grpc_listen_port: None,
@@ -452,6 +496,7 @@ where D: Deserializer<'de> {
 #[cfg(test)]
 mod tests {
     use std::env;
+    use std::net::Ipv4Addr;
 
     use super::*;
 
@@ -474,7 +519,7 @@ mod tests {
                 let config = QuickwitConfig::from_uri(&config_uri, file.as_bytes()).await?;
                 assert_eq!(config.version, 0);
                 assert_eq!(config.cluster_id, "quickwit-cluster");
-                assert_eq!(config.listen_address, "0.0.0.0".to_string());
+                assert_eq!(config.listen_address, Host::from(Ipv4Addr::UNSPECIFIED));
                 assert_eq!(config.rest_listen_port, 1111);
                 assert_eq!(
                     config.peer_seeds,
@@ -655,7 +700,7 @@ mod tests {
     async fn test_socket_addr_ports() {
         {
             let quickwit_config = QuickwitConfig {
-                listen_address: "127.0.0.1".to_string(),
+                listen_address: Host::from(Ipv4Addr::LOCALHOST),
                 ..Default::default()
             };
             assert_eq!(
@@ -685,7 +730,7 @@ mod tests {
         }
         {
             let quickwit_config = QuickwitConfig {
-                listen_address: "127.0.0.1".to_string(),
+                listen_address: Host::from(Ipv4Addr::LOCALHOST),
                 rest_listen_port: 1789,
                 ..Default::default()
             };
@@ -716,7 +761,7 @@ mod tests {
         }
         {
             let quickwit_config = QuickwitConfig {
-                listen_address: "127.0.0.1".to_string(),
+                listen_address: Host::from(Ipv4Addr::LOCALHOST),
                 rest_listen_port: 1789,
                 gossip_listen_port: Some(1889),
                 grpc_listen_port: Some(1989),


### PR DESCRIPTION
### Description
- Add public IP to node config
- Infer public IP from network interfaces if necessary.

Fixes #1661

This is what [memberlist](https://github.com/hashicorp/memberlist/blob/696ff46201c1b64d31b60d57971d07d8cf15df7a/net_transport.go#L130) does:

1. Use public IP from env var or config if provided
2. Use any private IP from network interfaces if listen address is unspecified (`0.0.0.0`)
3. Use `listen_address`.

### How was this PR tested?
- Added unit tests
- Tested on my machine
