### PR TITLE
Decouple configuration parsing logic from validation and transformation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,6 +2115,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_string_template"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427d2a595c488ee51abc942d6b7ebec8467a3edef0d928486ea2ce4f95516637"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2943,7 @@ dependencies = [
  "humansize",
  "humantime",
  "itertools",
+ "new_string_template",
  "once_cell",
  "openssl-probe",
  "opentelemetry",
@@ -3019,6 +3030,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "byte-unit",
+ "futures",
  "json_comments",
  "once_cell",
  "quickwit-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+checksum = "4b31b87a3367ed04dbcbc252bce3f2a8172fef861d47177524c503c908dff2c6"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -2675,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d50bfb8c23f23915855a00d98b5a35ef2e0b871bb52937bacadb798fbb66c8"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
  "once_cell",
  "thiserror",
@@ -2943,7 +2943,6 @@ dependencies = [
  "humansize",
  "humantime",
  "itertools",
- "new_string_template",
  "once_cell",
  "openssl-probe",
  "opentelemetry",
@@ -3030,8 +3029,9 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "byte-unit",
- "futures",
+ "derivative",
  "json_comments",
+ "new_string_template",
  "once_cell",
  "quickwit-common",
  "quickwit-doc-mapper",

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -48,7 +48,6 @@ quickwit-search = { version = "0.3.1", path = "../quickwit-search" }
 quickwit-serve = { version = "0.3.1", path = "../quickwit-serve" }
 quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 quickwit-telemetry = { version = "0.3.1", path = "../quickwit-telemetry" }
-new_string_template = "1.3.1"
 regex = "1.6.0"
 serde_json = "1.0"
 tabled = "0.8"

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -48,6 +48,7 @@ quickwit-search = { version = "0.3.1", path = "../quickwit-search" }
 quickwit-serve = { version = "0.3.1", path = "../quickwit-serve" }
 quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 quickwit-telemetry = { version = "0.3.1", path = "../quickwit-telemetry" }
+new_string_template = "1.3.1"
 regex = "1.6.0"
 serde_json = "1.0"
 tabled = "0.8"

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -514,9 +514,7 @@ pub async fn list_index_cli(args: ListIndexesArgs) -> anyhow::Result<()> {
     debug!(args = ?args, "list");
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
-    let metastore_uri = args
-        .metastore_uri
-        .unwrap_or_else(|| quickwit_config.metastore_uri());
+    let metastore_uri = args.metastore_uri.unwrap_or(quickwit_config.metastore_uri);
     let metastore = metastore_uri_resolver.resolve(&metastore_uri).await?;
     let indexes = metastore.list_indexes_metadatas().await?;
     let index_table = make_list_indexes_table(indexes);
@@ -552,7 +550,7 @@ pub async fn describe_index_cli(args: DescribeIndexArgs) -> anyhow::Result<()> {
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let quickwit_config = load_quickwit_config(&args.config_uri, args.data_dir).await?;
     let metastore = metastore_uri_resolver
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let index_metadata = metastore.index_metadata(&args.index_id).await?;
     let splits = metastore
@@ -777,12 +775,12 @@ pub async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
     let index_id = index_config.index_id.clone();
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let index_service = IndexService::new(
         metastore,
         quickwit_storage_uri_resolver().clone(),
-        quickwit_config.default_index_root_uri(),
+        quickwit_config.default_index_root_uri,
     );
     index_service
         .create_index(index_config, args.overwrite)
@@ -807,17 +805,17 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
         source_id: CLI_INGEST_SOURCE_ID.to_string(),
         source_params,
     };
-    run_index_checklist(&config.metastore_uri(), &args.index_id, Some(&source)).await?;
+    run_index_checklist(&config.metastore_uri, &args.index_id, Some(&source)).await?;
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&config.metastore_uri())
+        .resolve(&config.metastore_uri)
         .await?;
 
     if args.overwrite {
         let index_service = IndexService::new(
             metastore.clone(),
             quickwit_storage_uri_resolver().clone(),
-            config.default_index_root_uri(),
+            config.default_index_root_uri.clone(),
         );
         index_service.reset_index(&args.index_id).await?;
     }
@@ -883,7 +881,7 @@ pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchRespons
     let storage_uri_resolver = quickwit_storage_uri_resolver();
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let search_request = SearchRequest {
         index_id: args.index_id,
@@ -917,13 +915,13 @@ pub async fn merge_or_demux_cli(
 ) -> anyhow::Result<()> {
     debug!(args = ?args, merge_enabled = merge_enabled, demux_enabled = demux_enabled, "run-merge-operations");
     let config = load_quickwit_config(&args.config_uri, args.data_dir).await?;
-    run_index_checklist(&config.metastore_uri(), &args.index_id, None).await?;
+    run_index_checklist(&config.metastore_uri, &args.index_id, None).await?;
     let indexer_config = IndexerConfig {
         ..Default::default()
     };
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&config.metastore_uri())
+        .resolve(&config.metastore_uri)
         .await?;
     let storage_resolver = quickwit_storage_uri_resolver().clone();
     let indexing_server = IndexingService::new(
@@ -958,12 +956,12 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
 
     let quickwit_config = load_quickwit_config(&args.config_uri, args.data_dir).await?;
     let metastore = quickwit_metastore_uri_resolver()
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let index_service = IndexService::new(
         metastore,
         quickwit_storage_uri_resolver().clone(),
-        quickwit_config.default_index_root_uri(),
+        quickwit_config.default_index_root_uri,
     );
     let affected_files = index_service
         .delete_index(&args.index_id, args.dry_run)
@@ -997,12 +995,12 @@ pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow:
 
     let quickwit_config = load_quickwit_config(&args.config_uri, args.data_dir).await?;
     let metastore = quickwit_metastore_uri_resolver()
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let index_service = IndexService::new(
         metastore,
         quickwit_storage_uri_resolver().clone(),
-        quickwit_config.default_index_root_uri(),
+        quickwit_config.default_index_root_uri,
     );
     let deleted_files = index_service
         .garbage_collect_index(&args.index_id, args.grace_period, args.dry_run)

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -24,7 +24,7 @@ use anyhow::bail;
 use once_cell::sync::Lazy;
 use quickwit_common::run_checklist;
 use quickwit_common::uri::Uri;
-use quickwit_config::{QuickwitConfig, QuickwitConfigBuilder, SourceConfig};
+use quickwit_config::{QuickwitConfig, SourceConfig};
 use quickwit_indexing::check_source_connectivity;
 use quickwit_metastore::quickwit_metastore_uri_resolver;
 use quickwit_storage::{load_file, quickwit_storage_uri_resolver};
@@ -33,15 +33,12 @@ use tabled::object::Rows;
 use tabled::{Alignment, Header, Modify, Rotate, Style, Table, Tabled};
 use tracing::info;
 
-use crate::template::render_config_file;
-
 pub mod cli;
 pub mod index;
 pub mod service;
 pub mod source;
 pub mod split;
 pub mod stats;
-pub mod template;
 
 /// Throughput calculation window size.
 const THROUGHPUT_WINDOW_SIZE: usize = 5;
@@ -74,14 +71,13 @@ pub fn parse_duration_with_unit(duration_with_unit_str: &str) -> anyhow::Result<
 }
 
 async fn load_quickwit_config(
-    uri: &Uri,
-    data_dir: Option<PathBuf>,
+    config_uri: &Uri,
+    data_dir_path_opt: Option<PathBuf>,
 ) -> anyhow::Result<QuickwitConfig> {
-    let config_content = load_file(uri).await?;
-    let rendered_config = render_config_file(config_content.as_slice(), uri)?;
-    let config = QuickwitConfigBuilder::load(uri, rendered_config.as_bytes(), data_dir).await?;
-    let config = config.resolve().await?;
-    info!(config_uri = %uri, config = ?config, "Loaded Quickwit config.");
+    let config_content = load_file(config_uri).await?;
+    let config =
+        QuickwitConfig::load(config_uri, config_content.as_slice(), data_dir_path_opt).await?;
+    info!(config_uri=%config_uri, config=?config, "Loaded Quickwit config.");
     Ok(config)
 }
 

--- a/quickwit-cli/src/service.rs
+++ b/quickwit-cli/src/service.rs
@@ -114,7 +114,7 @@ impl RunCliCommand {
         // TODO: Remove these overrides when #1011 lands.
         if let Some(metastore_uri) = &self.metastore_uri {
             tracing::info!(metastore_uri = %metastore_uri, "Setting metastore URI from override.");
-            config.metastore_uri = Some(metastore_uri.clone());
+            config.metastore_uri = metastore_uri.clone();
         }
         if let Some(cluster_id) = &self.cluster_id {
             tracing::info!(cluster_id = %cluster_id, "Setting cluster ID from override.");

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -205,7 +205,7 @@ impl SourceCliCommand {
 async fn create_source_cli(args: CreateSourceArgs) -> anyhow::Result<()> {
     let qw_config = load_quickwit_config(&args.config_uri, None).await?;
     let metastore = quickwit_metastore_uri_resolver()
-        .resolve(&qw_config.metastore_uri())
+        .resolve(&qw_config.metastore_uri)
         .await?;
     let source_config_content = load_file(&args.source_config_uri).await?;
     let source =
@@ -224,7 +224,7 @@ async fn create_source_cli(args: CreateSourceArgs) -> anyhow::Result<()> {
 async fn delete_source_cli(args: DeleteSourceArgs) -> anyhow::Result<()> {
     let config = load_quickwit_config(&args.config_uri, None).await?;
     let metastore = quickwit_metastore_uri_resolver()
-        .resolve(&config.metastore_uri())
+        .resolve(&config.metastore_uri)
         .await?;
     metastore
         .delete_source(&args.index_id, &args.source_id)
@@ -238,7 +238,7 @@ async fn delete_source_cli(args: DeleteSourceArgs) -> anyhow::Result<()> {
 
 async fn describe_source_cli(args: DescribeSourceArgs) -> anyhow::Result<()> {
     let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
-    let index_metadata = resolve_index(&quickwit_config.metastore_uri(), &args.index_id).await?;
+    let index_metadata = resolve_index(&quickwit_config.metastore_uri, &args.index_id).await?;
     let source_checkpoint = index_metadata
         .checkpoint
         .source_checkpoint(&args.source_id)
@@ -291,7 +291,7 @@ where
 
 async fn list_sources_cli(args: ListSourcesArgs) -> anyhow::Result<()> {
     let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
-    let index_metadata = resolve_index(&quickwit_config.metastore_uri(), &args.index_id).await?;
+    let index_metadata = resolve_index(&quickwit_config.metastore_uri, &args.index_id).await?;
     let table = make_list_sources_table(index_metadata.sources.into_values());
     display_tables(&[table]);
     Ok(())

--- a/quickwit-cli/src/split.rs
+++ b/quickwit-cli/src/split.rs
@@ -316,7 +316,7 @@ async fn list_split_cli(args: ListSplitArgs) -> anyhow::Result<()> {
     let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let splits = metastore.list_all_splits(&args.index_id).await?;
 
@@ -353,7 +353,7 @@ async fn mark_splits_for_deletion_cli(args: MarkForDeletionArgs) -> anyhow::Resu
     let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let split_ids: Vec<&str> = args
         .split_ids
@@ -381,7 +381,7 @@ async fn describe_split_cli(args: DescribeSplitArgs) -> anyhow::Result<()> {
     let storage_uri_resolver = quickwit_storage_uri_resolver();
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let index_metadata = metastore.index_metadata(&args.index_id).await?;
     let index_storage = storage_uri_resolver.resolve(&index_metadata.index_uri)?;
@@ -444,7 +444,7 @@ async fn extract_split_cli(args: ExtractSplitArgs) -> anyhow::Result<()> {
     let storage_uri_resolver = quickwit_storage_uri_resolver();
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
-        .resolve(&quickwit_config.metastore_uri())
+        .resolve(&quickwit_config.metastore_uri)
         .await?;
     let index_metadata = metastore.index_metadata(&args.index_id).await?;
     let index_storage = storage_uri_resolver.resolve(&index_metadata.index_uri)?;

--- a/quickwit-cli/src/template.rs
+++ b/quickwit-cli/src/template.rs
@@ -1,0 +1,155 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use anyhow::{bail, Context, Result};
+use new_string_template::template::Template;
+use once_cell::sync::Lazy;
+use quickwit_common::uri::Uri;
+use regex::Regex;
+use tracing::debug;
+
+// Matches ${value} if value is in format of:
+// ENV_VAR or ENV_VAR:DEFAULT
+// Ignores whitespaces in curly braces
+static TEMPLATE_ENV_VAR_CAPTURE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\$\{\s*([A-Za-z0-9_]+)(?:(?::\-)([\S]+))?\s*}").expect("Failed to compile regular expression. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.")
+});
+
+pub fn render_config_file(contents: &[u8], uri: &Uri) -> Result<String> {
+    let contents_as_string = String::from_utf8(contents.to_vec())
+        .with_context(|| format!("Config file `{uri}` contains invalid UTF-8 characters."))?;
+    let template = Template::new(&contents_as_string).with_regex(&TEMPLATE_ENV_VAR_CAPTURE);
+    let mut data = HashMap::new();
+
+    for captured in TEMPLATE_ENV_VAR_CAPTURE.captures_iter(&contents_as_string) {
+        let env_var_name = captured.get(1).unwrap().as_str(); // Captures always have at least one match
+        let subst_val = {
+            if let Ok(env_var_value) = std::env::var(env_var_name) {
+                debug!(
+                    env_var_name,
+                    env_var_value, "Found ENV_VAR: {} with value: {}", env_var_name, env_var_value
+                );
+                env_var_value
+            } else if let Some(default_val) = captured.get(2) {
+                let default_val = default_val.as_str();
+                debug!(
+                    env_var_name,
+                    default_val,
+                    "Unable to get ENV_VAR specified: {}, Using default value instead: {}",
+                    env_var_name,
+                    default_val
+                );
+                default_val.to_string()
+            } else {
+                bail!(
+                    "Couldn't find ENV_VAR: {env_var_name} and the default value for the given \
+                     template"
+                );
+            }
+        };
+        data.insert(env_var_name, subst_val);
+    }
+
+    let rendered = template
+        .render(&data)
+        .with_context(|| format!("Failed to render templated config file `{uri}`."))?;
+    Ok(rendered)
+}
+
+#[cfg(test)]
+mod test {
+    use std::env;
+
+    use once_cell::sync::Lazy;
+    use quickwit_common::uri::Uri;
+
+    use super::render_config_file;
+
+    static TEST_URI: Lazy<Uri> = Lazy::new(|| Uri::new("file://config.yaml".to_string()));
+
+    #[test]
+    fn test_template_render() {
+        let mock_config = b"metastore_uri: ${TEST_TEMPLATE_RENDER_ENV_VAR_PLEASE_DONT_NOTICE}";
+        env::set_var(
+            "TEST_TEMPLATE_RENDER_ENV_VAR_PLEASE_DONT_NOTICE",
+            "s3://test-bucket/metastore",
+        );
+        let rendered = render_config_file(mock_config, &TEST_URI).unwrap();
+        std::env::remove_var("TEST_TEMPLATE_RENDER_ENV_VAR_PLEASE_DONT_NOTICE");
+        assert_eq!(rendered, "metastore_uri: s3://test-bucket/metastore");
+    }
+
+    #[test]
+    fn test_template_render_whitespaces() {
+        env::set_var(
+            "TEST_TEMPLATE_RENDER_WHITESPACE_QW_TEST",
+            "s3://test-bucket/metastore",
+        );
+
+        {
+            let mock_config = b"metastore_uri: ${TEST_TEMPLATE_RENDER_WHITESPACE_QW_TEST}";
+            let rendered = render_config_file(mock_config, &TEST_URI).unwrap();
+            assert_eq!(rendered, "metastore_uri: s3://test-bucket/metastore");
+        }
+        {
+            let mock_config = b"metastore_uri: ${TEST_TEMPLATE_RENDER_WHITESPACE_QW_TEST  }";
+            let rendered = render_config_file(mock_config, &TEST_URI).unwrap();
+            assert_eq!(rendered, "metastore_uri: s3://test-bucket/metastore");
+        }
+        {
+            let mock_config = b"metastore_uri: ${   TEST_TEMPLATE_RENDER_WHITESPACE_QW_TEST}";
+            let rendered = render_config_file(mock_config, &TEST_URI).unwrap();
+            assert_eq!(rendered, "metastore_uri: s3://test-bucket/metastore");
+        }
+        {
+            let mock_config = b"metastore_uri: ${  TEST_TEMPLATE_RENDER_WHITESPACE_QW_TEST    }";
+            let rendered = render_config_file(mock_config, &TEST_URI).unwrap();
+            assert_eq!(rendered, "metastore_uri: s3://test-bucket/metastore");
+        }
+    }
+
+    #[test]
+    fn test_template_render_default_value() {
+        let mock_config = b"metastore_uri: ${QW_NO_ENV_WITH_THIS_NAME:-s3://test-bucket/metastore}";
+        let rendered = render_config_file(mock_config, &TEST_URI).unwrap();
+        assert_eq!(rendered, "metastore_uri: s3://test-bucket/metastore");
+    }
+
+    #[test]
+    fn test_template_render_should_panic() {
+        let mock_config = b"metastore_uri: ${QW_NO_ENV_WITH_THIS_NAME}";
+        render_config_file(mock_config, &TEST_URI).unwrap_err();
+    }
+
+    #[test]
+    fn test_template_render_with_default_use_env() {
+        let mock_config =
+            b"metastore_uri: ${TEST_TEMPLATE_RENDER_ENV_VAR_DEFAULT_USE_ENV:-s3://test-bucket/wrongbucket}";
+        env::set_var(
+            "TEST_TEMPLATE_RENDER_ENV_VAR_DEFAULT_USE_ENV",
+            "s3://test-bucket/metastore",
+        );
+        let rendered = render_config_file(mock_config, &TEST_URI).unwrap();
+        std::env::remove_var("TEST_TEMPLATE_RENDER_ENV_VAR_DEFAULT_USE_ENV");
+        assert_eq!(rendered, "metastore_uri: s3://test-bucket/metastore");
+        assert_ne!(rendered, "metastore_uri: s3://test-bucket/wrongbucket");
+    }
+}

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -76,15 +76,15 @@ pub async fn start_cluster_service(
     let member = Member::new(
         quickwit_config.node_id.clone(),
         unix_timestamp(),
-        quickwit_config.gossip_advertise_addr().await?,
+        quickwit_config.gossip_advertise_addr,
     );
 
     let cluster = Cluster::join(
         member,
         services,
-        quickwit_config.gossip_listen_addr().await?,
+        quickwit_config.gossip_listen_addr,
         quickwit_config.cluster_id.clone(),
-        quickwit_config.grpc_advertise_addr().await?,
+        quickwit_config.grpc_advertise_addr,
         quickwit_config.peer_seed_addrs().await?,
         FailureDetectorConfig::default(),
         &UdpTransport,

--- a/quickwit-common/Cargo.toml
+++ b/quickwit-common/Cargo.toml
@@ -15,6 +15,7 @@ colored = "2"
 env_logger = "0.9"
 home = "0.5.3"
 itertools = "0.10.3"
+num_cpus = "1"
 once_cell = "1"
 pnet = { version = "0.31.0", features = [ "std" ] }
 prometheus = { version = "0.13", features = ["process"] }
@@ -24,7 +25,9 @@ serde = "1.0"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.29"
 warp = "0.3"
-num_cpus = "1"
+
+[features]
+testsuite = []
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/quickwit-common/src/net.rs
+++ b/quickwit-common/src/net.rs
@@ -64,6 +64,12 @@ impl Host {
     }
 }
 
+impl Default for Host {
+    fn default() -> Self {
+        Host::IpAddr(IpAddr::V4(Ipv4Addr::LOCALHOST))
+    }
+}
+
 impl Display for Host {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -175,11 +181,20 @@ impl HostAddr {
     }
 
     /// Resolves the host if necessary and returns a `SocketAddr`.
-    pub async fn to_socket_addr(&self) -> anyhow::Result<SocketAddr> {
+    pub async fn resolve(&self) -> anyhow::Result<SocketAddr> {
         self.host
             .resolve()
             .await
             .map(|ip_addr| SocketAddr::new(ip_addr, self.port))
+    }
+
+    /// Skips DNS resolution if possible and returns the host address as a `SocketAddr`.
+    pub fn to_socket_addr(self) -> Option<SocketAddr> {
+        if let Host::IpAddr(ip_addr) = self.host {
+            Some(SocketAddr::new(ip_addr, self.port))
+        } else {
+            None
+        }
     }
 }
 
@@ -205,16 +220,6 @@ pub fn find_available_tcp_port() -> anyhow::Result<u16> {
 /// Attempts to find the private IP of the host. Returns the matching interface name along with it.
 pub fn find_private_ip() -> Option<(String, IpAddr)> {
     _find_private_ip(&datalink::interfaces())
-}
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
-fn is_dormant(interface: &NetworkInterface) -> bool {
-    interface.is_dormant()
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
-fn is_dormant(_interface: &NetworkInterface) -> bool {
-    false
 }
 
 fn _find_private_ip(interfaces: &[NetworkInterface]) -> Option<(String, IpAddr)> {
@@ -246,6 +251,16 @@ fn _find_private_ip(interfaces: &[NetworkInterface]) -> Option<(String, IpAddr)>
         })
         .next()
         .map(|(interface, ip_net)| (interface.name.clone(), ip_net.ip()))
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn is_dormant(interface: &NetworkInterface) -> bool {
+    interface.is_dormant()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn is_dormant(_interface: &NetworkInterface) -> bool {
+    false
 }
 
 /// Converts an object into a resolved `SocketAddr`.

--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -32,11 +32,11 @@ use serde::{Serialize, Serializer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Protocol {
+    Azure,
     File,
     PostgreSQL,
     Ram,
     S3,
-    Azure,
 }
 
 impl Protocol {
@@ -75,7 +75,7 @@ impl Protocol {
     }
 
     pub fn is_object_storage(&self) -> bool {
-        matches!(&self, Protocol::S3 | Protocol::Azure)
+        matches!(&self, Protocol::Azure | Protocol::S3)
     }
 
     pub fn is_database(&self) -> bool {
@@ -192,8 +192,8 @@ impl Uri {
         Self { uri, protocol_idx }
     }
 
-    #[cfg(test)]
-    fn for_test(uri: &str) -> Self {
+    #[cfg(any(test, feature = "testsuite"))]
+    pub fn for_test(uri: &str) -> Self {
         Uri::new(uri.to_string())
     }
 

--- a/quickwit-config/Cargo.toml
+++ b/quickwit-config/Cargo.toml
@@ -12,8 +12,9 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = "1"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
-futures = "0.3"
+derivative = "2.2.0"
 json_comments = "0.2"
+new_string_template = "1.3.1"
 once_cell = "1.13.0"
 quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
 quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
@@ -23,6 +24,9 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 toml = "0.5"
 tracing = "0.1.29"
+
+[features]
+testsuite = []
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/quickwit-config/Cargo.toml
+++ b/quickwit-config/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = "1"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
+futures = "0.3"
 json_comments = "0.2"
 once_cell = "1.13.0"
 quickwit-common = { version = "0.3.1", path = "../quickwit-common" }

--- a/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit-config/resources/tests/config/quickwit.json
@@ -20,11 +20,5 @@
         "split_footer_cache_capacity": "1G",
         "max_num_concurrent_split_streams": 120,
         "max_num_concurrent_split_searches": 150
-    },
-    "storage": {
-        "s3": {
-            "region": "us-east-1",
-            "endpoint": "https://s3.us-east-1.amazonaws.com"
-        }
     }
 }

--- a/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit-config/resources/tests/config/quickwit.toml
@@ -17,5 +17,3 @@ split_footer_cache_capacity = "1G"
 max_num_concurrent_split_streams = 120
 max_num_concurrent_split_searches = 150
 
-[storage]
-s3 = { region = "us-east-1", endpoint = "https://s3.us-east-1.amazonaws.com" }

--- a/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit-config/resources/tests/config/quickwit.yaml
@@ -16,7 +16,3 @@ searcher:
   split_footer_cache_capacity: 1G
   max_num_concurrent_split_streams: 120
   max_num_concurrent_split_searches: 150
-storage:
-  s3:
-    region: us-east-1
-    endpoint: https://s3.us-east-1.amazonaws.com

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -29,10 +29,9 @@ use quickwit_doc_mapper::{
     DefaultDocMapperBuilder, DocMapper, FieldMappingEntry, ModeType, QuickwitJsonOptions, SortBy,
     SortByConfig, SortOrder,
 };
-use serde::de::IgnoredAny;
-use serde::{Deserialize, Serialize};
+use serde::de::{Error, IgnoredAny};
+use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::config::deser_and_validate_uri;
 use crate::source_config::SourceConfig;
 use crate::{is_false, validate_identifier};
 
@@ -78,6 +77,7 @@ impl IndexingResources {
         Byte::from_bytes(2_000_000_000) // 2GB
     }
 
+    #[cfg(any(test, feature = "testsuite"))]
     pub fn for_test() -> Self {
         Self {
             __num_threads_deprecated: IgnoredAny,
@@ -193,7 +193,7 @@ impl IndexingSettings {
         SortBy::DocId
     }
 
-    // TODO(guilload) Hide this method if possible.
+    #[cfg(any(test, feature = "testsuite"))]
     pub fn for_test() -> Self {
         Self {
             resources: IndexingResources::for_test(),
@@ -300,13 +300,13 @@ impl IndexConfig {
         if self.sources.len() > self.sources().len() {
             bail!("Index config contains duplicate sources.")
         }
-        for source in self.sources.iter() {
+        for source in &self.sources {
             source.validate()?;
         }
         // Validation is made by building the doc mapper.
         // Note: this needs a deep refactoring to separate the doc mapping configuration,
         // and doc mapper implementations.
-        let _ = build_doc_mapper(
+        build_doc_mapper(
             &self.doc_mapping,
             &self.search_settings,
             &self.indexing_settings,
@@ -346,6 +346,16 @@ pub fn build_doc_mapper(
         partition_key: doc_mapping.partition_key.clone(),
     };
     Ok(Arc::new(builder.try_build()?))
+}
+
+/// Deserializes and validates a [`Uri`].
+fn deser_and_validate_uri<'de, D>(deserializer: D) -> Result<Option<Uri>, D::Error>
+where D: Deserializer<'de> {
+    let uri_opt: Option<String> = Deserialize::deserialize(deserializer)?;
+    uri_opt
+        .map(|uri| Uri::try_new(&uri))
+        .transpose()
+        .map_err(D::Error::custom)
 }
 
 #[cfg(test)]

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -32,7 +32,7 @@ use quickwit_doc_mapper::{
 use serde::de::IgnoredAny;
 use serde::{Deserialize, Serialize};
 
-use crate::config::deser_valid_uri;
+use crate::config::deser_and_validate_uri;
 use crate::source_config::SourceConfig;
 use crate::{is_false, validate_identifier};
 
@@ -234,7 +234,7 @@ pub struct IndexConfig {
     pub version: usize,
     pub index_id: String,
     #[serde(default)]
-    #[serde(deserialize_with = "deser_valid_uri")]
+    #[serde(deserialize_with = "deser_and_validate_uri")]
     pub index_uri: Option<Uri>,
     pub doc_mapping: DocMapping,
     #[serde(default)]

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -24,10 +24,11 @@ use regex::Regex;
 mod config;
 mod index_config;
 mod source_config;
+mod templating;
 
 pub use config::{
-    get_searcher_config_instance, IndexerConfig, QuickwitConfig, QuickwitConfigBuilder,
-    SearcherConfig, DEFAULT_QW_CONFIG_PATH, SEARCHER_CONFIG_INSTANCE,
+    get_searcher_config_instance, IndexerConfig, QuickwitConfig, SearcherConfig,
+    DEFAULT_QW_CONFIG_PATH, SEARCHER_CONFIG_INSTANCE,
 };
 pub use index_config::{
     build_doc_mapper, DocMapping, IndexConfig, IndexingResources, IndexingSettings, MergePolicy,

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -26,8 +26,8 @@ mod index_config;
 mod source_config;
 
 pub use config::{
-    get_searcher_config_instance, IndexerConfig, QuickwitConfig, SearcherConfig,
-    DEFAULT_QW_CONFIG_PATH, SEARCHER_CONFIG_INSTANCE,
+    get_searcher_config_instance, IndexerConfig, QuickwitConfig, QuickwitConfigBuilder,
+    SearcherConfig, DEFAULT_QW_CONFIG_PATH, SEARCHER_CONFIG_INSTANCE,
 };
 pub use index_config::{
     build_doc_mapper, DocMapping, IndexConfig, IndexingResources, IndexingSettings, MergePolicy,

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -26,7 +26,9 @@ openssl = { version = "0.10.36", default-features = false, optional = true }
 quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
 quickwit-aws = { version = "0.3.1", path = "../quickwit-aws" }
 quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
-quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
+quickwit-config = { version = "0.3.1", path = "../quickwit-config", features = [
+  "testsuite"
+] }
 quickwit-directories = { version = "0.3.1", path = "../quickwit-directories" }
 quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper", features = [
     "testsuite",

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -189,7 +189,7 @@ async fn leaf_search_stream_single_split(
                     &m_request_fields,
                     timestamp_filter_builder_opt,
                     &searcher,
-                    query.as_ref(),
+                    &query,
                 )?;
                 super::serialize::<i64>(&collected_values, &mut buffer, output_format).map_err(
                     |_| {
@@ -204,7 +204,7 @@ async fn leaf_search_stream_single_split(
                     &m_request_fields,
                     timestamp_filter_builder_opt,
                     &searcher,
-                    query.as_ref(),
+                    &query,
                 )?;
                 super::serialize::<u64>(&collected_values, &mut buffer, output_format).map_err(
                     |_| {
@@ -234,7 +234,7 @@ async fn leaf_search_stream_single_split(
                     &m_request_fields,
                     timestamp_filter_builder_opt,
                     &searcher,
-                    query.as_ref(),
+                    &query,
                 )?;
                 super::serialize_partitions::<i64, i64>(collected_values.as_slice(), &mut buffer)
                     .map_err(|_| {
@@ -248,7 +248,7 @@ async fn leaf_search_stream_single_split(
                     &m_request_fields,
                     timestamp_filter_builder_opt,
                     &searcher,
-                    query.as_ref(),
+                    &query,
                 )?;
                 super::serialize_partitions::<u64, u64>(collected_values.as_slice(), &mut buffer)
                     .map_err(|_| {

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -55,6 +55,9 @@ warp = "0.3"
 [dev-dependencies]
 assert-json-diff = "2.0.1"
 mockall = "0.11"
+quickwit-common = { version = "0.3.1", path = "../quickwit-common", features = [
+  "testsuite"
+] }
 quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore", features = [
   "testsuite"
 ] }

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -96,7 +96,7 @@ pub async fn serve_quickwit(
     services: &HashSet<QuickwitService>,
 ) -> anyhow::Result<()> {
     let metastore = quickwit_metastore_uri_resolver()
-        .resolve(&config.metastore_uri())
+        .resolve(&config.metastore_uri)
         .await?;
     let indexes = metastore
         .list_indexes_metadatas()
@@ -148,10 +148,10 @@ pub async fn serve_quickwit(
     let index_service = Arc::new(IndexService::new(
         metastore,
         storage_resolver,
-        config.default_index_root_uri(),
+        config.default_index_root_uri.clone(),
     ));
-    let grpc_listen_addr = config.grpc_listen_addr().await?;
-    let rest_listen_addr = config.rest_listen_addr().await?;
+    let grpc_listen_addr = config.grpc_listen_addr;
+    let rest_listen_addr = config.rest_listen_addr;
 
     let quickwit_services = QuickwitServices {
         config: Arc::new(config),

--- a/quickwit-serve/src/node_info_handler.rs
+++ b/quickwit-serve/src/node_info_handler.rs
@@ -70,7 +70,6 @@ async fn get_config(config: Arc<QuickwitConfig>) -> Result<impl warp::Reply, Rej
 #[cfg(test)]
 mod tests {
     use assert_json_diff::assert_json_include;
-    use quickwit_config::QuickwitConfigBuilder;
 
     use super::*;
     use crate::recover_fn;
@@ -85,8 +84,8 @@ mod tests {
             commit_date: "commit_date",
             version: "version",
         };
-        let mut config = QuickwitConfigBuilder::default().resolve().await?;
-        config.metastore_uri = Uri::new("postgresql://username:password@db".to_string());
+        let mut config = QuickwitConfig::for_test();
+        config.metastore_uri = Uri::for_test("postgresql://username:password@db");
         let handler =
             super::node_info_handler(Arc::new(build_info.clone()), Arc::new(config.clone()))
                 .recover(recover_fn);


### PR DESCRIPTION
Closes #1011, #1742 

This PR separates the `QuickwitConfig` into two structs: `QuickwitConfig` and `QuickwitConfigObject`, and adds templating support to config files.

- `QuickwitConfig` is now only responsible for deserializing data. All other logic (value transformations, checking validities, accessing values) are transferred to `QuickwitConfigObject`

- `QuickwitConfigObject` does not have any accessor functions (one exception is `peer_seed_addrs` for DNS resolution purposes); instead, all of the required config values are generated when the config is initialized.

- All of the `QuickwitConfig` accesses are changed to `QuickwitConfigObject`.

- `StorageConfig` is removed because it is currently not used.

- Added templating support with docker-like syntax. For example:

> quickwit.yaml
> ```yaml
> rest_listen_port: ${REST_LISTEN_PORT:-4444}
> ```
replaces the value with `REST_LISTEN_PORT` or with `4444` if the given ENV_VAR couldn't be accessed.

We decided to drop some of the override requirements (_like half of them:_ overriding with environment vars and cli args, storing the source of the config value) since it would add too much complexity to the code.
The main reason for added complexity comes from accessing struct fields as strings and parsing them back. It is certainly possible, but we couldn't come up with anything simple and generic (all suggestions are welcome :) )