### PR TITLE
Update tutorial following change in Vector. ndjson => json + framing.…

### DIFF
--- a/docs/tutorials/send-logs-from-vector-to-quickwit.md
+++ b/docs/tutorials/send-logs-from-vector-to-quickwit.md
@@ -150,7 +150,8 @@ encoding.codec = "json"
 [sinks.quickwit_logs]
 type = "http"
 inputs = ["remap_syslog"]
-encoding.codec = "ndjson"
+encoding.codec = "json"
+framing.method = "newline_delimited"
 uri = "http://host.docker.internal:7280/api/v1/otel-logs/ingest"
 ```
 


### PR DESCRIPTION
…method := newline_delimited

### Description

Vector does not support encoding since 0.24 Codec="ndjson" configuration, adjusted to encoding codec = “ndjson”

framing. method = "newline_delimited"
