### PR TITLE
Update tantivy to allow bytes field indexing

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1200,7 +1200,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=c9cf9c95#c9cf9c952a6830290c482e2d27c83464943aeef5"
 dependencies = [
  "fastdivide",
  "itertools",
@@ -2572,7 +2572,7 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 [[package]]
 name = "ownedbytes"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=c9cf9c95#c9cf9c952a6830290c482e2d27c83464943aeef5"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=c9cf9c95#c9cf9c952a6830290c482e2d27c83464943aeef5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4851,12 +4851,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=c9cf9c95#c9cf9c952a6830290c482e2d27c83464943aeef5"
 
 [[package]]
 name = "tantivy-common"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=c9cf9c95#c9cf9c952a6830290c482e2d27c83464943aeef5"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -4876,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=c9cf9c95#c9cf9c952a6830290c482e2d27c83464943aeef5"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1200,7 +1200,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=97ccd6d#97ccd6d71200288a8ebb54d2acf596465a8aba3c"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
 dependencies = [
  "fastdivide",
  "itertools",
@@ -2572,7 +2572,7 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 [[package]]
 name = "ownedbytes"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=97ccd6d#97ccd6d71200288a8ebb54d2acf596465a8aba3c"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -2984,7 +2984,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.6.27",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
 ]
@@ -3840,7 +3840,7 @@ checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.6.27",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3849,14 +3849,8 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax 0.6.27",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 
 [[package]]
 name = "regex-syntax"
@@ -4805,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=97ccd6d#97ccd6d71200288a8ebb54d2acf596465a8aba3c"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4813,6 +4807,7 @@ dependencies = [
  "bitpacking",
  "byteorder",
  "census",
+ "ciborium",
  "crc32fast",
  "crossbeam-channel",
  "downcast-rs",
@@ -4838,7 +4833,6 @@ dependencies = [
  "regex",
  "rust-stemmers",
  "serde",
- "serde_cbor",
  "serde_json",
  "smallvec",
  "stable_deref_trait",
@@ -4857,12 +4851,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=97ccd6d#97ccd6d71200288a8ebb54d2acf596465a8aba3c"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
 
 [[package]]
 name = "tantivy-common"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=97ccd6d#97ccd6d71200288a8ebb54d2acf596465a8aba3c"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -4870,19 +4864,19 @@ dependencies = [
 
 [[package]]
 name = "tantivy-fst"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20cdc0d83e9184560bdde9cd60142dbb4af2e0f770e88fce45770495224205"
+checksum = "fc3c506b1a8443a3a65352df6382a1fb6a7afe1a02e871cee0d25e2c3d5f3944"
 dependencies = [
  "byteorder",
- "regex-syntax 0.4.2",
+ "regex-syntax",
  "utf8-ranges",
 ]
 
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=97ccd6d#97ccd6d71200288a8ebb54d2acf596465a8aba3c"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=e443ca6#e443ca63aa3b2a321b5a6f739be04c70d91271d7"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -190,14 +190,14 @@ quickwit-serve = { version = "0.3.1", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.3.1", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.3.1", path = "./quickwit-telemetry" }
 
-fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e443ca6" }
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e443ca6", default-features = false, features = [
+fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "c9cf9c95" }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "c9cf9c95", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",
   "quickwit",
 ] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e443ca6" }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "c9cf9c95" }
 
 
 # This is actually not used directly the goal is to fix the version

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -190,14 +190,14 @@ quickwit-serve = { version = "0.3.1", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.3.1", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.3.1", path = "./quickwit-telemetry" }
 
-fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "97ccd6d" }
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "97ccd6d", default-features = false, features = [
+fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e443ca6" }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e443ca6", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",
   "quickwit",
 ] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "97ccd6d" }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e443ca6" }
 
 
 # This is actually not used directly the goal is to fix the version

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -518,12 +518,12 @@ mod tests {
             "body": ["20200415T072306-0700 INFO This is a great log"],
             "response_date": ["2021-12-19T16:39:57Z"],
             "response_time": [2.3],
-            "response_payload": [[97,98,99]],
+            "response_payload": ["YWJj"],
             "owner": ["foo"],
             "isImportant": [false],
             "body_other_tokenizer": ["20200415T072306-0700 INFO This is a great log"],
             "attributes.server": ["ABC"],
-            "attributes.server\\.payload": [[97], [98]],
+            "attributes.server\\.payload": ["YQ==", "Yg=="],
             "attributes.tags": [22, 23],
             "attributes.server\\.status": ["200", "201"]
         }"#;

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -791,7 +791,7 @@ mod tests {
         let expected_json_paths_and_values: HashMap<String, JsonValue> = serde_json::from_str(
             r#"{
                 "city": ["tokio"],
-                "image": [[97,98,99]]
+                "image": ["YWJj"]
             }"#,
         )
         .unwrap();

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -315,6 +315,7 @@ fn deserialize_mapping_type(
             }
             Ok(FieldMappingType::Json(json_options, cardinality))
         }
+        Type::IpAddr => unimplemented!("IpAddr are not supported in quickwit yet."),
     }
 }
 

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_type.rs
@@ -125,6 +125,9 @@ fn primitive_type_to_str(primitive_type: &Type) -> &'static str {
         Type::Facet => {
             unimplemented!("Facets are not supported by quickwit at the moment.")
         }
+        Type::IpAddr => {
+            unimplemented!("IpAddr are not supported by quickwit at the moment.")
+        }
     }
 }
 

--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -329,7 +329,7 @@ mod tests {
                 }],
                 "body": ["happy"],
                 "response_date": ["2021-12-19T16:39:59Z"],
-                 "response_payload": [[97, 98, 99]],
+                 "response_payload": ["YWJj"],
                  "response_time": [2.0],
                  "timestamp": [1628837062]
             })

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -40,12 +40,14 @@ async fn test_single_node_simple() -> anyhow::Result<()> {
                 type: text
               - name: url
                 type: text
+              - name: binary
+                type: bytes
         "#;
     let test_sandbox =
         TestSandbox::create(index_id, doc_mapping_yaml, "{}", &["body"], None).await?;
     let docs = vec![
-        json!({"title": "snoopy", "body": "Snoopy is an anthropomorphic beagle[5] in the comic strip...", "url": "http://snoopy"}),
-        json!({"title": "beagle", "body": "The beagle is a breed of small scent hound, similar in appearance to the much larger foxhound.", "url": "http://beagle"}),
+        json!({"title": "snoopy", "body": "Snoopy is an anthropomorphic beagle[5] in the comic strip...", "url": "http://snoopy", "binary": "dGhpcyBpcyBhIHRlc3Qu"}),
+        json!({"title": "beagle", "body": "The beagle is a breed of small scent hound, similar in appearance to the much larger foxhound.", "url": "http://beagle", "binary": "bWFkZSB5b3UgbG9vay4="}),
     ];
     test_sandbox.add_documents(docs.clone()).await?;
     let search_request = SearchRequest {
@@ -67,7 +69,7 @@ async fn test_single_node_simple() -> anyhow::Result<()> {
     assert_eq!(single_node_result.num_hits, 1);
     assert_eq!(single_node_result.hits.len(), 1);
     let hit_json: serde_json::Value = serde_json::from_str(&single_node_result.hits[0].json)?;
-    let expected_json: serde_json::Value = json!({"title": "snoopy", "body": "Snoopy is an anthropomorphic beagle[5] in the comic strip...", "url": "http://snoopy"});
+    let expected_json: serde_json::Value = json!({"title": "snoopy", "body": "Snoopy is an anthropomorphic beagle[5] in the comic strip...", "url": "http://snoopy", "binary": "dGhpcyBpcyBhIHRlc3Qu"});
     assert_json_include!(actual: hit_json, expected: expected_json);
     assert!(single_node_result.elapsed_time_micros > 10);
     assert!(single_node_result.elapsed_time_micros < 1_000_000);


### PR DESCRIPTION
### Description

Changed the `Cargo.toml` to point a more recent version of tantivy which serialises the bytes field correctly now.

### How was this PR tested?

A check was added in `test_single_node_simple` in `quickwit-search/src/tests.rs` with a bytes field and updated all tests to match this behaviour.
