### PR TITLE
Failpoint test fix.

### DIFF
--- a/quickwit/quickwit-actors/src/actor_handle.rs
+++ b/quickwit/quickwit-actors/src/actor_handle.rs
@@ -158,11 +158,11 @@ impl<A: Actor> ActorHandle<A> {
     /// as the finalize logic may behave differently depending on the exit status.
     pub async fn kill(self) -> (ActorExitStatus, A::ObservableState) {
         self.actor_context.kill_switch().kill();
+        let _ = self
+            .actor_context
+            .mailbox()
+            .send_message_with_high_priority(Command::Nudge);
         self.join().await
-    }
-
-    pub(crate) fn activate_kill_switch(self) {
-        self.actor_context.kill_switch().kill();
     }
 
     /// Gracefully quit the actor, regardless of whether there are pending messages or not.

--- a/quickwit/quickwit-actors/src/supervisor.rs
+++ b/quickwit/quickwit-actors/src/supervisor.rs
@@ -34,12 +34,12 @@ pub struct SupervisorState {
 }
 
 pub struct Supervisor<A: Actor> {
-    pub(crate) actor_name: String,
-    pub(crate) actor_factory: Box<dyn Fn() -> A + Sync + Send>,
-    pub(crate) inbox: Inbox<A>,
-    pub(crate) mailbox: Mailbox<A>,
-    pub(crate) handle_opt: Option<ActorHandle<A>>,
-    pub(crate) state: SupervisorState,
+    actor_name: String,
+    actor_factory: Box<dyn Fn() -> A + Sync + Send>,
+    inbox: Inbox<A>,
+    mailbox: Mailbox<A>,
+    handle_opt: Option<ActorHandle<A>>,
+    state: SupervisorState,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -79,7 +79,7 @@ impl<A: Actor> Actor for Supervisor<A> {
             }
             ActorExitStatus::Killed => {
                 if let Some(handle) = self.handle_opt.take() {
-                    handle.activate_kill_switch();
+                    handle.kill().await;
                 }
             }
             ActorExitStatus::Failure(_)


### PR DESCRIPTION
After removing the use of the Kill message,
some actors could be stuck awaiting for a message, and never checking for possible message.

Relying on a Kill message is not an option, due to the recycling of mailbox introduced in the supervisor PR.

The fix consists in adding a Nudge message that
is No-op.