### PR TITLE
Fixes tracing in indexing

### DIFF
--- a/quickwit/quickwit-actors/src/actor.rs
+++ b/quickwit/quickwit-actors/src/actor.rs
@@ -29,7 +29,7 @@ use async_trait::async_trait;
 use futures::Future;
 use thiserror::Error;
 use tokio::sync::{oneshot, watch};
-use tracing::{debug, error, info_span, Span};
+use tracing::{debug, error};
 
 use crate::actor_state::{ActorState, AtomicState};
 use crate::progress::{Progress, ProtectedZoneGuard};
@@ -157,11 +157,6 @@ pub trait Actor: Send + Sync + Sized + 'static {
     ///
     /// This function should return quickly.
     fn observable_state(&self) -> Self::ObservableState;
-
-    /// Creates a span associated to all logging happening during the lifetime of an actor instance.
-    fn span(&self, _ctx: &ActorContext<Self>) -> Span {
-        info_span!("", actor = %self.name())
-    }
 
     /// Initialize is called before running the actor.
     ///
@@ -545,15 +540,6 @@ impl<A: Actor> ActorContext<A> {
 #[async_trait::async_trait]
 pub trait Handler<M>: Actor {
     type Reply: 'static + Send;
-
-    /// Returns a context span for the processing of a specific
-    /// message.
-    ///
-    /// `msg_id` is an autoincremented message id than can be added to the span.
-    /// The counter starts 0 at the beginning of the life of an actor instance.
-    fn message_span(&self, msg_id: u64, _msg: &M) -> Span {
-        info_span!("", msg_id = &msg_id)
-    }
 
     /// Processes a message.
     ///

--- a/quickwit/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit/quickwit-actors/src/spawn_builder.rs
@@ -19,7 +19,7 @@
 
 use anyhow::Context;
 use tokio::sync::watch;
-use tracing::{debug, error, info, Instrument};
+use tracing::{debug, error, info};
 
 use crate::envelope::Envelope;
 use crate::mailbox::Inbox;
@@ -103,9 +103,7 @@ impl<A: Actor> SpawnBuilder<A> {
         debug!(actor_id = %ctx.actor_instance_id(), "spawn-actor");
         let mailbox = ctx.mailbox().clone();
         let ctx_clone = ctx.clone();
-        let span = actor.span(&ctx);
-        let loop_async_actor_future =
-            async move { actor_loop(actor, inbox, ctx).await }.instrument(span);
+        let loop_async_actor_future = async move { actor_loop(actor, inbox, ctx).await };
         let join_handle = runtime_handle.spawn(loop_async_actor_future);
         let actor_handle = ActorHandle::new(state_rx, join_handle, ctx_clone);
         (mailbox, actor_handle)
@@ -175,7 +173,6 @@ struct ActorExecutionEnv<A: Actor> {
     actor: A,
     inbox: Inbox<A>,
     ctx: ActorContext<A>,
-    msg_id: u64,
 }
 
 impl<A: Actor> ActorExecutionEnv<A> {
@@ -196,10 +193,7 @@ impl<A: Actor> ActorExecutionEnv<A> {
         mut envelope: Envelope<A>,
     ) -> Result<(), ActorExitStatus> {
         self.yield_and_check_if_killed().await?;
-        envelope
-            .handle_message(self.msg_id, &mut self.actor, &self.ctx)
-            .await?;
-        self.msg_id += 1u64;
+        envelope.handle_message(&mut self.actor, &self.ctx).await?;
         Ok(())
     }
 
@@ -278,12 +272,7 @@ impl<A: Actor> Drop for ActorExecutionEnv<A> {
 }
 
 async fn actor_loop<A: Actor>(actor: A, inbox: Inbox<A>, ctx: ActorContext<A>) -> ActorExitStatus {
-    let mut actor_env = ActorExecutionEnv {
-        actor,
-        inbox,
-        ctx,
-        msg_id: 1u64,
-    };
+    let mut actor_env = ActorExecutionEnv { actor, inbox, ctx };
 
     let initialize_exit_status_res: Result<(), ActorExitStatus> = actor_env.initialize().await;
 

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -31,7 +31,7 @@ use quickwit_metastore::{IndexMetadata, Metastore, MetastoreError, SplitState};
 use quickwit_storage::Storage;
 use tokio::join;
 use tokio::sync::Semaphore;
-use tracing::{debug, error, info, info_span, instrument, Span};
+use tracing::{debug, error, info, instrument};
 
 use super::uploader::SplitsUpdateMailbox;
 use crate::actors::doc_processor::DocProcessor;
@@ -101,10 +101,6 @@ impl Actor for IndexingPipeline {
 
     fn name(&self) -> String {
         "IndexingPipeline".to_string()
-    }
-
-    fn span(&self, _ctx: &ActorContext<Self>) -> Span {
-        info_span!("")
     }
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
@@ -206,7 +202,14 @@ impl IndexingPipeline {
     }
 
     // TODO this should return an error saying whether we can retry or not.
-    #[instrument(name="", level="info", skip_all, fields(index=%self.params.pipeline_id.index_id, gen=self.generation()))]
+    #[instrument(
+        name="spawn_pipeline",
+        level="info",
+        skip_all,
+        fields(
+            index=%self.params.pipeline_id.index_id,
+            gen=self.generation()
+        ))]
     async fn spawn_pipeline(&mut self, ctx: &ActorContext<Self>) -> anyhow::Result<()> {
         let _spawn_pipeline_permit = SPAWN_PIPELINE_SEMAPHORE.acquire().await.expect("Failed to acquire spawn pipeline permit. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
         self.statistics.num_spawn_attempts += 1;

--- a/quickwit/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit/quickwit-indexing/src/models/indexed_split.rs
@@ -19,12 +19,12 @@
 
 use std::fmt;
 use std::path::Path;
-use std::time::Instant;
 
 use quickwit_actors::{KillSwitch, Progress};
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use tantivy::directory::MmapDirectory;
 use tantivy::IndexBuilder;
+use tracing::{instrument, Span};
 
 use crate::controlled_directory::ControlledDirectory;
 use crate::models::{IndexingPipelineId, PublishLock, ScratchDirectory, SplitAttrs};
@@ -113,6 +113,21 @@ impl IndexedSplitBuilder {
         })
     }
 
+    #[instrument(name="serialize_split",
+        skip_all,
+        fields(
+            index_id=%self.split_attrs.pipeline_id.index_id,
+            source_id=%self.split_attrs.pipeline_id.source_id,
+            node_id=%self.split_attrs.pipeline_id.node_id,
+            pipeline_id=%self.split_attrs.pipeline_id.pipeline_ord,
+            split_id=%self.split_attrs.split_id,
+            partition_id=%self.split_attrs.partition_id,
+            num_docs=%self.split_attrs.num_docs,
+            uncompressed_docs_size_in_bytes=%self.split_attrs.uncompressed_docs_size_in_bytes,
+            delete_opstamp=%self.split_attrs.delete_opstamp,
+            num_merge_ops=%self.split_attrs.num_merge_ops,
+        )
+    )]
     pub fn finalize(self) -> anyhow::Result<IndexedSplit> {
         let index = self.index_writer.finalize()?;
         Ok(IndexedSplit {
@@ -134,10 +149,10 @@ impl IndexedSplitBuilder {
 
 #[derive(Debug)]
 pub struct IndexedSplitBatch {
+    pub batch_parent_span: Span,
     pub splits: Vec<IndexedSplit>,
     pub checkpoint_delta: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
-    pub date_of_birth: Instant,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -150,9 +165,9 @@ pub enum CommitTrigger {
 
 #[derive(Debug)]
 pub struct IndexedSplitBatchBuilder {
+    pub batch_parent_span: Span,
     pub splits: Vec<IndexedSplitBuilder>,
     pub checkpoint_delta: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
-    pub date_of_birth: Instant,
     pub commit_trigger: CommitTrigger,
 }

--- a/quickwit/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit/quickwit-indexing/src/models/packaged_split.rs
@@ -19,9 +19,9 @@
 
 use std::collections::{BTreeSet, HashSet};
 use std::fmt;
-use std::time::Instant;
 
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
+use tracing::Span;
 
 use crate::models::{PublishLock, ScratchDirectory, SplitAttrs};
 
@@ -52,10 +52,10 @@ impl fmt::Debug for PackagedSplit {
 
 #[derive(Debug)]
 pub struct PackagedSplitBatch {
+    pub parent_span: Span,
     pub splits: Vec<PackagedSplit>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
-    pub date_of_birth: Instant,
 }
 
 impl PackagedSplitBatch {
@@ -67,7 +67,7 @@ impl PackagedSplitBatch {
         splits: Vec<PackagedSplit>,
         checkpoint_delta_opt: Option<IndexCheckpointDelta>,
         publish_lock: PublishLock,
-        date_of_birth: Instant,
+        span: Span,
     ) -> Self {
         assert!(!splits.is_empty());
         assert_eq!(
@@ -80,10 +80,10 @@ impl PackagedSplitBatch {
             "All splits must be on the same `index_id`."
         );
         Self {
+            parent_span: span,
             splits,
             checkpoint_delta_opt,
             publish_lock,
-            date_of_birth,
         }
     }
 

--- a/quickwit/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit/quickwit-indexing/src/models/publisher_message.rs
@@ -18,11 +18,11 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
-use std::time::Instant;
 
 use itertools::Itertools;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::SplitMetadata;
+use tracing::Span;
 
 use crate::models::PublishLock;
 
@@ -32,7 +32,7 @@ pub struct SplitsUpdate {
     pub replaced_split_ids: Vec<String>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
-    pub date_of_birth: Instant, // for logging
+    pub parent_span: Span,
 }
 
 impl fmt::Debug for SplitsUpdate {
@@ -46,7 +46,6 @@ impl fmt::Debug for SplitsUpdate {
             .field("index_id", &self.index_id)
             .field("new_splits", &new_split_ids)
             .field("checkpoint_delta", &self.checkpoint_delta_opt)
-            .field("tts_in_secs", &self.date_of_birth.elapsed().as_secs_f32())
             .finish()
     }
 }


### PR DESCRIPTION
Closes #2055 

Before this PR actors would be executed on a root span that was
associated to their execution loop.

That span would be gigantic and would never be closed.

In addition, the message spans did not have any associated name by
default. This solution made logs that looked good in stdout but were
terribly broken when consumed as traces in a tool like jaeger.

The following PR fixes the issue by removing the crazy root span.
It also does something a tiny bit more ambitious by creating a root span
per indexing batch. The batch follows the split, so that it is easier
to inspect how a trip travels through the indexing pipeline.

It is also possible to see the associated context, timings etc.
for each split creation or merge operation.

Closes https://github.com/quickwit-oss/quickwit/issues/2055

![screenshot2](https://user-images.githubusercontent.com/1021506/193558023-d6716353-2b06-4f47-af64-ebb1d5ca4201.png)
