### PR TITLE
Upgrade Kafka and ZooKeeper Docker images to Confluent 7.2.1

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
           --health-retries 5
 
       kafka-broker:
-        image: confluentinc/cp-kafka:6.2.0
+        image: confluentinc/cp-kafka:7.2.1
         ports:
           - "9092:9092"
           - "9101:9101"
@@ -80,7 +80,7 @@ jobs:
           --health-retries 5
 
       zookeeper:
-        image: confluentinc/cp-zookeeper:6.2.0
+        image: confluentinc/cp-zookeeper:7.2.1
         ports:
           - "2181:2181"
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       test: ["CMD", "pg_isready"]
 
   kafka-broker:
-    image: confluentinc/cp-kafka:6.2.0
+    image: confluentinc/cp-kafka:7.2.1
     container_name: kafka-broker
     depends_on:
       - zookeeper
@@ -78,7 +78,7 @@ services:
       test: ["CMD", "cub", "kafka-ready", "-b", "localhost:9092", "1", "30"]
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.2.0
+    image: confluentinc/cp-zookeeper:7.2.1
     container_name: zookeeper
     ports:
       - "2181:2181"


### PR DESCRIPTION
### Description
Before this upgrade, I was not able to get the Kafka and ZooKeeper containers in healthy mode on my M2. This upgrade seems to fix my issue.

### How was this PR tested?
`make test-all`