### PR TITLE
Bugfix: Replacing .progress() where .record_progress() was meant

### DIFF
--- a/quickwit/quickwit-actors/src/actor.rs
+++ b/quickwit/quickwit-actors/src/actor.rs
@@ -348,6 +348,7 @@ impl<A: Actor> ActorContext<A> {
         &self.kill_switch
     }
 
+    #[must_use]
     pub fn progress(&self) -> &Progress {
         &self.progress
     }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -143,7 +143,7 @@ impl DeleteTaskPlanner {
                     ctx,
                 )
                 .await?;
-            ctx.progress();
+            ctx.record_progress();
             info!(
                 index_id = self.index_id,
                 last_delete_opstamp = last_delete_opstamp,
@@ -161,7 +161,7 @@ impl DeleteTaskPlanner {
                 splits_with_deletes.len(),
                 splits_without_deletes.len()
             );
-            ctx.progress();
+            ctx.record_progress();
 
             // Updates `delete_opstamp` of splits that won't undergo delete operations.
             let split_ids_without_delete = splits_without_deletes
@@ -175,7 +175,7 @@ impl DeleteTaskPlanner {
                     last_delete_opstamp,
                 )
                 .await?;
-            ctx.progress();
+            ctx.record_progress();
 
             // Sends delete operations.
             for split_with_deletes in splits_with_deletes {
@@ -210,7 +210,7 @@ impl DeleteTaskPlanner {
                 .metastore
                 .list_delete_tasks(&self.index_id, stale_split.split_metadata.delete_opstamp)
                 .await?;
-            ctx.progress();
+            ctx.record_progress();
 
             // Keep only delete tasks that matches the split metadata.
             let pending_and_matching_metadata_tasks = pending_tasks
@@ -248,7 +248,7 @@ impl DeleteTaskPlanner {
                     ctx,
                 )
                 .await?;
-            ctx.progress();
+            ctx.record_progress();
 
             if has_split_docs_to_delete {
                 splits_with_deletes.push(stale_split.clone());
@@ -295,7 +295,7 @@ impl DeleteTaskPlanner {
                 vec![search_job.clone()],
             );
             let response = search_client.leaf_search(leaf_search_request).await?;
-            ctx.progress();
+            ctx.record_progress();
             if response.num_hits > 0 {
                 return Ok(true);
             }


### PR DESCRIPTION
.progress() is quite confusing. It just returns a `Progress` object. I added a `must_use` attribute to prevent misuse in the future.
