### PR TITLE
Issue/2022     Simplifies and fixes the local split cache.

### DIFF
--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -909,7 +909,8 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
         metastore,
         quickwit_storage_uri_resolver().clone(),
         enable_ingest_api,
-    );
+    )
+    .await?;
     let (indexing_server_mailbox, _) = universe.spawn_builder().spawn(indexing_server);
     let pipeline_id = indexing_server_mailbox
         .ask_for_res(SpawnPipeline {
@@ -945,12 +946,7 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
 
     if args.clear_cache {
         println!("Clearing local cache directory...");
-        clear_cache_directory(
-            &config.data_dir_path,
-            args.index_id.clone(),
-            CLI_INGEST_SOURCE_ID.to_string(),
-        )
-        .await?;
+        clear_cache_directory(&config.data_dir_path).await?;
     }
 
     match statistics.num_invalid_docs {
@@ -1013,7 +1009,8 @@ pub async fn merge_cli(args: MergeArgs, merge_enabled: bool) -> anyhow::Result<(
         metastore,
         storage_resolver,
         enable_ingest_api,
-    );
+    )
+    .await?;
     let universe = Universe::new();
     let (indexing_server_mailbox, _) = universe.spawn_builder().spawn(indexing_server);
     let pipeline_id = indexing_server_mailbox

--- a/quickwit/quickwit-common/src/fs.rs
+++ b/quickwit/quickwit-common/src/fs.rs
@@ -36,9 +36,7 @@ pub async fn empty_dir<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
 
 /// Helper function to get the cache path.
 pub fn get_cache_directory_path(data_dir_path: &Path) -> PathBuf {
-    data_dir_path
-        .join("cache")
-        .join("splits")
+    data_dir_path.join("cache").join("splits")
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-common/src/fs.rs
+++ b/quickwit/quickwit-common/src/fs.rs
@@ -36,8 +36,9 @@ pub async fn empty_dir<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
 
 /// Helper function to get the cache path.
 pub fn get_cache_directory_path(data_dir_path: &Path) -> PathBuf {
-    const CACHE: &str = "cache";
-    data_dir_path.join(CACHE)
+    data_dir_path
+        .join("cache")
+        .join("splits")
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-common/src/fs.rs
+++ b/quickwit/quickwit-common/src/fs.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tokio;
 
@@ -32,6 +32,12 @@ pub async fn empty_dir<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Helper function to get the cache path.
+pub fn get_cache_directory_path(data_dir_path: &Path) -> PathBuf {
+    const CACHE: &str = "cache";
+    data_dir_path.join(CACHE)
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-core/src/index.rs
+++ b/quickwit/quickwit-core/src/index.rs
@@ -18,15 +18,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use quickwit_common::fs::empty_dir;
+use quickwit_common::fs::{empty_dir, get_cache_directory_path};
 use quickwit_common::uri::Uri;
 use quickwit_config::{IndexConfig, QuickwitConfig};
 use quickwit_indexing::actors::INDEXING_DIR_NAME;
-use quickwit_indexing::models::CACHE;
 use quickwit_janitor::{
     delete_splits_with_files, run_garbage_collect, FileEntry, SplitDeletionError,
 };
@@ -302,27 +301,12 @@ impl IndexService {
     }
 }
 
-/// Helper function to get the cache path.
-pub fn get_cache_directory_path(data_dir_path: &Path, index_id: &str, source_id: &str) -> PathBuf {
-    data_dir_path
-        .join(INDEXING_DIR_NAME)
-        .join(index_id)
-        .join(source_id)
-        .join(CACHE)
-}
-
 /// Clears the cache directory of a given source.
 ///
 /// * `data_dir_path` - Path to directory where data (tmp data, splits kept for caching purpose) is
 ///   persisted.
-/// * `index_id` - The target index Id.
-/// * `source_id` -  The source Id.
-pub async fn clear_cache_directory(
-    data_dir_path: &Path,
-    index_id: String,
-    source_id: String,
-) -> anyhow::Result<()> {
-    let cache_directory_path = get_cache_directory_path(data_dir_path, &index_id, &source_id);
+pub async fn clear_cache_directory(data_dir_path: &Path) -> anyhow::Result<()> {
+    let cache_directory_path = get_cache_directory_path(data_dir_path);
     info!(path = %cache_directory_path.display(), "Clearing cache directory.");
     empty_dir(&cache_directory_path).await?;
     Ok(())

--- a/quickwit/quickwit-core/src/lib.rs
+++ b/quickwit/quickwit-core/src/lib.rs
@@ -20,8 +20,8 @@
 mod index;
 
 pub use index::{
-    clear_cache_directory, get_cache_directory_path, remove_indexing_directory,
-    validate_storage_uri, IndexService, IndexServiceError,
+    clear_cache_directory, remove_indexing_directory, validate_storage_uri, IndexService,
+    IndexServiceError,
 };
 
 #[cfg(test)]

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -216,15 +216,13 @@ impl IndexingPipeline {
         self.kill_switch = KillSwitch::default();
 
         let split_store = self.params.split_store.clone();
-        // TODO: We should not depend on split store when merge pipeline is refactored.
-        // merge pipeline should have been spawned at this point, we only get the handles.
-        let merge_policy = split_store.get_merge_policy();
+        let merge_policy =
+            crate::merge_policy::merge_policy_from_settings(&self.params.indexing_settings);
         info!(
             index_id=%self.params.pipeline_id.index_id,
             source_id=%self.params.pipeline_id.source_id,
             pipeline_ord=%self.params.pipeline_id.pipeline_ord,
             root_dir=%self.params.indexing_directory.path().display(),
-            merge_policy=?merge_policy,
             "Spawning indexing pipeline.",
         );
         let published_splits = ctx
@@ -238,9 +236,6 @@ impl IndexingPipeline {
             .into_iter()
             .map(|split| split.split_metadata)
             .collect::<Vec<_>>();
-        split_store
-            .remove_dangling_splits(&published_splits)
-            .await?;
 
         let (merge_planner_mailbox, merge_planner_inbox) =
             create_mailbox::<MergePlanner>("MergePlanner".to_string(), QueueCapacity::Unbounded);

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -18,13 +18,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, Health, Observation, Supervisable,
 };
+use quickwit_common::fs::get_cache_directory_path;
 use quickwit_config::merge_policy_config::MergePolicyConfig;
 use quickwit_config::{
     IndexerConfig, IngestApiSourceParams, SourceConfig, SourceParams, VecSourceParams,
@@ -36,7 +37,6 @@ use quickwit_proto::{ServiceError, ServiceErrorCode};
 use quickwit_storage::{Storage, StorageError, StorageResolverError, StorageUriResolver};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::Mutex;
 use tracing::{error, info};
 
 use crate::merge_policy::MergePolicy;
@@ -46,11 +46,8 @@ use crate::models::{
     WeakIndexingDirectory,
 };
 use crate::source::INGEST_API_SOURCE_ID;
-use crate::split_store::SplitStoreSpaceQuota;
-use crate::{
-    IndexingPipeline, IndexingPipelineParams, IndexingSplitStore, IndexingStatistics,
-    WeakIndexingSplitStore,
-};
+use crate::split_store::{IndexingSplitStore, LocalSplitStore, SplitStoreQuota};
+use crate::{IndexingPipeline, IndexingPipelineParams, IndexingStatistics};
 
 /// Name of the indexing directory, usually located at `<data_dir_path>/indexing`.
 pub const INDEXING_DIR_NAME: &str = "indexing";
@@ -108,8 +105,7 @@ pub struct IndexingService {
     state: IndexingServiceState,
     enable_ingest_api: bool,
     indexing_directories: HashMap<(IndexId, SourceId), WeakIndexingDirectory>,
-    split_stores: HashMap<(IndexId, SourceId), WeakIndexingSplitStore>,
-    split_store_space_quota: Arc<Mutex<SplitStoreSpaceQuota>>,
+    local_split_store: Arc<LocalSplitStore>,
     max_concurrent_split_uploads: usize,
 }
 
@@ -119,15 +115,22 @@ impl IndexingService {
         Health::Healthy
     }
 
-    pub fn new(
+    pub async fn new(
         node_id: String,
         data_dir_path: PathBuf,
         indexer_config: IndexerConfig,
         metastore: Arc<dyn Metastore>,
         storage_resolver: StorageUriResolver,
         enable_ingest_api: bool,
-    ) -> IndexingService {
-        Self {
+    ) -> anyhow::Result<IndexingService> {
+        let split_store_space_quota = SplitStoreQuota::new(
+            indexer_config.split_store_max_num_splits,
+            indexer_config.split_store_max_num_bytes,
+        );
+        let split_cache_dir_path = get_cache_directory_path(&data_dir_path);
+        let local_split_store =
+            LocalSplitStore::open(split_cache_dir_path, split_store_space_quota).await?;
+        Ok(Self {
             node_id,
             data_dir_path,
             metastore,
@@ -136,13 +139,9 @@ impl IndexingService {
             state: Default::default(),
             enable_ingest_api,
             indexing_directories: HashMap::new(),
-            split_stores: HashMap::new(),
-            split_store_space_quota: Arc::new(Mutex::new(SplitStoreSpaceQuota::new(
-                indexer_config.split_store_max_num_splits,
-                indexer_config.split_store_max_num_bytes.get_bytes() as usize,
-            ))),
             max_concurrent_split_uploads: indexer_config.max_concurrent_split_uploads,
-        }
+            local_split_store: Arc::new(local_split_store),
+        })
     }
 
     async fn detach_pipeline(
@@ -256,14 +255,7 @@ impl IndexingService {
         let storage = self.storage_resolver.resolve(&index_metadata.index_uri)?;
         let merge_policy =
             crate::merge_policy::merge_policy_from_settings(&index_metadata.indexing_settings);
-        let split_store = self
-            .get_or_create_split_store(
-                &pipeline_id,
-                indexing_directory.cache_directory(),
-                storage.clone(),
-                merge_policy,
-            )
-            .await?;
+        let split_store = self.create_split_store(storage.clone(), merge_policy);
 
         let pipeline_params = IndexingPipelineParams::try_new(
             pipeline_id.clone(),
@@ -396,31 +388,16 @@ impl IndexingService {
         Ok(indexing_directory)
     }
 
-    async fn get_or_create_split_store(
+    fn create_split_store(
         &mut self,
-        pipeline_id: &IndexingPipelineId,
-        cache_directory: &Path,
         storage: Arc<dyn Storage>,
         merge_policy: Arc<dyn MergePolicy>,
-    ) -> Result<IndexingSplitStore, IndexingServiceError> {
-        let key = (pipeline_id.index_id.clone(), pipeline_id.source_id.clone());
-        if let Some(split_store) = self
-            .split_stores
-            .get(&key)
-            .and_then(WeakIndexingSplitStore::upgrade)
-        {
-            return Ok(split_store);
-        }
-        let split_store = IndexingSplitStore::create_with_local_store(
+    ) -> IndexingSplitStore {
+        IndexingSplitStore::new(
             storage.clone(),
-            cache_directory,
             merge_policy,
-            self.split_store_space_quota.clone(),
+            self.local_split_store.clone(),
         )
-        .await?;
-
-        self.split_stores.insert(key, split_store.downgrade());
-        Ok(split_store)
     }
 }
 
@@ -659,7 +636,9 @@ mod tests {
             metastore.clone(),
             storage_resolver.clone(),
             enable_ingest_api,
-        );
+        )
+        .await
+        .unwrap();
         let (indexing_server_mailbox, indexing_server_handle) =
             universe.spawn_builder().spawn(indexing_server);
         let observation = indexing_server_handle.observe().await;

--- a/quickwit/quickwit-indexing/src/actors/ingest_api_garbage_collector.rs
+++ b/quickwit/quickwit-indexing/src/actors/ingest_api_garbage_collector.rs
@@ -225,7 +225,8 @@ mod tests {
             metastore.clone(),
             storage_resolver.clone(),
             enable_ingest_api,
-        );
+        )
+        .await?;
         let (indexing_server_mailbox, _indexing_server_handle) =
             universe.spawn_builder().spawn(indexing_server);
 

--- a/quickwit/quickwit-indexing/src/actors/merge_split_downloader.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_split_downloader.rs
@@ -109,7 +109,7 @@ impl MergeSplitDownloader {
             let _protect_guard = ctx.protect_zone();
             let tantivy_dir = self
                 .split_store
-                .fetch_split(split.split_id(), download_directory)
+                .fetch_and_open_split(split.split_id(), download_directory)
                 .await
                 .map_err(|error| {
                     let split_id = split.split_id();

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -33,10 +33,7 @@ pub use crate::actors::{
 };
 pub use crate::controlled_directory::ControlledDirectory;
 use crate::models::{IndexingStatistics, SpawnPipelines};
-pub use crate::split_store::{
-    get_tantivy_directory_from_split_bundle, IndexingSplitStore, SplitFolder,
-    WeakIndexingSplitStore,
-};
+pub use crate::split_store::{get_tantivy_directory_from_split_bundle, IndexingSplitStore};
 
 pub mod actors;
 mod controlled_directory;
@@ -74,7 +71,8 @@ pub async fn start_indexing_service(
         metastore.clone(),
         storage_resolver,
         enable_ingest_api,
-    );
+    )
+    .await?;
     let (indexing_service, _) = universe.spawn_builder().spawn(indexing_service);
 
     // List indexes and spawn indexing pipeline(s) for each of them.

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -35,7 +35,7 @@ mod split_attrs;
 pub use indexed_split::{
     CommitTrigger, IndexedSplit, IndexedSplitBatch, IndexedSplitBatchBuilder, IndexedSplitBuilder,
 };
-pub use indexing_directory::{IndexingDirectory, WeakIndexingDirectory, CACHE};
+pub use indexing_directory::{IndexingDirectory, WeakIndexingDirectory};
 pub use indexing_pipeline_id::IndexingPipelineId;
 pub use indexing_service_message::{
     DetachPipeline, ObservePipeline, ShutdownPipeline, ShutdownPipelines, SpawnMergePipeline,

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -140,7 +140,7 @@ impl IndexingSplitStore {
         self.inner
             .remote_storage
             .put(&key, put_payload)
-            .instrument(info_span!("store_split_in_remote_rstorage", split=?split.split_id(), is_mature=is_mature, num_bytes=split_num_bytes))
+            .instrument(info_span!("store_split_in_remote_storage", split=?split.split_id(), is_mature=is_mature, num_bytes=split_num_bytes))
             .await
             .with_context(|| {
                 format!(
@@ -218,7 +218,7 @@ impl IndexingSplitStore {
         self.inner
             .remote_storage
             .copy_to_file(&path, &dest_filepath)
-            .instrument(info_span!("fetch_split_from_remote_rstorage", path=?path))
+            .instrument(info_span!("fetch_split_from_remote_storage", path=?path))
             .await?;
         get_tantivy_directory_from_split_bundle(&dest_filepath)
     }

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -19,135 +19,22 @@
 
 #[cfg(any(test, feature = "testsuite"))]
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Weak};
 use std::time::Instant;
 
 use anyhow::Context;
-use quickwit_config::IndexerConfig;
+#[cfg(any(test, feature = "testsuite"))]
+use byte_unit::Byte;
 use quickwit_metastore::SplitMetadata;
-use quickwit_storage::{PutPayload, Storage, StorageErrorKind, StorageResult};
+use quickwit_storage::{PutPayload, Storage, StorageResult};
+use tantivy::directory::MmapDirectory;
 use tantivy::Directory;
-use tokio::sync::Mutex;
-use tracing::{info, info_span, instrument, warn, Instrument};
+use tracing::{info, info_span, instrument, Instrument};
 
 use super::LocalSplitStore;
-use crate::merge_policy::default_merge_policy;
-use crate::split_store::SPLIT_CACHE_DIR_NAME;
-use crate::{get_tantivy_directory_from_split_bundle, MergePolicy, SplitFolder};
-
-/// A struct for keeping in check multiple SplitStore.
-#[derive(Debug)]
-pub struct SplitStoreSpaceQuota {
-    /// Current number of splits in the cache.
-    num_splits_in_cache: usize,
-    /// Current size in bytes of splits in the cache.
-    size_in_bytes_in_cache: usize,
-    /// Maximum number of files allowed in the cache.
-    max_num_splits: usize,
-    /// Maximum size in bytes allowed in the cache.
-    max_num_bytes: usize,
-    /// Known split store local storage roots.
-    // A SplitStore can be opened several time for the lifetime
-    // of an indexing server. This set helps in avoiding adding
-    // the same SplitStore opening size again.
-    opened_split_store_roots: HashSet<PathBuf>,
-}
-
-impl Default for SplitStoreSpaceQuota {
-    fn default() -> Self {
-        Self {
-            num_splits_in_cache: 0,
-            size_in_bytes_in_cache: 0,
-            max_num_bytes: IndexerConfig::default_split_store_max_num_bytes().get_bytes() as usize,
-            max_num_splits: IndexerConfig::default_split_store_max_num_splits(),
-            opened_split_store_roots: HashSet::default(),
-        }
-    }
-}
-
-impl SplitStoreSpaceQuota {
-    pub fn new(max_num_splits: usize, max_num_bytes: usize) -> Self {
-        Self {
-            max_num_splits,
-            max_num_bytes,
-            ..Default::default()
-        }
-    }
-
-    pub fn can_fit_split(&self, split_size_in_bytes: usize) -> bool {
-        // Avoid storing in the cache when the maximum number of cached files is reached.
-        if self.num_splits() >= self.max_num_splits {
-            warn!("Failed to cache file: maximum number of files exceeded.");
-            return false;
-        }
-
-        // Ignore storing a file that cannot fit in remaining space in the cache.
-        if split_size_in_bytes > self.available_bytes() {
-            warn!("Failed to cache file: maximum size in bytes of cache exceeded.");
-            return false;
-        }
-        true
-    }
-
-    pub fn add_split(&mut self, split_size_in_bytes: usize) {
-        self.num_splits_in_cache += 1;
-        self.size_in_bytes_in_cache += split_size_in_bytes;
-    }
-
-    pub fn add_initial_splits(
-        &mut self,
-        local_storage_root: &Path,
-        num_splits: usize,
-        splits_size_in_bytes: usize,
-    ) -> StorageResult<()> {
-        if self.opened_split_store_roots.contains(local_storage_root) {
-            return Ok(());
-        }
-
-        let total_splits = self.num_splits_in_cache + num_splits;
-        if total_splits > self.max_num_splits {
-            return Err(StorageErrorKind::InternalError.with_error(anyhow::anyhow!(
-                "Initial number of files ({}) exceeds the maximum number ({}) of files allowed.",
-                total_splits,
-                self.max_num_splits
-            )));
-        }
-
-        let total_size_in_bytes = self.size_in_bytes_in_cache + splits_size_in_bytes;
-        if total_size_in_bytes > self.max_num_bytes {
-            return Err(StorageErrorKind::InternalError.with_error(anyhow::anyhow!(
-                "Initial cache size ({}) exceeds the maximum size ({}) in bytes allowed.",
-                total_size_in_bytes,
-                self.max_num_bytes
-            )));
-        }
-
-        self.opened_split_store_roots
-            .insert(local_storage_root.to_path_buf());
-        self.num_splits_in_cache = total_splits;
-        self.size_in_bytes_in_cache = total_size_in_bytes;
-        Ok(())
-    }
-
-    pub fn remove_splits(&mut self, num_splits: usize, splits_size_in_bytes: usize) {
-        self.num_splits_in_cache -= num_splits;
-        self.size_in_bytes_in_cache -= splits_size_in_bytes;
-    }
-
-    pub fn num_splits(&self) -> usize {
-        self.num_splits_in_cache
-    }
-
-    pub fn size_in_bytes(&self) -> usize {
-        self.size_in_bytes_in_cache
-    }
-
-    fn available_bytes(&self) -> usize {
-        self.max_num_bytes - self.size_in_bytes_in_cache
-    }
-}
+use crate::merge_policy::NopMergePolicy;
+use crate::{get_tantivy_directory_from_split_bundle, MergePolicy};
 
 /// IndexingSplitStore is a wrapper around a regular `Storage` to upload and
 /// download splits while allowing for efficient caching.
@@ -177,7 +64,7 @@ struct InnerIndexingSplitStore {
     /// The remote storage.
     remote_storage: Arc<dyn Storage>,
 
-    local_split_store: Option<Mutex<LocalSplitStore>>,
+    local_split_store: Arc<LocalSplitStore>,
 
     /// The merge policy is useful to identify whether a split
     /// should be stored in the local storage or not.
@@ -201,34 +88,30 @@ impl IndexingSplitStore {
     /// Creates an instance of [`IndexingSplitStore`]
     ///
     /// It needs the remote storage to work with.
-    pub async fn create_with_local_store(
+    pub fn new(
         remote_storage: Arc<dyn Storage>,
-        cache_directory: &Path,
         merge_policy: Arc<dyn MergePolicy>,
-        split_store_space_quota: Arc<Mutex<SplitStoreSpaceQuota>>,
-    ) -> StorageResult<Self> {
-        let local_storage_root = cache_directory.join(SPLIT_CACHE_DIR_NAME);
-        std::fs::create_dir_all(&local_storage_root)?;
-        let local_split_store =
-            LocalSplitStore::open(local_storage_root, split_store_space_quota).await?;
-
+        local_split_store: Arc<LocalSplitStore>,
+    ) -> Self {
         let inner = InnerIndexingSplitStore {
             remote_storage,
-            local_split_store: Some(Mutex::new(local_split_store)),
+            local_split_store,
             merge_policy,
         };
-        Ok(Self {
+        Self {
             inner: Arc::new(inner),
-        })
+        }
     }
 
+    /// Helper function to create a indexing split store for tests.
+    /// The resulting store does not have any local cache.
     pub fn create_without_local_store(remote_storage: Arc<dyn Storage>) -> Self {
         let inner = InnerIndexingSplitStore {
             remote_storage,
-            local_split_store: None,
-            merge_policy: default_merge_policy(),
+            local_split_store: Arc::new(LocalSplitStore::no_caching()),
+            merge_policy: Arc::new(NopMergePolicy),
         };
-        Self {
+        IndexingSplitStore {
             inner: Arc::new(inner),
         }
     }
@@ -243,20 +126,21 @@ impl IndexingSplitStore {
     /// In other words, after calling this function the file will not be available
     /// at `split_folder` anymore.
     #[instrument("store_split", skip_all)]
-    pub async fn store_split<'a>(
-        &'a self,
-        split: &'a SplitMetadata,
-        split_folder: &'a Path,
+    pub async fn store_split(
+        &self,
+        split: &SplitMetadata,
+        split_folder_path: &Path,
         put_payload: Box<dyn PutPayload>,
     ) -> anyhow::Result<()> {
         let start = Instant::now();
         let split_num_bytes = put_payload.len();
 
         let key = PathBuf::from(quickwit_common::split_file(split.split_id()));
+        let is_mature = self.inner.merge_policy.is_mature(split);
         self.inner
             .remote_storage
             .put(&key, put_payload)
-            .instrument(info_span!("storage_put"))
+            .instrument(info_span!("store_split_in_remote_rstorage", split=?split.split_id(), is_mature=is_mature, num_bytes=split_num_bytes))
             .await
             .with_context(|| {
                 format!(
@@ -265,10 +149,10 @@ impl IndexingSplitStore {
                     self.inner.remote_storage.uri()
                 )
             })?;
+
         let elapsed_secs = start.elapsed().as_secs_f32();
-        let split_size_in_megabytes = split_num_bytes / 1_000_000;
-        let throughput_mb_s = split_size_in_megabytes as f32 / elapsed_secs;
-        let is_mature = self.inner.merge_policy.is_mature(split);
+        let split_size_in_megabytes = split_num_bytes as f32 / 1_000_000f32;
+        let throughput_mb_s = split_size_in_megabytes / elapsed_secs;
 
         info!(
             split_size_in_megabytes = %split_size_in_megabytes,
@@ -281,90 +165,62 @@ impl IndexingSplitStore {
 
         if !is_mature {
             info!("store-in-cache");
-            if let Some(split_store) = &self.inner.local_split_store {
-                let mut split_store_guard = split_store.lock().await;
-                let tantivy_dir = SplitFolder::new(split_folder.to_path_buf());
-                if split_store_guard
-                    .move_into_cache(split.split_id(), tantivy_dir, split_num_bytes as usize)
-                    .await?
-                {
-                    return Ok(());
-                }
+            if self
+                .inner
+                .local_split_store
+                .move_into_cache(split.split_id(), split_folder_path)
+                .await?
+            {
+                return Ok(());
             }
         }
-        tokio::fs::remove_dir_all(split_folder).await?;
-        Ok(())
-    }
-
-    /// Delete a split.
-    pub async fn delete(&self, split_id: &str) -> StorageResult<()> {
-        let split_filename = quickwit_common::split_file(split_id);
-        let split_path = Path::new(&split_filename);
-        self.inner.remote_storage.delete(split_path).await?;
-        if let Some(local_split_store) = &self.inner.local_split_store {
-            let mut local_split_store_guard = local_split_store.lock().await;
-            local_split_store_guard.remove_split(split_id).await?;
-        }
+        tokio::fs::remove_dir_all(split_folder_path).await?;
         Ok(())
     }
 
     /// Gets a split from the split store, and makes it available to the given `output_path`.
+    /// If the split is available in the local disk cache, then it will be moved
+    /// from the cache to the `output_dir_path`.
     ///
     /// The output_path is expected to be a directory path.
-    pub async fn fetch_split(
+    ///
+    /// If not, it will be fetched from the remote `Storage`.
+    ///
+    ///
+    /// # Implementation detail:
+    ///
+    /// Depending on whether the split was obtained from the `Storage`
+    /// or the cache, it could consist in a direclty or a proper split file.
+    /// This method takes care of the dealing with opening the split correctly.
+    ///
+    /// As we fetch the split, we optimistically assume that this is for a merge
+    /// operation that will be successful and we remove the split from the cache.
+    #[instrument(skip(self, output_dir_path), fields(cache_hit))]
+    pub async fn fetch_and_open_split(
         &self,
         split_id: &str,
         output_dir_path: &Path,
     ) -> StorageResult<Box<dyn Directory>> {
         let path = PathBuf::from(quickwit_common::split_file(split_id));
-        if let Some(local_split_store) = &self.inner.local_split_store {
-            let mut local_split_store_guard = local_split_store.lock().await;
-            if let Some(split_folder) = local_split_store_guard
-                .get_cached_split(split_id, output_dir_path)
-                .await?
-            {
-                return split_folder.get_tantivy_directory();
-            }
+        if let Some(split_path) = self
+            .inner
+            .local_split_store
+            .get_cached_split(split_id, output_dir_path)
+            .await?
+        {
+            tracing::Span::current().record("cache_hit", true);
+            let mmap_directory: Box<dyn Directory> = Box::new(MmapDirectory::open(&split_path)?);
+            return Ok(mmap_directory);
+        } else {
+            tracing::Span::current().record("cache_hit", false);
         }
-        let start_time = Instant::now();
         let dest_filepath = output_dir_path.join(&path);
-        info!(split_id = split_id, "fetch-split-from-remote-storage-start");
         self.inner
             .remote_storage
             .copy_to_file(&path, &dest_filepath)
+            .instrument(info_span!("fetch_split_from_remote_rstorage", path=?path))
             .await?;
-        info!(split_id=split_id,elapsed=?start_time.elapsed(), "fetch-split-from_remote-storage-success");
         get_tantivy_directory_from_split_bundle(&dest_filepath)
-    }
-
-    /// Removes the danglings splits.
-    /// After a restart, the store might contains splits that are not relevant anymore.
-    /// For instance, if the failure happens right before its publication, the split will be in the
-    /// split store but not in the metastore.
-    pub async fn remove_dangling_splits(
-        &self,
-        published_splits: &[SplitMetadata],
-    ) -> StorageResult<()> {
-        if let Some(local_split_store) = &self.inner.local_split_store {
-            let published_split_ids: Vec<&str> = published_splits
-                .iter()
-                .filter(|split| !self.inner.merge_policy.is_mature(split))
-                .map(|split| split.split_id())
-                .collect();
-
-            return local_split_store
-                .lock()
-                .await
-                .retain_only(&published_split_ids)
-                .await;
-        }
-
-        Ok(())
-    }
-
-    // TODO: remove when merge_pipeline is refactored
-    pub fn get_merge_policy(&self) -> Arc<dyn MergePolicy> {
-        self.inner.merge_policy.clone()
     }
 
     pub fn downgrade(&self) -> WeakIndexingSplitStore {
@@ -375,111 +231,25 @@ impl IndexingSplitStore {
 
     /// Takes a snapshot of the cache view (only used for testing).
     #[cfg(any(test, feature = "testsuite"))]
-    pub async fn inspect_local_store(&self) -> HashMap<String, usize> {
-        if let Some(split_store) = &self.inner.local_split_store {
-            let split_store_guard = split_store.lock().await;
-            split_store_guard.inspect()
-        } else {
-            HashMap::default()
-        }
+    pub async fn inspect_local_store(&self) -> HashMap<String, Byte> {
+        self.inner.local_split_store.inspect().await
     }
 }
 
 #[cfg(test)]
-mod test_split_store {
-    use std::path::Path;
+mod tests {
     use std::sync::Arc;
 
+    use byte_unit::Byte;
     use quickwit_metastore::SplitMetadata;
-    use quickwit_storage::{
-        PutPayload, RamStorage, SplitPayloadBuilder, Storage, StorageError, StorageErrorKind,
-    };
+    use quickwit_storage::{RamStorage, SplitPayloadBuilder};
     use tempfile::tempdir;
     use tokio::fs;
-    use tokio::sync::Mutex;
+    use ulid::Ulid;
 
     use super::IndexingSplitStore;
     use crate::merge_policy::default_merge_policy;
-    use crate::split_store::{SplitStoreSpaceQuota, SPLIT_CACHE_DIR_NAME};
-    use crate::MergePolicy;
-
-    #[tokio::test]
-    async fn test_create_should_error_with_wrong_num_files() -> anyhow::Result<()> {
-        let local_dir = tempdir()?;
-        let root_path = local_dir.path().join(SPLIT_CACHE_DIR_NAME);
-        fs::create_dir_all(&root_path).await?;
-
-        fs::create_dir_all(&root_path.join("a.split")).await?;
-        fs::create_dir_all(&root_path.join("b.split")).await?;
-        fs::create_dir_all(&root_path.join("c.split")).await?;
-
-        let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(2, 10)));
-        let remote_storage = Arc::new(RamStorage::default());
-        let result = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            local_dir.path(),
-            default_merge_policy(),
-            split_store_space_quota,
-        )
-        .await;
-        assert!(matches!(
-            result,
-            Err(StorageError {
-                kind: StorageErrorKind::InternalError,
-                ..
-            })
-        ));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_create_should_error_with_wrong_num_bytes() -> anyhow::Result<()> {
-        let local_dir = tempdir()?;
-        let root_path = local_dir.path().join(SPLIT_CACHE_DIR_NAME);
-        fs::create_dir_all(&root_path).await?;
-
-        fs::create_dir_all(&root_path.join("a.split")).await?;
-        fs::create_dir_all(&root_path.join("b.split")).await?;
-
-        let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(4, 10)));
-        let remote_storage = Arc::new(RamStorage::default());
-        let result = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            local_dir.path(),
-            default_merge_policy(),
-            split_store_space_quota,
-        )
-        .await;
-        assert!(matches!(
-            result,
-            Err(StorageError {
-                kind: StorageErrorKind::InternalError,
-                ..
-            })
-        ));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_create_should_accept_a_file_size_exeeding_constraint() -> anyhow::Result<()> {
-        let local_dir = tempdir()?;
-        let root_path = local_dir.path().join(SPLIT_CACHE_DIR_NAME);
-        fs::create_dir_all(&root_path).await?;
-        fs::write(root_path.join("b.split"), b"abcd").await?;
-        fs::write(root_path.join("a.split"), b"abcdefgh").await?;
-
-        let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(100, 100)));
-        let remote_storage = Arc::new(RamStorage::default());
-        let result = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            local_dir.path(),
-            default_merge_policy(),
-            split_store_space_quota,
-        )
-        .await;
-        assert!(result.is_ok());
-        Ok(())
-    }
+    use crate::split_store::{LocalSplitStore, SplitStoreQuota};
 
     fn create_test_split_metadata(split_id: &str) -> SplitMetadata {
         SplitMetadata {
@@ -492,54 +262,67 @@ mod test_split_store {
     async fn test_local_store_cache_in_and_out() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let split_cache_dir = tempdir()?;
-        let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            split_cache_dir.path(),
-            default_merge_policy(),
-            Arc::new(Mutex::new(SplitStoreSpaceQuota::default())),
+
+        let local_split_store = LocalSplitStore::open(
+            split_cache_dir.path().to_path_buf(),
+            SplitStoreQuota::default(),
         )
         .await?;
-        {
-            let split_path = temp_dir.path().join("split1");
-            fs::create_dir_all(&split_path).await?;
-            let split_metadata1 = create_test_split_metadata("split1");
+        let remote_storage = Arc::new(RamStorage::default());
+        let split_store = IndexingSplitStore::new(
+            remote_storage,
+            default_merge_policy(),
+            Arc::new(local_split_store),
+        );
 
+        let split_id1 = Ulid::new().to_string();
+        let split_id2 = Ulid::new().to_string();
+
+        {
+            let split1_dir = temp_dir.path().join(&split_id1);
+            fs::create_dir_all(&split1_dir).await?;
+            let split_metadata1 = create_test_split_metadata(&split_id1);
+            fs::write(split1_dir.join("splitfile"), b"1234").await?;
             split_store
-                .store_split(&split_metadata1, &split_path, Box::new(vec![1, 2, 3, 4]))
+                .store_split(&split_metadata1, &split1_dir, Box::new(b"1234".to_vec()))
                 .await?;
-            assert!(!split_path.exists());
+            assert!(!split1_dir.exists());
             assert!(split_cache_dir
                 .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split1.split")
+                .join(format!("{split_id1}.split"))
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(4));
+            assert_eq!(
+                local_store_stats.get(&split_id1).cloned(),
+                Some(Byte::from_bytes(4))
+            );
         }
         {
-            let split_path = temp_dir.path().join("split2");
-            fs::create_dir_all(&split_path).await?;
-            let split_metadata1 = create_test_split_metadata("split2");
+            let split2_dir = temp_dir.path().join(&split_id2);
+            fs::create_dir_all(&split2_dir).await?;
+            fs::write(split2_dir.join("splitfile"), b"567").await?;
+            let split_metadata2 = create_test_split_metadata(&split_id2);
             split_store
-                .store_split(
-                    &split_metadata1,
-                    &split_path,
-                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
-                )
+                .store_split(&split_metadata2, &split2_dir, Box::new(b"567".to_vec()))
                 .await?;
-            assert!(!split_path.exists());
+            assert!(!split2_dir.exists());
             assert!(split_cache_dir
                 .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split2.split")
+                .join(format!("{split_id2}.split"))
                 .exists());
-            let local_store_stats = split_store.inspect_local_store().await;
-            assert_eq!(local_store_stats.len(), 2);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(4));
-            assert_eq!(local_store_stats.get("split2").cloned(), Some(31));
         }
+
+        let local_store_stats = split_store.inspect_local_store().await;
+        assert_eq!(local_store_stats.len(), 2);
+        assert_eq!(
+            local_store_stats.get(&split_id1).cloned(),
+            Some(Byte::from_bytes(4))
+        );
+        assert_eq!(
+            local_store_stats.get(&split_id2).cloned(),
+            Some(Byte::from_bytes(3))
+        );
 
         Ok(())
     }
@@ -549,19 +332,27 @@ mod test_split_store {
         let temp_dir = tempfile::tempdir()?;
 
         let split_cache_dir = tempdir()?;
-        let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            split_cache_dir.path(),
-            default_merge_policy(),
-            Arc::new(Mutex::new(SplitStoreSpaceQuota::new(1, 1_000_000))),
+        let local_split_store = LocalSplitStore::open(
+            split_cache_dir.path().to_path_buf(),
+            SplitStoreQuota::new(1, Byte::from_bytes(1_000_000u64)),
         )
         .await?;
 
+        let remote_storage = Arc::new(RamStorage::default());
+        let split_store = IndexingSplitStore::new(
+            remote_storage,
+            default_merge_policy(),
+            Arc::new(local_split_store),
+        );
+
+        let split_id1 = Ulid::new().to_string();
+        let split_id2 = Ulid::new().to_string();
+
         {
-            let split_path = temp_dir.path().join("split1");
+            let split_path = temp_dir.path().join(&split_id1);
             fs::create_dir_all(&split_path).await?;
-            let split_metadata1 = create_test_split_metadata("split1");
+            fs::write(split_path.join("splitdatafile"), b"hello-world").await?;
+            let split_metadata1 = create_test_split_metadata(&split_id1);
             split_store
                 .store_split(
                     &split_metadata1,
@@ -572,17 +363,20 @@ mod test_split_store {
             assert!(!split_path.exists());
             assert!(split_cache_dir
                 .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split1.split")
+                .join(format!("{split_id1}.split"))
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(31));
+            assert_eq!(
+                local_store_stats.get(&split_id1).cloned(),
+                Some(Byte::from_bytes(11))
+            );
         }
         {
-            let split_path = temp_dir.path().join("split2");
+            let split_path = temp_dir.path().join(&split_id2);
             fs::create_dir_all(&split_path).await?;
-            let split_metadata2 = create_test_split_metadata("split2");
+            fs::write(split_path.join("splitdatafile2"), b"hello-world2").await?;
+            let split_metadata2 = create_test_split_metadata(&split_id2);
 
             split_store
                 .store_split(
@@ -592,232 +386,28 @@ mod test_split_store {
                 )
                 .await?;
             assert!(!split_path.exists());
-            assert!(!split_cache_dir
+            assert!(split_cache_dir
                 .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split2.split")
+                .join(format!("{split_id2}.split"))
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(31));
+            assert_eq!(
+                local_store_stats.get(&split_id2).cloned(),
+                Some(Byte::from_bytes(12))
+            );
         }
         {
             let output = tempfile::tempdir()?;
             // get from cache
-            let _split1 = split_store.fetch_split("split1", output.path()).await?;
+            let _split1 = split_store
+                .fetch_and_open_split(&split_id1, output.path())
+                .await?;
             // get from remote storage
-            let _split2 = split_store.fetch_split("split2", output.path()).await?;
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_put_should_not_store_in_cache_when_max_num_bytes_reached() -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-
-        let split_cache_dir = tempdir()?;
-        let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            split_cache_dir.path(),
-            default_merge_policy(),
-            Arc::new(Mutex::new(SplitStoreSpaceQuota::new(10, 40))),
-        )
-        .await?;
-
-        {
-            let split_path = temp_dir.path().join("split1");
-            fs::create_dir_all(&split_path).await?;
-            let split_metadata1 = create_test_split_metadata("split1");
-            split_store
-                .store_split(
-                    &split_metadata1,
-                    &split_path,
-                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
-                )
+            let _split2 = split_store
+                .fetch_and_open_split(&split_id2, output.path())
                 .await?;
-            assert!(!split_path.exists());
-            assert!(split_cache_dir
-                .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split1.split")
-                .exists());
-            let local_store_stats = split_store.inspect_local_store().await;
-            assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(31));
         }
-
-        {
-            let split_path = temp_dir.path().join("split2");
-            fs::create_dir_all(&split_path).await?;
-            let split_metadata2 = create_test_split_metadata("split2");
-            split_store
-                .store_split(
-                    &split_metadata2,
-                    &split_path,
-                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
-                )
-                .await?;
-            assert!(!split_path.exists());
-            assert!(!split_cache_dir
-                .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split2.split")
-                .exists());
-            let local_store_stats = split_store.inspect_local_store().await;
-            assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split2").cloned(), None);
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_delete_should_remove_from_both_storage() -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-
-        let split_cache_dir = tempdir()?;
-        let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::create_with_local_store(
-            remote_storage.clone(),
-            split_cache_dir.path(),
-            default_merge_policy(),
-            Arc::new(Mutex::new(SplitStoreSpaceQuota::new(10, 40))),
-        )
-        .await?;
-
-        let split_streamer = SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?;
-        {
-            let split_path = temp_dir.path().join("split2");
-            fs::create_dir_all(&split_path).await?;
-            let split_metadata1 = create_test_split_metadata("split1");
-            split_store
-                .store_split(
-                    &split_metadata1,
-                    &split_path,
-                    Box::new(split_streamer.clone()),
-                )
-                .await?;
-            assert!(!split_path.exists());
-            assert!(split_cache_dir
-                .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split1.split")
-                .exists());
-            let local_store_stats = split_store.inspect_local_store().await;
-            assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(31));
-        }
-
-        let split1_bytes = remote_storage.get_all(Path::new("split1.split")).await?;
-        assert_eq!(split1_bytes, &split_streamer.read_all().await?);
-
-        split_store.delete("split1").await?;
-
-        let storage_err = remote_storage
-            .get_all(Path::new("split1.split"))
-            .await
-            .unwrap_err();
-        assert_eq!(storage_err.kind(), StorageErrorKind::DoesNotExist);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_remove_danglings_splits_should_remove_files() -> anyhow::Result<()> {
-        let local_dir = tempdir()?;
-        let root_path = local_dir.path().join(SPLIT_CACHE_DIR_NAME);
-        fs::create_dir_all(&root_path).await?;
-        fs::create_dir_all(&root_path.join("a.split")).await?;
-        fs::create_dir_all(&root_path.join("b.split")).await?;
-        fs::create_dir_all(&root_path.join("c.split")).await?;
-        fs::write(root_path.join("a.split").join("termdict"), b"a").await?;
-        fs::write(root_path.join("b.split").join("termdict"), b"b").await?;
-        fs::write(root_path.join("c.split").join("termdict"), b"c").await?;
-
-        let split_store_space_quota = Arc::new(Mutex::new(SplitStoreSpaceQuota::new(100, 200)));
-        let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            local_dir.path(),
-            default_merge_policy(),
-            split_store_space_quota.clone(),
-        )
-        .await?;
-        let initial_size = {
-            let split_store_space_quota_guard = split_store_space_quota.lock().await;
-            assert_eq!(split_store_space_quota_guard.num_splits(), 3);
-            split_store_space_quota_guard.size_in_bytes()
-        };
-        let published_splits = vec![SplitMetadata {
-            split_id: "b".to_string(),
-            footer_offsets: 5..20,
-            ..Default::default()
-        }];
-        split_store
-            .remove_dangling_splits(&published_splits)
-            .await?;
-        assert!(!root_path.join("a.split").as_path().exists());
-        assert!(!root_path.join("c.split").as_path().exists());
-        assert!(root_path.join("b.split").as_path().exists());
-        let split_store_space_quota_guard = split_store_space_quota.lock().await;
-        assert_eq!(split_store_space_quota_guard.num_splits(), 1);
-        assert!(split_store_space_quota_guard.size_in_bytes() < initial_size);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_mature_splits() -> anyhow::Result<()> {
-        #[derive(Debug)]
-        struct SplitsAreMature {}
-        impl MergePolicy for SplitsAreMature {
-            fn operations(
-                &self,
-                _: &mut Vec<SplitMetadata>,
-            ) -> Vec<crate::merge_policy::MergeOperation> {
-                unimplemented!()
-            }
-            fn is_mature(&self, _: &SplitMetadata) -> bool {
-                true
-            }
-        }
-        let temp_dir = tempfile::tempdir()?;
-        let split_cache_dir = tempdir()?;
-        let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::create_with_local_store(
-            remote_storage,
-            split_cache_dir.path(),
-            Arc::new(SplitsAreMature {}),
-            Arc::new(Mutex::new(SplitStoreSpaceQuota::default())),
-        )
-        .await?;
-        {
-            let split_path = temp_dir.path().join("split1");
-            fs::create_dir_all(&split_path).await?;
-            let file_in_split = split_path.join("myfile");
-            fs::write(&file_in_split, b"abcdefgh").await?;
-            let split_metadata1 = create_test_split_metadata("split1");
-
-            split_store
-                .store_split(
-                    &split_metadata1,
-                    &split_path,
-                    Box::new(SplitPayloadBuilder::get_split_payload(
-                        &[file_in_split.to_owned()],
-                        &[1, 2, 3],
-                    )?),
-                )
-                .await?;
-            assert!(!split_path.exists());
-            assert!(!split_cache_dir
-                .path()
-                .join(SPLIT_CACHE_DIR_NAME)
-                .join("split1.split")
-                .exists());
-            let local_store_stats = split_store.inspect_local_store().await;
-            assert_eq!(local_store_stats.len(), 0);
-            assert_eq!(local_store_stats.get("split1").cloned(), None);
-        }
-
         Ok(())
     }
 }

--- a/quickwit/quickwit-indexing/src/split_store/local_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/local_split_store.rs
@@ -39,7 +39,7 @@
 // The cache size is limited by 3 things:
 // - a maximum number of splits as defined in the `SplitStoreQuota`.
 // - a maximum number of bytes as defined in the `SplitStoreQuota`.
-// - finally, we evince older splits to make sure that newest split and the oldest
+// - finally, we evict older splits to make sure that the newest split and the oldest
 // split only differ by at most `SPLIT_MAX_AGE`.
 //
 // The point of this final rule invariant is to make sure that the disk space will be

--- a/quickwit/quickwit-indexing/src/split_store/mod.rs
+++ b/quickwit/quickwit-indexing/src/split_store/mod.rs
@@ -19,11 +19,8 @@
 
 mod indexing_split_store;
 mod local_split_store;
+mod split_store_quota;
 
-pub use indexing_split_store::{IndexingSplitStore, SplitStoreSpaceQuota, WeakIndexingSplitStore};
-use local_split_store::LocalSplitStore;
-pub use local_split_store::{get_tantivy_directory_from_split_bundle, SplitFolder};
-
-/// An intermediate folder created at `<cache dir>/SPLIT_CACHE_DIR_NAME`
-/// to hold the local split files.
-pub const SPLIT_CACHE_DIR_NAME: &str = "splits";
+pub use indexing_split_store::{IndexingSplitStore, WeakIndexingSplitStore};
+pub use local_split_store::{get_tantivy_directory_from_split_bundle, LocalSplitStore};
+pub use split_store_quota::SplitStoreQuota;

--- a/quickwit/quickwit-indexing/src/split_store/split_store_quota.rs
+++ b/quickwit/quickwit-indexing/src/split_store/split_store_quota.rs
@@ -1,0 +1,127 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use byte_unit::Byte;
+use quickwit_config::IndexerConfig;
+use tracing::warn;
+
+/// A struct for keeping in check multiple SplitStore.
+#[derive(Debug)]
+pub struct SplitStoreQuota {
+    /// Current number of splits in the cache.
+    num_splits_in_cache: usize,
+    /// Current size in bytes of splits in the cache.
+    size_in_bytes_in_cache: Byte,
+    /// Maximum number of files allowed in the cache.
+    max_num_splits: usize,
+    /// Maximum size in bytes allowed in the cache.
+    max_num_bytes: Byte,
+}
+
+impl Default for SplitStoreQuota {
+    fn default() -> Self {
+        Self {
+            num_splits_in_cache: 0,
+            size_in_bytes_in_cache: Byte::default(),
+            max_num_bytes: IndexerConfig::default_split_store_max_num_bytes(),
+            max_num_splits: IndexerConfig::default_split_store_max_num_splits(),
+        }
+    }
+}
+
+impl SplitStoreQuota {
+    pub fn new(max_num_splits: usize, max_num_bytes: Byte) -> Self {
+        Self {
+            max_num_splits,
+            max_num_bytes,
+            ..Default::default()
+        }
+    }
+
+    /// Space quota that prevents any caching.
+    pub fn no_caching() -> Self {
+        Self::new(0, Byte::default())
+    }
+
+    pub fn can_fit_split(&self, split_size_in_bytes: Byte) -> bool {
+        if self.num_splits_in_cache >= self.max_num_splits {
+            warn!("Failed to cache file: maximum number of files exceeded.");
+            return false;
+        }
+        if self.size_in_bytes_in_cache.get_bytes() + split_size_in_bytes.get_bytes()
+            > self.max_num_bytes.get_bytes()
+        {
+            warn!("Failed to cache file: maximum size in bytes of cache exceeded.");
+            return false;
+        }
+        true
+    }
+
+    pub fn add_split(&mut self, split_size_in_bytes: Byte) {
+        self.num_splits_in_cache += 1;
+        self.size_in_bytes_in_cache = Byte::from_bytes(
+            self.size_in_bytes_in_cache.get_bytes() + split_size_in_bytes.get_bytes(),
+        );
+    }
+
+    pub fn remove_split(&mut self, split_size_in_bytes: Byte) {
+        self.size_in_bytes_in_cache = Byte::from_bytes(
+            self.size_in_bytes_in_cache.get_bytes() - split_size_in_bytes.get_bytes(),
+        );
+        self.num_splits_in_cache -= 1;
+    }
+
+    pub fn max_num_bytes(&self) -> Byte {
+        self.max_num_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use byte_unit::Byte;
+
+    use crate::split_store::SplitStoreQuota;
+
+    #[test]
+    fn test_split_store_quota_max_bytes_accepted() {
+        let split_store_quota = SplitStoreQuota::new(3, Byte::from_bytes(100));
+        assert!(split_store_quota.can_fit_split(Byte::from_bytes(100)));
+    }
+
+    #[test]
+    fn test_split_store_quota_exceeding_bytes() {
+        let split_store_quota = SplitStoreQuota::new(3, Byte::from_bytes(100));
+        assert!(!split_store_quota.can_fit_split(Byte::from_bytes(101)));
+    }
+
+    #[test]
+    fn test_split_store_quota_max_num_files_accepted() {
+        let mut split_store_quota = SplitStoreQuota::new(2, Byte::from_bytes(100));
+        split_store_quota.add_split(Byte::from_bytes(1));
+        assert!(split_store_quota.can_fit_split(Byte::from_bytes(1)));
+    }
+
+    #[test]
+    fn test_split_store_quota_exceeding_max_num_files() {
+        let mut split_store_quota = SplitStoreQuota::new(2, Byte::from_bytes(100));
+        split_store_quota.add_split(Byte::from_bytes(1));
+        split_store_quota.add_split(Byte::from_bytes(1));
+        assert!(!split_store_quota.can_fit_split(Byte::from_bytes(1)));
+    }
+}

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -100,7 +100,8 @@ impl TestSandbox {
             metastore.clone(),
             storage_resolver.clone(),
             enable_ingest_api,
-        );
+        )
+        .await?;
         let (indexing_service, _indexing_service_handle) =
             universe.spawn_builder().spawn(indexing_service_actor);
         Ok(TestSandbox {

--- a/quickwit/quickwit-storage/src/split.rs
+++ b/quickwit/quickwit-storage/src/split.rs
@@ -237,13 +237,15 @@ mod tests {
         let test_filepath2 = temp_dir.path().join("f2");
 
         let mut file1 = File::create(&test_filepath1)?;
-        file1.write_all(&[123, 76])?;
+        file1.write_all(b"hello")?;
 
         let mut file2 = File::create(&test_filepath2)?;
-        file2.write_all(&[99, 55, 44])?;
+        file2.write_all(b"world")?;
 
-        let _split_streamer =
-            SplitPayloadBuilder::get_split_payload(&[test_filepath1, test_filepath2], &[1, 2, 3])?;
+        let split_payload =
+            SplitPayloadBuilder::get_split_payload(&[test_filepath1, test_filepath2], b"abc")?;
+
+        assert_eq!(split_payload.len(), 91);
 
         Ok(())
     }


### PR DESCRIPTION
It was tested via unit testing and by indexing wikipedia, and looking at the evolution of the datadir/cache directory.
`--keep-cache` was tested too.



After the fix, there is only one split cache shared
by all of the indexes.
    
Splits are all stored without any specific hierarchy in the
`data_dir/cache` directory.
    
The split cache evicts oldest splits first, and introduces
an extra constraint on the creation date to make sure
dangling splits eventually get removed even when the split is not under
capacity pressure.
    
---
    
    The Local Split Store is a local cache used to improve the performance of indexing nodes.
    Its purpose is simple: when a new split is freshly created, it is usely merged
    very rapidly after.
    
    In order to prevent this merge to force its download, we store it in the
    `LocalSplitStore`. This store is just a cache: a cache miss is acceptable and
    just means that the split will be redownloaded.
    
    The local split store eviction policy however, is rather uncommon.
    On our happy path, a split is stored into the cache, and is then used only once
    to undergo a merge.
    
    For this reason, we simply offer a way to `move splits into the cache`,
    and `move splits out of the cache`. A split is removed from the split store
    after its first access.
    
    Of course a failed merge could require accessing a given split more than once. In that
    case the split will be downloaded again.
    
    The cache size is limited by 3 things:
    - a maximum number of splits as defined in the `SplitStoreQuota`.
    - a maximum number of bytes as defined in the `SplitStoreQuota`.
    - finally, we evince older splits to make sure that newest split and the oldest
    split only differ by at most `SPLIT_MAX_AGE`.
    
    The point of this final rule invariant is to make sure that the disk space will be
    if the cache is NOT under pressure but some splits are actually useless.
    
    When adding a new split into the cache, if adding the split would break one of the following
    limit, we simply remove split one by one starting by the oldest first, until the split
    can be added.
    
    Closes #2022

