### PR TITLE
Make max concurrent split upload configurable

### DIFF
--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -33,6 +33,7 @@ This section contains the configuration options for an indexer. The split store 
 | --- | --- | --- |
 | split_store_max_num_bytes | Maximum size in bytes allowed in the split store for each index-source pair. | 200G |
 | split_store_max_num_splits | Maximum number of files allowed in the split store for each index-source pair. | 10000 |
+| max_concurrent_split_uploads | Maximum number of concurrent split uploads allowed on the node. | 4 |
 
 ## Searcher configuration
 

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -13,7 +13,8 @@
     ],
     "indexer": {
         "split_store_max_num_bytes": "1T",
-        "split_store_max_num_splits": 10000
+        "split_store_max_num_splits": 10000,
+        "max_concurrent_split_upload": 8
     },
     "searcher": {
         "fast_field_cache_capacity": "10G",

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -14,7 +14,7 @@
     "indexer": {
         "split_store_max_num_bytes": "1T",
         "split_store_max_num_splits": 10000,
-        "max_concurrent_split_upload": 8
+        "max_concurrent_split_uploads": 8
     },
     "searcher": {
         "fast_field_cache_capacity": "10G",

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -10,7 +10,7 @@ data_dir = "/opt/quickwit/data"
 [indexer]
 split_store_max_num_bytes = "1T"
 split_store_max_num_splits = 10_000
-max_concurrent_split_upload = 8
+max_concurrent_split_uploads = 8
 
 [searcher]
 fast_field_cache_capacity = "10G"

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -10,6 +10,7 @@ data_dir = "/opt/quickwit/data"
 [indexer]
 split_store_max_num_bytes = "1T"
 split_store_max_num_splits = 10_000
+max_concurrent_split_upload = 8
 
 [searcher]
 fast_field_cache_capacity = "10G"

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -11,6 +11,7 @@ data_dir: /opt/quickwit/data
 indexer:
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000
+  max_concurrent_split_upload: 8
 searcher:
   fast_field_cache_capacity: 10G
   split_footer_cache_capacity: 1G

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -11,7 +11,7 @@ data_dir: /opt/quickwit/data
 indexer:
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000
-  max_concurrent_split_upload: 8
+  max_concurrent_split_uploads: 8
 searcher:
   fast_field_cache_capacity: 10G
   split_footer_cache_capacity: 1G

--- a/quickwit/quickwit-config/src/config.rs
+++ b/quickwit/quickwit-config/src/config.rs
@@ -96,8 +96,8 @@ pub struct IndexerConfig {
     pub split_store_max_num_bytes: Byte,
     #[serde(default = "IndexerConfig::default_split_store_max_num_splits")]
     pub split_store_max_num_splits: usize,
-    #[serde(default = "IndexerConfig::default_max_concurrent_split_upload")]
-    pub max_concurrent_split_upload: usize,
+    #[serde(default = "IndexerConfig::default_max_concurrent_split_uploads")]
+    pub max_concurrent_split_uploads: usize,
 }
 
 impl IndexerConfig {
@@ -105,7 +105,7 @@ impl IndexerConfig {
         false
     }
 
-    fn default_max_concurrent_split_upload() -> usize {
+    fn default_max_concurrent_split_uploads() -> usize {
         4
     }
 
@@ -123,7 +123,7 @@ impl IndexerConfig {
             enable_opentelemetry_otlp_service: true,
             split_store_max_num_bytes: Byte::from_bytes(1_000_000),
             split_store_max_num_splits: 3,
-            max_concurrent_split_upload: 4,
+            max_concurrent_split_uploads: 4,
         };
         Ok(indexer_config)
     }
@@ -135,7 +135,7 @@ impl Default for IndexerConfig {
             enable_opentelemetry_otlp_service: Self::default_enable_opentelemetry_otlp_service(),
             split_store_max_num_bytes: Self::default_split_store_max_num_bytes(),
             split_store_max_num_splits: Self::default_split_store_max_num_splits(),
-            max_concurrent_split_upload: Self::default_max_concurrent_split_upload(),
+            max_concurrent_split_uploads: Self::default_max_concurrent_split_uploads(),
         }
     }
 }
@@ -647,7 +647,7 @@ mod tests {
                         enable_opentelemetry_otlp_service: false,
                         split_store_max_num_bytes: Byte::from_str("1T").unwrap(),
                         split_store_max_num_splits: 10_000,
-                        max_concurrent_split_upload: 8,
+                        max_concurrent_split_uploads: 8,
                     }
                 );
 

--- a/quickwit/quickwit-config/src/config.rs
+++ b/quickwit/quickwit-config/src/config.rs
@@ -96,11 +96,17 @@ pub struct IndexerConfig {
     pub split_store_max_num_bytes: Byte,
     #[serde(default = "IndexerConfig::default_split_store_max_num_splits")]
     pub split_store_max_num_splits: usize,
+    #[serde(default = "IndexerConfig::default_max_concurrent_split_upload")]
+    pub max_concurrent_split_upload: usize,
 }
 
 impl IndexerConfig {
     fn default_enable_opentelemetry_otlp_service() -> bool {
         false
+    }
+
+    fn default_max_concurrent_split_upload() -> usize {
+        4
     }
 
     pub fn default_split_store_max_num_bytes() -> Byte {
@@ -117,6 +123,7 @@ impl IndexerConfig {
             enable_opentelemetry_otlp_service: true,
             split_store_max_num_bytes: Byte::from_bytes(1_000_000),
             split_store_max_num_splits: 3,
+            max_concurrent_split_upload: 4,
         };
         Ok(indexer_config)
     }
@@ -128,6 +135,7 @@ impl Default for IndexerConfig {
             enable_opentelemetry_otlp_service: Self::default_enable_opentelemetry_otlp_service(),
             split_store_max_num_bytes: Self::default_split_store_max_num_bytes(),
             split_store_max_num_splits: Self::default_split_store_max_num_splits(),
+            max_concurrent_split_upload: Self::default_max_concurrent_split_upload(),
         }
     }
 }
@@ -639,6 +647,7 @@ mod tests {
                         enable_opentelemetry_otlp_service: false,
                         split_store_max_num_bytes: Byte::from_str("1T").unwrap(),
                         split_store_max_num_splits: 10_000,
+                        max_concurrent_split_upload: 8,
                     }
                 );
 

--- a/quickwit/quickwit-config/src/index_config.rs
+++ b/quickwit/quickwit-config/src/index_config.rs
@@ -230,11 +230,11 @@ impl Default for IndexingSettingsLegacy {
             timestamp_field: None,
             sort_field: None,
             sort_order: None,
-            commit_timeout_secs: Self::default_commit_timeout_secs(),
-            docstore_blocksize: Self::default_docstore_blocksize(),
-            docstore_compression_level: Self::default_docstore_compression_level(),
-            split_num_docs_target: Self::default_split_num_docs_target(),
-            merge_enabled: Self::default_merge_enabled(),
+            commit_timeout_secs: IndexingSettings::default_commit_timeout_secs(),
+            docstore_blocksize: IndexingSettings::default_docstore_blocksize(),
+            docstore_compression_level: IndexingSettings::default_docstore_compression_level(),
+            split_num_docs_target: IndexingSettings::default_split_num_docs_target(),
+            merge_enabled: IndexingSettings::default_merge_enabled(),
             merge_policy: MergePolicyLegacy::default(),
             resources: IndexingResources::default(),
         }
@@ -244,26 +244,6 @@ impl Default for IndexingSettingsLegacy {
 impl IndexingSettingsLegacy {
     pub fn commit_timeout(&self) -> Duration {
         Duration::from_secs(self.commit_timeout_secs as u64)
-    }
-
-    fn default_commit_timeout_secs() -> usize {
-        60
-    }
-
-    pub fn default_docstore_blocksize() -> usize {
-        1_000_000
-    }
-
-    pub fn default_docstore_compression_level() -> i32 {
-        8
-    }
-
-    fn default_split_num_docs_target() -> usize {
-        10_000_000
-    }
-
-    fn default_merge_enabled() -> bool {
-        true
     }
 
     pub fn sort_by(&self) -> SortBy {

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -265,6 +265,7 @@ impl IndexingPipeline {
             self.params.metastore.clone(),
             split_store.clone(),
             SplitsUpdateMailbox::Publisher(merge_publisher_mailbox),
+            self.params.max_concurrent_split_upload,
         );
         let (merge_uploader_mailbox, merge_uploader_handler) = ctx
             .spawn_actor()
@@ -340,6 +341,7 @@ impl IndexingPipeline {
             self.params.metastore.clone(),
             split_store.clone(),
             SplitsUpdateMailbox::Sequencer(sequencer_mailbox),
+            self.params.max_concurrent_split_upload,
         );
         let (uploader_mailbox, uploader_handler) = ctx
             .spawn_actor()
@@ -570,6 +572,7 @@ pub struct IndexingPipelineParams {
     pub metastore: Arc<dyn Metastore>,
     pub storage: Arc<dyn Storage>,
     pub split_store: IndexingSplitStore,
+    pub max_concurrent_split_upload: usize,
 }
 
 impl IndexingPipelineParams {
@@ -582,6 +585,7 @@ impl IndexingPipelineParams {
         split_store: IndexingSplitStore,
         metastore: Arc<dyn Metastore>,
         storage: Arc<dyn Storage>,
+        max_concurrent_split_upload: usize,
     ) -> anyhow::Result<Self> {
         let doc_mapper = build_doc_mapper(
             &index_metadata.doc_mapping,
@@ -597,6 +601,7 @@ impl IndexingPipelineParams {
             metastore,
             storage,
             split_store,
+            max_concurrent_split_upload,
         })
     }
 }
@@ -716,6 +721,7 @@ mod tests {
             metastore: Arc::new(metastore),
             storage,
             split_store,
+            max_concurrent_split_upload: 4,
         };
         let pipeline = IndexingPipeline::new(pipeline_params);
         let (_pipeline_mailbox, pipeline_handler) = universe.spawn_builder().spawn(pipeline);
@@ -802,6 +808,7 @@ mod tests {
             metastore: Arc::new(metastore),
             storage,
             split_store,
+            max_concurrent_split_upload: 4,
         };
         let pipeline = IndexingPipeline::new(pipeline_params);
         let (_pipeline_mailbox, pipeline_handler) = universe.spawn_builder().spawn(pipeline);

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -265,7 +265,7 @@ impl IndexingPipeline {
             self.params.metastore.clone(),
             split_store.clone(),
             SplitsUpdateMailbox::Publisher(merge_publisher_mailbox),
-            self.params.max_concurrent_split_upload,
+            self.params.max_concurrent_split_uploads,
         );
         let (merge_uploader_mailbox, merge_uploader_handler) = ctx
             .spawn_actor()
@@ -341,7 +341,7 @@ impl IndexingPipeline {
             self.params.metastore.clone(),
             split_store.clone(),
             SplitsUpdateMailbox::Sequencer(sequencer_mailbox),
-            self.params.max_concurrent_split_upload,
+            self.params.max_concurrent_split_uploads,
         );
         let (uploader_mailbox, uploader_handler) = ctx
             .spawn_actor()
@@ -572,7 +572,7 @@ pub struct IndexingPipelineParams {
     pub metastore: Arc<dyn Metastore>,
     pub storage: Arc<dyn Storage>,
     pub split_store: IndexingSplitStore,
-    pub max_concurrent_split_upload: usize,
+    pub max_concurrent_split_uploads: usize,
 }
 
 impl IndexingPipelineParams {
@@ -585,7 +585,7 @@ impl IndexingPipelineParams {
         split_store: IndexingSplitStore,
         metastore: Arc<dyn Metastore>,
         storage: Arc<dyn Storage>,
-        max_concurrent_split_upload: usize,
+        max_concurrent_split_uploads: usize,
     ) -> anyhow::Result<Self> {
         let doc_mapper = build_doc_mapper(
             &index_metadata.doc_mapping,
@@ -601,7 +601,7 @@ impl IndexingPipelineParams {
             metastore,
             storage,
             split_store,
-            max_concurrent_split_upload,
+            max_concurrent_split_uploads,
         })
     }
 }
@@ -721,7 +721,7 @@ mod tests {
             metastore: Arc::new(metastore),
             storage,
             split_store,
-            max_concurrent_split_upload: 4,
+            max_concurrent_split_uploads: 4,
         };
         let pipeline = IndexingPipeline::new(pipeline_params);
         let (_pipeline_mailbox, pipeline_handler) = universe.spawn_builder().spawn(pipeline);
@@ -808,7 +808,7 @@ mod tests {
             metastore: Arc::new(metastore),
             storage,
             split_store,
-            max_concurrent_split_upload: 4,
+            max_concurrent_split_uploads: 4,
         };
         let pipeline = IndexingPipeline::new(pipeline_params);
         let (_pipeline_mailbox, pipeline_handler) = universe.spawn_builder().spawn(pipeline);

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -110,6 +110,7 @@ pub struct IndexingService {
     indexing_directories: HashMap<(IndexId, SourceId), WeakIndexingDirectory>,
     split_stores: HashMap<(IndexId, SourceId), WeakIndexingSplitStore>,
     split_store_space_quota: Arc<Mutex<SplitStoreSpaceQuota>>,
+    max_concurrent_split_upload: usize,
 }
 
 impl IndexingService {
@@ -140,6 +141,7 @@ impl IndexingService {
                 indexer_config.split_store_max_num_splits,
                 indexer_config.split_store_max_num_bytes.get_bytes() as usize,
             ))),
+            max_concurrent_split_upload: indexer_config.max_concurrent_split_upload,
         }
     }
 
@@ -271,6 +273,7 @@ impl IndexingService {
             split_store,
             self.metastore.clone(),
             storage,
+            self.max_concurrent_split_upload,
         )
         .map_err(IndexingServiceError::InvalidParams)?;
 

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -110,7 +110,7 @@ pub struct IndexingService {
     indexing_directories: HashMap<(IndexId, SourceId), WeakIndexingDirectory>,
     split_stores: HashMap<(IndexId, SourceId), WeakIndexingSplitStore>,
     split_store_space_quota: Arc<Mutex<SplitStoreSpaceQuota>>,
-    max_concurrent_split_upload: usize,
+    max_concurrent_split_uploads: usize,
 }
 
 impl IndexingService {
@@ -141,7 +141,7 @@ impl IndexingService {
                 indexer_config.split_store_max_num_splits,
                 indexer_config.split_store_max_num_bytes.get_bytes() as usize,
             ))),
-            max_concurrent_split_upload: indexer_config.max_concurrent_split_upload,
+            max_concurrent_split_uploads: indexer_config.max_concurrent_split_uploads,
         }
     }
 
@@ -273,7 +273,7 @@ impl IndexingService {
             split_store,
             self.metastore.clone(),
             storage,
-            self.max_concurrent_split_upload,
+            self.max_concurrent_split_uploads,
         )
         .map_err(IndexingServiceError::InvalidParams)?;
 

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -44,7 +44,7 @@ use crate::models::{
 };
 use crate::split_store::IndexingSplitStore;
 
-/// This semaphore ensures that at most `MAX_CONCURRENT_SPLIT_UPLOAD` uploads can happen
+/// This semaphore ensures that, at most, `MAX_CONCURRENT_SPLIT_UPLOADS` uploads can happen
 /// concurrently.
 ///
 /// This permit applies to all uploader actors. In the future, we might want to have a nicer

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -141,7 +141,7 @@ pub struct Uploader {
     metastore: Arc<dyn Metastore>,
     split_store: IndexingSplitStore,
     split_update_mailbox: SplitsUpdateMailbox,
-    max_concurrent_split_upload: usize,
+    max_concurrent_split_uploads: usize,
     counters: UploaderCounters,
 }
 
@@ -151,14 +151,14 @@ impl Uploader {
         metastore: Arc<dyn Metastore>,
         split_store: IndexingSplitStore,
         split_update_mailbox: SplitsUpdateMailbox,
-        max_concurrent_split_upload: usize,
+        max_concurrent_split_uploads: usize,
     ) -> Uploader {
         Uploader {
             actor_name,
             metastore,
             split_store,
             split_update_mailbox,
-            max_concurrent_split_upload,
+            max_concurrent_split_uploads,
             counters: Default::default(),
         }
     }
@@ -168,7 +168,7 @@ impl Uploader {
     ) -> anyhow::Result<SemaphorePermit<'static>> {
         let _guard = ctx.protect_zone();
         CONCURRENT_UPLOAD_PERMITS
-            .get_or_init(|| Semaphore::const_new(self.max_concurrent_split_upload))
+            .get_or_init(|| Semaphore::const_new(self.max_concurrent_split_uploads))
             .acquire()
             .await
             .context("The uploader semaphore is closed. (This should never happen.)")

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -73,7 +73,7 @@ pub struct DeleteTaskPipeline {
     index_storage: Arc<dyn Storage>,
     delete_service_dir_path: PathBuf,
     handles: Option<DeletePipelineHandle>,
-    max_concurrent_split_upload: usize,
+    max_concurrent_split_uploads: usize,
 }
 
 #[async_trait]
@@ -108,7 +108,7 @@ impl DeleteTaskPipeline {
         indexing_settings: IndexingSettings,
         index_storage: Arc<dyn Storage>,
         delete_service_dir_path: PathBuf,
-        max_concurrent_split_upload: usize,
+        max_concurrent_split_uploads: usize,
     ) -> Self {
         Self {
             index_id,
@@ -118,7 +118,7 @@ impl DeleteTaskPipeline {
             index_storage,
             delete_service_dir_path,
             handles: Default::default(),
-            max_concurrent_split_upload,
+            max_concurrent_split_uploads,
         }
     }
 
@@ -146,7 +146,7 @@ impl DeleteTaskPipeline {
             self.metastore.clone(),
             split_store.clone(),
             SplitsUpdateMailbox::Publisher(publisher_mailbox),
-            self.max_concurrent_split_upload,
+            self.max_concurrent_split_uploads,
         );
         let (uploader_mailbox, uploader_handler) = ctx
             .spawn_actor()

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -73,6 +73,7 @@ pub struct DeleteTaskPipeline {
     index_storage: Arc<dyn Storage>,
     delete_service_dir_path: PathBuf,
     handles: Option<DeletePipelineHandle>,
+    max_concurrent_split_upload: usize,
 }
 
 #[async_trait]
@@ -107,6 +108,7 @@ impl DeleteTaskPipeline {
         indexing_settings: IndexingSettings,
         index_storage: Arc<dyn Storage>,
         delete_service_dir_path: PathBuf,
+        max_concurrent_split_upload: usize,
     ) -> Self {
         Self {
             index_id,
@@ -116,6 +118,7 @@ impl DeleteTaskPipeline {
             index_storage,
             delete_service_dir_path,
             handles: Default::default(),
+            max_concurrent_split_upload,
         }
     }
 
@@ -143,6 +146,7 @@ impl DeleteTaskPipeline {
             self.metastore.clone(),
             split_store.clone(),
             SplitsUpdateMailbox::Publisher(publisher_mailbox),
+            self.max_concurrent_split_upload,
         );
         let (uploader_mailbox, uploader_handler) = ctx
             .spawn_actor()
@@ -351,6 +355,7 @@ mod tests {
             indexing_settings,
             test_sandbox.storage(),
             data_dir_path,
+            4,
         );
         let universe = Universe::new();
 

--- a/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
@@ -45,7 +45,7 @@ pub struct DeleteTaskService {
     storage_resolver: StorageUriResolver,
     data_dir_path: PathBuf,
     pipeline_handles_by_index_id: HashMap<String, ActorHandle<DeleteTaskPipeline>>,
-    max_concurrent_split_upload: usize,
+    max_concurrent_split_uploads: usize,
 }
 
 impl DeleteTaskService {
@@ -54,7 +54,7 @@ impl DeleteTaskService {
         search_client_pool: SearchClientPool,
         storage_resolver: StorageUriResolver,
         data_dir_path: PathBuf,
-        max_concurrent_split_upload: usize,
+        max_concurrent_split_uploads: usize,
     ) -> Self {
         Self {
             metastore,
@@ -62,7 +62,7 @@ impl DeleteTaskService {
             storage_resolver,
             data_dir_path,
             pipeline_handles_by_index_id: Default::default(),
-            max_concurrent_split_upload,
+            max_concurrent_split_uploads,
         }
     }
 }
@@ -143,7 +143,7 @@ impl DeleteTaskService {
             index_metadata.indexing_settings,
             index_storage,
             delete_task_service_dir,
-            self.max_concurrent_split_upload,
+            self.max_concurrent_split_uploads,
         );
         let (_pipeline_mailbox, pipeline_handler) = ctx.spawn_actor().spawn(pipeline);
         self.pipeline_handles_by_index_id

--- a/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
@@ -45,6 +45,7 @@ pub struct DeleteTaskService {
     storage_resolver: StorageUriResolver,
     data_dir_path: PathBuf,
     pipeline_handles_by_index_id: HashMap<String, ActorHandle<DeleteTaskPipeline>>,
+    max_concurrent_split_upload: usize,
 }
 
 impl DeleteTaskService {
@@ -53,6 +54,7 @@ impl DeleteTaskService {
         search_client_pool: SearchClientPool,
         storage_resolver: StorageUriResolver,
         data_dir_path: PathBuf,
+        max_concurrent_split_upload: usize,
     ) -> Self {
         Self {
             metastore,
@@ -60,6 +62,7 @@ impl DeleteTaskService {
             storage_resolver,
             data_dir_path,
             pipeline_handles_by_index_id: Default::default(),
+            max_concurrent_split_upload,
         }
     }
 }
@@ -140,6 +143,7 @@ impl DeleteTaskService {
             index_metadata.indexing_settings,
             index_storage,
             delete_task_service_dir,
+            self.max_concurrent_split_upload,
         );
         let (_pipeline_mailbox, pipeline_handler) = ctx.spawn_actor().spawn(pipeline);
         self.pipeline_handles_by_index_id
@@ -225,6 +229,7 @@ mod tests {
             client_pool,
             StorageUriResolver::for_test(),
             data_dir_path,
+            4,
         );
         let universe = Universe::new();
         let (delete_task_service_mailbox, delete_task_service_handler) =

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -58,6 +58,7 @@ pub async fn start_janitor_service(
         search_client_pool,
         storage_uri_resolver,
         config.data_dir_path.clone(),
+        config.indexer_config.max_concurrent_split_upload,
     );
     let (_, delete_task_service_handle) = universe.spawn_builder().spawn(delete_task_service);
 

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -58,7 +58,7 @@ pub async fn start_janitor_service(
         search_client_pool,
         storage_uri_resolver,
         config.data_dir_path.clone(),
-        config.indexer_config.max_concurrent_split_upload,
+        config.indexer_config.max_concurrent_split_uploads,
     );
     let (_, delete_task_service_handle) = universe.spawn_builder().spawn(delete_task_service);
 

--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -157,6 +157,7 @@ mod tests {
             client_pool,
             StorageUriResolver::for_test(),
             data_dir_path,
+            4,
         );
         let universe = Universe::new();
         let (delete_task_service_mailbox, _delete_task_service_handler) =


### PR DESCRIPTION
### Description

Added `max_concurrent_split_upload` config parameter to IndexerConfig

Closes https://github.com/quickwit-oss/quickwit/issues/2080
