### PR TITLE
Add a search context to search queries.

### DIFF
--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -25,7 +25,6 @@ use anyhow::{bail, Context};
 use byte_unit::Byte;
 use derivative::Derivative;
 use json_comments::StripComments;
-use once_cell::sync::OnceCell;
 use quickwit_common::net::{find_private_ip, Host, HostAddr};
 use quickwit_common::new_coolid;
 use quickwit_common::uri::{Extension, Uri};
@@ -113,12 +112,6 @@ impl Default for IndexerConfig {
             split_store_max_num_splits: Self::default_split_store_max_num_splits(),
         }
     }
-}
-
-pub static SEARCHER_CONFIG_INSTANCE: once_cell::sync::OnceCell<SearcherConfig> = OnceCell::new();
-
-pub fn get_searcher_config_instance() -> &'static SearcherConfig {
-    SEARCHER_CONFIG_INSTANCE.get_or_init(SearcherConfig::default)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -26,10 +26,7 @@ mod index_config;
 mod source_config;
 mod templating;
 
-pub use config::{
-    get_searcher_config_instance, IndexerConfig, QuickwitConfig, SearcherConfig,
-    DEFAULT_QW_CONFIG_PATH, SEARCHER_CONFIG_INSTANCE,
-};
+pub use config::{IndexerConfig, QuickwitConfig, SearcherConfig, DEFAULT_QW_CONFIG_PATH};
 pub use index_config::{
     build_doc_mapper, DocMapping, IndexConfig, IndexingResources, IndexingSettings, MergePolicy,
     SearchSettings,

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -26,8 +26,6 @@ use anyhow::Context;
 use futures::future::try_join_all;
 use futures::Future;
 use itertools::{Either, Itertools};
-use once_cell::sync::OnceCell;
-use quickwit_config::get_searcher_config_instance;
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_doc_mapper::{DocMapper, QUICKWIT_TOKENIZER_MANAGER};
 use quickwit_proto::{
@@ -42,42 +40,20 @@ use tantivy::error::AsyncIoError;
 use tantivy::query::Query;
 use tantivy::schema::{Cardinality, FieldType};
 use tantivy::{Index, ReloadPolicy, Searcher, Term};
-use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio::task::spawn_blocking;
 use tracing::*;
 
 use crate::collector::{make_collector_for_split, make_merge_collector};
+use crate::service::SearcherContext;
 use crate::SearchError;
-
-async fn get_leaf_search_split_semaphore() -> SemaphorePermit<'static> {
-    static INSTANCE: OnceCell<Semaphore> = OnceCell::new();
-    INSTANCE
-        .get_or_init(|| {
-            let max_num_concurrent_split_streams = get_searcher_config_instance().max_num_concurrent_split_searches;
-            Semaphore::new(max_num_concurrent_split_streams)
-        })
-        .acquire()
-        .await
-        .expect("Failed to acquire permit. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.")
-}
-
-fn global_split_footer_cache() -> &'static MemorySizedCache<String> {
-    static INSTANCE: OnceCell<MemorySizedCache<String>> = OnceCell::new();
-    INSTANCE.get_or_init(|| {
-        let config = get_searcher_config_instance();
-        MemorySizedCache::with_capacity_in_bytes(
-            config.split_footer_cache_capacity.get_bytes() as usize,
-            &quickwit_storage::STORAGE_METRICS.split_footer_cache,
-        )
-    })
-}
 
 async fn get_split_footer_from_cache_or_fetch(
     index_storage: Arc<dyn Storage>,
     split_and_footer_offsets: &SplitIdAndFooterOffsets,
+    footer_cache: &MemorySizedCache<String>,
 ) -> anyhow::Result<OwnedBytes> {
     {
-        let possible_val = global_split_footer_cache().get(&split_and_footer_offsets.split_id);
+        let possible_val = footer_cache.get(&split_and_footer_offsets.split_id);
         if let Some(footer_data) = possible_val {
             return Ok(footer_data);
         }
@@ -98,7 +74,7 @@ async fn get_split_footer_from_cache_or_fetch(
             )
         })?;
 
-    global_split_footer_cache().put(
+    footer_cache.put(
         split_and_footer_offsets.split_id.to_owned(),
         footer_data_opt.clone(),
     );
@@ -110,31 +86,45 @@ async fn get_split_footer_from_cache_or_fetch(
 ///
 /// The resulting index uses a dynamic and a static cache.
 pub(crate) async fn open_index(
+    searcher_context: &Arc<SearcherContext>,
     index_storage: Arc<dyn Storage>,
     split_and_footer_offsets: &SplitIdAndFooterOffsets,
 ) -> anyhow::Result<Index> {
-    open_index_with_cache(index_storage, split_and_footer_offsets, true).await
+    open_index_with_cache(
+        searcher_context,
+        index_storage,
+        split_and_footer_offsets,
+        true,
+    )
+    .await
 }
 
 /// Opens a `tantivy::Index` for the given split.
 ///
 /// The resulting index uses a dynamic and a static cache.
 pub(crate) async fn open_index_with_cache(
+    searcher_context: &Arc<SearcherContext>,
     index_storage: Arc<dyn Storage>,
     split_and_footer_offsets: &SplitIdAndFooterOffsets,
     unlimited_cache: bool,
 ) -> anyhow::Result<Index> {
     let split_file = PathBuf::from(format!("{}.split", split_and_footer_offsets.split_id));
-    let footer_data =
-        get_split_footer_from_cache_or_fetch(index_storage.clone(), split_and_footer_offsets)
-            .await?;
+    let footer_data = get_split_footer_from_cache_or_fetch(
+        index_storage.clone(),
+        split_and_footer_offsets,
+        &searcher_context.split_footer_cache,
+    )
+    .await?;
 
     let (hotcache_bytes, bundle_storage) = BundleStorage::open_from_split_data(
         index_storage,
         split_file,
         FileSlice::new(Arc::new(footer_data)),
     )?;
-    let bundle_storage_with_cache = wrap_storage_with_long_term_cache(Arc::new(bundle_storage));
+    let bundle_storage_with_cache = wrap_storage_with_long_term_cache(
+        searcher_context.storage_long_term_cache.clone(),
+        Arc::new(bundle_storage),
+    );
     let directory = StorageDirectory::new(bundle_storage_with_cache);
     let hot_directory = if unlimited_cache {
         let caching_directory = CachingDirectory::new_with_unlimited_capacity(Arc::new(directory));
@@ -338,16 +328,16 @@ async fn warm_up_fieldnorms(searcher: &Searcher, requires_scoring: bool) -> anyh
 }
 
 /// Apply a leaf search on a single split.
-#[instrument(skip(search_request, storage, split, doc_mapper))]
+#[instrument(skip(searcher_context, search_request, storage, split, doc_mapper))]
 async fn leaf_search_single_split(
+    searcher_context: &Arc<SearcherContext>,
     search_request: &SearchRequest,
     storage: Arc<dyn Storage>,
     split: SplitIdAndFooterOffsets,
     doc_mapper: Arc<dyn DocMapper>,
-    leaf_split_search_permit: SemaphorePermit<'static>,
 ) -> crate::Result<LeafSearchResponse> {
     let split_id = split.split_id.to_string();
-    let index = open_index(storage, &split).await?;
+    let index = open_index(searcher_context, storage, &split).await?;
     let split_schema = index.schema();
     let quickwit_collector = make_collector_for_split(
         split_id.clone(),
@@ -388,6 +378,7 @@ async fn leaf_search_single_split(
 /// charge to consolidate, identify the actual final top hits to display, and
 /// fetch the actual documents to convert the partial hits into actual Hits.
 pub async fn leaf_search(
+    searcher_context: Arc<SearcherContext>,
     request: &SearchRequest,
     index_storage: Arc<dyn Storage>,
     splits: &[SplitIdAndFooterOffsets],
@@ -398,18 +389,22 @@ pub async fn leaf_search(
         .map(|split| {
             let doc_mapper_clone = doc_mapper.clone();
             let index_storage_clone = index_storage.clone();
+            let searcher_context_clone = searcher_context.clone();
             async move {
-                let leaf_split_search_permit = get_leaf_search_split_semaphore().await;
+                let _leaf_split_search_permit = searcher_context_clone.leaf_search_split_semaphore
+                    .acquire()
+                    .await
+                    .expect("Failed to acquire permit. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
                 crate::SEARCH_METRICS.leaf_searches_splits_total.inc();
                 let timer = crate::SEARCH_METRICS
                     .leaf_search_split_duration_secs
                     .start_timer();
                 let leaf_search_single_split_res = leaf_search_single_split(
+                    &searcher_context_clone,
                     request,
                     index_storage_clone,
                     split.clone(),
                     doc_mapper_clone,
-                    leaf_split_search_permit,
                 )
                 .await;
                 timer.observe_duration();

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -43,6 +43,7 @@ mod tests;
 
 use metrics::SEARCH_METRICS;
 use root::validate_request;
+use service::SearcherContext;
 
 /// Refer to this as `crate::Result<T>`.
 pub type Result<T> = std::result::Result<T, SearchError>;
@@ -55,7 +56,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use itertools::Itertools;
 use quickwit_cluster::Cluster;
-use quickwit_config::{build_doc_mapper, QuickwitConfig, SEARCHER_CONFIG_INSTANCE};
+use quickwit_config::{build_doc_mapper, QuickwitConfig, SearcherConfig};
 use quickwit_doc_mapper::tag_pruning::extract_tags_from_query;
 use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::{Metastore, SplitMetadata, SplitState};
@@ -211,8 +212,9 @@ pub async fn single_node_search(
 
     // Validates the query by effectively building it against the current schema.
     doc_mapper.query(doc_mapper.schema(), search_request)?;
-
+    let searcher_context = Arc::new(SearcherContext::new(SearcherConfig::default()));
     let leaf_search_response = leaf_search(
+        searcher_context.clone(),
         search_request,
         index_storage.clone(),
         &split_metadata[..],
@@ -221,6 +223,7 @@ pub async fn single_node_search(
     .await
     .context("Failed to perform leaf search.")?;
     let fetch_docs_response = fetch_docs(
+        searcher_context.clone(),
         leaf_search_response.partial_hits,
         index_storage,
         &split_metadata,
@@ -264,9 +267,6 @@ pub async fn start_searcher_service(
     storage_uri_resolver: StorageUriResolver,
     cluster: Arc<Cluster>,
 ) -> anyhow::Result<Arc<dyn SearchService>> {
-    SEARCHER_CONFIG_INSTANCE
-        .set(quickwit_config.searcher_config.clone())
-        .expect("could not set searcher config in global once cell");
     let client_pool = SearchClientPool::create_and_keep_updated(
         &cluster.members(),
         cluster.member_change_watcher(),
@@ -278,6 +278,7 @@ pub async fn start_searcher_service(
         storage_uri_resolver,
         cluster_client,
         client_pool,
+        quickwit_config.searcher_config.clone(),
     ));
     Ok(search_service)
 }

--- a/quickwit-search/src/tests.rs
+++ b/quickwit-search/src/tests.rs
@@ -20,6 +20,7 @@
 use std::collections::BTreeSet;
 
 use assert_json_diff::assert_json_include;
+use quickwit_config::SearcherConfig;
 use quickwit_doc_mapper::DefaultDocMapper;
 use quickwit_indexing::TestSandbox;
 use quickwit_proto::{LeafHit, SearchRequest, SortOrder};
@@ -578,7 +579,9 @@ async fn test_search_dynamic_util(test_sandbox: &TestSandbox, query: &str) -> Ve
         max_hits: 100,
         ..Default::default()
     };
+    let searcher_context = Arc::new(SearcherContext::new(SearcherConfig::default()));
     let search_response = leaf_search(
+        searcher_context,
         &request,
         test_sandbox.storage(),
         &splits_offsets,

--- a/quickwit-storage/src/cache/mod.rs
+++ b/quickwit-storage/src/cache/mod.rs
@@ -28,11 +28,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use once_cell::sync::OnceCell;
+pub use quickwit_cache::QuickwitCache;
+pub use storage_with_cache::StorageWithCache;
 
 pub use self::memory_sized_cache::MemorySizedCache;
-use crate::cache::quickwit_cache::QuickwitCache;
-use crate::cache::storage_with_cache::StorageWithCache;
 use crate::{OwnedBytes, Storage};
 
 /// Wraps the given directory with a slice cache that is actually global
@@ -43,12 +42,14 @@ use crate::{OwnedBytes, Storage};
 /// - it relies on the idea that all of the files we attempt to cache
 /// have universally unique names. It happens to be true today, but this might be very error prone
 /// in the future.
-pub fn wrap_storage_with_long_term_cache(storage: Arc<dyn Storage>) -> Arc<dyn Storage> {
-    static SINGLETON: OnceCell<Arc<dyn Cache>> = OnceCell::new();
-    let cache = SINGLETON
-        .get_or_init(|| Arc::new(QuickwitCache::default()))
-        .clone();
-    Arc::new(StorageWithCache { storage, cache })
+pub fn wrap_storage_with_long_term_cache(
+    long_term_cache: Arc<dyn Cache>,
+    storage: Arc<dyn Storage>,
+) -> Arc<dyn Storage> {
+    Arc::new(StorageWithCache {
+        storage,
+        cache: long_term_cache,
+    })
 }
 
 /// The `Cache` trait is the abstraction used to describe the caching logic

--- a/quickwit-storage/src/cache/storage_with_cache.rs
+++ b/quickwit-storage/src/cache/storage_with_cache.rs
@@ -28,7 +28,7 @@ use crate::cache::Cache;
 use crate::{OwnedBytes, Storage, StorageResult};
 
 /// Use with care, StorageWithCache is read-only.
-pub(crate) struct StorageWithCache {
+pub struct StorageWithCache {
     pub storage: Arc<dyn Storage>,
     pub cache: Arc<dyn Cache>,
 }

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -56,7 +56,7 @@ pub use tantivy::directory::OwnedBytes;
 pub use self::bundle_storage::{BundleStorage, BundleStorageFileOffsets};
 #[cfg(any(test, feature = "testsuite"))]
 pub use self::cache::MockCache;
-pub use self::cache::{wrap_storage_with_long_term_cache, MemorySizedCache};
+pub use self::cache::{wrap_storage_with_long_term_cache, Cache, MemorySizedCache, QuickwitCache};
 pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
 #[cfg(feature = "azure")]
 pub use self::object_storage::{AzureBlobStorage, AzureBlobStorageFactory};


### PR DESCRIPTION
### Description

I think it would be nice to remove all these once cells for a bunch of parameters, caching and semaphores.

What do you think?

I need to clean a bit the code but you will get the idea.

### How was this PR tested?

`make test-all` passing except for kafka but I need to check if I have the same issue on main.
