### PR TITLE
Fix and clean cluster members.

### DIFF
--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -30,7 +30,7 @@ use quickwit_config::QuickwitConfig;
 
 pub use crate::cluster::{
     create_cluster_for_test, grpc_addr_from_listen_addr_for_test, Cluster, ClusterMember,
-    ClusterState,
+    ClusterSnapshot,
 };
 pub use crate::error::{ClusterError, ClusterResult};
 

--- a/quickwit/quickwit-search/src/search_client_pool.rs
+++ b/quickwit/quickwit-search/src/search_client_pool.rs
@@ -131,9 +131,18 @@ impl SearchClientPool {
         })
     }
 
-    async fn update_members(&self, member_grpc_addrs: &[SocketAddr]) {
+    async fn update_members(&self, cluster_members: &[ClusterMember]) {
+        let members_grpc_addrs = cluster_members
+            .iter()
+            .filter(|member| {
+                member
+                    .available_services
+                    .contains(&QuickwitService::Searcher)
+            })
+            .map(|member| member.grpc_advertise_addr)
+            .collect_vec();
         let mut new_clients = self.clients();
-        update_client_map(member_grpc_addrs, &mut new_clients).await;
+        update_client_map(&members_grpc_addrs, &mut new_clients).await;
         *self.clients.write().unwrap() = new_clients;
     }
 
@@ -167,41 +176,15 @@ impl SearchClientPool {
     /// When a client pool is created, the thread that monitors cluster members
     /// will be started at the same time.
     pub async fn create_and_keep_updated(
-        current_members: &[ClusterMember],
         mut members_watch_channel: WatchStream<Vec<ClusterMember>>,
     ) -> anyhow::Result<Self> {
         let search_client_pool = SearchClientPool::default();
-        let members_grpc_addresses = current_members
-            .iter()
-            .filter(|member| {
-                member
-                    .available_services
-                    .contains(&QuickwitService::Searcher)
-            })
-            .map(|member| member.grpc_advertise_addr)
-            .collect_vec();
-        search_client_pool
-            .update_members(&members_grpc_addresses)
-            .await;
-
-        // Prepare to start a thread that will monitor cluster members.
         let search_clients_pool_clone = search_client_pool.clone();
 
-        // Start to monitor the cluster members.
+        // Start to monitor cluster member changes.
         tokio::spawn(async move {
             while let Some(new_members) = members_watch_channel.next().await {
-                let members_grpc_addresses = new_members
-                    .iter()
-                    .filter(|member| {
-                        member
-                            .available_services
-                            .contains(&QuickwitService::Searcher)
-                    })
-                    .map(|member| member.grpc_advertise_addr)
-                    .collect_vec();
-                search_clients_pool_clone
-                    .update_members(&members_grpc_addresses)
-                    .await;
+                search_clients_pool_clone.update_members(&new_members).await;
             }
             Result::<(), anyhow::Error>::Ok(())
         });
@@ -360,11 +343,10 @@ mod tests {
     async fn test_search_client_pool_single_node() -> anyhow::Result<()> {
         let transport = ChannelTransport::default();
         let cluster = create_cluster_simple_for_test(&transport).await?;
-        let client_pool = SearchClientPool::create_and_keep_updated(
-            &cluster.members(),
-            cluster.member_change_watcher(),
-        )
-        .await?;
+        let client_pool =
+            SearchClientPool::create_and_keep_updated(cluster.ready_member_change_watcher())
+                .await?;
+        tokio::time::sleep(Duration::from_millis(1)).await;
         let clients = client_pool.clients();
         let addrs: Vec<SocketAddr> = clients.into_keys().collect();
         let expected_addrs = vec![grpc_addr_from_listen_addr_for_test(
@@ -386,11 +368,10 @@ mod tests {
             .wait_for_members(|members| members.len() == 2, Duration::from_secs(5))
             .await?;
 
-        let client_pool = SearchClientPool::create_and_keep_updated(
-            &cluster1.members(),
-            cluster1.member_change_watcher(),
-        )
-        .await?;
+        let client_pool =
+            SearchClientPool::create_and_keep_updated(cluster1.ready_member_change_watcher())
+                .await?;
+        tokio::time::sleep(Duration::from_millis(1)).await;
         let clients = client_pool.clients();
 
         let addrs: Vec<SocketAddr> = clients.into_keys().sorted().collect();
@@ -407,11 +388,10 @@ mod tests {
     async fn test_search_client_pool_single_node_assign_jobs() -> anyhow::Result<()> {
         let transport = ChannelTransport::default();
         let cluster = create_cluster_simple_for_test(&transport).await?;
-        let client_pool = SearchClientPool::create_and_keep_updated(
-            &cluster.members(),
-            cluster.member_change_watcher(),
-        )
-        .await?;
+        let client_pool =
+            SearchClientPool::create_and_keep_updated(cluster.ready_member_change_watcher())
+                .await?;
+        tokio::time::sleep(Duration::from_millis(1)).await;
         let jobs = vec![
             SearchJob::for_test("split1", 1),
             SearchJob::for_test("split2", 2),

--- a/quickwit/quickwit-serve/src/cluster_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/cluster_api/rest_handler.rs
@@ -20,7 +20,7 @@
 use std::convert::Infallible;
 use std::sync::Arc;
 
-use quickwit_cluster::{Cluster, ClusterState};
+use quickwit_cluster::{Cluster, ClusterSnapshot};
 use serde::Deserialize;
 use warp::{Filter, Rejection};
 
@@ -62,6 +62,6 @@ async fn get_cluster(
         .make_rest_reply_non_serializable_error(cluster_endpoint(cluster).await))
 }
 
-async fn cluster_endpoint(cluster: Arc<Cluster>) -> Result<ClusterState, Infallible> {
-    Ok(cluster.state().await)
+async fn cluster_endpoint(cluster: Arc<Cluster>) -> Result<ClusterSnapshot, Infallible> {
+    Ok(cluster.snapshot().await)
 }

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -124,8 +124,7 @@ pub async fn serve_quickwit(
                 )
             })?;
         let metastore_client = MetastoreGrpcClient::create_and_update_from_members(
-            &cluster.members(),
-            cluster.member_change_watcher(),
+            cluster.ready_member_change_watcher(),
         )
         .await?;
         Arc::new(metastore_client)
@@ -157,11 +156,8 @@ pub async fn serve_quickwit(
         (None, None)
     };
 
-    let search_client_pool = SearchClientPool::create_and_keep_updated(
-        &cluster.members(),
-        cluster.member_change_watcher(),
-    )
-    .await?;
+    let search_client_pool =
+        SearchClientPool::create_and_keep_updated(cluster.ready_member_change_watcher()).await?;
 
     let janitor_service = if services.contains(&QuickwitService::Janitor) {
         let janitor_service = start_janitor_service(

--- a/quickwit/quickwit-serve/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-serve/src/test_utils/cluster_sandbox.rs
@@ -147,7 +147,7 @@ impl ClusterSandbox {
         })
     }
 
-    pub async fn wait_for_cluster_num_live_nodes(
+    pub async fn wait_for_cluster_num_ready_nodes(
         &self,
         expected_num_alive_nodes: usize,
     ) -> anyhow::Result<()> {
@@ -155,8 +155,8 @@ impl ClusterSandbox {
         let max_num_attempts = 3;
         while num_attempts < max_num_attempts {
             tokio::time::sleep(Duration::from_millis(100 * (num_attempts + 1))).await;
-            let cluster_state = self.rest_client.cluster_state().await?;
-            if cluster_state.live_nodes.len() == expected_num_alive_nodes {
+            let cluster_snapshot = self.rest_client.cluster_snapshot().await?;
+            if cluster_snapshot.ready_nodes.len() == expected_num_alive_nodes {
                 return Ok(());
             }
             num_attempts += 1;

--- a/quickwit/quickwit-serve/src/test_utils/rest_client.rs
+++ b/quickwit/quickwit-serve/src/test_utils/rest_client.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use hyper::client::HttpConnector;
 use hyper::{Body, Response, StatusCode};
-use quickwit_cluster::ClusterState;
+use quickwit_cluster::ClusterSnapshot;
 use quickwit_indexing::actors::IndexingServiceState;
 use serde::de::DeserializeOwned;
 use tokio_stream::StreamExt;
@@ -42,7 +42,7 @@ impl QuickwitRestClient {
         Self { api_root, client }
     }
 
-    pub async fn cluster_state(&self) -> anyhow::Result<ClusterState> {
+    pub async fn cluster_snapshot(&self) -> anyhow::Result<ClusterSnapshot> {
         let uri = format!("{}/cluster", self.api_root)
             .parse::<hyper::Uri>()
             .unwrap();

--- a/quickwit/quickwit-serve/src/tests.rs
+++ b/quickwit/quickwit-serve/src/tests.rs
@@ -74,7 +74,7 @@ async fn test_standalone_server() -> anyhow::Result<()> {
         })
         .await;
     assert!(search_result.is_ok());
-    let cluster_result = sandbox.rest_client.cluster_state().await;
+    let cluster_result = sandbox.rest_client.cluster_snapshot().await;
     assert!(cluster_result.is_ok());
     let is_ready_result = sandbox.rest_client.is_ready().await.unwrap();
     assert!(is_ready_result);
@@ -94,7 +94,7 @@ async fn test_multi_nodes_cluster() -> anyhow::Result<()> {
     let sandbox = ClusterSandbox::start_cluster_nodes(&nodes_services)
         .await
         .unwrap();
-    sandbox.wait_for_cluster_num_live_nodes(2).await.unwrap();
+    sandbox.wait_for_cluster_num_ready_nodes(2).await.unwrap();
     let mut search_client = sandbox.get_random_search_client();
     let search_result = search_client
         .root_search(SearchRequest {


### PR DESCRIPTION
Fix #1982.

And I also changed a bit the way we use the member watcher.

Note:  the current watcher is broken if we want to use up-to-date properties of cluster members. Example: we start a node with the server `searcher` and restart afterward with another server. Chitchat will probably not detect a change in readiness and the member watcher of other nodes will not receive member changes. And the other nodes will have their search pool with this no-more searcher node.

PTAL.