### PR TITLE
Tweaking cache eviction policy to help with super large queries.

### DIFF
--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -48,6 +48,7 @@ tracing = "0.1.29"
 [dev-dependencies]
 mockall = "0.11"
 tracing-subscriber = "0.3"
+tokio = { version = "1", features = ["full", "test-util"] }
 
 [features]
 testsuite = ["mockall"]

--- a/quickwit-storage/src/cache/memory_sized_cache.rs
+++ b/quickwit-storage/src/cache/memory_sized_cache.rs
@@ -22,13 +22,32 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use lru::{KeyRef, LruCache};
+use tokio::time::Instant;
 use tracing::{error, warn};
 
 use crate::cache::slice_address::{SliceAddress, SliceAddressKey, SliceAddressRef};
+use crate::cache::stored_item::StoredItem;
 use crate::metrics::CacheMetrics;
 use crate::OwnedBytes;
+
+/// We do not evict anything that has been accessed in the last 60s.
+///
+/// The goal is to behave better on scan access patterns, without being as aggressive as
+/// using a MRU strategy.
+///
+/// TLDR is:
+///
+/// If two items have been access in the last 60s it is not really worth considering the
+/// latter too be more recent than the previous and do an eviction.
+/// The difference is not significant enough to raise the probability of its future access.
+///
+/// On the other hand, for very large queries involving enough data to saturate the cache,
+/// we are facing a scanning pattern. If variations of this  query is repeated over and over
+/// a regular LRU eviction policy would yield a hit rate of 0.
+const MIN_TIME_SINCE_LAST_ACCESS: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug)]
 enum Capacity {
@@ -44,8 +63,9 @@ impl Capacity {
         }
     }
 }
+
 struct NeedMutMemorySizedCache<K: Hash + Eq> {
-    lru_cache: LruCache<K, OwnedBytes>,
+    lru_cache: LruCache<K, StoredItem>,
     num_items: usize,
     num_bytes: u64,
     capacity: Capacity,
@@ -97,14 +117,15 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
         KeyRef<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let item_opt = self.lru_cache.get(cache_key).cloned();
-        if let Some(item) = item_opt.as_ref() {
+        let item_opt = self.lru_cache.get_mut(cache_key);
+        if let Some(item) = item_opt {
             self.cache_counters.hits_num_items.inc();
             self.cache_counters.hits_num_bytes.inc_by(item.len() as u64);
+            Some(item.payload())
         } else {
             self.cache_counters.misses_num_items.inc();
+            None
         }
-        item_opt
     }
 
     /// Attempt to put the given amount of data in the cache.
@@ -123,10 +144,22 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
         if let Some(previous_data) = self.lru_cache.pop(&key) {
             self.drop_item(previous_data.len() as u64);
         }
+
+        let now = Instant::now();
         while self
             .capacity
             .exceeds_capacity(self.num_bytes as usize + bytes.len())
         {
+            if let Some((_, candidate_for_eviction)) = self.lru_cache.peek_lru() {
+                let time_since_last_access =
+                    now.duration_since(candidate_for_eviction.last_access_time());
+                if time_since_last_access < MIN_TIME_SINCE_LAST_ACCESS {
+                    // It is not worth doing an eviction.
+                    // TODO: It is sub-optimal that we might have needlessly evicted items in this
+                    // loop before just returning.
+                    return;
+                }
+            }
             if let Some((_, bytes)) = self.lru_cache.pop_lru() {
                 self.drop_item(bytes.len() as u64);
             } else {
@@ -139,7 +172,7 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
             }
         }
         self.record_item(bytes.len() as u64);
-        self.lru_cache.put(key, bytes);
+        self.lru_cache.put(key, StoredItem::new(bytes, now));
     }
 }
 
@@ -211,8 +244,9 @@ mod tests {
     use super::*;
     use crate::metrics::CACHE_METRICS_FOR_TESTS;
 
-    #[test]
-    fn test_cache_edge_condition() {
+    #[tokio::test]
+    async fn test_cache_edge_condition() {
+        tokio::time::pause();
         let cache = MemorySizedCache::<String>::with_capacity_in_bytes(5, &CACHE_METRICS_FOR_TESTS);
         {
             let data = OwnedBytes::new(&b"abc"[..]);
@@ -229,11 +263,19 @@ mod tests {
         {
             let data = OwnedBytes::new(&b"fghij"[..]);
             cache.put("5".to_string(), data);
+            // Eviction should not happen, because all items in cache are too young.
+            assert!(cache.get(&"5".to_string()).is_none());
+        }
+        tokio::time::advance(super::MIN_TIME_SINCE_LAST_ACCESS.mul_f32(1.1f32)).await;
+        {
+            let data = OwnedBytes::new(&b"fghij"[..]);
+            cache.put("5".to_string(), data);
             assert_eq!(cache.get(&"5".to_string()).unwrap(), &b"fghij"[..]);
             // our two first entries should have be removed from the cache
             assert!(cache.get(&"2".to_string()).is_none());
             assert!(cache.get(&"3".to_string()).is_none());
         }
+        tokio::time::advance(super::MIN_TIME_SINCE_LAST_ACCESS.mul_f32(1.1f32)).await;
         {
             let data = OwnedBytes::new(&b"klmnop"[..]);
             cache.put("6".to_string(), data);

--- a/quickwit-storage/src/cache/mod.rs
+++ b/quickwit-storage/src/cache/mod.rs
@@ -21,6 +21,7 @@ mod memory_sized_cache;
 mod quickwit_cache;
 mod slice_address;
 mod storage_with_cache;
+mod stored_item;
 
 use std::ops::Range;
 use std::path::{Path, PathBuf};

--- a/quickwit-storage/src/cache/quickwit_cache.rs
+++ b/quickwit-storage/src/cache/quickwit_cache.rs
@@ -80,6 +80,9 @@ impl QuickwitCache {
 #[async_trait]
 impl Cache for QuickwitCache {
     async fn get(&self, path: &Path, byte_range: Range<usize>) -> Option<OwnedBytes> {
+        // We don't check for the presence of the entire file in the
+        // cache.
+        // That's voluntary to avoid messing with the cache miss counts.
         if let Some(cache) = self.get_relevant_cache(path) {
             return cache.get(path, byte_range).await;
         }
@@ -133,9 +136,6 @@ impl SimpleCache {
 #[async_trait]
 impl Cache for SimpleCache {
     async fn get(&self, path: &Path, byte_range: Range<usize>) -> Option<OwnedBytes> {
-        if let Some(bytes) = self.get_all(path).await {
-            return Some(bytes.slice(byte_range.clone()));
-        }
         if let Some(bytes) = self.slice_cache.get_slice(path, byte_range) {
             return Some(bytes);
         }

--- a/quickwit-storage/src/cache/stored_item.rs
+++ b/quickwit-storage/src/cache/stored_item.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Quickwit, Inc.
+// Copyright (C) 2022 Quickwit, Inc.
 //
 // Quickwit is offered under the AGPL v3.0 and as commercial software.
 // For commercial licensing, contact us at hello@quickwit.io.
@@ -16,7 +16,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-//
 
 use tantivy::directory::OwnedBytes;
 use tokio::time::Instant;

--- a/quickwit-storage/src/cache/stored_item.rs
+++ b/quickwit-storage/src/cache/stored_item.rs
@@ -1,0 +1,53 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use tantivy::directory::OwnedBytes;
+use tokio::time::Instant;
+
+/// It is a bit overkill to put this in its own module, but I
+/// wanted to ensure that no one would access payload without updating `last_access_time`.
+pub(super) struct StoredItem {
+    last_access_time: Instant,
+    payload: OwnedBytes,
+}
+
+impl StoredItem {
+    pub fn new(payload: OwnedBytes, now: Instant) -> Self {
+        StoredItem {
+            last_access_time: now,
+            payload,
+        }
+    }
+}
+
+impl StoredItem {
+    pub fn payload(&mut self) -> OwnedBytes {
+        self.last_access_time = Instant::now();
+        self.payload.clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.payload.len()
+    }
+
+    pub fn last_access_time(&self) -> Instant {
+        self.last_access_time.clone()
+    }
+}


### PR DESCRIPTION
The new policy is like LRU, except we avoid admitting
a new item if it would mean evicting an item that has been accessed
in the last 60s.

The goal is to behave better on scan access patterns, without being as aggressive as
using a MRU strategy.

Closes #1714
