### PR TITLE
Partition friendly threading model for indexing.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -953,12 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,7 +1149,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ea72cf3#ea72cf34d60cf5080c609239b7bf935bfe18229f"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e029fdf#e029fdfca759fcb592041e1834d9e95e39a5b90b"
 dependencies = [
  "fastdivide",
  "log",
@@ -2452,18 +2446,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "ownedbytes"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ea72cf3#ea72cf34d60cf5080c609239b7bf935bfe18229f"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e029fdf#e029fdfca759fcb592041e1834d9e95e39a5b90b"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -2752,18 +2737,6 @@ checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
-dependencies = [
- "ansi_term",
- "ctor",
- "diff",
- "output_vt100",
 ]
 
 [[package]]
@@ -4641,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ea72cf3#ea72cf34d60cf5080c609239b7bf935bfe18229f"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e029fdf#e029fdfca759fcb592041e1834d9e95e39a5b90b"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4670,7 +4643,6 @@ dependencies = [
  "once_cell",
  "oneshot",
  "ownedbytes",
- "pretty_assertions",
  "rayon",
  "regex",
  "rust-stemmers",
@@ -4694,12 +4666,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ea72cf3#ea72cf34d60cf5080c609239b7bf935bfe18229f"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e029fdf#e029fdfca759fcb592041e1834d9e95e39a5b90b"
 
 [[package]]
 name = "tantivy-common"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ea72cf3#ea72cf34d60cf5080c609239b7bf935bfe18229f"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e029fdf#e029fdfca759fcb592041e1834d9e95e39a5b90b"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -4719,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ea72cf3#ea72cf34d60cf5080c609239b7bf935bfe18229f"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e029fdf#e029fdfca759fcb592041e1834d9e95e39a5b90b"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit/quickwit-actors/src/tests.rs
+++ b/quickwit/quickwit-actors/src/tests.rs
@@ -128,6 +128,17 @@ impl Handler<AddPeer> for PingerSenderActor {
 }
 
 #[tokio::test]
+async fn test_actor_stops_when_last_mailbox_is_dropped() {
+    quickwit_common::setup_logging_for_tests();
+    let universe = Universe::new();
+    let (ping_recv_mailbox, ping_recv_handle) =
+        universe.spawn_actor(PingReceiverActor::default()).spawn();
+    drop(ping_recv_mailbox);
+    let (exit_status, _) = ping_recv_handle.join().await;
+    assert!(exit_status.is_success());
+}
+
+#[tokio::test]
 async fn test_ping_actor() {
     quickwit_common::setup_logging_for_tests();
     let universe = Universe::new();

--- a/quickwit/quickwit-core/Cargo.toml
+++ b/quickwit/quickwit-core/Cargo.toml
@@ -28,7 +28,7 @@ quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-directories/Cargo.toml
+++ b/quickwit/quickwit-directories/Cargo.toml
@@ -19,7 +19,7 @@ quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 serde = "1"
 serde_cbor = "0.11"
 serde_json = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit/quickwit-doc-mapper/Cargo.toml
@@ -25,13 +25,13 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 siphasher = "0.3"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",
   "quickwit",
 ] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3" }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf" }
 thiserror = "1.0"
 time = { version = "0.3.10", features = ["std", "macros"] }
 tracing = "0.1.29"

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -53,7 +53,7 @@ rusoto_kinesis = { version = "0.48", default-features = false, features = [
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-indexing/README.md
+++ b/quickwit/quickwit-indexing/README.md
@@ -2,8 +2,10 @@
 flowchart LR
     subgraph Indexing pipeline
         direction LR
-        source[Source] --> indexer
-        indexer[Indexer] --> packager
+        source[Source] --> doc_processor
+        doc_processor[DocProcessor] --> indexer
+        indexer[Indexer] --> serializer
+        serializer[IndexSerializer] --> packager
         packager[Packager] --> uploader
         uploader[Uploader] --> publisher
     end

--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -1,0 +1,439 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
+use quickwit_common::runtimes::RuntimeType;
+use quickwit_doc_mapper::{DocMapper, DocParsingError};
+use tantivy::schema::{Field, Value};
+use tokio::runtime::Handle;
+use tracing::warn;
+
+use crate::actors::Indexer;
+use crate::models::{NewPublishLock, PreparedDoc, PreparedDocBatch, PublishLock, RawDocBatch};
+
+enum PrepareDocumentError {
+    ParsingError,
+    MissingField,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DocProcessorCounters {
+    /// Overall number of documents received, partitioned
+    /// into 3 categories:
+    /// - number docs that did not parse correctly.
+    /// - number docs missing a timestamp (if the index has no timestamp,
+    /// then this counter is 0)
+    /// - number of valid docs.
+    pub num_parse_errors: u64,
+    pub num_docs_with_missing_fields: u64,
+    pub num_valid_docs: u64,
+
+    /// Number of bytes that went through the indexer
+    /// during its entire lifetime.
+    ///
+    /// Includes both valid and invalid documents.
+    pub overall_num_bytes: u64,
+}
+
+impl DocProcessorCounters {
+    /// Returns the overall number of docs that went through the indexer (valid or not).
+    pub fn num_processed_docs(&self) -> u64 {
+        self.num_valid_docs + self.num_parse_errors + self.num_docs_with_missing_fields
+    }
+
+    /// Returns the overall number of docs that were sent to the indexer but were invalid.
+    /// (For instance, because they were missing a required field or because their because
+    /// their format was invalid)
+    pub fn num_invalid_docs(&self) -> u64 {
+        self.num_parse_errors + self.num_docs_with_missing_fields
+    }
+
+    pub fn record_parsing_error(&mut self, num_bytes: u64) {
+        self.num_parse_errors += 1;
+        self.overall_num_bytes += num_bytes;
+        crate::metrics::INDEXER_METRICS
+            .parsing_errors_num_docs_total
+            .inc();
+        crate::metrics::INDEXER_METRICS
+            .parsing_errors_num_bytes_total
+            .inc_by(num_bytes);
+    }
+
+    pub fn record_missing_field(&mut self, num_bytes: u64) {
+        self.num_docs_with_missing_fields += 1;
+        self.overall_num_bytes += num_bytes;
+        crate::metrics::INDEXER_METRICS
+            .missing_field_num_docs_total
+            .inc();
+        crate::metrics::INDEXER_METRICS
+            .missing_field_num_bytes_total
+            .inc_by(num_bytes);
+    }
+
+    pub fn record_valid(&mut self, num_bytes: u64) {
+        self.num_valid_docs += 1;
+        self.overall_num_bytes += num_bytes;
+        crate::metrics::INDEXER_METRICS.valid_num_docs_total.inc();
+        crate::metrics::INDEXER_METRICS
+            .valid_num_bytes_total
+            .inc_by(num_bytes);
+    }
+}
+
+pub struct DocProcessor {
+    doc_mapper: Arc<dyn DocMapper>,
+    indexer_mailbox: Mailbox<Indexer>,
+    timestamp_field_opt: Option<Field>,
+    counters: DocProcessorCounters,
+    publish_lock: PublishLock,
+}
+
+impl DocProcessor {
+    pub fn new(doc_mapper: Arc<dyn DocMapper>, indexer_mailbox: Mailbox<Indexer>) -> Self {
+        let schema = doc_mapper.schema();
+        let timestamp_field_opt = doc_mapper.timestamp_field(&schema);
+        Self {
+            doc_mapper,
+            indexer_mailbox,
+            timestamp_field_opt,
+            counters: Default::default(),
+            publish_lock: PublishLock::default(),
+        }
+    }
+
+    fn prepare_document(
+        &self,
+        doc_json: String,
+        ctx: &ActorContext<Self>,
+    ) -> Result<PreparedDoc, PrepareDocumentError> {
+        // Parse the document
+        let _protect_guard = ctx.protect_zone();
+        let num_bytes = doc_json.len();
+        let doc_parsing_result = self.doc_mapper.doc_from_json(doc_json);
+        let (partition, doc) = doc_parsing_result.map_err(|doc_parsing_error| {
+            warn!(err=?doc_parsing_error);
+            match doc_parsing_error {
+                DocParsingError::RequiredFastField(_) => PrepareDocumentError::MissingField,
+                _ => PrepareDocumentError::ParsingError,
+            }
+        })?;
+        // Extract timestamp if necessary
+        let timestamp_field = if let Some(timestamp_field) = self.timestamp_field_opt {
+            timestamp_field
+        } else {
+            // No need to check the timestamp, there are no timestamp.
+            return Ok(PreparedDoc {
+                doc,
+                timestamp_opt: None,
+                partition,
+                num_bytes,
+            });
+        };
+        let timestamp = doc
+            .get_first(timestamp_field)
+            .and_then(|value| match value {
+                Value::Date(date_time) => Some(date_time.into_timestamp_secs()),
+                value => value.as_i64(),
+            })
+            .ok_or(PrepareDocumentError::MissingField)?;
+        Ok(PreparedDoc {
+            doc,
+            timestamp_opt: Some(timestamp),
+            partition,
+            num_bytes,
+        })
+    }
+}
+
+#[async_trait]
+impl Actor for DocProcessor {
+    type ObservableState = DocProcessorCounters;
+
+    fn observable_state(&self) -> Self::ObservableState {
+        self.counters
+    }
+
+    fn queue_capacity(&self) -> QueueCapacity {
+        QueueCapacity::Bounded(10)
+    }
+
+    fn runtime_handle(&self) -> Handle {
+        RuntimeType::Blocking.get_runtime_handle()
+    }
+
+    async fn finalize(
+        &mut self,
+        exit_status: &ActorExitStatus,
+        ctx: &ActorContext<Self>,
+    ) -> anyhow::Result<()> {
+        match exit_status {
+            ActorExitStatus::DownstreamClosed
+            | ActorExitStatus::Killed
+            | ActorExitStatus::Failure(_)
+            | ActorExitStatus::Panicked => return Ok(()),
+            ActorExitStatus::Quit | ActorExitStatus::Success => {
+                ctx.send_exit_with_success(&self.indexer_mailbox).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<RawDocBatch> for DocProcessor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        raw_doc_batch: RawDocBatch,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        if self.publish_lock.is_dead() {
+            return Ok(());
+        }
+        let mut prepared_docs: Vec<PreparedDoc> = Vec::with_capacity(raw_doc_batch.docs.len());
+        for doc_json in raw_doc_batch.docs {
+            let doc_json_num_bytes = doc_json.len() as u64;
+            match self.prepare_document(doc_json, ctx) {
+                Ok(document) => {
+                    self.counters.record_valid(doc_json_num_bytes);
+                    prepared_docs.push(document);
+                }
+                Err(PrepareDocumentError::ParsingError) => {
+                    self.counters.record_parsing_error(doc_json_num_bytes);
+                }
+                Err(PrepareDocumentError::MissingField) => {
+                    self.counters.record_missing_field(doc_json_num_bytes);
+                }
+            }
+            ctx.record_progress();
+        }
+        let prepared_doc_batch = PreparedDocBatch {
+            docs: prepared_docs,
+            checkpoint_delta: raw_doc_batch.checkpoint_delta,
+        };
+        ctx.send_message(&self.indexer_mailbox, prepared_doc_batch)
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<NewPublishLock> for DocProcessor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        new_publish_lock: NewPublishLock,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        self.publish_lock = new_publish_lock.0.clone();
+        ctx.send_message(&self.indexer_mailbox, new_publish_lock)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use quickwit_actors::{create_test_mailbox, Universe};
+    use quickwit_doc_mapper::{default_doc_mapper_for_test, DefaultDocMapper};
+    use quickwit_metastore::checkpoint::SourceCheckpointDelta;
+
+    use super::*;
+    use crate::models::{PublishLock, RawDocBatch};
+
+    #[tokio::test]
+    async fn test_doc_processor_simple() -> anyhow::Result<()> {
+        let doc_mapper = Arc::new(default_doc_mapper_for_test());
+        let (indexer_mailbox, indexer_inbox) = create_test_mailbox();
+        let doc_processor = DocProcessor::new(doc_mapper.clone(), indexer_mailbox);
+        let universe = Universe::new();
+        let (doc_processor_mailbox, doc_processor_handle) =
+            universe.spawn_actor(doc_processor).spawn();
+        let checkpoint_delta = SourceCheckpointDelta::from(0..4);
+        doc_processor_mailbox
+            .send_message(RawDocBatch {
+                docs: vec![
+                        r#"{"body": "happy", "response_date": "2021-12-19T16:39:57+00:00", "response_time": 12, "response_payload": "YWJj"}"#.to_string(), // missing timestamp
+                        r#"{"body": "happy", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:59+00:00", "response_time": 2, "response_payload": "YWJj"}"#.to_string(), // ok
+                        r#"{"body": "happy2", "timestamp": 1628837062, "response_date": "2021-12-19T16:40:57+00:00", "response_time": 13, "response_payload": "YWJj"}"#.to_string(), // ok
+                        "{".to_string(),                    // invalid json
+                    ],
+                checkpoint_delta: checkpoint_delta.clone(),
+            })
+            .await?;
+        let doc_processor_counters = doc_processor_handle
+            .process_pending_and_observe()
+            .await
+            .state;
+        assert_eq!(
+            doc_processor_counters,
+            DocProcessorCounters {
+                num_parse_errors: 1,
+                num_docs_with_missing_fields: 1,
+                num_valid_docs: 2,
+                overall_num_bytes: 387,
+            }
+        );
+        let output_messages = indexer_inbox.drain_for_test();
+        assert_eq!(output_messages.len(), 1);
+        let batch = *(output_messages
+            .into_iter()
+            .next()
+            .unwrap()
+            .downcast::<PreparedDocBatch>()
+            .unwrap());
+        assert_eq!(batch.docs.len(), 2);
+        assert_eq!(batch.checkpoint_delta, checkpoint_delta);
+
+        let schema = doc_mapper.schema();
+        let doc_json: serde_json::Value =
+            serde_json::from_str(&schema.to_json(&batch.docs[0].doc)).unwrap();
+        assert_eq!(
+            doc_json,
+            serde_json::json!({
+                "_source": [{
+                    "body": "happy",
+                    "response_date": "2021-12-19T16:39:59+00:00",
+                    "response_payload": "YWJj",
+                    "response_time": 2,
+                    "timestamp": 1628837062
+                }],
+                "body": ["happy"],
+                "response_date": ["2021-12-19T16:39:59Z"],
+                 "response_payload": [[97, 98, 99]],
+                 "response_time": [2.0],
+                 "timestamp": [1628837062]
+            })
+        );
+        Ok(())
+    }
+
+    const DOCMAPPER_WITH_PARTITION_JSON: &str = r#"
+        {
+            "tag_fields": ["tenant"],
+            "partition_key": "tenant",
+            "field_mappings": [
+                { "name": "tenant", "type": "text", "tokenizer": "raw", "indexed": true },
+                { "name": "body", "type": "text" }
+            ]
+        }"#;
+
+    #[tokio::test]
+    async fn test_doc_processor_partitioning() -> anyhow::Result<()> {
+        let doc_mapper: Arc<dyn DocMapper> = Arc::new(
+            serde_json::from_str::<DefaultDocMapper>(DOCMAPPER_WITH_PARTITION_JSON).unwrap(),
+        );
+        let (indexer_mailbox, indexer_inbox) = create_test_mailbox();
+        let doc_processor = DocProcessor::new(doc_mapper, indexer_mailbox);
+        let universe = Universe::new();
+        let (doc_processor_mailbox, doc_processor_handle) =
+            universe.spawn_actor(doc_processor).spawn();
+        doc_processor_mailbox
+            .send_message(RawDocBatch {
+                docs: vec![
+                    r#"{"tenant": "tenant_1", "body": "first doc for tenant 1"}"#.to_string(),
+                    r#"{"tenant": "tenant_2", "body": "first doc for tenant 2"}"#.to_string(),
+                    r#"{"tenant": "tenant_1", "body": "second doc for tenant 1"}"#.to_string(),
+                    r#"{"tenant": "tenant_2", "body": "second doc for tenant 2"}"#.to_string(),
+                ],
+                checkpoint_delta: SourceCheckpointDelta::from(0..2),
+            })
+            .await?;
+        universe
+            .send_exit_with_success(&doc_processor_mailbox)
+            .await
+            .unwrap();
+        let (exit_status, _) = doc_processor_handle.join().await;
+        assert!(matches!(exit_status, ActorExitStatus::Success));
+        let prepared_doc_batches: Vec<PreparedDocBatch> = indexer_inbox.drain_for_test_typed();
+        assert_eq!(prepared_doc_batches.len(), 1);
+        let partition_ids: Vec<u64> = prepared_doc_batches[0]
+            .docs
+            .iter()
+            .map(|doc| doc.partition)
+            .collect();
+        assert_eq!(partition_ids[0], partition_ids[2]);
+        assert_eq!(partition_ids[1], partition_ids[3]);
+        assert_ne!(partition_ids[0], partition_ids[1]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_doc_processor_forward_publish_lock() {
+        let doc_mapper = Arc::new(default_doc_mapper_for_test());
+        let (indexer_mailbox, indexer_inbox) = create_test_mailbox();
+        let universe = Universe::new();
+        let doc_processor = DocProcessor::new(doc_mapper, indexer_mailbox);
+        let (doc_processor_mailbox, doc_processor_handle) =
+            universe.spawn_actor(doc_processor).spawn();
+        let publish_lock = PublishLock::default();
+        doc_processor_mailbox
+            .send_message(NewPublishLock(publish_lock.clone()))
+            .await
+            .unwrap();
+        universe
+            .send_exit_with_success(&doc_processor_mailbox)
+            .await
+            .unwrap();
+        let (exit_status, _) = doc_processor_handle.join().await;
+        assert!(matches!(exit_status, ActorExitStatus::Success));
+        let publish_locks: Vec<NewPublishLock> = indexer_inbox.drain_for_test_typed();
+        assert_eq!(&publish_locks, &[NewPublishLock(publish_lock)]);
+    }
+
+    #[tokio::test]
+    async fn test_doc_processor_ignores_messages_when_publish_lock_is_dead() {
+        let doc_mapper = Arc::new(default_doc_mapper_for_test());
+        let (indexer_mailbox, indexer_inbox) = create_test_mailbox();
+        let doc_processor = DocProcessor::new(doc_mapper, indexer_mailbox);
+        let universe = Universe::new();
+        let (doc_processor_mailbox, doc_processor_handle) =
+            universe.spawn_actor(doc_processor).spawn();
+        let publish_lock = PublishLock::default();
+        doc_processor_mailbox
+            .send_message(NewPublishLock(publish_lock.clone()))
+            .await
+            .unwrap();
+        doc_processor_handle.process_pending_and_observe().await;
+        publish_lock.kill().await;
+        doc_processor_mailbox
+            .send_message(RawDocBatch {
+                docs: vec![
+                        r#"{"body": "happy", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:59+00:00", "response_time": 2, "response_payload": "YWJj"}"#.to_string(),
+                    ],
+                checkpoint_delta: SourceCheckpointDelta::from(0..1),
+            })
+            .await.unwrap();
+        universe
+            .send_exit_with_success(&doc_processor_mailbox)
+            .await
+            .unwrap();
+        let (exit_status, _indexer_counters) = doc_processor_handle.join().await;
+        assert!(matches!(exit_status, ActorExitStatus::Success));
+        let indexer_messages: Vec<PreparedDocBatch> = indexer_inbox.drain_for_test_typed();
+        assert!(indexer_messages.is_empty());
+    }
+}

--- a/quickwit/quickwit-indexing/src/actors/index_serializer.rs
+++ b/quickwit/quickwit-indexing/src/actors/index_serializer.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use async_trait::async_trait;
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
+use quickwit_common::runtimes::RuntimeType;
+use tokio::runtime::Handle;
+
+use crate::actors::Packager;
+use crate::models::{IndexedSplit, IndexedSplitBatch, IndexedSplitBatchBuilder};
+
+/// The index serializer takes a non-serialized split,
+/// and serializes it before passing it to the packager.
+///
+/// This is usually a CPU heavy operation.
+///
+/// Depending on the data
+/// (terms cardinality) and the index settings (sorted or not)
+/// it can range from medium IO to IO heavy.
+pub struct IndexSerializer {
+    packager_mailbox: Mailbox<Packager>,
+}
+
+impl IndexSerializer {
+    pub fn new(packager_mailbox: Mailbox<Packager>) -> Self {
+        Self { packager_mailbox }
+    }
+}
+
+#[async_trait]
+impl Actor for IndexSerializer {
+    type ObservableState = ();
+
+    fn observable_state(&self) -> Self::ObservableState {}
+
+    fn queue_capacity(&self) -> QueueCapacity {
+        QueueCapacity::Bounded(0)
+    }
+
+    fn runtime_handle(&self) -> Handle {
+        RuntimeType::Blocking.get_runtime_handle()
+    }
+}
+
+#[async_trait]
+impl Handler<IndexedSplitBatchBuilder> for IndexSerializer {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        batch_builder: IndexedSplitBatchBuilder,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        let splits: Vec<IndexedSplit> = {
+            let _protect = ctx.protect_zone();
+            batch_builder
+                .splits
+                .into_iter()
+                .map(|split_builder| split_builder.finalize())
+                .collect::<Result<_, _>>()?
+        };
+        let indexed_split_batch = IndexedSplitBatch {
+            splits,
+            checkpoint_delta: batch_builder.checkpoint_delta,
+            publish_lock: batch_builder.publish_lock,
+            date_of_birth: batch_builder.date_of_birth,
+        };
+        ctx.send_message(&self.packager_mailbox, indexed_split_batch)
+            .await?;
+        Ok(())
+    }
+}

--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -24,26 +24,27 @@ use std::time::Instant;
 
 use anyhow::Context;
 use async_trait::async_trait;
+use byte_unit::Byte;
 use fail::fail_point;
 use fnv::FnvHashMap;
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
 use quickwit_common::runtimes::RuntimeType;
 use quickwit_config::IndexingSettings;
-use quickwit_doc_mapper::{DocMapper, DocParsingError, SortBy, QUICKWIT_TOKENIZER_MANAGER};
+use quickwit_doc_mapper::{DocMapper, SortBy, QUICKWIT_TOKENIZER_MANAGER};
 use quickwit_metastore::checkpoint::{IndexCheckpointDelta, SourceCheckpointDelta};
 use quickwit_metastore::Metastore;
-use tantivy::schema::{Field, Schema, Value};
+use tantivy::schema::Schema;
 use tantivy::store::{Compressor, ZstdCompressor};
-use tantivy::{Document, IndexBuilder, IndexSettings, IndexSortByField};
+use tantivy::{IndexBuilder, IndexSettings, IndexSortByField};
 use tokio::runtime::Handle;
-use tracing::{info, warn};
+use tracing::info;
 use ulid::Ulid;
 
-use crate::actors::Packager;
+use crate::actors::IndexSerializer;
 use crate::models::{
-    IndexedSplit, IndexedSplitBatch, IndexingDirectory, IndexingPipelineId, NewPublishLock,
-    PublishLock, RawDocBatch,
+    CommitTrigger, IndexedSplitBatchBuilder, IndexedSplitBuilder, IndexingDirectory,
+    IndexingPipelineId, NewPublishLock, PreparedDoc, PreparedDocBatch, PublishLock,
 };
 
 #[derive(Debug)]
@@ -53,117 +54,43 @@ struct CommitTimeout {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct IndexerCounters {
-    /// Overall number of documents received, partitioned
-    /// into 3 categories:
-    /// - number docs that did not parse correctly.
-    /// - number docs missing a timestamp (if the index has no timestamp,
-    /// then this counter is 0)
-    /// - number of valid docs.
-    pub num_parse_errors: u64,
-    pub num_missing_fields: u64,
-    pub num_valid_docs: u64,
-
     /// Number of splits that were emitted by the indexer.
     pub num_splits_emitted: u64,
 
     /// Number of split batches that were emitted by the indexer.
     pub num_split_batches_emitted: u64,
 
-    /// Number of bytes that went through the indexer
-    /// during its entire lifetime.
-    ///
-    /// Includes both valid and invalid documents.
-    pub overall_num_bytes: u64,
-
     /// Number of (valid) documents in the current workbench.
     /// This value is used to trigger commit and for observation.
     pub num_docs_in_workbench: u64,
 }
 
-impl IndexerCounters {
-    /// Returns the overall number of docs that went through the indexer (valid or not).
-    pub fn num_processed_docs(&self) -> u64 {
-        self.num_valid_docs + self.num_parse_errors + self.num_missing_fields
-    }
-
-    /// Returns the overall number of docs that were sent to the indexer but were invalid.
-    /// (For instance, because they were missing a required field or because their because
-    /// their format was invalid)
-    pub fn num_invalid_docs(&self) -> u64 {
-        self.num_parse_errors + self.num_missing_fields
-    }
-
-    pub fn record_parsing_error(&mut self, num_bytes: u64) {
-        self.num_parse_errors += 1;
-        self.overall_num_bytes += num_bytes;
-        crate::metrics::INDEXER_METRICS
-            .parsing_errors_num_docs_total
-            .inc();
-        crate::metrics::INDEXER_METRICS
-            .parsing_errors_num_bytes_total
-            .inc_by(num_bytes);
-    }
-
-    pub fn record_missing_field(&mut self, num_bytes: u64) {
-        self.num_missing_fields += 1;
-        self.overall_num_bytes += num_bytes;
-        crate::metrics::INDEXER_METRICS
-            .missing_field_num_docs_total
-            .inc();
-        crate::metrics::INDEXER_METRICS
-            .missing_field_num_bytes_total
-            .inc_by(num_bytes);
-    }
-
-    pub fn record_valid(&mut self, num_bytes: u64) {
-        self.num_valid_docs += 1;
-        self.overall_num_bytes += num_bytes;
-        crate::metrics::INDEXER_METRICS.valid_num_docs_total.inc();
-        crate::metrics::INDEXER_METRICS
-            .valid_num_bytes_total
-            .inc_by(num_bytes);
-    }
-}
-
 struct IndexerState {
     pipeline_id: IndexingPipelineId,
     metastore: Arc<dyn Metastore>,
-    doc_mapper: Arc<dyn DocMapper>,
     indexing_directory: IndexingDirectory,
     indexing_settings: IndexingSettings,
     publish_lock: PublishLock,
-    timestamp_field_opt: Option<Field>,
     schema: Schema,
     index_settings: IndexSettings,
 }
 
-enum PrepareDocumentOutcome {
-    ParsingError,
-    MissingField,
-    Document {
-        document: Document,
-        timestamp_opt: Option<i64>,
-        partition: u64,
-    },
-}
-
 impl IndexerState {
-    fn create_indexed_split(
+    fn create_indexed_split_builder(
         &self,
         partition_id: u64,
         last_delete_opstamp: u64,
         ctx: &ActorContext<Indexer>,
-    ) -> anyhow::Result<IndexedSplit> {
+    ) -> anyhow::Result<IndexedSplitBuilder> {
         let index_builder = IndexBuilder::new()
             .settings(self.index_settings.clone())
             .schema(self.schema.clone())
             .tokenizers(QUICKWIT_TOKENIZER_MANAGER.clone());
-        let indexed_split = IndexedSplit::new_in_dir(
+        let indexed_split = IndexedSplitBuilder::new_in_dir(
             self.pipeline_id.clone(),
             partition_id,
             last_delete_opstamp,
             self.indexing_directory.scratch_directory.clone(),
-            self.indexing_settings.resources.clone(),
             index_builder,
             ctx.progress().clone(),
             ctx.kill_switch().clone(),
@@ -176,14 +103,14 @@ impl IndexerState {
         &self,
         partition_id: u64,
         last_delete_opstamp: u64,
-        splits: &'a mut FnvHashMap<u64, IndexedSplit>,
+        splits: &'a mut FnvHashMap<u64, IndexedSplitBuilder>,
         ctx: &ActorContext<Indexer>,
-    ) -> anyhow::Result<&'a mut IndexedSplit> {
+    ) -> anyhow::Result<&'a mut IndexedSplitBuilder> {
         match splits.entry(partition_id) {
             Entry::Occupied(indexed_split) => Ok(indexed_split.into_mut()),
             Entry::Vacant(vacant_entry) => {
                 let indexed_split =
-                    self.create_indexed_split(partition_id, last_delete_opstamp, ctx)?;
+                    self.create_indexed_split_builder(partition_id, last_delete_opstamp, ctx)?;
                 Ok(vacant_entry.insert(indexed_split))
             }
         }
@@ -204,6 +131,7 @@ impl IndexerState {
             publish_lock: self.publish_lock.clone(),
             date_of_birth: Instant::now(),
             last_delete_opstamp,
+            memory_usage: Byte::from_bytes(0),
         };
         Ok(workbench)
     }
@@ -235,51 +163,9 @@ impl IndexerState {
         Ok(current_indexing_workbench)
     }
 
-    fn prepare_document(&self, doc_json: String) -> PrepareDocumentOutcome {
-        // Parse the document
-        let doc_parsing_result = self.doc_mapper.doc_from_json(doc_json);
-        let (partition, document) = match doc_parsing_result {
-            Ok((partition, doc)) => (partition, doc),
-            Err(doc_parsing_error) => {
-                warn!(err=?doc_parsing_error);
-                return match doc_parsing_error {
-                    DocParsingError::RequiredFastField(_) => PrepareDocumentOutcome::MissingField,
-                    _ => PrepareDocumentOutcome::ParsingError,
-                };
-            }
-        };
-        // Extract timestamp if necessary
-        let timestamp_field = if let Some(timestamp_field) = self.timestamp_field_opt {
-            timestamp_field
-        } else {
-            // No need to check the timestamp, there are no timestamp.
-            return PrepareDocumentOutcome::Document {
-                document,
-                timestamp_opt: None,
-                partition,
-            };
-        };
-        let timestamp_opt = document
-            .get_first(timestamp_field)
-            .and_then(|value| match value {
-                Value::Date(date_time) => Some(date_time.into_timestamp_secs()),
-                value => value.as_i64(),
-            });
-        assert!(
-            timestamp_opt.is_some(),
-            "We should always have a timestamp here as doc parsing returns a `RequiredFastField` \
-             error on a missing timestamp."
-        );
-        PrepareDocumentOutcome::Document {
-            document,
-            timestamp_opt,
-            partition,
-        }
-    }
-
-    async fn process_batch(
+    async fn index_batch(
         &self,
-        batch: RawDocBatch,
+        batch: PreparedDocBatch,
         indexing_workbench_opt: &mut Option<IndexingWorkbench>,
         counters: &mut IndexerCounters,
         ctx: &ActorContext<Indexer>,
@@ -289,6 +175,7 @@ impl IndexerState {
             indexed_splits,
             publish_lock,
             last_delete_opstamp,
+            memory_usage,
             ..
         } = self
             .get_or_create_workbench(indexing_workbench_opt, ctx)
@@ -300,46 +187,37 @@ impl IndexerState {
             .source_delta
             .extend(batch.checkpoint_delta)
             .context("Batch delta does not follow indexer checkpoint")?;
-        for doc_json in batch.docs {
-            let doc_json_num_bytes = doc_json.len() as u64;
-            let prepared_doc = {
-                let _protect_zone = ctx.protect_zone();
-                self.prepare_document(doc_json)
-            };
-            match prepared_doc {
-                PrepareDocumentOutcome::ParsingError => {
-                    counters.record_parsing_error(doc_json_num_bytes);
-                }
-                PrepareDocumentOutcome::MissingField => {
-                    counters.record_missing_field(doc_json_num_bytes);
-                }
-                PrepareDocumentOutcome::Document {
-                    document,
-                    timestamp_opt,
-                    partition,
-                } => {
-                    counters.record_valid(doc_json_num_bytes);
-                    counters.num_docs_in_workbench += 1;
-                    let indexed_split = self.get_or_create_indexed_split(
-                        partition,
-                        *last_delete_opstamp,
-                        indexed_splits,
-                        ctx,
-                    )?;
-                    indexed_split.split_attrs.uncompressed_docs_size_in_bytes += doc_json_num_bytes;
-                    indexed_split.split_attrs.num_docs += 1;
-                    if let Some(timestamp) = timestamp_opt {
-                        record_timestamp(timestamp, &mut indexed_split.split_attrs.time_range);
-                    }
-                    let _protect_guard = ctx.protect_zone();
-                    indexed_split
-                        .index_writer
-                        .add_document(document)
-                        .context("Failed to add document.")?;
-                }
+        let mut memory_usage_delta: u64 = 0;
+        for doc in batch.docs {
+            let PreparedDoc {
+                doc,
+                timestamp_opt,
+                partition,
+                num_bytes,
+            } = doc;
+            counters.num_docs_in_workbench += 1;
+            let indexed_split: &mut IndexedSplitBuilder = self.get_or_create_indexed_split(
+                partition,
+                *last_delete_opstamp,
+                indexed_splits,
+                ctx,
+            )?;
+            let mem_usage_before = indexed_split.index_writer.mem_usage() as u64;
+            indexed_split.split_attrs.uncompressed_docs_size_in_bytes += num_bytes as u64;
+            indexed_split.split_attrs.num_docs += 1;
+            if let Some(timestamp) = timestamp_opt {
+                record_timestamp(timestamp, &mut indexed_split.split_attrs.time_range);
             }
+            let _protect_guard = ctx.protect_zone();
+            indexed_split
+                .index_writer
+                .add_document(doc)
+                .context("Failed to add document.")?;
+            let mem_usage_after = indexed_split.index_writer.mem_usage() as u64;
+            memory_usage_delta += mem_usage_after - mem_usage_before;
             ctx.record_progress();
         }
+        *memory_usage = Byte::from_bytes(memory_usage.get_bytes() + memory_usage_delta);
         Ok(())
     }
 }
@@ -347,7 +225,7 @@ impl IndexerState {
 /// A workbench hosts the set of `IndexedSplit` that will are being built.
 struct IndexingWorkbench {
     workbench_id: Ulid,
-    indexed_splits: FnvHashMap<u64, IndexedSplit>,
+    indexed_splits: FnvHashMap<u64, IndexedSplitBuilder>,
     checkpoint_delta: IndexCheckpointDelta,
     publish_lock: PublishLock,
     // TODO create this Instant on the source side to be more accurate.
@@ -358,11 +236,13 @@ struct IndexingWorkbench {
     // On workbench creation, we fetch from the metastore the last delete task opstamp.
     // We use this value to set the `delete_opstamp` of the workbench splits.
     last_delete_opstamp: u64,
+    // Number of bytes declared as used by tantivy.
+    memory_usage: Byte,
 }
 
 pub struct Indexer {
     indexer_state: IndexerState,
-    packager_mailbox: Mailbox<Packager>,
+    index_serializer_mailbox: Mailbox<IndexSerializer>,
     indexing_workbench_opt: Option<IndexingWorkbench>,
     metastore: Arc<dyn Metastore>,
     counters: IndexerCounters,
@@ -399,7 +279,7 @@ impl Actor for Indexer {
             | ActorExitStatus::Failure(_)
             | ActorExitStatus::Panicked => return Ok(()),
             ActorExitStatus::Quit | ActorExitStatus::Success => {
-                self.send_to_packager(CommitTrigger::NoMoreDocs, ctx)
+                self.send_to_serializer(CommitTrigger::NoMoreDocs, ctx)
                     .await?;
             }
         }
@@ -432,21 +312,21 @@ impl Handler<CommitTimeout> for Indexer {
                 return Ok(());
             }
         }
-        self.send_to_packager(CommitTrigger::Timeout, ctx).await?;
+        self.send_to_serializer(CommitTrigger::Timeout, ctx).await?;
         Ok(())
     }
 }
 
 #[async_trait]
-impl Handler<RawDocBatch> for Indexer {
+impl Handler<PreparedDocBatch> for Indexer {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        batch: RawDocBatch,
+        doc_batch: PreparedDocBatch,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        self.process_batch(batch, ctx).await
+        self.index_batch(doc_batch, ctx).await
     }
 }
 
@@ -466,13 +346,6 @@ impl Handler<NewPublishLock> for Indexer {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-enum CommitTrigger {
-    Timeout,
-    NoMoreDocs,
-    NumDocsLimit,
-}
-
 impl Indexer {
     pub fn new(
         pipeline_id: IndexingPipelineId,
@@ -480,10 +353,9 @@ impl Indexer {
         metastore: Arc<dyn Metastore>,
         indexing_directory: IndexingDirectory,
         indexing_settings: IndexingSettings,
-        packager_mailbox: Mailbox<Packager>,
+        index_serializer_mailbox: Mailbox<IndexSerializer>,
     ) -> Self {
         let schema = doc_mapper.schema();
-        let timestamp_field_opt = doc_mapper.timestamp_field(&schema);
         let sort_by_field_opt = match indexing_settings.sort_by() {
             SortBy::DocId | SortBy::Score { .. } => None,
             SortBy::FastField { field_name, order } => Some(IndexSortByField {
@@ -491,60 +363,70 @@ impl Indexer {
                 order: order.into(),
             }),
         };
-        let schema = doc_mapper.schema();
         let index_settings = IndexSettings {
             sort_by_field: sort_by_field_opt,
             docstore_blocksize: indexing_settings.docstore_blocksize,
             docstore_compression: Compressor::Zstd(ZstdCompressor {
                 compression_level: Some(indexing_settings.docstore_compression_level),
             }),
+            docstore_compress_dedicated_thread: true,
         };
         let publish_lock = PublishLock::default();
         Self {
             indexer_state: IndexerState {
                 pipeline_id,
                 metastore: metastore.clone(),
-                doc_mapper,
                 indexing_directory,
                 indexing_settings,
                 publish_lock,
-                timestamp_field_opt,
                 schema,
                 index_settings,
             },
-            packager_mailbox,
+            index_serializer_mailbox,
             indexing_workbench_opt: None,
             metastore,
             counters: IndexerCounters::default(),
         }
     }
 
-    async fn process_batch(
+    fn memory_usage(&self) -> Byte {
+        if let Some(workbench) = &self.indexing_workbench_opt {
+            workbench.memory_usage
+        } else {
+            Byte::from_bytes(0)
+        }
+    }
+
+    async fn index_batch(
         &mut self,
-        batch: RawDocBatch,
+        batch: PreparedDocBatch,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         fail_point!("indexer:batch:before");
         self.indexer_state
-            .process_batch(
+            .index_batch(
                 batch,
                 &mut self.indexing_workbench_opt,
                 &mut self.counters,
                 ctx,
             )
             .await?;
+        if self.memory_usage() >= self.indexer_state.indexing_settings.resources.heap_size {
+            self.send_to_serializer(CommitTrigger::MemoryLimit, ctx)
+                .await?;
+        }
         if self.counters.num_docs_in_workbench
             >= self.indexer_state.indexing_settings.split_num_docs_target as u64
         {
-            self.send_to_packager(CommitTrigger::NumDocsLimit, ctx)
+            self.send_to_serializer(CommitTrigger::NumDocsLimit, ctx)
                 .await?;
         }
         fail_point!("indexer:batch:after");
         Ok(())
     }
 
-    /// Extract the indexed split and send it to the Packager.
-    async fn send_to_packager(
+    /// Extract the indexed split and send it to the IndexSerializer.
+    async fn send_to_serializer(
         &mut self,
         commit_trigger: CommitTrigger,
         ctx: &ActorContext<Self>,
@@ -561,7 +443,7 @@ impl Indexer {
             return Ok(());
         };
 
-        let splits: Vec<IndexedSplit> = indexed_splits.into_values().collect();
+        let splits: Vec<IndexedSplitBuilder> = indexed_splits.into_values().collect();
 
         // Avoid producing empty split, but still update the checkpoint to avoid
         // reprocessing the same faulty documents.
@@ -593,14 +475,16 @@ impl Indexer {
         }
         let num_splits = splits.len() as u64;
         let split_ids = splits.iter().map(|split| split.split_id()).join(",");
+
         info!(commit_trigger=?commit_trigger, split_ids=%split_ids, num_docs=self.counters.num_docs_in_workbench, "send-to-packager");
         ctx.send_message(
-            &self.packager_mailbox,
-            IndexedSplitBatch {
+            &self.index_serializer_mailbox,
+            IndexedSplitBatchBuilder {
                 splits,
                 checkpoint_delta: Some(checkpoint_delta),
                 publish_lock,
                 date_of_birth,
+                commit_trigger,
             },
         )
         .await?;
@@ -613,6 +497,7 @@ impl Indexer {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -620,10 +505,11 @@ mod tests {
     use quickwit_doc_mapper::{default_doc_mapper_for_test, DefaultDocMapper, SortOrder};
     use quickwit_metastore::checkpoint::SourceCheckpointDelta;
     use quickwit_metastore::MockMetastore;
+    use tantivy::doc;
 
     use super::*;
     use crate::actors::indexer::{record_timestamp, IndexerCounters};
-    use crate::models::{IndexingDirectory, RawDocBatch};
+    use crate::models::IndexingDirectory;
 
     #[test]
     fn test_record_timestamp() {
@@ -637,7 +523,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_indexer_simple() -> anyhow::Result<()> {
+    async fn test_indexer_trigger_on_target_num_docs() -> anyhow::Result<()> {
         let pipeline_id = IndexingPipelineId {
             index_id: "test-index".to_string(),
             source_id: "test-source".to_string(),
@@ -646,13 +532,16 @@ mod tests {
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
         let last_delete_opstamp = 10;
+        let schema = doc_mapper.schema();
+        let body_field = schema.get_field("body").unwrap();
+        let timestamp_field = schema.get_field("timestamp").unwrap();
         let indexing_directory = IndexingDirectory::for_test().await?;
         let mut indexing_settings = IndexingSettings::for_test();
         indexing_settings.split_num_docs_target = 3;
         indexing_settings.sort_field = Some("timestamp".to_string());
         indexing_settings.sort_order = Some(SortOrder::Desc);
         indexing_settings.timestamp_field = Some("timestamp".to_string());
-        let (packager_mailbox, packager_inbox) = create_test_mailbox();
+        let (index_serializer_mailbox, index_serializer_inbox) = create_test_mailbox();
         let mut metastore = MockMetastore::default();
         metastore
             .expect_publish_splits()
@@ -672,66 +561,100 @@ mod tests {
             Arc::new(metastore),
             indexing_directory,
             indexing_settings,
-            packager_mailbox,
+            index_serializer_mailbox,
         );
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
         indexer_mailbox
-            .send_message(RawDocBatch {
+            .send_message(PreparedDocBatch {
                 docs: vec![
-                        r#"{"body": "happy", "response_date": "2021-12-19T16:39:57+00:00", "response_time": 12, "response_payload": "YWJj"}"#.to_string(), // missing timestamp
-                        r#"{"body": "happy", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:59+00:00", "response_time": 2, "response_payload": "YWJj"}"#.to_string(), // ok
-                        r#"{"body": "happy2", "timestamp": 1628837062, "response_date": "2021-12-19T16:40:57+00:00", "response_time": 13, "response_payload": "YWJj"}"#.to_string(), // ok
-                        "{".to_string(),                    // invalid json
-                    ],
-                checkpoint_delta: SourceCheckpointDelta::from(0..4),
+                    PreparedDoc {
+                        doc: doc!(
+                            body_field=>"this is a test document",
+                            timestamp_field=>1_662_529_435_000_001i64
+                        ),
+                        timestamp_opt: Some(1_662_529_435_000_001i64),
+                        partition: 1,
+                        num_bytes: 30,
+                    },
+                    PreparedDoc {
+                        doc: doc!(
+                            body_field=>"this is a test document 2",
+                            timestamp_field=>1_662_529_435_000_002i64
+                        ),
+                        timestamp_opt: Some(1_662_529_435_000_002i64),
+                        partition: 1,
+                        num_bytes: 30,
+                    },
+                ],
+                checkpoint_delta: SourceCheckpointDelta::from(4..6),
+            })
+            .await?;
+        indexer_mailbox
+            .send_message(PreparedDocBatch {
+                docs: vec![
+                    PreparedDoc {
+                        doc: doc!(
+                            body_field=>"this is a test document 3",
+                            timestamp_field=>1_662_529_435_000_003i64
+                        ),
+                        timestamp_opt: Some(1_662_529_435_000_003i64),
+                        partition: 1,
+                        num_bytes: 30,
+                    },
+                    PreparedDoc {
+                        doc: doc!(
+                            body_field=>"this is a test document 4",
+                            timestamp_field=>1_662_529_435_000_004i64
+                        ),
+                        timestamp_opt: Some(1_662_529_435_000_004i64),
+                        partition: 1,
+                        num_bytes: 30,
+                    },
+                ],
+                checkpoint_delta: SourceCheckpointDelta::from(6..8),
+            })
+            .await?;
+        indexer_mailbox
+            .send_message(PreparedDocBatch {
+                docs: vec![PreparedDoc {
+                    doc: doc!(
+                        body_field=>"this is a test document 5",
+                        timestamp_field=>1_662_529_435_000_005i64
+                    ),
+                    timestamp_opt: Some(1_662_529_435_000_005i64),
+                    partition: 1,
+                    num_bytes: 30,
+                }],
+                checkpoint_delta: SourceCheckpointDelta::from(8..9),
             })
             .await?;
         let indexer_counters = indexer_handle.process_pending_and_observe().await.state;
         assert_eq!(
             indexer_counters,
             IndexerCounters {
-                num_parse_errors: 1,
-                num_missing_fields: 1,
-                num_valid_docs: 2,
-                num_splits_emitted: 0,
-                num_split_batches_emitted: 0,
-                num_docs_in_workbench: 2, //< we have not reached the commit limit yet.
-                overall_num_bytes: 387,
-            }
-        );
-        indexer_mailbox
-            .send_message(
-                RawDocBatch {
-                    docs: vec![r#"{"body": "happy3", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:57+00:00", "response_time": 12, "response_payload": "YWJj"}"#.to_string()],
-                    checkpoint_delta: SourceCheckpointDelta::from(4..5),
-                }
-            )
-            .await?;
-        let indexer_counters = indexer_handle.process_pending_and_observe().await.state;
-        assert_eq!(
-            indexer_counters,
-            IndexerCounters {
-                num_parse_errors: 1,
-                num_missing_fields: 1,
-                num_valid_docs: 3,
                 num_splits_emitted: 1,
                 num_split_batches_emitted: 1,
-                num_docs_in_workbench: 0, //< the num docs in split counter has been reset.
-                overall_num_bytes: 525,
+                num_docs_in_workbench: 1, //< the num docs in split counter has been reset.
             }
         );
-        let output_messages = packager_inbox.drain_for_test();
-        assert_eq!(output_messages.len(), 1);
-        let batch = output_messages[0]
-            .downcast_ref::<IndexedSplitBatch>()
-            .unwrap();
-        assert_eq!(batch.splits[0].split_attrs.num_docs, 3);
+        let messages: Vec<IndexedSplitBatchBuilder> = index_serializer_inbox.drain_for_test_typed();
+        assert_eq!(messages.len(), 1);
+        let batch = messages.into_iter().next().unwrap();
+        assert_eq!(batch.commit_trigger, CommitTrigger::NumDocsLimit);
+        assert_eq!(batch.splits[0].split_attrs.num_docs, 4);
         assert_eq!(
             batch.splits[0].split_attrs.delete_opstamp,
             last_delete_opstamp
         );
-        let sort_by_field = batch.splits[0].index.settings().sort_by_field.as_ref();
+        let index_checkpoint = batch.checkpoint_delta.unwrap();
+        assert_eq!(index_checkpoint.source_id, "test-source");
+        assert_eq!(
+            index_checkpoint.source_delta,
+            SourceCheckpointDelta::from(4..8)
+        );
+        let first_split = batch.splits.into_iter().next().unwrap().finalize()?;
+        let sort_by_field = first_split.index.settings().sort_by_field.as_ref();
         assert!(sort_by_field.is_some());
         assert_eq!(sort_by_field.unwrap().field, "timestamp");
         assert!(sort_by_field.unwrap().order.is_desc());
@@ -739,7 +662,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_indexer_timeout() -> anyhow::Result<()> {
+    async fn test_indexer_trigger_on_memory_limit() -> anyhow::Result<()> {
         let pipeline_id = IndexingPipelineId {
             index_id: "test-index".to_string(),
             source_id: "test-source".to_string(),
@@ -748,9 +671,12 @@ mod tests {
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
         let last_delete_opstamp = 10;
+        let schema = doc_mapper.schema();
+        let body_field = schema.get_field("body").unwrap();
         let indexing_directory = IndexingDirectory::for_test().await?;
-        let indexing_settings = IndexingSettings::for_test();
-        let (packager_mailbox, packager_inbox) = create_test_mailbox();
+        let mut indexing_settings = IndexingSettings::for_test();
+        indexing_settings.resources.heap_size = Byte::from_bytes(5_000_000);
+        let (index_serializer_mailbox, index_serializer_inbox) = create_test_mailbox();
         let mut metastore = MockMetastore::default();
         metastore
             .expect_publish_splits()
@@ -770,29 +696,109 @@ mod tests {
             Arc::new(metastore),
             indexing_directory,
             indexing_settings,
-            packager_mailbox,
+            index_serializer_mailbox,
+        );
+        let universe = Universe::new();
+        let (indexer_mailbox, _indexer_handle) = universe.spawn_actor(indexer).spawn();
+
+        let make_doc = |i: u64| {
+            let mut body = String::new();
+            for val in 100 * i..100 * (i + 1) {
+                write!(&mut body, "{val} ").unwrap();
+            }
+            let num_bytes = body.len() * 2;
+            PreparedDoc {
+                doc: doc!(body_field=>body),
+                timestamp_opt: None,
+                partition: 0,
+                num_bytes,
+            }
+        };
+        for i in 0..10_000 {
+            indexer_mailbox
+                .send_message(PreparedDocBatch {
+                    docs: vec![make_doc(i)],
+                    checkpoint_delta: SourceCheckpointDelta::from(i..i + 1),
+                })
+                .await?;
+            let output_messages: Vec<IndexedSplitBatchBuilder> =
+                index_serializer_inbox.drain_for_test_typed();
+            if !output_messages.is_empty() {
+                assert_eq!(output_messages.len(), 1);
+                assert_eq!(
+                    output_messages[0].commit_trigger,
+                    CommitTrigger::MemoryLimit
+                );
+                // The following assert is not a strict one. It should help detect large
+                // regression in memory usage.
+                assert!((500..1_000).contains(&i));
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_indexer_on_timeout() -> anyhow::Result<()> {
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
+        let doc_mapper = Arc::new(default_doc_mapper_for_test());
+        let last_delete_opstamp = 10;
+        let schema = doc_mapper.schema();
+        let body_field = schema.get_field("body").unwrap();
+        let timestamp_field = schema.get_field("timestamp").unwrap();
+        let indexing_directory = IndexingDirectory::for_test().await?;
+        let indexing_settings = IndexingSettings::for_test();
+        let (index_serializer_mailbox, index_serializer_inbox) = create_test_mailbox();
+        let mut metastore = MockMetastore::default();
+        metastore
+            .expect_publish_splits()
+            .returning(move |_, splits, _, _| {
+                assert!(splits.is_empty());
+                Ok(())
+            });
+        metastore
+            .expect_last_delete_opstamp()
+            .returning(move |index_id| {
+                assert_eq!("test-index", index_id);
+                Ok(last_delete_opstamp)
+            });
+        let indexer = Indexer::new(
+            pipeline_id,
+            doc_mapper,
+            Arc::new(metastore),
+            indexing_directory,
+            indexing_settings,
+            index_serializer_mailbox,
         );
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
         indexer_mailbox
-            .send_message(
-                RawDocBatch {
-                    docs: vec![r#"{"body": "happy", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:57+00:00", "response_time": 12, "response_payload": "YWJj"}"#.to_string()],
-                    checkpoint_delta: SourceCheckpointDelta::from(0..1),
-                }
-            )
-            .await?;
+            .send_message(PreparedDocBatch {
+                docs: vec![PreparedDoc {
+                    doc: doc!(
+                        body_field=>"this is a test document 5",
+                        timestamp_field=>1_662_529_435_000_005i64
+                    ),
+                    timestamp_opt: Some(1_662_529_435_000_005i64),
+                    partition: 1,
+                    num_bytes: 30,
+                }],
+                checkpoint_delta: SourceCheckpointDelta::from(8..9),
+            })
+            .await
+            .unwrap();
         let indexer_counters = indexer_handle.process_pending_and_observe().await.state;
         assert_eq!(
             indexer_counters,
             IndexerCounters {
-                num_parse_errors: 0,
-                num_missing_fields: 0,
-                num_valid_docs: 1,
                 num_splits_emitted: 0,
                 num_split_batches_emitted: 0,
                 num_docs_in_workbench: 1,
-                overall_num_bytes: 137,
             }
         );
         universe.simulate_time_shift(Duration::from_secs(61)).await;
@@ -800,23 +806,23 @@ mod tests {
         assert_eq!(
             indexer_counters,
             IndexerCounters {
-                num_parse_errors: 0,
-                num_missing_fields: 0,
-                num_valid_docs: 1,
                 num_splits_emitted: 1,
                 num_split_batches_emitted: 1,
                 num_docs_in_workbench: 0,
-                overall_num_bytes: 137,
             }
         );
-        let output_messages = packager_inbox.drain_for_test();
-        assert_eq!(output_messages.len(), 1);
-        let indexed_split_batch = output_messages[0]
-            .downcast_ref::<IndexedSplitBatch>()
-            .unwrap();
-        assert_eq!(indexed_split_batch.splits[0].split_attrs.num_docs, 1);
+        let indexed_split_batches: Vec<IndexedSplitBatchBuilder> =
+            index_serializer_inbox.drain_for_test_typed();
+        assert_eq!(indexed_split_batches.len(), 1);
         assert_eq!(
-            indexed_split_batch.splits[0].split_attrs.delete_opstamp,
+            indexed_split_batches[0].commit_trigger,
+            CommitTrigger::Timeout
+        );
+        assert_eq!(indexed_split_batches[0].splits[0].split_attrs.num_docs, 1);
+        assert_eq!(
+            indexed_split_batches[0].splits[0]
+                .split_attrs
+                .delete_opstamp,
             last_delete_opstamp
         );
         Ok(())
@@ -831,9 +837,12 @@ mod tests {
             pipeline_ord: 0,
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
+        let schema = doc_mapper.schema();
+        let body_field = schema.get_field("body").unwrap();
+        let timestamp_field = schema.get_field("timestamp").unwrap();
         let indexing_directory = IndexingDirectory::for_test().await?;
         let indexing_settings = IndexingSettings::for_test();
-        let (packager_mailbox, packager_inbox) = create_test_mailbox();
+        let (index_serializer_mailbox, index_serializer_inbox) = create_test_mailbox();
         let mut metastore = MockMetastore::default();
         metastore
             .expect_publish_splits()
@@ -853,56 +862,52 @@ mod tests {
             Arc::new(metastore),
             indexing_directory,
             indexing_settings,
-            packager_mailbox,
+            index_serializer_mailbox,
         );
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
         indexer_mailbox
-            .send_message(
-                RawDocBatch {
-                    docs: vec![r#"{"body": "happy", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:57+00:00", "response_time": 12, "response_payload": "YWJj"}"#.to_string()],
-                    checkpoint_delta: SourceCheckpointDelta::from(0..1),
-                }
-            )
-            .await?;
+            .send_message(PreparedDocBatch {
+                docs: vec![PreparedDoc {
+                    doc: doc!(
+                        body_field=>"this is a test document 5",
+                        timestamp_field=>1_662_529_435_000_005i64
+                    ),
+                    timestamp_opt: Some(1_662_529_435_000_005i64),
+                    partition: 1,
+                    num_bytes: 30,
+                }],
+                checkpoint_delta: SourceCheckpointDelta::from(8..9),
+            })
+            .await
+            .unwrap();
         universe.send_exit_with_success(&indexer_mailbox).await?;
         let (exit_status, indexer_counters) = indexer_handle.join().await;
         assert!(exit_status.is_success());
         assert_eq!(
             indexer_counters,
             IndexerCounters {
-                num_parse_errors: 0,
-                num_missing_fields: 0,
-                num_valid_docs: 1,
                 num_splits_emitted: 1,
                 num_split_batches_emitted: 1,
                 num_docs_in_workbench: 0,
-                overall_num_bytes: 137,
             }
         );
-        let output_messages = packager_inbox.drain_for_test();
+        let output_messages: Vec<IndexedSplitBatchBuilder> =
+            index_serializer_inbox.drain_for_test_typed();
         assert_eq!(output_messages.len(), 1);
-        assert_eq!(
-            output_messages[0]
-                .downcast_ref::<IndexedSplitBatch>()
-                .unwrap()
-                .splits[0]
-                .split_attrs
-                .num_docs,
-            1
-        );
+        assert_eq!(output_messages[0].commit_trigger, CommitTrigger::NoMoreDocs);
+        assert_eq!(output_messages[0].splits[0].split_attrs.num_docs, 1);
         Ok(())
     }
 
-    const DOCMAPPER_WITH_PARTITION_JSON: &str = r#"
-        {
-            "tag_fields": ["tenant"],
-            "partition_key": "tenant",
-            "field_mappings": [
-                { "name": "tenant", "type": "text", "tokenizer": "raw", "indexed": true },
-                { "name": "body", "type": "text" }
-            ]
-        }"#;
+    const DOCMAPPER_WITH_PARTITION_JSON: &str = r#"{
+        "tag_fields": ["tenant"],
+        "partition_key": "tenant",
+        "field_mappings": [
+            { "name": "tenant", "type": "text", "tokenizer": "raw", "indexed": true },
+            { "name": "body", "type": "text" }
+        ]
+    }"#;
 
     #[tokio::test]
     async fn test_indexer_partitioning() -> anyhow::Result<()> {
@@ -915,6 +920,10 @@ mod tests {
         let doc_mapper: Arc<dyn DocMapper> = Arc::new(
             serde_json::from_str::<DefaultDocMapper>(DOCMAPPER_WITH_PARTITION_JSON).unwrap(),
         );
+        let schema = doc_mapper.schema();
+        let tenant_field = schema.get_field("tenant").unwrap();
+        let body_field = schema.get_field("body").unwrap();
+
         let indexing_directory = IndexingDirectory::for_test().await?;
         let indexing_settings = IndexingSettings::for_test();
         let (packager_mailbox, packager_inbox) = create_test_mailbox();
@@ -942,13 +951,28 @@ mod tests {
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
         indexer_mailbox
-            .send_message(RawDocBatch {
+            .send_message(PreparedDocBatch {
                 docs: vec![
-                    r#"{"tenant": "tenant_1", "body": "first doc for tenant 1"}"#.to_string(),
-                    r#"{"tenant": "tenant_2", "body": "first doc for tenant 2"}"#.to_string(),
-                    r#"{"tenant": "tenant_1", "body": "second doc for tenant 1"}"#.to_string(),
+                    PreparedDoc {
+                        doc: doc!(
+                            body_field=>"doc 2",
+                            tenant_field=>"tenant_1",
+                        ),
+                        timestamp_opt: None,
+                        partition: 1,
+                        num_bytes: 30,
+                    },
+                    PreparedDoc {
+                        doc: doc!(
+                            body_field=>"doc 2",
+                            tenant_field=>"tenant_2",
+                        ),
+                        timestamp_opt: None,
+                        partition: 3,
+                        num_bytes: 30,
+                    },
                 ],
-                checkpoint_delta: SourceCheckpointDelta::from(0..2),
+                checkpoint_delta: SourceCheckpointDelta::from(8..9),
             })
             .await?;
 
@@ -956,13 +980,9 @@ mod tests {
         assert_eq!(
             indexer_counters,
             IndexerCounters {
-                num_parse_errors: 0,
-                num_missing_fields: 0,
-                num_valid_docs: 3,
-                num_docs_in_workbench: 3,
+                num_docs_in_workbench: 2,
                 num_splits_emitted: 0,
                 num_split_batches_emitted: 0,
-                overall_num_bytes: 169,
             }
         );
         universe.send_exit_with_success(&indexer_mailbox).await?;
@@ -971,25 +991,20 @@ mod tests {
         assert_eq!(
             indexer_counters,
             IndexerCounters {
-                num_parse_errors: 0,
-                num_missing_fields: 0,
-                num_valid_docs: 3,
                 num_docs_in_workbench: 0,
                 num_splits_emitted: 2,
                 num_split_batches_emitted: 1,
-                overall_num_bytes: 169,
             }
         );
-
-        let output_messages = packager_inbox.drain_for_test();
-        assert_eq!(output_messages.len(), 1);
-
-        let indexed_split_batch = output_messages[0]
-            .downcast_ref::<IndexedSplitBatch>()
-            .unwrap();
-        assert_eq!(indexed_split_batch.splits.len(), 2);
+        let split_batches: Vec<IndexedSplitBatchBuilder> = packager_inbox.drain_for_test_typed();
+        assert_eq!(split_batches.len(), 1);
+        assert_eq!(split_batches[0].splits.len(), 2);
         Ok(())
     }
+
+    const DOCMAPPER_SIMPLE_JSON: &str = r#"{
+        "field_mappings": [{"name": "body", "type": "text"}]
+    }"#;
 
     #[tokio::test]
     async fn test_indexer_propagates_publish_lock() {
@@ -999,7 +1014,9 @@ mod tests {
             node_id: "test-node".to_string(),
             pipeline_ord: 0,
         };
-        let doc_mapper = Arc::new(default_doc_mapper_for_test());
+        let doc_mapper: Arc<dyn DocMapper> =
+            Arc::new(serde_json::from_str::<DefaultDocMapper>(DOCMAPPER_SIMPLE_JSON).unwrap());
+        let body_field = doc_mapper.schema().get_field("body").unwrap();
         let indexing_directory = IndexingDirectory::for_test().await.unwrap();
         let mut indexing_settings = IndexingSettings::for_test();
         indexing_settings.split_num_docs_target = 1;
@@ -1023,22 +1040,26 @@ mod tests {
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
 
-        for id in ["foo-publish-lock", "bar-publish-lock"] {
-            let publish_lock = PublishLock::for_test(true, id);
+        let first_lock = PublishLock::default();
+        let second_lock = PublishLock::default();
 
+        for lock in [&first_lock, &second_lock] {
             indexer_mailbox
-                .send_message(NewPublishLock(publish_lock))
+                .send_message(NewPublishLock(lock.clone()))
                 .await
                 .unwrap();
-
             indexer_mailbox
-            .send_message(RawDocBatch {
-                docs: vec![
-                        r#"{"body": "happy", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:59+00:00", "response_time": 2, "response_payload": "YWJj"}"#.to_string(),
-                    ],
-                checkpoint_delta: SourceCheckpointDelta::from(0..1),
-            })
-            .await.unwrap();
+                .send_message(PreparedDocBatch {
+                    docs: vec![PreparedDoc {
+                        doc: doc!(body_field=>"doc 1"),
+                        timestamp_opt: None,
+                        partition: 0,
+                        num_bytes: 30,
+                    }],
+                    checkpoint_delta: SourceCheckpointDelta::from(0..1),
+                })
+                .await
+                .unwrap();
         }
         universe
             .send_exit_with_success(&indexer_mailbox)
@@ -1047,12 +1068,13 @@ mod tests {
         let (exit_status, _indexer_counters) = indexer_handle.join().await;
         assert!(matches!(exit_status, ActorExitStatus::Success));
 
-        let packager_messages: Vec<IndexedSplitBatch> = packager_inbox.drain_for_test_typed();
+        let packager_messages: Vec<IndexedSplitBatchBuilder> =
+            packager_inbox.drain_for_test_typed();
         assert_eq!(packager_messages.len(), 2);
         assert_eq!(packager_messages[0].splits.len(), 1);
-        assert_eq!(packager_messages[0].publish_lock.id, "foo-publish-lock");
+        assert_eq!(packager_messages[0].publish_lock, first_lock);
         assert_eq!(packager_messages[1].splits.len(), 1);
-        assert_eq!(packager_messages[1].publish_lock.id, "bar-publish-lock");
+        assert_eq!(packager_messages[1].publish_lock, second_lock);
     }
 
     #[tokio::test]
@@ -1063,7 +1085,9 @@ mod tests {
             node_id: "test-node".to_string(),
             pipeline_ord: 0,
         };
-        let doc_mapper = Arc::new(default_doc_mapper_for_test());
+        let doc_mapper: Arc<dyn DocMapper> =
+            Arc::new(serde_json::from_str::<DefaultDocMapper>(DOCMAPPER_SIMPLE_JSON).unwrap());
+        let body_field = doc_mapper.schema().get_field("body").unwrap();
         let indexing_directory = IndexingDirectory::for_test().await.unwrap();
         let mut indexing_settings = IndexingSettings::for_test();
         indexing_settings.split_num_docs_target = 1;
@@ -1087,83 +1111,25 @@ mod tests {
         let universe = Universe::new();
         let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
 
-        let publish_lock = PublishLock::for_test(false, "foo-publish-lock");
-
-        indexer_mailbox
-            .send_message(NewPublishLock(publish_lock))
-            .await
-            .unwrap();
-
-        indexer_mailbox
-            .send_message(RawDocBatch {
-                docs: vec![
-                        r#"{"body": "happy", "timestamp": 1628837062, "response_date": "2021-12-19T16:39:59+00:00", "response_time": 2, "response_payload": "YWJj"}"#.to_string(),
-                    ],
-                checkpoint_delta: SourceCheckpointDelta::from(0..1),
-            })
-            .await.unwrap();
-
-        universe
-            .send_exit_with_success(&indexer_mailbox)
-            .await
-            .unwrap();
-        let (exit_status, _indexer_counters) = indexer_handle.join().await;
-        assert!(matches!(exit_status, ActorExitStatus::Success));
-
-        let packager_messages = packager_inbox.drain_for_test();
-        assert!(packager_messages.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_indexer_acquires_publish_lock() {
-        let pipeline_id = IndexingPipelineId {
-            index_id: "test-index".to_string(),
-            source_id: "test-source".to_string(),
-            node_id: "test-node".to_string(),
-            pipeline_ord: 0,
-        };
-        let doc_mapper = Arc::new(default_doc_mapper_for_test());
-        let indexing_directory = IndexingDirectory::for_test().await.unwrap();
-        let indexing_settings = IndexingSettings::for_test();
-        let mut metastore = MockMetastore::default();
-        metastore
-            .expect_last_delete_opstamp()
-            .returning(move |index_id| {
-                assert_eq!("test-index", index_id);
-                Ok(10)
-            });
-        metastore.expect_publish_splits().never();
-        let (packager_mailbox, packager_inbox) = create_test_mailbox();
-        let indexer = Indexer::new(
-            pipeline_id,
-            doc_mapper,
-            Arc::new(metastore),
-            indexing_directory,
-            indexing_settings,
-            packager_mailbox,
-        );
-        let universe = Universe::new();
-        let (indexer_mailbox, indexer_handle) = universe.spawn_actor(indexer).spawn();
-
-        let publish_lock = PublishLock::for_test(true, "foo-publish-lock");
-
+        let publish_lock = PublishLock::default();
         indexer_mailbox
             .send_message(NewPublishLock(publish_lock.clone()))
             .await
             .unwrap();
-
+        indexer_handle.process_pending_and_observe().await;
+        publish_lock.kill().await;
         indexer_mailbox
-            .send_message(RawDocBatch {
-                docs: vec![
-                    "{".to_string(), // Bad JSON
-                ],
+            .send_message(PreparedDocBatch {
+                docs: vec![PreparedDoc {
+                    doc: doc!(body_field=>"doc 1"),
+                    timestamp_opt: None,
+                    partition: 0,
+                    num_bytes: 30,
+                }],
                 checkpoint_delta: SourceCheckpointDelta::from(0..1),
             })
             .await
             .unwrap();
-
-        publish_lock.kill().await;
-
         universe
             .send_exit_with_success(&indexer_mailbox)
             .await

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -347,8 +347,6 @@ impl MergeExecutor {
 
         let merged_index = open_index(controlled_directory.clone())?;
         ctx.record_progress();
-        let index_writer = merged_index.writer_with_num_threads(1, 3_000_000)?;
-        ctx.record_progress();
 
         let indexed_split = IndexedSplit {
             split_attrs: SplitAttrs {
@@ -362,7 +360,6 @@ impl MergeExecutor {
                 delete_opstamp,
             },
             index: merged_index,
-            index_writer,
             split_scratch_directory: merge_scratch_directory,
             controlled_directory_opt: Some(controlled_directory),
         };
@@ -445,7 +442,6 @@ impl MergeExecutor {
         ctx.record_progress();
         merged_index.set_tokenizers(QUICKWIT_TOKENIZER_MANAGER.clone());
 
-        let index_writer = merged_index.writer_with_num_threads(1, 3_000_000)?;
         ctx.record_progress();
 
         // Compute merged split attributes.
@@ -493,7 +489,6 @@ impl MergeExecutor {
                 delete_opstamp: last_delete_opstamp,
             },
             index: merged_index,
-            index_writer,
             split_scratch_directory: merge_scratch_directory,
             controlled_directory_opt: Some(controlled_directory),
         };

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -19,6 +19,8 @@
 
 mod indexing_pipeline;
 
+mod doc_processor;
+mod index_serializer;
 mod indexer;
 mod indexing_service;
 mod ingest_api_garbage_collector;
@@ -37,6 +39,8 @@ mod merge_executor;
 mod merge_planner;
 mod merge_split_downloader;
 
+pub use self::doc_processor::{DocProcessor, DocProcessorCounters};
+pub use self::index_serializer::IndexSerializer;
 pub use self::indexer::{Indexer, IndexerCounters};
 pub use self::ingest_api_garbage_collector::{
     IngestApiGarbageCollector, IngestApiGarbageCollectorCounters,

--- a/quickwit/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit/quickwit-indexing/src/models/indexed_split.rs
@@ -22,22 +22,32 @@ use std::path::Path;
 use std::time::Instant;
 
 use quickwit_actors::{KillSwitch, Progress};
-use quickwit_config::IndexingResources;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use tantivy::directory::MmapDirectory;
-use tantivy::merge_policy::NoMergePolicy;
 use tantivy::IndexBuilder;
 
 use crate::controlled_directory::ControlledDirectory;
 use crate::models::{IndexingPipelineId, PublishLock, ScratchDirectory, SplitAttrs};
 use crate::new_split_id;
 
+pub struct IndexedSplitBuilder {
+    pub split_attrs: SplitAttrs,
+    pub index_writer: tantivy::SingleSegmentIndexWriter,
+    pub split_scratch_directory: ScratchDirectory,
+    pub controlled_directory_opt: Option<ControlledDirectory>,
+}
+
 pub struct IndexedSplit {
     pub split_attrs: SplitAttrs,
     pub index: tantivy::Index,
-    pub index_writer: tantivy::IndexWriter,
     pub split_scratch_directory: ScratchDirectory,
     pub controlled_directory_opt: Option<ControlledDirectory>,
+}
+
+impl IndexedSplit {
+    pub fn split_id(&self) -> &str {
+        &self.split_attrs.split_id
+    }
 }
 
 impl fmt::Debug for IndexedSplit {
@@ -51,14 +61,23 @@ impl fmt::Debug for IndexedSplit {
     }
 }
 
-impl IndexedSplit {
-    #[allow(clippy::too_many_arguments)]
+impl fmt::Debug for IndexedSplitBuilder {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("IndexedSplitBuilder")
+            .field("id", &self.split_attrs.split_id)
+            .field("dir", &self.split_scratch_directory.path())
+            .field("num_docs", &self.split_attrs.num_docs)
+            .finish()
+    }
+}
+
+impl IndexedSplitBuilder {
     pub fn new_in_dir(
         pipeline_id: IndexingPipelineId,
         partition_id: u64,
         last_delete_opstamp: u64,
         scratch_directory: ScratchDirectory,
-        indexing_resources: IndexingResources,
         index_builder: IndexBuilder,
         progress: Progress,
         kill_switch: KillSwitch,
@@ -74,29 +93,32 @@ impl IndexedSplit {
         let box_mmap_directory = Box::new(mmap_directory);
         let controlled_directory =
             ControlledDirectory::new(box_mmap_directory, progress, kill_switch);
-        let index = index_builder.open_or_create(controlled_directory.clone())?;
-        let index_writer = index.writer_with_num_threads(
-            1, // DO NOT MODIFY THIS!
-            // This is not something that we want to use in quickwit.
-            indexing_resources.heap_size.get_bytes() as usize,
-        )?;
-        let split_attrs = SplitAttrs {
-            split_id,
-            partition_id,
-            pipeline_id,
-            num_docs: 0,
-            uncompressed_docs_size_in_bytes: 0,
-            time_range: None,
-            replaced_split_ids: Vec::new(),
-            delete_opstamp: last_delete_opstamp,
-        };
-        index_writer.set_merge_policy(Box::new(NoMergePolicy));
-        Ok(IndexedSplit {
-            split_attrs,
-            index,
+        let index_writer =
+            index_builder.single_segment_index_writer(controlled_directory.clone(), 10_000_000)?;
+        Ok(Self {
+            split_attrs: SplitAttrs {
+                pipeline_id,
+                partition_id,
+                split_id,
+                num_docs: 0,
+                replaced_split_ids: Vec::new(),
+                uncompressed_docs_size_in_bytes: 0,
+                time_range: None,
+                delete_opstamp: last_delete_opstamp,
+            },
             index_writer,
             split_scratch_directory,
             controlled_directory_opt: Some(controlled_directory),
+        })
+    }
+
+    pub fn finalize(self) -> anyhow::Result<IndexedSplit> {
+        let index = self.index_writer.finalize()?;
+        Ok(IndexedSplit {
+            split_attrs: self.split_attrs,
+            index,
+            split_scratch_directory: self.split_scratch_directory,
+            controlled_directory_opt: self.controlled_directory_opt,
         })
     }
 
@@ -115,4 +137,21 @@ pub struct IndexedSplitBatch {
     pub checkpoint_delta: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
     pub date_of_birth: Instant,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitTrigger {
+    Timeout,
+    NoMoreDocs,
+    NumDocsLimit,
+    MemoryLimit,
+}
+
+#[derive(Debug)]
+pub struct IndexedSplitBatchBuilder {
+    pub splits: Vec<IndexedSplitBuilder>,
+    pub checkpoint_delta: Option<IndexCheckpointDelta>,
+    pub publish_lock: PublishLock,
+    pub date_of_birth: Instant,
+    pub commit_trigger: CommitTrigger,
 }

--- a/quickwit/quickwit-indexing/src/models/indexing_statistics.rs
+++ b/quickwit/quickwit-indexing/src/models/indexing_statistics.rs
@@ -19,7 +19,7 @@
 
 use std::sync::atomic::Ordering;
 
-use crate::actors::{IndexerCounters, PublisherCounters, UploaderCounters};
+use crate::actors::{DocProcessorCounters, IndexerCounters, PublisherCounters, UploaderCounters};
 
 /// A Struct that holds all statistical data about indexing
 #[derive(Clone, Debug, Default)]
@@ -49,14 +49,15 @@ pub struct IndexingStatistics {
 impl IndexingStatistics {
     pub fn add_actor_counters(
         mut self,
+        doc_processor_counters: &DocProcessorCounters,
         indexer_counters: &IndexerCounters,
         uploader_counters: &UploaderCounters,
         publisher_counters: &PublisherCounters,
     ) -> Self {
-        self.num_docs += indexer_counters.num_processed_docs();
-        self.num_invalid_docs += indexer_counters.num_invalid_docs();
+        self.num_docs += doc_processor_counters.num_processed_docs();
+        self.num_invalid_docs += doc_processor_counters.num_invalid_docs();
         self.num_local_splits += indexer_counters.num_splits_emitted;
-        self.total_bytes_processed += indexer_counters.overall_num_bytes;
+        self.total_bytes_processed += doc_processor_counters.overall_num_bytes;
         self.num_staged_splits += uploader_counters.num_staged_splits.load(Ordering::SeqCst);
         self.num_uploaded_splits += uploader_counters.num_uploaded_splits.load(Ordering::SeqCst);
         self.num_published_splits += publisher_counters.num_published_splits;

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -25,13 +25,16 @@ mod indexing_statistics;
 mod merge_planner_message;
 mod merge_scratch;
 mod packaged_split;
+mod prepared_doc;
 mod publish_lock;
 mod publisher_message;
 mod raw_doc_batch;
 mod scratch_directory;
 mod split_attrs;
 
-pub use indexed_split::{IndexedSplit, IndexedSplitBatch};
+pub use indexed_split::{
+    CommitTrigger, IndexedSplit, IndexedSplitBatch, IndexedSplitBatchBuilder, IndexedSplitBuilder,
+};
 pub use indexing_directory::{IndexingDirectory, CACHE};
 pub use indexing_pipeline_id::IndexingPipelineId;
 pub use indexing_service_message::{
@@ -42,6 +45,7 @@ pub use indexing_statistics::IndexingStatistics;
 pub use merge_planner_message::NewSplits;
 pub use merge_scratch::MergeScratch;
 pub use packaged_split::{PackagedSplit, PackagedSplitBatch};
+pub use prepared_doc::{PreparedDoc, PreparedDocBatch};
 pub use publish_lock::{NewPublishLock, PublishLock};
 pub use publisher_message::SplitUpdate;
 pub use raw_doc_batch::RawDocBatch;

--- a/quickwit/quickwit-indexing/src/models/prepared_doc.rs
+++ b/quickwit/quickwit-indexing/src/models/prepared_doc.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt;
+
+use quickwit_metastore::checkpoint::SourceCheckpointDelta;
+use tantivy::Document;
+
+pub struct PreparedDoc {
+    pub doc: Document,
+    pub timestamp_opt: Option<i64>,
+    pub partition: u64,
+    pub num_bytes: usize,
+}
+
+#[derive(Debug)]
+pub struct PreparedDocBatch {
+    pub docs: Vec<PreparedDoc>,
+    pub checkpoint_delta: SourceCheckpointDelta,
+}
+
+impl fmt::Debug for PreparedDoc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedDoc")
+            .field("timestamp_opt", &self.timestamp_opt)
+            .field("partition", &self.partition)
+            .field("num_bytes", &self.num_bytes)
+            .finish()
+    }
+}

--- a/quickwit/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit/quickwit-indexing/src/source/void_source.rs
@@ -25,7 +25,7 @@ use quickwit_actors::{ActorExitStatus, Mailbox, HEARTBEAT};
 use quickwit_config::VoidSourceParams;
 use quickwit_metastore::checkpoint::SourceCheckpoint;
 
-use crate::actors::Indexer;
+use crate::actors::DocProcessor;
 use crate::source::{Source, SourceContext, SourceExecutionContext, TypedSourceFactory};
 
 pub struct VoidSource;
@@ -34,7 +34,7 @@ pub struct VoidSource;
 impl Source for VoidSource {
     async fn emit_batches(
         &mut self,
-        _: &Mailbox<Indexer>,
+        _: &Mailbox<DocProcessor>,
         _: &SourceContext,
     ) -> Result<Duration, ActorExitStatus> {
         tokio::time::sleep(HEARTBEAT / 2).await;
@@ -112,10 +112,10 @@ mod tests {
             SourceCheckpoint::default(),
         )
         .await?;
-        let (indexer_mailbox, _) = create_test_mailbox();
+        let (doc_processor_mailbox, _) = create_test_mailbox();
         let void_source_actor = SourceActor {
             source: Box::new(void_source),
-            indexer_mailbox,
+            doc_processor_mailbox,
         };
         let universe = Universe::new();
         let (_, void_source_handle) = universe.spawn_actor(void_source_actor).spawn();

--- a/quickwit/quickwit-janitor/Cargo.toml
+++ b/quickwit/quickwit-janitor/Cargo.toml
@@ -29,7 +29,7 @@ quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
+++ b/quickwit/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
@@ -166,11 +166,8 @@ pub(crate) fn sample_index_metadata_for_regression() -> IndexMetadata {
         sort_order: Some(SortOrder::Asc),
         commit_timeout_secs: 301,
         split_num_docs_target: 10_000_001,
-        merge_enabled: true,
         merge_policy,
         resources: indexing_resources,
-        docstore_blocksize: IndexingSettings::default_docstore_blocksize(),
-        docstore_compression_level: IndexingSettings::default_docstore_compression_level(),
         ..Default::default()
     };
     let search_settings = SearchSettings {

--- a/quickwit/quickwit-search/Cargo.toml
+++ b/quickwit/quickwit-search/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.13"
 bytes = "1"
 futures = "0.3"
 http = "0.2"
-fastfield_codecs = { git="https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3"}
+fastfield_codecs = { git="https://github.com/quickwit-oss/tantivy/", rev = "e029fdf"}
 hyper = { version = "0.14", features = [
   "stream",
   "server",
@@ -41,7 +41,7 @@ quickwit-storage = { version = "0.3.1", path = "../quickwit-storage" }
 rayon = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -33,7 +33,7 @@ rusoto_s3 = { version = "0.48", default-features = false, features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ea72cf3", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e029fdf", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",


### PR DESCRIPTION
### Description

This PR changes the threading model of indexing in order to deal with high number of partitions.

## Before the PR

- building tantivy document was done in the indexer task
- updating the in-memory datastructure used to build the index was done in an index spawned by tantivy's IndexWriter. One index per-partition. <- this was the problematic part.
- docstore building (mostly zstd compression) was also done on a tantivy dedicated thread.
- index serialization (tantivy's `index_writer::commit`) was done in the packager.


## After the PR

- building tantivy document was done in a different actor called DocProcessor
- updating the in-memory datastructure used to build the index is done in the indexer taks directly, using a new API added in tantivy.
- docstore building (mostly zstd compression) is still done in a tantivy dedicated thread.
- index serialization (tantivy's `index_writer::commit`) is done in a new dedicated actor called IndexSerializer.

The packager now takes a seiralized indexed,making it more natural for the merge and the indexing pipeline
to share its code.

### Missing

- Trigger commit on RAM limit.

Closes #1900