### PR TITLE
Improve the reliability of the localstack container startup for tests

### DIFF
--- a/.localstack/init.sh
+++ b/.localstack/init.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
-awslocal kinesis create-stream --stream-name quickwit-dev-stream --shard-count 3
 awslocal s3 mb s3://quickwit-dev
 awslocal s3 mb s3://quickwit-integration-tests && awslocal s3 rm --recursive s3://quickwit-integration-tests
+
+if ! awslocal kinesis list-streams | grep quickwit-dev-stream ; then
+    awslocal kinesis create-stream --stream-name quickwit-dev-stream --shard-count 3
+fi

--- a/.localstack/init.sh
+++ b/.localstack/init.sh
@@ -5,6 +5,6 @@ set -eu
 awslocal s3 mb s3://quickwit-dev
 awslocal s3 mb s3://quickwit-integration-tests && awslocal s3 rm --recursive s3://quickwit-integration-tests
 
-if ! awslocal kinesis list-streams | grep quickwit-dev-stream ; then
+if ! awslocal kinesis list-streams | grep -q quickwit-dev-stream ; then
     awslocal kinesis create-stream --stream-name quickwit-dev-stream --shard-count 3
 fi

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ help:
 # `make docker-compose-up DOCKER_SERVICES='jaeger,localstack'` starts the subset of services matching the profiles.
 docker-compose-up:
 	@echo "Launching ${DOCKER_SERVICES} Docker service(s)"
-	COMPOSE_PROFILES=$(DOCKER_SERVICES) docker-compose -f docker-compose.yml up -d --remove-orphans
+	COMPOSE_PROFILES=$(DOCKER_SERVICES) docker compose -f docker-compose.yml up -d --remove-orphans --wait
 
 docker-compose-down:
-	docker-compose -f docker-compose.yml down --remove-orphans
+	docker compose -f docker-compose.yml down --remove-orphans
 
 docker-compose-logs:
-	docker-compose logs -f -t
+	docker compose logs -f -t
 
 fmt:
 	@echo "Formatting Rust files"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
       - "14250:14250"
       - "14268:14268"
       - "16686:16686"
+    # This dependency is to insure that localstack is fully initialized and the test bucket
+    # created before docker-compose considers the stack fully up. Without this the localstack
+    # image will be labeled ok with indeterminate latency in bucket creation because the
+    # init script to create the bucket runs in the background.
+    depends_on:
+      localstack:
+        condition: service_healthy
 
   localstack:
     image: localstack/localstack:latest
@@ -42,9 +49,12 @@ services:
       SERVICES: kinesis,s3
     volumes:
       - ".localstack:/docker-entrypoint-initaws.d"
-      - "${TMPDIR:-/tmp}/quickwit/services/localstack:/tmp/localstack"
+      - "${TMPDIR:-/tmp}/quickwit/services/localstack:/var/lib/localstack"
     healthcheck:
-      test: ["CMD", "curl", "-k", "https://localhost:4566"]
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:4566/quickwit-integration-tests"]
+      interval: 1s
+      timeout: 5s
+      retries: 100
 
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,13 +23,6 @@ services:
       - "14250:14250"
       - "14268:14268"
       - "16686:16686"
-    # This dependency is to insure that localstack is fully initialized and the test bucket
-    # created before docker-compose considers the stack fully up. Without this the localstack
-    # image will be labeled ok with indeterminate latency in bucket creation because the
-    # init script to create the bucket runs in the background.
-    depends_on:
-      localstack:
-        condition: service_healthy
 
   localstack:
     image: localstack/localstack:latest


### PR DESCRIPTION
### Description

I've been running the tests on an M1 Mac and Docker may not have the best performance in this scenario. The tests pass for me about 20% of the time with various failures due to latency issues. This PR fixes one particular issue that I was seeing in the startup of the localstack container. The container runs the script that creates the bucket in the background which meant the container would be considered up and the tests would start running before the bucket was actually created. There is a surprising amount of latency in the bucket creation on my machine. Once the bucket gets created successfully the problem tests will pass but stopping the docker services will bring the issue back.

### How was this PR tested?

```
make test-all
make docker-compose-down
make test-all
```
