### PR TITLE
Improve fast field warm up logic

### DIFF
--- a/quickwit-search/src/collector.rs
+++ b/quickwit-search/src/collector.rs
@@ -30,10 +30,10 @@ use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResult
 use tantivy::aggregation::AggregationSegmentCollector;
 use tantivy::collector::{Collector, SegmentCollector};
 use tantivy::fastfield::{DynamicFastFieldReader, FastFieldReader};
-use tantivy::schema::{Field, Schema};
+use tantivy::schema::Schema;
 use tantivy::{DocId, Score, SegmentOrdinal, SegmentReader};
 
-use crate::filters::TimestampFilter;
+use crate::filters::{TimestampFilter, TimestampFilterBuilder};
 use crate::partial_hit_sorting_key;
 
 /// The `SortingFieldComputer` can be seen as the specialization of `SortBy` applied to a specific
@@ -240,18 +240,24 @@ pub struct QuickwitCollector {
     pub start_offset: usize,
     pub max_hits: usize,
     pub sort_by: SortBy,
-    pub fast_field_names: HashSet<String>,
-    pub timestamp_field_opt: Option<Field>,
-    pub start_timestamp_opt: Option<i64>,
-    pub end_timestamp_opt: Option<i64>,
+    timestamp_filter_builder_opt: Option<TimestampFilterBuilder>,
     pub aggregation: Option<Aggregations>,
 }
 
 impl QuickwitCollector {
     pub fn fast_field_names(&self) -> HashSet<String> {
-        let mut fast_field_names = self.fast_field_names.clone();
+        let mut fast_field_names = HashSet::default();
+        match &self.sort_by {
+            SortBy::DocId => {}
+            SortBy::FastField { field_name, .. } => {
+                fast_field_names.insert(field_name.clone());
+            }
+        }
         if let Some(aggregate) = self.aggregation.as_ref() {
             fast_field_names.extend(get_fast_field_names(aggregate));
+        }
+        if let Some(timestamp_filter_builder) = &self.timestamp_filter_builder_opt {
+            fast_field_names.insert(timestamp_filter_builder.timestamp_field_name.clone());
         }
         fast_field_names
     }
@@ -280,23 +286,12 @@ impl Collector for QuickwitCollector {
         // starting from 0 for every leaves.
         let leaf_max_hits = self.max_hits + self.start_offset;
 
-        // Timestamp filter is needed when:
-        //   - there is a timestamp field.
-        //   - AND there is a start OR end timestamp.
-        let timestamp_filter_opt = if let Some(timestamp_field) = self.timestamp_field_opt {
-            if self.start_timestamp_opt.is_some() || self.end_timestamp_opt.is_some() {
-                TimestampFilter::new(
-                    timestamp_field,
-                    self.start_timestamp_opt,
-                    self.end_timestamp_opt,
-                    segment_reader,
-                )?
+        let timestamp_filter_opt =
+            if let Some(timestamp_filter_builder) = &self.timestamp_filter_builder_opt {
+                timestamp_filter_builder.build(segment_reader)?
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
 
         Ok(QuickwitSegmentCollector {
             num_hits: 0u64,
@@ -423,26 +418,6 @@ fn top_k_partial_hits(mut partial_hits: Vec<PartialHit>, num_hits: usize) -> Vec
     partial_hits
 }
 
-/// Extracts all fast field names.
-fn extract_fast_field_names(
-    doc_mapper: &dyn DocMapper,
-    search_request: &SearchRequest,
-) -> HashSet<String> {
-    let mut fast_fields = HashSet::new();
-    if let Some(timestamp_field) = doc_mapper.timestamp_field_name() {
-        if search_request.start_timestamp.is_some() || search_request.end_timestamp.is_some() {
-            fast_fields.insert(timestamp_field);
-        }
-    }
-    if let SortBy::FastField { field_name, .. } = doc_mapper.sort_by() {
-        fast_fields.insert(field_name);
-    }
-    if let SortBy::FastField { field_name, .. } = SortBy::from(search_request) {
-        fast_fields.insert(field_name);
-    }
-    fast_fields
-}
-
 /// Builds the QuickwitCollector, in function of the information that was requested by the user.
 pub fn make_collector_for_split(
     split_id: String,
@@ -455,15 +430,21 @@ pub fn make_collector_for_split(
     } else {
         None
     };
+
+    let timestamp_field_opt = doc_mapper.timestamp_field(split_schema);
+    let timestamp_filter_builder_opt = TimestampFilterBuilder::new(
+        doc_mapper.timestamp_field_name(),
+        timestamp_field_opt,
+        search_request.start_timestamp,
+        search_request.end_timestamp,
+    );
+
     Ok(QuickwitCollector {
         split_id,
         start_offset: search_request.start_offset as usize,
         max_hits: search_request.max_hits as usize,
         sort_by: search_request.into(),
-        fast_field_names: extract_fast_field_names(doc_mapper, search_request),
-        timestamp_field_opt: doc_mapper.timestamp_field(split_schema),
-        start_timestamp_opt: search_request.start_timestamp,
-        end_timestamp_opt: search_request.end_timestamp,
+        timestamp_filter_builder_opt,
         aggregation,
     })
 }
@@ -478,16 +459,12 @@ pub fn make_merge_collector(search_request: &SearchRequest) -> crate::Result<Qui
     } else {
         None
     };
-
     Ok(QuickwitCollector {
         split_id: String::default(),
         start_offset: search_request.start_offset as usize,
         max_hits: search_request.max_hits as usize,
         sort_by: SortBy::DocId,
-        fast_field_names: HashSet::new(),
-        timestamp_field_opt: None,
-        start_timestamp_opt: search_request.start_timestamp,
-        end_timestamp_opt: search_request.end_timestamp,
+        timestamp_filter_builder_opt: None,
         aggregation,
     })
 }


### PR DESCRIPTION
Closes #1751
Related to #1749 (does not address the case where the entire split is
within the timestamp bounds)
