### PR TITLE
Adding prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,7 +2930,6 @@ dependencies = [
  "mockall",
  "once_cell",
  "opentelemetry",
- "prometheus",
  "quickwit-actors",
  "quickwit-cluster",
  "quickwit-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,6 +2614,7 @@ dependencies = [
  "tabled",
  "tempfile",
  "thousands",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "time 0.3.11",
  "tokio",
@@ -4224,6 +4225,17 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,7 @@ build-ui:
 
 rm-postgres:
 	rm -fr /tmp/quickwit/services/postgres
+
+start-prometheus:
+	docker run  --net=host -v `pwd`/scripts/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus --config.file=/etc/prometheus/prometheus.yml
+

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/generate_markdown.rs"
 anyhow = "1"
 async-trait = "0.1"
 tikv-jemallocator = "0.5"
+tikv-jemalloc-ctl = "0.5"
 atty = "0.2"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
 clap = { version = "= 3.1", features = ["yaml", "env"] }

--- a/quickwit-common/src/metrics.rs
+++ b/quickwit-common/src/metrics.rs
@@ -17,17 +17,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use prometheus::{Encoder, IntCounter, IntGauge, Opts, TextEncoder};
+use prometheus::{Encoder, Opts, TextEncoder};
+pub use prometheus::{IntCounter, IntGauge};
 
-pub fn new_counter(name: &str, description: &str) -> IntCounter {
-    let counter =
-        IntCounter::with_opts(Opts::new(name, description)).expect("Failed to create counter");
+pub fn new_counter(name: &str, description: &str, namespace: &str) -> IntCounter {
+    let counter_opts = Opts::new(name, description).namespace(namespace);
+    let counter = IntCounter::with_opts(counter_opts).expect("Failed to create counter");
     prometheus::register(Box::new(counter.clone())).expect("Failed to register counter");
     counter
 }
 
-pub fn new_gauge(name: &str, description: &str) -> IntGauge {
-    let gauge = IntGauge::with_opts(Opts::new(name, description)).expect("Failed to create gauge");
+pub fn new_gauge(name: &str, description: &str, namespace: &str) -> IntGauge {
+    let gauge_opts = Opts::new(name, description).namespace(namespace);
+    let gauge = IntGauge::with_opts(gauge_opts).expect("Failed to create gauge");
     prometheus::register(Box::new(gauge.clone())).expect("Failed to register gauge");
     gauge
 }

--- a/quickwit-directories/src/caching_directory.rs
+++ b/quickwit-directories/src/caching_directory.rs
@@ -54,7 +54,10 @@ impl CachingDirectory {
     ) -> CachingDirectory {
         CachingDirectory {
             underlying,
-            cache: Arc::new(SliceCache::with_capacity_in_bytes(capacity_in_bytes)),
+            cache: Arc::new(SliceCache::with_capacity_in_bytes(
+                capacity_in_bytes,
+                &quickwit_storage::STORAGE_METRICS.shortlived_cache,
+            )),
         }
     }
 
@@ -66,7 +69,9 @@ impl CachingDirectory {
     pub fn new_with_unlimited_capacity(underlying: Arc<dyn Directory>) -> CachingDirectory {
         CachingDirectory {
             underlying,
-            cache: Arc::new(SliceCache::with_infinite_capacity()),
+            cache: Arc::new(SliceCache::with_infinite_capacity(
+                &quickwit_storage::STORAGE_METRICS.shortlived_cache,
+            )),
         }
     }
 }

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -37,8 +37,11 @@ mod search_stream;
 mod service;
 mod thread_pool;
 
+mod metrics;
 #[cfg(test)]
 mod tests;
+
+use metrics::SEARCH_METRICS;
 
 /// Refer to this as `crate::Result<T>`.
 pub type Result<T> = std::result::Result<T, SearchError>;

--- a/quickwit-search/src/metrics.rs
+++ b/quickwit-search/src/metrics.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+// See https://prometheus.io/docs/practices/naming/
+
+use once_cell::sync::Lazy;
+use quickwit_common::metrics::{new_counter, IntCounter};
+
+pub struct SearchMetrics {
+    pub leaf_searches_splits_total: IntCounter,
+}
+
+impl Default for SearchMetrics {
+    fn default() -> Self {
+        SearchMetrics {
+            leaf_searches_splits_total: new_counter(
+                "leaf_searches_splits_total",
+                "Number of leaf search (count of splits) started.",
+                "quickwit_search",
+            ),
+        }
+    }
+}
+
+/// `SEARCH_METRICS` exposes a bunch a set of storage/cache related metrics through a prometheus
+/// endpoint.
+pub static SEARCH_METRICS: Lazy<SearchMetrics> = Lazy::new(SearchMetrics::default);

--- a/quickwit-search/src/metrics.rs
+++ b/quickwit-search/src/metrics.rs
@@ -20,10 +20,14 @@
 // See https://prometheus.io/docs/practices/naming/
 
 use once_cell::sync::Lazy;
-use quickwit_common::metrics::{new_counter, IntCounter};
+use quickwit_common::metrics::{
+    new_counter, new_gauge, new_histogram, Histogram, IntCounter, IntGauge,
+};
 
 pub struct SearchMetrics {
     pub leaf_searches_splits_total: IntCounter,
+    pub leaf_search_split_duration_secs: Histogram,
+    pub active_search_threads_count: IntGauge,
 }
 
 impl Default for SearchMetrics {
@@ -32,6 +36,17 @@ impl Default for SearchMetrics {
             leaf_searches_splits_total: new_counter(
                 "leaf_searches_splits_total",
                 "Number of leaf search (count of splits) started.",
+                "quickwit_search",
+            ),
+            leaf_search_split_duration_secs: new_histogram(
+                "leaf_search_split_duration_secs",
+                "Number of seconds required to run a leaf search over a single split. The timer \
+                 starts after the semaphore is obtained.",
+                "quickwit_search",
+            ),
+            active_search_threads_count: new_gauge(
+                "active_search_threads_count",
+                "Number of thread in use the CPU thread pool",
                 "quickwit_search",
             ),
         }

--- a/quickwit-search/src/thread_pool.rs
+++ b/quickwit-search/src/thread_pool.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use once_cell::sync::OnceCell;
+use quickwit_common::metrics::create_gauge_guard;
 use tracing::error;
 
 fn search_thread_pool() -> &'static rayon::ThreadPool {
@@ -59,6 +60,8 @@ where
 {
     let (tx, rx) = tokio::sync::oneshot::channel();
     search_thread_pool().spawn(move || {
+        let _active_thread_guard =
+            create_gauge_guard(&crate::SEARCH_METRICS.active_search_threads_count);
         if tx.is_closed() {
             return;
         }

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -26,7 +26,6 @@ hyper = { version = "0.14", features = [
 mime_guess = { version = "2.0.4" }
 once_cell = "1"
 opentelemetry = "0.17"
-prometheus = "0.13"
 quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
 quickwit-cluster = { version = "0.3.1", path = "../quickwit-cluster" }
 quickwit-common = { version = "0.3.1", path = "../quickwit-common" }

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -18,9 +18,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod args;
-mod counters;
 mod error;
 mod format;
+mod metrics;
 
 mod grpc;
 mod rest;
@@ -52,7 +52,7 @@ use quickwit_storage::quickwit_storage_uri_resolver;
 use warp::{Filter, Rejection};
 
 pub use crate::args::ServeArgs;
-pub use crate::counters::COUNTERS;
+pub use crate::metrics::SERVE_METRICS;
 #[cfg(test)]
 use crate::rest::recover_fn;
 

--- a/quickwit-serve/src/metrics.rs
+++ b/quickwit-serve/src/metrics.rs
@@ -18,19 +18,23 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use once_cell::sync::Lazy;
-use prometheus::IntCounter;
-use quickwit_common::metrics::new_counter;
+use quickwit_common::metrics::{new_counter, IntCounter};
 
-pub struct Counters {
-    pub num_requests: IntCounter,
+pub struct RestMetrics {
+    pub http_requests_total: IntCounter,
 }
 
-impl Default for Counters {
+impl Default for RestMetrics {
     fn default() -> Self {
-        Counters {
-            num_requests: new_counter("rest_api:search:num_requests", "Number of search requests"),
+        RestMetrics {
+            http_requests_total: new_counter(
+                "http_requests_total",
+                "Total number of HTTP requests received",
+                "quickwit",
+            ),
         }
     }
 }
 
-pub static COUNTERS: Lazy<Counters> = Lazy::new(Counters::default);
+/// Serve counters exposes a bunch a set of metrics about the request received to quickwit.
+pub static SERVE_METRICS: Lazy<RestMetrics> = Lazy::new(RestMetrics::default);

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -42,7 +42,7 @@ pub(crate) async fn start_rest_server(
 ) -> anyhow::Result<()> {
     info!(rest_listen_addr = %rest_listen_addr, "Starting REST server.");
     let request_counter = warp::log::custom(|_| {
-        crate::COUNTERS.num_requests.inc();
+        crate::SERVE_METRICS.http_requests_total.inc();
     });
     let metrics_service = warp::path("metrics")
         .and(warp::get())

--- a/quickwit-storage/src/cache/in_ram_slice_cache.rs
+++ b/quickwit-storage/src/cache/in_ram_slice_cache.rs
@@ -80,10 +80,11 @@ impl SliceCache {
 mod tests {
 
     use super::*;
+    use crate::metrics::CACHE_METRICS_FOR_TESTS;
 
     #[test]
     fn test_cache_edge_condition() {
-        let cache = SliceCache::with_capacity_in_bytes(5, &crate::metrics::CACHE_METRICS_FOR_TESTS);
+        let cache = SliceCache::with_capacity_in_bytes(5, &CACHE_METRICS_FOR_TESTS);
         {
             let data = OwnedBytes::new(&b"abc"[..]);
             cache.put(PathBuf::from("3"), 0..3, data);

--- a/quickwit-storage/src/cache/in_ram_slice_cache.rs
+++ b/quickwit-storage/src/cache/in_ram_slice_cache.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use super::memory_sized_cache::MemorySizedCache;
+use crate::metrics::CacheMetrics;
 use crate::OwnedBytes;
 
 #[derive(Hash, Debug, Clone, PartialEq, Eq)]
@@ -38,18 +39,22 @@ pub struct SliceCache {
 
 impl SliceCache {
     /// Creates an slice cache with the given capacity.
-    pub fn with_capacity_in_bytes(capacity_in_bytes: usize) -> Self {
+    pub fn with_capacity_in_bytes(
+        capacity_in_bytes: usize,
+        cache_counters: &'static CacheMetrics,
+    ) -> Self {
         SliceCache {
             inner: Mutex::new(MemorySizedCache::<SliceAddress>::with_capacity_in_bytes(
                 capacity_in_bytes,
+                cache_counters,
             )),
         }
     }
 
     /// Creates a slice cache that nevers removes any entry.
-    pub fn with_infinite_capacity() -> Self {
+    pub fn with_infinite_capacity(cache_counters: &'static CacheMetrics) -> Self {
         SliceCache {
-            inner: Mutex::new(MemorySizedCache::with_infinite_capacity()),
+            inner: Mutex::new(MemorySizedCache::with_infinite_capacity(cache_counters)),
         }
     }
 
@@ -78,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_cache_edge_condition() {
-        let cache = SliceCache::with_capacity_in_bytes(5);
+        let cache = SliceCache::with_capacity_in_bytes(5, &crate::metrics::CACHE_METRICS_FOR_TESTS);
         {
             let data = OwnedBytes::new(&b"abc"[..]);
             cache.put(PathBuf::from("3"), 0..3, data);
@@ -111,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_cache_edge_unlimited_capacity() {
-        let cache = SliceCache::with_infinite_capacity();
+        let cache = SliceCache::with_infinite_capacity(&STORAGE_METRICS.fast_field_cache);
         {
             let data = OwnedBytes::new(&b"abc"[..]);
             cache.put(PathBuf::from("3"), 0..3, data);
@@ -127,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_cache() {
-        let cache = SliceCache::with_capacity_in_bytes(10_000);
+        let cache = SliceCache::with_capacity_in_bytes(10_000, &STORAGE_METRICS.fast_field_cache);
         assert!(cache.get(Path::new("hello.seg"), 1..3).is_none());
         let data = OwnedBytes::new(&b"werwer"[..]);
         cache.put(PathBuf::from("hello.seg"), 1..3, data);
@@ -139,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_cache_different_slice() {
-        let cache = SliceCache::with_capacity_in_bytes(10_000);
+        let cache = SliceCache::with_capacity_in_bytes(10_000, &STORAGE_METRICS.fast_field_cache);
         assert!(cache.get(Path::new("hello.seg"), 1..3).is_none());
         let data = OwnedBytes::new(&b"werwer"[..]);
         // We could actually have a cache hit here, but this is not useful for Quickwit.

--- a/quickwit-storage/src/cache/memory_sized_cache.rs
+++ b/quickwit-storage/src/cache/memory_sized_cache.rs
@@ -96,7 +96,7 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
     {
         let item_opt = self.lru_cache.get(cache_key).cloned();
         if let Some(item) = item_opt.as_ref() {
-            self.cache_counters.hits_total.inc();
+            self.cache_counters.hits_num_items.inc();
             self.cache_counters.hits_num_bytes.inc_by(item.len() as u64);
         } else {
             self.cache_counters.misses_num_items.inc();

--- a/quickwit-storage/src/cache/memory_sized_cache.rs
+++ b/quickwit-storage/src/cache/memory_sized_cache.rs
@@ -24,6 +24,7 @@ use std::sync::Mutex;
 use lru::{KeyRef, LruCache};
 use tracing::{error, warn};
 
+use crate::metrics::CacheMetrics;
 use crate::OwnedBytes;
 
 #[derive(Clone, Copy, Debug)]
@@ -42,21 +43,50 @@ impl Capacity {
 }
 struct NeedMutMemorySizedCache<K: Hash + Eq> {
     lru_cache: LruCache<K, OwnedBytes>,
-    num_bytes: usize,
+    num_items: usize,
+    num_bytes: u64,
     capacity: Capacity,
+    cache_counters: &'static CacheMetrics,
+}
+
+impl<K: Hash + Eq> Drop for NeedMutMemorySizedCache<K> {
+    fn drop(&mut self) {
+        self.cache_counters
+            .in_cache_count
+            .sub(self.num_items as i64);
+        self.cache_counters
+            .in_cache_num_bytes
+            .sub(self.num_bytes as i64);
+    }
 }
 
 impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
     /// Creates a new NeedMutSliceCache with the given capacity.
-    fn with_capacity(capacity: Capacity) -> Self {
+    fn with_capacity(capacity: Capacity, cache_counters: &'static CacheMetrics) -> Self {
         NeedMutMemorySizedCache {
             // The limit will be decided by the amount of memory in the cache,
             // not the number of items in the cache.
             // Enforcing this limit is done in the `NeedMutCache` impl.
             lru_cache: LruCache::unbounded(),
+            num_items: 0,
             num_bytes: 0,
             capacity,
+            cache_counters,
         }
+    }
+
+    pub fn record_item(&mut self, num_bytes: u64) {
+        self.num_items += 1;
+        self.num_bytes += num_bytes;
+        self.cache_counters.in_cache_count.inc();
+        self.cache_counters.in_cache_num_bytes.add(num_bytes as i64);
+    }
+
+    pub fn drop_item(&mut self, num_bytes: u64) {
+        self.num_items -= 1;
+        self.num_bytes -= num_bytes;
+        self.cache_counters.in_cache_count.dec();
+        self.cache_counters.in_cache_num_bytes.sub(num_bytes as i64);
     }
 
     pub fn get<Q>(&mut self, cache_key: &Q) -> Option<OwnedBytes>
@@ -64,7 +94,14 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
         KeyRef<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.lru_cache.get(cache_key).cloned()
+        let item_opt = self.lru_cache.get(cache_key).cloned();
+        if let Some(item) = item_opt.as_ref() {
+            self.cache_counters.hits_total.inc();
+            self.cache_counters.hits_num_bytes.inc_by(item.len() as u64);
+        } else {
+            self.cache_counters.misses_num_items.inc();
+        }
+        item_opt
     }
 
     /// Attempt to put the given amount of data in the cache.
@@ -81,11 +118,14 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
             return;
         }
         if let Some(previous_data) = self.lru_cache.pop(&key) {
-            self.num_bytes -= previous_data.len();
+            self.drop_item(previous_data.len() as u64);
         }
-        while self.capacity.exceeds_capacity(self.num_bytes + bytes.len()) {
+        while self
+            .capacity
+            .exceeds_capacity(self.num_bytes as usize + bytes.len())
+        {
             if let Some((_, bytes)) = self.lru_cache.pop_lru() {
-                self.num_bytes -= bytes.len();
+                self.drop_item(bytes.len() as u64);
             } else {
                 error!(
                     "Logical error. Even after removing all of the items in the cache the \
@@ -95,7 +135,7 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
                 return;
             }
         }
-        self.num_bytes += bytes.len();
+        self.record_item(bytes.len() as u64);
         self.lru_cache.put(key, bytes);
     }
 }
@@ -107,18 +147,25 @@ pub struct MemorySizedCache<K: Hash + Eq> {
 
 impl<K: Hash + Eq> MemorySizedCache<K> {
     /// Creates an slice cache with the given capacity.
-    pub fn with_capacity_in_bytes(capacity_in_bytes: usize) -> Self {
+    pub fn with_capacity_in_bytes(
+        capacity_in_bytes: usize,
+        cache_counters: &'static CacheMetrics,
+    ) -> Self {
         MemorySizedCache {
-            inner: Mutex::new(NeedMutMemorySizedCache::with_capacity(Capacity::InBytes(
-                capacity_in_bytes,
-            ))),
+            inner: Mutex::new(NeedMutMemorySizedCache::with_capacity(
+                Capacity::InBytes(capacity_in_bytes),
+                cache_counters,
+            )),
         }
     }
 
     /// Creates a slice cache that nevers removes any entry.
-    pub fn with_infinite_capacity() -> Self {
+    pub fn with_infinite_capacity(cache_counters: &'static CacheMetrics) -> Self {
         MemorySizedCache {
-            inner: Mutex::new(NeedMutMemorySizedCache::with_capacity(Capacity::Unlimited)),
+            inner: Mutex::new(NeedMutMemorySizedCache::with_capacity(
+                Capacity::Unlimited,
+                cache_counters,
+            )),
         }
     }
 
@@ -143,10 +190,14 @@ impl<K: Hash + Eq> MemorySizedCache<K> {
 mod tests {
 
     use super::*;
+    use crate::STORAGE_METRICS;
 
     #[test]
     fn test_cache_edge_condition() {
-        let cache = MemorySizedCache::<String>::with_capacity_in_bytes(5);
+        let cache = MemorySizedCache::<String>::with_capacity_in_bytes(
+            5,
+            &STORAGE_METRICS.fast_field_cache,
+        );
         {
             let data = OwnedBytes::new(&b"abc"[..]);
             cache.put("3".to_string(), data);
@@ -179,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_cache_edge_unlimited_capacity() {
-        let cache = MemorySizedCache::with_infinite_capacity();
+        let cache = MemorySizedCache::with_infinite_capacity(&STORAGE_METRICS.fast_field_cache);
         {
             let data = OwnedBytes::new(&b"abc"[..]);
             cache.put("3".to_string(), data);
@@ -195,7 +246,8 @@ mod tests {
 
     #[test]
     fn test_cache() {
-        let cache = MemorySizedCache::with_capacity_in_bytes(10_000);
+        let cache =
+            MemorySizedCache::with_capacity_in_bytes(10_000, &STORAGE_METRICS.fast_field_cache);
         assert!(cache.get(&"hello.seg").is_none());
         let data = OwnedBytes::new(&b"werwer"[..]);
         cache.put("hello.seg", data);

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -30,7 +30,10 @@
 //!
 //! - The `BundleStorage` bundles together multiple files into a single file.
 mod cache;
+mod metrics;
 mod storage;
+
+pub use self::metrics::STORAGE_METRICS;
 pub use self::payload::PutPayload;
 pub use self::storage::Storage;
 

--- a/quickwit-storage/src/metrics.rs
+++ b/quickwit-storage/src/metrics.rs
@@ -1,0 +1,93 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+// See https://prometheus.io/docs/practices/naming/
+
+use once_cell::sync::Lazy;
+use quickwit_common::metrics::{new_counter, new_gauge, IntCounter, IntGauge};
+
+/// Counters associated to storage operations.
+pub struct StorageMetrics {
+    pub shortlived_cache: CacheMetrics,
+    pub fast_field_cache: CacheMetrics,
+    pub split_footer_cache: CacheMetrics,
+}
+
+/// Counters associated to a cache.
+#[derive(Clone)]
+pub struct CacheMetrics {
+    pub component_name: String,
+    pub in_cache_count: IntGauge,
+    pub in_cache_num_bytes: IntGauge,
+    pub hits_num_items: IntCounter,
+    pub hits_num_bytes: IntCounter,
+    pub miss_num_items: IntCounter,
+}
+
+impl CacheMetrics {
+    fn for_component(component_name: &str) -> Self {
+        let namespace = format!("cache_{component_name}");
+        CacheMetrics {
+            component_name: component_name.to_string(),
+            in_cache_count: new_gauge(
+                "in_cache_count",
+                "Count of {component_name} in cache",
+                &namespace,
+            ),
+            in_cache_num_bytes: new_gauge(
+                "in_cache_num_bytes",
+                "Number of {component_name} bytes in cache",
+                &namespace,
+            ),
+            hits_num_items: new_counter(
+                &format!("cache_hit_total"),
+                "Number of {component_name} cache hits",
+                &namespace,
+            ),
+            hits_num_bytes: new_counter(
+                "cache_hits_bytes",
+                "Number of {component_name} cache hits in bytes",
+                &namespace,
+            ),
+            miss_num_items: new_counter(
+                &format!("cache_miss_total"),
+                "Number of {component_name} cache hits",
+                &namespace,
+            ),
+        }
+    }
+}
+
+impl Default for StorageMetrics {
+    fn default() -> Self {
+        StorageMetrics {
+            fast_field_cache: CacheMetrics::for_component("fastfields"),
+            shortlived_cache: CacheMetrics::for_component("shortlived"),
+            split_footer_cache: CacheMetrics::for_component("splitfooter"),
+        }
+    }
+}
+
+/// Storage counters exposes a bunch a set of storage/cache related metrics through a prometheus
+/// endpoint.
+pub static STORAGE_METRICS: Lazy<StorageMetrics> = Lazy::new(StorageMetrics::default);
+
+#[cfg(test)]
+pub static CACHE_METRICS_FOR_TESTS: Lazy<CacheMetrics> =
+    Lazy::new(|| CacheMetrics::for_component("fortest"));

--- a/quickwit-storage/src/metrics.rs
+++ b/quickwit-storage/src/metrics.rs
@@ -27,6 +27,41 @@ pub struct StorageMetrics {
     pub shortlived_cache: CacheMetrics,
     pub fast_field_cache: CacheMetrics,
     pub split_footer_cache: CacheMetrics,
+    pub object_storage_get_total: IntCounter,
+    pub object_storage_put_total: IntCounter,
+    pub object_storage_put_parts: IntCounter,
+    pub object_storage_download_num_bytes: IntCounter,
+}
+
+impl Default for StorageMetrics {
+    fn default() -> Self {
+        StorageMetrics {
+            fast_field_cache: CacheMetrics::for_component("fastfields"),
+            shortlived_cache: CacheMetrics::for_component("shortlived"),
+            split_footer_cache: CacheMetrics::for_component("splitfooter"),
+            object_storage_get_total: new_counter(
+                "object_storage_gets_total",
+                "Number of objects fetched.",
+                "quickwit_storage",
+            ),
+            object_storage_put_total: new_counter(
+                "object_storage_puts_total",
+                "Number of objects uploaded. May differ from object_storage_requests_parts due to \
+                 multipart upload.",
+                "quickwit_storage",
+            ),
+            object_storage_put_parts: new_counter(
+                "object_storage_puts_parts",
+                "Number of object parts uploaded.",
+                "",
+            ),
+            object_storage_download_num_bytes: new_counter(
+                "object_storage_download_num_bytes",
+                "Amount of data download from an object storage.",
+                "quickwit_storage",
+            ),
+        }
+    }
 }
 
 /// Counters associated to a cache.
@@ -37,7 +72,7 @@ pub struct CacheMetrics {
     pub in_cache_num_bytes: IntGauge,
     pub hits_num_items: IntCounter,
     pub hits_num_bytes: IntCounter,
-    pub miss_num_items: IntCounter,
+    pub misses_num_items: IntCounter,
 }
 
 impl CacheMetrics {
@@ -56,7 +91,7 @@ impl CacheMetrics {
                 &namespace,
             ),
             hits_num_items: new_counter(
-                &format!("cache_hit_total"),
+                "cache_hit_total",
                 "Number of {component_name} cache hits",
                 &namespace,
             ),
@@ -65,21 +100,11 @@ impl CacheMetrics {
                 "Number of {component_name} cache hits in bytes",
                 &namespace,
             ),
-            miss_num_items: new_counter(
-                &format!("cache_miss_total"),
+            misses_num_items: new_counter(
+                "cache_miss_total",
                 "Number of {component_name} cache hits",
                 &namespace,
             ),
-        }
-    }
-}
-
-impl Default for StorageMetrics {
-    fn default() -> Self {
-        StorageMetrics {
-            fast_field_cache: CacheMetrics::for_component("fastfields"),
-            shortlived_cache: CacheMetrics::for_component("shortlived"),
-            split_footer_cache: CacheMetrics::for_component("splitfooter"),
         }
     }
 }

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -341,6 +341,7 @@ impl S3CompatibleObjectStorage {
             content_length: Some(len as i64),
             ..Default::default()
         };
+        crate::STORAGE_METRICS.object_storage_put_parts.inc();
         self.s3_client.put_object(request).await?;
         Ok(())
     }
@@ -434,6 +435,7 @@ impl S3CompatibleObjectStorage {
             upload_id: upload_id.0,
             ..Default::default()
         };
+        crate::STORAGE_METRICS.object_storage_put_parts.inc();
         let upload_part_output = self
             .s3_client
             .upload_part(upload_part_req)
@@ -551,6 +553,7 @@ impl S3CompatibleObjectStorage {
     ) -> GetObjectRequest {
         let key = self.key(path);
         let range_str = range_opt.map(|range| format!("bytes={}-{}", range.start, range.end - 1));
+        crate::STORAGE_METRICS.object_storage_get_total.inc();
         GetObjectRequest {
             bucket: self.bucket.clone(),
             key,
@@ -584,8 +587,12 @@ impl S3CompatibleObjectStorage {
 
 async fn download_all(byte_stream: &mut ByteStream, output: &mut Vec<u8>) -> io::Result<()> {
     output.clear();
+    let object_storage_download_num_bytes = crate::STORAGE_METRICS
+        .object_storage_download_num_bytes
+        .clone();
     while let Some(chunk_res) = byte_stream.next().await {
         let chunk = chunk_res?;
+        object_storage_download_num_bytes.inc_by(chunk.len() as u64);
         output.extend(chunk.as_ref());
     }
     // When calling `get_all`, the Vec capacity is not properly set.
@@ -611,6 +618,7 @@ impl Storage for S3CompatibleObjectStorage {
         path: &Path,
         payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
+        crate::STORAGE_METRICS.object_storage_put_total.inc();
         let key = self.key(path);
         let total_len = payload.len();
         let part_num_bytes = self.multipart_policy.part_num_bytes(total_len);

--- a/scripts/prometheus.yml
+++ b/scripts/prometheus.yml
@@ -1,0 +1,11 @@
+
+global:
+  scrape_interval: 800ms
+  scrape_timeout: 800ms
+
+scrape_configs:
+  - job_name: services
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - '127.0.0.1:7280'


### PR DESCRIPTION
Added a bunch of new prometheus metrics
- allocated memory
- number of active threads in the cpu intensive thread pool
- downloaded bytes from object storage
- number of split search run
- leaf split duration
