### PR TITLE
RocksDB configuration.

### DIFF
--- a/quickwit-ingest-api/src/queue.rs
+++ b/quickwit-ingest-api/src/queue.rs
@@ -39,6 +39,8 @@ fn default_rocks_db_options() -> rocksdb::Options {
     // TODO tweak
     let mut options = rocksdb::Options::default();
     options.create_if_missing(true);
+    options.set_max_open_files(512);
+    options.set_max_total_wal_size(100_000_000);
     options
 }
 
@@ -153,6 +155,8 @@ impl Queues {
             last_position
         };
 
+        self.db
+            .delete_file_in_range_cf(&cf_ref, Position::default(), truncation_end_offset)?;
         self.db
             .delete_range_cf(&cf_ref, Position::default(), truncation_end_offset)?;
         Ok(())


### PR DESCRIPTION
We are using one column family per index and a shared WAL for
all column family.

RocksDB seem to not being able to truncate the WAL itself
on delete range unfortunately, and the default policy tends
to be per-cf which leads to a very high disk usage
when using a lot of indexes.

This PR force flush once the WAL reaches 100MB.
This is quite low, to avoid the push service to block
for too long.

### Description

Describe the proposed changes made in this PR.

### How was this PR tested?

Describe how you tested this PR.
