### PR TITLE
Limit the number of indexing pipelines that can be spawned concurrently.

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -30,6 +30,7 @@ use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::{IndexMetadata, Metastore, MetastoreError, SplitState};
 use quickwit_storage::Storage;
 use tokio::join;
+use tokio::sync::Semaphore;
 use tracing::{debug, error, info, info_span, instrument, Span};
 
 use crate::actors::doc_processor::DocProcessor;
@@ -43,6 +44,11 @@ use crate::source::{quickwit_supported_sources, SourceActor, SourceExecutionCont
 use crate::split_store::IndexingSplitStore;
 
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(600); // 10 min.
+
+/// Spawning an indexing pipeline puts a lot of pressure on the file system, metastore, etc. so
+/// we rely on this semaphore to limit the number of indexing pipelines that can be spawned
+/// concurrently. See also #1638.
+static SPAWN_PIPELINE_SEMAPHORE: Semaphore = Semaphore::const_new(10);
 
 pub struct IndexingPipelineHandle {
     /// Indexing pipeline
@@ -202,6 +208,7 @@ impl IndexingPipeline {
     // TODO this should return an error saying whether we can retry or not.
     #[instrument(name="", level="info", skip_all, fields(index=%self.params.pipeline_id.index_id, gen=self.generation()))]
     async fn spawn_pipeline(&mut self, ctx: &ActorContext<Self>) -> anyhow::Result<()> {
+        let _spawn_pipeline_permit = SPAWN_PIPELINE_SEMAPHORE.acquire().await.expect("Failed to acquire spawn pipeline permit. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
         self.statistics.num_spawn_attempts += 1;
         self.kill_switch = KillSwitch::default();
 

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -47,7 +47,8 @@ const MAX_RETRY_DELAY: Duration = Duration::from_secs(600); // 10 min.
 
 /// Spawning an indexing pipeline puts a lot of pressure on the file system, metastore, etc. so
 /// we rely on this semaphore to limit the number of indexing pipelines that can be spawned
-/// concurrently. See also #1638.
+/// concurrently.
+/// See also <https://github.com/quickwit-oss/quickwit/issues/1638>.
 static SPAWN_PIPELINE_SEMAPHORE: Semaphore = Semaphore::const_new(10);
 
 pub struct IndexingPipelineHandle {

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -223,6 +223,7 @@ impl IndexingService {
                 .await?;
                 pipeline_ids.push(pipeline_id);
             }
+            ctx.record_progress();
         }
         if self.enable_ingest_api {
             let pipeline_id = self
@@ -247,7 +248,6 @@ impl IndexingService {
                 pipeline_ord: pipeline_id.pipeline_ord,
             });
         }
-
         let indexing_dir_path = self.data_dir_path.join(INDEXING_DIR_NAME);
         let indexing_directory = self
             .get_or_create_indexing_directory(&pipeline_id, indexing_dir_path)
@@ -255,7 +255,7 @@ impl IndexingService {
         let storage = self.storage_resolver.resolve(&index_metadata.index_uri)?;
         let merge_policy = self.get_or_create_merge_policy(&pipeline_id, &index_metadata);
         let split_store = self
-            .get_or_init_split_store(
+            .get_or_create_split_store(
                 &pipeline_id,
                 indexing_directory.cache_directory(),
                 storage.clone(),
@@ -376,7 +376,6 @@ impl IndexingService {
                 return merge_policy;
             }
         }
-
         let merge_policy = merge_policy_from_settings(&index_metadata.indexing_settings);
 
         self.merge_policies
@@ -409,7 +408,7 @@ impl IndexingService {
         Ok(indexing_directory)
     }
 
-    async fn get_or_init_split_store(
+    async fn get_or_create_split_store(
         &mut self,
         pipeline_id: &IndexingPipelineId,
         cache_directory: &Path,

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -17,13 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-mod no_merge_policy;
+mod nop_merge_policy;
 mod stable_log_merge_policy;
 
 use std::fmt;
 use std::sync::Arc;
 
-pub use no_merge_policy::NoMergePolicy;
+pub use nop_merge_policy::NopMergePolicy;
 use quickwit_config::IndexingSettings;
 use quickwit_metastore::SplitMetadata;
 pub(crate) use stable_log_merge_policy::StableLogMergePolicy;
@@ -99,7 +99,7 @@ pub trait MergePolicy: Send + Sync + fmt::Debug {
 
 pub fn merge_policy_from_settings(indexing_settings: &IndexingSettings) -> Arc<dyn MergePolicy> {
     if !indexing_settings.merge_enabled {
-        return Arc::new(NoMergePolicy);
+        return Arc::new(NopMergePolicy);
     }
     let stable_log_merge_policy = StableLogMergePolicy {
         merge_factor: indexing_settings.merge_policy.merge_factor,

--- a/quickwit/quickwit-indexing/src/merge_policy/nop_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/nop_merge_policy.rs
@@ -21,17 +21,18 @@ use std::fmt;
 
 use crate::merge_policy::MergePolicy;
 
-/// The NoMergePolicy simply... does not run any merges!
+/// The NopMergePolicy, as the name suggests, is no-op and does not perform any merges.
+/// <https://en.wikipedia.org/wiki/NOP_(code)>
 #[derive(Debug)]
-pub struct NoMergePolicy;
+pub struct NopMergePolicy;
 
-impl fmt::Display for NoMergePolicy {
+impl fmt::Display for NopMergePolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
-impl MergePolicy for NoMergePolicy {
+impl MergePolicy for NopMergePolicy {
     fn operations(
         &self,
         _splits: &mut Vec<quickwit_metastore::SplitMetadata>,
@@ -47,7 +48,7 @@ impl MergePolicy for NoMergePolicy {
 
 #[cfg(test)]
 mod tests {
-    use crate::merge_policy::{MergePolicy, NoMergePolicy};
+    use crate::merge_policy::{MergePolicy, NopMergePolicy};
 
     #[test]
     pub fn test_no_merge_policy_is_mature() {
@@ -56,13 +57,13 @@ mod tests {
             .next()
             .unwrap();
         // All splits are mature when merge is disabled.
-        assert!(NoMergePolicy.is_mature(&split));
+        assert!(NopMergePolicy.is_mature(&split));
     }
 
     #[test]
     pub fn test_no_merge_policy_operations() {
         let mut splits = super::super::tests::create_splits(vec![1; 100]);
-        assert!(NoMergePolicy.operations(&mut splits).is_empty());
+        assert!(NopMergePolicy.operations(&mut splits).is_empty());
         assert_eq!(splits.len(), 100);
     }
 }

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -266,7 +266,6 @@ impl Handler<Loop> for SourceActor {
             .source
             .emit_batches(&self.doc_processor_mailbox, ctx)
             .await?;
-        ctx.record_progress();
         if wait_for.is_zero() {
             ctx.send_self_message(Loop).await?;
             return Ok(());

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -364,7 +364,7 @@ impl Handler<PlanDeleteOperationsLoop> for DeleteTaskPlanner {
 mod tests {
     use quickwit_actors::{create_test_mailbox, ActorState, Universe};
     use quickwit_config::build_doc_mapper;
-    use quickwit_indexing::merge_policy::{MergeOperation, NoMergePolicy};
+    use quickwit_indexing::merge_policy::{MergeOperation, NopMergePolicy};
     use quickwit_indexing::TestSandbox;
     use quickwit_metastore::SplitMetadata;
     use quickwit_proto::metastore_api::DeleteQuery;
@@ -463,7 +463,7 @@ mod tests {
             doc_mapper_str,
             metastore.clone(),
             client_pool,
-            Arc::new(NoMergePolicy),
+            Arc::new(NopMergePolicy),
             downloader_mailbox,
         );
         let universe = Universe::new();


### PR DESCRIPTION
### Description
Limit the number of indexing pipelines that can be spawned concurrently.

### How was this PR tested?
`make test-all`
