### PR TITLE
Enrich cluster member struct with services and gRPC address.

### DIFF
--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -102,7 +102,7 @@ fn build_member_from_chichat<'a>(
 ) -> anyhow::Result<Member> {
     let (node_unique_id_str, generation_str) = node_id.id.split_once('/').ok_or_else(|| {
         anyhow::anyhow!(
-            "Could not create a Member instance from NodeId `{}`",
+            "Failed to create Member instance from NodeId `{}`.",
             node_id.id
         )
     })?;

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -119,7 +119,7 @@ fn build_member_from_chichat<'a>(
         .get(AVAILABLE_SERVICES_KEY)
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Could not find `{}` key on node `{}` state.",
+                "Could not find `{}` key in node `{}` state.",
                 AVAILABLE_SERVICES_KEY,
                 node_unique_id_str
             )

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -76,15 +76,15 @@ pub async fn start_cluster_service(
     let member = Member::new(
         quickwit_config.node_id.clone(),
         unix_timestamp(),
-        quickwit_config.gossip_advertise_addr,
+        quickwit_config.grpc_advertise_addr,
+        services.clone(),
+        quickwit_config.grpc_listen_addr,
     );
 
     let cluster = Cluster::join(
         member,
-        services,
         quickwit_config.gossip_listen_addr,
         quickwit_config.cluster_id.clone(),
-        quickwit_config.grpc_advertise_addr,
         quickwit_config.peer_seed_addrs().await?,
         FailureDetectorConfig::default(),
         &UdpTransport,

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -29,7 +29,8 @@ use chitchat::FailureDetectorConfig;
 use quickwit_config::QuickwitConfig;
 
 pub use crate::cluster::{
-    create_cluster_for_test, grpc_addr_from_listen_addr_for_test, Cluster, ClusterState, Member,
+    create_cluster_for_test, grpc_addr_from_listen_addr_for_test, Cluster, ClusterMember,
+    ClusterState,
 };
 pub use crate::error::{ClusterError, ClusterResult};
 
@@ -73,7 +74,7 @@ pub async fn start_cluster_service(
     quickwit_config: &QuickwitConfig,
     services: &HashSet<QuickwitService>,
 ) -> anyhow::Result<Arc<Cluster>> {
-    let member = Member::new(
+    let member = ClusterMember::new(
         quickwit_config.node_id.clone(),
         unix_timestamp(),
         quickwit_config.grpc_advertise_addr,

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -260,7 +260,11 @@ pub async fn start_searcher_service(
     SEARCHER_CONFIG_INSTANCE
         .set(quickwit_config.searcher_config.clone())
         .expect("could not set searcher config in global once cell");
-    let client_pool = SearchClientPool::create_and_keep_updated(cluster).await?;
+    let client_pool = SearchClientPool::create_and_keep_updated(
+        &cluster.members(),
+        cluster.member_change_watcher(),
+    )
+    .await?;
     let cluster_client = ClusterClient::new(client_pool.clone());
     let search_service = Arc::new(SearchServiceImpl::new(
         metastore,

--- a/quickwit-search/src/search_client_pool.rs
+++ b/quickwit-search/src/search_client_pool.rs
@@ -27,7 +27,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::bail;
 use http::Uri;
 use itertools::Itertools;
-use quickwit_cluster::{Member, QuickwitService};
+use quickwit_cluster::{ClusterMember, QuickwitService};
 use quickwit_proto::tonic;
 use tokio_stream::wrappers::WatchStream;
 use tokio_stream::StreamExt;
@@ -165,8 +165,8 @@ impl SearchClientPool {
     /// When a client pool is created, the thread that monitors cluster members
     /// will be started at the same time.
     pub async fn create_and_keep_updated(
-        current_members: &[Member],
-        mut members_watch_channel: WatchStream<Vec<Member>>,
+        current_members: &[ClusterMember],
+        mut members_watch_channel: WatchStream<Vec<ClusterMember>>,
     ) -> anyhow::Result<Self> {
         let search_client_pool = SearchClientPool::default();
         let members_grpc_addresses = current_members
@@ -176,7 +176,7 @@ impl SearchClientPool {
                     .available_services
                     .contains(&QuickwitService::Searcher)
             })
-            .map(|member| member.grpc_address)
+            .map(|member| member.grpc_advertise_addr)
             .collect_vec();
         search_client_pool
             .update_members(&members_grpc_addresses)
@@ -195,7 +195,7 @@ impl SearchClientPool {
                             .available_services
                             .contains(&QuickwitService::Searcher)
                     })
-                    .map(|member| member.grpc_address)
+                    .map(|member| member.grpc_advertise_addr)
                     .collect_vec();
                 search_clients_pool_clone
                     .update_members(&members_grpc_addresses)


### PR DESCRIPTION
### Description

Refactor a bit how we build cluster members and how we use it.

One benefit is that you can define the search client pool without depending on `Cluster` and thus `Chitchat`. This is nice for testing purposes. This will help me to test the upcoming `MetastoreService`.


### How was this PR tested?

Waiting for `make test-all` results... 
