### PR TITLE
Fix merge CLI command.

### DIFF
--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -41,7 +41,7 @@ use quickwit_core::{
 };
 use quickwit_indexing::actors::{IndexingPipeline, IndexingService};
 use quickwit_indexing::models::{
-    DetachPipeline, IndexingStatistics, SpawnMergePipeline, SpawnPipeline,
+    DetachPipeline, IndexingPipelineId, IndexingStatistics, SpawnMergePipeline, SpawnPipeline,
 };
 use quickwit_metastore::{quickwit_metastore_uri_resolver, IndexMetadata, Split, SplitState};
 use quickwit_proto::{SearchRequest, SearchResponse};
@@ -144,9 +144,13 @@ pub fn build_index_command<'a>() -> Command<'a> {
             )
         .subcommand(
             Command::new("merge")
-                .about("Merges an index.")
+                .about("Merges splits of a pipeline.")
                 .args(&[
                     arg!(--index <INDEX> "ID of the target index"),
+                    arg!(--source <INDEX> "ID of the target source"),
+                    arg!(--"pipeline-ord" <PIPELINE_ORD> "Pipeline ordinal.")
+                        .default_value("0")
+                        .required(false),
                     arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
                         .env("QW_DATA_DIR")
                         .required(false),
@@ -262,6 +266,8 @@ pub struct GarbageCollectIndexArgs {
 pub struct MergeArgs {
     pub config_uri: Uri,
     pub index_id: String,
+    pub source_id: String,
+    pub pipeline_ord: Option<usize>,
     pub data_dir: Option<PathBuf>,
 }
 
@@ -468,6 +474,15 @@ impl IndexCliCommand {
             .value_of("index")
             .context("'index-id' is a required arg.")?
             .to_string();
+        let source_id = matches
+            .value_of("source")
+            .context("'source-id' is a required arg.")?
+            .to_string();
+        let pipeline_ord = matches
+            .value_of("pipeline-ord")
+            .map(|value| value.parse::<usize>())
+            .transpose()
+            .context("`pipeline_ord` must be an integer >= 0.")?;
         let config_uri = matches
             .value_of("config")
             .map(Uri::try_new)
@@ -475,6 +490,8 @@ impl IndexCliCommand {
         let data_dir = matches.value_of("data-dir").map(PathBuf::from);
         Ok(Self::Merge(MergeArgs {
             index_id,
+            source_id,
+            pipeline_ord,
             config_uri,
             data_dir,
         }))
@@ -995,6 +1012,7 @@ pub async fn merge_cli(args: MergeArgs, merge_enabled: bool) -> anyhow::Result<(
     debug!(args=?args, merge_enabled = merge_enabled, "run-merge-operations");
     let config = load_quickwit_config(&args.config_uri, args.data_dir).await?;
     run_index_checklist(&config.metastore_uri, &args.index_id, None).await?;
+    start_actor_runtimes(&HashSet::from_iter([QuickwitService::Indexer]))?;
     let indexer_config = IndexerConfig {
         ..Default::default()
     };
@@ -1004,6 +1022,7 @@ pub async fn merge_cli(args: MergeArgs, merge_enabled: bool) -> anyhow::Result<(
         .await?;
     let storage_resolver = quickwit_storage_uri_resolver().clone();
     let enable_ingest_api = false;
+    let node_id = config.node_id.clone();
     let indexing_server = IndexingService::new(
         config.node_id,
         config.data_dir_path,
@@ -1014,17 +1033,24 @@ pub async fn merge_cli(args: MergeArgs, merge_enabled: bool) -> anyhow::Result<(
     )
     .await?;
     let universe = Universe::new();
-    let (indexing_server_mailbox, _) = universe.spawn_builder().spawn(indexing_server);
-    let pipeline_id = indexing_server_mailbox
+    let (indexing_service_mailbox, indexing_service_handle) =
+        universe.spawn_builder().spawn(indexing_server);
+    let pipeline_id = IndexingPipelineId {
+        index_id: args.index_id,
+        source_id: args.source_id,
+        node_id,
+        pipeline_ord: args.pipeline_ord.unwrap_or(0),
+    };
+    indexing_service_mailbox
         .ask_for_res(SpawnMergePipeline {
-            index_id: args.index_id.clone(),
-            merge_enabled,
+            pipeline_id: pipeline_id.clone(),
         })
         .await?;
-    let pipeline_handle = indexing_server_mailbox
+    let pipeline_handle = indexing_service_mailbox
         .ask_for_res(DetachPipeline { pipeline_id })
         .await?;
     let (pipeline_exit_status, _pipeline_statistics) = pipeline_handle.join().await;
+    indexing_service_handle.quit().await;
     if !pipeline_exit_status.is_success() {
         bail!(pipeline_exit_status);
     }

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -500,6 +500,10 @@ mod tests {
             "merge",
             "--index",
             "wikipedia",
+            "--source",
+            "ingest-source",
+            "--pipeline-ord",
+            "1",
             "--config",
             "/config.yaml",
         ])?;
@@ -508,8 +512,10 @@ mod tests {
             command,
             CliCommand::Index(IndexCliCommand::Merge(MergeArgs {
                 index_id,
+                source_id,
+                pipeline_ord,
                 ..
-            })) if &index_id == "wikipedia"
+            })) if &index_id == "wikipedia" && source_id == "ingest-source" && pipeline_ord.unwrap() == 1
         ));
         Ok(())
     }

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -237,6 +237,7 @@ impl IndexingPipeline {
             .map(|split| split.split_metadata)
             .collect::<Vec<_>>();
 
+        info!("splits {:?}", published_splits);
         let (merge_planner_mailbox, merge_planner_inbox) =
             create_mailbox::<MergePlanner>("MergePlanner".to_string(), QueueCapacity::Unbounded);
 

--- a/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
+++ b/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
@@ -63,6 +63,5 @@ pub struct ObservePipeline {
 
 #[derive(Debug)]
 pub struct SpawnMergePipeline {
-    pub index_id: String,
-    pub merge_enabled: bool,
+    pub pipeline_id: IndexingPipelineId,
 }


### PR DESCRIPTION
Fix #2062 and partially #1981

Partially because the logs end up like this:

```
2022-10-19T18:45:18.936Z  INFO quickwit_actors::spawn_builder: actor-exit actor_id=IndexingPipeline-twilight-8Ygs exit_status=Success
2022-10-19T18:45:18.938Z  INFO quickwit_actors::spawn_builder: actor-exit actor_id=quickwit_indexing::actors::indexing_service::IndexingService-blue-Swh0 exit_status=Quit
2022-10-19T18:45:18.938Z ERROR quickwit_actors::actor: actor-failure actor_name="quickwit_indexing::actors::indexing_service::IndexingService-blue-Swh0" actor_exit_status=Quit
2022-10-19T18:45:19.939Z  INFO quickwit_actors::spawn_builder: actor-exit actor_id=Scheduler-icy-gsOt exit_status=Killed
2022-10-19T18:45:19.939Z ERROR quickwit_actors::actor: actor-failure actor_name="Scheduler-icy-gsOt" actor_exit_status=Killed
```

We don't want `ERROR` logs when everything goes well. I think we should not print an `ERROR` on an "actor_handle.quit()".

I opened an issue to see what we can do on that #2150.
  