### PR TITLE
Simple refactoring PR.

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -38,7 +38,7 @@ use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{error, info};
 
-use crate::merge_policy::{MergePolicy, StableMultitenantWithTimestampMergePolicy};
+use crate::merge_policy::{MergePolicy, StableLogMergePolicy};
 use crate::models::{
     DetachPipeline, IndexingDirectory, IndexingPipelineId, Observe, ObservePipeline,
     ShutdownPipeline, ShutdownPipelines, SpawnMergePipeline, SpawnPipeline, SpawnPipelines,
@@ -377,7 +377,7 @@ impl IndexingService {
             }
         }
 
-        let stable_multitenant_merge_policy = StableMultitenantWithTimestampMergePolicy {
+        let merge_policy = StableLogMergePolicy {
             merge_enabled: index_metadata.indexing_settings.merge_enabled,
             merge_factor: index_metadata.indexing_settings.merge_policy.merge_factor,
             max_merge_factor: index_metadata
@@ -387,7 +387,7 @@ impl IndexingService {
             split_num_docs_target: index_metadata.indexing_settings.split_num_docs_target,
             ..Default::default()
         };
-        let merge_policy: Arc<dyn MergePolicy> = Arc::new(stable_multitenant_merge_policy);
+        let merge_policy: Arc<dyn MergePolicy> = Arc::new(merge_policy);
 
         self.merge_policies
             .insert(pipeline_id.index_id.clone(), Arc::downgrade(&merge_policy));

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -168,7 +168,7 @@ mod tests {
 
     use super::*;
     use crate::actors::combine_partition_ids;
-    use crate::merge_policy::{MergeOperation, StableMultitenantWithTimestampMergePolicy};
+    use crate::merge_policy::{MergeOperation, StableLogMergePolicy};
     use crate::new_split_id;
 
     fn merge_time_range(splits: &[SplitMetadata]) -> Option<RangeInclusive<i64>> {
@@ -319,7 +319,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simulate_merge_planner_constant_case() -> anyhow::Result<()> {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        let merge_policy = StableLogMergePolicy::default();
         aux_test_simulate_merge_planner_num_docs(
             Arc::new(merge_policy.clone()),
             &vec![10_000; 100_000],
@@ -343,8 +343,8 @@ mod tests {
     proptest! {
         #![proptest_config(proptest_config())]
         #[test]
-        fn test_proptest_simulate_stable_multitenant_merge_planner_adversarial(batch_num_docs in proptest::collection::vec(select(&[11, 1_990, 10_000, 50_000, 310_000][..]), 1..1_000)) {
-            let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        fn test_proptest_simulate_stable_log_merge_planner_adversarial(batch_num_docs in proptest::collection::vec(select(&[11, 1_990, 10_000, 50_000, 310_000][..]), 1..1_000)) {
+            let merge_policy = StableLogMergePolicy::default();
             let rt = Runtime::new().unwrap();
             rt.block_on(
             aux_test_simulate_merge_planner_num_docs(
@@ -359,8 +359,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_simulate_stable_multitenant_merge_planner_ideal_case() -> anyhow::Result<()> {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    async fn test_simulate_stable_log_merge_planner_ideal_case() -> anyhow::Result<()> {
+        let merge_policy = StableLogMergePolicy::default();
         aux_test_simulate_merge_planner_num_docs(
             Arc::new(merge_policy.clone()),
             &vec![10_000; 1_000],
@@ -374,8 +374,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_simulate_stable_multitenant_merge_planner_bug() -> anyhow::Result<()> {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    async fn test_simulate_stable_log_merge_planner_bug() -> anyhow::Result<()> {
+        let merge_policy = StableLogMergePolicy::default();
         let vals = &[11, 11, 11, 11, 11, 11, 310000, 11, 11, 11, 11, 11, 11, 11];
         aux_test_simulate_merge_planner_num_docs(
             Arc::new(merge_policy.clone()),

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -1,0 +1,397 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod stable_log_merge_policy;
+
+use std::fmt;
+
+use quickwit_metastore::SplitMetadata;
+pub use stable_log_merge_policy::StableLogMergePolicy;
+
+use crate::new_split_id;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MergeOperationType {
+    Merge,
+    DeleteAndMerge,
+}
+
+impl fmt::Display for MergeOperationType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Clone)]
+pub struct MergeOperation {
+    pub merge_split_id: String,
+    pub splits: Vec<SplitMetadata>,
+    pub operation_type: MergeOperationType,
+}
+
+impl MergeOperation {
+    pub fn new_merge_operation(splits: Vec<SplitMetadata>) -> Self {
+        Self {
+            merge_split_id: new_split_id(),
+            splits,
+            operation_type: MergeOperationType::Merge,
+        }
+    }
+
+    pub fn new_delete_and_merge_operation(split: SplitMetadata) -> Self {
+        Self {
+            merge_split_id: new_split_id(),
+            splits: vec![split],
+            operation_type: MergeOperationType::DeleteAndMerge,
+        }
+    }
+
+    pub fn splits_as_slice(&self) -> &[SplitMetadata] {
+        self.splits.as_slice()
+    }
+}
+
+impl fmt::Debug for MergeOperation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Merge(operation_type={}, merged_split_id={},splits=[",
+            self.operation_type, self.merge_split_id
+        )?;
+        for split in &self.splits {
+            write!(f, "{},", split.split_id())?;
+        }
+        write!(f, "])")?;
+        Ok(())
+    }
+}
+
+/// A merge policy wraps the logic that decide what should be merged.
+/// The SplitMetadata must be extracted from the splits `Vec`.
+///
+/// It is called by the merge planner whenever a new split is added.
+pub trait MergePolicy: Send + Sync + fmt::Debug {
+    /// Returns the list of merge operations that should be performed.
+    fn operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation>;
+    /// A mature split is a split that won't undergo a merge operation in the future.
+    fn is_mature(&self, split: &SplitMetadata) -> bool;
+}
+
+struct SplitShortDebug<'a>(&'a SplitMetadata);
+
+impl<'a> fmt::Debug for SplitShortDebug<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Split")
+            .field("split_id", &self.0.split_id())
+            .field("num_docs", &self.0.num_docs)
+            .finish()
+    }
+}
+
+fn splits_short_debug(splits: &[SplitMetadata]) -> Vec<SplitShortDebug> {
+    splits.iter().map(SplitShortDebug).collect()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::ops::RangeInclusive;
+
+    use super::*;
+
+    fn create_splits(num_docs_vec: Vec<usize>) -> Vec<SplitMetadata> {
+        let num_docs_with_timestamp = num_docs_vec
+            .into_iter()
+            // we give the same timestamp to all of them and rely on stable sort to keep the split
+            // order.
+            .map(|num_docs| (num_docs, (1630563067..=1630564067)))
+            .collect();
+        create_splits_with_timestamps(num_docs_with_timestamp)
+    }
+
+    fn create_splits_with_timestamps(
+        num_docs_vec: Vec<(usize, RangeInclusive<i64>)>,
+    ) -> Vec<SplitMetadata> {
+        num_docs_vec
+            .into_iter()
+            .enumerate()
+            .map(|(split_ord, (num_docs, time_range))| SplitMetadata {
+                split_id: format!("split_{:02}", split_ord),
+                num_docs,
+                time_range: Some(time_range),
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_split_is_mature() {
+        let merge_policy = StableLogMergePolicy::default();
+        // Split under max_merge_docs is not mature.
+        let mut split = create_splits(vec![9_000_000]).into_iter().next().unwrap();
+        assert!(!merge_policy.is_mature(&split));
+        // All splits are mature when merge is disabled.
+        let merge_policy_with_disabled_merge = StableLogMergePolicy {
+            merge_enabled: false,
+            ..Default::default()
+        };
+        assert!(merge_policy_with_disabled_merge.is_mature(&split));
+        // Split under max_merge_docs is not mature.
+        assert!(!merge_policy.is_mature(&split));
+        // Split with docs > max_merge_docs is mature.
+        split.num_docs = merge_policy.split_num_docs_target + 1;
+        assert!(merge_policy.is_mature(&split));
+    }
+
+    #[test]
+    fn test_build_split_levels() {
+        let merge_policy = StableLogMergePolicy::default();
+        let splits = Vec::new();
+        let split_groups = merge_policy.build_split_levels(&splits);
+        assert!(split_groups.is_empty());
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_build_split_simple() {
+        let merge_policy = StableLogMergePolicy::default();
+        let splits = create_splits(vec![100_000, 100_000, 100_000, 800_000, 900_000]);
+        let split_groups = merge_policy.build_split_levels(&splits);
+        assert_eq!(&split_groups, &[0..3, 3..5]);
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_build_split_perfect_world() {
+        let merge_policy = StableLogMergePolicy::default();
+        let splits = create_splits(vec![
+            100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
+            1_600_000,
+        ]);
+        let split_groups = merge_policy.build_split_levels(&splits);
+        assert_eq!(&split_groups, &[0..8, 8..10]);
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_build_split_decreasing() {
+        let merge_policy = StableLogMergePolicy::default();
+        let splits = create_splits(vec![
+            100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
+            100_000, 1_600_000,
+        ]);
+        let split_groups = merge_policy.build_split_levels(&splits);
+        assert_eq!(&split_groups, &[0..8, 8..11]);
+    }
+
+    #[test]
+    #[should_panic(expected = "All splits are expected to be smaller than `max_merge_docs`.")]
+    fn test_stable_log_merge_policy_build_split_panics_if_exceeding_max_merge_docs() {
+        let merge_policy = StableLogMergePolicy::default();
+        let splits = create_splits(vec![11_000_000]);
+        merge_policy.build_split_levels(&splits);
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_not_enough_splits() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![100; 7]);
+        assert_eq!(splits.len(), 7);
+        assert!(merge_policy.operations(&mut splits).is_empty());
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_just_enough_splits_for_a_merge() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![100; 10]);
+        let mut merge_ops = merge_policy.operations(&mut splits);
+        assert!(splits.is_empty());
+        assert_eq!(merge_ops.len(), 1);
+        let merge_op = merge_ops.pop().unwrap();
+        let mut merge_segment_ids: Vec<String> = merge_op
+            .splits_as_slice()
+            .iter()
+            .map(|split| split.split_id().to_string())
+            .collect();
+        merge_segment_ids.sort();
+        assert_eq!(
+            merge_segment_ids,
+            &[
+                "split_00", "split_01", "split_02", "split_03", "split_04", "split_05", "split_06",
+                "split_07", "split_08", "split_09"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_many_splits_on_same_level() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![100; 13]);
+        let mut merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].split_id(), "split_00");
+        assert_eq!(merge_ops.len(), 1);
+        let merge_op = merge_ops.pop().unwrap();
+        let mut merge_split_ids: Vec<String> = merge_op
+            .splits_as_slice()
+            .iter()
+            .map(|split| split.split_id().to_string())
+            .collect();
+        merge_split_ids.sort();
+        assert_eq!(
+            merge_split_ids,
+            &[
+                "split_01", "split_02", "split_03", "split_04", "split_05", "split_06", "split_07",
+                "split_08", "split_09", "split_10", "split_11", "split_12"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_splits_below_min_level() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![
+            100, 1000, 10_000, 10_000, 10_000, 10_000, 10_000, 40_000, 40_000, 40_000,
+        ]);
+        let mut merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 0);
+        assert_eq!(merge_ops.len(), 1);
+        let merge_op = merge_ops.pop().unwrap();
+        let mut merge_split_ids: Vec<String> = merge_op
+            .splits_as_slice()
+            .iter()
+            .map(|split| split.split_id().to_string())
+            .collect();
+        merge_split_ids.sort();
+        assert_eq!(
+            merge_split_ids,
+            &[
+                "split_00", "split_01", "split_02", "split_03", "split_04", "split_05", "split_06",
+                "split_07", "split_08", "split_09"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_splits_above_min_level() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![
+            100_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000,
+        ]);
+        let merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 8);
+        assert_eq!(merge_ops.len(), 0);
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_above_max_merge_docs_is_ignored() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![
+            100_000, 100_000, 100_000, 100_000, 100_000,
+            10_000_000, // this split should not interfere with the merging of other splits
+            100_000, 100_000, 100_000, 100_000, 100_000,
+        ]);
+        let merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].num_docs, 10_000_000);
+        assert_eq!(merge_ops.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_policy_splits_too_large_are_ignored() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![9_999_999, 10_000_000]);
+        let merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 2);
+        assert_eq!(splits[0].num_docs, 9_999_999);
+        assert_eq!(splits[1].num_docs, 10_000_000);
+        assert!(merge_ops.is_empty());
+    }
+
+    #[test]
+    fn test_merge_policy_splits_entire_level_reach_merge_max_doc() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![5_000_000, 5_000_000]);
+        let merge_ops = merge_policy.operations(&mut splits);
+        assert!(splits.is_empty());
+        assert_eq!(merge_ops.len(), 1);
+        assert_eq!(merge_ops[0].splits_as_slice().len(), 2);
+    }
+
+    #[test]
+    fn test_merge_policy_last_merge_can_have_a_lower_merge_factor() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![9_999_997, 9_999_998, 9_999_999]);
+        let merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].num_docs, 9_999_997);
+        assert_eq!(merge_ops.len(), 1);
+        assert_eq!(merge_ops[0].splits_as_slice().len(), 2);
+    }
+
+    #[test]
+    fn test_merge_policy_no_merge_with_only_one_split() {
+        let merge_policy = StableLogMergePolicy::default();
+        let mut splits = create_splits(vec![9_999_999]);
+        let merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].num_docs, 9_999_999);
+        assert!(merge_ops.is_empty());
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_max_num_splits_worst_case() {
+        let merge_policy = StableLogMergePolicy::default();
+        assert_eq!(merge_policy.max_num_splits_worst_case(99), 9);
+        assert_eq!(merge_policy.max_num_splits_worst_case(1_000_000), 27);
+        assert_eq!(merge_policy.max_num_splits_worst_case(2_000_000), 36);
+        assert_eq!(merge_policy.max_num_splits_worst_case(3_000_000), 36);
+        assert_eq!(merge_policy.max_num_splits_worst_case(4_000_000), 36);
+        assert_eq!(merge_policy.max_num_splits_worst_case(5_000_000), 45);
+        assert_eq!(merge_policy.max_num_splits_worst_case(7_000_000), 45);
+        assert_eq!(merge_policy.max_num_splits_worst_case(10_000_000), 45);
+        assert_eq!(merge_policy.max_num_splits_worst_case(20_000_000), 54);
+        assert_eq!(merge_policy.max_num_splits_worst_case(100_000_000), 63);
+        assert_eq!(merge_policy.max_num_splits_worst_case(1_000_000_000), 153);
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_max_num_splits_ideal_case() {
+        let merge_policy = StableLogMergePolicy::default();
+        assert_eq!(merge_policy.max_num_splits_ideal_case(1_000_000), 18);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(99), 9);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(2_000_000), 20);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(3_000_000), 21);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(4_000_000), 22);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(5_000_000), 23);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(7_000_000), 25);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(10_000_000), 27);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(100_000_000), 37);
+        assert_eq!(merge_policy.max_num_splits_ideal_case(1_000_000_000), 127);
+    }
+
+    #[test]
+    fn test_stable_log_merge_policy_merge_not_enabled() {
+        let merge_policy = StableLogMergePolicy {
+            merge_enabled: false,
+            ..Default::default()
+        };
+        let mut splits = create_splits(vec![100; 10]);
+        let merge_ops = merge_policy.operations(&mut splits);
+        assert_eq!(splits.len(), 10);
+        assert_eq!(merge_ops.len(), 0);
+    }
+}

--- a/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
@@ -18,82 +18,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::cmp::Reverse;
-use std::fmt;
 use std::ops::Range;
 
 use quickwit_metastore::SplitMetadata;
 use tracing::debug;
 
-use crate::new_split_id;
+use crate::merge_policy::{splits_short_debug, MergeOperation, MergePolicy};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum MergeOperationType {
-    Merge,
-    DeleteAndMerge,
-}
-
-impl fmt::Display for MergeOperationType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-#[derive(Clone)]
-pub struct MergeOperation {
-    pub merge_split_id: String,
-    pub splits: Vec<SplitMetadata>,
-    pub operation_type: MergeOperationType,
-}
-
-impl MergeOperation {
-    pub fn new_merge_operation(splits: Vec<SplitMetadata>) -> Self {
-        Self {
-            merge_split_id: new_split_id(),
-            splits,
-            operation_type: MergeOperationType::Merge,
-        }
-    }
-
-    pub fn new_delete_and_merge_operation(split: SplitMetadata) -> Self {
-        Self {
-            merge_split_id: new_split_id(),
-            splits: vec![split],
-            operation_type: MergeOperationType::DeleteAndMerge,
-        }
-    }
-
-    pub fn splits_as_slice(&self) -> &[SplitMetadata] {
-        self.splits.as_slice()
-    }
-}
-
-impl fmt::Debug for MergeOperation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Merge(operation_type={}, merged_split_id={},splits=[",
-            self.operation_type, self.merge_split_id
-        )?;
-        for split in &self.splits {
-            write!(f, "{},", split.split_id())?;
-        }
-        write!(f, "])")?;
-        Ok(())
-    }
-}
-
-/// A merge policy wraps the logic that decide what should be merged.
-/// The SplitMetadata must be extracted from the splits `Vec`.
-///
-/// It is called by the merge planner whenever a new split is added.
-pub trait MergePolicy: Send + Sync + fmt::Debug {
-    /// Returns the list of merge operations that should be performed.
-    fn operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation>;
-    /// A mature split is a split that won't undergo a merge operation in the future.
-    fn is_mature(&self, split: &SplitMetadata) -> bool;
-}
-
-/// StableMultitenantMergePolicy is a rather naive implementation optimized
+/// `StableLogMergePolicy` is a rather naive implementation optimized
 /// for splits produced by a rather stable stream of splits,
 /// with incoming documents ordered more or less as expected time, so that splits are
 /// time pruning is efficient out of the box.
@@ -126,7 +58,7 @@ pub trait MergePolicy: Send + Sync + fmt::Debug {
 /// Because we stop merging splits reaching a size larger than if it would result in a size larger
 /// than `target_num_docs`.
 #[derive(Clone, Debug)]
-pub struct StableMultitenantWithTimestampMergePolicy {
+pub struct StableLogMergePolicy {
     pub min_level_num_docs: usize,
     pub merge_enabled: bool,
     pub merge_factor: usize,
@@ -139,9 +71,9 @@ pub struct StableMultitenantWithTimestampMergePolicy {
     pub split_num_docs_target: usize,
 }
 
-impl Default for StableMultitenantWithTimestampMergePolicy {
+impl Default for StableLogMergePolicy {
     fn default() -> Self {
-        StableMultitenantWithTimestampMergePolicy {
+        StableLogMergePolicy {
             min_level_num_docs: 100_000,
             merge_enabled: true,
             merge_factor: 10,
@@ -165,22 +97,7 @@ fn remove_matching_items<T, Pred: Fn(&T) -> bool>(items: &mut Vec<T>, predicate:
     matching_items
 }
 
-struct SplitShortDebug<'a>(&'a SplitMetadata);
-
-impl<'a> fmt::Debug for SplitShortDebug<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Split")
-            .field("split_id", &self.0.split_id())
-            .field("num_docs", &self.0.num_docs)
-            .finish()
-    }
-}
-
-fn splits_short_debug(splits: &[SplitMetadata]) -> Vec<SplitShortDebug> {
-    splits.iter().map(SplitShortDebug).collect()
-}
-
-impl MergePolicy for StableMultitenantWithTimestampMergePolicy {
+impl MergePolicy for StableLogMergePolicy {
     fn operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation> {
         let original_num_splits = splits.len();
         let operations = self.merge_operations(splits);
@@ -215,7 +132,7 @@ enum MergeCandidateSize {
     OneMoreSplitWouldBeTooBig,
 }
 
-impl StableMultitenantWithTimestampMergePolicy {
+impl StableLogMergePolicy {
     /// A mature split for merge is a split that won't undergo merge operation in the future.
     fn is_mature_for_merge(&self, split: &SplitMetadata) -> bool {
         // If merge is disabled, split is considered mature as it will not undergo a merge
@@ -440,12 +357,12 @@ mod tests {
 
     #[test]
     fn test_split_is_mature() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        let merge_policy = StableLogMergePolicy::default();
         // Split under max_merge_docs is not mature.
         let mut split = create_splits(vec![9_000_000]).into_iter().next().unwrap();
         assert!(!merge_policy.is_mature(&split));
         // All splits are mature when merge is disabled.
-        let merge_policy_with_disabled_merge = StableMultitenantWithTimestampMergePolicy {
+        let merge_policy_with_disabled_merge = StableLogMergePolicy {
             merge_enabled: false,
             ..Default::default()
         };
@@ -459,23 +376,23 @@ mod tests {
 
     #[test]
     fn test_build_split_levels() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        let merge_policy = StableLogMergePolicy::default();
         let splits = Vec::new();
         let split_groups = merge_policy.build_split_levels(&splits);
         assert!(split_groups.is_empty());
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_build_split_simple() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_build_split_simple() {
+        let merge_policy = StableLogMergePolicy::default();
         let splits = create_splits(vec![100_000, 100_000, 100_000, 800_000, 900_000]);
         let split_groups = merge_policy.build_split_levels(&splits);
         assert_eq!(&split_groups, &[0..3, 3..5]);
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_build_split_perfect_world() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_build_split_perfect_world() {
+        let merge_policy = StableLogMergePolicy::default();
         let splits = create_splits(vec![
             100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
             1_600_000,
@@ -485,8 +402,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_build_split_decreasing() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_build_split_decreasing() {
+        let merge_policy = StableLogMergePolicy::default();
         let splits = create_splits(vec![
             100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
             100_000, 1_600_000,
@@ -497,23 +414,23 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "All splits are expected to be smaller than `max_merge_docs`.")]
-    fn test_stable_multitenant_merge_policy_build_split_panics_if_exceeding_max_merge_docs() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_build_split_panics_if_exceeding_max_merge_docs() {
+        let merge_policy = StableLogMergePolicy::default();
         let splits = create_splits(vec![11_000_000]);
         merge_policy.build_split_levels(&splits);
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_not_enough_splits() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_not_enough_splits() {
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![100; 7]);
         assert_eq!(splits.len(), 7);
         assert!(merge_policy.operations(&mut splits).is_empty());
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_just_enough_splits_for_a_merge() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_just_enough_splits_for_a_merge() {
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![100; 10]);
         let mut merge_ops = merge_policy.operations(&mut splits);
         assert!(splits.is_empty());
@@ -535,8 +452,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_many_splits_on_same_level() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_many_splits_on_same_level() {
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![100; 13]);
         let mut merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 1);
@@ -559,8 +476,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_splits_below_min_level() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_splits_below_min_level() {
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![
             100, 1000, 10_000, 10_000, 10_000, 10_000, 10_000, 40_000, 40_000, 40_000,
         ]);
@@ -584,8 +501,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_splits_above_min_level() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_splits_above_min_level() {
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![
             100_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000,
         ]);
@@ -595,8 +512,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_above_max_merge_docs_is_ignored() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_above_max_merge_docs_is_ignored() {
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![
             100_000, 100_000, 100_000, 100_000, 100_000,
             10_000_000, // this split should not interfere with the merging of other splits
@@ -610,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_merge_policy_splits_too_large_are_ignored() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![9_999_999, 10_000_000]);
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 2);
@@ -621,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_merge_policy_splits_entire_level_reach_merge_max_doc() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![5_000_000, 5_000_000]);
         let merge_ops = merge_policy.operations(&mut splits);
         assert!(splits.is_empty());
@@ -631,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_merge_policy_last_merge_can_have_a_lower_merge_factor() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![9_999_997, 9_999_998, 9_999_999]);
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 1);
@@ -642,7 +559,7 @@ mod tests {
 
     #[test]
     fn test_merge_policy_no_merge_with_only_one_split() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+        let merge_policy = StableLogMergePolicy::default();
         let mut splits = create_splits(vec![9_999_999]);
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 1);
@@ -651,8 +568,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_max_num_splits_worst_case() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_max_num_splits_worst_case() {
+        let merge_policy = StableLogMergePolicy::default();
         assert_eq!(merge_policy.max_num_splits_worst_case(99), 9);
         assert_eq!(merge_policy.max_num_splits_worst_case(1_000_000), 27);
         assert_eq!(merge_policy.max_num_splits_worst_case(2_000_000), 36);
@@ -667,8 +584,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_max_num_splits_ideal_case() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
+    fn test_stable_log_merge_policy_max_num_splits_ideal_case() {
+        let merge_policy = StableLogMergePolicy::default();
         assert_eq!(merge_policy.max_num_splits_ideal_case(1_000_000), 18);
         assert_eq!(merge_policy.max_num_splits_ideal_case(99), 9);
         assert_eq!(merge_policy.max_num_splits_ideal_case(2_000_000), 20);
@@ -682,8 +599,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stable_multitenant_merge_policy_merge_not_enabled() {
-        let merge_policy = StableMultitenantWithTimestampMergePolicy {
+    fn test_stable_log_merge_policy_merge_not_enabled() {
+        let merge_policy = StableLogMergePolicy {
             merge_enabled: false,
             ..Default::default()
         };

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -33,7 +33,7 @@ use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use super::LocalSplitStore;
-use crate::merge_policy::StableMultitenantWithTimestampMergePolicy;
+use crate::merge_policy::StableLogMergePolicy;
 use crate::split_store::SPLIT_CACHE_DIR_NAME;
 use crate::{get_tantivy_directory_from_split_bundle, MergePolicy, SplitFolder};
 
@@ -226,7 +226,7 @@ impl IndexingSplitStore {
         let inner = InnerIndexingSplitStore {
             remote_storage,
             local_split_store: None,
-            merge_policy: Arc::new(StableMultitenantWithTimestampMergePolicy::default()),
+            merge_policy: Arc::new(StableLogMergePolicy::default()),
         };
         Self {
             inner: Arc::new(inner),
@@ -399,7 +399,7 @@ mod test_split_store {
     use tokio::sync::Mutex;
 
     use super::IndexingSplitStore;
-    use crate::merge_policy::StableMultitenantWithTimestampMergePolicy;
+    use crate::merge_policy::StableLogMergePolicy;
     use crate::split_store::{SplitStoreSpaceQuota, SPLIT_CACHE_DIR_NAME};
     use crate::MergePolicy;
 
@@ -415,7 +415,7 @@ mod test_split_store {
 
         let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(2, 10)));
         let remote_storage = Arc::new(RamStorage::default());
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let result = IndexingSplitStore::create_with_local_store(
             remote_storage,
             local_dir.path(),
@@ -444,7 +444,7 @@ mod test_split_store {
 
         let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(4, 10)));
         let remote_storage = Arc::new(RamStorage::default());
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let result = IndexingSplitStore::create_with_local_store(
             remote_storage,
             local_dir.path(),
@@ -472,7 +472,7 @@ mod test_split_store {
 
         let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(100, 100)));
         let remote_storage = Arc::new(RamStorage::default());
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let result = IndexingSplitStore::create_with_local_store(
             remote_storage,
             local_dir.path(),
@@ -495,7 +495,7 @@ mod test_split_store {
     async fn test_local_store_cache_in_and_out() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let split_cache_dir = tempdir()?;
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let remote_storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_with_local_store(
             remote_storage,
@@ -553,7 +553,7 @@ mod test_split_store {
         let temp_dir = tempfile::tempdir()?;
 
         let split_cache_dir = tempdir()?;
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let remote_storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_with_local_store(
             remote_storage,
@@ -621,7 +621,7 @@ mod test_split_store {
         let temp_dir = tempfile::tempdir()?;
 
         let split_cache_dir = tempdir()?;
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let remote_storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_with_local_store(
             remote_storage,
@@ -682,7 +682,7 @@ mod test_split_store {
         let temp_dir = tempfile::tempdir()?;
 
         let split_cache_dir = tempdir()?;
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let remote_storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_with_local_store(
             remote_storage.clone(),
@@ -743,7 +743,7 @@ mod test_split_store {
 
         let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(100, 200)));
         let remote_storage = Arc::new(RamStorage::default());
-        let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
+        let merge_policy = Arc::new(StableLogMergePolicy::default());
         let split_store = IndexingSplitStore::create_with_local_store(
             remote_storage,
             local_dir.path(),

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -32,7 +32,7 @@ use quickwit_config::{build_doc_mapper, IndexingSettings};
 use quickwit_indexing::actors::{
     MergeExecutor, MergeSplitDownloader, Packager, Publisher, Uploader,
 };
-use quickwit_indexing::merge_policy::{MergePolicy, StableMultitenantWithTimestampMergePolicy};
+use quickwit_indexing::merge_policy::{MergePolicy, StableLogMergePolicy};
 use quickwit_indexing::models::{IndexingDirectory, IndexingPipelineId};
 use quickwit_indexing::{IndexingSplitStore, PublisherType, Sequencer};
 use quickwit_metastore::Metastore;
@@ -188,14 +188,14 @@ impl DeleteTaskPipeline {
             .spawn_actor()
             .set_kill_switch(KillSwitch::default())
             .spawn(merge_split_downloader);
-        let stable_multitenant_merge_policy = StableMultitenantWithTimestampMergePolicy {
+        let merge_policy = StableLogMergePolicy {
             merge_enabled: true,
             merge_factor: self.indexing_settings.merge_policy.merge_factor,
             max_merge_factor: self.indexing_settings.merge_policy.max_merge_factor,
             split_num_docs_target: self.indexing_settings.split_num_docs_target,
             ..Default::default()
         };
-        let merge_policy: Arc<dyn MergePolicy> = Arc::new(stable_multitenant_merge_policy);
+        let merge_policy: Arc<dyn MergePolicy> = Arc::new(merge_policy);
         let doc_mapper_str = serde_json::to_string(&doc_mapper)?;
         let task_planner = DeleteTaskPlanner::new(
             self.index_id.clone(),

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -364,9 +364,7 @@ impl Handler<PlanDeleteOperationsLoop> for DeleteTaskPlanner {
 mod tests {
     use quickwit_actors::{create_test_mailbox, ActorState, Universe};
     use quickwit_config::build_doc_mapper;
-    use quickwit_indexing::merge_policy::{
-        MergeOperation, StableMultitenantWithTimestampMergePolicy,
-    };
+    use quickwit_indexing::merge_policy::{MergeOperation, StableLogMergePolicy};
     use quickwit_indexing::TestSandbox;
     use quickwit_metastore::SplitMetadata;
     use quickwit_proto::metastore_api::DeleteQuery;
@@ -459,7 +457,7 @@ mod tests {
         );
         let client_pool = SearchClientPool::from_mocks(vec![Arc::new(mock_search_service)]).await?;
         let (downloader_mailbox, downloader_inbox) = create_test_mailbox();
-        let merge_policy = StableMultitenantWithTimestampMergePolicy {
+        let merge_policy = StableLogMergePolicy {
             split_num_docs_target: 1, // <- Set to 1 to have a mature split.
             merge_enabled: true,
             ..Default::default()


### PR DESCRIPTION
Renamed the StableMultitenant...MergePolicy into StableLogMergePolicy. Moved it into an independent file as we are about to add another log merge policy.
