### PR TITLE
Improve fetch of stale splits.

### DIFF
--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -37,8 +37,8 @@ use quickwit_proto::SearchRequest;
 use quickwit_search::{jobs_to_leaf_request, SearchClientPool, SearchJob};
 use tracing::{debug, info};
 
-const PLANNER_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
-const NUM_STALE_SPLITS_TO_FETCH: usize = 100;
+const PLANNER_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const NUM_STALE_SPLITS_TO_FETCH: usize = 1000;
 
 /// The `DeleteTaskPlanner` plans delete operations on splits for a given index.
 /// For each split, the planner checks if there is some documents to delete:

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -503,7 +503,20 @@ impl Metastore for FileBackedMetastore {
             let splits = index
                 .list_splits(SplitState::Published, None, None, Some(delete_opstamp))?
                 .into_iter()
-                .sorted_by_key(|split| split.split_metadata.delete_opstamp)
+                // Ordering by:
+                // - delete_opstamp ASC
+                // - publish_timestamp ASC
+                .sorted_by(|split_left, split_right| {
+                    split_left
+                        .split_metadata
+                        .delete_opstamp
+                        .cmp(&split_right.split_metadata.delete_opstamp)
+                        .then_with(|| {
+                            split_left
+                                .publish_timestamp
+                                .cmp(&split_right.publish_timestamp)
+                        })
+                })
                 .take(num_splits)
                 .collect_vec();
             Ok(splits)

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -878,7 +878,7 @@ impl Metastore for PostgresqlMetastore {
                     index_id = $1
                     AND delete_opstamp < $2
                     AND split_state = $3
-                ORDER BY delete_opstamp ASC
+                ORDER BY delete_opstamp ASC, publish_timestamp ASC
                 LIMIT $4
                 "#,
                 )

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2443,8 +2443,8 @@ pub mod test_suite {
                 .publish_splits(index_id, &[split_id_4], &[], None)
                 .await
                 .unwrap();
-            // Sleep 1 millisecond to have different publish timestamp.
-            tokio::time::sleep(Duration::from_millis(1000)).await;
+            // Sleep for 1 second to have different publish timestamps.
+            tokio::time::sleep(Duration::from_secs(1)).await;
             metastore
                 .publish_splits(index_id, &[split_id_1, split_id_2], &[], None)
                 .await

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2392,6 +2392,16 @@ pub mod test_suite {
             delete_opstamp: 0,
             ..Default::default()
         };
+        let split_id_4 = "list-stale-splits-four";
+        let split_metadata_4 = SplitMetadata {
+            footer_offsets: 1000..2000,
+            split_id: split_id_4.to_string(),
+            num_docs: 1,
+            uncompressed_docs_size_in_bytes: 2,
+            create_timestamp: current_timestamp,
+            delete_opstamp: 20,
+            ..Default::default()
+        };
 
         {
             info!("List stale splits on a non-existent index");
@@ -2417,21 +2427,28 @@ pub mod test_suite {
                 .stage_split(index_id, split_metadata_1.clone())
                 .await
                 .unwrap();
-
             metastore
                 .stage_split(index_id, split_metadata_2.clone())
                 .await
                 .unwrap();
-
             metastore
                 .stage_split(index_id, split_metadata_3.clone())
                 .await
                 .unwrap();
             metastore
+                .stage_split(index_id, split_metadata_4.clone())
+                .await
+                .unwrap();
+            metastore
+                .publish_splits(index_id, &[split_id_4], &[], None)
+                .await
+                .unwrap();
+            // Sleep 1 millisecond to have different publish timestamp.
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+            metastore
                 .publish_splits(index_id, &[split_id_1, split_id_2], &[], None)
                 .await
                 .unwrap();
-
             let splits = metastore.list_stale_splits(index_id, 100, 1).await.unwrap();
             assert_eq!(splits.len(), 1);
             assert_eq!(
@@ -2439,10 +2456,13 @@ pub mod test_suite {
                 split_metadata_2.delete_opstamp
             );
 
-            let splits = metastore.list_stale_splits(index_id, 100, 2).await.unwrap();
-            assert_eq!(splits.len(), 2);
+            let splits = metastore.list_stale_splits(index_id, 100, 4).await.unwrap();
+            assert_eq!(splits.len(), 3);
+            assert_eq!(splits[0].split_id(), split_metadata_2.split_id());
+            assert_eq!(splits[1].split_id(), split_metadata_4.split_id());
+            assert_eq!(splits[2].split_id(), split_metadata_1.split_id());
             assert_eq!(
-                splits[1].split_metadata.delete_opstamp,
+                splits[2].split_metadata.delete_opstamp,
                 split_metadata_1.delete_opstamp
             );
 

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v2-530db64d96f5702110983c32d628efa6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v2-530db64d96f5702110983c32d628efa6.expected.json
@@ -1,0 +1,96 @@
+{
+  "checkpoint": {
+    "kafka-source": {
+      "00000000000000000000": "00000000000000000042"
+    }
+  },
+  "create_timestamp": 1789,
+  "doc_mapping": {
+    "field_mappings": [
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "tenant_id",
+        "stored": true,
+        "type": "u64"
+      },
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "timestamp",
+        "stored": true,
+        "type": "i64"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "log_level",
+        "stored": true,
+        "tokenizer": "raw",
+        "type": "text"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "message",
+        "record": "position",
+        "stored": true,
+        "tokenizer": "default",
+        "type": "text"
+      }
+    ],
+    "max_num_partitions": 20,
+    "mode": "dynamic",
+    "partition_key": "tenant",
+    "store_source": true,
+    "tag_fields": [
+      "log_level",
+      "tenant_id"
+    ]
+  },
+  "index_id": "my-index",
+  "index_uri": "s3://quickwit-indexes/my-index",
+  "indexing_settings": {
+    "commit_timeout_secs": 301,
+    "docstore_blocksize": 1000000,
+    "docstore_compression_level": 8,
+    "merge_policy": {
+      "max_merge_factor": 11,
+      "merge_factor": 9,
+      "min_level_num_docs": 100000,
+      "type": "stable_log"
+    },
+    "resources": {
+      "heap_size": 3
+    },
+    "sort_field": "timestamp",
+    "sort_order": "asc",
+    "split_num_docs_target": 10000001,
+    "timestamp_field": "timestamp"
+  },
+  "retention_policy": {
+    "cutoff_reference": "publish_timestamp",
+    "period": "90 days",
+    "schedule": "daily"
+  },
+  "search_settings": {
+    "default_search_fields": [
+      "message"
+    ]
+  },
+  "sources": [
+    {
+      "num_pipelines": 2,
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
+      "source_id": "kafka-source",
+      "source_type": "kafka"
+    }
+  ],
+  "update_timestamp": 1789,
+  "version": "2"
+}

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v2-530db64d96f5702110983c32d628efa6.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v2-530db64d96f5702110983c32d628efa6.json
@@ -1,0 +1,96 @@
+{
+  "checkpoint": {
+    "kafka-source": {
+      "00000000000000000000": "00000000000000000042"
+    }
+  },
+  "create_timestamp": 1789,
+  "doc_mapping": {
+    "field_mappings": [
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "tenant_id",
+        "stored": true,
+        "type": "u64"
+      },
+      {
+        "fast": true,
+        "indexed": true,
+        "name": "timestamp",
+        "stored": true,
+        "type": "i64"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "log_level",
+        "stored": true,
+        "tokenizer": "raw",
+        "type": "text"
+      },
+      {
+        "fast": false,
+        "fieldnorms": false,
+        "indexed": true,
+        "name": "message",
+        "record": "position",
+        "stored": true,
+        "tokenizer": "default",
+        "type": "text"
+      }
+    ],
+    "max_num_partitions": 20,
+    "mode": "dynamic",
+    "partition_key": "tenant",
+    "store_source": true,
+    "tag_fields": [
+      "log_level",
+      "tenant_id"
+    ]
+  },
+  "index_id": "my-index",
+  "index_uri": "s3://quickwit-indexes/my-index",
+  "indexing_settings": {
+    "commit_timeout_secs": 301,
+    "docstore_blocksize": 1000000,
+    "docstore_compression_level": 8,
+    "merge_policy": {
+      "max_merge_factor": 11,
+      "merge_factor": 9,
+      "min_level_num_docs": 100000,
+      "type": "stable_log"
+    },
+    "resources": {
+      "heap_size": 3
+    },
+    "sort_field": "timestamp",
+    "sort_order": "asc",
+    "split_num_docs_target": 10000001,
+    "timestamp_field": "timestamp"
+  },
+  "retention_policy": {
+    "cutoff_reference": "publish_timestamp",
+    "period": "90 days",
+    "schedule": "daily"
+  },
+  "search_settings": {
+    "default_search_fields": [
+      "message"
+    ]
+  },
+  "sources": [
+    {
+      "num_pipelines": 2,
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
+      "source_id": "kafka-source",
+      "source_type": "kafka"
+    }
+  ],
+  "update_timestamp": 1789,
+  "version": "2"
+}


### PR DESCRIPTION

Currently, it's very easy to not get any stale splits if there are more than 100 immature splits... which can happen very easily.

This PR tries to mitigate the issue by:
- fetch 1000 splits
- order splits also by publishing date (it was already ordered by delete_opstamp) to get old split first

I put a longer polling loop on the delete task planner to avoid sending the same operations twice or even more.

 