### PR TITLE
Separating the semaphore limiting concurrent uploads.

### DIFF
--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -33,7 +33,7 @@ This section contains the configuration options for an indexer. The split store 
 | --- | --- | --- |
 | split_store_max_num_bytes | Maximum size in bytes allowed in the split store for each index-source pair. | 200G |
 | split_store_max_num_splits | Maximum number of files allowed in the split store for each index-source pair. | 10000 |
-| max_concurrent_split_uploads | Maximum number of concurrent split uploads allowed on the node. | 4 |
+| max_concurrent_split_uploads | Maximum number of concurrent split uploads allowed on the node. | 12 |
 
 ## Searcher configuration
 

--- a/quickwit/quickwit-config/src/config.rs
+++ b/quickwit/quickwit-config/src/config.rs
@@ -106,7 +106,7 @@ impl IndexerConfig {
     }
 
     fn default_max_concurrent_split_uploads() -> usize {
-        4
+        12
     }
 
     pub fn default_split_store_max_num_bytes() -> Byte {

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -298,6 +298,9 @@ impl IndexingService {
             )
             .await?;
 
+        let max_concurrent_split_uploads_index = (self.max_concurrent_split_uploads / 2).max(1);
+        let max_concurrent_split_uploads_merge =
+            (self.max_concurrent_split_uploads - max_concurrent_split_uploads_index).max(1);
         let pipeline_params = IndexingPipelineParams {
             pipeline_id: pipeline_id.clone(),
             doc_mapper,
@@ -307,7 +310,8 @@ impl IndexingService {
             metastore: self.metastore.clone(),
             storage,
             split_store,
-            max_concurrent_split_uploads: self.max_concurrent_split_uploads,
+            max_concurrent_split_uploads_index,
+            max_concurrent_split_uploads_merge,
             queues_dir_path,
             merge_planner_mailbox,
         };

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -34,7 +34,7 @@ use crate::actors::indexing_pipeline::wait_duration_before_retry;
 use crate::actors::merge_split_downloader::MergeSplitDownloader;
 use crate::actors::publisher::PublisherType;
 use crate::actors::sequencer::Sequencer;
-use crate::actors::{MergeExecutor, MergePlanner, Packager, Publisher, Uploader};
+use crate::actors::{MergeExecutor, MergePlanner, Packager, Publisher, Uploader, UploaderType};
 use crate::merge_policy::MergePolicy;
 use crate::models::{IndexingDirectory, IndexingPipelineId, MergeStatistics, Observe};
 use crate::split_store::IndexingSplitStore;
@@ -219,7 +219,7 @@ impl MergePipeline {
 
         // Merge uploader
         let merge_uploader = Uploader::new(
-            "MergeUploader",
+            UploaderType::MergeUploader,
             self.params.metastore.clone(),
             self.params.split_store.clone(),
             merge_sequencer_mailbox.into(),

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -50,4 +50,4 @@ pub use self::merge_planner::MergePlanner;
 pub use self::merge_split_downloader::MergeSplitDownloader;
 pub use self::packager::Packager;
 pub use self::publisher::{Publisher, PublisherCounters, PublisherType};
-pub use self::uploader::{SplitsUpdateMailbox, Uploader, UploaderCounters};
+pub use self::uploader::{SplitsUpdateMailbox, Uploader, UploaderCounters, UploaderType};

--- a/quickwit/quickwit-indexing/src/metrics.rs
+++ b/quickwit/quickwit-indexing/src/metrics.rs
@@ -27,7 +27,8 @@ pub struct IndexerMetrics {
     pub parsing_errors_num_bytes_total: IntCounterVec,
     pub missing_field_num_bytes_total: IntCounterVec,
     pub valid_num_bytes_total: IntCounterVec,
-    pub concurrent_upload_available_permits: IntGauge,
+    pub concurrent_upload_available_permits_index: IntGauge,
+    pub concurrent_upload_available_permits_merge: IntGauge,
 }
 
 impl Default for IndexerMetrics {
@@ -71,9 +72,14 @@ impl Default for IndexerMetrics {
                 "quickwit_indexing",
                 &["index"],
             ),
-            concurrent_upload_available_permits: new_gauge(
-                "concurrent_upload_available_permits",
-                "Number of concurrent upload available permits.",
+            concurrent_upload_available_permits_index: new_gauge(
+                "concurrent_upload_available_index",
+                "Number of concurrent uploader available permits for indexing.",
+                "quickwit_indexing",
+            ),
+            concurrent_upload_available_permits_merge: new_gauge(
+                "concurrent_upload_available_merge",
+                "Number of concurrent uploader available permits for merging.",
                 "quickwit_indexing",
             ),
         }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -28,7 +28,7 @@ use quickwit_actors::{
 };
 use quickwit_config::{build_doc_mapper, IndexingSettings};
 use quickwit_indexing::actors::{
-    MergeExecutor, MergeSplitDownloader, Packager, Publisher, Uploader,
+    MergeExecutor, MergeSplitDownloader, Packager, Publisher, Uploader, UploaderType,
 };
 use quickwit_indexing::merge_policy::merge_policy_from_settings;
 use quickwit_indexing::models::{IndexingDirectory, IndexingPipelineId};
@@ -136,7 +136,7 @@ impl DeleteTaskPipeline {
         let split_store =
             IndexingSplitStore::create_without_local_store(self.index_storage.clone());
         let uploader = Uploader::new(
-            "MergeUploader",
+            UploaderType::DeleteUploader,
             self.metastore.clone(),
             split_store.clone(),
             SplitsUpdateMailbox::Publisher(publisher_mailbox),


### PR DESCRIPTION
Using a different number of concurrent uploads
for the indexing pipeline and the merge pipeline.

This PR also increases the number of concurrent uploads from 4 to 12.
With this setting, the indexing pipeline therefore gets 6 and 6.

Closes #2129