### PR TITLE
Rocks db free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "crc32fast",
  "flume",
  "futures",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,25 +308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bindgen"
-version = "0.60.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,17 +412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,15 +437,6 @@ name = "census"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5927edd8345aef08578bcbb4aea7314f340d80c7f4931f99fbeb40b99d8f5060"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -519,17 +480,6 @@ name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
-
-[[package]]
-name = "clang-sys"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
 
 [[package]]
 name = "clap"
@@ -1847,12 +1797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "levenshtein_automata"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,34 +1809,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
-name = "libloading"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
-dependencies = [
- "cfg-if",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
-
-[[package]]
-name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "glob",
- "libc",
- "libz-sys",
-]
 
 [[package]]
 name = "libz-sys"
@@ -2491,12 +2411,6 @@ name = "paste"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -3218,7 +3132,6 @@ dependencies = [
  "quickwit-proto",
  "rand 0.8.5",
  "rand_distr",
- "rocksdb",
  "serde",
  "serde_json",
  "tempfile",
@@ -3705,16 +3618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "rusoto_core"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,12 +3771,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/quickwit-directories/src/caching_directory.rs
+++ b/quickwit-directories/src/caching_directory.rs
@@ -66,7 +66,7 @@ impl CachingDirectory {
     /// Warming: The resulting CacheDirectory will cache all information without ever
     /// removing any item from the cache.
     /// Prefer using `.new_with_capacity_in_bytes(...)` in most case.
-    pub fn new_with_unlimited_capacity(underlying: Arc<dyn Directory>) -> CachingDirectory {
+    pub fn new_unbounded(underlying: Arc<dyn Directory>) -> CachingDirectory {
         CachingDirectory {
             underlying,
             cache: Arc::new(MemorySizedCache::with_infinite_capacity(

--- a/quickwit-directories/src/hot_directory.rs
+++ b/quickwit-directories/src/hot_directory.rs
@@ -468,7 +468,7 @@ pub fn write_hotcache<D: Directory>(
     // We use the caching directory here in order to defensively ensure that
     // the content of the directory that will be written in the hotcache is precisely
     // the same that was read on the first pass.
-    let caching_directory = CachingDirectory::new_with_unlimited_capacity(Arc::new(directory));
+    let caching_directory = CachingDirectory::new_unbounded(Arc::new(directory));
     let debug_proxy_directory = DebugProxyDirectory::wrap(caching_directory);
     let index = Index::open(debug_proxy_directory.clone())?;
     let schema = index.schema();

--- a/quickwit-ingest-api/Cargo.toml
+++ b/quickwit-ingest-api/Cargo.toml
@@ -14,7 +14,6 @@ once_cell = "1"
 quickwit-actors = { version = "0.3.1", path = "../quickwit-actors" }
 quickwit-common = {path="../quickwit-common", version = "0.3.1"}
 quickwit-proto = { version = "0.3.1", path = "../quickwit-proto" }
-rocksdb = { version = "0.19", features = [], default-features = false }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = "1"

--- a/quickwit-ingest-api/Cargo.toml
+++ b/quickwit-ingest-api/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
+crc32fast = "1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/quickwit-ingest-api/src/errors.rs
+++ b/quickwit-ingest-api/src/errors.rs
@@ -38,7 +38,7 @@ pub enum IngestApiError {
     #[error("Read record error. `{0:?}`")]
     ReadRecordError(#[from] ReadRecordError),
     #[error("Io Error")]
-    IoError(String)
+    IoError(String),
 }
 
 impl From<io::Error> for IngestApiError {

--- a/quickwit-ingest-api/src/errors.rs
+++ b/quickwit-ingest-api/src/errors.rs
@@ -27,7 +27,7 @@ use crate::recordlog::ReadRecordError;
 
 #[derive(Error, Debug, Serialize)]
 pub enum IngestApiError {
-    #[error("Rocks DB Error: {msg}.")]
+    #[error("Data Corruption : {msg}.")]
     Corruption { msg: String },
     #[error("Index `{index_id}` does not exist.")]
     IndexDoesNotExist { index_id: String },

--- a/quickwit-ingest-api/src/ingest_api_service.rs
+++ b/quickwit-ingest-api/src/ingest_api_service.rs
@@ -60,7 +60,9 @@ impl IngestApiService {
             // TODO better error handling.
             // If there is an error, we probably want a transactional behavior.
             let records_it = iter_doc_payloads(doc_batch);
-            self.queues.append_batch(&doc_batch.index_id, records_it).await?;
+            self.queues
+                .append_batch(&doc_batch.index_id, records_it)
+                .await?;
             num_docs += doc_batch.doc_lens.len();
         }
         Ok(IngestResponse {
@@ -78,10 +80,9 @@ impl IngestApiService {
     }
 
     async fn suggest_truncate(&mut self, request: SuggestTruncateRequest) -> crate::Result<()> {
-        self.queues.suggest_truncate(
-            &request.index_id,
-            request.up_to_position_included,
-        ).await?;
+        self.queues
+            .suggest_truncate(&request.index_id, request.up_to_position_included)
+            .await?;
         Ok(())
     }
 }

--- a/quickwit-ingest-api/src/lib.rs
+++ b/quickwit-ingest-api/src/lib.rs
@@ -57,7 +57,7 @@ pub async fn init_ingest_api(
         return Ok(mailbox.clone());
     }
     let ingest_api_actor =
-        IngestApiService::with_queues_dir(queues_dir_path).with_context(|| {
+        IngestApiService::with_queues_dir(queues_dir_path).await.with_context(|| {
             format!(
                 "Failed to open RocksDB instance located at `{}`.",
                 queues_dir_path.display()

--- a/quickwit-ingest-api/src/lib.rs
+++ b/quickwit-ingest-api/src/lib.rs
@@ -21,6 +21,7 @@ mod errors;
 mod ingest_api_service;
 mod position;
 mod queue;
+mod recordlog;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/quickwit-ingest-api/src/lib.rs
+++ b/quickwit-ingest-api/src/lib.rs
@@ -56,8 +56,9 @@ pub async fn init_ingest_api(
     if let Some(mailbox) = guard.get(queues_dir_path) {
         return Ok(mailbox.clone());
     }
-    let ingest_api_actor =
-        IngestApiService::with_queues_dir(queues_dir_path).await.with_context(|| {
+    let ingest_api_actor = IngestApiService::with_queues_dir(queues_dir_path)
+        .await
+        .with_context(|| {
             format!(
                 "Failed to open the ingest API record log located at `{}`.",
                 queues_dir_path.display()

--- a/quickwit-ingest-api/src/lib.rs
+++ b/quickwit-ingest-api/src/lib.rs
@@ -59,7 +59,7 @@ pub async fn init_ingest_api(
     let ingest_api_actor =
         IngestApiService::with_queues_dir(queues_dir_path).await.with_context(|| {
             format!(
-                "Failed to open RocksDB instance located at `{}`.",
+                "Failed to open the ingest API record log located at `{}`.",
                 queues_dir_path.display()
             )
         })?;

--- a/quickwit-ingest-api/src/recordlog/frame/header.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/header.rs
@@ -100,7 +100,7 @@ impl FrameType {
 
 #[cfg(test)]
 mod tests {
-    use super::{Header, HEADER_LEN, FrameType};
+    use super::{FrameType, Header, HEADER_LEN};
 
     #[test]
     fn test_frame_type_serialize_deserialize() {

--- a/quickwit-ingest-api/src/recordlog/frame/header.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/header.rs
@@ -1,0 +1,141 @@
+use crc32fast;
+
+use super::BLOCK_LEN;
+
+pub const HEADER_LEN: usize = 4 + 2 + 1;
+
+fn crc32(data: &[u8]) -> u32 {
+    let mut hash = crc32fast::Hasher::default();
+    hash.update(data);
+    hash.finalize()
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Header {
+    checksum: u32,
+    len: u16,
+    frame_type: FrameType,
+}
+
+impl Header {
+    pub fn for_payload(frame_type: FrameType, payload: &[u8]) -> Header {
+        assert!(payload.len() < BLOCK_LEN);
+        Header {
+            checksum: crc32(payload),
+            len: payload.len() as u16,
+            frame_type,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    pub fn frame_type(&self) -> FrameType {
+        self.frame_type
+    }
+
+    pub fn check(&self, payload: &[u8]) -> bool {
+        crc32(payload) == self.checksum
+    }
+
+    pub fn serialize(&self, dest: &mut [u8]) {
+        assert_eq!(dest.len(), HEADER_LEN);
+        dest[..4].copy_from_slice(&self.checksum.to_le_bytes()[..]);
+        dest[4..6].copy_from_slice(&self.len.to_le_bytes()[..]);
+        dest[6] = self.frame_type.to_u8();
+    }
+
+    pub fn deserialize(data: &[u8]) -> Option<Header> {
+        assert_eq!(data.len(), HEADER_LEN);
+        let checksum = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let len = u16::from_le_bytes([data[4], data[5]]);
+        let frame_type = FrameType::from_u8(data[6])?;
+        Some(Header {
+            checksum,
+            len,
+            frame_type,
+        })
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum FrameType {
+    FULL = 1u8,
+    FIRST = 2u8,
+    MIDDLE = 3u8,
+    LAST = 4u8,
+}
+
+impl FrameType {
+    fn from_u8(b: u8) -> Option<FrameType> {
+        match b {
+            1u8 => Some(FrameType::FULL),
+            2u8 => Some(FrameType::FIRST),
+            3u8 => Some(FrameType::MIDDLE),
+            4u8 => Some(FrameType::LAST),
+            _ => None,
+        }
+    }
+
+    fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    pub fn is_first_frame_of_record(&self) -> bool {
+        match self {
+            FrameType::FULL | FrameType::FIRST => true,
+            FrameType::LAST | FrameType::MIDDLE => false,
+        }
+    }
+
+    pub fn is_last_frame_of_record(&self) -> bool {
+        match self {
+            FrameType::FULL | FrameType::LAST => true,
+            FrameType::FIRST | FrameType::MIDDLE => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Header, HEADER_LEN, FrameType};
+
+    #[test]
+    fn test_frame_type_serialize_deserialize() {
+        const ALL_FRAME_TYPES: [FrameType; 4] = [
+            FrameType::FULL,
+            FrameType::FIRST,
+            FrameType::MIDDLE,
+            FrameType::LAST,
+        ];
+        for frame_type in ALL_FRAME_TYPES {
+            assert_eq!(FrameType::from_u8(frame_type.to_u8()), Some(frame_type));
+        }
+    }
+
+    #[test]
+    fn test_frame_deserialize_invalid() {
+        assert_eq!(FrameType::from_u8(14u8), None);
+    }
+
+    #[test]
+    fn test_header_serialize_deserialize() {
+        let header = Header {
+            checksum: 17u32,
+            len: 42,
+            frame_type: FrameType::FULL,
+        };
+        let mut buffer = [0u8; HEADER_LEN];
+        header.serialize(&mut buffer);
+        let serdeser_header = Header::deserialize(&buffer).unwrap();
+        assert_eq!(header, serdeser_header);
+    }
+
+    #[test]
+    fn test_header_deserialize_invalid() {
+        let invalid_header_buffer = [14u8; HEADER_LEN];
+        assert_eq!(Header::deserialize(&invalid_header_buffer), None);
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/frame/header.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/header.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use crc32fast;
 
 use super::BLOCK_LEN;

--- a/quickwit-ingest-api/src/recordlog/frame/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/mod.rs
@@ -2,9 +2,8 @@ mod header;
 mod reader;
 mod writer;
 
-pub(crate) use self::header::FrameType;
 use self::header::Header;
-pub(crate) use self::header::HEADER_LEN;
+pub(crate) use self::header::{FrameType, HEADER_LEN};
 pub(crate) use self::reader::{FrameReader, ReadFrameError};
 pub(crate) use self::writer::FrameWriter;
 pub(crate) const BLOCK_LEN: usize = 32_768;
@@ -13,8 +12,7 @@ pub(crate) const BLOCK_LEN: usize = 32_768;
 mod tests {
     use std::io;
 
-    use super::{FrameType, HEADER_LEN};
-    use super::{FrameReader, FrameWriter, ReadFrameError, BLOCK_LEN};
+    use super::{FrameReader, FrameType, FrameWriter, ReadFrameError, BLOCK_LEN, HEADER_LEN};
 
     #[tokio::test]
     async fn test_frame_simple() -> io::Result<()> {

--- a/quickwit-ingest-api/src/recordlog/frame/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/mod.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 mod header;
 mod reader;
 mod writer;

--- a/quickwit-ingest-api/src/recordlog/frame/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/mod.rs
@@ -1,0 +1,164 @@
+mod header;
+mod reader;
+mod writer;
+
+pub(crate) use self::header::FrameType;
+use self::header::Header;
+pub(crate) use self::header::HEADER_LEN;
+pub(crate) use self::reader::{FrameReader, ReadFrameError};
+pub(crate) use self::writer::FrameWriter;
+pub(crate) const BLOCK_LEN: usize = 32_768;
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::{FrameType, HEADER_LEN};
+    use super::{FrameReader, FrameWriter, ReadFrameError, BLOCK_LEN};
+
+    #[tokio::test]
+    async fn test_frame_simple() -> io::Result<()> {
+        let mut wrt: Vec<u8> = Vec::new();
+        {
+            let mut frame_writer = FrameWriter::create_with_aligned_write(&mut wrt);
+            frame_writer
+                .write_frame(FrameType::FIRST, &b"abc"[..])
+                .await?;
+            frame_writer
+                .write_frame(FrameType::MIDDLE, &b"de"[..])
+                .await?;
+            frame_writer
+                .write_frame(FrameType::LAST, &b"fgh"[..])
+                .await?;
+            frame_writer.flush().await?;
+        }
+        let mut frame_reader = FrameReader::open(&wrt[..]);
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Ok((FrameType::FIRST, b"abc"))
+        ));
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Ok((FrameType::MIDDLE, b"de"))
+        ));
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Ok((FrameType::LAST, b"fgh"))
+        ));
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Err(ReadFrameError::NotAvailable)
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_frame_partial() -> io::Result<()> {
+        let mut wrt: Vec<u8> = Vec::new();
+        {
+            let mut frame_writer = FrameWriter::create_with_aligned_write(&mut wrt);
+            frame_writer
+                .write_frame(FrameType::FIRST, &b"abc"[..])
+                .await?;
+            frame_writer.flush().await?;
+        }
+        assert_eq!(wrt.len(), HEADER_LEN + 3);
+        wrt.truncate(HEADER_LEN + 2);
+        let mut frame_reader = FrameReader::open(&wrt[..]);
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Err(ReadFrameError::NotAvailable)
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_frame_corruption_in_payload() -> io::Result<()> {
+        let mut wrt: Vec<u8> = Vec::new();
+        {
+            let mut frame_writer = FrameWriter::create_with_aligned_write(&mut wrt);
+            frame_writer
+                .write_frame(FrameType::FIRST, &b"abc"[..])
+                .await?;
+            frame_writer.flush().await?;
+        }
+        {
+            let mut frame_writer = FrameWriter::create_with_aligned_write(&mut wrt);
+            frame_writer
+                .write_frame(FrameType::MIDDLE, &b"de"[..])
+                .await?;
+            frame_writer.flush().await?;
+        }
+        wrt[8] = 0u8;
+        let mut frame_reader = FrameReader::open(&wrt[..]);
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Err(ReadFrameError::Corruption)
+        ));
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Ok((FrameType::MIDDLE, b"de"))
+        ));
+        Ok(())
+    }
+
+    async fn repeat_empty_frame_util(repeat: usize) -> Vec<u8> {
+        let mut wrt: Vec<u8> = Vec::new();
+        {
+            let mut frame_writer = FrameWriter::create_with_aligned_write(&mut wrt);
+            for _ in 0..repeat {
+                frame_writer
+                    .write_frame(FrameType::FULL, &b""[..])
+                    .await
+                    .unwrap();
+            }
+            frame_writer.flush().await.unwrap();
+        }
+        wrt
+    }
+
+    #[tokio::test]
+    async fn test_simple_multiple_blocks() -> io::Result<()> {
+        let num_frames = 1 + BLOCK_LEN / HEADER_LEN;
+        let buffer = repeat_empty_frame_util(num_frames).await;
+        assert_eq!(buffer.len(), BLOCK_LEN + HEADER_LEN);
+        let mut frame_reader = FrameReader::open(&buffer[..]);
+        for _ in 0..num_frames {
+            let read_frame_res = frame_reader.read_frame().await;
+            assert!(matches!(read_frame_res, Ok((FrameType::FULL, &[]))));
+        }
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Err(ReadFrameError::NotAvailable)
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_blocks_corruption_on_length() -> io::Result<()> {
+        // We end up with 4681 frames on the first block.
+        // 1 frame on the second block
+        let num_frames = 1 + BLOCK_LEN / HEADER_LEN;
+        let mut buffer = repeat_empty_frame_util(num_frames).await;
+        buffer[2000 * HEADER_LEN + 5] = 255u8;
+        assert_eq!(buffer.len(), BLOCK_LEN + HEADER_LEN);
+        let mut frame_reader = FrameReader::open(&buffer[..]);
+        for _ in 0..2000 {
+            let read_frame_res = frame_reader.read_frame().await;
+            assert!(matches!(read_frame_res, Ok((FrameType::FULL, &[]))));
+        }
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Err(ReadFrameError::Corruption)
+        ));
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Ok((FrameType::FULL, &[]))
+        ));
+        assert!(matches!(
+            frame_reader.read_frame().await,
+            Err(ReadFrameError::NotAvailable)
+        ));
+        Ok(())
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/frame/reader.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/reader.rs
@@ -1,0 +1,174 @@
+use std::io;
+use std::ops::Range;
+
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::{FrameType, Header, BLOCK_LEN, HEADER_LEN};
+
+const NUM_BLOCKS_BUFFERED: usize = 10;
+const BUFFER_LEN: usize = NUM_BLOCKS_BUFFERED * BLOCK_LEN;
+
+pub struct FrameReader<R> {
+    reader: R,
+
+    /// At any point our buffer is split into
+    /// | consumed_bytes | available_bytes | free bytes |
+    buffer: Box<[u8; BUFFER_LEN]>,
+    /// Range of the available bytes.
+    available: Range<usize>,
+    // The current block is corrupted.
+    block_corrupted: bool,
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum ReadFrameError {
+    #[error("Io error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("Corruption in frame")]
+    Corruption,
+    #[error("Next frame not available")]
+    NotAvailable,
+}
+
+impl<R: AsyncRead + Unpin> FrameReader<R> {
+    pub fn open(reader: R) -> Self {
+        FrameReader {
+            reader,
+            buffer: Box::new([0u8; BUFFER_LEN]),
+            available: 0..0,
+            block_corrupted: false,
+        }
+    }
+
+    /// Number of bytes available to read in our buffer.
+    fn available_len(&self) -> usize {
+        self.available.len()
+    }
+
+    /// Amount of bytes that are still available to fill
+    /// in the buffer.
+    fn free_len(&self) -> usize {
+        BUFFER_LEN - self.available.end
+    }
+
+    /// Rotating the buffer move the available bytes
+    /// to the beginning of the buffer:
+    ///
+    /// | ... consumed_bytes...  |   ... available_bytes ...  | ... free bytes ... |
+    /// Becomes:
+    /// |   ... available_bytes ...  | ... free bytes ...                          |
+    fn rotate_buffer(&mut self) {
+        assert!(self.free_len() < BLOCK_LEN);
+        assert!(self.available_len() < BLOCK_LEN);
+        let num_bytes_available = self.available_len();
+        let (free_area, unread_data) = self.buffer.split_at_mut(self.available.start);
+        // We don't just stet new_available_start to 0, because we want to keep block_alignment
+        // within our buffer.
+        let new_available_start = self.available.start % BLOCK_LEN;
+        let new_available = new_available_start..new_available_start + num_bytes_available;
+        free_area[new_available.clone()].copy_from_slice(&unread_data[..num_bytes_available]);
+        self.available = new_available;
+    }
+
+    /// Attempts to read data.
+    ///
+    /// Attempts to fill the internal `buffer`,
+    /// which is why it does not take a number of bytes to
+    /// attempt to read.
+    async fn read_slab(&mut self) -> io::Result<usize> {
+        assert!(self.available_len() < BLOCK_LEN);
+        if self.free_len() < BLOCK_LEN {
+            // We are reaching the saturation of our buffer.
+            // Let's "rotate" our buffer to make some room.
+            self.rotate_buffer();
+        }
+        assert!(self.free_len() >= BLOCK_LEN);
+        assert!(self.buffer[self.available.end..].len() >= BLOCK_LEN);
+        let num_read_bytes: usize = self
+            .reader
+            .read(&mut self.buffer[self.available.end..])
+            .await?;
+        self.available.end += num_read_bytes;
+        Ok(num_read_bytes)
+    }
+
+    // Returns the number of bytes remaining into
+    // the current block.
+    //
+    // These bytes may or may not be available.
+    fn num_bytes_to_end_of_block(&self) -> usize {
+        BLOCK_LEN - (self.available.start % BLOCK_LEN)
+    }
+
+    async fn go_to_next_block_if_necessary(&mut self) -> Result<(), ReadFrameError> {
+        let num_bytes_to_end_of_block = self.num_bytes_to_end_of_block();
+        let need_to_skip_block = self.block_corrupted || num_bytes_to_end_of_block < HEADER_LEN;
+        if !need_to_skip_block {
+            return Ok(());
+        }
+        self.ensure_bytes_available(num_bytes_to_end_of_block)
+            .await?;
+        self.advance(num_bytes_to_end_of_block);
+        self.block_corrupted = false;
+        Ok(())
+    }
+
+    async fn ensure_bytes_available(&mut self, required_len: usize) -> Result<(), ReadFrameError> {
+        if self.available_len() >= required_len {
+            return Ok(());
+        }
+        while self.read_slab().await? > 0 {
+            if self.available_len() >= required_len {
+                return Ok(());
+            }
+        }
+        Err(ReadFrameError::NotAvailable)
+    }
+
+    fn advance(&mut self, num_bytes: usize) {
+        self.available.start += num_bytes;
+    }
+
+    // Attempt to read the header of the next frame
+    // This method does not consume any bytes (which is why it is called get and not read).
+    async fn get_frame_header(&mut self) -> Result<Header, ReadFrameError> {
+        self.ensure_bytes_available(HEADER_LEN).await?;
+        let header_bytes = &self.buffer[self.available.clone()][..HEADER_LEN];
+        match Header::deserialize(&header_bytes) {
+            Some(header) => Ok(header),
+            None => {
+                self.block_corrupted = true;
+                Err(ReadFrameError::Corruption)
+            }
+        }
+    }
+
+    // Reads the next frame.
+    pub(crate) async fn read_frame(&mut self) -> Result<(FrameType, &[u8]), ReadFrameError> {
+        self.go_to_next_block_if_necessary().await?;
+        let header = self.get_frame_header().await?;
+        let frame_num_bytes = header.len() + HEADER_LEN;
+        if self.num_bytes_to_end_of_block() < frame_num_bytes {
+            // The number of bytes for this frame would span over
+            // the next block.
+            // This is a corruption for which we need to drop the entire block.
+            self.block_corrupted = true;
+            return Err(ReadFrameError::Corruption);
+        }
+        self.ensure_bytes_available(frame_num_bytes).await?;
+        let frame_payload_range =
+            (self.available.start + HEADER_LEN)..(self.available.start + frame_num_bytes);
+        self.advance(frame_num_bytes);
+        let frame_payload = &self.buffer[frame_payload_range];
+        if !header.check(frame_payload) {
+            // The CRC check is wrong.
+            // We do not necessarily need to corrupt the block.
+            //
+            // With a little luck, a single frame payload byte was corrupted
+            // but the frame length was correct.
+            return Err(ReadFrameError::Corruption);
+        }
+        Ok((header.frame_type(), frame_payload))
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/frame/reader.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/reader.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::io;
 use std::ops::Range;
 

--- a/quickwit-ingest-api/src/recordlog/frame/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/writer.rs
@@ -1,4 +1,5 @@
 use std::io;
+
 use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 
 use super::{FrameType, Header, BLOCK_LEN, HEADER_LEN};

--- a/quickwit-ingest-api/src/recordlog/frame/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/writer.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::io;
 
 use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};

--- a/quickwit-ingest-api/src/recordlog/frame/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/frame/writer.rs
@@ -1,0 +1,78 @@
+use std::io;
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
+
+use super::{FrameType, Header, BLOCK_LEN, HEADER_LEN};
+
+pub(crate) struct FrameWriter<W> {
+    wrt: BufWriter<W>,
+    buffer: Box<[u8; BLOCK_LEN]>,
+    current_block_len: usize,
+    num_bytes_written: u64,
+}
+
+impl<W: AsyncWrite + Unpin> FrameWriter<W> {
+    pub(crate) fn create_with_aligned_write(wrt: W) -> Self {
+        FrameWriter {
+            wrt: BufWriter::new(wrt),
+            buffer: Box::new([0u8; BLOCK_LEN]),
+            current_block_len: 0,
+            num_bytes_written: 0u64,
+        }
+    }
+
+    pub fn num_bytes_written(&self) -> u64 {
+        self.num_bytes_written
+    }
+
+    pub async fn write_frame(&mut self, frame_type: FrameType, payload: &[u8]) -> io::Result<()> {
+        if self.available_num_bytes_in_block() < HEADER_LEN {
+            self.pad_block().await?;
+        }
+        assert!(payload.len() <= self.max_writable_frame_length());
+        let record_len = HEADER_LEN + payload.len();
+        assert!(record_len <= BLOCK_LEN);
+        let (buffer_header, buffer_record) = self.buffer[..record_len].split_at_mut(HEADER_LEN);
+        buffer_record.copy_from_slice(payload);
+        Header::for_payload(frame_type, &payload).serialize(buffer_header);
+        self.current_block_len = (self.current_block_len + record_len) % BLOCK_LEN;
+        self.wrt.write_all(&self.buffer[..record_len]).await?;
+        self.num_bytes_written += record_len as u64;
+        Ok(())
+    }
+
+    /// Flush the buffered writer used in the FrameWriter.
+    ///
+    /// When writing to a file, this performs a syscall and
+    /// the OS will be in charge of eventually writing the data
+    /// to disk, but this is not sufficient to ensure durability.
+    pub async fn flush(&mut self) -> io::Result<()> {
+        self.wrt.flush().await
+    }
+
+    async fn pad_block(&mut self) -> io::Result<()> {
+        let remaining_num_bytes_in_block = self.available_num_bytes_in_block();
+        let b = vec![0u8; remaining_num_bytes_in_block];
+        self.wrt.write_all(&b).await?;
+        self.num_bytes_written += b.len() as u64;
+        Ok(())
+    }
+
+    fn available_num_bytes_in_block(&self) -> usize {
+        BLOCK_LEN - self.current_block_len
+    }
+
+    /// Returns he
+    pub fn max_writable_frame_length(&self) -> usize {
+        let available_num_bytes_in_block = self.available_num_bytes_in_block();
+        if available_num_bytes_in_block >= HEADER_LEN {
+            available_num_bytes_in_block - HEADER_LEN
+        } else {
+            // That block is finished. We will have to pad it.
+            BLOCK_LEN - HEADER_LEN
+        }
+    }
+
+    pub fn get_underlying_wrt(&mut self) -> &mut W {
+        self.wrt.get_mut()
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/mem.rs
+++ b/quickwit-ingest-api/src/recordlog/mem.rs
@@ -1,0 +1,226 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::ops::Range;
+
+#[derive(Clone, Copy, Debug)]
+struct RecordMeta {
+    start_offset: usize,
+    position: u64,
+}
+
+#[derive(Default)]
+struct MemQueue {
+    // Concatenated records
+    concatenated_records: Vec<u8>,
+    record_metas: Vec<RecordMeta>,
+}
+
+impl MemQueue {
+    fn first_retained_position(&self) -> Option<u64> {
+        Some(self.record_metas.first()?.position)
+    }
+
+    fn add_record(&mut self, position: u64, payload: &[u8]) {
+        let record_meta = RecordMeta {
+            start_offset: self.concatenated_records.len(),
+            position,
+        };
+        self.record_metas.push(record_meta);
+        self.concatenated_records.extend_from_slice(payload);
+    }
+
+    fn position_to_idx(&self, position: u64) -> Result<usize, usize> {
+        self.record_metas
+            .binary_search_by_key(&position, |record_meta| record_meta.position)
+    }
+
+    /// Returns the first record with position greater of equal to position.
+    fn get_after(&self, position: u64) -> Option<(u64, &[u8])> {
+        let idx = self
+            .position_to_idx(position)
+            .unwrap_or_else(|first_element_after| first_element_after);
+        if idx > self.record_metas.len() {
+            return None;
+        }
+        let record_meta = self.record_metas.get(idx)?;
+        let start_offset = record_meta.start_offset;
+        if let Some(next_record_meta) = self.record_metas.get(idx + 1) {
+            let end_offset = next_record_meta.start_offset;
+            Some((
+                record_meta.position,
+                &self.concatenated_records[start_offset..end_offset],
+            ))
+        } else {
+            Some((
+                record_meta.position,
+                &self.concatenated_records[start_offset..],
+            ))
+        }
+    }
+
+    /// Removes all records coming before position,
+    /// and including the record at "position".
+    ///
+    /// If a truncation occurs,
+    /// this function returns the previous lowest position held.
+    fn truncate(&mut self, truncate_up_to_pos: u64) -> Option<u64> {
+        if self.record_metas[0].position > truncate_up_to_pos {
+            return None;
+        }
+        let first_position = self.record_metas.first()?.position;
+        if first_position > truncate_up_to_pos {
+            return None;
+        }
+        let first_idx_to_keep = self
+            .position_to_idx(truncate_up_to_pos)
+            .map(|idx| idx + 1)
+            .unwrap_or_else(|op| op);
+        let start_offset_to_keep: usize = self
+            .record_metas
+            .get(first_idx_to_keep)
+            .map(|record_meta| record_meta.start_offset)
+            .unwrap_or(self.concatenated_records.len());
+        self.record_metas.drain(..first_idx_to_keep);
+        for record_meta in &mut self.record_metas {
+            record_meta.start_offset -= start_offset_to_keep;
+        }
+        self.concatenated_records.drain(..start_offset_to_keep);
+        Some(first_position)
+    }
+}
+
+#[derive(Default)]
+pub struct MemQueues {
+    queues: HashMap<String, MemQueue>,
+    // Range of records currently being held in all queues.
+    retained_range: Range<u64>,
+}
+
+impl MemQueues {
+    fn get_or_create_queue(&mut self, queue_id: &str) -> &mut MemQueue {
+        // We do not rely on `entry` in order to avoid
+        // the allocation.
+        if !self.queues.contains_key(queue_id) {
+            self.queues.insert(queue_id.to_string(), Default::default());
+        }
+        self.queues.get_mut(queue_id).unwrap()
+    }
+}
+
+impl MemQueues {
+    /// Appends a new record.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new position is not greater than the last seen position.
+    pub(crate) fn add_record(&mut self, queue_id: &str, position: u64, record: &[u8]) {
+        assert!(position >= self.retained_range.end);
+        self.retained_range.end = position;
+        self.get_or_create_queue(queue_id)
+            .add_record(position, record);
+    }
+
+    /// Returns the first record with position greater of equal to position.
+    pub(crate) fn get_after(&self, queue_id: &str, after_position: u64) -> Option<(u64, &[u8])> {
+        let (position, payload) = self.queues.get(queue_id)?.get_after(after_position)?;
+        assert!(position >= after_position);
+        Some((position, payload))
+    }
+
+    /// Removes records up to the supplied `position`,
+    /// including the position itself.
+    ///
+    /// If the queue `queue_id` does not exist, it
+    /// will be created, and the first record appended will be `position + 1`.
+    ///
+    /// If there are no records `<= position`, the method will
+    /// not do anything.
+    ///
+    /// Returns a position up to which including it is safe to truncate files as well.
+    pub fn truncate(&mut self, queue_id: &str, position: u64) -> Option<u64> {
+        let previous_lowest_retained_position: u64 =
+            self.get_or_create_queue(queue_id).truncate(position)?;
+        // Optimization here.
+        if self.retained_range.start != previous_lowest_retained_position {
+            return None;
+        }
+        if let Some(new_lowest) = self
+            .queues
+            .values_mut()
+            .flat_map(|queue| queue.first_retained_position())
+            .min()
+        {
+            self.retained_range.start = new_lowest;
+        } else {
+            self.retained_range.start = self.retained_range.end;
+        }
+        if self.retained_range.start > 0 {
+            Some(self.retained_range.start - 1)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mem_queues() {
+        let mut mem_queues = MemQueues::default();
+        mem_queues.add_record("droopy", 0, b"hello");
+        mem_queues.add_record("droopy", 1, b"happy");
+        mem_queues.add_record("fable", 2, b"maitre");
+        mem_queues.add_record("fable", 3, b"corbeau");
+        mem_queues.add_record("droopy", 4, b"tax");
+        mem_queues.add_record("droopy", 5, b"payer");
+        assert_eq!(mem_queues.get_after("droopy", 0), Some((0, &b"hello"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 1), Some((1, &b"happy"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 2), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 3), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 4), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 5), Some((5, &b"payer"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 6), None);
+        assert_eq!(mem_queues.get_after("fable", 0), Some((2, &b"maitre"[..])));
+        assert_eq!(mem_queues.get_after("fable", 1), Some((2, &b"maitre"[..])));
+        assert_eq!(mem_queues.get_after("fable", 2), Some((2, &b"maitre"[..])));
+        assert_eq!(mem_queues.get_after("fable", 3), Some((3, &b"corbeau"[..])));
+        assert_eq!(mem_queues.get_after("fable", 4), None);
+    }
+
+    #[test]
+    fn test_mem_queues_truncate() {
+        let mut mem_queues = MemQueues::default();
+        mem_queues.add_record("droopy", 0, b"hello");
+        mem_queues.add_record("droopy", 1, b"happy");
+        mem_queues.add_record("droopy", 4, b"tax");
+        mem_queues.add_record("droopy", 5, b"payer");
+        mem_queues.truncate("droopy", 3);
+        assert_eq!(mem_queues.get_after("droopy", 0), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 1), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 2), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 3), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 4), Some((4, &b"tax"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 5), Some((5, &b"payer"[..])));
+        assert_eq!(mem_queues.get_after("droopy", 6), None);
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/mem.rs
+++ b/quickwit-ingest-api/src/recordlog/mem.rs
@@ -131,10 +131,7 @@ impl MemQueues {
     }
 
     pub fn list_queues(&self) -> Vec<String> {
-        self.queues
-            .keys()
-            .cloned()
-            .collect()
+        self.queues.keys().cloned().collect()
     }
 
     pub fn create_queue(&mut self, queue: &str) -> bool {

--- a/quickwit-ingest-api/src/recordlog/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/mod.rs
@@ -1,0 +1,129 @@
+//! This library defines a `log`.
+//!
+//! This log is strongly inspired by leveldb and rocksdb's implementation.
+//!
+//! The log is a sequence of blocks of `2^15 = 32_768 bytes`.
+//! Even when resuming writing a log after a failure, the alignment of
+//! blocks is guaranteed by the Writer.
+//!
+//! Record's payload can be of any size (including 0). They may span over
+//! several blocks.
+//!
+//! The integrity of the log is protected by a checksum at the block
+//! level. In case of corruption, some punctual record can be lost, while
+//! later records are ok.
+//!
+//! # Usage
+//!
+mod frame;
+mod mem;
+mod multi_record_log;
+mod record;
+mod rolling;
+
+#[cfg(test)]
+mod tests;
+
+pub use multi_record_log::MultiRecordLog;
+
+use std::convert::TryInto;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum Record<'a> {
+    AddRecord {
+        position: u64,
+        queue: &'a str,
+        payload: &'a [u8],
+    },
+    Truncate {
+        position: u64,
+        queue: &'a str,
+    },
+}
+
+impl<'a> Record<'a> {
+    pub fn position(&self) -> u64 {
+        match self {
+            Record::AddRecord { position, .. } => *position,
+            Record::Truncate { position, .. } => *position,
+        }
+    }
+}
+
+pub trait Serializable<'a>: Sized {
+    /// Clears the buffer first.
+    fn serialize(&self, buffer: &mut Vec<u8>);
+    fn deserialize(buffer: &'a [u8]) -> Option<Self>;
+}
+
+impl<'a> Serializable<'a> for Record<'a> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer.clear();
+        match *self {
+            Record::AddRecord {
+                position,
+                queue,
+                payload,
+            } => {
+                buffer.push(0u8);
+                buffer.extend_from_slice(&position.to_le_bytes());
+                buffer.extend_from_slice(&(queue.len() as u16).to_le_bytes());
+                buffer.extend(queue.as_bytes());
+                buffer.extend(payload);
+            }
+            Record::Truncate { queue, position } => {
+                buffer.push(1u8);
+                buffer.extend(&position.to_le_bytes());
+                buffer.extend_from_slice(&(queue.len() as u16).to_le_bytes());
+                buffer.extend(queue.as_bytes());
+            }
+        }
+    }
+
+    fn deserialize(buffer: &'a [u8]) -> Option<Record<'a>> {
+        if buffer.len() < 8 {
+            return None;
+        }
+        let enum_tag = buffer[0];
+        let position = u64::from_le_bytes(buffer[1..9].try_into().unwrap());
+        let queue_id_len = u16::from_le_bytes(buffer[9..11].try_into().unwrap()) as usize;
+        let queue_id = std::str::from_utf8(&buffer[11..][..queue_id_len]).ok()?;
+        match enum_tag {
+            0u8 => {
+                let payload = &buffer[11 + queue_id_len..];
+                Some(Record::AddRecord {
+                    position,
+                    queue: queue_id,
+                    payload,
+                })
+            }
+            1u8 => Some(Record::Truncate {
+                position,
+                queue: queue_id,
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> Serializable<'a> for &'a str {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer.clear();
+        buffer.extend_from_slice(self.as_bytes())
+    }
+
+    fn deserialize(buffer: &'a [u8]) -> Option<Self> {
+        std::str::from_utf8(buffer).ok()
+    }
+}
+
+impl<'a> Serializable<'a> for &'a [u8] {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer.clear();
+        buffer.extend_from_slice(self);
+    }
+
+    fn deserialize(buffer: &'a [u8]) -> Option<Self> {
+        Some(buffer)
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/mod.rs
@@ -14,7 +14,6 @@
 //! later records are ok.
 //!
 //! # Usage
-//!
 mod frame;
 mod mem;
 mod multi_record_log;
@@ -24,9 +23,10 @@ mod rolling;
 #[cfg(test)]
 mod tests;
 
-pub use multi_record_log::MultiRecordLog;
-
 use std::convert::TryInto;
+pub use self::record::ReadRecordError;
+
+pub use multi_record_log::MultiRecordLog;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum Record<'a> {

--- a/quickwit-ingest-api/src/recordlog/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/mod.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 //! This library defines a `log`.
 //!
 //! This log is strongly inspired by leveldb and rocksdb's implementation.
@@ -24,9 +43,10 @@ mod rolling;
 mod tests;
 
 use std::convert::TryInto;
-pub use self::record::ReadRecordError;
 
 pub use multi_record_log::MultiRecordLog;
+
+pub use self::record::ReadRecordError;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum Record<'a> {

--- a/quickwit-ingest-api/src/recordlog/multi_record_log.rs
+++ b/quickwit-ingest-api/src/recordlog/multi_record_log.rs
@@ -1,0 +1,82 @@
+use std::io;
+use std::path::Path;
+
+use super::mem;
+use super::record::ReadRecordError;
+use super::rolling;
+use super::rolling::RecordLogReader;
+use super::Record;
+
+pub struct MultiRecordLog {
+    record_log_writer: rolling::RecordLogWriter,
+    in_mem_queues: mem::MemQueues,
+    last_position: u64,
+}
+
+impl MultiRecordLog {
+    pub async fn open(directory_path: &Path) -> Result<Self, ReadRecordError> {
+        let mut record_log_reader = RecordLogReader::open(directory_path).await?;
+        let mut in_mem_queues = mem::MemQueues::default();
+        let mut last_position = 0u64;
+        while let Some(record) = record_log_reader.read_record().await? {
+            match record {
+                Record::AddRecord {
+                    position,
+                    queue,
+                    payload,
+                } => {
+                    in_mem_queues.add_record(queue, position, payload);
+                    last_position = position;
+                }
+                Record::Truncate { position, queue } => {
+                    in_mem_queues.truncate(queue, position);
+                    last_position = position;
+                }
+            }
+        }
+        let record_log_writer = record_log_reader.into_writer();
+        Ok(MultiRecordLog {
+            record_log_writer,
+            in_mem_queues,
+            last_position,
+        })
+    }
+
+    pub fn num_files(&self) -> usize {
+        self.record_log_writer.num_files()
+    }
+
+    // Returns a new position.
+    fn inc_position(&mut self) -> u64 {
+        self.last_position += 1;
+        self.last_position
+    }
+
+    pub async fn append_record(&mut self, queue: &str, payload: &[u8]) -> io::Result<()> {
+        let position = self.inc_position();
+        let record = Record::AddRecord {
+            position,
+            queue,
+            payload,
+        };
+        self.record_log_writer.write_record(record).await?;
+        self.record_log_writer.flush().await?;
+        self.in_mem_queues.add_record(queue, position, payload);
+        Ok(())
+    }
+
+    /// Returns the first record with position greater of equal to position.
+    pub fn get_after(&self, queue_id: &str, position: u64) -> Option<(u64, &[u8])> {
+        self.in_mem_queues.get_after(queue_id, position)
+    }
+
+    pub async fn truncate(&mut self, queue: &str, position: u64) -> io::Result<()> {
+        self.record_log_writer
+            .write_record(Record::Truncate { position, queue })
+            .await?;
+        if let Some(position) = self.in_mem_queues.truncate(queue, position) {
+            self.record_log_writer.truncate(position).await?;
+        }
+        Ok(())
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/multi_record_log.rs
+++ b/quickwit-ingest-api/src/recordlog/multi_record_log.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::io;
 use std::path::Path;
 
@@ -42,7 +61,8 @@ impl MultiRecordLog {
         })
     }
 
-    pub fn num_files(&self) -> usize {
+    #[cfg(test)]
+    pub(crate) fn num_files(&self) -> usize {
         self.record_log_writer.num_files()
     }
 

--- a/quickwit-ingest-api/src/recordlog/multi_record_log.rs
+++ b/quickwit-ingest-api/src/recordlog/multi_record_log.rs
@@ -1,11 +1,9 @@
 use std::io;
 use std::path::Path;
 
-use super::mem;
 use super::record::ReadRecordError;
-use super::rolling;
 use super::rolling::RecordLogReader;
-use super::Record;
+use super::{mem, rolling, Record};
 
 pub struct MultiRecordLog {
     record_log_writer: rolling::RecordLogWriter,
@@ -46,6 +44,10 @@ impl MultiRecordLog {
         self.record_log_writer.num_files()
     }
 
+    pub fn list_queues(&self) -> Vec<String> {
+        self.in_mem_queues.list_queues()
+    }
+
     // Returns a new position.
     fn inc_position(&mut self) -> u64 {
         self.last_position += 1;
@@ -63,6 +65,22 @@ impl MultiRecordLog {
         self.record_log_writer.flush().await?;
         self.in_mem_queues.add_record(queue, position, payload);
         Ok(())
+    }
+
+    pub fn queue_exists(&self, queue: &str) -> bool {
+        self.in_mem_queues.queue_exists(queue)
+    }
+
+    /// Returns false if the queue was already existing.
+    pub fn create_queue(&mut self, queue: &str) -> bool {
+        // TODO append to the logs too.
+        self.in_mem_queues.create_queue(queue)
+    }
+
+    /// Returns false if the queue does not exist.
+    pub fn remove_queue(&mut self, queue: &str) -> bool {
+        // TODO append to the logs too.
+        self.in_mem_queues.remove_queue(queue)
     }
 
     /// Returns the first record with position greater of equal to position.

--- a/quickwit-ingest-api/src/recordlog/multi_record_log.rs
+++ b/quickwit-ingest-api/src/recordlog/multi_record_log.rs
@@ -1,7 +1,6 @@
 use std::io;
 use std::path::Path;
 
-use super::record::ReadRecordError;
 use super::rolling::RecordLogReader;
 use super::{mem, rolling, Record};
 
@@ -12,7 +11,10 @@ pub struct MultiRecordLog {
 }
 
 impl MultiRecordLog {
-    pub async fn open(directory_path: &Path) -> Result<Self, ReadRecordError> {
+    pub async fn open(directory_path: &Path) -> crate::Result<Self> {
+        if !directory_path.exists() {
+            tokio::fs::create_dir(directory_path).await?;
+        }
         let mut record_log_reader = RecordLogReader::open(directory_path).await?;
         let mut in_mem_queues = mem::MemQueues::default();
         let mut last_position = 0u64;

--- a/quickwit-ingest-api/src/recordlog/record/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/record/mod.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 mod reader;
 mod writer;
 pub use self::reader::{ReadRecordError, RecordReader};

--- a/quickwit-ingest-api/src/recordlog/record/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/record/mod.rs
@@ -1,0 +1,7 @@
+mod reader;
+mod writer;
+pub use self::reader::{ReadRecordError, RecordReader};
+pub use self::writer::RecordWriter;
+
+#[cfg(test)]
+mod tests;

--- a/quickwit-ingest-api/src/recordlog/record/reader.rs
+++ b/quickwit-ingest-api/src/recordlog/record/reader.rs
@@ -1,0 +1,88 @@
+use crate::recordlog::{
+    frame::{FrameReader, ReadFrameError},
+    Serializable,
+};
+use std::io;
+use thiserror::Error;
+use tokio::io::AsyncRead;
+
+pub struct RecordReader<R> {
+    frame_reader: FrameReader<R>,
+    record_buffer: Vec<u8>,
+    // true if we are in the middle of reading a multifragment record.
+    // This is useful, as it makes it possible to drop a record
+    // if one of its fragment was corrupted.
+    within_record: bool,
+}
+
+#[derive(Error, Debug)]
+pub enum ReadRecordError {
+    #[error("Io error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("Corruption")]
+    Corruption,
+}
+
+impl<R: AsyncRead + Unpin> RecordReader<R> {
+    pub fn open(reader: R) -> Self {
+        let frame_reader = FrameReader::open(reader);
+        RecordReader {
+            frame_reader,
+            record_buffer: Vec::with_capacity(10_000),
+            within_record: false,
+        }
+    }
+
+    pub fn record<'a, S: Serializable<'a>>(&'a self) -> Option<S> {
+        S::deserialize(&self.record_buffer)
+    }
+
+    #[cfg(test)]
+    pub async fn read_record<'a, S: Serializable<'a>>(
+        &'a mut self,
+    ) -> Result<Option<S>, ReadRecordError> {
+        let has_record = self.go_next().await?;
+        if has_record {
+            let record = self.record().ok_or(ReadRecordError::Corruption)?;
+            Ok(Some(record))
+        } else {
+            Ok(None)
+        }
+    }
+
+    // Attempts to position the reader to the next record and return
+    // true or false whether such a record is available or not.
+    pub async fn go_next(&mut self) -> Result<bool, ReadRecordError> {
+        loop {
+            let frame = self.frame_reader.read_frame().await;
+            match frame {
+                Ok((frame_type, frame_payload)) => {
+                    if frame_type.is_first_frame_of_record() {
+                        self.within_record = true;
+                        self.record_buffer.clear();
+                    }
+                    if self.within_record {
+                        self.record_buffer.extend_from_slice(frame_payload);
+                    }
+                    if frame_type.is_last_frame_of_record() {
+                        if self.within_record {
+                            self.within_record = false;
+                            return Ok(true);
+                        }
+                    }
+                }
+                Err(ReadFrameError::Corruption) => {
+                    self.within_record = false;
+                    return Err(ReadRecordError::Corruption);
+                }
+                Err(ReadFrameError::IoError(io_err)) => {
+                    self.within_record = false;
+                    return Err(ReadRecordError::IoError(io_err));
+                }
+                Err(ReadFrameError::NotAvailable) => {
+                    return Ok(false);
+                }
+            }
+        }
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/record/reader.rs
+++ b/quickwit-ingest-api/src/recordlog/record/reader.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::io;
 
 use serde::Serialize;

--- a/quickwit-ingest-api/src/recordlog/record/tests.rs
+++ b/quickwit-ingest-api/src/recordlog/record/tests.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::iter;
 
 use super::{ReadRecordError, RecordReader, RecordWriter};

--- a/quickwit-ingest-api/src/recordlog/record/tests.rs
+++ b/quickwit-ingest-api/src/recordlog/record/tests.rs
@@ -1,0 +1,137 @@
+use std::iter;
+
+use super::{ReadRecordError, RecordReader, RecordWriter};
+use crate::recordlog::frame::{BLOCK_LEN, HEADER_LEN};
+
+#[tokio::test]
+async fn test_no_data() {
+    let mut reader = RecordReader::open(&b""[..]);
+    assert_eq!(reader.read_record::<&str>().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn test_empty_record() {
+    let mut buffer = Vec::new();
+    let mut writer = RecordWriter::open(&mut buffer);
+    writer.write_record("").await.unwrap();
+    writer.flush().await.unwrap();
+    let mut reader = RecordReader::open(&buffer[..]);
+    assert_eq!(reader.read_record::<&str>().await.unwrap(), Some(""));
+    assert_eq!(reader.read_record::<&str>().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn test_simple_record() {
+    let mut buffer = Vec::new();
+    let mut writer = RecordWriter::open(&mut buffer);
+    let record = "hello";
+    writer.write_record(record).await.unwrap();
+    writer.flush().await.unwrap();
+    let mut reader = RecordReader::open(&buffer[..]);
+    assert!(matches!(
+        reader.read_record::<&str>().await,
+        Ok(Some("hello"))
+    ));
+    assert!(matches!(reader.read_record::<&str>().await, Ok(None)));
+}
+
+fn make_long_entry(len: usize) -> String {
+    iter::repeat('A').take(len).collect()
+}
+
+#[tokio::test]
+async fn test_spans_over_more_than_one_block() {
+    let mut buffer = Vec::new();
+    let long_entry: String = make_long_entry(80_000);
+    let mut writer = RecordWriter::open(&mut buffer);
+    writer.write_record(long_entry.as_str()).await.unwrap();
+    writer.flush().await.unwrap();
+    let mut reader = RecordReader::open(&buffer[..]);
+    let record_payload: &str = reader.read_record().await.unwrap().unwrap();
+    assert_eq!(record_payload, &long_entry);
+    assert_eq!(reader.read_record::<&str>().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn test_block_requires_padding() {
+    let mut buffer = Vec::new();
+    // We'll miss 1 byte to be able to fit our next chunk header in the
+    // first block.
+    let long_record = make_long_entry(BLOCK_LEN - HEADER_LEN - HEADER_LEN - 1 - 8);
+    let short_record = "hello";
+    let mut writer = RecordWriter::open(&mut buffer);
+    writer.write_record(long_record.as_str()).await.unwrap();
+    writer.write_record(short_record).await.unwrap();
+    writer.flush().await.unwrap();
+    let mut reader = RecordReader::open(&buffer[..]);
+    assert_eq!(
+        reader.read_record::<&str>().await.unwrap(),
+        Some(long_record.as_str())
+    );
+    assert_eq!(
+        reader.read_record::<&str>().await.unwrap(),
+        Some(short_record)
+    );
+    assert_eq!(reader.read_record::<&str>().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn test_first_chunk_empty() {
+    let mut buffer = Vec::new();
+    // We'll miss 1 byte to be able to fit our next chunk header in the
+    // first block.
+    let long_record = make_long_entry(BLOCK_LEN - HEADER_LEN - HEADER_LEN);
+    let short_record = "hello";
+    let mut writer = RecordWriter::open(&mut buffer);
+    writer.write_record(&long_record[..]).await.unwrap();
+    writer.write_record(short_record).await.unwrap();
+    writer.flush().await.unwrap();
+    let mut reader = RecordReader::open(&buffer[..]);
+    assert_eq!(
+        reader.read_record::<&str>().await.unwrap(),
+        Some(long_record.as_str())
+    );
+    assert_eq!(
+        reader.read_record::<&str>().await.unwrap(),
+        Some(short_record)
+    );
+    assert_eq!(reader.read_record::<&str>().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn test_behavior_upon_corruption() {
+    let mut buffer = Vec::new();
+    let records: Vec<String> = (0..1_000).map(|i| format!("hello{}", i)).collect();
+    {
+        let mut writer = RecordWriter::open(&mut buffer);
+        for record in &records {
+            writer.write_record(record.as_str()).await.unwrap();
+        }
+        writer.flush().await.unwrap();
+    }
+    {
+        let mut reader = RecordReader::open(&buffer[..]);
+        for record in &records {
+            assert_eq!(
+                reader.read_record::<&str>().await.unwrap(),
+                Some(record.as_str())
+            );
+        }
+        assert_eq!(reader.read_record::<&str>().await.unwrap(), None);
+    }
+    buffer[1_000] = 3;
+    {
+        let mut reader = RecordReader::open(&buffer[..]);
+        for record in &records[0..72] {
+            // bug at i=72
+            assert_eq!(
+                reader.read_record::<&str>().await.unwrap(),
+                Some(record.as_str())
+            );
+        }
+        assert!(matches!(
+            reader.read_record::<&str>().await,
+            Err(ReadRecordError::Corruption)
+        ));
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/record/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/record/writer.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use tokio::io::{self, AsyncWrite};
 
 use crate::recordlog::frame::{FrameType, FrameWriter};

--- a/quickwit-ingest-api/src/recordlog/record/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/record/writer.rs
@@ -1,0 +1,78 @@
+use crate::recordlog::{frame::{FrameType, FrameWriter}, Serializable};
+use tokio::io::{self, AsyncWrite};
+
+pub struct RecordWriter<W> {
+    frame_writer: FrameWriter<W>,
+    buffer: Vec<u8>,
+}
+
+impl<W: io::AsyncWrite> RecordWriter<W> {}
+
+fn frame_type(is_first_frame: bool, is_last_frame: bool) -> FrameType {
+    match (is_first_frame, is_last_frame) {
+        (true, true) => FrameType::FULL,
+        (true, false) => FrameType::FIRST,
+        (false, true) => FrameType::LAST,
+        (false, false) => FrameType::MIDDLE,
+    }
+}
+
+impl<W: io::AsyncWrite + Unpin> RecordWriter<W> {
+    pub fn open(wrt: W) -> Self {
+        let frame_writer = FrameWriter::create_with_aligned_write(wrt);
+        RecordWriter {
+            frame_writer,
+            buffer: Vec::with_capacity(10_000),
+        }
+    }
+}
+
+impl<W: AsyncWrite + Unpin> RecordWriter<W> {
+    /// Writes a record.
+    ///
+    /// Even if this call returns `Ok(())`, at this point the data
+    /// is likely to be not durably stored on disk.
+    ///
+    /// For instance, the data could be stale in a library level buffer,
+    /// by a writer level buffer, or an application buffer,
+    /// or could not be flushed to disk yet by the OS.
+    pub async fn write_record(&mut self, record: impl Serializable<'_>) -> io::Result<()> {
+        let mut is_first_frame = true;
+        self.buffer.clear();
+        record.serialize(&mut self.buffer);
+        let mut payload = &self.buffer[..];
+        loop {
+            let frame_payload_len = self
+                .frame_writer
+                .max_writable_frame_length()
+                .min(payload.len());
+            let frame_payload = &payload[..frame_payload_len];
+            payload = &payload[frame_payload_len..];
+            let is_last_frame = payload.is_empty();
+            let frame_type = frame_type(is_first_frame, is_last_frame);
+            self.frame_writer
+                .write_frame(frame_type, frame_payload)
+                .await?;
+            is_first_frame = false;
+            if is_last_frame {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Flushes and sync the data to disk.
+    pub async fn flush(&mut self) -> io::Result<()> {
+        // Empty the application buffer.
+        self.frame_writer.flush().await?;
+        Ok(())
+    }
+
+    pub fn get_underlying_wrt(&mut self) -> &mut W {
+        self.frame_writer.get_underlying_wrt()
+    }
+
+    pub fn num_bytes_written(&self) -> u64 {
+        self.frame_writer.num_bytes_written()
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/record/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/record/writer.rs
@@ -1,5 +1,7 @@
-use crate::recordlog::{frame::{FrameType, FrameWriter}, Serializable};
 use tokio::io::{self, AsyncWrite};
+
+use crate::recordlog::frame::{FrameType, FrameWriter};
+use crate::recordlog::Serializable;
 
 pub struct RecordWriter<W> {
     frame_writer: FrameWriter<W>,

--- a/quickwit-ingest-api/src/recordlog/rolling/directory.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/directory.rs
@@ -1,0 +1,225 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeSet;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+use tokio::fs::File;
+use tokio::fs::OpenOptions;
+
+pub struct Directory {
+    dir: PathBuf,
+    // First position in files.
+    file_set: BTreeSet<u64>,
+}
+
+fn filename_to_position(file_name: &str) -> Option<u64> {
+    if file_name.len() != 24 {
+        return None;
+    }
+    if !file_name.starts_with("wal-") {
+        return None;
+    }
+    let seq_number_str = &file_name[4..];
+    if !seq_number_str
+        .as_bytes()
+        .iter()
+        .all(|b| (b'0'..=b'9').contains(b))
+    {
+        return None;
+    }
+    file_name[4..].parse::<u64>().ok()
+}
+
+impl Directory {
+    pub async fn open(dir_path: &Path) -> io::Result<Directory> {
+        let mut seq_numbers: BTreeSet<u64> = Default::default();
+        let mut read_dir = tokio::fs::read_dir(dir_path).await?;
+        while let Some(dir_entry) = read_dir.next_entry().await? {
+            if !dir_entry.file_type().await?.is_file() {
+                continue;
+            }
+            let file_name = if let Some(file_name) = dir_entry.file_name().to_str() {
+                file_name.to_string()
+            } else {
+                continue;
+            };
+            if let Some(seq_number) = filename_to_position(&file_name) {
+                seq_numbers.insert(seq_number);
+            }
+        }
+        Ok(Directory {
+            dir: dir_path.to_path_buf(),
+            file_set: seq_numbers,
+        })
+    }
+
+    pub fn num_files(&self) -> usize {
+        self.file_set.len()
+    }
+
+    pub async fn truncate(&mut self, position: u64) -> io::Result<()> {
+        if let Some(&first_file_to_retain) = self.file_set.range(..=position).last() {
+            let mut removed_files = Vec::new();
+            for &position in self.file_set.range(..first_file_to_retain) {
+                let filepath = self.filepath(position);
+                tokio::fs::remove_file(&filepath).await?;
+                removed_files.push(position);
+            }
+            for position in removed_files {
+                self.file_set.remove(&position);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn file_paths<'a>(&'a self) -> impl Iterator<Item = PathBuf> + 'a {
+        self.file_set
+            .iter()
+            .copied()
+            .map(move |seq_number| self.filepath(seq_number))
+    }
+
+    fn filepath(&self, seq_number: u64) -> PathBuf {
+        self.dir.join(&format!("wal-{seq_number:020}"))
+    }
+
+    pub async fn new_file(&mut self, position: u64) -> io::Result<File> {
+        assert!(self
+            .file_set
+            .iter()
+            .last()
+            .copied()
+            .map(|last_position| last_position < position)
+            .unwrap_or(true));
+        self.file_set.insert(position);
+        let new_filepath = self.filepath(position);
+        OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&new_filepath)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    #[test]
+    fn test_filename_to_seq_number_invalid_prefix_rejected() {
+        assert_eq!(filename_to_position("fil-00000000000000000001"), None);
+    }
+
+    #[test]
+    fn test_filename_to_seq_number_invalid_padding_rejected() {
+        assert_eq!(filename_to_position("wal-0000000000000000001"), None);
+    }
+
+    #[test]
+    fn test_filename_to_seq_number_invalid_len_rejected() {
+        assert_eq!(filename_to_position("wal-000000000000000000011"), None);
+    }
+
+    #[test]
+    fn test_filename_to_seq_number_simple() {
+        assert_eq!(filename_to_position("wal-00000000000000000001"), Some(1u64));
+    }
+
+    #[test]
+    fn test_filename_to_seq_number() {
+        assert_eq!(filename_to_position("wal-00000000000000000001"), Some(1u64));
+    }
+
+    fn test_directory_file_aux(directory: &Directory, dir_path: &Path) -> Vec<String> {
+        directory
+            .file_paths()
+            .map(|filepath| {
+                assert_eq!(filepath.parent().unwrap(), dir_path);
+                filepath.file_name().unwrap().to_str().unwrap().to_string()
+            })
+            .collect::<Vec<String>>()
+    }
+
+    #[tokio::test]
+    async fn test_directory() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        {
+            let mut directory = Directory::open(tmp_dir.path()).await.unwrap();
+            let mut file = directory.new_file(0u64).await.unwrap();
+            file.write_all(b"hello").await.unwrap();
+            file.flush().await.unwrap();
+        }
+        {
+            let mut directory = Directory::open(tmp_dir.path()).await.unwrap();
+            let filepaths = test_directory_file_aux(&directory, tmp_dir.path());
+            assert_eq!(&filepaths, &["wal-00000000000000000000"]);
+            let mut file = directory.new_file(3u64).await.unwrap();
+            file.write_all(b"hello2").await.unwrap();
+            file.flush().await.unwrap()
+        }
+        {
+            let directory = Directory::open(tmp_dir.path()).await.unwrap();
+            let filepaths = test_directory_file_aux(&directory, tmp_dir.path());
+            assert_eq!(
+                &filepaths,
+                &["wal-00000000000000000000", "wal-00000000000000000003"]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_directory_truncate() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        {
+            let mut directory = Directory::open(tmp_dir.path()).await.unwrap();
+            let mut file = directory.new_file(0u64).await.unwrap();
+            file.write_all(b"hello").await.unwrap();
+            file.flush().await.unwrap();
+        }
+        {
+            let mut directory = Directory::open(tmp_dir.path()).await.unwrap();
+            let filepaths = test_directory_file_aux(&directory, tmp_dir.path());
+            assert_eq!(&filepaths, &["wal-00000000000000000000"]);
+            let mut file = directory.new_file(3u64).await.unwrap();
+            file.write_all(b"hello2").await.unwrap();
+            file.flush().await.unwrap();
+            file.write_all(b"hello3").await.unwrap();
+            file.flush().await.unwrap()
+        }
+        {
+            let directory = Directory::open(tmp_dir.path()).await.unwrap();
+            let filepaths = test_directory_file_aux(&directory, tmp_dir.path());
+            assert_eq!(
+                &filepaths,
+                &["wal-00000000000000000000", "wal-00000000000000000003"]
+            );
+        }
+        {
+            let mut directory = Directory::open(tmp_dir.path()).await.unwrap();
+            directory.truncate(3).await.unwrap();
+            let filepaths = test_directory_file_aux(&directory, tmp_dir.path());
+            assert_eq!(&filepaths, &["wal-00000000000000000003"]);
+        }
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/rolling/directory.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/directory.rs
@@ -19,11 +19,9 @@
 
 use std::collections::BTreeSet;
 use std::io;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use tokio::fs::File;
-use tokio::fs::OpenOptions;
+use tokio::fs::{File, OpenOptions};
 
 pub struct Directory {
     dir: PathBuf,

--- a/quickwit-ingest-api/src/recordlog/rolling/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/mod.rs
@@ -1,0 +1,29 @@
+mod directory;
+mod reader;
+mod writer;
+
+pub use self::directory::Directory;
+use serde::{Deserialize, Serialize};
+pub(crate) use self::reader::RecordLogReader;
+pub(crate) use self::writer::RecordLogWriter;
+
+#[derive(Serialize, Deserialize)]
+enum MultiQueueRecord<'a> {
+    /// Appends a record to a given queue.
+    Record {
+        queue_id: &'a str,
+        seq_number: u64,
+        payload: &'a [u8],
+    },
+    /// Truncation happens at the level of a specific queue.
+    /// It is simply added to the record log as an operation...
+    /// The client will be in charge of detecting when a file can actually
+    /// be deleted and will removing the file accordingly.
+    Truncate { queue_id: &'a str, seq_number: u64 },
+    /// After removing a log file, in order to avoid losing the last seq_number,
+    /// we can append a `LastPosition` record to the log.
+    LastPosition { queue_id: &'a str, seq_number: u64 },
+}
+
+#[cfg(test)]
+mod tests;

--- a/quickwit-ingest-api/src/recordlog/rolling/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/mod.rs
@@ -2,8 +2,9 @@ mod directory;
 mod reader;
 mod writer;
 
-pub use self::directory::Directory;
 use serde::{Deserialize, Serialize};
+
+pub use self::directory::Directory;
 pub(crate) use self::reader::RecordLogReader;
 pub(crate) use self::writer::RecordLogWriter;
 

--- a/quickwit-ingest-api/src/recordlog/rolling/mod.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/mod.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 mod directory;
 mod reader;
 mod writer;

--- a/quickwit-ingest-api/src/recordlog/rolling/reader.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/reader.rs
@@ -19,16 +19,13 @@
 
 use std::collections::VecDeque;
 use std::io;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tokio::fs::File;
 
-use crate::recordlog::record::ReadRecordError;
-use crate::recordlog::record::RecordReader;
-use crate::recordlog::rolling::Directory;
+use crate::recordlog::record::{ReadRecordError, RecordReader};
+use crate::recordlog::rolling::{Directory, RecordLogWriter};
 use crate::recordlog::Record;
-use crate::recordlog::rolling::RecordLogWriter;
 
 pub(crate) struct RecordLogReader {
     directory: Directory,

--- a/quickwit-ingest-api/src/recordlog/rolling/reader.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/reader.rs
@@ -1,0 +1,99 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::VecDeque;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+use tokio::fs::File;
+
+use crate::recordlog::record::ReadRecordError;
+use crate::recordlog::record::RecordReader;
+use crate::recordlog::rolling::Directory;
+use crate::recordlog::Record;
+use crate::recordlog::rolling::RecordLogWriter;
+
+pub(crate) struct RecordLogReader {
+    directory: Directory,
+    files: VecDeque<PathBuf>,
+    reader_opt: Option<RecordReader<File>>,
+}
+
+impl RecordLogReader {
+    pub async fn open(dir_path: &Path) -> io::Result<Self> {
+        let directory = Directory::open(dir_path).await?;
+        let files = directory.file_paths().collect();
+        Ok(RecordLogReader {
+            files,
+            directory,
+            reader_opt: None,
+        })
+    }
+
+    pub fn into_writer(self) -> RecordLogWriter {
+        RecordLogWriter::open(self.directory.into())
+    }
+
+    async fn go_next_record_current_reader(&mut self) -> Result<bool, ReadRecordError> {
+        if let Some(record_reader) = self.reader_opt.as_mut() {
+            record_reader.go_next().await
+        } else {
+            Ok(false)
+        }
+    }
+
+    async fn go_next_record(&mut self) -> Result<bool, ReadRecordError> {
+        loop {
+            if self.go_next_record_current_reader().await? {
+                return Ok(true);
+            }
+            if !self.load_next_file().await? {
+                return Ok(false);
+            }
+        }
+    }
+
+    async fn load_next_file(&mut self) -> io::Result<bool> {
+        if let Some(next_file_path) = self.files.pop_front() {
+            let next_file = File::open(next_file_path).await?;
+            let record_reader = RecordReader::open(next_file);
+            self.reader_opt = Some(record_reader);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub(crate) async fn read_record<'a>(
+        &'a mut self,
+    ) -> Result<Option<Record<'a>>, ReadRecordError> {
+        if self.go_next_record().await? {
+            let record: Record = self
+                .reader_opt
+                .as_ref()
+                .unwrap()
+                .record()
+                .ok_or(ReadRecordError::Corruption)?;
+            Ok(Some(record))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/rolling/tests.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/tests.rs
@@ -20,8 +20,8 @@
 
 use tempfile::tempdir;
 
-use crate::recordlog::Record;
 use super::RecordLogReader;
+use crate::recordlog::Record;
 
 #[tokio::test]
 async fn test_record_log_reader_empty() {

--- a/quickwit-ingest-api/src/recordlog/rolling/tests.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/tests.rs
@@ -16,7 +16,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-//
 
 use tempfile::tempdir;
 

--- a/quickwit-ingest-api/src/recordlog/rolling/tests.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/tests.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use tempfile::tempdir;
+
+use crate::recordlog::Record;
+use super::RecordLogReader;
+
+#[tokio::test]
+async fn test_record_log_reader_empty() {
+    let tempdir = tempdir().unwrap();
+    let mut record_log_reader = RecordLogReader::open(tempdir.path()).await.unwrap();
+    assert!(record_log_reader.read_record().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_record_log_reader_simple() {
+    let tempdir = tempdir().unwrap();
+    {
+        let mut record_log_reader = RecordLogReader::open(tempdir.path()).await.unwrap();
+        assert!(record_log_reader.read_record().await.unwrap().is_none());
+        let mut record_log_writer = record_log_reader.into_writer();
+        let record0 = Record::AddRecord {
+            position: 0,
+            queue: "queue",
+            payload: b"hello0",
+        };
+        let record1 = Record::AddRecord {
+            position: 1,
+            queue: "queue",
+            payload: b"hello1",
+        };
+        record_log_writer.write_record(record0).await.unwrap();
+        record_log_writer.write_record(record1).await.unwrap();
+        record_log_writer.flush().await.unwrap();
+        let mut record_log_reader = RecordLogReader::open(tempdir.path()).await.unwrap();
+        assert_eq!(
+            record_log_reader.read_record().await.unwrap(),
+            Some(record0)
+        );
+        assert_eq!(
+            record_log_reader.read_record().await.unwrap(),
+            Some(record1)
+        );
+        let mut record_log_writer = record_log_reader.into_writer();
+        record_log_writer.flush().await.unwrap()
+    }
+    {
+        let mut record_log_reader = RecordLogReader::open(tempdir.path()).await.unwrap();
+        let record0 = Record::AddRecord {
+            position: 0,
+            queue: "queue",
+            payload: b"hello0",
+        };
+        let record1 = Record::AddRecord {
+            position: 1,
+            queue: "queue",
+            payload: b"hello1",
+        };
+        assert_eq!(
+            record_log_reader.read_record().await.unwrap(),
+            Some(record0)
+        );
+        assert_eq!(
+            record_log_reader.read_record().await.unwrap(),
+            Some(record1)
+        );
+        let mut record_log_writer = record_log_reader.into_writer();
+        let record2 = Record::AddRecord {
+            position: 2,
+            queue: "queue",
+            payload: b"hello2",
+        };
+        record_log_writer.write_record(record2).await.unwrap();
+        record_log_writer.flush().await.unwrap()
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/rolling/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/writer.rs
@@ -1,0 +1,105 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::io;
+
+use tokio::fs::File;
+use tokio::io::BufWriter;
+
+const LIMIT_NUM_BYTES: u64 = 50_000_000u64;
+
+use crate::recordlog::record::RecordWriter;
+use crate::recordlog::Record;
+use super::Directory;
+
+pub(crate) struct RecordLogWriter {
+    record_writer_opt: Option<RecordWriter<BufWriter<File>>>,
+    directory: super::Directory,
+}
+
+async fn new_record_writer(
+    directory: &mut Directory,
+    position: u64,
+) -> io::Result<RecordWriter<BufWriter<File>>> {
+    // TODO sync parent dir.
+    let new_file = directory.new_file(position).await?;
+    let buf_writer = tokio::io::BufWriter::new(new_file);
+    Ok(RecordWriter::open(buf_writer))
+}
+
+impl RecordLogWriter {
+    async fn open_new_file(
+        &mut self,
+        position: u64,
+    ) -> io::Result<&mut RecordWriter<BufWriter<File>>> {
+        if let Some(mut record_writer) = self.record_writer_opt.take() {
+            record_writer.flush().await?;
+            record_writer
+                .get_underlying_wrt()
+                .get_mut()
+                .sync_all()
+                .await?;
+        }
+        self.record_writer_opt = Some(new_record_writer(&mut self.directory, position).await?);
+        Ok(self.record_writer_opt.as_mut().unwrap())
+    }
+
+    pub fn num_files(&self) -> usize {
+        self.directory.num_files()
+    }
+
+    pub(crate) fn open(directory: Directory) -> Self {
+        RecordLogWriter {
+            directory,
+            record_writer_opt: None,
+        }
+    }
+
+    fn need_new_file(&self) -> bool {
+        if let Some(record_writer) = self.record_writer_opt.as_ref() {
+            record_writer.num_bytes_written() >= LIMIT_NUM_BYTES
+        } else {
+            true
+        }
+    }
+
+    pub(crate) async fn write_record(&mut self, record: Record<'_>) -> io::Result<()> {
+        let record_writer = if self.need_new_file() {
+            self.open_new_file(record.position()).await?
+        } else {
+            self.record_writer_opt.as_mut().unwrap()
+        };
+        record_writer.write_record(record).await?;
+        Ok(())
+    }
+
+    /// Remove files that only contain records <= position.
+    pub async fn truncate(&mut self, position: u64) -> io::Result<()> {
+        self.directory.truncate(position).await?;
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> io::Result<()> {
+        if let Some(record_writer) = self.record_writer_opt.as_mut() {
+            record_writer.flush().await?;
+        }
+        // TODO add file-sync according to some sync policy
+        Ok(())
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/rolling/writer.rs
+++ b/quickwit-ingest-api/src/recordlog/rolling/writer.rs
@@ -24,9 +24,9 @@ use tokio::io::BufWriter;
 
 const LIMIT_NUM_BYTES: u64 = 50_000_000u64;
 
+use super::Directory;
 use crate::recordlog::record::RecordWriter;
 use crate::recordlog::Record;
-use super::Directory;
 
 pub(crate) struct RecordLogWriter {
     record_writer_opt: Option<RecordWriter<BufWriter<File>>>,

--- a/quickwit-ingest-api/src/recordlog/tests.rs
+++ b/quickwit-ingest-api/src/recordlog/tests.rs
@@ -1,0 +1,69 @@
+use crate::recordlog::MultiRecordLog;
+
+fn read_all_records<'a>(multi_record_log: &'a MultiRecordLog, queue: &str) -> Vec<(u64, &'a [u8])> {
+    let mut records = Vec::new();
+    let mut next_pos = 0;
+    while let Some((pos, payload)) = multi_record_log.get_after(queue, next_pos) {
+        records.push((pos, payload));
+        next_pos = pos + 1;
+    }
+    records
+}
+
+#[tokio::test]
+async fn test_multi_record_log() {
+    let tempdir = tempfile::tempdir().unwrap();
+    {
+        let mut multi_record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();
+        multi_record_log
+            .append_record("queue1", b"hello")
+            .await
+            .unwrap();
+        multi_record_log
+            .append_record("queue2", b"maitre")
+            .await
+            .unwrap();
+        multi_record_log
+            .append_record("queue1", b"happy")
+            .await
+            .unwrap();
+        multi_record_log
+            .append_record("queue1", b"tax")
+            .await
+            .unwrap();
+        multi_record_log
+            .append_record("queue2", b"corbeau")
+            .await
+            .unwrap();
+        assert_eq!(
+            &read_all_records(&multi_record_log, "queue1"),
+            &[
+                (1u64, b"hello".as_slice()),
+                (3u64, b"happy".as_slice()),
+                (4u64, b"tax".as_slice())
+            ]
+        );
+        assert_eq!(
+            &read_all_records(&multi_record_log, "queue2"),
+            &[(2u64, b"maitre".as_slice()), (5u64, b"corbeau".as_slice())]
+        );
+        assert_eq!(multi_record_log.num_files(), 1);
+    }
+    {
+        let mut multi_record_log = MultiRecordLog::open(tempdir.path()).await.unwrap();
+        multi_record_log
+            .append_record("queue1", b"bubu")
+            .await
+            .unwrap();
+        assert_eq!(
+            &read_all_records(&multi_record_log, "queue1"),
+            &[
+                (1u64, b"hello".as_slice()),
+                (3u64, b"happy".as_slice()),
+                (4u64, b"tax".as_slice()),
+                (6u64, b"bubu".as_slice())
+            ]
+        );
+        assert_eq!(multi_record_log.num_files(), 2);
+    }
+}

--- a/quickwit-ingest-api/src/recordlog/tests.rs
+++ b/quickwit-ingest-api/src/recordlog/tests.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use crate::recordlog::MultiRecordLog;
 
 fn read_all_records<'a>(multi_record_log: &'a MultiRecordLog, queue: &str) -> Vec<(u64, &'a [u8])> {

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -82,31 +82,15 @@ async fn get_split_footer_from_cache_or_fetch(
     Ok(footer_data_opt)
 }
 
-/// Opens a `tantivy::Index` for the given split.
-///
-/// The resulting index uses a dynamic and a static cache.
-pub(crate) async fn open_index(
+/// Opens a `tantivy::Index` for the given split with several cache layers:
+/// - A split footer cache given by `SearcherContext.split_footer_cache`.
+/// - A fast fields cache given by `SearcherContext.storage_long_term_cache`.
+/// - An ephemeral unbounded cache directory whose lifetime is tied to the returned `Index`.
+pub(crate) async fn open_index_with_caches(
     searcher_context: &Arc<SearcherContext>,
     index_storage: Arc<dyn Storage>,
     split_and_footer_offsets: &SplitIdAndFooterOffsets,
-) -> anyhow::Result<Index> {
-    open_index_with_cache(
-        searcher_context,
-        index_storage,
-        split_and_footer_offsets,
-        true,
-    )
-    .await
-}
-
-/// Opens a `tantivy::Index` for the given split.
-///
-/// The resulting index uses a dynamic and a static cache.
-pub(crate) async fn open_index_with_cache(
-    searcher_context: &Arc<SearcherContext>,
-    index_storage: Arc<dyn Storage>,
-    split_and_footer_offsets: &SplitIdAndFooterOffsets,
-    unlimited_cache: bool,
+    ephemeral_unbounded_cache: bool,
 ) -> anyhow::Result<Index> {
     let split_file = PathBuf::from(format!("{}.split", split_and_footer_offsets.split_id));
     let footer_data = get_split_footer_from_cache_or_fetch(
@@ -122,12 +106,12 @@ pub(crate) async fn open_index_with_cache(
         FileSlice::new(Arc::new(footer_data)),
     )?;
     let bundle_storage_with_cache = wrap_storage_with_long_term_cache(
-        searcher_context.storage_long_term_cache.clone(),
+        searcher_context.fast_fields_cache.clone(),
         Arc::new(bundle_storage),
     );
     let directory = StorageDirectory::new(bundle_storage_with_cache);
-    let hot_directory = if unlimited_cache {
-        let caching_directory = CachingDirectory::new_with_unlimited_capacity(Arc::new(directory));
+    let hot_directory = if ephemeral_unbounded_cache {
+        let caching_directory = CachingDirectory::new_unbounded(Arc::new(directory));
         HotDirectory::open(caching_directory, hotcache_bytes.read_bytes()?)?
     } else {
         HotDirectory::open(directory, hotcache_bytes.read_bytes()?)?
@@ -337,7 +321,7 @@ async fn leaf_search_single_split(
     doc_mapper: Arc<dyn DocMapper>,
 ) -> crate::Result<LeafSearchResponse> {
     let split_id = split.split_id.to_string();
-    let index = open_index(searcher_context, storage, &split).await?;
+    let index = open_index_with_caches(searcher_context, storage, &split, true).await?;
     let split_schema = index.schema();
     let quickwit_collector = make_collector_for_split(
         split_id.clone(),

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -39,7 +39,7 @@ use tracing::*;
 use super::collector::{PartionnedFastFieldCollector, PartitionValues};
 use super::FastFieldCollector;
 use crate::filters::TimestampFilterBuilder;
-use crate::leaf::{open_index, warmup};
+use crate::leaf::{open_index_with_caches, warmup};
 use crate::service::SearcherContext;
 use crate::{Result, SearchError};
 
@@ -118,7 +118,7 @@ async fn leaf_search_stream_single_split(
         .await
         .expect("Failed to acquire permit. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
 
-    let index = open_index(&searcher_context, storage, &split).await?;
+    let index = open_index_with_caches(&searcher_context, storage, &split, true).await?;
     let split_schema = index.schema();
 
     let request_fields = Arc::new(SearchStreamRequestFields::from_request(

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -234,8 +234,8 @@ pub struct SearcherContext {
     pub split_stream_semaphore: Semaphore,
     /// Split footer cache.
     pub split_footer_cache: MemorySizedCache<String>,
-    /// Storage cache that lives until the searcher stops.
-    pub storage_long_term_cache: Arc<dyn Cache>,
+    /// Fast fields cache.
+    pub fast_fields_cache: Arc<dyn Cache>,
 }
 
 impl SearcherContext {
@@ -257,7 +257,7 @@ impl SearcherContext {
             split_footer_cache: global_split_footer_cache,
             leaf_search_split_semaphore,
             split_stream_semaphore,
-            storage_long_term_cache,
+            fast_fields_cache: storage_long_term_cache,
         }
     }
 }


### PR DESCRIPTION
This is a WIP.

Flushing my brain here so it can be resumed later.
Here is what is missing:

With the rocksdb solution was based on the idea that position were local to a given queue. My recordlog on the other hand uses a single global position.
As a complicated side effect, it did not implement queue creation/existence. Queues are created on the fly and just either have
records or are empty. We do not need to track the last position for each individual queues... just the last position.

I have not dug into whether queue existence is a requirement for quickwit, but I suspect it is.
The code will require some modificcation in that case.

I added a rather artificial create_queue remove_queue operation, but those are bogus as they are not durable. (they only update the memqueue). The problem is trickier than just adding a Create operation to the log, as it needs to survive truncation.

- the position returned by the queue are not necessarily contiguous, so the fetch record calls response does not make any sense.

- the batch fetch (one hashmap lookup) & batch ingest (one hashmap lookup + one flush) are not optimized at all.

Finally, we need more tests.



If we end up deciding that we truely need queue existence & local positions, we can probably add global truncation operation
that lists existing queues, and then truncates... and have both local and global id on each record.