### PR TITLE
Fix proto build

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Install awslocal
         run: pip install awscli-local
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
       - name: Prepare LocalStack S3
         run: ./quickwit-cli/tests/prepare_tests.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -y update \
                           libssl-dev \
                           llvm \
                           nodejs \
+                          protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 # Required by tonic


### PR DESCRIPTION
### Description
Somehow `protoc` is no longer available when building Quickwit. I suspect this has to do with #1820, but I don't really have the time to investigate further. So, installing `protoc` manually moving forward.

### How was this PR tested?
Built Docker image locally/
