### PR TITLE
Updated section S3-compatible Object Storage in docs "storage-uri.md"

### DIFF
--- a/docs/reference/storage-uri.md
+++ b/docs/reference/storage-uri.md
@@ -77,7 +77,9 @@ This is done by setting an endpoint url in the `QW_S3_ENDPOINT` environment vari
 
 In this case, the region will be ignored.
 
-Set up the endpoint url:
+Example of using Google Cloud Storage: 
+```bash
+export QW_S3_ENDPOINT=https://storage.googleapis.com
 ```bash
 export QW_S3_ENDPOINT=http://localhost:9000/
 ```

--- a/docs/reference/storage-uri.md
+++ b/docs/reference/storage-uri.md
@@ -69,15 +69,26 @@ The region or custom endpoint will be detected using the first successful method
 - `AWS_REGION` environment variable
 - Amazon’s instance metadata API [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
 
-### S3-compatible Objective storage like Minio
+### S3-compatible Object Storage like Minio, Google Cloud Storage, and more.
 
 
-Quickwit can target other S3-compatible storage like MinIO.
+Quickwit can target other S3-compatible storage.
 This is done by setting an endpoint url in the `QW_S3_ENDPOINT` environment variable.
 
 In this case, the region will be ignored.
 
-For instance:
+Set up the endpoint url:
 ```bash
 export QW_S3_ENDPOINT=http://localhost:9000/
+```
+
+:::note
+In case that you are using Google Cloud Storage, use ``` https://storage.googleapis.com ``` as the endpoint url. 
+
+:::
+
+Get an access key & a secret key from the object storage of your preference and run the following commands:
+```bash
+export AWS_SECRET_ACCESS_KEY=***
+export AWS_ACCESS_KEY_ID=***
 ```

--- a/docs/reference/storage-uri.md
+++ b/docs/reference/storage-uri.md
@@ -77,17 +77,14 @@ This is done by setting an endpoint url in the `QW_S3_ENDPOINT` environment vari
 
 In this case, the region will be ignored.
 
-Example of using Google Cloud Storage: 
-```bash
-export QW_S3_ENDPOINT=https://storage.googleapis.com
+Example: 
 ```bash
 export QW_S3_ENDPOINT=http://localhost:9000/
 ```
-
-:::note
-In case that you are using Google Cloud Storage, use ``` https://storage.googleapis.com ``` as the endpoint url. 
-
-:::
+Example for Google Cloud Storage:
+```bash
+export QW_S3_ENDPOINT=https://storage.googleapis.com
+```
 
 Get an access key & a secret key from the object storage of your preference and run the following commands:
 ```bash


### PR DESCRIPTION
### Description

The methods used were proposed by Saroh in a closed issue #1584 

Added note with the endpoint url for Google Cloud Storage
Added instructions to get and to run commands for AWS_SECRET_ACCESS_KEY & AWS_ACCESS_KEY_ID
Typo fixes

### How was this PR tested?

Tried to create an index with Google Cloud Storage. Only works if access token, secret token, and the right GCS endpoint url assigned.