### PR TITLE
First stab: extracting the checkpoint delta from the indexed split.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.14"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943a505c17b494638a38a9af129067f760c9c06794b9f57d499266909be8e72"
+checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -2622,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6ffbe862780245013cb1c0a48c4e44b7d665548088f91f6b90876d0625e4c2"
+checksum = "fffbe84bf1905c007253d1f10ffb85fbc8ca8624a40cff8f2ded6f36920e38e0"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit-indexing/src/actors/merge_executor.rs
@@ -328,8 +328,6 @@ impl MergeExecutor {
             demux_num_ops: 0,
             num_docs,
             docs_size_in_bytes,
-            // start_time is not very interesting here.
-            split_date_of_birth: Instant::now(),
             index: merged_index,
             index_writer,
             split_scratch_directory: merge_scratch_directory,
@@ -341,6 +339,7 @@ impl MergeExecutor {
             IndexedSplitBatch {
                 splits: vec![indexed_split],
                 checkpoint_delta: Default::default(),
+                date_of_birth: start,
             },
         )
         .await?;
@@ -473,7 +472,6 @@ impl MergeExecutor {
                 demux_num_ops: initial_demux_num_ops + 1,
                 num_docs: num_docs as u64,
                 docs_size_in_bytes,
-                split_date_of_birth: Instant::now(),
                 index,
                 index_writer,
                 split_scratch_directory: scratched_directory,
@@ -494,6 +492,7 @@ impl MergeExecutor {
             IndexedSplitBatch {
                 splits: indexed_splits,
                 checkpoint_delta: None,
+                date_of_birth: start,
             },
         )
         .await?;

--- a/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit-indexing/src/actors/merge_executor.rs
@@ -31,7 +31,6 @@ use quickwit_common::runtimes::RuntimeType;
 use quickwit_common::split_file;
 use quickwit_directories::{BundleDirectory, UnionDirectory};
 use quickwit_doc_mapper::QUICKWIT_TOKENIZER_MANAGER;
-use quickwit_metastore::checkpoint::CheckpointDelta;
 use quickwit_metastore::SplitMetadata;
 use tantivy::directory::{DirectoryClone, MmapDirectory, RamDirectory};
 use tantivy::fastfield::{DynamicFastFieldReader, FastFieldReader};
@@ -331,7 +330,6 @@ impl MergeExecutor {
             docs_size_in_bytes,
             // start_time is not very interesting here.
             split_date_of_birth: Instant::now(),
-            checkpoint_delta: CheckpointDelta::default(), //< TODO fixme
             index: merged_index,
             index_writer,
             split_scratch_directory: merge_scratch_directory,
@@ -342,6 +340,7 @@ impl MergeExecutor {
             &self.merge_packager_mailbox,
             IndexedSplitBatch {
                 splits: vec![indexed_split],
+                checkpoint_delta: Default::default(),
             },
         )
         .await?;
@@ -475,7 +474,6 @@ impl MergeExecutor {
                 num_docs: num_docs as u64,
                 docs_size_in_bytes,
                 split_date_of_birth: Instant::now(),
-                checkpoint_delta: CheckpointDelta::default(), //< TODO fixme
                 index,
                 index_writer,
                 split_scratch_directory: scratched_directory,
@@ -495,6 +493,7 @@ impl MergeExecutor {
             &self.merge_packager_mailbox,
             IndexedSplitBatch {
                 splits: indexed_splits,
+                checkpoint_delta: None,
             },
         )
         .await?;

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -144,7 +144,7 @@ impl Handler<IndexedSplitBatch> for Packager {
         }
         ctx.send_message(
             &self.uploader_mailbox,
-            PackagedSplitBatch::new(packaged_splits, batch.checkpoint_delta),
+            PackagedSplitBatch::new(packaged_splits, batch.checkpoint_delta, batch.date_of_birth),
         )
         .await?;
         fail_point!("packager:after");
@@ -350,7 +350,6 @@ fn create_packaged_split(
         time_range: split.time_range,
         size_in_bytes: split.docs_size_in_bytes,
         tags,
-        split_date_of_birth: split.split_date_of_birth,
         split_files,
         hotcache_bytes,
     };

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -440,7 +440,6 @@ mod tests {
             demux_num_ops: 0,
             num_docs,
             docs_size_in_bytes: num_docs * 15, //< bogus number
-            split_date_of_birth: Instant::now(),
             index,
             index_writer,
             split_scratch_directory,
@@ -483,6 +482,7 @@ mod tests {
             .send_message(IndexedSplitBatch {
                 splits: vec![indexed_split],
                 checkpoint_delta: IndexCheckpointDelta::for_test("source_id", 10..20).into(),
+                date_of_birth: Instant::now(),
             })
             .await?;
         assert_eq!(
@@ -526,6 +526,7 @@ mod tests {
             .send_message(IndexedSplitBatch {
                 splits: vec![indexed_split],
                 checkpoint_delta: IndexCheckpointDelta::for_test("source_id", 10..20).into(),
+                date_of_birth: Instant::now(),
             })
             .await?;
         assert_eq!(
@@ -551,6 +552,7 @@ mod tests {
             .send_message(IndexedSplitBatch {
                 splits: vec![indexed_split_1, indexed_split_2],
                 checkpoint_delta: IndexCheckpointDelta::for_test("source_id", 10..20).into(),
+                date_of_birth: Instant::now(),
             })
             .await?;
         assert_eq!(

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -128,7 +128,7 @@ impl Handler<SplitUpdate> for Publisher {
             index_id,
             new_splits,
             replaced_split_ids,
-            split_date_of_birth,
+            date_of_birth,
             checkpoint_delta_opt,
         } = split_update;
 
@@ -147,7 +147,7 @@ impl Handler<SplitUpdate> for Publisher {
             .await
             .context("Failed to publish splits.")?;
 
-        info!(new_splits=?split_ids, tts=%split_date_of_birth.elapsed().as_secs_f32(), checkpoint_delta=?checkpoint_delta_opt, "publish-new-splits");
+        info!(new_splits=?split_ids, tts=%date_of_birth.elapsed().as_secs_f32(), checkpoint_delta=?checkpoint_delta_opt, "publish-new-splits");
         if let Some(source_mailbox) = self.source_mailbox_opt.as_ref() {
             if let Some(checkpoint) = checkpoint_delta_opt {
                 // We voluntarily do not log anything here.

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -23,12 +23,11 @@ use anyhow::Context;
 use async_trait::async_trait;
 use fail::fail_point;
 use quickwit_actors::{Actor, ActorContext, Handler, Mailbox};
-use quickwit_metastore::checkpoint::SourceCheckpoint;
 use quickwit_metastore::Metastore;
 use tracing::info;
 
 use crate::actors::{GarbageCollector, MergePlanner};
-use crate::models::{NewSplits, PublishNewSplit, PublisherMessage, ReplaceSplits};
+use crate::models::{NewSplits, SplitUpdate};
 use crate::source::{SourceActor, SuggestTruncate};
 
 #[derive(Debug, Clone, Default)]
@@ -54,7 +53,6 @@ impl PublisherType {
 
 pub struct Publisher {
     publisher_type: PublisherType,
-    source_id: String,
     metastore: Arc<dyn Metastore>,
     merge_planner_mailbox: Mailbox<MergePlanner>,
     garbage_collector_mailbox: Mailbox<GarbageCollector>,
@@ -65,7 +63,6 @@ pub struct Publisher {
 impl Publisher {
     pub fn new(
         publisher_type: PublisherType,
-        source_id: String,
         metastore: Arc<dyn Metastore>,
         merge_planner_mailbox: Mailbox<MergePlanner>,
         garbage_collector_mailbox: Mailbox<GarbageCollector>,
@@ -73,7 +70,6 @@ impl Publisher {
     ) -> Publisher {
         Publisher {
             publisher_type,
-            source_id,
             metastore,
             merge_planner_mailbox,
             garbage_collector_mailbox,
@@ -118,92 +114,56 @@ impl Actor for Publisher {
 }
 
 #[async_trait]
-impl Handler<PublishNewSplit> for Publisher {
+impl Handler<SplitUpdate> for Publisher {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        publish_new_split: PublishNewSplit,
+        split_update: SplitUpdate,
         ctx: &ActorContext<Self>,
     ) -> Result<(), quickwit_actors::ActorExitStatus> {
         fail_point!("publisher:before");
 
-        let PublishNewSplit {
+        let SplitUpdate {
             index_id,
-            new_split,
+            new_splits,
+            replaced_split_ids,
             split_date_of_birth,
-            checkpoint_delta,
-        } = publish_new_split;
+            checkpoint_delta_opt,
+        } = split_update;
+
+        let split_ids: Vec<&str> = new_splits.iter().map(|split| split.split_id()).collect();
+
+        let replaced_split_ids_ref_vec: Vec<&str> =
+            replaced_split_ids.iter().map(String::as_str).collect();
 
         self.metastore
             .publish_splits(
                 &index_id,
-                &self.source_id,
-                &[new_split.split_id()],
-                checkpoint_delta.clone(),
+                &split_ids[..],
+                &replaced_split_ids_ref_vec,
+                checkpoint_delta_opt.clone(),
             )
             .await
             .context("Failed to publish splits.")?;
 
-        info!(new_split=new_split.split_id(), tts=%split_date_of_birth.elapsed().as_secs_f32(), checkpoint_delta=?checkpoint_delta, "publish-new-splits");
-        let checkpoint: SourceCheckpoint = checkpoint_delta.get_source_checkpoint();
+        info!(new_splits=?split_ids, tts=%split_date_of_birth.elapsed().as_secs_f32(), checkpoint_delta=?checkpoint_delta_opt, "publish-new-splits");
         if let Some(source_mailbox) = self.source_mailbox_opt.as_ref() {
-            // We voluntarily do not log anything here.
-            //
-            // Not being to send the truncation message is a common event and should not be
-            // considered an error. For instance, if the source is a
-            // FileSource, it will terminate upon EOF and drop its
-            // mailbox.
-            let _ = ctx
-                .send_message(source_mailbox, SuggestTruncate(checkpoint))
-                .await;
+            if let Some(checkpoint) = checkpoint_delta_opt {
+                // We voluntarily do not log anything here.
+                //
+                // Not being to send the truncation message is a common event and should not be
+                // considered an error. For instance, if the source is a
+                // FileSource, it will terminate upon EOF and drop its
+                // mailbox.
+                let _ = ctx
+                    .send_message(
+                        source_mailbox,
+                        SuggestTruncate(checkpoint.source_delta.get_source_checkpoint()),
+                    )
+                    .await;
+            }
         }
-
-        // The merge planner is not necessarily awake and this is not an error.
-        // For instance, when a source reaches its end, and the last "new" split
-        // has been packaged, the packager finalizer sends a message to the merge
-        // planner in order to stop it.
-        let _ = ctx
-            .send_message(
-                &self.merge_planner_mailbox,
-                NewSplits {
-                    new_splits: vec![new_split],
-                },
-            )
-            .await;
-        self.counters.num_published_splits += 1;
-        fail_point!("publisher:after");
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Handler<ReplaceSplits> for Publisher {
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        replace_splits: ReplaceSplits,
-        ctx: &ActorContext<Self>,
-    ) -> Result<(), quickwit_actors::ActorExitStatus> {
-        let ReplaceSplits {
-            index_id,
-            new_splits,
-            replaced_split_ids,
-        } = replace_splits;
-
-        let new_split_ids: Vec<&str> = new_splits
-            .iter()
-            .map(|new_split| new_split.split_id())
-            .collect();
-        let replaced_split_ids_ref_vec: Vec<&str> =
-            replaced_split_ids.iter().map(String::as_str).collect();
-        self.metastore
-            .replace_splits(&index_id, &new_split_ids, &replaced_split_ids_ref_vec[..])
-            .await
-            .context("Failed to replace splits.")?;
-
-        info!(new_splits=?new_split_ids, replaced_splits=?replaced_split_ids, "replace-splits");
 
         // The merge planner is not necessarily awake and this is not an error.
         // For instance, when a source reaches its end, and the last "new" split
@@ -212,28 +172,13 @@ impl Handler<ReplaceSplits> for Publisher {
         let _ = ctx
             .send_message(&self.merge_planner_mailbox, NewSplits { new_splits })
             .await;
-
-        self.counters.num_replace_operations += 1;
-
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Handler<PublisherMessage> for Publisher {
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        publisher_message: PublisherMessage,
-        ctx: &ActorContext<Self>,
-    ) -> Result<(), quickwit_actors::ActorExitStatus> {
-        match publisher_message {
-            PublisherMessage::NewSplit(new_split) => self.handle(new_split, ctx).await,
-            PublisherMessage::ReplaceSplits(replace_splits) => {
-                self.handle(replace_splits, ctx).await
-            }
+        if replaced_split_ids.is_empty() {
+            self.counters.num_published_splits += 1;
+        } else {
+            self.counters.num_replace_operations += 1;
         }
+        fail_point!("publisher:after");
+        Ok(())
     }
 }
 
@@ -242,7 +187,9 @@ mod tests {
     use std::time::Instant;
 
     use quickwit_actors::{create_test_mailbox, Universe};
-    use quickwit_metastore::checkpoint::{CheckpointDelta, PartitionId, Position};
+    use quickwit_metastore::checkpoint::{
+        IndexCheckpointDelta, PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
+    };
     use quickwit_metastore::{MockMetastore, SplitMetadata};
 
     use super::*;
@@ -253,12 +200,16 @@ mod tests {
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
             .expect_publish_splits()
-            .withf(|index_id, source_id, split_ids, checkpoint_delta| {
-                index_id == "index"
-                    && source_id == "source"
-                    && split_ids[..] == ["split"]
-                    && checkpoint_delta == &CheckpointDelta::from(1..3)
-            })
+            .withf(
+                |index_id, split_ids, replaced_split_ids, checkpoint_delta_opt| {
+                    let checkpoint_delta = checkpoint_delta_opt.as_ref().unwrap();
+                    index_id == "index"
+                        && checkpoint_delta.source_id == "source"
+                        && split_ids[..] == ["split"]
+                        && replaced_split_ids.is_empty()
+                        && &checkpoint_delta.source_delta == &SourceCheckpointDelta::from(1..3)
+                },
+            )
             .times(1)
             .returning(|_, _, _, _| Ok(()));
         let (merge_planner_mailbox, merge_planner_inbox) = create_test_mailbox();
@@ -268,7 +219,6 @@ mod tests {
 
         let publisher = Publisher::new(
             PublisherType::MainPublisher,
-            "source".to_string(),
             Arc::new(mock_metastore),
             merge_planner_mailbox,
             garbage_collector_mailbox,
@@ -278,13 +228,17 @@ mod tests {
         let (publisher_mailbox, publisher_handle) = universe.spawn_actor(publisher).spawn();
 
         assert!(publisher_mailbox
-            .send_message(PublishNewSplit {
+            .send_message(SplitUpdate {
                 index_id: "index".to_string(),
-                new_split: SplitMetadata {
+                new_splits: vec![SplitMetadata {
                     split_id: "split".to_string(),
                     ..Default::default()
-                },
-                checkpoint_delta: CheckpointDelta::from(1..3),
+                }],
+                replaced_split_ids: Vec::new(),
+                checkpoint_delta_opt: Some(IndexCheckpointDelta {
+                    source_id: "source".to_string(),
+                    source_delta: SourceCheckpointDelta::from(1..3),
+                }),
                 split_date_of_birth: Instant::now(),
             })
             .await
@@ -317,19 +271,21 @@ mod tests {
         quickwit_common::setup_logging_for_tests();
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
-            .expect_replace_splits()
-            .withf(|index_id, new_split_ids, replaced_split_ids| {
-                index_id == "index"
-                    && new_split_ids[..] == ["split3"]
-                    && replaced_split_ids[..] == ["split1", "split2"]
-            })
+            .expect_publish_splits()
+            .withf(
+                |index_id, new_split_ids, replaced_split_ids, checkpoint_delta_opt| {
+                    index_id == "index"
+                        && new_split_ids[..] == ["split3"]
+                        && replaced_split_ids[..] == ["split1", "split2"]
+                        && checkpoint_delta_opt.is_none()
+                },
+            )
             .times(1)
-            .returning(|_, _, _| Ok(()));
+            .returning(|_, _, _, _| Ok(()));
         let (merge_planner_mailbox, merge_planner_inbox) = create_test_mailbox();
         let (garbage_collector_mailbox, _garbage_collector_inbox) = create_test_mailbox();
         let publisher = Publisher::new(
             PublisherType::MainPublisher,
-            "source".to_string(),
             Arc::new(mock_metastore),
             merge_planner_mailbox,
             garbage_collector_mailbox,
@@ -337,13 +293,15 @@ mod tests {
         );
         let universe = Universe::new();
         let (publisher_mailbox, publisher_handle) = universe.spawn_actor(publisher).spawn();
-        let publisher_message = ReplaceSplits {
+        let publisher_message = SplitUpdate {
             index_id: "index".to_string(),
             new_splits: vec![SplitMetadata {
                 split_id: "split3".to_string(),
                 ..Default::default()
             }],
             replaced_split_ids: vec!["split1".to_string(), "split2".to_string()],
+            checkpoint_delta_opt: None,
+            split_date_of_birth: Instant::now(),
         };
         assert!(publisher_mailbox
             .send_message(publisher_message)

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -207,7 +207,7 @@ mod tests {
                         && checkpoint_delta.source_id == "source"
                         && split_ids[..] == ["split"]
                         && replaced_split_ids.is_empty()
-                        && &checkpoint_delta.source_delta == &SourceCheckpointDelta::from(1..3)
+                        && checkpoint_delta.source_delta == SourceCheckpointDelta::from(1..3)
                 },
             )
             .times(1)
@@ -239,7 +239,7 @@ mod tests {
                     source_id: "source".to_string(),
                     source_delta: SourceCheckpointDelta::from(1..3),
                 }),
-                split_date_of_birth: Instant::now(),
+                date_of_birth: Instant::now(),
             })
             .await
             .is_ok());
@@ -301,7 +301,7 @@ mod tests {
             }],
             replaced_split_ids: vec!["split1".to_string(), "split2".to_string()],
             checkpoint_delta_opt: None,
-            split_date_of_birth: Instant::now(),
+            date_of_birth: Instant::now(),
         };
         assert!(publisher_mailbox
             .send_message(publisher_message)

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -326,11 +326,11 @@ mod tests {
                     demux_num_ops: 0,
                     tags: Default::default(),
                     replaced_split_ids: Vec::new(),
-                    split_date_of_birth: Instant::now(),
                     hotcache_bytes: vec![],
                     split_files: vec![],
                 }],
                 checkpoint_delta_opt,
+                Instant::now(),
             ))
             .await?;
         assert_eq!(
@@ -350,7 +350,7 @@ mod tests {
             new_splits,
             checkpoint_delta_opt,
             replaced_split_ids,
-            split_update_date_of_birth: _,
+            date_of_birth: _,
         } = publisher_message;
         assert_eq!(new_splits.len(), 1);
         assert_eq!(index_id, "test-index");
@@ -409,7 +409,6 @@ mod tests {
                 "replaced-split-1".to_string(),
                 "replaced-split-2".to_string(),
             ],
-            split_date_of_birth: Instant::now(), // FIXE ME
             split_files: vec![],
             hotcache_bytes: vec![],
         };
@@ -426,7 +425,6 @@ mod tests {
                 "replaced-split-1".to_string(),
                 "replaced-split-2".to_string(),
             ],
-            split_date_of_birth: Instant::now(),
             split_files: vec![],
             hotcache_bytes: vec![],
         };
@@ -434,6 +432,7 @@ mod tests {
             .send_message(PackagedSplitBatch::new(
                 vec![packaged_split_1, package_split_2],
                 None,
+                Instant::now(),
             ))
             .await?;
         assert_eq!(
@@ -454,7 +453,7 @@ mod tests {
             new_splits,
             mut replaced_split_ids,
             checkpoint_delta_opt,
-            split_update_date_of_birth: _,
+            date_of_birth: _,
         } = publisher_message;
         assert_eq!(&index_id, "test-index");
         // Sort first to avoid test failing.

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -23,12 +23,14 @@ use std::mem;
 use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::{bail, Context};
 use async_trait::async_trait;
 use fail::fail_point;
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
+use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::{Metastore, SplitMetadata};
 use quickwit_storage::SplitPayloadBuilder;
 use time::OffsetDateTime;
@@ -37,9 +39,7 @@ use tracing::{info, info_span, warn, Instrument, Span};
 
 use crate::actors::sequencer::Sequencer;
 use crate::actors::Publisher;
-use crate::models::{
-    PackagedSplit, PackagedSplitBatch, PublishNewSplit, PublisherMessage, ReplaceSplits,
-};
+use crate::models::{PackagedSplit, PackagedSplitBatch, SplitUpdate};
 use crate::split_store::IndexingSplitStore;
 
 pub const MAX_CONCURRENT_SPLIT_UPLOAD: usize = 4;
@@ -132,7 +132,7 @@ impl Handler<PackagedSplitBatch> for Uploader {
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         fail_point!("uploader:before");
-        let (split_uploaded_tx, split_uploaded_rx) = oneshot::channel::<PublisherMessage>();
+        let (split_uploaded_tx, split_uploaded_rx) = oneshot::channel::<SplitUpdate>();
 
         // We send the future to the sequencer right away.
 
@@ -181,7 +181,7 @@ impl Handler<PackagedSplitBatch> for Uploader {
                     }
                     packaged_splits_and_metadatas.push((split, upload_result.unwrap()));
                 }
-                let publisher_message = make_publish_operation(index_id, packaged_splits_and_metadatas);
+                let publisher_message = make_publish_operation(index_id, packaged_splits_and_metadatas, batch.checkpoint_delta_opt);
                 if let Err(publisher_message) = split_uploaded_tx.send(publisher_message) {
                     bail!(
                         "Failed to send upload split `{:?}`. The publisher is probably dead.",
@@ -216,32 +216,24 @@ fn create_split_metadata(split: &PackagedSplit, footer_offsets: Range<u64>) -> S
 
 fn make_publish_operation(
     index_id: String,
-    mut packaged_splits_and_metadatas: Vec<(PackagedSplit, SplitMetadata)>,
-) -> PublisherMessage {
+    packaged_splits_and_metadatas: Vec<(PackagedSplit, SplitMetadata)>,
+    checkpoint_delta_opt: Option<IndexCheckpointDelta>,
+) -> SplitUpdate {
     assert!(!packaged_splits_and_metadatas.is_empty());
     let replaced_split_ids = packaged_splits_and_metadatas
         .iter()
         .flat_map(|(split, _)| split.replaced_split_ids.clone())
         .collect::<HashSet<_>>();
-    if packaged_splits_and_metadatas.len() == 1 && replaced_split_ids.is_empty() {
-        let (mut packaged_split, split_metadata) = packaged_splits_and_metadatas.pop().unwrap();
-        assert_eq!(packaged_split.checkpoint_deltas.len(), 1);
-        let checkpoint_delta = packaged_split.checkpoint_deltas.pop().unwrap();
-        PublisherMessage::NewSplit(PublishNewSplit {
-            index_id,
-            new_split: split_metadata,
-            checkpoint_delta,
-            split_date_of_birth: packaged_split.split_date_of_birth,
-        })
-    } else {
-        PublisherMessage::ReplaceSplits(ReplaceSplits {
-            index_id,
-            new_splits: packaged_splits_and_metadatas
-                .into_iter()
-                .map(|split_and_meta| split_and_meta.1)
-                .collect_vec(),
-            replaced_split_ids: Vec::from_iter(replaced_split_ids),
-        })
+    SplitUpdate {
+        index_id,
+        new_splits: packaged_splits_and_metadatas
+            .into_iter()
+            .map(|split_and_meta| split_and_meta.1)
+            .collect_vec(),
+        replaced_split_ids: Vec::from_iter(replaced_split_ids),
+        checkpoint_delta_opt,
+        //         split_date_of_birth: packaged_split.split_date_of_birth,
+        split_date_of_birth: Instant::now(), // FIXME
     }
 }
 
@@ -284,7 +276,7 @@ mod tests {
     use std::time::Instant;
 
     use quickwit_actors::{create_test_mailbox, ObservationType, Universe};
-    use quickwit_metastore::checkpoint::CheckpointDelta;
+    use quickwit_metastore::checkpoint::{IndexCheckpointDelta, SourceCheckpointDelta};
     use quickwit_metastore::MockMetastore;
     use quickwit_storage::RamStorage;
     use tokio::sync::oneshot;
@@ -318,22 +310,28 @@ mod tests {
         );
         let (uploader_mailbox, uploader_handle) = universe.spawn_actor(uploader).spawn();
         let split_scratch_directory = ScratchDirectory::for_test()?;
+        let checkpoint_delta_opt: Option<IndexCheckpointDelta> = Some(IndexCheckpointDelta {
+            source_id: "source".to_string(),
+            source_delta: SourceCheckpointDelta::from(3..15),
+        });
         uploader_mailbox
-            .send_message(PackagedSplitBatch::new(vec![PackagedSplit {
-                split_id: "test-split".to_string(),
-                index_id: "test-index".to_string(),
-                checkpoint_deltas: vec![CheckpointDelta::from(3..15)],
-                time_range: Some(1_628_203_589i64..=1_628_203_640i64),
-                size_in_bytes: 1_000,
-                split_scratch_directory,
-                num_docs: 10,
-                demux_num_ops: 0,
-                tags: Default::default(),
-                replaced_split_ids: Vec::new(),
-                split_date_of_birth: Instant::now(),
-                hotcache_bytes: vec![],
-                split_files: vec![],
-            }]))
+            .send_message(PackagedSplitBatch::new(
+                vec![PackagedSplit {
+                    split_id: "test-split".to_string(),
+                    index_id: "test-index".to_string(),
+                    time_range: Some(1_628_203_589i64..=1_628_203_640i64),
+                    size_in_bytes: 1_000,
+                    split_scratch_directory,
+                    num_docs: 10,
+                    demux_num_ops: 0,
+                    tags: Default::default(),
+                    replaced_split_ids: Vec::new(),
+                    split_date_of_birth: Instant::now(),
+                    hotcache_bytes: vec![],
+                    split_files: vec![],
+                }],
+                checkpoint_delta_opt,
+            ))
             .await?;
         assert_eq!(
             uploader_handle.process_pending_and_observe().await.obs_type,
@@ -344,22 +342,26 @@ mod tests {
         let publish_future = *publish_futures
             .pop()
             .unwrap()
-            .downcast::<oneshot::Receiver<PublisherMessage>>()
+            .downcast::<oneshot::Receiver<SplitUpdate>>()
             .unwrap();
         let publisher_message = publish_future.await?;
-        if let PublisherMessage::NewSplit(PublishNewSplit {
+        let SplitUpdate {
             index_id,
-            new_split,
-            checkpoint_delta,
-            ..
-        }) = publisher_message
-        {
-            assert_eq!(index_id, "test-index");
-            assert_eq!(new_split.split_id(), "test-split");
-            assert_eq!(checkpoint_delta, CheckpointDelta::from(3..15));
-        } else {
-            panic!("Expected publish new split operation");
-        }
+            new_splits,
+            checkpoint_delta_opt,
+            replaced_split_ids,
+            split_date_of_birth: _,
+        } = publisher_message;
+        assert_eq!(new_splits.len(), 1);
+        assert_eq!(index_id, "test-index");
+        assert_eq!(new_splits[0].split_id(), "test-split");
+        let checkpoint_delta = checkpoint_delta_opt.unwrap();
+        assert_eq!(checkpoint_delta.source_id, "source");
+        assert_eq!(
+            checkpoint_delta.source_delta,
+            SourceCheckpointDelta::from(3..15)
+        );
+        assert!(replaced_split_ids.is_empty());
         let mut files = ram_storage.list_files().await;
         files.sort();
         assert_eq!(&files, &[PathBuf::from("test-split.split")]);
@@ -397,7 +399,6 @@ mod tests {
         let packaged_split_1 = PackagedSplit {
             split_id: "test-split-1".to_string(),
             index_id: "test-index".to_string(),
-            checkpoint_deltas: vec![CheckpointDelta::from(3..15), CheckpointDelta::from(16..18)],
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
             split_scratch_directory: split_scratch_directory_1,
@@ -408,14 +409,13 @@ mod tests {
                 "replaced-split-1".to_string(),
                 "replaced-split-2".to_string(),
             ],
-            split_date_of_birth: Instant::now(),
+            split_date_of_birth: Instant::now(), // FIXE ME
             split_files: vec![],
             hotcache_bytes: vec![],
         };
         let package_split_2 = PackagedSplit {
             split_id: "test-split-2".to_string(),
             index_id: "test-index".to_string(),
-            checkpoint_deltas: vec![CheckpointDelta::from(3..15), CheckpointDelta::from(16..18)],
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
             split_scratch_directory: split_scratch_directory_2,
@@ -431,10 +431,10 @@ mod tests {
             hotcache_bytes: vec![],
         };
         uploader_mailbox
-            .send_message(PackagedSplitBatch::new(vec![
-                packaged_split_1,
-                package_split_2,
-            ]))
+            .send_message(PackagedSplitBatch::new(
+                vec![packaged_split_1, package_split_2],
+                None,
+            ))
             .await?;
         assert_eq!(
             uploader_handle.process_pending_and_observe().await.obs_type,
@@ -446,33 +446,33 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .downcast::<oneshot::Receiver<PublisherMessage>>()
+            .downcast::<oneshot::Receiver<SplitUpdate>>()
             .unwrap();
         let publisher_message = publish_future.await?;
-        if let PublisherMessage::ReplaceSplits(ReplaceSplits {
+        let SplitUpdate {
             index_id,
             new_splits,
             mut replaced_split_ids,
-        }) = publisher_message
-        {
-            assert_eq!(&index_id, "test-index");
-            // Sort first to avoid test failing.
-            replaced_split_ids.sort();
-            assert_eq!(new_splits.len(), 2);
-            assert_eq!(new_splits[0].split_id(), "test-split-1");
-            assert_eq!(new_splits[1].split_id(), "test-split-2");
-            assert_eq!(
-                &replaced_split_ids,
-                &[
-                    "replaced-split-1".to_string(),
-                    "replaced-split-2".to_string()
-                ]
-            );
-            assert_eq!(new_splits[0].demux_num_ops, 1);
-            assert_eq!(new_splits[1].demux_num_ops, 1);
-        } else {
-            panic!("Expected publish new split operation");
-        }
+            checkpoint_delta_opt,
+            split_date_of_birth: _,
+        } = publisher_message;
+        assert_eq!(&index_id, "test-index");
+        // Sort first to avoid test failing.
+        replaced_split_ids.sort();
+        assert_eq!(new_splits.len(), 2);
+        assert_eq!(new_splits[0].split_id(), "test-split-1");
+        assert_eq!(new_splits[1].split_id(), "test-split-2");
+        assert_eq!(
+            &replaced_split_ids,
+            &[
+                "replaced-split-1".to_string(),
+                "replaced-split-2".to_string()
+            ]
+        );
+        assert!(checkpoint_delta_opt.is_none());
+        assert_eq!(new_splits[0].demux_num_ops, 1);
+        assert_eq!(new_splits[1].demux_num_ops, 1);
+
         let mut files = ram_storage.list_files().await;
         files.sort();
         assert_eq!(

--- a/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit-indexing/src/models/indexed_split.rs
@@ -24,7 +24,7 @@ use std::time::Instant;
 
 use quickwit_actors::{KillSwitch, Progress};
 use quickwit_config::IndexingResources;
-use quickwit_metastore::checkpoint::CheckpointDelta;
+use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use tantivy::directory::MmapDirectory;
 use tantivy::merge_policy::NoMergePolicy;
 use tantivy::IndexBuilder;
@@ -57,8 +57,6 @@ pub struct IndexedSplit {
 
     /// Number of demux operations this split has undergone.
     pub demux_num_ops: usize,
-
-    pub checkpoint_delta: CheckpointDelta,
 
     pub index: tantivy::Index,
     pub index_writer: tantivy::IndexWriter,
@@ -117,7 +115,6 @@ impl IndexedSplit {
             index,
             index_writer,
             split_scratch_directory,
-            checkpoint_delta: CheckpointDelta::default(),
             controlled_directory_opt: Some(controlled_directory),
         })
     }
@@ -130,4 +127,5 @@ impl IndexedSplit {
 #[derive(Debug)]
 pub struct IndexedSplitBatch {
     pub splits: Vec<IndexedSplit>,
+    pub checkpoint_delta: Option<IndexCheckpointDelta>,
 }

--- a/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit-indexing/src/models/indexed_split.rs
@@ -48,13 +48,6 @@ pub struct IndexedSplit {
     // invalid.
     pub docs_size_in_bytes: u64,
 
-    /// Instant of reception of the first document in the indexer.
-    ///
-    /// This is mostly useful to understand part of the time to search.
-    /// However, note that the document may have been waiting for a long time in the source
-    /// before actually reaching the indexer.
-    pub split_date_of_birth: Instant,
-
     /// Number of demux operations this split has undergone.
     pub demux_num_ops: usize,
 
@@ -111,7 +104,6 @@ impl IndexedSplit {
             demux_num_ops: 0,
             docs_size_in_bytes: 0,
             num_docs: 0,
-            split_date_of_birth: Instant::now(),
             index,
             index_writer,
             split_scratch_directory,
@@ -128,4 +120,5 @@ impl IndexedSplit {
 pub struct IndexedSplitBatch {
     pub splits: Vec<IndexedSplit>,
     pub checkpoint_delta: Option<IndexCheckpointDelta>,
+    pub date_of_birth: Instant,
 }

--- a/quickwit-indexing/src/models/mod.rs
+++ b/quickwit-indexing/src/models/mod.rs
@@ -38,7 +38,7 @@ pub use indexing_statistics::IndexingStatistics;
 pub use merge_planner_message::NewSplits;
 pub use merge_scratch::MergeScratch;
 pub use packaged_split::{PackagedSplit, PackagedSplitBatch};
-pub use publisher_message::{PublishNewSplit, PublisherMessage, ReplaceSplits};
+pub use publisher_message::SplitUpdate;
 pub use raw_doc_batch::RawDocBatch;
 pub use scratch_directory::ScratchDirectory;
 

--- a/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit-indexing/src/models/packaged_split.rs
@@ -36,7 +36,6 @@ pub struct PackagedSplit {
     pub num_docs: u64,
     pub demux_num_ops: usize,
     pub tags: BTreeSet<String>,
-    pub split_date_of_birth: Instant,
     pub split_files: Vec<std::path::PathBuf>,
     pub hotcache_bytes: Vec<u8>,
 }
@@ -53,7 +52,6 @@ impl fmt::Debug for PackagedSplit {
             .field("num_docs", &self.num_docs)
             .field("demux_num_ops", &self.demux_num_ops)
             .field("tags", &self.tags)
-            .field("split_date_of_birth", &self.split_date_of_birth)
             .field("split_files", &self.split_files)
             .finish()
     }
@@ -63,6 +61,7 @@ impl fmt::Debug for PackagedSplit {
 pub struct PackagedSplitBatch {
     pub splits: Vec<PackagedSplit>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
+    pub date_of_birth: Instant,
 }
 
 impl PackagedSplitBatch {
@@ -73,6 +72,7 @@ impl PackagedSplitBatch {
     pub fn new(
         splits: Vec<PackagedSplit>,
         checkpoint_delta_opt: Option<IndexCheckpointDelta>,
+        date_of_birth: Instant,
     ) -> Self {
         assert!(!splits.is_empty());
         assert_eq!(
@@ -87,6 +87,7 @@ impl PackagedSplitBatch {
         Self {
             splits,
             checkpoint_delta_opt,
+            date_of_birth,
         }
     }
 

--- a/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit-indexing/src/models/publisher_message.rs
@@ -20,6 +20,7 @@
 use std::fmt;
 use std::time::Instant;
 
+use itertools::Itertools;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::SplitMetadata;
 
@@ -28,24 +29,21 @@ pub struct SplitUpdate {
     pub new_splits: Vec<SplitMetadata>,
     pub replaced_split_ids: Vec<String>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
-    pub split_date_of_birth: Instant, // for logging
+    pub date_of_birth: Instant, // for logging
 }
 
 impl fmt::Debug for SplitUpdate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let new_split_ids: Vec<&str> = self
+        let new_split_ids: String = self
             .new_splits
             .iter()
             .map(|split| split.split_id())
-            .collect();
+            .join(",");
         f.debug_struct("SplitUpdate")
             .field("index_id", &self.index_id)
             .field("new_splits", &new_split_ids)
             .field("checkpoint_delta", &self.checkpoint_delta_opt)
-            .field(
-                "tts_in_secs",
-                &self.split_date_of_birth.elapsed().as_secs_f32(),
-            )
+            .field("tts_in_secs", &self.date_of_birth.elapsed().as_secs_f32())
             .finish()
     }
 }

--- a/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit-indexing/src/models/publisher_message.rs
@@ -20,55 +20,32 @@
 use std::fmt;
 use std::time::Instant;
 
-use quickwit_metastore::checkpoint::CheckpointDelta;
+use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::SplitMetadata;
 
-/// Publish a new split, coming from the indexer.
-pub struct PublishNewSplit {
+pub struct SplitUpdate {
     pub index_id: String,
-    pub new_split: SplitMetadata,
-    pub checkpoint_delta: CheckpointDelta,
+    pub new_splits: Vec<SplitMetadata>,
+    pub replaced_split_ids: Vec<String>,
+    pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub split_date_of_birth: Instant, // for logging
 }
 
-impl fmt::Debug for PublishNewSplit {
+impl fmt::Debug for SplitUpdate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("PublishNewSplit")
+        let new_split_ids: Vec<&str> = self
+            .new_splits
+            .iter()
+            .map(|split| split.split_id())
+            .collect();
+        f.debug_struct("SplitUpdate")
             .field("index_id", &self.index_id)
-            .field("new_split_id", &self.new_split.split_id())
-            .field("checkpoint_delta", &self.checkpoint_delta)
+            .field("new_splits", &new_split_ids)
+            .field("checkpoint_delta", &self.checkpoint_delta_opt)
             .field(
                 "tts_in_secs",
                 &self.split_date_of_birth.elapsed().as_secs_f32(),
             )
             .finish()
     }
-}
-
-/// Publish a merge, replacing several splits (typically 10)
-/// by a single larger split.
-pub struct ReplaceSplits {
-    pub index_id: String,
-    pub new_splits: Vec<SplitMetadata>,
-    pub replaced_split_ids: Vec<String>,
-}
-
-impl fmt::Debug for ReplaceSplits {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let new_split_ids: Vec<String> = self
-            .new_splits
-            .iter()
-            .map(|split| split.split_id().to_string())
-            .collect();
-        f.debug_struct("ReplaceSplits")
-            .field("new_split_ids", &new_split_ids)
-            .field("replaced_split_ids", &self.replaced_split_ids)
-            .finish()
-    }
-}
-
-#[derive(Debug)]
-pub enum PublisherMessage {
-    NewSplit(PublishNewSplit),
-    ReplaceSplits(ReplaceSplits),
 }

--- a/quickwit-indexing/src/models/raw_doc_batch.rs
+++ b/quickwit-indexing/src/models/raw_doc_batch.rs
@@ -19,12 +19,27 @@
 
 use std::fmt;
 
-use quickwit_metastore::checkpoint::CheckpointDelta;
+use quickwit_metastore::checkpoint::SourceCheckpointDelta;
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct RawDocBatch {
     pub docs: Vec<String>,
-    pub checkpoint_delta: CheckpointDelta,
+    pub checkpoint_delta: SourceCheckpointDelta,
+}
+
+impl RawDocBatch {
+    pub fn new(docs: Vec<String>, checkpoint_delta: SourceCheckpointDelta) -> Self {
+        RawDocBatch {
+            docs,
+            checkpoint_delta,
+        }
+    }
+}
+
+impl Default for RawDocBatch {
+    fn default() -> Self {
+        RawDocBatch::new(Vec::new(), SourceCheckpointDelta::default())
+    }
 }
 
 impl fmt::Debug for RawDocBatch {

--- a/quickwit-indexing/src/models/raw_doc_batch.rs
+++ b/quickwit-indexing/src/models/raw_doc_batch.rs
@@ -21,7 +21,7 @@ use std::fmt;
 
 use quickwit_metastore::checkpoint::SourceCheckpointDelta;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RawDocBatch {
     pub docs: Vec<String>,
     pub checkpoint_delta: SourceCheckpointDelta,
@@ -33,12 +33,6 @@ impl RawDocBatch {
             docs,
             checkpoint_delta,
         }
-    }
-}
-
-impl Default for RawDocBatch {
-    fn default() -> Self {
-        RawDocBatch::new(Vec::new(), SourceCheckpointDelta::default())
     }
 }
 

--- a/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit-indexing/src/source/ingest_api_source.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use quickwit_actors::{ActorContext, ActorExitStatus, Mailbox};
 use quickwit_config::IngestApiSourceParams;
 use quickwit_ingest_api::{get_ingest_api_service, iter_doc_payloads, IngestApiService};
-use quickwit_metastore::checkpoint::{CheckpointDelta, PartitionId, Position, SourceCheckpoint};
+use quickwit_metastore::checkpoint::{PartitionId, Position, SourceCheckpoint};
 use quickwit_proto::ingest_api::{FetchRequest, FetchResponse, SuggestTruncateRequest};
 use serde::Serialize;
 
@@ -134,23 +134,22 @@ impl Source for IngestApiSource {
             return Ok(INGEST_API_POLLING_COOL_DOWN);
         };
 
-        let docs = iter_doc_payloads(&doc_batch)
+        // TODO use a timestamp (in the raw doc batch) given by at ingest time to be more accurate.
+        let mut raw_doc_batch = RawDocBatch::default();
+
+        raw_doc_batch.docs = iter_doc_payloads(&doc_batch)
             .map(|buff| String::from_utf8_lossy(buff).to_string())
             .collect::<Vec<_>>();
-        let current_offset = first_position + docs.len() as u64 - 1;
-        let mut checkpoint_delta = CheckpointDelta::default();
+        let current_offset = first_position + raw_doc_batch.docs.len() as u64 - 1;
         let partition_id = PartitionId::from(self.params.index_id.as_str());
-        checkpoint_delta
+        raw_doc_batch
+            .checkpoint_delta
             .record_partition_delta(
                 partition_id,
                 Position::from(self.counters.previous_offset.unwrap_or(0)),
                 Position::from(current_offset),
             )
             .unwrap();
-        let raw_doc_batch = RawDocBatch {
-            docs,
-            checkpoint_delta,
-        };
 
         self.update_counters(current_offset, raw_doc_batch.docs.len() as u64);
         ctx.send_message(batch_sink, raw_doc_batch).await?;
@@ -216,7 +215,7 @@ mod tests {
 
     use quickwit_actors::{create_test_mailbox, Universe};
     use quickwit_ingest_api::{add_doc, spawn_ingest_api_actor, Queues};
-    use quickwit_metastore::checkpoint::SourceCheckpoint;
+    use quickwit_metastore::checkpoint::{SourceCheckpoint, SourceCheckpointDelta};
     use quickwit_proto::ingest_api::{DocBatch, IngestRequest};
 
     use super::*;
@@ -360,7 +359,7 @@ mod tests {
         };
         let mut checkpoint = SourceCheckpoint::default();
         let partition_id = PartitionId::from(params.index_id.clone());
-        let checkpoint_delta = CheckpointDelta::from_partition_delta(
+        let checkpoint_delta = SourceCheckpointDelta::from_partition_delta(
             partition_id,
             Position::from(0u64),
             Position::from(1200u64),

--- a/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit-indexing/src/source/ingest_api_source.rs
@@ -136,10 +136,9 @@ impl Source for IngestApiSource {
 
         // TODO use a timestamp (in the raw doc batch) given by at ingest time to be more accurate.
         let mut raw_doc_batch = RawDocBatch::default();
-
-        raw_doc_batch.docs = iter_doc_payloads(&doc_batch)
-            .map(|buff| String::from_utf8_lossy(buff).to_string())
-            .collect::<Vec<_>>();
+        raw_doc_batch.docs.extend(
+            iter_doc_payloads(&doc_batch).map(|buff| String::from_utf8_lossy(buff).to_string()),
+        );
         let current_offset = first_position + raw_doc_batch.docs.len() as u64 - 1;
         let partition_id = PartitionId::from(self.params.index_id.as_str());
         raw_doc_batch

--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -30,7 +30,9 @@ use itertools::Itertools;
 use quickwit_actors::{ActorExitStatus, Mailbox};
 use quickwit_common::new_coolid;
 use quickwit_config::KafkaSourceParams;
-use quickwit_metastore::checkpoint::{CheckpointDelta, PartitionId, Position, SourceCheckpoint};
+use quickwit_metastore::checkpoint::{
+    PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
+};
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::consumer::{Consumer, ConsumerContext, Rebalance};
@@ -182,7 +184,7 @@ impl Source for KafkaSource {
         ctx: &SourceContext,
     ) -> Result<Duration, ActorExitStatus> {
         let mut docs = Vec::new();
-        let mut checkpoint_delta = CheckpointDelta::default();
+        let mut checkpoint_delta = SourceCheckpointDelta::default();
 
         let deadline = tokio::time::sleep(quickwit_actors::HEARTBEAT / 2);
         let mut message_stream = Box::pin(self.consumer.stream().take_until(deadline));
@@ -913,7 +915,7 @@ mod kafka_broker_tests {
             ];
             assert_eq!(batch.docs, expected_docs);
 
-            let mut expected_checkpoint_delta = CheckpointDelta::default();
+            let mut expected_checkpoint_delta = SourceCheckpointDelta::default();
             for partition in 0u64..3u64 {
                 expected_checkpoint_delta.record_partition_delta(
                     PartitionId::from(partition),
@@ -965,7 +967,7 @@ mod kafka_broker_tests {
             let expected_docs = vec!["Message #002", "Message #200", "Message #202"];
             assert_eq!(batch.docs, expected_docs);
 
-            let mut expected_checkpoint_delta = CheckpointDelta::default();
+            let mut expected_checkpoint_delta = SourceCheckpointDelta::default();
             expected_checkpoint_delta.record_partition_delta(
                 PartitionId::from(0u64),
                 Position::from(0u64),

--- a/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -27,7 +27,9 @@ use itertools::Itertools;
 use quickwit_actors::{ActorExitStatus, Mailbox};
 use quickwit_aws::retry::RetryParams;
 use quickwit_config::{KinesisSourceParams, RegionOrEndpoint};
-use quickwit_metastore::checkpoint::{CheckpointDelta, PartitionId, Position, SourceCheckpoint};
+use quickwit_metastore::checkpoint::{
+    PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
+};
 use rusoto_core::Region;
 use rusoto_kinesis::KinesisClient;
 use serde_json::json;
@@ -200,7 +202,7 @@ impl Source for KinesisSource {
     ) -> Result<Duration, ActorExitStatus> {
         let mut batch_num_bytes = 0;
         let mut docs = Vec::new();
-        let mut checkpoint_delta = CheckpointDelta::default();
+        let mut checkpoint_delta = SourceCheckpointDelta::default();
 
         let deadline = time::sleep(quickwit_actors::HEARTBEAT / 2);
         tokio::pin!(deadline);
@@ -474,7 +476,7 @@ mod tests {
             ];
             assert_eq!(batch.docs, expected_docs);
 
-            let mut expected_checkpoint_delta = CheckpointDelta::default();
+            let mut expected_checkpoint_delta = SourceCheckpointDelta::default();
             for shard_id in 0..3 {
                 expected_checkpoint_delta
                     .record_partition_delta(
@@ -538,7 +540,7 @@ mod tests {
             let expected_docs = vec!["Record #00", "Record #01", "Record #11"];
             assert_eq!(batch.docs, expected_docs);
 
-            let mut expected_checkpoint_delta = CheckpointDelta::default();
+            let mut expected_checkpoint_delta = SourceCheckpointDelta::default();
             for (shard_id, from_position) in [
                 Position::Beginning,
                 Position::from(from_sequence_number_exclusive_shard_1),

--- a/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
+++ b/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
@@ -28,7 +28,7 @@ use quickwit_config::{
 use quickwit_doc_mapper::{ModeType, SortOrder};
 
 use crate::checkpoint::{
-    CheckpointDelta, IndexCheckpoint, PartitionId, Position, SourceCheckpoint,
+    IndexCheckpoint, PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
 };
 use crate::IndexMetadata;
 
@@ -86,7 +86,7 @@ pub(crate) fn test_index_metadata_eq(
 /// Creates a new [`IndexMetadata`] object against which backward compatibility tests will be run.
 pub(crate) fn sample_index_metadata_for_regression() -> IndexMetadata {
     let mut source_checkpoint = SourceCheckpoint::default();
-    let delta = CheckpointDelta::from_partition_delta(
+    let delta = SourceCheckpointDelta::from_partition_delta(
         PartitionId::from(0i64),
         Position::Beginning,
         Position::from(42u64),

--- a/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/mod.rs
@@ -32,7 +32,7 @@ use quickwit_common::uri::Uri;
 use quickwit_config::SourceConfig;
 use quickwit_doc_mapper::tag_pruning::TagFilterAst;
 
-use crate::checkpoint::CheckpointDelta;
+use crate::checkpoint::IndexCheckpointDelta;
 use crate::{MetastoreResult, Split, SplitMetadata, SplitState};
 
 /// Metastore meant to manage Quickwit's indexes and their splits.
@@ -120,20 +120,9 @@ pub trait Metastore: Send + Sync + 'static {
     async fn publish_splits<'a>(
         &self,
         index_id: &str,
-        source_id: &str,
         split_ids: &[&'a str],
-        checkpoint_delta: CheckpointDelta,
-    ) -> MetastoreResult<()>;
-
-    /// Replaces a list of splits with another list.
-    ///
-    /// This API is useful during merge and demux operations.
-    /// The new splits should be staged, and the replaced splits should exist.
-    async fn replace_splits<'a>(
-        &self,
-        index_id: &str,
-        new_split_ids: &[&'a str],
         replaced_split_ids: &[&'a str],
+        checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     ) -> MetastoreResult<()>;
 
     /// Lists the splits.

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -30,7 +30,7 @@ pub mod test_suite {
     use tokio::time::{sleep, Duration};
     use tracing::{error, info};
 
-    use crate::checkpoint::{CheckpointDelta, PartitionId, Position, SourceCheckpoint};
+    use crate::checkpoint::{IndexCheckpointDelta, PartitionId, Position, SourceCheckpoint};
     use crate::{IndexMetadata, Metastore, MetastoreError, SplitMetadata, SplitState};
 
     #[async_trait]
@@ -308,9 +308,13 @@ pub mod test_suite {
             let result = metastore
                 .publish_splits(
                     "non-existent-index",
-                    source_id,
                     &[],
-                    CheckpointDelta::from(1..10),
+                    &[],
+                    {
+                        let offsets = 1..10;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -327,7 +331,16 @@ pub mod test_suite {
                 .unwrap();
 
             let result = metastore
-                .publish_splits(index_id, source_id, &[], CheckpointDelta::from(0..100))
+                .publish_splits(
+                    index_id,
+                    &[],
+                    &[],
+                    {
+                        let offsets = 0..100;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
+                )
                 .await;
             assert!(result.is_ok());
 
@@ -384,9 +397,13 @@ pub mod test_suite {
             let result = metastore
                 .publish_splits(
                     "non-existent-index",
-                    source_id,
                     &["non-existent-split"],
-                    CheckpointDelta::from(1..10),
+                    &[],
+                    {
+                        let offsets = 1..10;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -401,12 +418,7 @@ pub mod test_suite {
                 .unwrap();
 
             let result = metastore
-                .publish_splits(
-                    index_id,
-                    source_id,
-                    &["non-existent-split"],
-                    CheckpointDelta::default(),
-                )
+                .publish_splits(index_id, &["non-existent-split"], &[], None)
                 .await
                 .unwrap_err();
             assert!(matches!(result, MetastoreError::SplitsDoNotExist { .. }));
@@ -427,12 +439,7 @@ pub mod test_suite {
                 .unwrap();
 
             metastore
-                .publish_splits(
-                    index_id,
-                    source_id,
-                    &[split_id_1],
-                    CheckpointDelta::default(),
-                )
+                .publish_splits(index_id, &[split_id_1], &[], None)
                 .await
                 .unwrap();
 
@@ -454,9 +461,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1],
-                    CheckpointDelta::from(1..12),
+                    &[],
+                    {
+                        let offsets = 1..12;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -464,9 +475,13 @@ pub mod test_suite {
             let publish_error = metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1],
-                    CheckpointDelta::from(1..12),
+                    &[],
+                    {
+                        let offsets = 1..12;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -493,9 +508,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1],
-                    CheckpointDelta::from(12..15),
+                    &[],
+                    {
+                        let offsets = 12..15;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -508,9 +527,13 @@ pub mod test_suite {
             let result = metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1],
-                    CheckpointDelta::from(15..18),
+                    &[],
+                    {
+                        let offsets = 15..18;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -534,9 +557,13 @@ pub mod test_suite {
             let result = metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1, "non-existent-split"],
-                    CheckpointDelta::from(15..18),
+                    &[],
+                    {
+                        let offsets = 15..18;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -560,9 +587,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1],
-                    CheckpointDelta::from(15..18),
+                    &[],
+                    {
+                        let offsets = 15..18;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -570,9 +601,13 @@ pub mod test_suite {
             let result = metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1, "non-existent-split"],
-                    CheckpointDelta::from(18..24),
+                    &[],
+                    {
+                        let offsets = 18..24;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -596,9 +631,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1],
-                    CheckpointDelta::from(18..24),
+                    &[],
+                    {
+                        let offsets = 18..24;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -611,9 +650,13 @@ pub mod test_suite {
             let result = metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1, "non-existent-split"],
-                    CheckpointDelta::from(24..26),
+                    &[],
+                    {
+                        let offsets = 24..26;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -642,9 +685,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1, split_id_2],
-                    CheckpointDelta::from(24..26),
+                    &[],
+                    {
+                        let offsets = 24..26;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -672,9 +719,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_2],
-                    CheckpointDelta::from(26..28),
+                    &[],
+                    {
+                        let offsets = 26..28;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -682,9 +733,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1, split_id_2],
-                    CheckpointDelta::from(28..30),
+                    &[],
+                    {
+                        let offsets = 28..30;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -712,9 +767,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1, split_id_2],
-                    CheckpointDelta::from(30..31),
+                    &[],
+                    {
+                        let offsets = 30..31;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -722,9 +781,13 @@ pub mod test_suite {
             let publish_error = metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1, split_id_2],
-                    CheckpointDelta::from(30..31),
+                    &[],
+                    {
+                        let offsets = 30..31;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap_err();
@@ -744,7 +807,6 @@ pub mod test_suite {
 
         let index_id = append_random_suffix("test-metastore-replace-splits");
         let index_uri = format!("ram://indexes/{index_id}");
-        let source_id = format!("{index_id}--source");
         let index_metadata = IndexMetadata::for_test(&index_id, &index_uri);
 
         let split_id_1 = format!("{index_id}--split-one");
@@ -783,10 +845,11 @@ pub mod test_suite {
         // Replace splits on a non-existent index
         {
             let error = metastore
-                .replace_splits(
+                .publish_splits(
                     "non-existent-index",
                     &["non-existent-split-one"],
                     &["non-existent-split-two"],
+                    None,
                 )
                 .await
                 .unwrap_err();
@@ -800,11 +863,13 @@ pub mod test_suite {
                 .await
                 .unwrap();
 
+            // TODO source id
             let result = metastore
-                .replace_splits(
+                .publish_splits(
                     &index_id,
                     &["non-existent-split"],
                     &["non-existent-split-two"],
+                    None,
                 )
                 .await
                 .unwrap_err();
@@ -826,17 +891,13 @@ pub mod test_suite {
                 .unwrap();
 
             metastore
-                .publish_splits(
-                    &index_id,
-                    &source_id,
-                    &[&split_id_1],
-                    CheckpointDelta::default(),
-                )
+                .publish_splits(&index_id, &[&split_id_1], &[], None)
                 .await
                 .unwrap();
 
+            // TODO Source id
             let result = metastore
-                .replace_splits(&index_id, &[&split_id_2], &[&split_id_1])
+                .publish_splits(&index_id, &[&split_id_2], &[&split_id_1], None)
                 .await
                 .unwrap_err();
             assert!(matches!(result, MetastoreError::SplitsDoNotExist { .. }));
@@ -862,12 +923,7 @@ pub mod test_suite {
                 .unwrap();
 
             metastore
-                .publish_splits(
-                    &index_id,
-                    &source_id,
-                    &[&split_id_1, &split_id_2],
-                    CheckpointDelta::default(),
-                )
+                .publish_splits(&index_id, &[&split_id_1, &split_id_2], &[], None)
                 .await
                 .unwrap();
 
@@ -876,8 +932,9 @@ pub mod test_suite {
                 .await
                 .unwrap();
 
+            // TODO source_id
             let result = metastore
-                .replace_splits(&index_id, &[&split_id_2], &[&split_id_1])
+                .publish_splits(&index_id, &[&split_id_2], &[&split_id_1], None)
                 .await
                 .unwrap_err();
             assert!(matches!(result, MetastoreError::SplitsNotStaged { .. }));
@@ -898,12 +955,7 @@ pub mod test_suite {
                 .unwrap();
 
             metastore
-                .publish_splits(
-                    &index_id,
-                    &source_id,
-                    &[&split_id_1],
-                    CheckpointDelta::default(),
-                )
+                .publish_splits(&index_id, &[&split_id_1], &[], None)
                 .await
                 .unwrap();
 
@@ -913,7 +965,7 @@ pub mod test_suite {
                 .unwrap();
 
             let result = metastore
-                .replace_splits(&index_id, &[&split_id_2, &split_id_3], &[&split_id_1])
+                .publish_splits(&index_id, &[&split_id_2, &split_id_3], &[&split_id_1], None) // TODO source id
                 .await
                 .unwrap_err();
             assert!(matches!(result, MetastoreError::SplitsDoNotExist { .. }));
@@ -934,12 +986,7 @@ pub mod test_suite {
                 .unwrap();
 
             metastore
-                .publish_splits(
-                    &index_id,
-                    &source_id,
-                    &[&split_id_1],
-                    CheckpointDelta::default(),
-                )
+                .publish_splits(&index_id, &[&split_id_1], &[], None)
                 .await
                 .unwrap();
 
@@ -954,7 +1001,7 @@ pub mod test_suite {
                 .unwrap();
 
             let error = metastore
-                .replace_splits(&index_id, &[&split_id_2], &[&split_id_1])
+                .publish_splits(&index_id, &[&split_id_2], &[&split_id_1], None)
                 .await
                 .unwrap_err();
             assert!(
@@ -977,12 +1024,7 @@ pub mod test_suite {
                 .unwrap();
 
             metastore
-                .publish_splits(
-                    &index_id,
-                    &source_id,
-                    &[&split_id_1],
-                    CheckpointDelta::default(),
-                )
+                .publish_splits(&index_id, &[&split_id_1], &[], None)
                 .await
                 .unwrap();
 
@@ -996,8 +1038,9 @@ pub mod test_suite {
                 .await
                 .unwrap();
 
+            // TODO Source id
             metastore
-                .replace_splits(&index_id, &[&split_id_2, &split_id_3], &[&split_id_1])
+                .publish_splits(&index_id, &[&split_id_2, &split_id_3], &[&split_id_1], None)
                 .await
                 .unwrap();
 
@@ -1185,9 +1228,13 @@ pub mod test_suite {
             metastore
                 .publish_splits(
                     index_id,
-                    source_id,
                     &[split_id_1],
-                    CheckpointDelta::from(0..5),
+                    &[],
+                    {
+                        let offsets = 0..5;
+                        IndexCheckpointDelta::for_test(source_id, offsets)
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -1880,9 +1927,13 @@ pub mod test_suite {
         metastore
             .publish_splits(
                 index_id,
-                source_id,
                 &[split_id],
-                CheckpointDelta::from(0..5),
+                &[],
+                {
+                    let offsets = 0..5;
+                    IndexCheckpointDelta::for_test(source_id, offsets)
+                }
+                .into(),
             )
             .await
             .unwrap();


### PR DESCRIPTION
Refactoring to prepare partitioning.

- NewSplit and Replace messages are merged.
- Delta is extracted from the IndexedSplitmessage
- Added a CheckpointDelta / SourceCheckpointDelta distinction.
- Moved source_id into the checkpoint delta.