### PR TITLE
Remove sequencer from merge pipelines.

### DIFF
--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -66,7 +66,9 @@ rand = { workspace = true }
 tempfile = { workspace = true }
 
 quickwit-actors = { workspace = true, features = ["testsuite"] }
+quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }
 quickwit-common = { workspace = true, features = ["testsuite"] }
+quickwit-config = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-storage = { workspace = true, features = ["testsuite"] }
 

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -49,4 +49,4 @@ pub use self::merge_planner::MergePlanner;
 pub use self::merge_split_downloader::MergeSplitDownloader;
 pub use self::packager::Packager;
 pub use self::publisher::{Publisher, PublisherCounters, PublisherType};
-pub use self::uploader::{Uploader, UploaderCounters};
+pub use self::uploader::{SplitsUpdateMailbox, Uploader, UploaderCounters};

--- a/quickwit/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit/quickwit-indexing/src/actors/publisher.rs
@@ -27,7 +27,7 @@ use quickwit_metastore::Metastore;
 use tracing::info;
 
 use crate::actors::MergePlanner;
-use crate::models::{NewSplits, SplitUpdate};
+use crate::models::{NewSplits, SplitsUpdate};
 use crate::source::{SourceActor, SuggestTruncate};
 
 #[derive(Clone, Debug, Default)]
@@ -108,17 +108,17 @@ impl Actor for Publisher {
 }
 
 #[async_trait]
-impl Handler<SplitUpdate> for Publisher {
+impl Handler<SplitsUpdate> for Publisher {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        split_update: SplitUpdate,
+        split_update: SplitsUpdate,
         ctx: &ActorContext<Self>,
     ) -> Result<(), quickwit_actors::ActorExitStatus> {
         fail_point!("publisher:before");
 
-        let SplitUpdate {
+        let SplitsUpdate {
             index_id,
             new_splits,
             replaced_split_ids,
@@ -231,7 +231,7 @@ mod tests {
         let (publisher_mailbox, publisher_handle) = universe.spawn_builder().spawn(publisher);
 
         assert!(publisher_mailbox
-            .send_message(SplitUpdate {
+            .send_message(SplitsUpdate {
                 index_id: "index".to_string(),
                 new_splits: vec![SplitMetadata {
                     split_id: "split".to_string(),
@@ -294,7 +294,7 @@ mod tests {
         );
         let universe = Universe::new();
         let (publisher_mailbox, publisher_handle) = universe.spawn_builder().spawn(publisher);
-        let publisher_message = SplitUpdate {
+        let publisher_message = SplitsUpdate {
             index_id: "index".to_string(),
             new_splits: vec![SplitMetadata {
                 split_id: "split3".to_string(),
@@ -336,7 +336,7 @@ mod tests {
         publish_lock.kill().await;
 
         publisher_mailbox
-            .send_message(SplitUpdate {
+            .send_message(SplitsUpdate {
                 index_id: "test-index".to_string(),
                 new_splits: vec![SplitMetadata::for_test("test-split".to_string())],
                 replaced_split_ids: Vec::new(),

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -649,6 +649,7 @@ mod tests {
                         replaced_split_ids: Vec::new(),
                         split_id: "test-split".to_string(),
                         delete_opstamp: 10,
+                        num_merge_ops: 0,
                     },
                     split_scratch_directory,
                     tags: Default::default(),

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -34,12 +34,13 @@ use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::{Metastore, SplitMetadata};
 use quickwit_storage::SplitPayloadBuilder;
 use time::OffsetDateTime;
+use tokio::sync::oneshot::Sender;
 use tokio::sync::{oneshot, Semaphore, SemaphorePermit};
 use tracing::{info, info_span, warn, Instrument, Span};
 
 use crate::actors::sequencer::{Sequencer, SequencerCommand};
 use crate::actors::Publisher;
-use crate::models::{PackagedSplit, PackagedSplitBatch, PublishLock, SplitUpdate};
+use crate::models::{PackagedSplit, PackagedSplitBatch, PublishLock, SplitsUpdate};
 use crate::split_store::IndexingSplitStore;
 
 pub const MAX_CONCURRENT_SPLIT_UPLOAD: usize = 4;
@@ -52,11 +53,95 @@ pub const MAX_CONCURRENT_SPLIT_UPLOAD: usize = 4;
 /// actor for all indexing pipeline.
 static CONCURRENT_UPLOAD_PERMITS: Semaphore = Semaphore::const_new(MAX_CONCURRENT_SPLIT_UPLOAD);
 
+/// [`SplitsUpdateMailbox`] wraps either a [`Mailbox<Sequencer>`] or [`Mailbox<Publisher>`].
+/// It makes it possible to send a [`SplitsUpdate`] either to the [`Sequencer`] or directly
+/// to [`Publisher`]. It is used in combination with `SplitsUpdateSender` that will do the send.
+///
+/// This is useful as we have different requirements between the indexing pipeline and
+/// the merge/delete task pipelines.
+/// 1. In the indexing pipeline, we want to publish splits in the same order as they
+///    are produced by the indexer/packager to ensure we are publishing splits without
+///    "holes" in checkpoints. We thus send [`SplitsUpdate`] to the [`Sequencer`]
+///    to keep the right ordering.
+/// 2. In the merge pipeline and the delete task pipeline, we are merging splits and in
+///    in this case, publishing order does not matter. In this case, we can just
+///    send [`SplitsUpdate`] directly to the [`Publisher`].
+#[derive(Clone, Debug)]
+pub enum SplitsUpdateMailbox {
+    Sequencer(Mailbox<Sequencer<Publisher>>),
+    Publisher(Mailbox<Publisher>),
+}
+
+impl SplitsUpdateMailbox {
+    async fn get_split_update_sender(
+        &self,
+        ctx: &ActorContext<Uploader>,
+    ) -> anyhow::Result<SplitsUpdateSender> {
+        match self {
+            SplitsUpdateMailbox::Sequencer(sequencer_mailbox) => {
+                // We send the future to the sequencer right away.
+                // The sequencer will then resolve the future in their arrival order and ensure that
+                // the publisher publishes splits in order.
+                let (split_uploaded_tx, split_uploaded_rx) =
+                    oneshot::channel::<SequencerCommand<SplitsUpdate>>();
+                ctx.send_message(sequencer_mailbox, split_uploaded_rx)
+                    .await?;
+                Ok(SplitsUpdateSender::Sequencer(split_uploaded_tx))
+            }
+            SplitsUpdateMailbox::Publisher(publisher_mailbox) => {
+                // We just need the publisher mailbox to send the split in this case.
+                Ok(SplitsUpdateSender::Publisher(publisher_mailbox.clone()))
+            }
+        }
+    }
+}
+
+enum SplitsUpdateSender {
+    Sequencer(Sender<SequencerCommand<SplitsUpdate>>),
+    Publisher(Mailbox<Publisher>),
+}
+
+impl SplitsUpdateSender {
+    fn discard(self) -> anyhow::Result<()> {
+        if let SplitsUpdateSender::Sequencer(split_uploader_tx) = self {
+            if split_uploader_tx.send(SequencerCommand::Discard).is_err() {
+                bail!(
+                    "Failed to send cancel command to sequencer. The sequencer is probably dead."
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn send(
+        self,
+        split_update: SplitsUpdate,
+        ctx: &ActorContext<Uploader>,
+    ) -> anyhow::Result<()> {
+        match self {
+            SplitsUpdateSender::Sequencer(split_uploaded_tx) => {
+                if let Err(publisher_message) =
+                    split_uploaded_tx.send(SequencerCommand::Proceed(split_update))
+                {
+                    bail!(
+                        "Failed to send upload split `{:?}`. The publisher is probably dead.",
+                        &publisher_message
+                    );
+                }
+            }
+            SplitsUpdateSender::Publisher(publisher_mailbox) => {
+                ctx.send_message(&publisher_mailbox, split_update).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
 pub struct Uploader {
     actor_name: &'static str,
     metastore: Arc<dyn Metastore>,
     split_store: IndexingSplitStore,
-    sequencer_mailbox: Mailbox<Sequencer<Publisher>>,
+    split_update_mailbox: SplitsUpdateMailbox,
     counters: UploaderCounters,
 }
 
@@ -65,13 +150,13 @@ impl Uploader {
         actor_name: &'static str,
         metastore: Arc<dyn Metastore>,
         split_store: IndexingSplitStore,
-        sequencer_mailbox: Mailbox<Sequencer<Publisher>>,
+        split_update_mailbox: SplitsUpdateMailbox,
     ) -> Uploader {
         Uploader {
             actor_name,
             metastore,
             split_store,
-            sequencer_mailbox,
+            split_update_mailbox,
             counters: Default::default(),
         }
     }
@@ -132,14 +217,9 @@ impl Handler<PackagedSplitBatch> for Uploader {
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         fail_point!("uploader:before");
-        let (split_uploaded_tx, split_uploaded_rx) =
-            oneshot::channel::<SequencerCommand<SplitUpdate>>();
-
-        // We send the future to the sequencer right away.
-
-        // The sequencer will then resolve the future in their arrival order and ensure that the
-        // publisher publishes splits in order.
-        ctx.send_message(&self.sequencer_mailbox, split_uploaded_rx)
+        let split_udpate_sender = self
+            .split_update_mailbox
+            .get_split_update_sender(ctx)
             .await?;
 
         // The permit will be added back manually to the semaphore the task after it is finished.
@@ -161,6 +241,7 @@ impl Handler<PackagedSplitBatch> for Uploader {
         let split_store = self.split_store.clone();
         let counters = self.counters.clone();
         let index_id = batch.index_id();
+        let ctx_clone = ctx.clone();
         let span = Span::current();
         info!(split_ids=?split_ids, "start-stage-and-store-splits");
         tokio::spawn(
@@ -174,10 +255,8 @@ impl Handler<PackagedSplitBatch> for Uploader {
                             split_ids=?split_ids,
                             "Splits' publish lock is dead."
                         );
-                        if split_uploaded_tx.send(SequencerCommand::Discard).is_err() {
-                            bail!("Failed to send cancel command to sequencer. The sequencer is probably dead.");
-                        }
-                        return Ok(())
+                        split_udpate_sender.discard()?;
+                        return Ok(());
                     }
                     let upload_result = stage_and_upload_split(
                         &split,
@@ -193,13 +272,8 @@ impl Handler<PackagedSplitBatch> for Uploader {
                     }
                     packaged_splits_and_metadatas.push((split, upload_result.unwrap()));
                 }
-                let publisher_message = make_publish_operation(index_id, batch.publish_lock, packaged_splits_and_metadatas, batch.checkpoint_delta_opt, batch.date_of_birth);
-                if let Err(publisher_message) = split_uploaded_tx.send(publisher_message) {
-                    bail!(
-                        "Failed to send upload split `{:?}`. The publisher is probably dead.",
-                        &publisher_message
-                    );
-                }
+                let splits_update = make_publish_operation(index_id, batch.publish_lock, packaged_splits_and_metadatas, batch.checkpoint_delta_opt, batch.date_of_birth);
+                split_udpate_sender.send(splits_update, &ctx_clone).await?;
                 info!("success-stage-and-store-splits");
                 // We explicitely drop it in order to force move the permit guard into the async
                 // task.
@@ -238,13 +312,13 @@ fn make_publish_operation(
     packaged_splits_and_metadatas: Vec<(PackagedSplit, SplitMetadata)>,
     checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     date_of_birth: Instant,
-) -> SequencerCommand<SplitUpdate> {
+) -> SplitsUpdate {
     assert!(!packaged_splits_and_metadatas.is_empty());
     let replaced_split_ids = packaged_splits_and_metadatas
         .iter()
         .flat_map(|(split, _)| split.split_attrs.replaced_split_ids.clone())
         .collect::<HashSet<_>>();
-    SequencerCommand::Proceed(SplitUpdate {
+    SplitsUpdate {
         index_id,
         publish_lock,
         new_splits: packaged_splits_and_metadatas
@@ -254,7 +328,7 @@ fn make_publish_operation(
         replaced_split_ids: Vec::from_iter(replaced_split_ids),
         checkpoint_delta_opt,
         date_of_birth,
-    })
+    }
 }
 
 async fn stage_and_upload_split(
@@ -293,7 +367,7 @@ async fn stage_and_upload_split(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     use quickwit_actors::{create_test_mailbox, ObservationType, Universe};
     use quickwit_metastore::checkpoint::{IndexCheckpointDelta, SourceCheckpointDelta};
@@ -305,7 +379,7 @@ mod tests {
     use crate::models::{IndexingPipelineId, ScratchDirectory, SplitAttrs};
 
     #[tokio::test]
-    async fn test_uploader_1() -> anyhow::Result<()> {
+    async fn test_uploader_with_sequencer() -> anyhow::Result<()> {
         let pipeline_id = IndexingPipelineId {
             index_id: "test-index".to_string(),
             source_id: "test-source".to_string(),
@@ -331,7 +405,7 @@ mod tests {
             "TestUploader",
             Arc::new(mock_metastore),
             split_store,
-            sequencer_mailbox,
+            SplitsUpdateMailbox::Sequencer(sequencer_mailbox),
         );
         let (uploader_mailbox, uploader_handle) = universe.spawn_builder().spawn(uploader);
         let split_scratch_directory = ScratchDirectory::for_test()?;
@@ -367,7 +441,7 @@ mod tests {
             uploader_handle.process_pending_and_observe().await.obs_type,
             ObservationType::Alive
         );
-        let mut publish_futures: Vec<oneshot::Receiver<SequencerCommand<SplitUpdate>>> =
+        let mut publish_futures: Vec<oneshot::Receiver<SequencerCommand<SplitsUpdate>>> =
             sequencer_inbox.drain_for_test_typed();
         assert_eq!(publish_futures.len(), 1);
 
@@ -378,7 +452,7 @@ mod tests {
             ),
             SequencerCommand::Proceed(publisher_message) => publisher_message,
         };
-        let SplitUpdate {
+        let SplitsUpdate {
             index_id,
             new_splits,
             checkpoint_delta_opt,
@@ -403,7 +477,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_uploader_emits_replace() -> anyhow::Result<()> {
+    async fn test_uploader_with_sequencer_emits_replace() -> anyhow::Result<()> {
         let pipeline_id = IndexingPipelineId {
             index_id: "test-index".to_string(),
             source_id: "test-source".to_string(),
@@ -430,7 +504,7 @@ mod tests {
             "TestUploader",
             Arc::new(mock_metastore),
             split_store,
-            sequencer_mailbox,
+            SplitsUpdateMailbox::Sequencer(sequencer_mailbox),
         );
         let (uploader_mailbox, uploader_handle) = universe.spawn_builder().spawn(uploader);
         let split_scratch_directory_1 = ScratchDirectory::for_test()?;
@@ -487,7 +561,7 @@ mod tests {
             uploader_handle.process_pending_and_observe().await.obs_type,
             ObservationType::Alive
         );
-        let mut publish_futures: Vec<oneshot::Receiver<SequencerCommand<SplitUpdate>>> =
+        let mut publish_futures: Vec<oneshot::Receiver<SequencerCommand<SplitsUpdate>>> =
             sequencer_inbox.drain_for_test_typed();
         assert_eq!(publish_futures.len(), 1);
 
@@ -498,7 +572,7 @@ mod tests {
             ),
             SequencerCommand::Proceed(publisher_message) => publisher_message,
         };
-        let SplitUpdate {
+        let SplitsUpdate {
             index_id,
             new_splits,
             mut replaced_split_ids,
@@ -529,6 +603,82 @@ mod tests {
                 PathBuf::from("test-split-2.split")
             ]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_uploader_without_sequencer() -> anyhow::Result<()> {
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index-no-sequencer".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
+        let universe = Universe::new();
+        let (publisher_mailbox, publisher_inbox) = create_test_mailbox::<Publisher>();
+        let mut mock_metastore = MockMetastore::default();
+        mock_metastore
+            .expect_stage_split()
+            .withf(move |index_id, _| -> bool { index_id == "test-index-no-sequencer" })
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let ram_storage = RamStorage::default();
+        let split_store =
+            IndexingSplitStore::create_without_local_store(Arc::new(ram_storage.clone()));
+        let uploader = Uploader::new(
+            "TestUploader",
+            Arc::new(mock_metastore),
+            split_store,
+            SplitsUpdateMailbox::Publisher(publisher_mailbox),
+        );
+        let (uploader_mailbox, uploader_handle) = universe.spawn_builder().spawn(uploader);
+        let split_scratch_directory = ScratchDirectory::for_test()?;
+        let checkpoint_delta_opt: Option<IndexCheckpointDelta> = Some(IndexCheckpointDelta {
+            source_id: "test-source".to_string(),
+            source_delta: SourceCheckpointDelta::from(3..15),
+        });
+        uploader_mailbox
+            .send_message(PackagedSplitBatch::new(
+                vec![PackagedSplit {
+                    split_attrs: SplitAttrs {
+                        partition_id: 3u64,
+                        pipeline_id,
+                        time_range: None,
+                        uncompressed_docs_size_in_bytes: 1_000,
+                        num_docs: 10,
+                        replaced_split_ids: Vec::new(),
+                        split_id: "test-split".to_string(),
+                        delete_opstamp: 10,
+                    },
+                    split_scratch_directory,
+                    tags: Default::default(),
+                    hotcache_bytes: vec![],
+                    split_files: vec![],
+                }],
+                checkpoint_delta_opt,
+                PublishLock::default(),
+                Instant::now(),
+            ))
+            .await?;
+        assert_eq!(
+            uploader_handle.process_pending_and_observe().await.obs_type,
+            ObservationType::Alive
+        );
+        // We have to wait a bit to make sure uploader has sent the message.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let mut splits_updates: Vec<SplitsUpdate> = publisher_inbox.drain_for_test_typed();
+        assert_eq!(splits_updates.len(), 1);
+
+        let SplitsUpdate {
+            index_id,
+            new_splits,
+            replaced_split_ids,
+            ..
+        } = splits_updates.pop().unwrap();
+
+        assert_eq!(index_id, "test-index-no-sequencer");
+        assert_eq!(new_splits.len(), 1);
+        assert!(replaced_split_ids.is_empty());
         Ok(())
     }
 }

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -29,7 +29,7 @@ use tracing::info;
 
 pub use crate::actors::{
     IndexingPipeline, IndexingPipelineParams, IndexingService, IndexingServiceError,
-    IngestApiGarbageCollector, PublisherType, Sequencer,
+    IngestApiGarbageCollector, PublisherType, Sequencer, SplitsUpdateMailbox,
 };
 pub use crate::controlled_directory::ControlledDirectory;
 use crate::models::{IndexingStatistics, SpawnPipelines};

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -47,7 +47,7 @@ pub use merge_scratch::MergeScratch;
 pub use packaged_split::{PackagedSplit, PackagedSplitBatch};
 pub use prepared_doc::{PreparedDoc, PreparedDocBatch};
 pub use publish_lock::{NewPublishLock, PublishLock};
-pub use publisher_message::SplitUpdate;
+pub use publisher_message::SplitsUpdate;
 pub use raw_doc_batch::RawDocBatch;
 pub use scratch_directory::ScratchDirectory;
 pub use split_attrs::SplitAttrs;

--- a/quickwit/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit/quickwit-indexing/src/models/publisher_message.rs
@@ -26,7 +26,7 @@ use quickwit_metastore::SplitMetadata;
 
 use crate::models::PublishLock;
 
-pub struct SplitUpdate {
+pub struct SplitsUpdate {
     pub index_id: String,
     pub new_splits: Vec<SplitMetadata>,
     pub replaced_split_ids: Vec<String>,
@@ -35,14 +35,14 @@ pub struct SplitUpdate {
     pub date_of_birth: Instant, // for logging
 }
 
-impl fmt::Debug for SplitUpdate {
+impl fmt::Debug for SplitsUpdate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let new_split_ids: String = self
             .new_splits
             .iter()
             .map(|split| split.split_id())
             .join(",");
-        f.debug_struct("SplitUpdate")
+        f.debug_struct("SplitsUpdate")
             .field("index_id", &self.index_id)
             .field("new_splits", &new_split_ids)
             .field("checkpoint_delta", &self.checkpoint_delta_opt)


### PR DESCRIPTION
Fix #1940 

This PR updates the `Uploader` actor to bypass the `Sequencer` when it's not needed (that is for merge & delete pipelines).

It's still a draft as I need to add a test. Even if the code is not "beautiful" as I'm just using enums to handle the case where we use the sequencer and the case where we use the publisher, I think it's worth it as it removes the sequencer from 2 pipelines.