### PR TITLE
Handle rebalance events in source rather than consumer context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
  "libz-sys",
  "mockall",
  "once_cell",
+ "oneshot",
  "openssl",
  "proptest",
  "quickwit-actors",

--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -13,7 +13,7 @@ version: 0
 #
 # Node ID. Must be unique within a cluster. If not set, a random node ID is generated on each startup.
 #
-# node_id: node-1
+node_id: ${QW_NODE_ID:-node-1}
 #
 # Quickwit opens three sockets.
 # - for its HTTP server, hosting the UI and the REST API (TCP)
@@ -32,12 +32,13 @@ version: 0
 #   2. pass `0.0.0.0` and let Quickwit do its best to discover the node's IP (see `advertise_address`)
 #
 # listen_address: 127.0.0.1
-# rest_listen_port: 7280
+rest_listen_port: ${QW_REST_LISTEN_PORT:-7280}
 #
 # IP address advertised by the node, i.e. the IP address that peer nodes should use to connect to the node for RPCs.
 # The environment variable `QW_ADVERTISE_ADDRESS` can also be used to override this value.
 # The default advertise address is `listen_address`. If `listen_address` is unspecified (`0.0.0.0`),
 # Quickwit attempts to sniff the node's IP by scanning the available network interfaces.
+#
 # advertise_address: 192.168.0.42
 #
 # In order to join a cluster, one needs to specify a list of
@@ -52,13 +53,13 @@ version: 0
 # Path to directory where temporary data (caches, intermediate indexing data structures)
 # is stored. Defaults to `./qwdata`.
 #
-# data_dir: /path/to/data/dir
+data_dir: ${QW_DATA_DIR:-./qwdata}
 #
 # Metastore URI. Defaults to `data_dir/indexes#polling_interval=30s`,
 # which is a file-backed metastore and mostly convenient for testing. A cluster would
 # require a metastore backed by Amzon S3 or PostgreSQL.
 #
-# metastore_uri: s3://your-bucket/indexes
+metastore_uri: ${QW_METASTORE_URI:-./qwdata/indexes#polling_interval=5s}
 # metastore_uri: postgres://username:password@host:port/db
 #
 # When using a file-backed metastore, the state of the metastore will be cached forever.

--- a/config/tutorials/gh-archive/index-config.yaml
+++ b/config/tutorials/gh-archive/index-config.yaml
@@ -34,10 +34,10 @@ doc_mapping:
       tokenizer: default
     - name: created_at
       type: datetime
-      input_formats:
-        - "rfc3339"
-      precision: "seconds"
       fast: true
+      input_formats:
+        - rfc3339
+      precision: seconds
 
 indexing_settings:
   timestamp_field: created_at

--- a/quickwit-actors/src/envelope.rs
+++ b/quickwit-actors/src/envelope.rs
@@ -44,6 +44,14 @@ impl<A: Actor> Envelope<A> {
         self.0.message()
     }
 
+    pub fn message_typed<M: 'static>(&mut self) -> Option<M> {
+        if let Ok(boxed_msg) = self.0.message().downcast::<M>() {
+            Some(*boxed_msg)
+        } else {
+            None
+        }
+    }
+
     /// Execute the captured handle function.
     pub async fn handle_message(
         &mut self,

--- a/quickwit-actors/src/mailbox.rs
+++ b/quickwit-actors/src/mailbox.rs
@@ -228,7 +228,7 @@ impl<A: Actor> Inbox<A> {
         self.rx
             .drain_low_priority()
             .into_iter()
-            .map(|mut msg| msg.message())
+            .map(|mut envelope| envelope.message())
             .collect()
     }
 
@@ -241,14 +241,7 @@ impl<A: Actor> Inbox<A> {
         self.rx
             .drain_low_priority()
             .into_iter()
-            .map(|mut msg| msg.message())
-            .flat_map(|any_msg| {
-                if let Ok(boxed_m) = any_msg.downcast::<M>() {
-                    Some(*boxed_m)
-                } else {
-                    None
-                }
-            })
+            .flat_map(|mut envelope| envelope.message_typed())
             .collect()
     }
 }

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3"
 itertools = "0.10.3"
 libz-sys = { version = "1.1.3", optional = true }
 once_cell = "1"
+oneshot = "0.1.3"
 openssl = { version = "0.10.36", default-features = false, optional = true }
 quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
 quickwit-aws = { version = "0.3.1", path = "../quickwit-aws" }

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -168,9 +168,9 @@ impl IndexerState {
     ///
     /// This function will then create it, and can hence return an Error.
     async fn get_or_create_workbench<'a>(
-        &self,
+        &'a self,
         indexing_workbench_opt: &'a mut Option<IndexingWorkbench>,
-        ctx: &ActorContext<Indexer>,
+        ctx: &'a ActorContext<Indexer>,
     ) -> anyhow::Result<&'a mut IndexingWorkbench> {
         if indexing_workbench_opt.is_none() {
             let indexing_workbench = self.create_workbench()?;
@@ -184,7 +184,7 @@ impl IndexerState {
             .await;
             *indexing_workbench_opt = Some(indexing_workbench);
         }
-        let current_indexing_workbench: &'a mut IndexingWorkbench = indexing_workbench_opt.as_mut().context(
+        let current_indexing_workbench = indexing_workbench_opt.as_mut().context(
             "No index writer available. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues."
         )?;
         Ok(current_indexing_workbench)

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -414,7 +414,7 @@ impl IndexingPipeline {
             .await?;
         let actor_source = SourceActor {
             source,
-            batch_sink: indexer_mailbox,
+            indexer_mailbox,
         };
         let (_source_mailbox, source_handler) = ctx
             .spawn_actor(actor_source)

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -407,7 +407,7 @@ impl IndexingPipeline {
                 Arc::new(SourceExecutionContext {
                     metastore: self.params.metastore.clone(),
                     index_id: self.params.index_id.clone(),
-                    config: self.params.source.clone(),
+                    source_config: self.params.source.clone(),
                 }),
                 source_checkpoint,
             )

--- a/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit-indexing/src/source/file_source.rs
@@ -202,7 +202,7 @@ mod tests {
         .await?;
         let file_source_actor = SourceActor {
             source: Box::new(file_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_file_source_mailbox, file_source_handle) =
             universe.spawn_actor(file_source_actor).spawn();
@@ -263,7 +263,7 @@ mod tests {
         .await?;
         let file_source_actor = SourceActor {
             source: Box::new(source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_file_source_mailbox, file_source_handle) =
             universe.spawn_actor(file_source_actor).spawn();
@@ -346,7 +346,7 @@ mod tests {
         .await?;
         let file_source_actor = SourceActor {
             source: Box::new(source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_file_source_mailbox, file_source_handle) =
             universe.spawn_actor(file_source_actor).spawn();

--- a/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit-indexing/src/source/ingest_api_source.rs
@@ -203,11 +203,11 @@ impl TypedSourceFactory for IngestApiSourceFactory {
         let ingest_api_mailbox = get_ingest_api_service().ok_or_else(|| {
             anyhow::anyhow!(
                 "Could not get the `IngestApiSource {{ source_id: {} }}` instance.",
-                ctx.config.source_id
+                ctx.source_config.source_id
             )
         })?;
         IngestApiSource::make(
-            ctx.config.source_id.clone(),
+            ctx.source_config.source_id.clone(),
             params,
             ingest_api_mailbox,
             checkpoint,

--- a/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit-indexing/src/source/ingest_api_source.rs
@@ -280,7 +280,7 @@ mod tests {
         .await?;
         let ingest_api_source_actor = SourceActor {
             source: Box::new(ingest_api_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_ingest_api_source_mailbox, ingest_api_source_handle) =
             universe.spawn_actor(ingest_api_source_actor).spawn();
@@ -330,7 +330,7 @@ mod tests {
         .await?;
         let ingest_api_source_actor = SourceActor {
             source: Box::new(ingest_api_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_ingest_api_source_mailbox, ingest_api_source_handle) =
             universe.spawn_actor(ingest_api_source_actor).spawn();
@@ -382,7 +382,7 @@ mod tests {
         .await?;
         let ingest_api_source_actor = SourceActor {
             source: Box::new(ingest_api_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_ingest_api_source_mailbox, ingest_api_source_handle) =
             universe.spawn_actor(ingest_api_source_actor).spawn();
@@ -442,7 +442,7 @@ mod tests {
         .await?;
         let ingest_api_source_actor = SourceActor {
             source: Box::new(ingest_api_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_ingest_api_source_mailbox, ingest_api_source_handle) =
             universe.spawn_actor(ingest_api_source_actor).spawn();

--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -153,8 +153,12 @@ impl ConsumerContext for RdKafkaContext {
                 "New partition assignment"
             );
             for (partition, offset) in assignment {
-                let mut partition = tpl.find_partition(&self.topic, partition).expect("");
-                partition.set_offset(offset).expect("");
+                let mut partition = tpl
+                    .find_partition(&self.topic, partition)
+                    .expect("Failed to find partition in assignment. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
+                partition
+                    .set_offset(offset)
+                    .expect("Failed to convert `Offset` to `i64`. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
             }
         }
         if let Rebalance::Revoke(tpl) = rebalance {

--- a/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -61,7 +61,7 @@ impl TypedSourceFactory for KinesisSourceFactory {
         params: KinesisSourceParams,
         checkpoint: SourceCheckpoint,
     ) -> anyhow::Result<Self::Source> {
-        KinesisSource::try_new(ctx.config.source_id.clone(), params, checkpoint).await
+        KinesisSource::try_new(ctx.source_config.source_id.clone(), params, checkpoint).await
     }
 }
 

--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -97,7 +97,7 @@ use crate::source::ingest_api_source::IngestApiSourceFactory;
 pub struct SourceExecutionContext {
     pub metastore: Arc<dyn Metastore>,
     pub index_id: String,
-    pub config: SourceConfig,
+    pub source_config: SourceConfig,
 }
 
 pub type SourceContext = ActorContext<SourceActor>;

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -160,7 +160,7 @@ mod tests {
         .await?;
         let vec_source_actor = SourceActor {
             source: Box::new(vec_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         assert_eq!(
             vec_source_actor.name(),
@@ -215,7 +215,7 @@ mod tests {
         .await?;
         let vec_source_actor = SourceActor {
             source: Box::new(vec_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_vec_source_mailbox, vec_source_handle) =
             universe.spawn_actor(vec_source_actor).spawn();

--- a/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit-indexing/src/source/void_source.rs
@@ -125,7 +125,7 @@ mod tests {
         .await?;
         let void_source_actor = SourceActor {
             source: Box::new(void_source),
-            batch_sink: mailbox,
+            indexer_mailbox: mailbox,
         };
         let (_, void_source_handle) = universe.spawn_actor(void_source_actor).spawn();
         matches!(void_source_handle.health(), Health::Healthy);

--- a/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit-metastore/src/checkpoint.rs
@@ -386,16 +386,16 @@ pub struct IndexCheckpointDelta {
 }
 
 impl IndexCheckpointDelta {
+    pub fn is_empty(&self) -> bool {
+        self.source_delta.is_empty()
+    }
+
     #[cfg(any(test, feature = "testsuite"))]
     pub fn for_test(source_id: &str, pos_range: Range<u64>) -> Self {
         IndexCheckpointDelta {
             source_id: source_id.to_string(),
             source_delta: SourceCheckpointDelta::from(pos_range),
         }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.source_delta.is_empty()
     }
 }
 

--- a/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit-metastore/src/checkpoint.rs
@@ -178,7 +178,7 @@ impl IndexCheckpoint {
             source_id: source_id.to_string(),
             source_delta: SourceCheckpointDelta::default(),
         })
-        .expect("Applying an empty checkpoint delta should never fail");
+        .expect("Applying an empty checkpoint delta should never fail.");
     }
 
     /// Removes an source.

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -51,3 +51,22 @@ pub(crate) use split_metadata_version::VersionedSplitMetadataDeserializeHelper;
 
 #[cfg(test)]
 mod backward_compatibility_tests;
+
+#[cfg(any(test, feature = "testsuite"))]
+mod for_test {
+    use std::sync::Arc;
+
+    use quickwit_storage::RamStorage;
+
+    use super::{FileBackedMetastore, Metastore};
+
+    /// Returns a metastore backed by an "in-memory file" for testing.
+    pub fn metastore_for_test() -> Arc<dyn Metastore> {
+        Arc::new(FileBackedMetastore::for_test(Arc::new(
+            RamStorage::default(),
+        )))
+    }
+}
+
+#[cfg(any(test, feature = "testsuite"))]
+pub use for_test::metastore_for_test;

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -117,6 +117,15 @@ impl SplitMetadata {
     pub fn split_id(&self) -> &str {
         &self.split_id
     }
+
+    #[cfg(any(test, feature = "testsuite"))]
+    /// Returns an instance of `SplitMetadata` for testing.
+    pub fn for_test(split_id: String) -> Self {
+        Self {
+            split_id,
+            ..Default::default()
+        }
+    }
 }
 
 /// A split state.

--- a/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit-storage/src/storage_resolver.rs
@@ -120,7 +120,7 @@ impl StorageUriResolver {
         StorageUriResolverBuilder::default()
     }
 
-    /// Creates `StorageUriResolver` for testing.
+    /// Creates a `StorageUriResolver` for testing.
     #[doc(hidden)]
     pub fn for_test() -> Self {
         #[allow(unused_mut)]


### PR DESCRIPTION
### Description
I moved the event handling logic into the main actor using sync channels in the consumer context. This simplifies the code, removes the need for messing with the tokio runtime, and makes testing easier.

### How was this PR tested?
Pending
