### PR TITLE
Implement dummy OpenTelemetry OTLP service for ingesting traces

### DIFF
--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -75,7 +75,8 @@ version: 0
 #
 # -------------------------------- Indexer settings --------------------------------
 #
-# indexer:
+indexer:
+  enable_opentelemetry_otlp_service: ${QW_ENABLE_OPENTELEMETRY_OTLP_SERVICE:-false}
 #   split_store_max_num_bytes: 200G
 #   split_store_max_num_splits: 10000
 #

--- a/config/tutorials/otel-trace/index-config.yaml
+++ b/config/tutorials/otel-trace/index-config.yaml
@@ -1,0 +1,68 @@
+#
+# Index config file for receiving logs in OpenTelemetry format.
+# Link: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md
+#
+
+version: 0
+
+index_id: otel-trace
+
+doc_mapping:
+  mode: lenient
+  field_mappings:
+    - name: trace_id
+      type: text
+      tokenizer: raw
+    - name: trace_state
+      type: text
+      indexed: true # TODO: set to false
+      stored: true
+    - name: service_name
+      type: text
+      tokenizer: raw
+    - name: span_id
+      type: text
+      tokenizer: raw
+    - name: span_kind
+      type: json
+      tokenizer: raw
+    - name: span_name
+      type: text
+      tokenizer: raw
+    - name: span_start_timestamp_nanos
+      type: datetime
+      input_formats:
+        - unix_ts_nanos
+      fast: true
+      precision: seconds
+    - name: span_end_timestamp_nanos
+      type: datetime
+      input_formats:
+        - unix_ts_nanos
+      fast: true
+      precision: seconds
+    - name: span_attributes
+      type: json
+      tokenizer: raw
+    - name: span_dropped_attributes_count
+      type: u64
+      indexed: false
+    - name: span_dropped_events_count
+      type: u64
+      indexed: false
+    - name: span_dropped_links_count
+      type: u64
+      indexed: false
+    - name: span_status
+      type: json
+      indexed: false
+    - name: parent_span_id
+      type: text
+      tokenizer: raw
+
+indexing_settings:
+  commit_timeout_secs: 30
+  timestamp_field: span_start_timestamp_nanos
+
+search_settings:
+  default_search_fields: []

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1712,9 +1712,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humansize"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e12090e3b87a266157c30eef7ee8f430f4226feb8dd970cccea2cc67f52f70e"
+checksum = "a866837516f34ad34fb221f3ee01fd0db75f2c2f6abeda2047dc6963fb04ad9a"
 dependencies = [
  "libm",
 ]
@@ -3470,8 +3470,12 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "quickwit-metastore",
+ "base64",
+ "quickwit-actors",
+ "quickwit-ingest-api",
  "quickwit-proto",
+ "serde",
+ "serde_json",
  "tokio",
  "tonic",
  "tracing",

--- a/quickwit/quickwit-opentelemetry/Cargo.toml
+++ b/quickwit/quickwit-opentelemetry/Cargo.toml
@@ -12,11 +12,15 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 
-quickwit-metastore = { workspace = true }
+quickwit-actors = { workspace = true }
+quickwit-ingest-api = { workspace = true }
 quickwit-proto = { workspace = true }
 
 [dev-dependencies]

--- a/quickwit/quickwit-opentelemetry/src/otlp/trace.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/trace.rs
@@ -17,14 +17,72 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
+use base64;
+use quickwit_actors::Mailbox;
+use quickwit_ingest_api::IngestApiService;
+use quickwit_proto::ingest_api::{DocBatch, IngestRequest};
 use quickwit_proto::opentelemetry::proto::collector::trace::v1::trace_service_server::TraceService;
 use quickwit_proto::opentelemetry::proto::collector::trace::v1::{
     ExportTraceServiceRequest, ExportTraceServiceResponse,
 };
+use quickwit_proto::opentelemetry::proto::common::v1::any_value::Value as OtlpValue;
+use quickwit_proto::opentelemetry::proto::common::v1::KeyValue;
+use quickwit_proto::opentelemetry::proto::trace::v1::Status;
+use serde::Serialize;
+use serde_json::{Number as JsonNumber, Value as JsonValue};
+use tracing::{error, warn};
 
-#[derive(Default, Clone)]
-pub struct OtlpGrpcTraceService {}
+const TRACE_INDEX_ID: &str = "otel-trace";
+
+#[derive(Clone)]
+pub struct OtlpGrpcTraceService {
+    ingest_api_service: Mailbox<IngestApiService>,
+}
+
+impl OtlpGrpcTraceService {
+    // TODO: remove and use registry
+    pub fn new(ingest_api_service: Mailbox<IngestApiService>) -> Self {
+        Self { ingest_api_service }
+    }
+}
+
+type Base64 = String;
+
+#[derive(Debug, Serialize)]
+struct Span {
+    trace_id: Base64,
+    trace_state: String,
+    service_name: Option<String>,
+    span_id: Base64,
+    span_kind: SpanKind,
+    span_name: String,
+    span_start_timestamp_nanos: i64,
+    span_end_timestamp_nanos: i64,
+    span_attributes: HashMap<String, JsonValue>,
+    span_dropped_attributes_count: u64,
+    span_dropped_events_count: u64,
+    span_dropped_links_count: u64,
+    span_status: Option<Status>,
+    parent_span_id: Option<Base64>,
+    // events: Vec<Event<'a>> TODO
+}
+
+#[derive(Debug, Serialize)]
+struct Event {
+    // trace_id: &'a Base64,
+    // service_name: &'a Option<String>,
+    // span_id: &'a Base64,
+    // span_kind: SpanKind,
+    // span_name: &'a String,
+    // span_attributes: &'a HashMap<String, JsonValue>,
+    event_timestamp_nanos: i64,
+    event_name: String,
+    event_attributes: HashMap<String, JsonValue>,
+    event_dropped_attributes_count: u64,
+}
 
 #[async_trait]
 impl TraceService for OtlpGrpcTraceService {
@@ -33,10 +91,138 @@ impl TraceService for OtlpGrpcTraceService {
         request: tonic::Request<ExportTraceServiceRequest>,
     ) -> Result<tonic::Response<ExportTraceServiceResponse>, tonic::Status> {
         let request = request.into_inner();
+        let mut doc_batch = DocBatch {
+            index_id: TRACE_INDEX_ID.to_string(),
+            ..Default::default()
+        };
         for resource_span in request.resource_spans {
-            println!("{:?}", resource_span);
+            // println!("Resource: {:?}", resource_span.resource);
+            let service_name = match resource_span
+                .resource
+                .and_then(|resource| extract_value(resource.attributes, "service.name"))
+            {
+                Some(OtlpValue::StringValue(service_name)) => Some(service_name),
+                _ => None,
+            };
+            for scope_span in resource_span.scope_spans {
+                // println!("\tScope: {:?}", scope_span.scope);
+                for span in scope_span.spans {
+                    // println!("\t\tSpan: {:?}", span);
+                    let trace_id = base64::encode(span.trace_id);
+                    let span_id = base64::encode(span.span_id);
+                    let parent_span_id = if !span.parent_span_id.is_empty() {
+                        Some(base64::encode(span.parent_span_id))
+                    } else {
+                        None
+                    };
+                    let span_name = if !span.name.is_empty() {
+                        span.name
+                    } else {
+                        "unknown".to_string()
+                    };
+                    let span_start_timestamp_nanos = span.start_time_unix_nano as i64;
+                    let span_end_timestamp_nanos = span.end_time_unix_nano as i64;
+                    let span_attributes = extract_attributes(span.attributes);
+                    // for event in span.events {
+                    //     let event = Event {
+                    //         // trace_id: &trace_id,
+                    //         // service_name: &service_name,
+                    //         // span_id: &span_id,
+                    //         // span_kind: to_span_kind(span.kind),
+                    //         // span_name: &span_name,
+                    //         // span_attributes: &span_attributes,
+                    //         event_timestamp_nanos: event.time_unix_nano as i64,
+                    //         event_name: event.name,
+                    //         event_attributes: extract_attributes(event.attributes),
+                    //         event_dropped_attributes_count: event.dropped_attributes_count as
+                    // u64,     };
+                    // }
+                    let span = Span {
+                        trace_id,
+                        trace_state: span.trace_state,
+                        service_name: service_name.clone(),
+                        span_id,
+                        span_kind: to_span_kind(span.kind),
+                        span_name,
+                        span_start_timestamp_nanos,
+                        span_end_timestamp_nanos,
+                        span_attributes,
+                        span_dropped_attributes_count: span.dropped_attributes_count as u64,
+                        span_dropped_events_count: span.dropped_events_count as u64,
+                        span_dropped_links_count: span.dropped_links_count as u64,
+                        span_status: span.status,
+                        parent_span_id,
+                    };
+                    let span_json = serde_json::to_vec(&span).expect("");
+                    let span_json_len = span_json.len() as u64;
+                    doc_batch.concat_docs.extend_from_slice(&span_json);
+                    doc_batch.doc_lens.push(span_json_len);
+                }
+            }
+        }
+        let ingest_request = IngestRequest {
+            doc_batches: vec![doc_batch],
+        };
+        // TODO: return appropriate tonic status
+        if let Err(error) = self.ingest_api_service.ask_for_res(ingest_request).await {
+            error!(error=?error, "Failed to ingest trace");
         }
         let response = ExportTraceServiceResponse::default();
         Ok(tonic::Response::new(response))
     }
+}
+
+#[derive(Debug, Serialize)]
+struct SpanKind {
+    id: i32,
+    name: &'static str,
+}
+
+fn extract_attributes(attributes: Vec<KeyValue>) -> HashMap<String, JsonValue> {
+    let mut attrs = HashMap::new();
+    for attribute in attributes {
+        // Filtering out empty attribute values is fine according to the OTel spec: <https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/common#attribute>
+        if let Some(value) = attribute
+            .value
+            .and_then(|value| value.value)
+            .and_then(to_json_value)
+        {
+            attrs.insert(attribute.key, value);
+        }
+    }
+    attrs
+}
+
+fn extract_value(attributes: Vec<KeyValue>, key: &str) -> Option<OtlpValue> {
+    attributes
+        .iter()
+        .find(|attribute| attribute.key == key)
+        .and_then(|attribute| attribute.value.clone())
+        .and_then(|value| value.value)
+}
+
+fn to_json_value(value: OtlpValue) -> Option<JsonValue> {
+    match value {
+        OtlpValue::StringValue(value) => Some(JsonValue::String(value)),
+        OtlpValue::BoolValue(value) => Some(JsonValue::Bool(value)),
+        OtlpValue::IntValue(value) => Some(JsonValue::Number(JsonNumber::from(value))),
+        OtlpValue::DoubleValue(value) => JsonNumber::from_f64(value).map(JsonValue::Number),
+        OtlpValue::ArrayValue(_) | OtlpValue::BytesValue(_) | OtlpValue::KvlistValue(_) => {
+            warn!(value=?value, "Skipping unsupported OTLP value type");
+            None
+        }
+    }
+}
+
+fn to_span_kind(id: i32) -> SpanKind {
+    let name = match id {
+        0 => "unspecified",
+        1 => "internal",
+        2 => "server",
+        3 => "client",
+        4 => "producer",
+        5 => "consumer",
+        _ => panic!("Unknown span kind: `{id}`."),
+    };
+    SpanKind { id, name }
 }

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -58,16 +58,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
             &["./proto"],
         )?;
-    tonic_build::configure().out_dir("src/").compile(
-        &[
-            "./otlp/opentelemetry/proto/common/v1/common.proto", // Must be compiled first.
-            "./otlp/opentelemetry/proto/resource/v1/resource.proto", // Must be compiled second.
-            "./otlp/opentelemetry/proto/logs/v1/logs.proto",
-            "./otlp/opentelemetry/proto/trace/v1/trace.proto",
-            "./otlp/opentelemetry/proto/collector/logs/v1/logs_service.proto",
-            "./otlp/opentelemetry/proto/collector/trace/v1/trace_service.proto",
-        ],
-        &["./otlp"],
-    )?;
+    tonic_build::configure()
+        .type_attribute(".", "#[derive(Serialize, Deserialize)]")
+        .out_dir("src/")
+        .compile(
+            &[
+                "./otlp/opentelemetry/proto/common/v1/common.proto", // Must be compiled first.
+                "./otlp/opentelemetry/proto/resource/v1/resource.proto", // Must be compiled second.
+                "./otlp/opentelemetry/proto/logs/v1/logs.proto",
+                "./otlp/opentelemetry/proto/trace/v1/trace.proto",
+                "./otlp/opentelemetry/proto/collector/logs/v1/logs_service.proto",
+                "./otlp/opentelemetry/proto/collector/trace/v1/trace_service.proto",
+            ],
+            &["./otlp"],
+        )?;
     Ok(())
 }

--- a/quickwit/quickwit-proto/src/opentelemetry.proto.collector.logs.v1.rs
+++ b/quickwit/quickwit-proto/src/opentelemetry.proto.collector.logs.v1.rs
@@ -1,3 +1,4 @@
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceRequest {
     /// An array of ResourceLogs.
@@ -8,6 +9,7 @@ pub struct ExportLogsServiceRequest {
     #[prost(message, repeated, tag="1")]
     pub resource_logs: ::prost::alloc::vec::Vec<super::super::super::logs::v1::ResourceLogs>,
 }
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceResponse {
     /// The details of a partially successful export request.
@@ -28,6 +30,7 @@ pub struct ExportLogsServiceResponse {
     #[prost(message, optional, tag="1")]
     pub partial_success: ::core::option::Option<ExportLogsPartialSuccess>,
 }
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsPartialSuccess {
     /// The number of rejected log records.

--- a/quickwit/quickwit-proto/src/opentelemetry.proto.collector.trace.v1.rs
+++ b/quickwit/quickwit-proto/src/opentelemetry.proto.collector.trace.v1.rs
@@ -1,3 +1,4 @@
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceRequest {
     /// An array of ResourceSpans.
@@ -8,6 +9,7 @@ pub struct ExportTraceServiceRequest {
     #[prost(message, repeated, tag="1")]
     pub resource_spans: ::prost::alloc::vec::Vec<super::super::super::trace::v1::ResourceSpans>,
 }
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceResponse {
     /// The details of a partially successful export request.
@@ -28,6 +30,7 @@ pub struct ExportTraceServiceResponse {
     #[prost(message, optional, tag="1")]
     pub partial_success: ::core::option::Option<ExportTracePartialSuccess>,
 }
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTracePartialSuccess {
     /// The number of rejected spans.

--- a/quickwit/quickwit-proto/src/opentelemetry.proto.common.v1.rs
+++ b/quickwit/quickwit-proto/src/opentelemetry.proto.common.v1.rs
@@ -1,6 +1,7 @@
 /// AnyValue is used to represent any type of attribute value. AnyValue may contain a
 /// primitive value such as a string or integer or it may contain an arbitrary nested
 /// object containing arrays, key-value lists and primitives.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AnyValue {
     /// The value is one of the listed fields. It is valid for all values to be unspecified
@@ -12,6 +13,7 @@ pub struct AnyValue {
 pub mod any_value {
     /// The value is one of the listed fields. It is valid for all values to be unspecified
     /// in which case this AnyValue is considered to be "empty".
+    #[derive(Serialize, Deserialize)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
         #[prost(string, tag="1")]
@@ -32,6 +34,7 @@ pub mod any_value {
 }
 /// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
 /// since oneof in AnyValue does not allow repeated fields.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrayValue {
     /// Array of values. The array may be empty (contain 0 elements).
@@ -43,6 +46,7 @@ pub struct ArrayValue {
 /// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
 /// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
 /// are semantically equivalent.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValueList {
     /// A collection of key/value pairs of key-value pairs. The list may be empty (may
@@ -54,6 +58,7 @@ pub struct KeyValueList {
 }
 /// KeyValue is a key-value pair that is used to store Span attributes, Link
 /// attributes, etc.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValue {
     #[prost(string, tag="1")]
@@ -63,6 +68,7 @@ pub struct KeyValue {
 }
 /// InstrumentationScope is a message representing the instrumentation scope information
 /// such as the fully qualified name and version. 
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstrumentationScope {
     /// An empty instrumentation scope name means the name is unknown.

--- a/quickwit/quickwit-proto/src/opentelemetry.proto.logs.v1.rs
+++ b/quickwit/quickwit-proto/src/opentelemetry.proto.logs.v1.rs
@@ -8,6 +8,7 @@
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogsData {
     /// An array of ResourceLogs.
@@ -19,6 +20,7 @@ pub struct LogsData {
     pub resource_logs: ::prost::alloc::vec::Vec<ResourceLogs>,
 }
 /// A collection of ScopeLogs from a Resource.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceLogs {
     /// The resource for the logs in this message.
@@ -34,6 +36,7 @@ pub struct ResourceLogs {
     pub schema_url: ::prost::alloc::string::String,
 }
 /// A collection of Logs produced by a Scope.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeLogs {
     /// The instrumentation scope information for the logs in this message.
@@ -50,6 +53,7 @@ pub struct ScopeLogs {
 }
 /// A log record according to OpenTelemetry Log Data Model:
 /// <https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md>
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogRecord {
     /// time_unix_nano is the time when the event occurred.
@@ -115,6 +119,7 @@ pub struct LogRecord {
     pub span_id: ::prost::alloc::vec::Vec<u8>,
 }
 /// Possible values for LogRecord.SeverityNumber.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SeverityNumber {
@@ -181,6 +186,7 @@ impl SeverityNumber {
     }
 }
 /// Masks for LogRecord.flags field.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum LogRecordFlags {

--- a/quickwit/quickwit-proto/src/opentelemetry.proto.resource.v1.rs
+++ b/quickwit/quickwit-proto/src/opentelemetry.proto.resource.v1.rs
@@ -1,4 +1,5 @@
 /// Resource information.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Resource {
     /// Set of attributes that describe the resource.

--- a/quickwit/quickwit-proto/src/opentelemetry.proto.trace.v1.rs
+++ b/quickwit/quickwit-proto/src/opentelemetry.proto.trace.v1.rs
@@ -8,6 +8,7 @@
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TracesData {
     /// An array of ResourceSpans.
@@ -19,6 +20,7 @@ pub struct TracesData {
     pub resource_spans: ::prost::alloc::vec::Vec<ResourceSpans>,
 }
 /// A collection of ScopeSpans from a Resource.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceSpans {
     /// The resource for the spans in this message.
@@ -34,6 +36,7 @@ pub struct ResourceSpans {
     pub schema_url: ::prost::alloc::string::String,
 }
 /// A collection of Spans produced by an InstrumentationScope.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeSpans {
     /// The instrumentation scope information for the spans in this message.
@@ -51,6 +54,7 @@ pub struct ScopeSpans {
 /// A Span represents a single operation performed by a single component of the system.
 ///
 /// The next available field id is 17.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
     /// A unique identifier for a trace. All spans from the same trace share
@@ -159,6 +163,7 @@ pub struct Span {
 pub mod span {
     /// Event is a time-stamped annotation of the span, consisting of user-supplied
     /// text description and key-value pairs.
+    #[derive(Serialize, Deserialize)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Event {
         /// time_unix_nano is the time the event occurred.
@@ -182,6 +187,7 @@ pub mod span {
     /// different trace. For example, this can be used in batching operations,
     /// where a single batch handler processes multiple requests from different
     /// traces or when the handler receives a request from a different project.
+    #[derive(Serialize, Deserialize)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Link {
         /// A unique identifier of a trace that this linked span is part of. The ID is a
@@ -206,6 +212,7 @@ pub mod span {
     }
     /// SpanKind is the type of span. Can be used to specify additional relationships between spans
     /// in addition to a parent/child relationship.
+    #[derive(Serialize, Deserialize)]
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SpanKind {
@@ -249,6 +256,7 @@ pub mod span {
 }
 /// The Status type defines a logical error model that is suitable for different
 /// programming environments, including REST APIs and RPC APIs.
+#[derive(Serialize, Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Status {
     /// A developer-facing human readable error message.
@@ -262,6 +270,7 @@ pub struct Status {
 pub mod status {
     /// For the semantics of status codes see
     /// <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status>
+    #[derive(Serialize, Deserialize)]
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum StatusCode {


### PR DESCRIPTION
### Description
Per title.

### How was this PR tested?
```
QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER=1 QW_ENABLE_OPENTELEMETRY_OTLP_SERVICE=true OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:7281 RUST_BACKTRACE=1 RUST_LOG=info,quickwit=info,quickwit_jaeger=debug cargo run --manifest-path quickwit/Cargo.toml --all-features -- index create --index-config config/tutorials/otel-trace/index-config.yaml --overwrite --yes
```
then
```
QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER=1 QW_ENABLE_OPENTELEMETRY_OTLP_SERVICE=true OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:7281 RUST_BACKTRACE=1 RUST_LOG=info,quickwit=info,quickwit_jaeger=debug cargo run --manifest-path quickwit/Cargo.toml --all-features -- run
```
