### PR TITLE
Using jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2614,7 @@ dependencies = [
  "tabled",
  "tempfile",
  "thousands",
+ "tikv-jemallocator",
  "time 0.3.11",
  "tokio",
  "tokio-util 0.7.3",
@@ -4218,6 +4225,27 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.1+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931e876f91fed0827f863a2d153897790da0b24d882c721a79cb3beb0b903261"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/generate_markdown.rs"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+tikv-jemallocator = "0.5"
 atty = "0.2"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
 clap = { version = "= 3.1", features = ["yaml", "env"] }

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -25,10 +25,14 @@ use opentelemetry::sdk::propagation::TraceContextPropagator;
 use quickwit_cli::cli::{build_cli, CliCommand};
 use quickwit_cli::QW_JAEGER_ENABLED_ENV_KEY;
 use quickwit_telemetry::payload::TelemetryEvent;
+use tikv_jemallocator::Jemalloc;
 use tracing::{info, Level};
 use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 fn setup_logging_and_tracing(level: Level) -> anyhow::Result<()> {
     #[cfg(feature = "tokio-console")]

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -588,6 +588,8 @@ async fn download_all(byte_stream: &mut ByteStream, output: &mut Vec<u8>) -> io:
         let chunk = chunk_res?;
         output.extend(chunk.as_ref());
     }
+    // When calling `get_all`, the Vec capacity is not properly set.
+    output.shrink_to_fit();
     Ok(())
 }
 


### PR DESCRIPTION
Attempt to address #1679

This PR also ensure that `get_all()` returns with a `Vec` with no extra
capacity.
This was a bug in quickwit, but it was only affecting the metastore.json
file since all other files are fetched with a specific slice.
