### PR TITLE
Fix datetime parsing when using strftime format

### DIFF
--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_type.rs
@@ -89,12 +89,12 @@ impl QuickwitDateTimeOptions {
             }
         }
         Err(format!(
-            "Could not parse datetime `{}` using the specified formats `{}`.",
+            "Failed to parse datetime `{}` using the specified formats `{}`.",
             value,
             self.input_formats
                 .iter()
-                .map(ToString::to_string)
-                .join(", ")
+                .map(|input_format| input_format.as_str())
+                .join("`, `")
         ))
     }
 
@@ -495,8 +495,8 @@ mod tests {
                 .unwrap_err();
             assert_eq!(
                 error,
-                "Could not parse datetime `foo` using the specified formats `iso8601, rfc3339, \
-                 rfc2822, %Y-%m-%d %H:%M:%S, unix_ts_millis`.",
+                "Failed to parse datetime `foo` using the specified formats `iso8601`, `rfc3339`, \
+                 `rfc2822`, `%Y-%m-%d %H:%M:%S`, `unix_ts_millis`.",
             );
         }
     }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
@@ -967,8 +967,8 @@ mod tests {
         let err = typ.value_from_json(json!("foo-datetime")).unwrap_err();
         assert_eq!(
             err,
-            "Could not parse datetime `foo-datetime` using the specified formats `rfc3339, \
-             unix_ts_secs`."
+            "Failed to parse datetime `foo-datetime` using the specified formats `rfc3339`, \
+             `unix_ts_secs`."
         );
     }
 


### PR DESCRIPTION
### Description
Found a bug as I was implementing support for `unix_ts_nanos` for OpenTelemetry.

### How was this PR tested?
Added unit test.
