### PR TITLE
QW-2126: Relax trigger condition from ROW to STATEMENT

### DIFF
--- a/quickwit/quickwit-metastore/migrations/postgresql/2_create-splits.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/2_create-splits.up.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS splits (
 DROP TRIGGER IF EXISTS quickwit_set_index_update_timestamp_on_split_change ON splits CASCADE;
 CREATE TRIGGER quickwit_set_index_update_timestamp_on_split_change
     AFTER INSERT OR DELETE OR UPDATE ON splits
-    FOR EACH ROW
+    FOR EACH STATEMENT
     EXECUTE PROCEDURE set_index_update_timestamp_for_split();
 
 -- We also want to update an index `update_timestamp` field whenever a related split

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2014,6 +2014,8 @@ pub mod test_suite {
             .stage_split(index_id, split_metadata.clone())
             .await
             .unwrap();
+        
+        sleep(Duration::from_secs(1)).await;
         let split_meta = metastore.list_all_splits(index_id).await.unwrap()[0].clone();
         assert!(split_meta.update_timestamp > current_timestamp);
         assert!(split_meta.publish_timestamp.is_none());


### PR DESCRIPTION
Changes the trigger condition from running for every row to running once per statement.

This has roughly the same effect as removing the trigger and manually implementing the update logic. Still, IMO this is more maintainable as it prevents the update call from being missed if the code which interacts with the splits table changes.

Related to #2126 