### PR TITLE
The index serializer should set its progress/killswitch on the contro…

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -160,6 +160,33 @@ quickwit index ingest --index wikipedia --config=./config/quickwit.yaml --input-
 cat hdfs-log.json | quickwit index ingest --index wikipedia --config=./config/quickwit.yaml
 ```
 
+### enable/disable ingest API
+
+Enable or disable the ingest API for an index.
+`quickwit index ingest-api [args]`
+
+*Synopsis*
+
+```bash
+quickwit index ingest-api
+    --index <index>
+    --config <config>
+    --enable
+```
+
+*Options*
+
+`--index` ID of the target index. \
+`--config` Quickwit config file. \
+`--enable` or `--disable` Enable or disable the ingest API.
+
+*Examples*
+
+*Disable the ingest API of your index*
+```bash
+quickwit index ingest-api --index wikipedia --config ./config/quickwit.yaml --disable 
+```
+
 ### index describe
 
 Displays descriptive statistics of an index: number of published splits, number of documents, splits min/max timestamps, size of splits.
@@ -505,6 +532,60 @@ EOF
 quickwit source add --index wikipedia --source wikipedia-source --type kafka --params wikipedia-kafka-source.json --config ./config/quickwit.yaml
 ```
 
+### source enable
+
+Enables a source.
+`quickwit source enable [args]`
+
+*Synopsis*
+
+```bash
+quickwit source enable
+    --index <index>
+    --source <source>
+    --config <config>
+```
+
+*Options*
+
+`--index` ID of the target index. \
+`--source` ID of the target source. \
+`--config` Quickwit config file.
+
+*Examples*
+
+*Enable a `wikipedia-source` source*
+```bash
+quickwit source enable --index wikipedia --source wikipedia-source --config ./config/quickwit.yaml
+```
+
+### source disable
+
+Disables a source.
+`quickwit source disable [args]`
+
+*Synopsis*
+
+```bash
+quickwit source disable
+    --index <index>
+    --source <source_id>
+    --config <config>
+```
+
+*Options*
+
+`--index` ID of the target index. \
+`--source` ID of the target source. \
+`--config` Quickwit config file.
+
+*Examples*
+
+*Disable a `wikipedia-source` source*
+```bash
+quickwit source disable --index wikipedia --source wikipedia-source --config ./config/quickwit.yaml
+```
+
 ### source delete
 
 Deletes a source.
@@ -523,7 +604,7 @@ quickwit source delete
 
 `--index` ID of the target index. \
 `--source` ID of the target source. \
-`--config` Quickwit config file. \
+`--config` Quickwit config file.
 
 *Examples*
 
@@ -550,7 +631,7 @@ quickwit source describe
 
 `--index` ID of the target index. \
 `--source` ID of the target source. \
-`--config` Quickwit config file. \
+`--config` Quickwit config file.
 
 *Examples*
 
@@ -575,7 +656,7 @@ quickwit source list
 *Options*
 
 `--index` ID of the target index. \
-`--config` Quickwit config file. \
+`--config` Quickwit config file.
 
 *Examples*
 

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3383,6 +3383,7 @@ dependencies = [
  "once_cell",
  "oneshot",
  "openssl",
+ "parking_lot 0.12.1",
  "proptest",
  "quickwit-actors",
  "quickwit-aws",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3248,6 +3248,7 @@ dependencies = [
  "serde_json",
  "tantivy",
  "tempfile",
+ "thiserror",
  "tokio",
  "tracing",
  "warp",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -91,6 +91,7 @@ openssl-probe = "0.1.4"
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.11.0"
+parking_lot = {version="0.12", features=["send_guard"]}
 pnet = { version = "0.31.0", features = ["std"] }
 predicates = "2"
 prometheus = { version = "0.13", features = ["process"] }

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -131,7 +131,7 @@ pub async fn run_index_checklist(
             ));
         }
     }
-    run_checklist(checks);
+    run_checklist(checks)?;
     Ok(())
 }
 

--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -24,6 +24,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 tantivy = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 warp = { workspace = true }

--- a/quickwit/quickwit-common/src/checklist.rs
+++ b/quickwit/quickwit-common/src/checklist.rs
@@ -17,7 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt::Display;
+
 use colored::{Color, Colorize};
+use itertools::Itertools;
+use thiserror::Error;
 
 /// Quickwit main colors slightly adapted to be readable on a terminal.
 pub const BLUE_COLOR: Color = Color::TrueColor {
@@ -84,12 +88,49 @@ pub fn print_checklist(check_list_results: &[(&str, anyhow::Result<()>)]) {
 /// Run a checklist and print out its successes and failures on stdout.
 ///
 /// If an error is encountered, the proccess will exit with exit code 1.
-pub fn run_checklist(checks: Vec<(&str, anyhow::Result<()>)>) {
+pub fn run_checklist(checks: Vec<(&str, anyhow::Result<()>)>) -> Result<(), ChecklistError> {
     print_checklist(&checks);
     if !checks
         .iter()
         .all(|(_, check_items_res)| check_items_res.is_ok())
     {
-        std::process::exit(1);
+        return Err(ChecklistError::from_results(checks));
+    }
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+pub struct ChecklistError {
+    pub errors: Vec<(String, anyhow::Result<()>)>,
+}
+
+impl ChecklistError {
+    pub fn from_results(results: Vec<(&str, anyhow::Result<()>)>) -> Self {
+        let errors = results
+            .into_iter()
+            .filter(|(_, check_res)| check_res.is_err())
+            .map(|(check_elem, check_res)| (check_elem.to_string(), check_res))
+            .collect();
+        ChecklistError { errors }
+    }
+}
+
+impl Display for ChecklistError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let err_string = self
+            .errors
+            .iter()
+            .map(|(check_item, check_item_err)| {
+                format!(
+                    "\n{}: {}",
+                    check_item,
+                    check_item_err
+                        .as_ref()
+                        .expect_err("ChecklistError can't contain success results.")
+                )
+            })
+            .join("");
+        write!(f, "{}", err_string)
     }
 }

--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -32,7 +32,9 @@ use std::fmt::Debug;
 use std::ops::{Range, RangeInclusive};
 use std::str::FromStr;
 
-pub use checklist::{print_checklist, run_checklist, BLUE_COLOR, GREEN_COLOR, RED_COLOR};
+pub use checklist::{
+    print_checklist, run_checklist, ChecklistError, BLUE_COLOR, GREEN_COLOR, RED_COLOR,
+};
 pub use coolid::new_coolid;
 use tracing::{error, info};
 

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -24,6 +24,7 @@ libz-sys = { workspace = true, optional = true }
 once_cell = { workspace = true }
 oneshot = { workspace = true }
 openssl = { workspace = true, optional = true }
+parking_lot = { workspace = true }
 rdkafka = { workspace = true, optional = true }
 rusoto_core = { workspace = true, optional = true }
 rusoto_kinesis = { workspace = true, optional = true }

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -134,14 +134,6 @@ impl Handler<IndexedSplitBatch> for Packager {
             split_ids=?split_ids,
             "start-packaging-splits"
         );
-        for split in &batch.splits {
-            if let Some(controlled_directory) = &split.controlled_directory_opt {
-                controlled_directory.set_progress_and_kill_switch(
-                    ctx.progress().clone(),
-                    ctx.kill_switch().clone(),
-                );
-            }
-        }
         fail_point!("packager:before");
         let mut packaged_splits = Vec::new();
         for split in batch.splits {

--- a/quickwit/quickwit-indexing/src/controlled_directory.rs
+++ b/quickwit/quickwit-indexing/src/controlled_directory.rs
@@ -51,6 +51,7 @@ impl ControlledDirectory {
         directory: Box<dyn Directory>,
         progress: Progress,
         kill_switch: KillSwitch,
+        // write_throttle_per_secs: Byte
     ) -> ControlledDirectory {
         ControlledDirectory {
             inner: Inner {
@@ -81,7 +82,6 @@ impl fmt::Debug for ControlledDirectory {
         f.debug_struct("ControlledDirectory").finish()
     }
 }
-
 #[derive(Clone)]
 struct Controls {
     progress: Progress,

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -44,6 +44,7 @@ pub mod source;
 mod split_store;
 #[cfg(any(test, feature = "testsuite"))]
 mod test_utils;
+pub(crate) mod throttle;
 
 #[cfg(any(test, feature = "testsuite"))]
 pub use test_utils::{mock_split, mock_split_meta, TestSandbox};

--- a/quickwit/quickwit-indexing/src/throttle.rs
+++ b/quickwit/quickwit-indexing/src/throttle.rs
@@ -1,0 +1,241 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Weak;
+use std::time::Duration;
+use std::time::Instant;
+pub struct Throttle {
+    num_units_consumed: AtomicU64,
+    // Should wait is a atomic bool that we read with a relaxed ordering.
+    // On our happy path (no cooldown required), we don't pick any lock nor have any memory barrier.
+    should_wait: AtomicBool,
+    // We use RwLock as a synchronization primitive.
+    sync_rw_lock: parking_lot::RwLock<()>, //< we rely on parking_lot because the guard are `Send`
+    async_rw_lock: tokio::sync::RwLock<()>,
+}
+
+impl Throttle {
+    /// Records that we are about to consume `num_units`.
+    /// A throttling task may have identified that some throttling is needed.
+    ///
+    /// In this case, this function will be block for as long is required by the throttling
+    /// logic.
+    ///
+    /// When no throttling happens -our happy path-, this call is as light as can be.
+    pub fn consume(&self, num_units: u64) {
+        let should_wait = self.should_wait.load(Ordering::Relaxed);
+        if should_wait {
+            let _ = self.sync_rw_lock.read();
+        }
+        self.num_units_consumed
+            .fetch_add(num_units, Ordering::Relaxed);
+    }
+
+    // Async version of consume
+    pub async fn consume_async(&self, num_units: u64) {
+        let should_wait = self.should_wait.load(Ordering::Relaxed);
+        if should_wait {
+            let _ = self.async_rw_lock.read().await;
+        }
+        self.num_units_consumed
+            .fetch_add(num_units, Ordering::Relaxed);
+    }
+}
+
+async fn apply_cooldown(throttle: &Throttle, cool_down_duration: Duration) {
+    let _async_lock = throttle.async_rw_lock.write().await;
+    let _sync_lock = throttle.sync_rw_lock.write();
+    throttle.should_wait.store(true, Ordering::Relaxed);
+    tokio::time::sleep(cool_down_duration).await;
+    throttle.should_wait.store(false, Ordering::Relaxed);
+}
+
+async fn throttling_control_loop(
+    throttle_weak: Weak<Throttle>,
+    units_per_secs: u64,
+    throttling_reactivity: Duration,
+) {
+    let mut window_start = Instant::now();
+
+    let mut credit: i64 = 0i64;
+    let credit_cap: i64 =
+        throttling_reactivity.as_micros() as i64 * units_per_secs as i64 / 1_000_000;
+
+    loop {
+        if let Some(throttle) = throttle_weak.upgrade() {
+            let elapsed = window_start.elapsed();
+            window_start = Instant::now();
+
+            let units_consumed = throttle.num_units_consumed.swap(0, Ordering::Relaxed);
+
+            credit += (elapsed.as_micros() as u64 * units_per_secs) as i64 / 1_000_000;
+            credit -= units_consumed as i64;
+            credit = credit.min(credit_cap);
+
+            if credit < 0 {
+                // Cooldown. Everyone stops long enough to make the credit
+                let cool_down_micros = (-credit as u64) * 1_000_000 / units_per_secs;
+                let cool_down_duration =
+                    Duration::from_micros(cool_down_micros as u64) + throttling_reactivity;
+                apply_cooldown(&throttle, cool_down_duration).await;
+            } else {
+                // Let everyone unhinged for 1 full second.
+                tokio::time::sleep(throttling_reactivity).await;
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+/// Creates a new throttle.
+///
+/// A throttle can be cloned to share a given "budget" between several objects/threads.
+///
+/// * units_per_secs: Number of units per second allowed. This is our maximum target throughput.
+/// * throttling_reactivity (1s is a good default value):
+///     - Measures at which frequency the throttler will stop resume tasks.
+///     - What is the "window" on which throttling is enforced.
+pub fn create_throttle(units_per_sec: u64, throttling_reactivity: Duration) -> Arc<Throttle> {
+    assert!(units_per_sec > 0);
+    let throttle = Arc::new(Throttle {
+        num_units_consumed: Default::default(),
+        should_wait: Default::default(),
+        sync_rw_lock: Default::default(),
+        async_rw_lock: Default::default(),
+    });
+    let throttle_weak = Arc::downgrade(&throttle);
+    tokio::task::spawn(throttling_control_loop(
+        throttle_weak,
+        units_per_sec,
+        throttling_reactivity,
+    ));
+    throttle
+}
+
+/// Returns a `throttle` object that will actually never enforce any throttling.
+pub fn no_throttling() -> Arc<Throttle> {
+    // In case you were wondering, apparently fetch_add guarantees wrapping behavior for fetch_add.
+    Arc::new(Throttle {
+        num_units_consumed: Default::default(),
+        should_wait: Default::default(),
+        sync_rw_lock: Default::default(),
+        async_rw_lock: Default::default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use super::create_throttle;
+
+    #[tokio::test]
+    async fn test_sync_throttling() {
+        let throttler = create_throttle(1_000, Duration::from_millis(10));
+        let now = Instant::now();
+        // We try to consume 400 at a pace of 4_000 / secs.
+        // Because we are throttled, it will actually take around 400ms.
+        let join_handle = tokio::task::spawn_blocking(move || {
+            let start = Instant::now();
+            for _ in 0..100 {
+                std::thread::sleep(Duration::from_millis(1));
+                throttler.consume(4);
+            }
+            start.elapsed()
+        });
+        let elapsed = join_handle.await.unwrap();
+        assert!(elapsed.as_millis() > 350);
+        assert!(elapsed.as_millis() < 450);
+    }
+
+    #[tokio::test]
+    async fn test_async_throttling() {
+        let throttler = create_throttle(1_000, Duration::from_millis(20));
+        let now = Instant::now();
+        // We try to consume 400 at a pace of 4_000 / secs.
+        // Because we are throttled, it will actually take around 400ms.
+        for _ in 0..100 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            throttler.consume_async(4).await;
+        }
+        let elapsed = now.elapsed();
+        assert!(elapsed.as_millis() > 350);
+        assert!(elapsed.as_millis() < 450)
+    }
+
+    #[tokio::test]
+    async fn test_credit_do_not_accumulate_forever() {
+        let throttler = create_throttle(1_000, Duration::from_millis(10));
+        let now = Instant::now();
+        // We try to consume intermittently.
+        //
+        // - 100 at a pace of 4000/secs
+        // - no consumption for 100ms
+        // ... repeated 5 times.
+        //
+        // The point of this test is too see if extended (= much larger than `reactivity`)
+        // lack of call to consume accumulate credits.
+        //
+        // We are hoping here to see throttling happen, and hope the result will take around
+        // (100 + 100) * 5 = 1sec
+        for _ in 0..5 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            for _ in 0..25 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                throttler.consume_async(4).await;
+            }
+        }
+        let elapsed = now.elapsed();
+        assert!(elapsed.as_millis() > 900);
+        assert!(elapsed.as_millis() < 1100)
+    }
+
+    #[tokio::test]
+    async fn test_credit_do_accumulate() {
+        let throttler = create_throttle(100_000, Duration::from_millis(100));
+        let now = Instant::now();
+        // We try to consume intermittently.
+        //
+        // - 100 at a pace of 4000/secs
+        // - no consumption for 100ms
+        // ... repeated 5 times.
+        //
+        // The point of this test is too see if extended (= much larger than `reactivity`)
+        // lack of call to consume accumulate credits.
+        //
+        // We are hoping here to see throttling happen, and hope the result will take around
+        // [100ms + 25ms ] * 5 = 625ms
+        for _ in 0..5 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            for _ in 0..5 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                throttler.consume_async(20).await;
+            }
+        }
+        let elapsed = now.elapsed();
+        assert!(elapsed.as_millis() > 550);
+        assert!(elapsed.as_millis() < 720)
+    }
+}

--- a/quickwit/quickwit-indexing/src/throttle.rs
+++ b/quickwit/quickwit-indexing/src/throttle.rs
@@ -17,17 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::sync::Weak;
-use std::time::Duration;
-use std::time::Instant;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::{Duration, Instant};
 pub struct Throttle {
     num_units_consumed: AtomicU64,
     // Should wait is a atomic bool that we read with a relaxed ordering.
-    // On our happy path (no cooldown required), we don't pick any lock nor have any memory barrier.
+    // On our happy path (no cooldown required), we don't pick any lock nor have any memory
+    // barrier.
     should_wait: AtomicBool,
     // We use RwLock as a synchronization primitive.
     sync_rw_lock: parking_lot::RwLock<()>, //< we rely on parking_lot because the guard are `Send`
@@ -146,8 +143,7 @@ pub fn no_throttling() -> Arc<Throttle> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     use super::create_throttle;
 


### PR DESCRIPTION
    The index serializer should set its progress/killswitch on the controlled directory
    
    This logic existed on the Packager, and should have been moved
    when we moved the serialization to the IndexSerializer.


