### PR TITLE
Add support for parallel indexing pipelines

### DIFF
--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -811,11 +811,12 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
     } else {
         SourceParams::stdin()
     };
-    let source = SourceConfig {
+    let source_config = SourceConfig {
         source_id: CLI_INGEST_SOURCE_ID.to_string(),
+        num_pipelines: 1,
         source_params,
     };
-    run_index_checklist(&config.metastore_uri, &args.index_id, Some(&source)).await?;
+    run_index_checklist(&config.metastore_uri, &args.index_id, Some(&source_config)).await?;
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
         .resolve(&config.metastore_uri)
@@ -834,7 +835,8 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
     };
     let universe = Universe::new();
     let indexing_server = IndexingService::new(
-        config.clone().data_dir_path,
+        config.node_id.clone(),
+        config.data_dir_path.clone(),
         indexer_config,
         metastore,
         quickwit_storage_uri_resolver().clone(),
@@ -844,7 +846,8 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
     let pipeline_id = indexing_server_mailbox
         .ask_for_res(SpawnPipeline {
             index_id: args.index_id.clone(),
-            source,
+            source_config,
+            pipeline_ord: 0,
         })
         .await?;
     let pipeline_handle = indexing_server_mailbox
@@ -938,6 +941,7 @@ pub async fn merge_or_demux_cli(
         .await?;
     let storage_resolver = quickwit_storage_uri_resolver().clone();
     let indexing_server = IndexingService::new(
+        config.node_id,
         config.data_dir_path,
         indexer_config,
         metastore,

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -490,6 +490,7 @@ mod tests {
             .collect();
         let sources = vec![SourceConfig {
             source_id: "foo-source".to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::file("path/to/file"),
         }];
         let expected_source = vec![SourceRow {
@@ -552,10 +553,12 @@ mod tests {
         let sources = [
             SourceConfig {
                 source_id: "foo-source".to_string(),
+                num_pipelines: 1,
                 source_params: SourceParams::stdin(),
             },
             SourceConfig {
                 source_id: "bar-source".to_string(),
+                num_pipelines: 1,
                 source_params: SourceParams::stdin(),
             },
         ];

--- a/quickwit-config/resources/tests/source_config/kafka-source.json
+++ b/quickwit-config/resources/tests/source_config/kafka-source.json
@@ -1,5 +1,6 @@
 {
     "source_id": "hdfs-logs-kafka-source",
+    "num_pipelines": 2,
     "source_type": "kafka",
     "params": {
         "topic": "cloudera-cluster-logs",

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -584,10 +584,12 @@ mod tests {
             invalid_index_config.sources = vec![
                 SourceConfig {
                     source_id: "void_1".to_string(),
+                    num_pipelines: 1,
                     source_params: SourceParams::void(),
                 },
                 SourceConfig {
                     source_id: "void_1".to_string(),
+                    num_pipelines: 1,
                     source_params: SourceParams::void(),
                 },
             ];
@@ -603,6 +605,7 @@ mod tests {
             let mut invalid_index_config = index_config.clone();
             invalid_index_config.sources = vec![SourceConfig {
                 source_id: "file_params_1".to_string(),
+                num_pipelines: 1,
                 source_params: SourceParams::stdin(),
             }];
             assert!(invalid_index_config.validate().is_err());

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -72,6 +72,7 @@ kafka-broker-tests = []
 vendored-kafka = ["kafka", "libz-sys/static", "openssl/vendored"]
 kinesis = ["rusoto_core", "rusoto_kinesis", "quickwit-aws/kinesis"]
 kinesis-localstack-tests = []
+testsuite = []
 
 [dev-dependencies]
 bytes = "1"

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -41,7 +41,9 @@ use tracing::{info, warn};
 use ulid::Ulid;
 
 use crate::actors::Packager;
-use crate::models::{IndexedSplit, IndexedSplitBatch, IndexingDirectory, RawDocBatch};
+use crate::models::{
+    IndexedSplit, IndexedSplitBatch, IndexingDirectory, IndexingPipelineId, RawDocBatch,
+};
 
 #[derive(Debug)]
 struct CommitTimeout {
@@ -92,8 +94,7 @@ impl IndexerCounters {
 }
 
 struct IndexerState {
-    index_id: String,
-    source_id: String,
+    pipeline_id: IndexingPipelineId,
     doc_mapper: Arc<dyn DocMapper>,
     indexing_directory: IndexingDirectory,
     indexing_settings: IndexingSettings,
@@ -123,7 +124,7 @@ impl IndexerState {
             .schema(self.schema.clone())
             .tokenizers(QUICKWIT_TOKENIZER_MANAGER.clone());
         let indexed_split = IndexedSplit::new_in_dir(
-            self.index_id.clone(),
+            self.pipeline_id.clone(),
             partition_id,
             self.indexing_directory.scratch_directory.clone(),
             self.indexing_settings.resources.clone(),
@@ -153,7 +154,7 @@ impl IndexerState {
     fn create_workbench(&self) -> anyhow::Result<IndexingWorkbench> {
         let workbench = IndexingWorkbench {
             checkpoint_delta: IndexCheckpointDelta {
-                source_id: self.source_id.clone(),
+                source_id: self.pipeline_id.source_id.clone(),
                 source_delta: SourceCheckpointDelta::default(),
             },
             indexed_splits: FnvHashMap::with_capacity_and_hasher(250, Default::default()),
@@ -403,9 +404,8 @@ enum CommitTrigger {
 
 impl Indexer {
     pub fn new(
-        index_id: String,
+        pipeline_id: IndexingPipelineId,
         doc_mapper: Arc<dyn DocMapper>,
-        source_id: String,
         metastore: Arc<dyn Metastore>,
         indexing_directory: IndexingDirectory,
         indexing_settings: IndexingSettings,
@@ -430,8 +430,7 @@ impl Indexer {
         };
         Self {
             indexer_state: IndexerState {
-                index_id,
-                source_id,
+                pipeline_id,
                 doc_mapper,
                 indexing_directory,
                 indexing_settings,
@@ -494,7 +493,7 @@ impl Indexer {
         if splits.is_empty() {
             self.metastore
                 .publish_splits(
-                    &self.indexer_state.index_id,
+                    &self.indexer_state.pipeline_id.index_id,
                     &[],
                     &[],
                     Some(checkpoint_delta),
@@ -504,7 +503,8 @@ impl Indexer {
                     format!(
                         "Failed to update the checkpoint for {}, {} after a split containing only \
                          errors.",
-                        &self.indexer_state.index_id, &self.indexer_state.source_id
+                        &self.indexer_state.pipeline_id.index_id,
+                        &self.indexer_state.pipeline_id.source_id
                     )
                 })?;
             return Ok(());
@@ -556,7 +556,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_simple() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         let doc_mapper = Arc::new(quickwit_doc_mapper::default_doc_mapper_for_tests());
         let indexing_directory = IndexingDirectory::for_test().await?;
         let mut indexing_settings = IndexingSettings::for_test();
@@ -564,7 +569,7 @@ mod tests {
         indexing_settings.sort_field = Some("timestamp".to_string());
         indexing_settings.sort_order = Some(SortOrder::Desc);
         indexing_settings.timestamp_field = Some("timestamp".to_string());
-        let (mailbox, inbox) = create_test_mailbox();
+        let (packager_mailbox, packager_inbox) = create_test_mailbox();
         let mut metastore = MockMetastore::default();
         metastore
             .expect_publish_splits()
@@ -572,15 +577,13 @@ mod tests {
                 assert!(splits.is_empty());
                 Ok(())
             });
-
         let indexer = Indexer::new(
-            "test-index".to_string(),
+            pipeline_id,
             doc_mapper,
-            "source-id".to_string(),
             Arc::new(metastore),
             indexing_directory,
             indexing_settings,
-            mailbox,
+            packager_mailbox,
         );
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
@@ -629,7 +632,7 @@ mod tests {
                 overall_num_bytes: 525
             }
         );
-        let output_messages = inbox.drain_for_test();
+        let output_messages = packager_inbox.drain_for_test();
         assert_eq!(output_messages.len(), 1);
         let batch = output_messages[0]
             .downcast_ref::<IndexedSplitBatch>()
@@ -644,11 +647,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_timeout() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         let doc_mapper = Arc::new(quickwit_doc_mapper::default_doc_mapper_for_tests());
         let indexing_directory = IndexingDirectory::for_test().await?;
         let indexing_settings = IndexingSettings::for_test();
-        let (mailbox, inbox) = create_test_mailbox();
+        let (packager_mailbox, packager_inbox) = create_test_mailbox();
         let mut metastore = MockMetastore::default();
         metastore
             .expect_publish_splits()
@@ -656,15 +664,13 @@ mod tests {
                 assert!(splits.is_empty());
                 Ok(())
             });
-
         let indexer = Indexer::new(
-            "test-index".to_string(),
+            pipeline_id,
             doc_mapper,
-            "source-id".to_string(),
             Arc::new(metastore),
             indexing_directory,
             indexing_settings,
-            mailbox,
+            packager_mailbox,
         );
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
@@ -703,7 +709,7 @@ mod tests {
                 overall_num_bytes: 137
             }
         );
-        let output_messages = inbox.drain_for_test();
+        let output_messages = packager_inbox.drain_for_test();
         assert_eq!(output_messages.len(), 1);
         let indexed_split_batch = output_messages[0]
             .downcast_ref::<IndexedSplitBatch>()
@@ -714,11 +720,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_eof() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         let doc_mapper = Arc::new(quickwit_doc_mapper::default_doc_mapper_for_tests());
         let indexing_directory = IndexingDirectory::for_test().await?;
         let indexing_settings = IndexingSettings::for_test();
-        let (mailbox, inbox) = create_test_mailbox();
+        let (packager_mailbox, packager_inbox) = create_test_mailbox();
         let mut metastore = MockMetastore::default();
         metastore
             .expect_publish_splits()
@@ -727,13 +738,12 @@ mod tests {
                 Ok(())
             });
         let indexer = Indexer::new(
-            "test-index".to_string(),
+            pipeline_id,
             doc_mapper,
-            "source-id".to_string(),
             Arc::new(metastore),
             indexing_directory,
             indexing_settings,
-            mailbox,
+            packager_mailbox,
         );
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
@@ -760,7 +770,7 @@ mod tests {
                 overall_num_bytes: 137
             }
         );
-        let output_messages = inbox.drain_for_test();
+        let output_messages = packager_inbox.drain_for_test();
         assert_eq!(output_messages.len(), 1);
         assert_eq!(
             output_messages[0]
@@ -785,13 +795,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_indexer_partitioning() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         let doc_mapper: Arc<dyn DocMapper> = Arc::new(
             serde_json::from_str::<DefaultDocMapper>(DOCMAPPER_WITH_PARTITION_JSON).unwrap(),
         );
         let indexing_directory = IndexingDirectory::for_test().await?;
         let indexing_settings = IndexingSettings::for_test();
-        let (mailbox, inbox) = create_test_mailbox();
+        let (packager_mailbox, packager_inbox) = create_test_mailbox();
         let mut metastore = MockMetastore::default();
         metastore
             .expect_publish_splits()
@@ -801,13 +816,12 @@ mod tests {
             });
 
         let indexer = Indexer::new(
-            "test-index".to_string(),
+            pipeline_id,
             doc_mapper,
-            "source-id".to_string(),
             Arc::new(metastore),
             indexing_directory,
             indexing_settings,
-            mailbox,
+            packager_mailbox,
         );
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
@@ -851,7 +865,7 @@ mod tests {
             }
         );
 
-        let output_messages = inbox.drain_for_test();
+        let output_messages = packager_inbox.drain_for_test();
         assert_eq!(output_messages.len(), 1);
 
         let indexed_split_batch = output_messages[0]

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -23,7 +23,6 @@ use std::time::Duration;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use itertools::Itertools;
 use quickwit_actors::{
     create_mailbox, Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, Health, KillSwitch,
     QueueCapacity, Supervisable,
@@ -42,14 +41,14 @@ use crate::actors::{
     GarbageCollector, Indexer, MergeExecutor, MergePlanner, NamedField, Packager, Publisher,
     Uploader,
 };
-use crate::models::{IndexingDirectory, IndexingStatistics, Observe};
+use crate::models::{IndexingDirectory, IndexingPipelineId, IndexingStatistics, Observe};
 use crate::source::{quickwit_supported_sources, SourceActor};
 use crate::split_store::{IndexingSplitStore, IndexingSplitStoreParams};
 use crate::{MergePolicy, StableMultitenantWithTimestampMergePolicy};
 
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(600); // 10 min.
 
-pub struct IndexingPipelineHandler {
+pub struct IndexingPipelineHandle {
     /// Indexing pipeline
     pub source: ActorHandle<SourceActor>,
     pub indexer: ActorHandle<Indexer>,
@@ -83,7 +82,7 @@ pub struct IndexingPipeline {
     params: IndexingPipelineParams,
     previous_generations_statistics: IndexingStatistics,
     statistics: IndexingStatistics,
-    handlers: Option<IndexingPipelineHandler>,
+    handles: Option<IndexingPipelineHandle>,
     // Killswitch used for the actors in the pipeline. This is not the supervisor killswitch.
     kill_switch: KillSwitch,
 }
@@ -117,29 +116,29 @@ impl IndexingPipeline {
         Self {
             params,
             previous_generations_statistics: Default::default(),
-            handlers: None,
+            handles: None,
             kill_switch: KillSwitch::default(),
             statistics: IndexingStatistics::default(),
         }
     }
 
     fn supervisables(&self) -> Vec<&dyn Supervisable> {
-        if let Some(handlers) = self.handlers.as_ref() {
+        if let Some(handles) = &self.handles {
             let supervisables: Vec<&dyn Supervisable> = vec![
-                &handlers.source,
-                &handlers.indexer,
-                &handlers.packager,
-                &handlers.uploader,
-                &handlers.sequencer,
-                &handlers.publisher,
-                &handlers.garbage_collector,
-                &handlers.merge_planner,
-                &handlers.merge_split_downloader,
-                &handlers.merge_executor,
-                &handlers.merge_packager,
-                &handlers.merge_uploader,
-                &handlers.merge_sequencer,
-                &handlers.merge_publisher,
+                &handles.source,
+                &handles.indexer,
+                &handles.packager,
+                &handles.uploader,
+                &handles.sequencer,
+                &handles.publisher,
+                &handles.garbage_collector,
+                &handles.merge_planner,
+                &handles.merge_split_downloader,
+                &handles.merge_executor,
+                &handles.merge_packager,
+                &handles.merge_uploader,
+                &handles.merge_sequencer,
+                &handles.merge_publisher,
             ];
             supervisables
         } else {
@@ -169,18 +168,34 @@ impl IndexingPipeline {
         }
 
         if !failure_or_unhealthy_actors.is_empty() {
-            error!(index=%self.params.index_id, gen=self.generation(), healthy=?healthy_actors, failure_or_unhealthy_actors=?failure_or_unhealthy_actors, success=?success_actors, "indexing pipeline error.");
+            error!(
+                pipeline_id=?self.params.pipeline_id,
+                generation=self.generation(),
+                healthy_actors=?healthy_actors,
+                failed_or_unhealthy_actors=?failure_or_unhealthy_actors,
+                success_actors=?success_actors,
+                "Indexing pipeline failure."
+            );
             return Health::FailureOrUnhealthy;
         }
-
         if healthy_actors.is_empty() {
-            // all actors finished successfully.
-            info!(index=%self.params.index_id, gen=self.generation(), "indexing-pipeline-success");
+            // All the actors finished successfully.
+            info!(
+                pipeline_id=?self.params.pipeline_id,
+                generation=self.generation(),
+                "Indexing pipeline success."
+            );
             return Health::Success;
         }
-
-        // No error at this point, and there are still actors running
-        debug!(index=%self.params.index_id, gen=self.generation(), healthy=?healthy_actors, failure_or_unhealthy_actors=?failure_or_unhealthy_actors, success=?success_actors, "pipeline is judged healthy.");
+        // No error at this point and there are still some actors running.
+        debug!(
+            pipeline_id=?self.params.pipeline_id,
+            generation=self.generation(),
+            healthy_actors=?healthy_actors,
+            failed_or_unhealthy_actors=?failure_or_unhealthy_actors,
+            success_actors=?success_actors,
+            "Indexing pipeline running."
+        );
         Health::Healthy
     }
 
@@ -189,7 +204,7 @@ impl IndexingPipeline {
     }
 
     // TODO this should return an error saying whether we can retry or not.
-    #[instrument(name="", level="info", skip_all, fields(index=%self.params.index_id, gen=self.generation()))]
+    #[instrument(name="", level="info", skip_all, fields(index=%self.params.pipeline_id.index_id, gen=self.generation()))]
     async fn spawn_pipeline(&mut self, ctx: &ActorContext<Self>) -> anyhow::Result<()> {
         self.statistics.num_spawn_attempts += 1;
         self.kill_switch = KillSwitch::default();
@@ -205,9 +220,12 @@ impl IndexingPipeline {
         };
         let merge_policy: Arc<dyn MergePolicy> = Arc::new(stable_multitenant_merge_policy);
         info!(
-            root_dir = %self.params.indexing_directory.path().display(),
-            merge_policy = ?merge_policy,
-            "spawn-indexing-pipeline",
+            index_id=%self.params.pipeline_id.index_id,
+            source_id=%self.params.pipeline_id.source_id,
+            pipeline_ord=%self.params.pipeline_id.pipeline_ord,
+            root_dir=%self.params.indexing_directory.path().display(),
+            merge_policy=?merge_policy,
+            "Spawning indexing pipeline.",
         );
         let split_store = IndexingSplitStore::create_with_local_store(
             self.params.storage.clone(),
@@ -221,7 +239,12 @@ impl IndexingPipeline {
         let published_splits = self
             .params
             .metastore
-            .list_splits(&self.params.index_id, SplitState::Published, None, None)
+            .list_splits(
+                &self.params.pipeline_id.index_id,
+                SplitState::Published,
+                None,
+                None,
+            )
             .await?
             .into_iter()
             .map(|split| split.split_metadata)
@@ -235,7 +258,7 @@ impl IndexingPipeline {
 
         // Garbage colletor
         let garbage_collector = GarbageCollector::new(
-            self.params.index_id.clone(),
+            self.params.pipeline_id.clone(),
             split_store.clone(),
             self.params.metastore.clone(),
         );
@@ -301,7 +324,7 @@ impl IndexingPipeline {
             .spawn();
 
         let merge_executor = MergeExecutor::new(
-            self.params.index_id.clone(),
+            self.params.pipeline_id.clone(),
             merge_packager_mailbox,
             self.params.indexing_settings.timestamp_field.clone(),
             self.params.indexing_settings.demux_field.clone(),
@@ -324,9 +347,9 @@ impl IndexingPipeline {
             .spawn();
 
         // Merge planner
-        let published_split_metadatas = published_splits.into_iter().collect_vec();
         let merge_planner = MergePlanner::new(
-            published_split_metadatas,
+            self.params.pipeline_id.clone(),
+            published_splits,
             merge_policy.clone(),
             merge_split_downloader_mailbox,
         );
@@ -378,9 +401,8 @@ impl IndexingPipeline {
             .spawn();
         // Indexer
         let indexer = Indexer::new(
-            self.params.index_id.clone(),
+            self.params.pipeline_id.clone(),
             self.params.doc_mapper.clone(),
-            self.params.source.source_id.clone(),
             self.params.metastore.clone(),
             self.params.indexing_directory.clone(),
             self.params.indexing_settings.clone(),
@@ -395,15 +417,15 @@ impl IndexingPipeline {
         let index_metadata = self
             .params
             .metastore
-            .index_metadata(&self.params.index_id)
+            .index_metadata(&self.params.pipeline_id.index_id)
             .await?;
         let source_checkpoint = index_metadata
             .checkpoint
-            .source_checkpoint(&self.params.source.source_id)
+            .source_checkpoint(&self.params.pipeline_id.source_id)
             .cloned()
             .unwrap_or_default(); // TODO Have a stricter check.
         let source = quickwit_supported_sources()
-            .load_source(self.params.source.clone(), source_checkpoint)
+            .load_source(self.params.source_config.clone(), source_checkpoint)
             .await?;
         let actor_source = SourceActor {
             source,
@@ -418,7 +440,7 @@ impl IndexingPipeline {
         // Increment generation once we are sure there will be no spawning error.
         self.previous_generations_statistics = self.statistics.clone();
         self.statistics.generation += 1;
-        self.handlers = Some(IndexingPipelineHandler {
+        self.handles = Some(IndexingPipelineHandle {
             source: source_handler,
             indexer: indexer_handler,
             packager: packager_handler,
@@ -453,7 +475,7 @@ impl IndexingPipeline {
 
     async fn terminate(&mut self) {
         self.kill_switch.kill();
-        if let Some(handlers) = self.handlers.take() {
+        if let Some(handlers) = self.handles.take() {
             tokio::join!(
                 handlers.source.kill(),
                 handlers.indexer.kill(),
@@ -480,11 +502,11 @@ impl Handler<Observe> for IndexingPipeline {
         _: Observe,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        if let Some(handlers) = self.handlers.as_ref() {
+        if let Some(handles) = &self.handles {
             let (indexer_counters, uploader_counters, publisher_counters) = join!(
-                handlers.indexer.observe(),
-                handlers.uploader.observe(),
-                handlers.publisher.observe(),
+                handles.indexer.observe(),
+                handles.uploader.observe(),
+                handles.publisher.observe(),
             );
             self.statistics = self
                 .previous_generations_statistics
@@ -511,7 +533,7 @@ impl Handler<Supervise> for IndexingPipeline {
         _: Supervise,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        if self.handlers.is_some() {
+        if self.handles.is_some() {
             match self.healthcheck() {
                 Health::Healthy => {}
                 Health::FailureOrUnhealthy => {
@@ -539,7 +561,7 @@ impl Handler<Spawn> for IndexingPipeline {
         spawn: Spawn,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        if self.handlers.is_some() {
+        if self.handles.is_some() {
             return Ok(());
         }
         self.previous_generations_statistics.num_spawn_attempts = 1 + spawn.retry_count;
@@ -565,11 +587,11 @@ impl Handler<Spawn> for IndexingPipeline {
 }
 
 pub struct IndexingPipelineParams {
-    pub index_id: String,
+    pub pipeline_id: IndexingPipelineId,
     pub doc_mapper: Arc<dyn DocMapper>,
     pub indexing_directory: IndexingDirectory,
     pub indexing_settings: IndexingSettings,
-    pub source: SourceConfig,
+    pub source_config: SourceConfig,
     pub split_store_max_num_bytes: usize,
     pub split_store_max_num_splits: usize,
     pub metastore: Arc<dyn Metastore>,
@@ -577,9 +599,11 @@ pub struct IndexingPipelineParams {
 }
 
 impl IndexingPipelineParams {
+    #[allow(clippy::too_many_arguments)]
     pub async fn try_new(
+        pipeline_id: IndexingPipelineId,
         index_metadata: IndexMetadata,
-        source: SourceConfig,
+        source_config: SourceConfig,
         indexing_dir_path: PathBuf,
         split_store_max_num_bytes: usize,
         split_store_max_num_splits: usize,
@@ -592,15 +616,15 @@ impl IndexingPipelineParams {
             &index_metadata.indexing_settings,
         )?;
         let indexing_directory_path = indexing_dir_path
-            .join(&index_metadata.index_id)
-            .join(&source.source_id);
+            .join(&pipeline_id.index_id)
+            .join(&pipeline_id.source_id);
         let indexing_directory = IndexingDirectory::create_in_dir(indexing_directory_path).await?;
         Ok(Self {
-            index_id: index_metadata.index_id,
+            pipeline_id,
             doc_mapper,
             indexing_directory,
             indexing_settings: index_metadata.indexing_settings,
-            source,
+            source_config,
             split_store_max_num_bytes,
             split_store_max_num_splits,
             metastore,
@@ -696,22 +720,29 @@ mod tests {
             .times(1)
             .returning(|_, _, _, _| Ok(()));
         let universe = Universe::new();
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         let source_config = SourceConfig {
             source_id: "test-source".to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::file(PathBuf::from("data/test_corpus.json")),
         };
-        let indexing_pipeline_params = IndexingPipelineParams {
-            index_id: "test-index".to_string(),
+        let pipeline_params = IndexingPipelineParams {
+            pipeline_id,
             doc_mapper: Arc::new(default_doc_mapper_for_tests()),
+            source_config,
             indexing_directory: IndexingDirectory::for_test().await?,
             indexing_settings: IndexingSettings::for_test(),
             split_store_max_num_bytes: 10_000_000,
             split_store_max_num_splits: 100,
-            source: source_config,
             metastore: Arc::new(metastore),
             storage: Arc::new(RamStorage::default()),
         };
-        let pipeline = IndexingPipeline::new(indexing_pipeline_params);
+        let pipeline = IndexingPipeline::new(pipeline_params);
         let (_pipeline_mailbox, pipeline_handler) = universe.spawn_actor(pipeline).spawn();
         let (pipeline_exit_status, pipeline_statistics) = pipeline_handler.join().await;
         assert_eq!(pipeline_statistics.generation, 1);
@@ -778,18 +809,25 @@ mod tests {
             .times(1)
             .returning(|_, _, _, _| Ok(()));
         let universe = Universe::new();
-        let source = SourceConfig {
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
             source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
+        let source_config = SourceConfig {
+            source_id: "test-source".to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::file(PathBuf::from("data/test_corpus.json")),
         };
         let pipeline_params = IndexingPipelineParams {
-            index_id: "test-index".to_string(),
+            pipeline_id,
             doc_mapper: Arc::new(default_doc_mapper_for_tests()),
+            source_config,
             indexing_directory: IndexingDirectory::for_test().await?,
             indexing_settings: IndexingSettings::for_test(),
             split_store_max_num_bytes: 10_000_000,
             split_store_max_num_splits: 100,
-            source,
             metastore: Arc::new(metastore),
             storage: Arc::new(RamStorage::default()),
         };

--- a/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit-indexing/src/actors/mod.rs
@@ -28,7 +28,7 @@ mod publisher;
 mod sequencer;
 mod uploader;
 
-pub use indexing_pipeline::{IndexingPipeline, IndexingPipelineHandler, IndexingPipelineParams};
+pub use indexing_pipeline::{IndexingPipeline, IndexingPipelineHandle, IndexingPipelineParams};
 pub use indexing_service::{
     IndexingService, IndexingServiceError, IndexingServiceState, INDEXING_DIR_NAME,
 };

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -341,10 +341,10 @@ fn create_packaged_split(
     ctx.record_progress();
 
     let packaged_split = PackagedSplit {
-        split_id: split.split_id.to_string(),
+        split_id: split.split_id,
         partition_id: split.partition_id,
+        pipeline_id: split.pipeline_id,
         replaced_split_ids: split.replaced_split_ids,
-        index_id: split.index_id,
         split_scratch_directory: split.split_scratch_directory,
         num_docs,
         demux_num_ops: split.demux_num_ops,
@@ -377,7 +377,7 @@ mod tests {
     use tantivy::{doc, Index};
 
     use super::*;
-    use crate::models::ScratchDirectory;
+    use crate::models::{IndexingPipelineId, ScratchDirectory};
 
     fn make_indexed_split_for_test(segments_timestamps: &[&[i64]]) -> anyhow::Result<IndexedSplit> {
         let split_scratch_directory = ScratchDirectory::for_test()?;
@@ -430,14 +430,20 @@ mod tests {
                 }
             }
         }
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         // We don't commit, that's the job of the packager.
         //
         // TODO: In the future we would like that kind of segment flush to emit a new split,
         // but this will require work on tantivy.
         let indexed_split = IndexedSplit {
             split_id: "test-split".to_string(),
-            index_id: "test-index".to_string(),
             partition_id: 17u64,
+            pipeline_id,
             time_range: timerange_opt,
             demux_num_ops: 0,
             num_docs,

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -205,6 +205,9 @@ fn create_split_metadata(split: &PackagedSplit, footer_offsets: Range<u64>) -> S
     SplitMetadata {
         split_id: split.split_id.clone(),
         partition_id: split.partition_id,
+        source_id: split.pipeline_id.source_id.clone(),
+        node_id: split.pipeline_id.node_id.clone(),
+        pipeline_ord: split.pipeline_id.pipeline_ord,
         num_docs: split.num_docs as usize,
         time_range: split.time_range.clone(),
         uncompressed_docs_size_in_bytes: split.size_in_bytes,
@@ -252,14 +255,14 @@ async fn stage_and_upload_split(
         packaged_split,
         split_streamer.footer_range.start as u64..split_streamer.footer_range.end as u64,
     );
-    let index_id = packaged_split.index_id.clone();
-    info!(split_id = packaged_split.split_id.as_str(), "staging-split");
+    let index_id = &packaged_split.pipeline_id.index_id.clone();
+    info!(split_id=%packaged_split.split_id, "staging-split");
     metastore
-        .stage_split(&index_id, split_metadata.clone())
+        .stage_split(index_id, split_metadata.clone())
         .await?;
     counters.num_staged_splits.fetch_add(1, Ordering::SeqCst);
 
-    info!(split_id = packaged_split.split_id.as_str(), "storing-split");
+    info!(split_id=%packaged_split.split_id, "storing-split");
     split_store
         .store_split(
             &split_metadata,
@@ -283,11 +286,16 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
-    use crate::models::ScratchDirectory;
+    use crate::models::{IndexingPipelineId, ScratchDirectory};
 
     #[tokio::test]
     async fn test_uploader_1() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         let universe = Universe::new();
         let (mailbox, inbox) = create_test_mailbox::<Sequencer<Publisher>>();
         let mut mock_metastore = MockMetastore::default();
@@ -312,7 +320,7 @@ mod tests {
         let (uploader_mailbox, uploader_handle) = universe.spawn_actor(uploader).spawn();
         let split_scratch_directory = ScratchDirectory::for_test()?;
         let checkpoint_delta_opt: Option<IndexCheckpointDelta> = Some(IndexCheckpointDelta {
-            source_id: "source".to_string(),
+            source_id: "test-source".to_string(),
             source_delta: SourceCheckpointDelta::from(3..15),
         });
         uploader_mailbox
@@ -320,7 +328,7 @@ mod tests {
                 vec![PackagedSplit {
                     split_id: "test-split".to_string(),
                     partition_id: 3u64,
-                    index_id: "test-index".to_string(),
+                    pipeline_id,
                     time_range: Some(1_628_203_589i64..=1_628_203_640i64),
                     size_in_bytes: 1_000,
                     split_scratch_directory,
@@ -358,7 +366,7 @@ mod tests {
         assert_eq!(index_id, "test-index");
         assert_eq!(new_splits[0].split_id(), "test-split");
         let checkpoint_delta = checkpoint_delta_opt.unwrap();
-        assert_eq!(checkpoint_delta.source_id, "source");
+        assert_eq!(checkpoint_delta.source_id, "test-source");
         assert_eq!(
             checkpoint_delta.source_delta,
             SourceCheckpointDelta::from(3..15)
@@ -372,7 +380,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_uploader_emits_replace() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
         let universe = Universe::new();
         let (mailbox, inbox) = create_test_mailbox::<Sequencer<Publisher>>();
         let mut mock_metastore = MockMetastore::default();
@@ -401,11 +414,11 @@ mod tests {
         let packaged_split_1 = PackagedSplit {
             split_id: "test-split-1".to_string(),
             partition_id: 3u64,
+            pipeline_id: pipeline_id.clone(),
             replaced_split_ids: vec![
                 "replaced-split-1".to_string(),
                 "replaced-split-2".to_string(),
             ],
-            index_id: "test-index".to_string(),
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
             split_scratch_directory: split_scratch_directory_1,
@@ -418,11 +431,11 @@ mod tests {
         let package_split_2 = PackagedSplit {
             split_id: "test-split-2".to_string(),
             partition_id: 3u64,
+            pipeline_id,
             replaced_split_ids: vec![
                 "replaced-split-1".to_string(),
                 "replaced-split-2".to_string(),
             ],
-            index_id: "test-index".to_string(),
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
             split_scratch_directory: split_scratch_directory_2,

--- a/quickwit-indexing/src/merge_policy.rs
+++ b/quickwit-indexing/src/merge_policy.rs
@@ -287,7 +287,7 @@ impl StableMultitenantWithTimestampMergePolicy {
     }
 
     fn merge_operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation> {
-        if !self.merge_enabled || splits.is_empty() {
+        if !self.merge_enabled || splits.len() < 2 {
             return Vec::new();
         }
         // First we isolate splits that are mature.

--- a/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit-indexing/src/models/indexed_split.rs
@@ -30,13 +30,13 @@ use tantivy::merge_policy::NoMergePolicy;
 use tantivy::IndexBuilder;
 
 use crate::controlled_directory::ControlledDirectory;
-use crate::models::ScratchDirectory;
+use crate::models::{IndexingPipelineId, ScratchDirectory};
 use crate::new_split_id;
 
 pub struct IndexedSplit {
     pub split_id: String,
-    pub index_id: String,
     pub partition_id: u64,
+    pub pipeline_id: IndexingPipelineId,
 
     pub replaced_split_ids: Vec<String>,
 
@@ -73,7 +73,7 @@ impl fmt::Debug for IndexedSplit {
 
 impl IndexedSplit {
     pub fn new_in_dir(
-        index_id: String,
+        pipeline_id: IndexingPipelineId,
         partition_id: u64,
         scratch_directory: ScratchDirectory,
         indexing_resources: IndexingResources,
@@ -100,7 +100,7 @@ impl IndexedSplit {
         )?;
         index_writer.set_merge_policy(Box::new(NoMergePolicy));
         Ok(IndexedSplit {
-            index_id,
+            pipeline_id,
             partition_id,
             split_id,
             replaced_split_ids: Vec::new(),

--- a/quickwit-indexing/src/models/indexing_pipeline_id.rs
+++ b/quickwit-indexing/src/models/indexing_pipeline_id.rs
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct IndexingPipelineId {
+    pub index_id: String,
+    pub source_id: String,
+    pub node_id: String,
+    pub pipeline_ord: usize,
+}

--- a/quickwit-indexing/src/models/indexing_service_message.rs
+++ b/quickwit-indexing/src/models/indexing_service_message.rs
@@ -19,10 +19,33 @@
 
 use quickwit_config::SourceConfig;
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
-pub struct IndexingPipelineId {
+use super::IndexingPipelineId;
+
+#[derive(Debug)]
+pub struct SpawnPipelines {
     pub index_id: String,
-    pub source_id: String,
+    // TODO
+    // pub source_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SpawnPipeline {
+    pub index_id: String,
+    pub source_config: SourceConfig,
+    pub pipeline_ord: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct ShutdownPipelines {
+    pub index_id: String,
+    pub source_id: Option<String>,
+    // TODO
+    // pub pipeline_ord: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ShutdownPipeline {
+    pub pipeline_id: IndexingPipelineId,
 }
 
 /// Detaches a pipeline from the indexing service. The pipeline is no longer managed by the
@@ -43,21 +66,4 @@ pub struct SpawnMergePipeline {
     pub index_id: String,
     pub merge_enabled: bool,
     pub demux_enabled: bool,
-}
-
-#[derive(Debug)]
-pub struct SpawnPipelinesForIndex {
-    pub index_id: String,
-}
-
-#[derive(Clone, Debug)]
-pub struct SpawnPipeline {
-    pub index_id: String,
-    pub source: SourceConfig,
-}
-
-#[derive(Clone, Debug)]
-pub struct ShutdownPipeline {
-    pub index_id: String,
-    pub source_id: String,
 }

--- a/quickwit-indexing/src/models/mod.rs
+++ b/quickwit-indexing/src/models/mod.rs
@@ -19,6 +19,7 @@
 
 mod indexed_split;
 mod indexing_directory;
+mod indexing_pipeline_id;
 mod indexing_service_message;
 mod indexing_statistics;
 mod merge_planner_message;
@@ -30,9 +31,10 @@ mod scratch_directory;
 
 pub use indexed_split::{IndexedSplit, IndexedSplitBatch};
 pub use indexing_directory::{IndexingDirectory, CACHE};
+pub use indexing_pipeline_id::IndexingPipelineId;
 pub use indexing_service_message::{
-    DetachPipeline, IndexingPipelineId, ObservePipeline, ShutdownPipeline, SpawnMergePipeline,
-    SpawnPipeline, SpawnPipelinesForIndex,
+    DetachPipeline, ObservePipeline, ShutdownPipeline, ShutdownPipelines, SpawnMergePipeline,
+    SpawnPipeline, SpawnPipelines,
 };
 pub use indexing_statistics::IndexingStatistics;
 pub use merge_planner_message::NewSplits;

--- a/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit-indexing/src/models/packaged_split.rs
@@ -24,12 +24,12 @@ use std::time::Instant;
 
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 
-use crate::models::ScratchDirectory;
+use crate::models::{IndexingPipelineId, ScratchDirectory};
 
 pub struct PackagedSplit {
     pub split_id: String,
-    pub index_id: String,
     pub partition_id: u64,
+    pub pipeline_id: IndexingPipelineId,
 
     pub replaced_split_ids: Vec<String>,
     pub time_range: Option<RangeInclusive<i64>>,
@@ -48,7 +48,6 @@ impl fmt::Debug for PackagedSplit {
             .field("split_id", &self.split_id)
             .field("partition_id", &self.partition_id)
             .field("replaced_split_ids", &self.replaced_split_ids)
-            .field("index_id", &self.index_id)
             .field("time_range", &self.time_range)
             .field("size_in_bytes", &self.size_in_bytes)
             .field("split_scratch_directory", &self.split_scratch_directory)
@@ -81,7 +80,7 @@ impl PackagedSplitBatch {
         assert_eq!(
             splits
                 .iter()
-                .map(|split| split.index_id.clone())
+                .map(|split| split.pipeline_id.index_id.clone())
                 .collect::<HashSet<_>>()
                 .len(),
             1,
@@ -97,7 +96,7 @@ impl PackagedSplitBatch {
     pub fn index_id(&self) -> String {
         self.splits
             .get(0)
-            .map(|split| split.index_id.clone())
+            .map(|split| split.pipeline_id.index_id.clone())
             .unwrap()
     }
 

--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -818,6 +818,7 @@ mod kafka_broker_tests {
 
         let source_config = SourceConfig {
             source_id: "test-kafka-source".to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::Kafka(KafkaSourceParams {
                 topic: topic.clone(),
                 client_log_level: None,

--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -320,6 +320,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "void".to_string(),
+                num_pipelines: 1,
                 source_params: SourceParams::void(),
             };
             check_source_connectivity(&source_config).await?;
@@ -327,6 +328,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "vec".to_string(),
+                num_pipelines: 1,
                 source_params: SourceParams::Vec(VecSourceParams::default()),
             };
             check_source_connectivity(&source_config).await?;
@@ -334,6 +336,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "file".to_string(),
+                num_pipelines: 1,
                 source_params: SourceParams::file("file-does-not-exist.json"),
             };
             assert!(check_source_connectivity(&source_config).await.is_err());
@@ -341,6 +344,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "file".to_string(),
+                num_pipelines: 1,
                 source_params: SourceParams::file("data/test_corpus.json"),
             };
             assert!(check_source_connectivity(&source_config).await.is_ok());

--- a/quickwit-indexing/src/source/source_factory.rs
+++ b/quickwit-indexing/src/source/source_factory.rs
@@ -132,6 +132,7 @@ mod tests {
         let source_loader = quickwit_supported_sources();
         let source_config = SourceConfig {
             source_id: "test-source".to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::void(),
         };
         source_loader

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -86,7 +86,7 @@ impl Source for VecSource {
     ) -> Result<Duration, ActorExitStatus> {
         let mut doc_batch = RawDocBatch::default();
         doc_batch.docs.extend(
-            self.params.items[self.next_item_idx..]
+            self.params.docs[self.next_item_idx..]
                 .iter()
                 .take(self.params.batch_num_docs)
                 .cloned(),
@@ -132,11 +132,11 @@ mod tests {
         quickwit_common::setup_logging_for_tests();
         let universe = Universe::new();
         let (mailbox, inbox) = create_test_mailbox();
-        let items = std::iter::repeat_with(|| "{}".to_string())
+        let docs = std::iter::repeat_with(|| "{}".to_string())
             .take(100)
             .collect();
         let params = VecSourceParams {
-            items,
+            docs,
             batch_num_docs: 3,
             partition: "partition".to_string(),
         };
@@ -178,9 +178,9 @@ mod tests {
         quickwit_common::setup_logging_for_tests();
         let universe = Universe::new();
         let (mailbox, inbox) = create_test_mailbox();
-        let items = (0..10).map(|i| format!("{}", i)).collect();
+        let docs = (0..10).map(|i| format!("{}", i)).collect();
         let params = VecSourceParams {
-            items,
+            docs,
             batch_num_docs: 3,
             partition: "".to_string(),
         };

--- a/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit-indexing/src/source/void_source.rs
@@ -79,6 +79,7 @@ mod tests {
     async fn test_void_source_loading() -> anyhow::Result<()> {
         let source_config = SourceConfig {
             source_id: "void-test-source".to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::void(),
         };
         let source_loader = quickwit_supported_sources();

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -22,7 +22,6 @@ quickwit-common = { version = "0.3.1", path = "../quickwit-common" }
 quickwit-config = { version = "0.3.1", path = "../quickwit-config" }
 quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper" }
 quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
-
 regex = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -37,6 +36,9 @@ dotenv = "0.15"
 futures = "0.3"
 md5 = "0.7"
 mockall = "0.11"
+quickwit-config = { version = "0.3.1", path = "../quickwit-config", features = [
+  "testsuite"
+] }
 quickwit-doc-mapper = { version = "0.3.1", path = "../quickwit-doc-mapper", features = [
   "testsuite"
 ] }

--- a/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
+++ b/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
@@ -172,6 +172,7 @@ pub(crate) fn sample_index_metadata_for_regression() -> IndexMetadata {
     };
     let kafka_source = SourceConfig {
         source_id: "kafka-source".to_string(),
+        num_pipelines: 2,
         source_params: SourceParams::Kafka(KafkaSourceParams {
             topic: "kafka-topic".to_string(),
             client_log_level: None,

--- a/quickwit-metastore/src/backward_compatibility_tests/split_metadata.rs
+++ b/quickwit-metastore/src/backward_compatibility_tests/split_metadata.rs
@@ -24,6 +24,9 @@ use crate::SplitMetadata;
 pub(crate) fn sample_split_metadata_for_regression() -> SplitMetadata {
     SplitMetadata {
         split_id: "split".to_string(),
+        source_id: "source".to_string(),
+        node_id: "node".to_string(),
+        pipeline_ord: 1,
         partition_id: 7u64,
         num_docs: 12303,
         uncompressed_docs_size_in_bytes: 234234,

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -47,7 +47,7 @@ pub use metastore_resolver::{
     quickwit_metastore_uri_resolver, MetastoreFactory, MetastoreUriResolver,
 };
 pub use split_metadata::{Split, SplitMetadata, SplitState};
-pub(crate) use split_metadata_version::VersionedSplitMetadataDeserializeHelper;
+pub(crate) use split_metadata_version::VersionedSplitMetadata;
 
 #[cfg(test)]
 mod backward_compatibility_tests;

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -89,6 +89,7 @@ pub mod test_suite {
 
         let source = SourceConfig {
             source_id: source_id.to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::void(),
         };
 
@@ -147,6 +148,7 @@ pub mod test_suite {
 
         let source = SourceConfig {
             source_id: source_id.to_string(),
+            num_pipelines: 1,
             source_params: SourceParams::void(),
         };
 
@@ -1388,7 +1390,7 @@ pub mod test_suite {
             time_range: Some(0..=99),
             create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:foo", "tag:bar"]),
-            demux_num_ops: 0,
+            ..Default::default()
         };
 
         let split_metadata_2 = SplitMetadata {
@@ -1400,7 +1402,7 @@ pub mod test_suite {
             time_range: Some(100..=199),
             create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:bar"]),
-            demux_num_ops: 0,
+            ..Default::default()
         };
 
         let split_metadata_3 = SplitMetadata {
@@ -1412,7 +1414,7 @@ pub mod test_suite {
             time_range: Some(200..=299),
             create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:foo", "tag:baz"]),
-            demux_num_ops: 0,
+            ..Default::default()
         };
 
         let split_metadata_4 = SplitMetadata {
@@ -1424,7 +1426,7 @@ pub mod test_suite {
             time_range: Some(300..=399),
             create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:foo"]),
-            demux_num_ops: 0,
+            ..Default::default()
         };
 
         let split_metadata_5 = SplitMetadata {
@@ -1436,7 +1438,7 @@ pub mod test_suite {
             time_range: None,
             create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:baz", "tag:biz"]),
-            demux_num_ops: 0,
+            ..Default::default()
         };
 
         {
@@ -1827,7 +1829,7 @@ pub mod test_suite {
                 time_range: None,
                 create_timestamp: current_timestamp,
                 tags: to_set(&[]),
-                demux_num_ops: 0,
+                ..Default::default()
             };
             metastore
                 .stage_split(index_id, split_metadata_6.clone())

--- a/quickwit-metastore/test-data/file-backed-index/v0-6e3177e8924ef49dbdd8dcac421b0642.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-6e3177e8924ef49dbdd8dcac421b0642.expected.json
@@ -98,8 +98,10 @@
         "end": 2000,
         "start": 1000
       },
+      "node_id": "unknown/0",
       "num_docs": 12303,
       "partition_id": 0,
+      "source_id": "unknown",
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-7ccb0811468081880595c160fa16fef7.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-7ccb0811468081880595c160fa16fef7.expected.json
@@ -98,8 +98,10 @@
         "end": 2000,
         "start": 1000
       },
+      "node_id": "unknown/0",
       "num_docs": 12303,
       "partition_id": 0,
+      "source_id": "unknown",
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-7e1e1d06f4d5d051134c6ec82c09a55f.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-7e1e1d06f4d5d051134c6ec82c09a55f.expected.json
@@ -98,8 +98,10 @@
         "end": 2000,
         "start": 1000
       },
+      "node_id": "unknown/0",
       "num_docs": 12303,
       "partition_id": 0,
+      "source_id": "unknown",
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-92a02bbda38485cfb39171b0b2fee51f.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-92a02bbda38485cfb39171b0b2fee51f.expected.json
@@ -98,8 +98,10 @@
         "end": 2000,
         "start": 1000
       },
+      "node_id": "unknown/0",
       "num_docs": 12303,
       "partition_id": 0,
+      "source_id": "unknown",
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-c226796cebaf431fc7707ff63c28c27f.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-c226796cebaf431fc7707ff63c28c27f.expected.json
@@ -79,6 +79,7 @@
     },
     "sources": [
       {
+        "num_pipelines": 2,
         "params": {
           "client_params": {},
           "topic": "kafka-topic"
@@ -98,10 +99,10 @@
         "end": 2000,
         "start": 1000
       },
-      "node_id": "unknown/0",
+      "node_id": "node/1",
       "num_docs": 12303,
-      "partition_id": 0,
-      "source_id": "unknown",
+      "partition_id": 7,
+      "source_id": "source",
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-c226796cebaf431fc7707ff63c28c27f.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-c226796cebaf431fc7707ff63c28c27f.json
@@ -79,6 +79,7 @@
     },
     "sources": [
       {
+        "num_pipelines": 2,
         "params": {
           "client_params": {},
           "topic": "kafka-topic"
@@ -98,10 +99,10 @@
         "end": 2000,
         "start": 1000
       },
-      "node_id": "unknown/0",
+      "node_id": "node/1",
       "num_docs": 12303,
-      "partition_id": 0,
-      "source_id": "unknown",
+      "partition_id": 7,
+      "source_id": "source",
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/file-backed-index/v0-f4bcb5a22eb3fb4f663463adb38a057b.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-f4bcb5a22eb3fb4f663463adb38a057b.expected.json
@@ -98,8 +98,10 @@
         "end": 2000,
         "start": 1000
       },
+      "node_id": "unknown/0",
       "num_docs": 12303,
       "partition_id": 0,
+      "source_id": "unknown",
       "split_id": "split",
       "split_state": "Published",
       "tags": [

--- a/quickwit-metastore/test-data/index-metadata/v1-47a77429a39539b19dc9618a699b4135.expected.json
+++ b/quickwit-metastore/test-data/index-metadata/v1-47a77429a39539b19dc9618a699b4135.expected.json
@@ -1,0 +1,92 @@
+{
+  "checkpoint": {
+    "kafka-source": {
+      "00000000000000000000": "00000000000000000042"
+    }
+  },
+  "create_timestamp": 1789,
+  "doc_mapping": {
+    "field_mappings": [
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "tenant_id",
+        "stored": true,
+        "type": "u64"
+      },
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "timestamp",
+        "stored": true,
+        "type": "i64"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "log_level",
+        "record": "basic",
+        "stored": true,
+        "tokenizer": "raw",
+        "type": "text"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "message",
+        "record": "position",
+        "stored": true,
+        "tokenizer": "default",
+        "type": "text"
+      }
+    ],
+    "mode": "dynamic",
+    "store_source": true,
+    "tag_fields": [
+      "log_level",
+      "tenant_id"
+    ]
+  },
+  "index_id": "my-index",
+  "index_uri": "s3://quickwit-indexes/my-index",
+  "indexing_settings": {
+    "commit_timeout_secs": 301,
+    "demux_enabled": true,
+    "demux_field": "tenant_id",
+    "docstore_blocksize": 1000000,
+    "docstore_compression_level": 8,
+    "merge_enabled": true,
+    "merge_policy": {
+      "demux_factor": 7,
+      "max_merge_factor": 11,
+      "merge_factor": 9
+    },
+    "resources": {
+      "heap_size": 3
+    },
+    "sort_field": "timestamp",
+    "sort_order": "asc",
+    "split_num_docs_target": 10000001,
+    "timestamp_field": "timestamp"
+  },
+  "search_settings": {
+    "default_search_fields": [
+      "message"
+    ]
+  },
+  "sources": [
+    {
+      "num_pipelines": 2,
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
+      "source_id": "kafka-source",
+      "source_type": "kafka"
+    }
+  ],
+  "update_timestamp": 1789,
+  "version": "1"
+}

--- a/quickwit-metastore/test-data/index-metadata/v1-47a77429a39539b19dc9618a699b4135.json
+++ b/quickwit-metastore/test-data/index-metadata/v1-47a77429a39539b19dc9618a699b4135.json
@@ -1,0 +1,92 @@
+{
+  "checkpoint": {
+    "kafka-source": {
+      "00000000000000000000": "00000000000000000042"
+    }
+  },
+  "create_timestamp": 1789,
+  "doc_mapping": {
+    "field_mappings": [
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "tenant_id",
+        "stored": true,
+        "type": "u64"
+      },
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "timestamp",
+        "stored": true,
+        "type": "i64"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "log_level",
+        "record": "basic",
+        "stored": true,
+        "tokenizer": "raw",
+        "type": "text"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "message",
+        "record": "position",
+        "stored": true,
+        "tokenizer": "default",
+        "type": "text"
+      }
+    ],
+    "mode": "dynamic",
+    "store_source": true,
+    "tag_fields": [
+      "log_level",
+      "tenant_id"
+    ]
+  },
+  "index_id": "my-index",
+  "index_uri": "s3://quickwit-indexes/my-index",
+  "indexing_settings": {
+    "commit_timeout_secs": 301,
+    "demux_enabled": true,
+    "demux_field": "tenant_id",
+    "docstore_blocksize": 1000000,
+    "docstore_compression_level": 8,
+    "merge_enabled": true,
+    "merge_policy": {
+      "demux_factor": 7,
+      "max_merge_factor": 11,
+      "merge_factor": 9
+    },
+    "resources": {
+      "heap_size": 3
+    },
+    "sort_field": "timestamp",
+    "sort_order": "asc",
+    "split_num_docs_target": 10000001,
+    "timestamp_field": "timestamp"
+  },
+  "search_settings": {
+    "default_search_fields": [
+      "message"
+    ]
+  },
+  "sources": [
+    {
+      "num_pipelines": 2,
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
+      "source_id": "kafka-source",
+      "source_type": "kafka"
+    }
+  ],
+  "update_timestamp": 1789,
+  "version": "1"
+}

--- a/quickwit-metastore/test-data/split-metadata/v0-a56cdae1f7333d023f1d6303ed5fd301.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v0-a56cdae1f7333d023f1d6303ed5fd301.expected.json
@@ -5,8 +5,10 @@
     "end": 2000,
     "start": 1000
   },
+  "node_id": "unknown/0",
   "num_docs": 12303,
   "partition_id": 0,
+  "source_id": "unknown",
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v0-noversion.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v0-noversion.expected.json
@@ -5,8 +5,10 @@
     "end": 2000,
     "start": 1000
   },
+  "node_id": "unknown/0",
   "num_docs": 12303,
   "partition_id": 0,
+  "source_id": "unknown",
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v1-24f3b32a0eeb98ec45808446925e667c.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-24f3b32a0eeb98ec45808446925e667c.expected.json
@@ -5,10 +5,10 @@
     "end": 2000,
     "start": 1000
   },
-  "node_id": "unknown/0",
+  "node_id": "node/1",
   "num_docs": 12303,
-  "partition_id": 0,
-  "source_id": "unknown",
+  "partition_id": 7,
+  "source_id": "source",
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v1-24f3b32a0eeb98ec45808446925e667c.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-24f3b32a0eeb98ec45808446925e667c.json
@@ -5,10 +5,10 @@
     "end": 2000,
     "start": 1000
   },
-  "node_id": "unknown/0",
+  "node_id": "node/1",
   "num_docs": 12303,
-  "partition_id": 0,
-  "source_id": "unknown",
+  "partition_id": 7,
+  "source_id": "source",
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v1-3fa70f6513f800c681c0c317d89d4298.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-3fa70f6513f800c681c0c317d89d4298.expected.json
@@ -5,8 +5,10 @@
     "end": 2000,
     "start": 1000
   },
+  "node_id": "unknown/0",
   "num_docs": 12303,
   "partition_id": 0,
+  "source_id": "unknown",
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v1-b9a036ccc850646c89bc008c65c4249f.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-b9a036ccc850646c89bc008c65c4249f.expected.json
@@ -5,8 +5,10 @@
     "end": 2000,
     "start": 1000
   },
+  "node_id": "unknown/0",
   "num_docs": 12303,
   "partition_id": 0,
+  "source_id": "unknown",
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-metastore/test-data/split-metadata/v1-c7b54a9dfd9b75174914d063df366aa6.expected.json
+++ b/quickwit-metastore/test-data/split-metadata/v1-c7b54a9dfd9b75174914d063df366aa6.expected.json
@@ -5,8 +5,10 @@
     "end": 2000,
     "start": 1000
   },
+  "node_id": "unknown/0",
   "num_docs": 12303,
   "partition_id": 7,
+  "source_id": "unknown",
   "split_id": "split",
   "tags": [
     "234",

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -56,7 +56,9 @@ tracing-opentelemetry = "0.17"
 [dev-dependencies]
 assert-json-diff = "2"
 chitchat = "0.4"
-quickwit-indexing = { version = "0.3.1", path = "../quickwit-indexing" }
+quickwit-indexing = { version = "0.3.1", path = "../quickwit-indexing", features = [
+  "testsuite"
+] }
 quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore", features = [
   "testsuite"
 ] }


### PR DESCRIPTION
### Description
- Add `num_pipelines` parameter to source config
- Spawn `num_pipelines` in indexing service, each pipeline is assigned a `pipeline_ord` between 0 and `num_pipelines` - 1
- Add `source_id`, `node_id` and `pipeline_ord` to split metadata
- Fence split merges by `partition_id` and `pipeline_id`
- Disable garbage collector actors with `pipeline_ord` > 0

### How was this PR tested?
Add unit tests