### PR TITLE
Added a copy_to method to the Storage.

### DIFF
--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -215,9 +215,10 @@ impl IndexingSplitStore {
             tracing::Span::current().record("cache_hit", false);
         }
         let dest_filepath = output_dir_path.join(&path);
+        let mut dest_file = tokio::fs::File::create(&dest_filepath).await?;
         self.inner
             .remote_storage
-            .copy_to_file(&path, &dest_filepath)
+            .copy_to(&path, &mut dest_file)
             .instrument(info_span!("fetch_split_from_remote_storage", path=?path))
             .await?;
         get_tantivy_directory_from_split_bundle(&dest_filepath)

--- a/quickwit/quickwit-storage/src/cache/storage_with_cache.rs
+++ b/quickwit/quickwit-storage/src/cache/storage_with_cache.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use quickwit_common::uri::Uri;
 
 use crate::cache::Cache;
+use crate::storage::SendableAsync;
 use crate::{OwnedBytes, Storage, StorageResult};
 
 /// Use with care, StorageWithCache is read-only.
@@ -47,8 +48,8 @@ impl Storage for StorageWithCache {
         unimplemented!("StorageWithCache is readonly. Failed to put {:?}", path)
     }
 
-    async fn copy_to_file(&self, path: &Path, output_path: &Path) -> StorageResult<()> {
-        self.storage.copy_to_file(path, output_path).await
+    async fn copy_to(&self, path: &Path, output: &mut dyn SendableAsync) -> StorageResult<()> {
+        self.storage.copy_to(path, output).await
     }
 
     async fn get_slice(&self, path: &Path, byte_range: Range<usize>) -> StorageResult<OwnedBytes> {

--- a/quickwit/quickwit-storage/src/debouncer.rs
+++ b/quickwit/quickwit-storage/src/debouncer.rs
@@ -29,6 +29,7 @@ use futures::{Future, FutureExt};
 use quickwit_common::uri::Uri;
 use tantivy::directory::OwnedBytes;
 
+use crate::storage::SendableAsync;
 use crate::{Storage, StorageResult};
 
 /// The AsyncDebouncer debounces inflight Futures, so that concurrent async request to the same data
@@ -141,8 +142,8 @@ impl<T: Storage> Storage for DebouncedStorage<T> {
         self.underlying.put(path, payload).await
     }
 
-    async fn copy_to_file(&self, path: &Path, output_path: &Path) -> StorageResult<()> {
-        self.underlying.copy_to_file(path, output_path).await
+    async fn copy_to(&self, path: &Path, output: &mut dyn SendableAsync) -> StorageResult<()> {
+        self.underlying.copy_to(path, output).await
     }
 
     async fn get_slice(&self, path: &Path, range: Range<usize>) -> StorageResult<OwnedBytes> {

--- a/quickwit/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit/quickwit-storage/src/prefix_storage.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use quickwit_common::uri::Uri;
 
+use crate::storage::SendableAsync;
 use crate::{OwnedBytes, Storage};
 
 /// This storage acts as a proxy to another storage that simply modifies each API call
@@ -48,10 +49,12 @@ impl Storage for PrefixStorage {
         self.storage.put(&self.prefix.join(path), payload).await
     }
 
-    async fn copy_to_file(&self, path: &Path, output_path: &Path) -> crate::StorageResult<()> {
-        self.storage
-            .copy_to_file(&self.prefix.join(path), output_path)
-            .await
+    async fn copy_to(
+        &self,
+        path: &Path,
+        output: &mut dyn SendableAsync,
+    ) -> crate::StorageResult<()> {
+        self.storage.copy_to(&self.prefix.join(path), output).await
     }
 
     async fn get_slice(

--- a/quickwit/quickwit-storage/tests/azure_storage.rs
+++ b/quickwit/quickwit-storage/tests/azure_storage.rs
@@ -25,9 +25,7 @@ use std::path::Path;
 
 use anyhow::Context;
 use azure_storage_blobs::prelude::ClientBuilder;
-#[cfg(feature = "azure")]
-use quickwit_storage::AzureBlobStorage;
-use quickwit_storage::MultiPartPolicy;
+use quickwit_storage::{AzureBlobStorage, MultiPartPolicy};
 
 #[cfg(feature = "testsuite")]
 #[tokio::test]


### PR DESCRIPTION
We want to be able to add some throttling to the
download of merge splits.

The current Storage API does not make that possible. This PR adds a new method called `.copy_to` that
target an `AsyncWrite` rather than a `File` as a
destination.
