### PR TITLE
Fix internal objects id prefix

### DIFF
--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -205,7 +205,7 @@ fn test_cmd_ingest_on_non_existing_file() -> Result<()> {
     )
     .assert()
     .failure()
-    .stderr(predicate::str::contains("✖ .cli-ingest-source"));
+    .stderr(predicate::str::contains("✖ _cli-ingest-source"));
     Ok(())
 }
 

--- a/quickwit/quickwit-config/src/source_config.rs
+++ b/quickwit/quickwit-config/src/source_config.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{is_false, validate_identifier};
 
 /// Reserved source ID for the `quickwit index ingest` CLI command.
-pub const CLI_INGEST_SOURCE_ID: &str = ".cli-ingest-source";
+pub const CLI_INGEST_SOURCE_ID: &str = "_cli-ingest-source";
 
 fn default_num_pipelines() -> usize {
     1

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -94,7 +94,7 @@ use crate::actors::DocProcessor;
 use crate::source::ingest_api_source::IngestApiSourceFactory;
 
 /// Reserved source ID used for the ingest API.
-pub const INGEST_API_SOURCE_ID: &str = ".ingest-api";
+pub const INGEST_API_SOURCE_ID: &str = "_ingest-api";
 
 /// Runtime configuration used during execution of a source actor.
 pub struct SourceExecutionContext {


### PR DESCRIPTION
### Description

Changed some internal object id prefix from  `.` to `_`

Closes https://github.com/quickwit-oss/quickwit/issues/2069