### PR TITLE
Cluster setup not using the correct advertise address for grpc

### DIFF
--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -85,7 +85,7 @@ pub async fn start_cluster_service(
         unix_timestamp(),
         quickwit_config.gossip_advertise_addr,
         services.clone(),
-        quickwit_config.grpc_listen_addr,
+        quickwit_config.grpc_advertise_addr,
     );
 
     let cluster = Cluster::join(


### PR DESCRIPTION
### Description

Cluster setup was losing the advertise address set in `QW_ADVERTISE_ADDRESS` which prevents the cluster from working in K8s with a separate Metastore process.

```
2022-09-02T16:25:44.514Z  INFO quickwit_config::config: Using advertise address from environment variable `QW_ADVERTISE_ADDRESS`. advertise_address=192.168.86.168
...
2022-09-02T16:25:44.519Z  INFO quickwit_cluster::cluster: Joining cluster. cluster_id=quickwit-default-cluster node_id=node-1 grpc_public_addr=127.0.0.1:7281 available_services={Indexer, Searcher, Metastore} gossip_listen_addr=127.0.0.1:7280 gossip_public_addr=192.168.86.168:7280 peer_seed_addrs=
```

### How was this PR tested?

```
make test-all
```

Manual testing to confirm correct address shows up.

```
2022-09-02T16:11:03.488Z  INFO quickwit_config::config: Using advertise address from environment variable `QW_ADVERTISE_ADDRESS`. advertise_address=192.168.86.168
...
2022-09-02T16:11:03.492Z  INFO quickwit_cluster::cluster: Joining cluster. cluster_id=quickwit-default-cluster node_id=node-1 grpc_public_addr=192.168.86.168:7281 available_services={Searcher, Indexer, Metastore} gossip_listen_addr=127.0.0.1:7280 gossip_public_addr=192.168.86.168:7280 peer_seed_addrs=

```
