### PR TITLE
Fix CLI inconsistencies #1320

### DIFF
--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -35,7 +35,8 @@ pub fn build_cli<'a>() -> Command<'a> {
                 .help("Config file location")
                 .env("QW_CONFIG")
                 .default_value(DEFAULT_QW_CONFIG_PATH)
-                .global(true),
+                .global(true)
+                .display_order(1),
         )
         .subcommand(build_run_command().display_order(1))
         .subcommand(build_index_command().display_order(2))

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -686,9 +686,7 @@ pub async fn list_index_cli(args: ListIndexesArgs) -> anyhow::Result<()> {
 }
 
 fn make_list_indexes_table<I>(indexes: I) -> Table
-where
-    I: IntoIterator<Item = IndexMetadata>,
-{
+where I: IntoIterator<Item = IndexMetadata> {
     let rows = indexes
         .into_iter()
         .map(|index| IndexRow {

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -90,7 +90,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("ingest")
                 .about("Indexes JSON documents read from a file or streamed from stdin.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
                         .required(false),
@@ -106,7 +107,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("ingest-api")
                 .about("Enables/disables the ingest API of an index.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
                     arg!(--enable "Enables the ingest API.")
                         .required(true)
                         .conflicts_with("disable")
@@ -120,7 +122,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("describe")
                 .about("Displays descriptive statistics of an index: number of published splits, number of documents, splits min/max timestamps, size of splits.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
                         .required(false),
@@ -130,7 +133,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("search")
                 .about("Searches an index.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
                         .required(false),
@@ -161,7 +165,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("merge")
                 .about("Merges all the splits of the index pipeline defined by the tuple (index ID, source ID, pipeline ordinal). The pipeline ordinal is 0 by default. If you have a source with `num_pipelines > 0`, you may want to merge splits on ordinals > 0.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index."),
+                    arg!(--index <INDEX> "ID of the target index.")
+                        .display_order(1),
                     arg!(--source <INDEX> "ID of the target source."),
                     arg!(--"pipeline-ord" <PIPELINE_ORD> "Pipeline ordinal.")
                         .default_value("0")
@@ -175,7 +180,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
             Command::new("gc")
                 .about("Garbage collects stale staged splits and splits marked for deletion.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
                         .required(false),
@@ -191,7 +197,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
                 .alias("clr")
                 .about("Clears and index. Deletes all its splits and resets its checkpoint. This operation is destructive and cannot be undone, proceed with caution.")
                 .args(&[
-                    arg!(--index <INDEX> "Index ID"),
+                    arg!(--index <INDEX> "Index ID")
+                        .display_order(1),
                     arg!(--yes),
                 ])
             )
@@ -200,7 +207,8 @@ pub fn build_index_command<'a>() -> Command<'a> {
             .alias("del")
                 .about("Deletes an index. This operation is destructive and cannot be undone, proceed with caution.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
                         .required(false),
@@ -678,7 +686,9 @@ pub async fn list_index_cli(args: ListIndexesArgs) -> anyhow::Result<()> {
 }
 
 fn make_list_indexes_table<I>(indexes: I) -> Table
-where I: IntoIterator<Item = IndexMetadata> {
+where
+    I: IntoIterator<Item = IndexMetadata>,
+{
     let rows = indexes
         .into_iter()
         .map(|index| IndexRow {

--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -38,7 +38,8 @@ pub fn build_source_command<'a>() -> Command<'a> {
             Command::new("create")
                 .about("Adds a new source to an index.")
                 .args(&[
-                    arg!(--index <INDEX_ID> "ID of the target index"),
+                    arg!(--index <INDEX_ID> "ID of the target index")
+                        .display_order(1),
                     arg!(--"source-config" <SOURCE_CONFIG> "Path to source config file. Please, refer to the documentation for more details."),
                 ])
             )
@@ -62,31 +63,38 @@ pub fn build_source_command<'a>() -> Command<'a> {
             Command::new("delete")
                 .about("Deletes a source from an index.")
                 .args(&[
-                    arg!(--index <INDEX_ID> "ID of the target index"),
-                    arg!(--source <SOURCE_ID> "ID of the source."),
+                    arg!(--index <INDEX_ID> "ID of the target index")
+                        .display_order(1),
+                    arg!(--source <SOURCE_ID> "ID of the source.")
+                        .display_order(2),
                 ])
             )
         .subcommand(
             Command::new("describe")
                 .about("Describes a source.")
                 .args(&[
-                    arg!(--index <INDEX_ID> "ID of the target index"),
-                    arg!(--source <SOURCE_ID> "ID of the source."),
+                    arg!(--index <INDEX_ID> "ID of the target index")
+                        .display_order(1),
+                    arg!(--source <SOURCE_ID> "ID of the source.")
+                        .display_order(2),
                 ])
             )
         .subcommand(
             Command::new("list")
                 .about("Lists the sources of an index.")
                 .args(&[
-                    arg!(--index <INDEX_ID> "ID of the target index"),
+                    arg!(--index <INDEX_ID> "ID of the target index")
+                        .display_order(1),
                 ])
             )
         .subcommand(
             Command::new("reset-checkpoint")
                 .about("Resets a source checkpoint. This operation is destructive and cannot be undone. Proceed with caution.")
                 .args(&[
-                    arg!(--index <INDEX_ID> "Index ID"),
-                    arg!(--source <SOURCE_ID> "Source ID"),
+                    arg!(--index <INDEX_ID> "Index ID")
+                        .display_order(1),
+                    arg!(--source <SOURCE_ID> "Source ID")
+                        .display_order(2),
                 ])
             )
         .arg_required_else_help(true)

--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -62,6 +62,7 @@ pub fn build_source_command<'a>() -> Command<'a> {
         .subcommand(
             Command::new("delete")
                 .about("Deletes a source from an index.")
+                .alias("del")
                 .args(&[
                     arg!(--index <INDEX_ID> "ID of the target index")
                         .display_order(1),
@@ -72,6 +73,7 @@ pub fn build_source_command<'a>() -> Command<'a> {
         .subcommand(
             Command::new("describe")
                 .about("Describes a source.")
+                .alias("desc")
                 .args(&[
                     arg!(--index <INDEX_ID> "ID of the target index")
                         .display_order(1),
@@ -82,6 +84,7 @@ pub fn build_source_command<'a>() -> Command<'a> {
         .subcommand(
             Command::new("list")
                 .about("Lists the sources of an index.")
+                .alias("ls")
                 .args(&[
                     arg!(--index <INDEX_ID> "ID of the target index")
                         .display_order(1),
@@ -90,6 +93,7 @@ pub fn build_source_command<'a>() -> Command<'a> {
         .subcommand(
             Command::new("reset-checkpoint")
                 .about("Resets a source checkpoint. This operation is destructive and cannot be undone. Proceed with caution.")
+                .alias("reset")
                 .args(&[
                     arg!(--index <INDEX_ID> "Index ID")
                         .display_order(1),

--- a/quickwit/quickwit-cli/src/split.rs
+++ b/quickwit/quickwit-cli/src/split.rs
@@ -42,6 +42,7 @@ pub fn build_split_command<'a>() -> Command<'a> {
         .subcommand(
             Command::new("list")
                 .about("Lists the splits of an index.")
+                .alias("ls")
                 .args(&[
                     arg!(--index <INDEX> "Target index ID")
                         .display_order(1)
@@ -87,6 +88,7 @@ pub fn build_split_command<'a>() -> Command<'a> {
         .subcommand(
             Command::new("describe")
                 .about("Displays metadata about a split.")
+                .alias("desc")
                 .args(&[
                     arg!(--index <INDEX> "ID of the target index")
                         .display_order(1),

--- a/quickwit/quickwit-cli/src/split.rs
+++ b/quickwit/quickwit-cli/src/split.rs
@@ -74,8 +74,10 @@ pub fn build_split_command<'a>() -> Command<'a> {
             Command::new("extract")
                 .about("Downloads and extracts a split to a directory.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
-                    arg!(--split <SPLIT> "ID of the target split"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
+                    arg!(--split <SPLIT> "ID of the target split")
+                        .display_order(2),
                     arg!(--"target-dir" <TARGET_DIR> "Directory to extract the split to."),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -86,8 +88,10 @@ pub fn build_split_command<'a>() -> Command<'a> {
             Command::new("describe")
                 .about("Displays metadata about a split.")
                 .args(&[
-                    arg!(--index <INDEX> "ID of the target index"),
-                    arg!(--split <SPLIT> "ID of the target split"),
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1),
+                    arg!(--split <SPLIT> "ID of the target split")
+                        .display_order(2),
                     arg!(--verbose "Displays additional metadata about the hotcache."),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
@@ -100,10 +104,10 @@ pub fn build_split_command<'a>() -> Command<'a> {
                 .alias("mark")
                 .args(&[
                     arg!(--index <INDEX_ID> "Target index ID")
-                        .display_order(2)
+                        .display_order(1)
                         .required(true),
                     arg!(--splits <SPLIT_IDS> "Comma-separated list of split IDs")
-                        .display_order(3)
+                        .display_order(2)
                         .required(true)
                         .use_value_delimiter(true),
                 ])


### PR DESCRIPTION
### Description

Fix CLI inconsistencies:

- [ ] Remove data-dir option when not necessary
- [x] Fix the display order of some commands (1. config, 2. index, 3. source/split, 4. other options)
- [x] Make required options such as config or index actually required
- [ ] Set default values with default_value
- [x] Add aliases (ls, rm, ...) whenever possible

### How was this PR tested?

Try local CLI + run tests

### Content

- Fix the display order of some commands (1. config, 2. index, 3. source/split, 4. other options) 
- Add aliases (`ls` for list, `del` for delete, `desc` for describe)
- Remove data-dir when not necessary

close #1320 

