### PR TITLE
Fix source actor timeout

### DIFF
--- a/quickwit/quickwit-actors/src/tests.rs
+++ b/quickwit/quickwit-actors/src/tests.rs
@@ -341,6 +341,10 @@ impl Actor for LoopingActor {
         self.clone()
     }
 
+    fn yield_after_each_message(&self) -> bool {
+        false
+    }
+
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
         self.handle(Loop, ctx).await
     }
@@ -374,7 +378,7 @@ impl Handler<SingleShot> for LoopingActor {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_looping() -> anyhow::Result<()> {
     let universe = Universe::new();
     let looping_actor = LoopingActor::default();

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -266,6 +266,7 @@ impl Handler<Loop> for SourceActor {
             .source
             .emit_batches(&self.doc_processor_mailbox, ctx)
             .await?;
+        ctx.record_progress();
         if wait_for.is_zero() {
             ctx.send_self_message(Loop).await?;
             return Ok(());


### PR DESCRIPTION
### Description
Attempt to fix source actor timeout reported in #2004. Recording progress after each pass through the `emit_batches` method seems to fix the issue, but I feel like this problem should be addressed in the actor framework, so I attempted to reproduce the bug in a unit test in the actors' crate. Without success, alas.

### How was this PR tested?
Successfully spawned 50 indexing pipelines consuming an empty topic on my local branch. I was not able to do so on `main`.
