### PR TITLE
Fix docs build issue - broken link.

### DIFF
--- a/docs/reference/storage-uri.md
+++ b/docs/reference/storage-uri.md
@@ -92,5 +92,5 @@ export AWS_ACCESS_KEY_ID=***
 ```
 
 :::note
-We also support Azure storage, however since it is not S3-Compatible, you can refer to our [Azure Setup Guide](/docs/guides/azure-setup.md) for more info and steps to connect. 
+We also support Azure storage, however since it is not S3-Compatible, you can refer to our [Azure Setup Guide](/docs/guides/azure-setup) for more info and steps to connect. 
 :::


### PR DESCRIPTION
### Description

It seems that there was an extra .md in the link, which didn't let docs to build. 

### How was this PR tested?

Tested by removing it locally.
