### PR TITLE
Improved CLI docs and add prompt to confirm index create overwrite.

### DIFF
--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -335,7 +335,7 @@ impl IndexCliCommand {
             .expect("`index-config` is a required arg.")?;
         let data_dir = matches.value_of("data-dir").map(PathBuf::from);
         let overwrite = matches.is_present("overwrite");
-        let assume_yes = matches.is_present("assume-yes");
+        let assume_yes = matches.is_present("yes");
 
         Ok(Self::Create(CreateIndexArgs {
             config_uri,

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -76,7 +76,9 @@ pub fn build_index_command<'a>() -> Command<'a> {
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
                         .required(false),
-                    arg!(--overwrite "Overwrites pre-existing index.")
+                    arg!(--overwrite "Overwrites pre-existing index. This will delete all existing data stored at `index-uri` before creating a new index.")
+                        .required(false),
+                    arg!(-y --"yes" "Assume \"yes\" as an answer to all prompts and run non-interactively.")
                         .required(false),
                 ])
             )
@@ -200,6 +202,7 @@ pub struct CreateIndexArgs {
     pub index_config_uri: Uri,
     pub data_dir: Option<PathBuf>,
     pub overwrite: bool,
+    pub assume_yes: bool,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -332,12 +335,14 @@ impl IndexCliCommand {
             .expect("`index-config` is a required arg.")?;
         let data_dir = matches.value_of("data-dir").map(PathBuf::from);
         let overwrite = matches.is_present("overwrite");
+        let assume_yes = matches.is_present("assume-yes");
 
         Ok(Self::Create(CreateIndexArgs {
             config_uri,
             data_dir,
             index_config_uri,
             overwrite,
+            assume_yes,
         }))
     }
 
@@ -363,7 +368,6 @@ impl IndexCliCommand {
             .value_of("config")
             .map(Uri::try_new)
             .expect("`config` is a required arg.")?;
-
         let metastore_uri = matches
             .value_of("metastore-uri")
             .map(Uri::try_new)
@@ -563,7 +567,27 @@ pub async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
         .resolve(&quickwit_config.metastore_uri)
         .await?;
 
-    validate_storage_uri(metastore_uri_resolver, &quickwit_config, &index_config).await?;
+    validate_storage_uri(
+        quickwit_storage_uri_resolver(),
+        &quickwit_config,
+        &index_config,
+    )
+    .await?;
+
+    // On overwrite and index present and `assume_yes` if false, ask the user to confirm the
+    // destructive operation.
+    let index_exists = metastore.index_exists(&index_id).await?;
+    if args.overwrite && index_exists && !args.assume_yes {
+        // Stop if user answers no.
+        let prompt = format!(
+            "This operation will overwrite the index `{}` and delete all its data. Do you want to \
+             proceed?",
+            index_id
+        );
+        if !prompt_confirmation(&prompt, false) {
+            return Ok(());
+        }
+    }
 
     let index_service = IndexService::new(
         metastore,

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -287,6 +287,7 @@ mod tests {
             index_config_uri: expected_index_config_uri.clone(),
             overwrite: false,
             data_dir: None,
+            assume_yes: false,
         }));
         assert_eq!(command, expected_cmd);
 
@@ -306,6 +307,7 @@ mod tests {
             index_config_uri: expected_index_config_uri,
             overwrite: true,
             data_dir: None,
+            assume_yes: false,
         }));
         assert_eq!(command, expected_cmd);
 

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -126,7 +126,7 @@ async fn test_cmd_create() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     make_command(
         format!(
-            "index create --index-config {} --config {} --overwrite",
+            "index create --index-config {} --config {} --overwrite -y",
             test_env.resource_files["index_config_without_uri"].display(),
             test_env.resource_files["config"].display(),
         )
@@ -1001,6 +1001,7 @@ async fn test_cmd_all_with_s3_localstack_internal_api() -> Result<()> {
         config_uri: Uri::try_new(&test_env.resource_files["config"].display().to_string()).unwrap(),
         overwrite: false,
         data_dir: None,
+        assume_yes: true,
     };
     create_index_cli(args).await?;
     let index_metadata = test_env

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -31,8 +31,8 @@ use quickwit_janitor::{
     delete_splits_with_files, run_garbage_collect, FileEntry, SplitDeletionError,
 };
 use quickwit_metastore::{
-    quickwit_metastore_uri_resolver, IndexMetadata, Metastore, MetastoreError,
-    MetastoreUriResolver, Split, SplitMetadata, SplitState,
+    quickwit_metastore_uri_resolver, IndexMetadata, Metastore, MetastoreError, Split,
+    SplitMetadata, SplitState,
 };
 use quickwit_proto::{ServiceError, ServiceErrorCode};
 use quickwit_storage::{quickwit_storage_uri_resolver, StorageResolverError, StorageUriResolver};
@@ -345,17 +345,15 @@ pub async fn remove_indexing_directory(data_dir_path: &Path, index_id: String) -
 
 /// Resolve storage endpoints to validate.
 pub async fn validate_storage_uri(
-    metastore_uri_resolver: &MetastoreUriResolver,
+    storage_uri_resolver: &StorageUriResolver,
     quickwit_config: &QuickwitConfig,
     index_config: &IndexConfig,
 ) -> anyhow::Result<()> {
-    metastore_uri_resolver
-        .resolve(&quickwit_config.default_index_root_uri)
-        .await?;
+    storage_uri_resolver.resolve(&quickwit_config.default_index_root_uri)?;
 
     // Optional: check custom index uri
     if let Some(index_uri) = index_config.index_uri.as_ref() {
-        metastore_uri_resolver.resolve(index_uri).await?;
+        storage_uri_resolver.resolve(index_uri)?;
     }
     Ok(())
 }


### PR DESCRIPTION
### Description

Improve CLI docs and add prompt to confirm overwrite. By default, the answer is no.
A flag "-y --assume-yes" is here  

### Note

I like having a better XP on the CLI. Unfortunately, the current code I introduce is lame as it's very specific to one command.

I think other risky operations should behave the same way. 

### prompt

<img width="1429" alt="Capture d’écran 2022-06-30 à 23 07 18" src="https://user-images.githubusercontent.com/653704/176783747-82de43bf-b630-4f41-85ac-ec4c24f6f991.png">

### yes
<img width="1410" alt="Capture d’écran 2022-06-30 à 23 08 19" src="https://user-images.githubusercontent.com/653704/176783740-9b21f789-073e-4344-91b3-bfcb9859a25b.png">

### no

<img width="1403" alt="Capture d’écran 2022-06-30 à 23 08 01" src="https://user-images.githubusercontent.com/653704/176783744-8ddc5120-4cfe-453f-94c7-4bcc4f8af8d2.png">



### How was this PR tested?

With the current tests.
