### PR TITLE
Added partition_id to split metadata data.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "arc-swap"
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byte-unit"
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -693,9 +693,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "1079fb8528d9f9c888b1e8aa651e6e079ade467323d58f75faf1d30b1808f540"
 dependencies = [
  "libc",
 ]
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -1195,9 +1195,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1220,15 +1220,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1248,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
 
 [[package]]
 name = "futures-lite"
@@ -1269,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1280,21 +1280,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1383,9 +1383,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.0"
+version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
+checksum = "6ea9fe3952d32674a14e0975009a3547af9ea364995b5ec1add2e23c2ae523ab"
 dependencies = [
  "base64",
  "byteorder",
@@ -1678,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.44"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1831,9 +1831,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -2001,9 +2001,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2e4455be2010e8c5e77f0d10234b30f3a636a5305725609b5a71ad00d22577"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -2241,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "oneshot"
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "output_vt100"
@@ -2493,18 +2493,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2531,9 +2531,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
+checksum = "716b4eeb6c4a1d3ecc956f75b43ec2e8e8ba80026413e70a3f41fd3313d3492b"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2550,9 +2550,9 @@ checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -3116,6 +3116,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "siphasher",
  "tantivy",
  "tantivy-query-grammar 0.18.0 (git+https://github.com/quickwit-oss/tantivy/?rev=d24f31f)",
  "thiserror",
@@ -3950,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4084,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.4"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
+checksum = "f50845f68d5c693aac7d72a25415ddd21cb8182c04eafe447b73af55a05f9e1b"
 dependencies = [
  "indexmap",
  "itoa 1.0.3",
@@ -4207,6 +4208,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"

--- a/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit-doc-mapper/Cargo.toml
@@ -24,6 +24,7 @@ quickwit-proto = { version = "0.3.1", path = "../quickwit-proto" }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+siphasher = "0.3"
 tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "f4d7621", default-features = false, features = [
   "mmap",
   "lz4-compression",

--- a/quickwit-doc-mapper/src/routing_expression/mod.rs
+++ b/quickwit-doc-mapper/src/routing_expression/mod.rs
@@ -17,10 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::hash_map::DefaultHasher;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
+use std::sync::Arc;
+
+use siphasher::sip::SipHasher;
 
 pub trait RoutingExprContext {
     // TODO see if we can get rid of the alloc in some specific case
@@ -78,32 +80,102 @@ impl RoutingExprContext for serde_json::Map<String, serde_json::Value> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum RoutingExpr {
-    Field(String),
-    Composite(Vec<RoutingExpr>),
-    // TODO Enrich me! Map / Modulo
+#[derive(Clone)]
+pub struct RoutingExpr {
+    inner: Arc<InnerRoutingExpr>,
+    salted_hasher: SipHasher,
 }
 
 impl FromStr for RoutingExpr {
     type Err = anyhow::Error;
 
+    fn from_str(expr_dsl_str: &str) -> Result<Self, Self::Err> {
+        let inner = InnerRoutingExpr::from_str(expr_dsl_str)?;
+        let mut salted_hasher: SipHasher = SipHasher::new();
+        // We hash the expression tree here instead of hashing the str, or
+        // hash the display of the tree, in order to make the partition id less brittle to
+        // a minor change in formatting, or a change in the DSL itself.
+        //
+        // We do not use the standard library DefaultHasher to make sure we
+        // get the same hash values.
+        inner.hash(&mut salted_hasher);
+        Ok(RoutingExpr {
+            inner: Arc::new(inner),
+            salted_hasher,
+        })
+    }
+}
+
+impl Display for RoutingExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum InnerRoutingExpr {
+    Field(String),
+    Composite(Vec<InnerRoutingExpr>),
+    // TODO Enrich me! Map / Modulo
+}
+
+impl InnerRoutingExpr {
+    fn eval_hash<Ctx: RoutingExprContext, H: Hasher>(&self, ctx: &Ctx, hasher: &mut H) {
+        match self {
+            InnerRoutingExpr::Field(field_name) => {
+                ExprType::Field.hash(hasher);
+                ctx.hash_attribute(field_name, hasher);
+            }
+            InnerRoutingExpr::Composite(children) => {
+                ExprType::Composite.hash(hasher);
+                for child in children {
+                    child.eval_hash(ctx, hasher);
+                }
+            }
+        }
+    }
+}
+
+// We don't rely on Derive here to make it easier to keep the
+// implementation stable.
+#[allow(clippy::derive_hash_xor_eq)]
+impl Hash for InnerRoutingExpr {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        match self {
+            InnerRoutingExpr::Field(field_name) => {
+                ExprType::Field.hash(hasher);
+                hasher.write_usize(field_name.len());
+                hasher.write(field_name.as_bytes());
+            }
+            InnerRoutingExpr::Composite(children) => {
+                ExprType::Composite.hash(hasher);
+                for child in children {
+                    child.hash(hasher);
+                }
+            }
+        }
+    }
+}
+
+impl FromStr for InnerRoutingExpr {
+    type Err = anyhow::Error;
+
     fn from_str(expr_dsl_str: &str) -> anyhow::Result<Self> {
         if expr_dsl_str.is_empty() {
-            return Ok(RoutingExpr::Composite(Vec::new()));
+            return Ok(InnerRoutingExpr::Composite(Vec::new()));
         }
-        Ok(RoutingExpr::Field(expr_dsl_str.to_string()))
+        Ok(InnerRoutingExpr::Field(expr_dsl_str.to_string()))
     }
 }
 
 // The display implementation should be consistent with `FromString`.
-impl Display for RoutingExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Display for InnerRoutingExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
-            RoutingExpr::Field(field) => {
+            InnerRoutingExpr::Field(field) => {
                 write!(f, "{}", field)?;
             }
-            RoutingExpr::Composite(children) => {
+            InnerRoutingExpr::Composite(children) => {
                 if children.is_empty() {
                     return Ok(());
                 }
@@ -130,24 +202,9 @@ impl RoutingExpr {
     ///
     /// Obviously this function is not perfectly injective.
     pub fn eval_hash<Ctx: RoutingExprContext>(&self, ctx: &Ctx) -> u64 {
-        let mut hasher = DefaultHasher::default();
-        self.hash(ctx, &mut hasher);
+        let mut hasher = self.salted_hasher;
+        self.inner.eval_hash(ctx, &mut hasher);
         hasher.finish()
-    }
-
-    fn hash<Ctx: RoutingExprContext, H: Hasher>(&self, ctx: &Ctx, hasher: &mut H) {
-        match self {
-            RoutingExpr::Field(field_name) => {
-                ExprType::Field.hash(hasher);
-                ctx.hash_attribute(field_name, hasher);
-            }
-            RoutingExpr::Composite(children) => {
-                ExprType::Composite.hash(hasher);
-                for child in children {
-                    child.hash(ctx, hasher);
-                }
-            }
-        }
     }
 }
 
@@ -155,13 +212,13 @@ impl RoutingExpr {
 mod tests {
     use super::*;
 
-    fn test_ser_deser(expr: &RoutingExpr) {
+    fn test_ser_deser(expr: &InnerRoutingExpr) {
         let ser = expr.to_string();
-        assert_eq!(&RoutingExpr::from_str(&ser).unwrap(), expr);
+        assert_eq!(&InnerRoutingExpr::from_str(&ser).unwrap(), expr);
     }
 
-    fn deser_util(expr_dsl: &str) -> RoutingExpr {
-        let expr = RoutingExpr::from_str(expr_dsl).unwrap();
+    fn deser_util(expr_dsl: &str) -> InnerRoutingExpr {
+        let expr = InnerRoutingExpr::from_str(expr_dsl).unwrap();
         test_ser_deser(&expr);
         expr
     }
@@ -169,12 +226,39 @@ mod tests {
     #[test]
     fn test_routing_expr_empty() {
         let routing_expr = deser_util("");
-        assert!(matches!(routing_expr, RoutingExpr::Composite(leaves) if leaves.is_empty()));
+        assert!(matches!(routing_expr, InnerRoutingExpr::Composite(leaves) if leaves.is_empty()));
     }
 
     #[test]
     fn test_routing_expr_single_field() {
         let routing_expr = deser_util("tenant_id");
-        assert!(matches!(routing_expr, RoutingExpr::Field(attr_name) if attr_name == "tenant_id"));
+        assert!(
+            matches!(routing_expr, InnerRoutingExpr::Field(attr_name) if attr_name == "tenant_id")
+        );
+    }
+
+    // This unit test is here to ensure that the routing expr hash depends on
+    // the expression itself as well as the expression value.
+    #[test]
+    fn test_routing_expr_depends_on_both_expr_and_value() {
+        let routing_expr = RoutingExpr::from_str("tenant_id").unwrap();
+        let routing_expr2 = RoutingExpr::from_str("app").unwrap();
+        let ctx: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(r#"{"tenant_id": "happy", "app": "happy"}"#).unwrap();
+        let ctx2: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(r#"{"tenant_id": "happy2"}"#).unwrap();
+        // This assert is important.
+        assert_ne!(routing_expr.eval_hash(&ctx), routing_expr2.eval_hash(&ctx),);
+        assert_ne!(routing_expr.eval_hash(&ctx), routing_expr.eval_hash(&ctx2),);
+    }
+
+    // This unit test is here to detect a change in the hash logic.
+    // Breaking it is not catastrophic but it should not happen too often.
+    #[test]
+    fn test_routing_expr_change_detection() {
+        let routing_expr = RoutingExpr::from_str("tenant_id").unwrap();
+        let ctx: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(r#"{"tenant_id": "happy", "app": "happy"}"#).unwrap();
+        assert_eq!(routing_expr.eval_hash(&ctx), 8236810766200219304u64);
     }
 }

--- a/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit-indexing/src/actors/merge_executor.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::RangeInclusive;
 use std::path::Path;
 use std::time::Instant;
@@ -223,6 +223,32 @@ fn merge_all_segments(index: &Index) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Following Boost's hash_combine.
+fn combine_two_hashes(lhs: u64, rhs: u64) -> u64 {
+    let update_to_xor = rhs
+        .wrapping_add(0x9e3779b9)
+        .wrapping_add(lhs << 6)
+        .wrapping_add(lhs >> 2);
+    lhs ^ update_to_xor
+}
+
+fn combine_partition_ids_aux(partition_ids: impl Iterator<Item = u64>) -> u64 {
+    let sorted_unique_partition_ids: BTreeSet<u64> = partition_ids.collect();
+    let mut sorted_unique_partition_ids_it = sorted_unique_partition_ids.into_iter();
+    if let Some(partition_id) = sorted_unique_partition_ids_it.next() {
+        sorted_unique_partition_ids_it.fold(partition_id, |acc, partition_id| {
+            combine_two_hashes(acc, partition_id)
+        })
+    } else {
+        // This is not forbidden but this should never happen.
+        0u64
+    }
+}
+
+pub fn combine_partition_ids(splits: &[SplitMetadata]) -> u64 {
+    combine_partition_ids_aux(splits.iter().map(|split| split.partition_id))
+}
+
 fn merge_split_directories(
     union_index_meta: IndexMeta,
     split_directories: Vec<Box<dyn Directory>>,
@@ -290,6 +316,7 @@ impl MergeExecutor {
     ) -> anyhow::Result<()> {
         let start = Instant::now();
         info!("merge-start");
+        let partition_id = combine_partition_ids_aux(splits.iter().map(|split| split.partition_id));
         let replaced_split_ids: Vec<String> = splits
             .iter()
             .map(|split| split.split_id().to_string())
@@ -323,6 +350,7 @@ impl MergeExecutor {
         let indexed_split = IndexedSplit {
             split_id: split_merge_id,
             index_id: self.index_id.clone(),
+            partition_id,
             replaced_split_ids,
             time_range,
             demux_num_ops: 0,
@@ -360,6 +388,7 @@ impl MergeExecutor {
             self.demux_field_name.is_some(),
             "`process_demux` cannot be called without a demux field."
         );
+        let partition_id = combine_partition_ids_aux(splits.iter().map(|split| split.partition_id));
         let demux_field_name = self.demux_field_name.as_ref().unwrap();
         let replaced_split_ids = splits
             .iter()
@@ -467,6 +496,7 @@ impl MergeExecutor {
             let indexed_split = IndexedSplit {
                 split_id,
                 index_id: self.index_id.clone(),
+                partition_id,
                 replaced_split_ids: replaced_split_ids.clone(),
                 time_range,
                 demux_num_ops: initial_demux_num_ops + 1,
@@ -1174,5 +1204,34 @@ mod tests {
                 proptest::collection::vec(100_000..5_000_000_usize, num_tenants)
             })
             .boxed()
+    }
+
+    #[test]
+    fn test_combine_partition_ids_singleton_unchanged() {
+        assert_eq!(combine_partition_ids_aux([17].into_iter()), 17);
+    }
+
+    #[test]
+    fn test_combine_partition_ids_zero_has_an_impact() {
+        assert_ne!(
+            combine_partition_ids_aux([12u64, 0u64].into_iter()),
+            combine_partition_ids_aux([12u64].into_iter())
+        );
+    }
+
+    #[test]
+    fn test_combine_partition_ids_depends_on_partition_id_set() {
+        assert_eq!(
+            combine_partition_ids_aux([12, 16, 12, 13].into_iter()),
+            combine_partition_ids_aux([12, 16, 13].into_iter())
+        );
+    }
+
+    #[test]
+    fn test_combine_partition_ids_order_does_not_matter() {
+        assert_eq!(
+            combine_partition_ids_aux([7, 12, 13].into_iter()),
+            combine_partition_ids_aux([12, 13, 7].into_iter())
+        );
     }
 }

--- a/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit-indexing/src/actors/merge_planner.rs
@@ -117,6 +117,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use super::*;
+    use crate::actors::combine_partition_ids;
     use crate::actors::merge_executor::{demux_virtual_split, VirtualSplit};
     use crate::merge_policy::MergeOperation;
     use crate::{new_split_id, StableMultitenantWithTimestampMergePolicy};
@@ -165,6 +166,7 @@ mod tests {
         let tags = compute_merge_tags(splits);
         SplitMetadata {
             split_id: merged_split_id,
+            partition_id: combine_partition_ids(splits),
             num_docs,
             uncompressed_docs_size_in_bytes: size_in_bytes,
             time_range,
@@ -202,6 +204,7 @@ mod tests {
         for demuxed_split in demuxed_splits {
             let split_metadata = SplitMetadata {
                 split_id: new_split_id(),
+                partition_id: combine_partition_ids(splits),
                 num_docs: demuxed_split.total_num_docs(),
                 uncompressed_docs_size_in_bytes: (size_in_bytes as f32 / num_docs as f32) as u64
                     * demuxed_split.total_num_docs() as u64,
@@ -285,6 +288,7 @@ mod tests {
     ) -> SplitMetadata {
         SplitMetadata {
             split_id: crate::new_split_id(),
+            partition_id: 3u64,
             num_docs: num_docs as usize,
             uncompressed_docs_size_in_bytes: 256u64 * num_docs,
             time_range: Some(time_range),

--- a/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit-indexing/src/actors/mod.rs
@@ -40,7 +40,7 @@ pub use self::indexer::{Indexer, IndexerCounters};
 pub use self::ingest_api_garbage_collector::{
     IngestApiGarbageCollector, IngestApiGarbageCollectorCounters,
 };
-pub use self::merge_executor::MergeExecutor;
+pub use self::merge_executor::{combine_partition_ids, MergeExecutor};
 pub use self::merge_planner::MergePlanner;
 pub use self::merge_split_downloader::MergeSplitDownloader;
 pub use self::packager::Packager;

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -342,6 +342,7 @@ fn create_packaged_split(
 
     let packaged_split = PackagedSplit {
         split_id: split.split_id.to_string(),
+        partition_id: split.partition_id,
         replaced_split_ids: split.replaced_split_ids,
         index_id: split.index_id,
         split_scratch_directory: split.split_scratch_directory,
@@ -436,6 +437,7 @@ mod tests {
         let indexed_split = IndexedSplit {
             split_id: "test-split".to_string(),
             index_id: "test-index".to_string(),
+            partition_id: 17u64,
             time_range: timerange_opt,
             demux_num_ops: 0,
             num_docs,

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -204,6 +204,7 @@ impl Handler<PackagedSplitBatch> for Uploader {
 fn create_split_metadata(split: &PackagedSplit, footer_offsets: Range<u64>) -> SplitMetadata {
     SplitMetadata {
         split_id: split.split_id.clone(),
+        partition_id: split.partition_id,
         num_docs: split.num_docs as usize,
         time_range: split.time_range.clone(),
         uncompressed_docs_size_in_bytes: split.size_in_bytes,
@@ -318,6 +319,7 @@ mod tests {
             .send_message(PackagedSplitBatch::new(
                 vec![PackagedSplit {
                     split_id: "test-split".to_string(),
+                    partition_id: 3u64,
                     index_id: "test-index".to_string(),
                     time_range: Some(1_628_203_589i64..=1_628_203_640i64),
                     size_in_bytes: 1_000,
@@ -398,6 +400,11 @@ mod tests {
         let split_scratch_directory_2 = ScratchDirectory::for_test()?;
         let packaged_split_1 = PackagedSplit {
             split_id: "test-split-1".to_string(),
+            partition_id: 3u64,
+            replaced_split_ids: vec![
+                "replaced-split-1".to_string(),
+                "replaced-split-2".to_string(),
+            ],
             index_id: "test-index".to_string(),
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
@@ -405,15 +412,16 @@ mod tests {
             num_docs: 10,
             demux_num_ops: 1,
             tags: Default::default(),
-            replaced_split_ids: vec![
-                "replaced-split-1".to_string(),
-                "replaced-split-2".to_string(),
-            ],
             split_files: vec![],
             hotcache_bytes: vec![],
         };
         let package_split_2 = PackagedSplit {
             split_id: "test-split-2".to_string(),
+            partition_id: 3u64,
+            replaced_split_ids: vec![
+                "replaced-split-1".to_string(),
+                "replaced-split-2".to_string(),
+            ],
             index_id: "test-index".to_string(),
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
@@ -421,10 +429,6 @@ mod tests {
             num_docs: 10,
             demux_num_ops: 1,
             tags: Default::default(),
-            replaced_split_ids: vec![
-                "replaced-split-1".to_string(),
-                "replaced-split-2".to_string(),
-            ],
             split_files: vec![],
             hotcache_bytes: vec![],
         };

--- a/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit-indexing/src/models/indexed_split.rs
@@ -34,8 +34,10 @@ use crate::models::ScratchDirectory;
 use crate::new_split_id;
 
 pub struct IndexedSplit {
-    pub index_id: String,
     pub split_id: String,
+    pub index_id: String,
+    pub partition_id: u64,
+
     pub replaced_split_ids: Vec<String>,
 
     pub time_range: Option<RangeInclusive<i64>>,
@@ -72,6 +74,7 @@ impl fmt::Debug for IndexedSplit {
 impl IndexedSplit {
     pub fn new_in_dir(
         index_id: String,
+        partition_id: u64,
         scratch_directory: ScratchDirectory,
         indexing_resources: IndexingResources,
         index_builder: IndexBuilder,
@@ -98,6 +101,7 @@ impl IndexedSplit {
         index_writer.set_merge_policy(Box::new(NoMergePolicy));
         Ok(IndexedSplit {
             index_id,
+            partition_id,
             split_id,
             replaced_split_ids: Vec::new(),
             time_range: None,

--- a/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit-indexing/src/models/packaged_split.rs
@@ -28,8 +28,10 @@ use crate::models::ScratchDirectory;
 
 pub struct PackagedSplit {
     pub split_id: String,
-    pub replaced_split_ids: Vec<String>,
     pub index_id: String,
+    pub partition_id: u64,
+
+    pub replaced_split_ids: Vec<String>,
     pub time_range: Option<RangeInclusive<i64>>,
     pub size_in_bytes: u64,
     pub split_scratch_directory: ScratchDirectory,
@@ -44,6 +46,7 @@ impl fmt::Debug for PackagedSplit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("PackagedSplit")
             .field("split_id", &self.split_id)
+            .field("partition_id", &self.partition_id)
             .field("replaced_split_ids", &self.replaced_split_ids)
             .field("index_id", &self.index_id)
             .field("time_range", &self.time_range)

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -185,6 +185,7 @@ pub fn mock_split(split_id: &str) -> Split {
 pub fn mock_split_meta(split_id: &str) -> SplitMetadata {
     SplitMetadata {
         split_id: split_id.to_string(),
+        partition_id: 13u64,
         num_docs: 10,
         uncompressed_docs_size_in_bytes: 256,
         time_range: None,

--- a/quickwit-metastore/src/backward_compatibility_tests/split_metadata.rs
+++ b/quickwit-metastore/src/backward_compatibility_tests/split_metadata.rs
@@ -24,6 +24,7 @@ use crate::SplitMetadata;
 pub(crate) fn sample_split_metadata_for_regression() -> SplitMetadata {
     SplitMetadata {
         split_id: "split".to_string(),
+        partition_id: 7u64,
         num_docs: 12303,
         uncompressed_docs_size_in_bytes: 234234,
         time_range: Some(121000..=130198),
@@ -36,12 +37,12 @@ pub(crate) fn sample_split_metadata_for_regression() -> SplitMetadata {
 
 #[test]
 fn test_split_metadata_backward_compatibility() -> anyhow::Result<()> {
-    let sample_split_metdata = sample_split_metadata_for_regression();
+    let sample_split_metadata = sample_split_metadata_for_regression();
     super::test_json_backward_compatibility_helper(
         "split-metadata",
         |deserialized: &SplitMetadata, expected: &SplitMetadata| {
             assert_eq!(deserialized, expected);
         },
-        sample_split_metdata,
+        sample_split_metadata,
     )
 }

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -60,6 +60,14 @@ pub struct SplitMetadata {
     /// in the storage URI resolver: for instance, the Amazon S3 region.
     pub split_id: String,
 
+    /// Partition to which the split belong to.
+    ///
+    /// Partitions are usually meant to isolate documents based on some field like
+    /// `tenant_id`. For this reason, ideally splits with a different `partition_id`
+    /// should not be merged together. Merging two splits with different `partition_id`
+    /// does not hurt correctness however.
+    pub partition_id: u64,
+
     /// Number of records (or documents) in the split.
     /// TODO make u64
     pub num_docs: usize,
@@ -105,20 +113,6 @@ pub struct SplitMetadata {
 }
 
 impl SplitMetadata {
-    /// Creates a new instance of split metadata.
-    pub fn new(split_id: String) -> Self {
-        Self {
-            split_id,
-            num_docs: 0,
-            uncompressed_docs_size_in_bytes: 0,
-            time_range: None,
-            create_timestamp: utc_now_timestamp(),
-            tags: Default::default(),
-            demux_num_ops: 0,
-            footer_offsets: Default::default(),
-        }
-    }
-
     /// Returns the split_id.
     pub fn split_id(&self) -> &str {
         &self.split_id

--- a/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit-metastore/src/split_metadata_version.rs
@@ -79,6 +79,7 @@ impl From<SplitMetadataAndFooterV0> for SplitMetadata {
         SplitMetadata {
             footer_offsets: v0.footer_offsets,
             split_id: v0.split_metadata.split_id,
+            partition_id: 0u64,
             num_docs: v0.split_metadata.num_docs,
             uncompressed_docs_size_in_bytes: v0.split_metadata.size_in_bytes,
             time_range: v0.split_metadata.time_range,
@@ -96,6 +97,9 @@ pub(crate) struct SplitMetadataV1 {
     /// In reality, some information may be implicitly configured
     /// in the storage URI resolver: for instance, the Amazon S3 region.
     pub split_id: String,
+
+    #[serde(default)]
+    pub partition_id: u64,
 
     /// Number of records (or documents) in the split.
     pub num_docs: usize,
@@ -135,6 +139,7 @@ impl From<SplitMetadataV1> for SplitMetadata {
     fn from(v1: SplitMetadataV1) -> Self {
         SplitMetadata {
             footer_offsets: v1.footer_offsets,
+            partition_id: v1.partition_id,
             split_id: v1.split_id,
             num_docs: v1.num_docs,
             uncompressed_docs_size_in_bytes: v1.uncompressed_docs_size_in_bytes,
@@ -150,6 +155,7 @@ impl From<SplitMetadata> for SplitMetadataV1 {
     fn from(v1: SplitMetadata) -> Self {
         SplitMetadataV1 {
             footer_offsets: v1.footer_offsets,
+            partition_id: v1.partition_id,
             split_id: v1.split_id,
             num_docs: v1.num_docs,
             uncompressed_docs_size_in_bytes: v1.uncompressed_docs_size_in_bytes,

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -1382,6 +1382,7 @@ pub mod test_suite {
         let split_metadata_1 = SplitMetadata {
             footer_offsets: 1000..2000,
             split_id: split_id_1.to_string(),
+            partition_id: 3u64,
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(0..=99),
@@ -1393,6 +1394,7 @@ pub mod test_suite {
         let split_metadata_2 = SplitMetadata {
             footer_offsets: 1000..2000,
             split_id: "list-splits-two".to_string(),
+            partition_id: 3u64,
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(100..=199),
@@ -1404,6 +1406,7 @@ pub mod test_suite {
         let split_metadata_3 = SplitMetadata {
             footer_offsets: 1000..2000,
             split_id: "list-splits-three".to_string(),
+            partition_id: 3u64,
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(200..=299),
@@ -1415,6 +1418,7 @@ pub mod test_suite {
         let split_metadata_4 = SplitMetadata {
             footer_offsets: 1000..2000,
             split_id: "list-splits-four".to_string(),
+            partition_id: 3u64,
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(300..=399),
@@ -1426,6 +1430,7 @@ pub mod test_suite {
         let split_metadata_5 = SplitMetadata {
             footer_offsets: 1000..2000,
             split_id: "list-splits-five".to_string(),
+            partition_id: 3u64,
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: None,
@@ -1816,6 +1821,7 @@ pub mod test_suite {
             let split_metadata_6 = SplitMetadata {
                 footer_offsets: 1000..2000,
                 split_id: "list-splits-six".to_string(),
+                partition_id: 3u64,
                 num_docs: 1,
                 uncompressed_docs_size_in_bytes: 2,
                 time_range: None,

--- a/quickwit-metastore/test-data/file-backed-index/v0-41c287d5b41d3247e3394574c7f3618c.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-41c287d5b41d3247e3394574c7f3618c.expected.json
@@ -99,6 +99,7 @@
         "start": 1000
       },
       "num_docs": 12303,
+      "partition_id": 0,
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-6e3177e8924ef49dbdd8dcac421b0642.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-6e3177e8924ef49dbdd8dcac421b0642.expected.json
@@ -99,7 +99,7 @@
         "start": 1000
       },
       "num_docs": 12303,
-      "uncompressed_docs_size_in_bytes": 234234,
+      "partition_id": 0,
       "split_id": "split",
       "split_state": "Published",
       "tags": [
@@ -110,6 +110,7 @@
         "end": 130198,
         "start": 121000
       },
+      "uncompressed_docs_size_in_bytes": 234234,
       "update_timestamp": 1789,
       "version": "1"
     }

--- a/quickwit-metastore/test-data/file-backed-index/v0-7ccb0811468081880595c160fa16fef7.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-7ccb0811468081880595c160fa16fef7.expected.json
@@ -99,7 +99,7 @@
         "start": 1000
       },
       "num_docs": 12303,
-      "uncompressed_docs_size_in_bytes": 234234,
+      "partition_id": 0,
       "split_id": "split",
       "split_state": "Published",
       "tags": [
@@ -110,6 +110,7 @@
         "end": 130198,
         "start": 121000
       },
+      "uncompressed_docs_size_in_bytes": 234234,
       "update_timestamp": 1789,
       "version": "1"
     }

--- a/quickwit-metastore/test-data/file-backed-index/v0-7e1e1d06f4d5d051134c6ec82c09a55f.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-7e1e1d06f4d5d051134c6ec82c09a55f.expected.json
@@ -99,7 +99,7 @@
         "start": 1000
       },
       "num_docs": 12303,
-      "uncompressed_docs_size_in_bytes": 234234,
+      "partition_id": 0,
       "split_id": "split",
       "split_state": "Published",
       "tags": [
@@ -110,6 +110,7 @@
         "end": 130198,
         "start": 121000
       },
+      "uncompressed_docs_size_in_bytes": 234234,
       "update_timestamp": 1789,
       "version": "1"
     }

--- a/quickwit-metastore/test-data/file-backed-index/v0-92a02bbda38485cfb39171b0b2fee51f.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-92a02bbda38485cfb39171b0b2fee51f.expected.json
@@ -99,6 +99,7 @@
         "start": 1000
       },
       "num_docs": 12303,
+      "partition_id": 0,
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-f4bcb5a22eb3fb4f663463adb38a057b.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-f4bcb5a22eb3fb4f663463adb38a057b.expected.json
@@ -99,7 +99,7 @@
         "start": 1000
       },
       "num_docs": 12303,
-      "uncompressed_docs_size_in_bytes": 234234,
+      "partition_id": 0,
       "split_id": "split",
       "split_state": "Published",
       "tags": [
@@ -110,6 +110,7 @@
         "end": 130198,
         "start": 121000
       },
+      "uncompressed_docs_size_in_bytes": 234234,
       "update_timestamp": 1789,
       "version": "1"
     }

--- a/quickwit-metastore/test-data/split-metadata/v0-a56cdae1f7333d023f1d6303ed5fd301.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v0-a56cdae1f7333d023f1d6303ed5fd301.expected.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "num_docs": 12303,
-  "uncompressed_docs_size_in_bytes": 234234,
+  "partition_id": 0,
   "split_id": "split",
   "tags": [
     "234",
@@ -16,5 +16,6 @@
     "end": 130198,
     "start": 121000
   },
+  "uncompressed_docs_size_in_bytes": 234234,
   "version": "1"
 }

--- a/quickwit-metastore/test-data/split-metadata/v0-noversion.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v0-noversion.expected.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "num_docs": 12303,
-  "uncompressed_docs_size_in_bytes": 234234,
+  "partition_id": 0,
   "split_id": "split",
   "tags": [
     "234",
@@ -16,5 +16,6 @@
     "end": 130198,
     "start": 121000
   },
+  "uncompressed_docs_size_in_bytes": 234234,
   "version": "1"
 }

--- a/quickwit-metastore/test-data/split-metadata/v1-3fa70f6513f800c681c0c317d89d4298.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-3fa70f6513f800c681c0c317d89d4298.expected.json
@@ -6,6 +6,7 @@
     "start": 1000
   },
   "num_docs": 12303,
+  "partition_id": 0,
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v1-b9a036ccc850646c89bc008c65c4249f.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-b9a036ccc850646c89bc008c65c4249f.expected.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "num_docs": 12303,
-  "uncompressed_docs_size_in_bytes": 234234,
+  "partition_id": 0,
   "split_id": "split",
   "tags": [
     "234",
@@ -16,5 +16,6 @@
     "end": 130198,
     "start": 121000
   },
+  "uncompressed_docs_size_in_bytes": 234234,
   "version": "1"
 }

--- a/quickwit-metastore/test-data/split-metadata/v1-c7b54a9dfd9b75174914d063df366aa6.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-c7b54a9dfd9b75174914d063df366aa6.expected.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "num_docs": 12303,
-  "partition_id": 0,
+  "partition_id": 7,
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v1-c7b54a9dfd9b75174914d063df366aa6.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-c7b54a9dfd9b75174914d063df366aa6.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "num_docs": 12303,
-  "partition_id": 0,
+  "partition_id": 7,
   "split_id": "split",
   "tags": [
     "234",


### PR DESCRIPTION
  Added partition_id to split metadata data.
    
    The `partition_id` is required for the merge planner to avoid
    merging  splits with different `partition_id`.
    
    Related to #1796 and #1795
    
    This PR also changes the hasher for the SipHasher, since nothing
    ensures that the implementation of the DefaultHasher won't change
    in the future.
    
    Finally, it seeds the hash using the expression itself, to avoid
    a class of collisions that could happpen with a change in the partition
    logic.

