### PR TITLE
Make QuickwitConfig.data_dir_path accept file://

### DIFF
--- a/quickwit/quickwit-config/src/config.rs
+++ b/quickwit/quickwit-config/src/config.rs
@@ -356,6 +356,17 @@ impl QuickwitConfigBuilder {
         }
     }
 
+    fn data_dir_path(&self) -> anyhow::Result<PathBuf> {
+        let data_dir_uri = Uri::try_new(&self.data_dir_path.to_string_lossy())
+            .expect("Failed to create URI from data_dir.");
+        match data_dir_uri.filepath() {
+            Some(path) => Ok(path.to_owned()),
+            _ => Err(anyhow::anyhow!(
+                "Only `file://` protocol allowed for data_dir `{data_dir_uri}`."
+            )),
+        }
+    }
+
     pub async fn build(self) -> anyhow::Result<QuickwitConfig> {
         let listen_host = self.listen_address.parse::<Host>()?;
 
@@ -368,10 +379,10 @@ impl QuickwitConfigBuilder {
             metastore_uri: self.metastore_uri()?,
             default_index_root_uri: self.default_index_root_uri()?,
             enabled_services: self.parse_services()?,
+            data_dir_path: self.data_dir_path()?,
             version: self.version,
             cluster_id: self.cluster_id,
             node_id: self.node_id,
-            data_dir_path: self.data_dir_path,
             peer_seeds: self.peer_seeds,
             indexer_config: self.indexer_config,
             searcher_config: self.searcher_config,
@@ -672,7 +683,10 @@ mod tests {
                 env::current_dir().unwrap().display()
             )
         );
-        assert_eq!(config.data_dir_path.to_string_lossy(), "./qwdata");
+        assert_eq!(
+            config.data_dir_path.to_string_lossy(),
+            format!("{}/qwdata", env::current_dir().unwrap().display())
+        );
     }
 
     #[tokio::test]
@@ -878,6 +892,43 @@ mod tests {
             let config_builder =
                 serde_yaml::from_str::<QuickwitConfigBuilder>(config_yaml).unwrap();
             config_builder.build().await.unwrap_err();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_quickwit_config_data_dir_accepts_both_file_uris_and_file_paths() {
+        {
+            let config_yaml = r#"
+                version: 0
+                data_dir: /opt/quickwit/data
+            "#;
+            let config_builder =
+                serde_yaml::from_str::<QuickwitConfigBuilder>(config_yaml).unwrap();
+            let config = config_builder.build().await.unwrap();
+            assert_eq!(config.data_dir_path, PathBuf::from("/opt/quickwit/data"));
+        }
+        {
+            let config_yaml = r#"
+                version: 0
+                data_dir: file:///opt/quickwit/data
+            "#;
+            let config_builder =
+                serde_yaml::from_str::<QuickwitConfigBuilder>(config_yaml).unwrap();
+            let config = config_builder.build().await.unwrap();
+            assert_eq!(config.data_dir_path, PathBuf::from("/opt/quickwit/data"));
+        }
+        {
+            let config_yaml = r#"
+                version: 0
+                data_dir: s3://indexes/foo
+            "#;
+            let config_builder =
+                serde_yaml::from_str::<QuickwitConfigBuilder>(config_yaml).unwrap();
+            let error = config_builder.build().await.unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "Only `file://` protocol allowed for data_dir `s3://indexes/foo`."
+            );
         }
     }
 }

--- a/quickwit/quickwit-config/src/config.rs
+++ b/quickwit/quickwit-config/src/config.rs
@@ -360,10 +360,8 @@ impl QuickwitConfigBuilder {
         let data_dir_uri = Uri::try_new(&self.data_dir_path.to_string_lossy())
             .expect("Failed to create URI from data_dir.");
         match data_dir_uri.filepath() {
-            Some(path) => Ok(path.to_owned()),
-            _ => Err(anyhow::anyhow!(
-                "Only `file://` protocol allowed for data_dir `{data_dir_uri}`."
-            )),
+            Some(path) => Ok(path.to_path_buf()),
+            _ => bail!("Only `file://` protocol allowed for data_dir `{data_dir_uri}`."),
         }
     }
 
@@ -925,10 +923,7 @@ mod tests {
             let config_builder =
                 serde_yaml::from_str::<QuickwitConfigBuilder>(config_yaml).unwrap();
             let error = config_builder.build().await.unwrap_err();
-            assert_eq!(
-                error.to_string(),
-                "Only `file://` protocol allowed for data_dir `s3://indexes/foo`."
-            );
+            assert!(error.to_string().contains("Only `file://` protocol"));
         }
     }
 }


### PR DESCRIPTION
Make QuickwitConfig `data_dir` to accept both file protocol uris and path.
Closes https://github.com/quickwit-oss/quickwit/issues/1996