### PR TITLE
[Kafka source] Use `consumer.recv()` directly rather than `consumer.stream()`

### DIFF
--- a/quickwit-config/resources/tests/source_config/kafka-source.json
+++ b/quickwit-config/resources/tests/source_config/kafka-source.json
@@ -4,7 +4,7 @@
     "params": {
         "topic": "cloudera-cluster-logs",
         "client_params": {
-            "bootstrap.servers": "host:9092"
+            "bootstrap.servers": "localhost:9092"
         }
     }
 }

--- a/quickwit-config/src/source_config.rs
+++ b/quickwit-config/src/source_config.rs
@@ -214,6 +214,10 @@ pub struct KafkaSourceParams {
     #[serde(default = "serde_json::Value::default")]
     #[serde(skip_serializing_if = "serde_json::Value::is_null")]
     pub client_params: serde_json::Value,
+    /// When backfill mode is enabled, the source exits after reaching the end of the topic.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "is_false")]
+    pub enable_backfill_mode: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -229,9 +233,9 @@ pub struct KinesisSourceParams {
     pub stream_name: String,
     #[serde(flatten)]
     pub region_or_endpoint: Option<RegionOrEndpoint>,
-    #[doc(hidden)]
+    /// When backfill mode is enabled, the source exits after reaching the end of the stream.
     #[serde(skip_serializing_if = "is_false")]
-    pub shutdown_at_stream_eof: bool,
+    pub enable_backfill_mode: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
@@ -240,9 +244,8 @@ struct KinesisSourceParamsInner {
     pub stream_name: String,
     pub region: Option<String>,
     pub endpoint: Option<String>,
-    #[doc(hidden)]
     #[serde(default)]
-    pub shutdown_at_stream_eof: bool,
+    pub enable_backfill_mode: bool,
 }
 
 impl TryFrom<KinesisSourceParamsInner> for KinesisSourceParams {
@@ -261,7 +264,7 @@ impl TryFrom<KinesisSourceParamsInner> for KinesisSourceParams {
         Ok(KinesisSourceParams {
             stream_name: value.stream_name,
             region_or_endpoint,
-            shutdown_at_stream_eof: value.shutdown_at_stream_eof,
+            enable_backfill_mode: value.enable_backfill_mode,
         })
     }
 }
@@ -317,10 +320,79 @@ mod tests {
             source_params: SourceParams::Kafka(KafkaSourceParams {
                 topic: "cloudera-cluster-logs".to_string(),
                 client_log_level: None,
-                client_params: json! {{"bootstrap.servers": "host:9092"}},
+                client_params: json! {{"bootstrap.servers": "localhost:9092"}},
+                enable_backfill_mode: false,
             }),
         };
         assert_eq!(source_config, expected_source_config);
+    }
+
+    #[test]
+    fn test_kafka_source_params_serialization() {
+        {
+            let params = KafkaSourceParams {
+                topic: "my-topic".to_string(),
+                client_log_level: None,
+                client_params: json!(null),
+                enable_backfill_mode: false,
+            };
+            let params_yaml = serde_yaml::to_string(&params).unwrap();
+
+            assert_eq!(
+                serde_yaml::from_str::<KafkaSourceParams>(&params_yaml).unwrap(),
+                params,
+            )
+        }
+        {
+            let params = KafkaSourceParams {
+                topic: "my-topic".to_string(),
+                client_log_level: Some("info".to_string()),
+                client_params: json! {{"bootstrap.servers": "localhost:9092"}},
+                enable_backfill_mode: false,
+            };
+            let params_yaml = serde_yaml::to_string(&params).unwrap();
+
+            assert_eq!(
+                serde_yaml::from_str::<KafkaSourceParams>(&params_yaml).unwrap(),
+                params,
+            )
+        }
+    }
+
+    #[test]
+    fn test_kafka_source_params_deserialization() {
+        {
+            let yaml = r#"
+                    topic: my-topic
+                "#;
+            assert_eq!(
+                serde_yaml::from_str::<KafkaSourceParams>(yaml).unwrap(),
+                KafkaSourceParams {
+                    topic: "my-topic".to_string(),
+                    client_log_level: None,
+                    client_params: json!(null),
+                    enable_backfill_mode: false,
+                }
+            );
+        }
+        {
+            let yaml = r#"
+                    topic: my-topic
+                    client_log_level: info
+                    client_params:
+                        bootstrap.servers: localhost:9092
+                    enable_backfill_mode: true
+                "#;
+            assert_eq!(
+                serde_yaml::from_str::<KafkaSourceParams>(yaml).unwrap(),
+                KafkaSourceParams {
+                    topic: "my-topic".to_string(),
+                    client_log_level: Some("info".to_string()),
+                    client_params: json! {{"bootstrap.servers": "localhost:9092"}},
+                    enable_backfill_mode: true,
+                }
+            );
+        }
     }
 
     #[tokio::test]
@@ -336,7 +408,7 @@ mod tests {
             source_params: SourceParams::Kinesis(KinesisSourceParams {
                 stream_name: "emr-cluster-logs".to_string(),
                 region_or_endpoint: None,
-                shutdown_at_stream_eof: false,
+                enable_backfill_mode: false,
             }),
         };
         assert_eq!(source_config, expected_source_config);
@@ -363,7 +435,7 @@ mod tests {
             let params = KinesisSourceParams {
                 stream_name: "my-stream".to_string(),
                 region_or_endpoint: None,
-                shutdown_at_stream_eof: false,
+                enable_backfill_mode: false,
             };
             let params_yaml = serde_yaml::to_string(&params).unwrap();
 
@@ -376,7 +448,7 @@ mod tests {
             let params = KinesisSourceParams {
                 stream_name: "my-stream".to_string(),
                 region_or_endpoint: Some(RegionOrEndpoint::Region("us-west-1".to_string())),
-                shutdown_at_stream_eof: false,
+                enable_backfill_mode: false,
             };
             let params_yaml = serde_yaml::to_string(&params).unwrap();
 
@@ -391,7 +463,7 @@ mod tests {
                 region_or_endpoint: Some(RegionOrEndpoint::Endpoint(
                     "https://localhost:4566".to_string(),
                 )),
-                shutdown_at_stream_eof: false,
+                enable_backfill_mode: false,
             };
             let params_yaml = serde_yaml::to_string(&params).unwrap();
 
@@ -405,43 +477,41 @@ mod tests {
     #[test]
     fn test_kinesis_source_params_deserialization() {
         {
-            {
-                let yaml = r#"
+            let yaml = r#"
                     stream_name: my-stream
                 "#;
-                assert_eq!(
-                    serde_yaml::from_str::<KinesisSourceParams>(yaml).unwrap(),
-                    KinesisSourceParams {
-                        stream_name: "my-stream".to_string(),
-                        region_or_endpoint: None,
-                        shutdown_at_stream_eof: false,
-                    }
-                );
-            }
-            {
-                let yaml = r#"
+            assert_eq!(
+                serde_yaml::from_str::<KinesisSourceParams>(yaml).unwrap(),
+                KinesisSourceParams {
+                    stream_name: "my-stream".to_string(),
+                    region_or_endpoint: None,
+                    enable_backfill_mode: false,
+                }
+            );
+        }
+        {
+            let yaml = r#"
                     stream_name: my-stream
                     region: us-west-1
-                    shutdown_at_stream_eof: true
+                    enable_backfill_mode: true
                 "#;
-                assert_eq!(
-                    serde_yaml::from_str::<KinesisSourceParams>(yaml).unwrap(),
-                    KinesisSourceParams {
-                        stream_name: "my-stream".to_string(),
-                        region_or_endpoint: Some(RegionOrEndpoint::Region("us-west-1".to_string())),
-                        shutdown_at_stream_eof: true,
-                    }
-                );
-            }
-            {
-                let yaml = r#"
+            assert_eq!(
+                serde_yaml::from_str::<KinesisSourceParams>(yaml).unwrap(),
+                KinesisSourceParams {
+                    stream_name: "my-stream".to_string(),
+                    region_or_endpoint: Some(RegionOrEndpoint::Region("us-west-1".to_string())),
+                    enable_backfill_mode: true,
+                }
+            );
+        }
+        {
+            let yaml = r#"
                     stream_name: my-stream
                     region: us-west-1
                     endpoint: https://localhost:4566
                 "#;
-                let error = serde_yaml::from_str::<KinesisSourceParams>(yaml).unwrap_err();
-                assert!(error.to_string().starts_with("Kinesis source parameters "));
-            }
+            let error = serde_yaml::from_str::<KinesisSourceParams>(yaml).unwrap_err();
+            assert!(error.to_string().starts_with("Kinesis source parameters "));
         }
     }
 

--- a/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
+++ b/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
@@ -175,6 +175,7 @@ pub(crate) fn sample_index_metadata_for_regression() -> IndexMetadata {
             topic: "kafka-topic".to_string(),
             client_log_level: None,
             client_params: serde_json::json!({}),
+            enable_backfill_mode: false,
         }),
     };
     let mut sources = HashMap::default();


### PR DESCRIPTION
### Description
Simplify tokio select loop using  `consumer.recv()` directly rather than `consumer.stream()`

### How was this PR tested?
Ran Kafka source on an empty topic.