### PR TITLE
Bump Rust version from 1.62 to 1.63

### DIFF
--- a/quickwit-actors/src/actor.rs
+++ b/quickwit-actors/src/actor.rs
@@ -41,7 +41,7 @@ use crate::{AskError, Command, KillSwitch, Mailbox, QueueCapacity, SendError};
 /// after the end of the execution.
 ///
 /// It is in many ways, similar to the exit status code of a program.
-#[derive(Error, Debug, Clone)]
+#[derive(Clone, Debug, Error)]
 pub enum ActorExitStatus {
     /// The actor successfully exited.
     ///

--- a/quickwit-actors/src/actor_state.rs
+++ b/quickwit-actors/src/actor_state.rs
@@ -20,7 +20,7 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
 #[repr(u32)]
-#[derive(Clone, Debug, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ActorState {
     /// Processing implies that the actor has some message(s) (this includes commands) to process.
     Processing = 0,

--- a/quickwit-actors/src/channel_with_priority.rs
+++ b/quickwit-actors/src/channel_with_priority.rs
@@ -28,7 +28,7 @@ pub enum SendError {
     Full,
 }
 
-#[derive(Debug, Error, Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
 pub enum RecvError {
     #[error("No message are currently available.")]
     NoMessageAvailable,

--- a/quickwit-actors/src/observation.rs
+++ b/quickwit-actors/src/observation.rs
@@ -35,7 +35,7 @@ impl<ObservableState> Deref for Observation<ObservableState> {
 }
 
 // Describes the actual outcome of observation.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ObservationType {
     /// The actor is alive and was able to snapshot its state within `HEARTBEAT`
     Alive,

--- a/quickwit-actors/src/progress.rs
+++ b/quickwit-actors/src/progress.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct Progress(Arc<AtomicU32>);
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ProgressState {
     // No update recorded since the last call to .check_for_update()
     NoUpdate,

--- a/quickwit-actors/src/tests.rs
+++ b/quickwit-actors/src/tests.rs
@@ -70,13 +70,13 @@ pub struct PingerSenderActor {
     peers: HashMap<String, Mailbox<PingReceiverActor>>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SenderState {
     pub count: usize,
     pub num_peers: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct AddPeer(Mailbox<PingReceiverActor>);
 
 impl Actor for PingerSenderActor {
@@ -202,10 +202,10 @@ async fn test_ping_actor() {
 
 struct BuggyActor;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct DoNothing;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct Block;
 
 impl Actor for BuggyActor {
@@ -310,7 +310,7 @@ async fn test_actor_running_states() {
     assert_eq!(ping_handle.state(), ActorState::Idle);
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 struct LoopingActor {
     pub loop_count: usize,
     pub single_shot_count: usize,

--- a/quickwit-aws/src/retry.rs
+++ b/quickwit-aws/src/retry.rs
@@ -34,7 +34,7 @@ pub trait Retryable {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Retry<E> {
     Transient(E),
     Permanent(E),

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -192,7 +192,7 @@ pub struct DescribeIndexArgs {
     pub index_id: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CreateIndexArgs {
     pub index_config_uri: Uri,
     pub config_uri: Uri,
@@ -200,7 +200,7 @@ pub struct CreateIndexArgs {
     pub overwrite: bool,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct IngestDocsArgs {
     pub index_id: String,
     pub input_path_opt: Option<PathBuf>,
@@ -210,7 +210,7 @@ pub struct IngestDocsArgs {
     pub clear_cache: bool,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SearchIndexArgs {
     pub index_id: String,
     pub query: String,
@@ -225,7 +225,7 @@ pub struct SearchIndexArgs {
     pub sort_by_score: bool,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DeleteIndexArgs {
     pub index_id: String,
     pub dry_run: bool,
@@ -233,7 +233,7 @@ pub struct DeleteIndexArgs {
     pub data_dir: Option<PathBuf>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct GarbageCollectIndexArgs {
     pub index_id: String,
     pub grace_period: Duration,
@@ -242,20 +242,20 @@ pub struct GarbageCollectIndexArgs {
     pub data_dir: Option<PathBuf>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MergeOrDemuxArgs {
     pub index_id: String,
     pub config_uri: Uri,
     pub data_dir: Option<PathBuf>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ListIndexesArgs {
     pub config_uri: Uri,
     pub metastore_uri: Option<Uri>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum IndexCliCommand {
     List(ListIndexesArgs),
     Create(CreateIndexArgs),

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -61,13 +61,14 @@ pub fn parse_duration_with_unit(duration_with_unit_str: &str) -> anyhow::Result<
         .ok_or_else(|| anyhow::anyhow!("Invalid duration format: `[0-9]+[smhd]`"))?;
     let value = captures.get(1).unwrap().as_str().parse::<u64>().unwrap();
     let unit = captures.get(2).unwrap().as_str();
-    return match unit {
+
+    match unit {
         "s" => Ok(Duration::from_secs(value)),
         "m" => Ok(Duration::from_secs(value * 60)),
         "h" => Ok(Duration::from_secs(value * 60 * 60)),
         "d" => Ok(Duration::from_secs(value * 60 * 60 * 24)),
         _ => bail!("Invalid duration format: `[0-9]+[smhd]`"),
-    };
+    }
 }
 
 async fn load_quickwit_config(

--- a/quickwit-cli/src/service.rs
+++ b/quickwit-cli/src/service.rs
@@ -52,7 +52,7 @@ pub fn build_run_command<'a>() -> Command<'a> {
         ])
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct RunCliCommand {
     pub config_uri: Uri,
     pub data_dir_path: Option<PathBuf>,

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -68,34 +68,34 @@ pub fn build_source_command<'a>() -> Command<'a> {
         .arg_required_else_help(true)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CreateSourceArgs {
     pub config_uri: Uri,
     pub index_id: String,
     pub source_config_uri: Uri,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DeleteSourceArgs {
     pub config_uri: Uri,
     pub index_id: String,
     pub source_id: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DescribeSourceArgs {
     pub config_uri: Uri,
     pub index_id: String,
     pub source_id: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ListSourcesArgs {
     pub config_uri: Uri,
     pub index_id: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum SourceCliCommand {
     CreateSource(CreateSourceArgs),
     DeleteSource(DeleteSourceArgs),

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -48,7 +48,7 @@ const GOSSIP_INTERVAL: Duration = if cfg!(test) {
 const AVAILABLE_SERVICES_KEY: &str = "available_services";
 
 /// A member information.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Member {
     /// An ID that makes a member unique.
     pub node_unique_id: String,

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -40,7 +40,7 @@ fn unix_timestamp() -> u64 {
     duration_since_epoch.as_secs()
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Hash, Clone)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum QuickwitService {
     Indexer,
     Searcher,

--- a/quickwit-common/src/net.rs
+++ b/quickwit-common/src/net.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use tokio::net::{lookup_host, ToSocketAddrs};
 
 /// Represents a host, i.e. an IP address (`127.0.0.1`) or a hostname (`localhost`).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Host {
     Hostname(String),
     IpAddr(IpAddr),

--- a/quickwit-common/src/runtimes.rs
+++ b/quickwit-common/src/runtimes.rs
@@ -28,7 +28,7 @@ use tracing::warn;
 static RUNTIMES: OnceCell<HashMap<RuntimeType, tokio::runtime::Runtime>> = OnceCell::new();
 
 /// Describes which runtime an actor should run on.
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub enum RuntimeType {
     /// The blocking runtime runs blocking actors.
     /// This runtime is only used as a nice thread pool with

--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -106,7 +106,7 @@ impl FromStr for Protocol {
 
 const PROTOCOL_SEPARATOR: &str = "://";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Extension {
     Json,
     Toml,
@@ -127,7 +127,7 @@ impl Extension {
 }
 
 /// Encapsulates the URI type.
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Uri {
     uri: String,
     protocol_idx: usize,

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -78,7 +78,7 @@ fn default_rest_listen_port() -> u16 {
     7280
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct IndexerConfig {
     #[serde(default = "IndexerConfig::default_split_store_max_num_bytes")]
@@ -121,7 +121,7 @@ pub fn get_searcher_config_instance() -> &'static SearcherConfig {
     SEARCHER_CONFIG_INSTANCE.get_or_init(SearcherConfig::default)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SearcherConfig {
     #[serde(default = "SearcherConfig::default_fast_field_cache_capacity")]
@@ -383,7 +383,7 @@ fn redact_uri(
     Ok(())
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct QuickwitConfig {
     pub version: usize,
     pub cluster_id: String,
@@ -461,8 +461,7 @@ impl QuickwitConfig {
         // finally return the addresses as strings, which is tricky for IPv6. We let the logic baked
         // in `HostAddr` handle this complexity.
         for peer_seed in &self.peer_seeds {
-            let peer_seed_addr =
-                HostAddr::parse_with_default_port(&*peer_seed, default_gossip_port)?;
+            let peer_seed_addr = HostAddr::parse_with_default_port(peer_seed, default_gossip_port)?;
             if let Err(error) = peer_seed_addr.resolve().await {
                 warn!(peer_seed = %peer_seed_addr, error = ?error, "Failed to resolve peer seed address.");
                 continue;

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -95,7 +95,7 @@ impl Default for IndexingResources {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MergePolicy {
     #[serde(default = "MergePolicy::default_demux_factor")]
@@ -221,7 +221,7 @@ impl Default for IndexingSettings {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SearchSettings {
     #[serde(default)]

--- a/quickwit-config/src/source_config.rs
+++ b/quickwit-config/src/source_config.rs
@@ -30,7 +30,7 @@ use crate::{is_false, validate_identifier};
 /// Reserved source ID for the `quickwit index ingest` CLI command.
 pub const CLI_INGEST_SOURCE_ID: &str = ".cli-ingest-source";
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SourceConfig {
     pub source_id: String,
     #[serde(flatten)]
@@ -137,7 +137,7 @@ impl SourceConfig {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "source_type", content = "params")]
 pub enum SourceParams {
     #[serde(rename = "file")]
@@ -168,7 +168,7 @@ impl SourceParams {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileSourceParams {
     /// Path of the file to read. Assume stdin if None.
@@ -202,7 +202,7 @@ impl FileSourceParams {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct KafkaSourceParams {
     /// Name of the topic that the source consumes.
@@ -216,14 +216,14 @@ pub struct KafkaSourceParams {
     pub client_params: serde_json::Value,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RegionOrEndpoint {
     Region(String),
     Endpoint(String),
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "KinesisSourceParamsInner")]
 pub struct KinesisSourceParams {
     pub stream_name: String,
@@ -234,7 +234,7 @@ pub struct KinesisSourceParams {
     pub shutdown_at_stream_eof: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct KinesisSourceParamsInner {
     pub stream_name: String,
@@ -266,7 +266,7 @@ impl TryFrom<KinesisSourceParamsInner> for KinesisSourceParams {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VecSourceParams {
     pub items: Vec<String>,
@@ -275,11 +275,11 @@ pub struct VecSourceParams {
     pub partition: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VoidSourceParams;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct IngestApiSourceParams {
     pub index_id: String,

--- a/quickwit-directories/src/debug_proxy_directory.rs
+++ b/quickwit-directories/src/debug_proxy_directory.rs
@@ -53,7 +53,7 @@ impl OperationBuffer {
 
 /// A ReadOperation records meta data about a read operation.
 /// It is recorded by the `DebugProxyDirectory`.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReadOperation {
     /// Path that was read
     pub path: PathBuf,

--- a/quickwit-directories/src/union_directory.rs
+++ b/quickwit-directories/src/union_directory.rs
@@ -33,7 +33,7 @@ use tantivy::Directory;
 ///
 /// The first directory of the list will receive all write operations.
 /// Deletes on the other hand will be applied on all directories containing the file.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct UnionDirectory {
     directories: Arc<Vec<Box<dyn Directory>>>,
 }

--- a/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -65,7 +65,7 @@ impl From<SortByConfig> for SortBy {
 }
 
 /// Defines how an unmapped field should be handled.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) enum Mode {
     Lenient,
     Strict,

--- a/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
@@ -72,7 +72,7 @@ pub struct DefaultDocMapperBuilder {
 }
 
 /// `Mode` describing how the unmapped field should be handled.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ModeType {
     /// Lenient mode: unmapped fields are just ignored.

--- a/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -37,7 +37,7 @@ pub struct QuickwitObjectOptions {
 
 /// A `FieldMappingEntry` defines how a field is indexed, stored,
 /// and mapped from a JSON document to the related index fields.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(
     try_from = "FieldMappingEntryForSerialization",
     into = "FieldMappingEntryForSerialization"
@@ -92,7 +92,7 @@ impl Default for QuickwitNumericOptions {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum QuickwitTextTokenizer {
     #[serde(rename = "raw")]
     Raw,
@@ -177,7 +177,7 @@ fn default_json_tokenizer() -> QuickwitTextTokenizer {
 ///
 /// `QuickwitJsonOptions` is also used to configure
 /// the dynamic mapping.
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct QuickwitJsonOptions {
     /// Optional description of JSON object.

--- a/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
+++ b/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
@@ -36,7 +36,7 @@ use crate::default_doc_mapper::field_mapping_entry::{
 use crate::default_doc_mapper::{FieldMappingType, QuickwitJsonOptions};
 use crate::{DocParsingError, FieldMappingEntry, ModeType};
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 enum JsonType {
     Null,
     Bool,

--- a/quickwit-doc-mapper/src/error.rs
+++ b/quickwit-doc-mapper/src/error.rs
@@ -33,7 +33,7 @@ impl From<tantivy::query::QueryParserError> for QueryParserError {
 
 /// Error that may happen when parsing
 /// a document from JSON.
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq)]
 pub enum DocParsingError {
     /// The provided string is not valid JSON.
     #[error("The provided string is not a valid JSON object. {0}")]

--- a/quickwit-doc-mapper/src/sort_by.rs
+++ b/quickwit-doc-mapper/src/sort_by.rs
@@ -28,7 +28,7 @@ use tantivy::Order as TantivyOrder;
 
 /// Sort order, either ascending or descending.
 /// Use `SortOrder::Desc` for top-k queries.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SortOrder {
     /// Ascending order.
@@ -55,7 +55,7 @@ impl From<SortOrder> for TantivyOrder {
 /// Specifies how documents are sorted.
 /// In case of a tie, the documents are ordered according to descending `(split_id, segment_ord,
 /// doc_id)`.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SortByField {
     /// Name of the field to sort by.
     pub field_name: String,
@@ -79,7 +79,7 @@ impl From<String> for SortByField {
 /// Specifies how documents are sorted.
 /// In case of a tie, the documents are ordered according to descending `(split_id, segment_ord,
 /// doc_id)`.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SortBy {
     /// Sort by document ID.
     DocId,

--- a/quickwit-doc-mapper/src/tag_pruning.rs
+++ b/quickwit-doc-mapper/src/tag_pruning.rs
@@ -52,7 +52,7 @@ pub fn extract_tags_from_query(user_query: &str) -> Result<Option<TagFilterAst>,
 
 /// Intermediary AST that may contain leaf that are
 /// equivalent to the "Uninformative" predicate.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum UnsimplifiedTagFilterAst {
     And(Vec<UnsimplifiedTagFilterAst>),
     Or(Vec<UnsimplifiedTagFilterAst>),

--- a/quickwit-indexing/src/actors/garbage_collector.rs
+++ b/quickwit-indexing/src/actors/garbage_collector.rs
@@ -42,7 +42,7 @@ const STAGED_GRACE_PERIOD: Duration = Duration::from_secs(60 * 60 * 24); // 24 h
 /// This duration is controlled by `DELETION_GRACE_PERIOD`.
 const DELETION_GRACE_PERIOD: Duration = Duration::from_secs(120); // 2 min
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct GarbageCollectorCounters {
     /// The number of passes the garbage collector has performed.
     pub num_passes: usize,

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -48,7 +48,7 @@ struct CommitTimeout {
     workbench_id: Ulid,
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct IndexerCounters {
     /// Overall number of documents received, partitioned
     /// into 3 categories:
@@ -389,7 +389,7 @@ impl Handler<RawDocBatch> for Indexer {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum CommitTrigger {
     Timeout,
     NoMoreDocs,

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -71,10 +71,10 @@ pub struct IndexingPipelineHandler {
 
 // Messages
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Supervise;
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Spawn {
     retry_count: usize,
 }

--- a/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit-indexing/src/actors/indexing_service.rs
@@ -62,7 +62,7 @@ pub enum IndexingServiceError {
     InvalidParams(anyhow::Error),
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct IndexingServiceState {
     num_running_pipelines: usize,
     num_successful_pipelines: usize,

--- a/quickwit-indexing/src/actors/ingest_api_garbage_collector.rs
+++ b/quickwit-indexing/src/actors/ingest_api_garbage_collector.rs
@@ -39,7 +39,7 @@ const RUN_INTERVAL: Duration = if cfg!(test) {
     Duration::from_secs(60 * 60) // 1h
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct IngestApiGarbageCollectorCounters {
     /// The number of passes the garbage collector has performed.
     pub num_passes: usize,

--- a/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit-indexing/src/actors/merge_executor.rs
@@ -631,7 +631,7 @@ pub fn build_demux_mapping(
 // split as input and produced demuxed virtual splits. The virtual splits are
 // then used for the real demux that will create real split.
 // Hence the usage of `virtual`.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct VirtualSplit(BTreeMap<u64, usize>);
 
 impl VirtualSplit {

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -30,7 +30,7 @@ use crate::actors::{GarbageCollector, MergePlanner};
 use crate::models::{NewSplits, SplitUpdate};
 use crate::source::{SourceActor, SuggestTruncate};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PublisherCounters {
     pub num_published_splits: u64,
     pub num_replace_operations: u64,

--- a/quickwit-indexing/src/garbage_collection.rs
+++ b/quickwit-indexing/src/garbage_collection.rs
@@ -46,7 +46,7 @@ pub enum SplitDeletionError {
 }
 
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct FileEntry {
     /// The file_name is a file name, within an index directory.
     pub file_name: String,

--- a/quickwit-indexing/src/models/indexing_service_message.rs
+++ b/quickwit-indexing/src/models/indexing_service_message.rs
@@ -19,7 +19,7 @@
 
 use quickwit_config::SourceConfig;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct IndexingPipelineId {
     pub index_id: String,
     pub source_id: String,
@@ -50,13 +50,13 @@ pub struct SpawnPipelinesForIndex {
     pub index_id: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct SpawnPipeline {
     pub index_id: String,
     pub source: SourceConfig,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct ShutdownPipeline {
     pub index_id: String,
     pub source_id: String,

--- a/quickwit-indexing/src/models/indexing_statistics.rs
+++ b/quickwit-indexing/src/models/indexing_statistics.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::Ordering;
 use crate::actors::{IndexerCounters, PublisherCounters, UploaderCounters};
 
 /// A Struct that holds all statistical data about indexing
-#[derive(Debug, Default, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct IndexingStatistics {
     /// Number of document processed (valid or not)
     pub num_docs: u64,

--- a/quickwit-indexing/src/models/merge_planner_message.rs
+++ b/quickwit-indexing/src/models/merge_planner_message.rs
@@ -19,7 +19,7 @@
 
 use quickwit_metastore::SplitMetadata;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct NewSplits {
     pub new_splits: Vec<SplitMetadata>,
 }

--- a/quickwit-indexing/src/models/mod.rs
+++ b/quickwit-indexing/src/models/mod.rs
@@ -42,5 +42,5 @@ pub use publisher_message::SplitUpdate;
 pub use raw_doc_batch::RawDocBatch;
 pub use scratch_directory::ScratchDirectory;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Observe;

--- a/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 
 /// `IndexingSplitStoreParams` encapsulates the various contraints of the cache.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IndexingSplitStoreParams {
     /// Maximum number of files allowed in the cache.
     pub max_num_splits: usize,

--- a/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit-metastore/src/checkpoint.rs
@@ -31,7 +31,7 @@ use thiserror::Error;
 use tracing::{info, warn};
 
 /// PartitionId identifies a partition for a given source.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PartitionId(pub Arc<String>);
 
 impl From<String> for PartitionId {
@@ -73,7 +73,7 @@ impl From<i64> for PartitionId {
 ///
 /// The empty string can be used to represent the beginning of the source,
 /// if no position makes sense. It can be built via `Position::default()`.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
 pub enum Position {
     Beginning,
     Offset(Arc<String>),
@@ -122,7 +122,7 @@ impl<'a> From<&'a str> for Position {
     }
 }
 
-#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct IndexCheckpoint {
     #[serde(flatten)]
     per_source: BTreeMap<String, SourceCheckpoint>,
@@ -192,7 +192,7 @@ impl IndexCheckpoint {
 ///
 /// If a partition is missing, it implicitely means that none of its message
 /// has been processed.
-#[derive(Default, Clone, PartialEq)]
+#[derive(Default, Clone, Eq, PartialEq)]
 pub struct SourceCheckpoint {
     per_partition: BTreeMap<PartitionId, Position>,
 }
@@ -233,7 +233,7 @@ impl Serialize for SourceCheckpoint {
     where S: serde::Serializer {
         let mut map = serializer.serialize_map(Some(self.per_partition.len()))?;
         for (partition, position) in &self.per_partition {
-            map.serialize_entry(&*partition.0, &*position.as_str())?;
+            map.serialize_entry(&*partition.0, position.as_str())?;
         }
         map.end()
     }
@@ -256,7 +256,7 @@ impl<'de> Deserialize<'de> for SourceCheckpoint {
 /// Error returned when trying to apply a checkpoint delta to a checkpoint that is not
 /// compatible. ie: the checkpoint delta starts from a point anterior to
 /// the checkpoint.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq)]
 #[error(
     "IncompatibleChkptDelta at partition: {partition_id:?} cur_pos:{current_position:?} \
      delta_pos:{delta_position_from:?}"
@@ -358,7 +358,7 @@ impl fmt::Debug for SourceCheckpoint {
 }
 
 /// A partition delta represents an interval (from, to] over a partition of a source.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct PartitionDelta {
     pub from: Position,
     pub to: Position,

--- a/quickwit-metastore/src/error.rs
+++ b/quickwit-metastore/src/error.rs
@@ -99,6 +99,6 @@ pub enum MetastoreResolverError {
     /// but the resolver failed to actually connect to the storage.
     /// e.g. Connection error, credential error, incompatible version,
     /// internal error in third party, etc.
-    #[error("Failed to open metastore: `{0}`")]
+    #[error("Failed to connect to metastore: `{0}`")]
     FailedToOpenMetastore(MetastoreError),
 }

--- a/quickwit-metastore/src/metastore/file_backed_metastore/lazy_file_backed_index.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/lazy_file_backed_index.rs
@@ -87,7 +87,7 @@ async fn poll_index_metadata_once(
     index_id: &str,
     metadata_mutex: &Mutex<FileBackedIndex>,
 ) {
-    let index_fetch_res = fetch_index(&*storage, index_id).await;
+    let index_fetch_res = fetch_index(storage, index_id).await;
     match index_fetch_res {
         Ok(index) => {
             *metadata_mutex.lock().await = index;

--- a/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -845,8 +845,8 @@ mod tests {
             .times(1)
             .returning(move |path, _| {
                 assert!(path == Path::new("indexes_states.json"));
-                return Err(StorageErrorKind::Io
-                    .with_error(anyhow::anyhow!("Oops. Some network problem maybe?")));
+                Err(StorageErrorKind::Io
+                    .with_error(anyhow::anyhow!("Oops. Some network problem maybe?")))
             });
         mock_storage
             .expect_get_all()
@@ -890,8 +890,8 @@ mod tests {
                 if path == Path::new("indexes_states.json") {
                     return block_on(ram_storage_clone.put(path, put_payload));
                 }
-                return Err(StorageErrorKind::Io
-                    .with_error(anyhow::anyhow!("Oops. Some network problem maybe?")));
+                Err(StorageErrorKind::Io
+                    .with_error(anyhow::anyhow!("Oops. Some network problem maybe?")))
             });
         mock_storage
             .expect_get_all()

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -28,7 +28,7 @@ use time::OffsetDateTime;
 use crate::VersionedSplitMetadataDeserializeHelper;
 
 /// Carries split metadata.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Split {
     /// The state of the split.
     pub split_state: SplitState,
@@ -51,7 +51,7 @@ impl Split {
 /// Carries immutable split metadata.
 /// This struct can deserialize older format automatically
 /// but can only serialize to the last version.
-#[derive(Clone, Eq, PartialEq, Default, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 #[serde(into = "VersionedSplitMetadataDeserializeHelper")]
 pub struct SplitMetadata {
     /// Split ID. Joined with the index URI (<index URI>/<split ID>), this ID
@@ -126,7 +126,7 @@ impl SplitMetadata {
 }
 
 /// A split state.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum SplitState {
     /// The split is almost ready. Some of its files may have been uploaded in the storage.
     Staged,

--- a/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit-metastore/src/split_metadata_version.rs
@@ -89,7 +89,7 @@ impl From<SplitMetadataAndFooterV0> for SplitMetadata {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SplitMetadataV1 {
     /// Split ID. Joined with the index URI (<index URI>/<split ID>), this ID
     /// should be enough to uniquely identify a split.

--- a/quickwit-proto/src/lib.rs
+++ b/quickwit-proto/src/lib.rs
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 mod quickwit;
 mod quickwit_ingest_api;
 

--- a/quickwit-search/src/search_client_pool.rs
+++ b/quickwit-search/src/search_client_pool.rs
@@ -198,7 +198,7 @@ fn job_order_key<J: Job>(job: &J) -> (Reverse<u32>, &str) {
 
 /// Node is a utility struct used to represent a rendez-vous hashing node.
 /// It's used to track the load and the computed hash for a given key
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct Node {
     pub peer_grpc_addr: SocketAddr,
     pub load: u64,

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -120,7 +120,7 @@ pub struct PartionnedFastFieldCollector<Item: FastValue, PartitionItem: FastValu
     pub _marker: PhantomData<(Item, PartitionItem)>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PartitionValues<Item: FastValue, PartitionItem: FastValue> {
     pub partition_value: PartitionItem,
     pub fast_field_values: Vec<Item>,

--- a/quickwit-search/src/thread_pool.rs
+++ b/quickwit-search/src/thread_pool.rs
@@ -34,7 +34,7 @@ fn search_thread_pool() -> &'static rayon::ThreadPool {
     })
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Panicked;
 
 /// Function similar to `tokio::spawn_blocking`.

--- a/quickwit-serve/src/args.rs
+++ b/quickwit-serve/src/args.rs
@@ -20,7 +20,7 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ServeArgs {
     /// Socket address of the REST server.
     pub rest_socket_addr: SocketAddr,

--- a/quickwit-serve/src/cluster_api/rest_handler.rs
+++ b/quickwit-serve/src/cluster_api/rest_handler.rs
@@ -37,7 +37,7 @@ pub fn cluster_handler(
 
 /// This struct represents the QueryString passed to
 /// the rest API.
-#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 struct ClusterStateQueryString {
     /// The output format requested.

--- a/quickwit-serve/src/format.rs
+++ b/quickwit-serve/src/format.rs
@@ -27,7 +27,7 @@ use crate::error::{ServiceError, ServiceErrorCode};
 const JSON_SERIALIZATION_ERROR: &str = "JSON serialization failed.";
 
 /// Output format for the search results.
-#[derive(Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum Format {
     Json,

--- a/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -56,7 +56,7 @@ pub enum BulkApiError {
 
 impl warp::reject::Reject for BulkApiError {}
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all(deserialize = "lowercase"))]
 enum BulkAction {
     Index(BulkActionMeta),
@@ -72,7 +72,7 @@ impl BulkAction {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 struct BulkActionMeta {
     #[serde(alias = "_index")]
     index: String,

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -201,7 +201,7 @@ fn check_is_configured_for_cluster(
     Ok(())
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct QuickwitBuildInfo {
     pub commit_version_tag: &'static str,
     pub cargo_pkg_version: &'static str,

--- a/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit-serve/src/search_api/rest_handler.rs
@@ -78,7 +78,7 @@ where D: Deserializer<'de> {
 
 /// This struct represents the QueryString passed to
 /// the rest API.
-#[derive(Deserialize, Debug, PartialEq, Eq, Default)]
+#[derive(Deserialize, Debug, Eq, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct SearchRequestQueryString {
     /// Query text. The query language is that of tantivy.
@@ -208,7 +208,7 @@ pub fn search_stream_handler(
 
 /// This struct represents the search stream query passed to
 /// the REST API.
-#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 struct SearchStreamRequestQueryString {
     /// Query text. The query language is that of tantivy.

--- a/quickwit-storage/src/cache/slice_address.rs
+++ b/quickwit-storage/src/cache/slice_address.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 
 use lru::KeyRef;
 
-#[derive(Hash, Debug, Clone, PartialEq, Eq)]
+#[derive(Hash, Clone, Debug, Eq, PartialEq)]
 pub struct SliceAddress {
     pub path: PathBuf,
     pub byte_range: Range<usize>,

--- a/quickwit-storage/src/debouncer.rs
+++ b/quickwit-storage/src/debouncer.rs
@@ -204,7 +204,7 @@ mod tests {
         is_send::<AsyncDebouncer<String, Result<String, String>>>();
     }
 
-    #[derive(Hash, Debug, Clone, PartialEq, Eq)]
+    #[derive(Hash, Clone, Debug, Eq, PartialEq)]
     pub struct SliceAddress {
         pub path: PathBuf,
         pub byte_range: Range<usize>,

--- a/quickwit-storage/src/error.rs
+++ b/quickwit-storage/src/error.rs
@@ -25,7 +25,7 @@ use tantivy::directory::error::{OpenDirectoryError, OpenReadError};
 use thiserror::Error;
 
 /// Storage error kind.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum StorageErrorKind {
     /// The target index does not exist.
     DoesNotExist,
@@ -83,7 +83,7 @@ impl From<StorageError> for io::Error {
 }
 
 /// Generic StorageError.
-#[derive(Error, Debug, Clone)]
+#[derive(Clone, Debug, Error)]
 #[error("StorageError(kind={kind:?}, source={source})")]
 #[allow(missing_docs)]
 pub struct StorageError {

--- a/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit-storage/src/local_file_storage.rs
@@ -227,7 +227,7 @@ impl Storage for LocalFileStorage {
 }
 
 /// A File storage resolver
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct LocalFileStorageFactory {}
 
 impl StorageFactory for LocalFileStorageFactory {

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -308,10 +308,10 @@ pub fn parse_s3_uri(uri: &Uri) -> Option<(String, PathBuf)> {
         })
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct MultipartUploadId(pub String);
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct Part {
     pub part_number: usize,
     pub range: Range<u64>,

--- a/quickwit-storage/src/split.rs
+++ b/quickwit-storage/src/split.rs
@@ -101,7 +101,7 @@ impl PutPayload for FilePayload {
 }
 
 /// SplitPayloadBuilder is used to create a `SplitPayload`.
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct SplitPayloadBuilder {
     metadata: BundleStorageFileOffsets,
     current_offset: usize,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.62"
+channel = "1.63"


### PR DESCRIPTION
### Description
Per title. I also updated the builder image.

### How was this PR tested?
Ran `make fmt` and `make test-all`
