### PR TITLE
Add delete query REST API.

### DIFF
--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -94,7 +94,7 @@ impl Actor for DeleteTaskPipeline {
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
         self.spawn_pipeline(ctx).await?;
-        self.handle(SuperviseLoop, ctx).await?;
+        self.handle(DeletePipelineSuperviseLoop, ctx).await?;
         Ok(())
     }
 }
@@ -241,15 +241,15 @@ impl DeleteTaskPipeline {
 }
 
 #[derive(Debug)]
-struct SuperviseLoop;
+pub(crate) struct DeletePipelineSuperviseLoop;
 
 #[async_trait]
-impl Handler<SuperviseLoop> for DeleteTaskPipeline {
+impl Handler<DeletePipelineSuperviseLoop> for DeleteTaskPipeline {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _: SuperviseLoop,
+        _: DeletePipelineSuperviseLoop,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         if self.handles.is_some() {
@@ -279,7 +279,8 @@ impl Handler<SuperviseLoop> for DeleteTaskPipeline {
                 );
             }
         }
-        ctx.schedule_self_msg(SUPERVISE_DELAY, SuperviseLoop).await;
+        ctx.schedule_self_msg(SUPERVISE_DELAY, DeletePipelineSuperviseLoop)
+            .await;
         Ok(())
     }
 }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -241,7 +241,7 @@ impl DeleteTaskPipeline {
 }
 
 #[derive(Debug)]
-pub(crate) struct DeletePipelineSuperviseLoop;
+struct DeletePipelineSuperviseLoop;
 
 #[async_trait]
 impl Handler<DeletePipelineSuperviseLoop> for DeleteTaskPipeline {
@@ -356,7 +356,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let data_dir_path = temp_dir.path().to_path_buf();
         let mut indexing_settings = IndexingSettings::for_test();
-        indexing_settings.split_num_docs_target = 1; //
+        // Ensures that all split will be mature and thus be candidates for deletion.
+        indexing_settings.split_num_docs_target = 1;
         let pipeline = DeleteTaskPipeline::new(
             index_id.to_string(),
             metastore.clone(),

--- a/quickwit/quickwit-janitor/src/actors/mod.rs
+++ b/quickwit/quickwit-janitor/src/actors/mod.rs
@@ -23,6 +23,6 @@ mod delete_task_service;
 mod garbage_collector;
 mod retention_policy_executor;
 
-pub use delete_task_service::{DeleteTaskService, NewDeleteTask};
+pub use delete_task_service::DeleteTaskService;
 pub use garbage_collector::GarbageCollector;
 pub use retention_policy_executor::RetentionPolicyExecutor;

--- a/quickwit/quickwit-janitor/src/janitor_service.rs
+++ b/quickwit/quickwit-janitor/src/janitor_service.rs
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use quickwit_actors::ActorHandle;
+use quickwit_actors::{ActorHandle, Mailbox};
 
 use crate::actors::{DeleteTaskService, GarbageCollector, RetentionPolicyExecutor};
 
 pub struct JanitorService {
     _garbage_collector_handle: ActorHandle<GarbageCollector>,
     _retention_policy_executor_handle: ActorHandle<RetentionPolicyExecutor>,
-    _delete_task_service_handle: ActorHandle<DeleteTaskService>,
+    delete_task_service_handle: ActorHandle<DeleteTaskService>,
 }
 
 impl JanitorService {
@@ -36,7 +36,11 @@ impl JanitorService {
         Self {
             _garbage_collector_handle: garbage_collector_handle,
             _retention_policy_executor_handle: retention_policy_executor_handle,
-            _delete_task_service_handle: delete_task_service_handle,
+            delete_task_service_handle,
         }
+    }
+
+    pub fn delete_task_service_mailbox(&self) -> &Mailbox<DeleteTaskService> {
+        self.delete_task_service_handle.mailbox()
     }
 }

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0-b3d35a1f7e54163927ae797e03ecb6ba.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0-b3d35a1f7e54163927ae797e03ecb6ba.expected.json
@@ -3,11 +3,9 @@
     {
       "create_timestamp": 0,
       "delete_query": {
-        "end_timestamp": null,
         "index_id": "index",
         "query": "Harry Potter",
-        "search_fields": [],
-        "start_timestamp": null
+        "search_fields": []
       },
       "opstamp": 10
     }

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0-b3d35a1f7e54163927ae797e03ecb6ba.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0-b3d35a1f7e54163927ae797e03ecb6ba.json
@@ -3,11 +3,9 @@
     {
       "create_timestamp": 0,
       "delete_query": {
-        "end_timestamp": null,
         "index_id": "index",
         "query": "Harry Potter",
-        "search_fields": [],
-        "start_timestamp": null
+        "search_fields": []
       },
       "opstamp": 10
     }

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -38,6 +38,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     prost_config.protoc_arg("--experimental_allow_proto3_optional");
     tonic_build::configure()
         .type_attribute(".", "#[derive(Serialize, Deserialize)]")
+        .type_attribute("DeleteQuery", "#[serde(default)]")
+        .field_attribute(
+            "DeleteQuery.start_timestamp",
+            "#[serde(skip_serializing_if = \"Option::is_none\")]",
+        )
+        .field_attribute(
+            "DeleteQuery.end_timestamp",
+            "#[serde(skip_serializing_if = \"Option::is_none\")]",
+        )
         .type_attribute("OutputFormat", "#[serde(rename_all = \"snake_case\")]")
         .out_dir("src/")
         .compile_with_config(

--- a/quickwit/quickwit-proto/src/quickwit_metastore_api.rs
+++ b/quickwit/quickwit-proto/src/quickwit_metastore_api.rs
@@ -153,6 +153,7 @@ pub struct DeleteTask {
     pub delete_query: ::core::option::Option<DeleteQuery>,
 }
 #[derive(Serialize, Deserialize)]
+#[serde(default)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteQuery {
     /// / Index ID.
@@ -160,9 +161,11 @@ pub struct DeleteQuery {
     pub index_id: ::prost::alloc::string::String,
     /// / If set, restrict search to documents with a `timestamp >= start_timestamp`.
     #[prost(int64, optional, tag="2")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_timestamp: ::core::option::Option<i64>,
     /// / If set, restrict search to documents with a `timestamp < end_timestamp``.
     #[prost(int64, optional, tag="3")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub end_timestamp: ::core::option::Option<i64>,
     /// / Query text. The query language is that of tantivy.
     #[prost(string, tag="4")]

--- a/quickwit/quickwit-serve/Cargo.toml
+++ b/quickwit/quickwit-serve/Cargo.toml
@@ -72,6 +72,9 @@ quickwit-indexing = { version = "0.3.1", path = "../quickwit-indexing", features
 quickwit-metastore = { version = "0.3.1", path = "../quickwit-metastore", features = [
   "testsuite"
 ] }
+quickwit-search = { version = "0.3.1", path = "../quickwit-search", features = [
+  "testsuite"
+] }
 quickwit-storage = { version = "0.3.1", path = "../quickwit-storage", features = [
   "testsuite"
 ] }

--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -1,0 +1,196 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use quickwit_actors::Mailbox;
+use quickwit_janitor::actors::{DeleteTaskService, NewDeleteTask};
+use quickwit_metastore::Metastore;
+use quickwit_proto::metastore_api::DeleteQuery;
+use serde::Deserialize;
+use warp::{Filter, Rejection};
+
+use crate::format::Format;
+use crate::{require, with_arg};
+
+/// This struct represents the delete query passed to
+/// the rest API.
+#[derive(Deserialize, Debug, Eq, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct DeleteQueryRequest {
+    /// Query text. The query language is that of tantivy.
+    pub query: String,
+    // Fields to search on
+    #[serde(default)]
+    pub search_fields: Vec<String>,
+    /// If set, restrict delete to documents with a `timestamp >= start_timestamp`.
+    pub start_timestamp: Option<i64>,
+    /// If set, restrict delete to documents with a `timestamp < end_timestamp``.
+    pub end_timestamp: Option<i64>,
+}
+
+/// Delete query API handlers.
+pub fn delete_task_api_handlers(
+    metastore: Arc<dyn Metastore>,
+    delete_task_service_mailbox_opt: Option<Mailbox<DeleteTaskService>>,
+) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+    get_delete_tasks_handler(metastore.clone(), delete_task_service_mailbox_opt.clone()).or(
+        post_delete_tasks_handler(metastore, delete_task_service_mailbox_opt),
+    )
+}
+
+pub fn get_delete_tasks_handler(
+    metastore: Arc<dyn Metastore>,
+    delete_task_service_mailbox: Option<Mailbox<DeleteTaskService>>,
+) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+    warp::path!(String / "delete-tasks")
+        .and(warp::get())
+        .and(with_arg(metastore))
+        .and(require(delete_task_service_mailbox))
+        .and_then(get_delete_tasks)
+}
+
+// Returns delete tasks in json format for a given `index_id`.
+// Note that `_delete_task_service_mailbox` is not used...
+// Explanation: we don't want to expose any delete tasks endpoints without a running
+// `DeleteTaskService`. This is ensured by requiring a `Mailbox<DeleteTaskService>` in
+// `get_delete_tasks_handler` and consequently we get the mailbox in `get_delete_tasks` signature.
+async fn get_delete_tasks(
+    index_id: String,
+    metastore: Arc<dyn Metastore>,
+    _delete_task_service_mailbox: Mailbox<DeleteTaskService>,
+) -> Result<impl warp::Reply, Infallible> {
+    let delete_tasks = metastore.list_delete_tasks(&index_id, 0).await;
+    Ok(Format::PrettyJson.make_rest_reply(delete_tasks))
+}
+
+pub fn post_delete_tasks_handler(
+    metastore: Arc<dyn Metastore>,
+    delete_task_service_mailbox: Option<Mailbox<DeleteTaskService>>,
+) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+    warp::path!(String / "delete-tasks")
+        .and(warp::body::json())
+        .and(warp::post())
+        .and(with_arg(metastore))
+        .and(require(delete_task_service_mailbox))
+        .and_then(post_delete_request)
+}
+
+async fn post_delete_request(
+    index_id: String,
+    delete_request: DeleteQueryRequest,
+    metastore: Arc<dyn Metastore>,
+    delete_task_service_mailbox: Mailbox<DeleteTaskService>,
+) -> Result<impl warp::Reply, Infallible> {
+    let delete_query = DeleteQuery {
+        index_id: index_id.clone(),
+        start_timestamp: delete_request.start_timestamp,
+        end_timestamp: delete_request.end_timestamp,
+        query: delete_request.query,
+        search_fields: delete_request.search_fields,
+    };
+    let delete_task = metastore.create_delete_task(delete_query).await;
+    let _ = delete_task_service_mailbox
+        .send_message(NewDeleteTask { index_id })
+        .await;
+    Ok(Format::PrettyJson.make_rest_reply(delete_task))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use quickwit_actors::Universe;
+    use quickwit_indexing::TestSandbox;
+    use quickwit_janitor::actors::DeleteTaskService;
+    use quickwit_proto::metastore_api::DeleteTask;
+    use quickwit_search::{MockSearchService, SearchClientPool};
+    use quickwit_storage::StorageUriResolver;
+    use warp::Filter;
+
+    use crate::rest::recover_fn;
+
+    #[tokio::test]
+    async fn test_delete_task_api() {
+        quickwit_common::setup_logging_for_tests();
+        let index_id = "test-delete-task-rest";
+        let doc_mapping_yaml = r#"
+            field_mappings:
+              - name: body
+                type: text
+              - name: ts
+                type: i64
+                fast: true
+        "#;
+        let metastore_uri = "ram:///delete-task-rest";
+        let test_sandbox = TestSandbox::create(
+            index_id,
+            doc_mapping_yaml,
+            "{}",
+            &["body"],
+            Some(metastore_uri),
+        )
+        .await
+        .unwrap();
+        let metastore = test_sandbox.metastore();
+        let mock_search_service = MockSearchService::new();
+        let client_pool = SearchClientPool::from_mocks(vec![Arc::new(mock_search_service)])
+            .await
+            .unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_dir_path = temp_dir.path().to_path_buf();
+        let delete_task_service = DeleteTaskService::new(
+            metastore.clone(),
+            client_pool,
+            StorageUriResolver::for_test(),
+            data_dir_path,
+        );
+        let universe = Universe::new();
+        let (delete_task_service_mailbox, _delete_task_service_handler) =
+            universe.spawn_builder().spawn(delete_task_service);
+
+        let delete_query_api_handlers =
+            super::delete_task_api_handlers(metastore, Some(delete_task_service_mailbox))
+                .recover(recover_fn);
+        let resp = warp::test::request()
+            .path("/test-delete-task-rest/delete-tasks")
+            .method("POST")
+            .json(&true)
+            .body(r#"{"query": "term", "start_timestamp": 1, "end_timestamp": 10}"#)
+            .reply(&delete_query_api_handlers)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let created_delete_task: DeleteTask = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(created_delete_task.opstamp, 1);
+        let created_delete_query = created_delete_task.delete_query.unwrap();
+        assert_eq!(created_delete_query.index_id, index_id);
+        assert_eq!(created_delete_query.query, "term");
+        assert_eq!(created_delete_query.start_timestamp, Some(1));
+        assert_eq!(created_delete_query.end_timestamp, Some(10));
+
+        let resp = warp::test::request()
+            .path("/test-delete-task-rest/delete-tasks")
+            .reply(&delete_query_api_handlers)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let delete_tasks: Vec<DeleteTask> = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(delete_tasks.len(), 1);
+    }
+}

--- a/quickwit/quickwit-serve/src/delete_task_api/mod.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/mod.rs
@@ -17,12 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-mod delete_task_pipeline;
-mod delete_task_planner;
-mod delete_task_service;
-mod garbage_collector;
-mod retention_policy_executor;
+mod handler;
 
-pub use delete_task_service::{DeleteTaskService, NewDeleteTask};
-pub use garbage_collector::GarbageCollector;
-pub use retention_policy_executor::RetentionPolicyExecutor;
+pub use handler::delete_task_api_handlers;

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -25,6 +25,7 @@ mod grpc;
 mod rest;
 
 mod cluster_api;
+mod delete_task_api;
 mod health_check_api;
 mod index_api;
 mod indexing_api;

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -26,6 +26,7 @@ use tracing::{error, info};
 use warp::{redirect, Filter, Rejection, Reply};
 
 use crate::cluster_api::cluster_handler;
+use crate::delete_task_api::delete_task_api_handlers;
 use crate::format::FormatError;
 use crate::health_check_api::health_check_handlers;
 use crate::index_api::index_management_handlers;
@@ -71,6 +72,13 @@ pub(crate) async fn start_rest_server(
         ))
         .or(index_management_handlers(
             quickwit_services.index_service.clone(),
+        ))
+        .or(delete_task_api_handlers(
+            quickwit_services.metastore.clone(),
+            quickwit_services
+                .janitor_service
+                .as_ref()
+                .map(|service| service.delete_task_service_mailbox().clone()),
         ))
         .or(health_check_handlers(quickwit_services.cluster.clone()));
     let api_v1_root_route = api_v1_root_url.and(api_v1_routes);


### PR DESCRIPTION
Fix #1939 

Two endpoints were added:

- GET `/api/v1/{index-id}/delete-tasks` returns all delete tasks of a given index.
- POST `/api/v1/{index-id}/delete-tasks` create a new delete task. The payload is a dedicated `DeleteQueryRequest` and the created `DeleteTask` is returned.

There is one current limitation that we should track in a dedicated issue: when a user create a delete task, we do not immediately trigger a refresh on the delete task planner, the user will have to wait 60 seconds before seeing some planned delete operations.


