### PR TITLE
Track merge operations in merge and delete planner.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "futures",
  "itertools",
  "mockall",
+ "once_cell",
  "quickwit-actors",
  "quickwit-cluster",
  "quickwit-common",

--- a/quickwit/quickwit-common/src/metrics.rs
+++ b/quickwit/quickwit-common/src/metrics.rs
@@ -18,7 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use prometheus::{Encoder, HistogramOpts, Opts, TextEncoder};
-pub use prometheus::{Histogram, HistogramTimer, IntCounter, IntCounterVec, IntGauge};
+pub use prometheus::{Histogram, HistogramTimer, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 pub fn new_counter(name: &str, description: &str, namespace: &str) -> IntCounter {
     let counter_opts = Opts::new(name, description).namespace(namespace);
@@ -51,6 +51,18 @@ pub fn new_gauge(name: &str, description: &str, namespace: &str) -> IntGauge {
     let gauge = IntGauge::with_opts(gauge_opts).expect("Failed to create gauge");
     prometheus::register(Box::new(gauge.clone())).expect("Failed to register gauge");
     gauge
+}
+
+pub fn new_gauge_vec(
+    name: &str,
+    description: &str,
+    namespace: &str,
+    labels: &[&str],
+) -> IntGaugeVec {
+    let gauge_opts = Opts::new(name, description).namespace(namespace);
+    let gauge_vec = IntGaugeVec::new(gauge_opts, labels).expect("Failed to create gauge vec");
+    prometheus::register(Box::new(gauge_vec.clone())).expect("Failed to register gauge vec");
+    gauge_vec
 }
 
 pub fn metrics_handler() -> impl warp::Reply {

--- a/quickwit/quickwit-indexing/src/actors/index_serializer.rs
+++ b/quickwit/quickwit-indexing/src/actors/index_serializer.rs
@@ -98,6 +98,7 @@ impl Handler<IndexedSplitBatchBuilder> for IndexSerializer {
             splits,
             checkpoint_delta: batch_builder.checkpoint_delta,
             publish_lock: batch_builder.publish_lock,
+            merge_operation: None,
         };
         ctx.send_message(&self.packager_mailbox, indexed_split_batch)
             .await?;

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -107,7 +107,7 @@ impl Handler<MergeScratch> for MergeExecutor {
                     "Delete tasks can be applied only on one split."
                 );
                 assert_eq!(merge_scratch.tantivy_dirs.len(), 1);
-                let split_with_docs_to_delete = merge_op.splits.into_iter().next().unwrap();
+                let split_with_docs_to_delete = merge_op.splits.first().unwrap().clone();
                 self.process_delete_and_merge(
                     merge_op.merge_split_id.clone(),
                     split_with_docs_to_delete,
@@ -128,10 +128,11 @@ impl Handler<MergeScratch> for MergeExecutor {
             ctx.send_message(
                 &self.merge_packager_mailbox,
                 IndexedSplitBatch {
-                    batch_parent_span: merge_op.merge_parent_span,
+                    batch_parent_span: merge_op.merge_parent_span.clone(),
                     splits: vec![indexed_split],
                     checkpoint_delta: Default::default(),
                     publish_lock: PublishLock::default(),
+                    merge_operation: Some(merge_op),
                 },
             )
             .await?;
@@ -506,6 +507,7 @@ mod tests {
     use quickwit_common::split_file;
     use quickwit_metastore::SplitMetadata;
     use quickwit_proto::metastore_api::DeleteQuery;
+    use tantivy::Inventory;
 
     use super::*;
     use crate::merge_policy::MergeOperation;
@@ -566,8 +568,11 @@ mod tests {
                 .await?;
             tantivy_dirs.push(get_tantivy_directory_from_split_bundle(&dest_filepath).unwrap())
         }
+        let merge_ops_inventory = Inventory::new();
+        let merge_operation =
+            merge_ops_inventory.track(MergeOperation::new_merge_operation(split_metas));
         let merge_scratch = MergeScratch {
-            merge_operation: MergeOperation::new_merge_operation(split_metas),
+            merge_operation,
             tantivy_dirs,
             merge_scratch_directory,
             downloaded_splits_directory,
@@ -707,8 +712,12 @@ mod tests {
             .copy_to_file(Path::new(&split_filename), &dest_filepath)
             .await?;
         let tantivy_dir = get_tantivy_directory_from_split_bundle(&dest_filepath).unwrap();
+        let merge_ops_inventory = Inventory::new();
+        let merge_operation = merge_ops_inventory.track(
+            MergeOperation::new_delete_and_merge_operation(new_split_metadata),
+        );
         let merge_scratch = MergeScratch {
-            merge_operation: MergeOperation::new_delete_and_merge_operation(new_split_metadata),
+            merge_operation,
             tantivy_dirs: vec![tantivy_dir],
             merge_scratch_directory,
             downloaded_splits_directory,

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -107,7 +107,7 @@ impl Handler<MergeScratch> for MergeExecutor {
                     "Delete tasks can be applied only on one split."
                 );
                 assert_eq!(merge_scratch.tantivy_dirs.len(), 1);
-                let split_with_docs_to_delete = merge_op.splits.first().unwrap().clone();
+                let split_with_docs_to_delete = merge_op.splits[0].clone();
                 self.process_delete_and_merge(
                     merge_op.merge_split_id.clone(),
                     split_with_docs_to_delete,

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -222,6 +222,7 @@ mod tests {
     use quickwit_actors::{create_mailbox, QueueCapacity, Universe};
     use quickwit_config::merge_policy_config::StableLogMergePolicyConfig;
     use quickwit_metastore::SplitMetadata;
+    use tantivy::TrackedObject;
 
     use crate::actors::MergePlanner;
     use crate::merge_policy::{MergeOperation, StableLogMergePolicy};
@@ -308,11 +309,10 @@ mod tests {
                 ],
             };
             merge_planner_mailbox.send_message(message).await?;
-            let operations = merge_split_downloader_inbox.drain_for_test();
+            let operations = merge_split_downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
             assert_eq!(operations.len(), 2);
             let mut merge_operations = operations
                 .into_iter()
-                .map(|operation| operation.downcast::<MergeOperation>().unwrap())
                 .sorted_by(|left_op, right_op| {
                     left_op.splits[0]
                         .partition_id

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -309,15 +309,14 @@ mod tests {
                 ],
             };
             merge_planner_mailbox.send_message(message).await?;
-            let operations = merge_split_downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
+            let operations = merge_split_downloader_inbox
+                .drain_for_test_typed::<TrackedObject<MergeOperation>>();
             assert_eq!(operations.len(), 2);
-            let mut merge_operations = operations
-                .into_iter()
-                .sorted_by(|left_op, right_op| {
-                    left_op.splits[0]
-                        .partition_id
-                        .cmp(&right_op.splits[0].partition_id)
-                });
+            let mut merge_operations = operations.into_iter().sorted_by(|left_op, right_op| {
+                left_op.splits[0]
+                    .partition_id
+                    .cmp(&right_op.splits[0].partition_id)
+            });
 
             let first_merge_operation = merge_operations.next().unwrap();
             assert_eq!(first_merge_operation.splits.len(), 4);

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -154,6 +154,7 @@ impl Handler<IndexedSplitBatch> for Packager {
                 packaged_splits,
                 batch.checkpoint_delta,
                 batch.publish_lock,
+                batch.merge_operation,
                 batch.batch_parent_span,
             ),
         )
@@ -432,6 +433,7 @@ mod tests {
                 checkpoint_delta: IndexCheckpointDelta::for_test("source_id", 10..20).into(),
                 publish_lock: PublishLock::default(),
                 batch_parent_span: Span::none(),
+                merge_operation: None,
             })
             .await?;
         assert_eq!(

--- a/quickwit/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit/quickwit-indexing/src/actors/publisher.rs
@@ -134,6 +134,7 @@ impl Handler<SplitsUpdate> for Publisher {
             replaced_split_ids,
             checkpoint_delta_opt,
             publish_lock,
+            merge_operation: _,
             parent_span: _,
         } = split_update;
 
@@ -252,6 +253,7 @@ mod tests {
                     source_delta: SourceCheckpointDelta::from(1..3),
                 }),
                 publish_lock: PublishLock::default(),
+                merge_operation: None,
                 parent_span: tracing::Span::none(),
             })
             .await
@@ -312,6 +314,7 @@ mod tests {
             replaced_split_ids: vec!["split1".to_string(), "split2".to_string()],
             checkpoint_delta_opt: None,
             publish_lock: PublishLock::default(),
+            merge_operation: None,
             parent_span: Span::none(),
         };
         assert!(publisher_mailbox
@@ -351,6 +354,7 @@ mod tests {
                 replaced_split_ids: Vec::new(),
                 checkpoint_delta_opt: None,
                 publish_lock,
+                merge_operation: None,
                 parent_span: Span::none(),
             })
             .await

--- a/quickwit/quickwit-indexing/src/metrics.rs
+++ b/quickwit/quickwit-indexing/src/metrics.rs
@@ -18,7 +18,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use once_cell::sync::Lazy;
-use quickwit_common::metrics::{new_counter_vec, new_gauge, IntCounterVec, IntGauge};
+use quickwit_common::metrics::{
+    new_counter_vec, new_gauge, new_gauge_vec, IntCounterVec, IntGauge, IntGaugeVec,
+};
 
 pub struct IndexerMetrics {
     pub parsing_errors_num_docs_total: IntCounterVec,
@@ -29,6 +31,7 @@ pub struct IndexerMetrics {
     pub valid_num_bytes_total: IntCounterVec,
     pub concurrent_upload_available_permits_index: IntGauge,
     pub concurrent_upload_available_permits_merge: IntGauge,
+    pub ongoing_num_merge_operations_total: IntGaugeVec,
 }
 
 impl Default for IndexerMetrics {
@@ -81,6 +84,12 @@ impl Default for IndexerMetrics {
                 "concurrent_upload_available_merge",
                 "Number of concurrent uploader available permits for merging.",
                 "quickwit_indexing",
+            ),
+            ongoing_num_merge_operations_total: new_gauge_vec(
+                "ongoing_num_merge_operations_total",
+                "Num of ongoing merge operations (per index).",
+                "quickwit_indexing",
+                &["index"],
             ),
         }
     }

--- a/quickwit/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit/quickwit-indexing/src/models/indexed_split.rs
@@ -154,6 +154,10 @@ pub struct IndexedSplitBatch {
     pub splits: Vec<IndexedSplit>,
     pub checkpoint_delta: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
+    /// A [`MergeOperation`] tracked by either the [`MergePlannner`] or the [`DeleteTaksPlanner`]
+    /// in the [`MergePipeline`] or [`DeleteTaskPipeilne`].
+    /// See planners docs to understand the usage.
+    /// If `None`, the split batch was built in the [`IndexingPipeline`].
     pub merge_operation: Option<TrackedObject<MergeOperation>>,
 }
 

--- a/quickwit/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit/quickwit-indexing/src/models/indexed_split.rs
@@ -23,10 +23,11 @@ use std::path::Path;
 use quickwit_common::io::IoControls;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use tantivy::directory::MmapDirectory;
-use tantivy::IndexBuilder;
+use tantivy::{IndexBuilder, TrackedObject};
 use tracing::{instrument, Span};
 
 use crate::controlled_directory::ControlledDirectory;
+use crate::merge_policy::MergeOperation;
 use crate::models::{IndexingPipelineId, PublishLock, ScratchDirectory, SplitAttrs};
 use crate::new_split_id;
 
@@ -153,6 +154,7 @@ pub struct IndexedSplitBatch {
     pub splits: Vec<IndexedSplit>,
     pub checkpoint_delta: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
+    pub merge_operation: Option<TrackedObject<MergeOperation>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/quickwit/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit/quickwit-indexing/src/models/indexed_split.rs
@@ -154,10 +154,10 @@ pub struct IndexedSplitBatch {
     pub splits: Vec<IndexedSplit>,
     pub checkpoint_delta: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
-    /// A [`MergeOperation`] tracked by either the [`MergePlannner`] or the [`DeleteTaksPlanner`]
-    /// in the [`MergePipeline`] or [`DeleteTaskPipeilne`].
+    /// A [`MergeOperation`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
+    /// in the `MergePipeline` or `DeleteTaskPipeline`.
     /// See planners docs to understand the usage.
-    /// If `None`, the split batch was built in the [`IndexingPipeline`].
+    /// If `None`, the split batch was built in the `IndexingPipeline`.
     pub merge_operation: Option<TrackedObject<MergeOperation>>,
 }
 

--- a/quickwit/quickwit-indexing/src/models/merge_scratch.rs
+++ b/quickwit/quickwit-indexing/src/models/merge_scratch.rs
@@ -24,6 +24,8 @@ use crate::models::ScratchDirectory;
 
 #[derive(Debug)]
 pub struct MergeScratch {
+    /// A [`MergeOperation`] tracked by either the `MergePlannner` or the `DeleteTaksPlanner`
+    /// See planners docs to understand the usage.
     pub merge_operation: TrackedObject<MergeOperation>,
     /// Scratch directory for computing the merge.
     pub merge_scratch_directory: ScratchDirectory,

--- a/quickwit/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit/quickwit-indexing/src/models/packaged_split.rs
@@ -21,8 +21,10 @@ use std::collections::{BTreeSet, HashSet};
 use std::fmt;
 
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
+use tantivy::TrackedObject;
 use tracing::Span;
 
+use crate::merge_policy::MergeOperation;
 use crate::models::{PublishLock, ScratchDirectory, SplitAttrs};
 
 pub struct PackagedSplit {
@@ -55,6 +57,7 @@ pub struct PackagedSplitBatch {
     pub parent_span: Span,
     pub splits: Vec<PackagedSplit>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
+    pub merge_operation: Option<TrackedObject<MergeOperation>>,
     pub publish_lock: PublishLock,
 }
 
@@ -67,6 +70,7 @@ impl PackagedSplitBatch {
         splits: Vec<PackagedSplit>,
         checkpoint_delta_opt: Option<IndexCheckpointDelta>,
         publish_lock: PublishLock,
+        merge_operation: Option<TrackedObject<MergeOperation>>,
         span: Span,
     ) -> Self {
         assert!(!splits.is_empty());
@@ -84,6 +88,7 @@ impl PackagedSplitBatch {
             splits,
             checkpoint_delta_opt,
             publish_lock,
+            merge_operation,
         }
     }
 

--- a/quickwit/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit/quickwit-indexing/src/models/packaged_split.rs
@@ -57,10 +57,10 @@ pub struct PackagedSplitBatch {
     pub parent_span: Span,
     pub splits: Vec<PackagedSplit>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
-    /// A [`MergeOperation`] tracked by either the `MergePlannner` or the `DeleteTaksPlanner`
-    /// in the [`MergePipeline`] or [`DeleteTaskPipeilne`].
+    /// A [`MergeOperation`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
+    /// in the `MergePipeline` or `DeleteTaskPipeline`.
     /// See planners docs to understand the usage.
-    /// If `None`, the split batch was built in the [`IndexingPipeline`].
+    /// If `None`, the split batch was built in the `IndexingPipeline`.
     pub merge_operation: Option<TrackedObject<MergeOperation>>,
     pub publish_lock: PublishLock,
 }

--- a/quickwit/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit/quickwit-indexing/src/models/packaged_split.rs
@@ -57,6 +57,10 @@ pub struct PackagedSplitBatch {
     pub parent_span: Span,
     pub splits: Vec<PackagedSplit>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
+    /// A [`MergeOperation`] tracked by either the `MergePlannner` or the `DeleteTaksPlanner`
+    /// in the [`MergePipeline`] or [`DeleteTaskPipeilne`].
+    /// See planners docs to understand the usage.
+    /// If `None`, the split batch was built in the [`IndexingPipeline`].
     pub merge_operation: Option<TrackedObject<MergeOperation>>,
     pub publish_lock: PublishLock,
 }

--- a/quickwit/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit/quickwit-indexing/src/models/publisher_message.rs
@@ -22,8 +22,10 @@ use std::fmt;
 use itertools::Itertools;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::SplitMetadata;
+use tantivy::TrackedObject;
 use tracing::Span;
 
+use crate::merge_policy::MergeOperation;
 use crate::models::PublishLock;
 
 pub struct SplitsUpdate {
@@ -32,6 +34,7 @@ pub struct SplitsUpdate {
     pub replaced_split_ids: Vec<String>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
+    pub merge_operation: Option<TrackedObject<MergeOperation>>,
     pub parent_span: Span,
 }
 

--- a/quickwit/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit/quickwit-indexing/src/models/publisher_message.rs
@@ -34,6 +34,10 @@ pub struct SplitsUpdate {
     pub replaced_split_ids: Vec<String>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
+    /// A [`MergeOperation`] tracked by either the `MergePlannner` or the `DeleteTaksPlanner`
+    /// in the [`MergePipeline`] or [`DeleteTaskPipeilne`].
+    /// See planners docs to understand the usage.
+    /// If `None`, the split batch was built in the [`IndexingPipeline`].
     pub merge_operation: Option<TrackedObject<MergeOperation>>,
     pub parent_span: Span,
 }

--- a/quickwit/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit/quickwit-indexing/src/models/publisher_message.rs
@@ -34,10 +34,10 @@ pub struct SplitsUpdate {
     pub replaced_split_ids: Vec<String>,
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
-    /// A [`MergeOperation`] tracked by either the `MergePlannner` or the `DeleteTaksPlanner`
-    /// in the [`MergePipeline`] or [`DeleteTaskPipeilne`].
+    /// A [`MergeOperation`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
+    /// in the `MergePipeline` or `DeleteTaskPipeline`.
     /// See planners docs to understand the usage.
-    /// If `None`, the split batch was built in the [`IndexingPipeline`].
+    /// If `None`, the split batch was built in the `IndexingPipeline`.
     pub merge_operation: Option<TrackedObject<MergeOperation>>,
     pub parent_span: Span,
 }

--- a/quickwit/quickwit-janitor/Cargo.toml
+++ b/quickwit/quickwit-janitor/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
+once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -35,9 +35,13 @@ use quickwit_metastore::{
 use quickwit_proto::metastore_api::DeleteTask;
 use quickwit_proto::SearchRequest;
 use quickwit_search::{jobs_to_leaf_request, SearchClientPool, SearchJob};
+use serde::Serialize;
+use tantivy::Inventory;
 use tracing::{debug, info};
 
-const PLANNER_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
+use crate::metrics::JANITOR_METRICS;
+
+const PLANNER_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 const NUM_STALE_SPLITS_TO_FETCH: usize = 1000;
 
 /// The `DeleteTaskPlanner` plans delete operations on splits for a given index.
@@ -51,13 +55,8 @@ const NUM_STALE_SPLITS_TO_FETCH: usize = 1000;
 /// 1. Fetches the delete tasks and deduce the last `opstamp`.
 /// 2. Fetches the last `N` stale splits ordered by their `delete_opstamp`.
 ///    A stale split is a split a `delete_opstamp` inferior to the last `opstamp`
-///    In theory, this works but... there is two difficulties:
-///    - The planner can send the [`MergeOperation`] operation several times. Indeed, while the
-///      `MergeExecutor` is processing a merge operation on a split, the planner can still fetch
-///      this same stale split and resend it. This is partly avoided by keeping a local list of
-///      ongoing delete operations in the `send_operations` method and by setting the queue capacity
-///      of the downloader to 0.
-///    - Delete operation do not run on immature splits and they are excluded after fetching stale
+///    In theory, this works but... there is one difficulty:
+///    - Delete operations do not run on immature splits and they are excluded after fetching stale
 ///      splits from the metastore as the metastore has no knowledge about the merge policy. If
 ///      there are more than `N` immature stale splits, the planner will plan no operations.
 ///      However, this is mitigated by the fact that a merge policy should consider "old split" as
@@ -81,13 +80,25 @@ pub struct DeleteTaskPlanner {
     search_client_pool: SearchClientPool,
     merge_policy: Arc<dyn MergePolicy>,
     merge_split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
+    // Keeps merge operations until publication.
+    ongoing_delete_operations_inventory: Inventory<MergeOperation>,
 }
 
 #[async_trait]
 impl Actor for DeleteTaskPlanner {
-    type ObservableState = ();
+    type ObservableState = DeleteTaskPlannerState;
 
-    fn observable_state(&self) -> Self::ObservableState {}
+    fn observable_state(&self) -> Self::ObservableState {
+        let ongoing_delete_operations = self
+            .ongoing_delete_operations_inventory
+            .list()
+            .iter()
+            .map(|tracked_operation| tracked_operation.as_ref().clone())
+            .collect_vec();
+        DeleteTaskPlannerState {
+            ongoing_delete_operations,
+        }
+    }
 
     fn name(&self) -> String {
         "DeleteTaskPlanner".to_string()
@@ -98,7 +109,7 @@ impl Actor for DeleteTaskPlanner {
     }
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
-        self.handle(PlanDeleteOperationsLoop, ctx).await
+        self.handle(Supervise, ctx).await
     }
 }
 
@@ -120,28 +131,17 @@ impl DeleteTaskPlanner {
             search_client_pool,
             merge_policy,
             merge_split_downloader_mailbox,
+            ongoing_delete_operations_inventory: Inventory::new(),
         }
     }
 
     /// Send delete operations for a given `index_id`.
     async fn send_delete_operations(&mut self, ctx: &ActorContext<Self>) -> anyhow::Result<()> {
-        // Keep already send operations to avoid several times the same ones.
-        // This solves only locally this issues as the next time `send_delete_operations` is called,
-        // we may send the same operations. Keeping the `ongoing_delete_operations` at the
-        // planner level would be better but requires more work to udpate the list.
-        // TODO: Make sure that
-        let mut ongoing_delete_operations = Vec::new();
-
         // Loop until there is no more stale splits.
         loop {
             let last_delete_opstamp = self.metastore.last_delete_opstamp(&self.index_id).await?;
             let stale_splits = self
-                .get_relevant_stale_splits(
-                    &self.index_id,
-                    last_delete_opstamp,
-                    &ongoing_delete_operations,
-                    ctx,
-                )
+                .get_relevant_stale_splits(&self.index_id, last_delete_opstamp, ctx)
                 .await?;
             ctx.record_progress();
             info!(
@@ -181,12 +181,18 @@ impl DeleteTaskPlanner {
                     split_with_deletes.split_metadata,
                 );
                 info!(delete_operation=?delete_operation, "Planned delete operation.");
+                let tracked_delete_operation = self
+                    .ongoing_delete_operations_inventory
+                    .track(delete_operation);
                 ctx.send_message(
                     &self.merge_split_downloader_mailbox,
-                    delete_operation.clone(),
+                    tracked_delete_operation,
                 )
                 .await?;
-                ongoing_delete_operations.push(delete_operation);
+                JANITOR_METRICS
+                    .ongoing_num_delete_operations_total
+                    .with_label_values(&[&self.index_id])
+                    .set(self.ongoing_delete_operations_inventory.list().len() as i64);
             }
         }
 
@@ -310,7 +316,6 @@ impl DeleteTaskPlanner {
         &self,
         index_id: &str,
         last_delete_opstamp: u64,
-        ongoing_delete_operations: &[MergeOperation],
         ctx: &ActorContext<Self>,
     ) -> MetastoreResult<Vec<Split>> {
         let stale_splits = ctx
@@ -327,6 +332,7 @@ impl DeleteTaskPlanner {
         );
         // Keep only mature splits and splits that are not already part of ongoing delete
         // operations.
+        let ongoing_delete_operations = self.ongoing_delete_operations_inventory.list();
         let filtered_splits = stale_splits
             .into_iter()
             .filter(|stale_split| self.merge_policy.is_mature(&stale_split.split_metadata))
@@ -345,20 +351,42 @@ impl DeleteTaskPlanner {
     }
 }
 
+#[derive(Clone, Debug, Serialize)]
+pub struct DeleteTaskPlannerState {
+    ongoing_delete_operations: Vec<MergeOperation>,
+}
+
 #[derive(Debug)]
-struct PlanDeleteOperationsLoop;
+struct PlanDeleteOperations;
 
 #[async_trait]
-impl Handler<PlanDeleteOperationsLoop> for DeleteTaskPlanner {
+impl Handler<PlanDeleteOperations> for DeleteTaskPlanner {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _: PlanDeleteOperationsLoop,
+        _: PlanDeleteOperations,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         self.send_delete_operations(ctx).await?;
-        ctx.schedule_self_msg(PLANNER_REFRESH_INTERVAL, PlanDeleteOperationsLoop)
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct Supervise;
+
+#[async_trait]
+impl Handler<Supervise> for DeleteTaskPlanner {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _: Supervise,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        self.handle(PlanDeleteOperations, ctx).await?;
+        ctx.schedule_self_msg(PLANNER_REFRESH_INTERVAL, Supervise)
             .await;
         Ok(())
     }
@@ -374,6 +402,7 @@ mod tests {
     use quickwit_proto::metastore_api::DeleteQuery;
     use quickwit_proto::{LeafSearchRequest, LeafSearchResponse};
     use quickwit_search::MockSearchService;
+    use tantivy::TrackedObject;
 
     use super::*;
 
@@ -471,21 +500,49 @@ mod tests {
             downloader_mailbox,
         );
         let universe = Universe::new();
-        let (_, delete_planner_executor_handle) =
+        let (delete_planner_mailbox, delete_planner_handle) =
             universe.spawn_builder().spawn(delete_planner_executor);
-        delete_planner_executor_handle
-            .process_pending_and_observe()
-            .await;
-        let mut downloader_msgs = downloader_inbox.drain_for_test();
+        delete_planner_handle.process_pending_and_observe().await;
+        let downloader_msgs =
+            downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
         assert_eq!(downloader_msgs.len(), 1);
-        let downloader_msg = downloader_msgs
-            .pop()
-            .unwrap()
-            .downcast::<MergeOperation>()
-            .unwrap();
         // The last split will undergo a delete operation.
         assert_eq!(
-            downloader_msg.splits[0].split_id(),
+            downloader_msgs[0].splits[0].split_id(),
+            split_metas[2].split_id()
+        );
+        // Check planner state is inline.
+        let delete_planner_state = delete_planner_handle.observe().await;
+        assert_eq!(
+            delete_planner_state.ongoing_delete_operations[0].splits[0].split_id(),
+            split_metas[2].split_id()
+        );
+        // Trigger new plan evaluation and check that we don't have new merge operation.
+        delete_planner_mailbox
+            .send_message(PlanDeleteOperations)
+            .await
+            .unwrap();
+        assert!(downloader_inbox.drain_for_test().is_empty());
+        // Now drop the current merge operation and check that the planner will plan a new
+        // operation.
+        drop(downloader_msgs.into_iter().next().unwrap());
+        // Check planner state is inline.
+        assert!(delete_planner_handle
+            .observe()
+            .await
+            .ongoing_delete_operations
+            .is_empty());
+
+        // Trigger operations planning.
+        delete_planner_mailbox
+            .send_message(PlanDeleteOperations)
+            .await
+            .unwrap();
+        let downloader_last_msgs =
+            downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
+        assert_eq!(downloader_last_msgs.len(), 1);
+        assert_eq!(
+            downloader_last_msgs[0].splits[0].split_id(),
             split_metas[2].split_id()
         );
         // The other splits has just their delete opstamps updated to the last opstamps which is 2
@@ -497,7 +554,7 @@ mod tests {
         assert_eq!(all_splits[2].split_metadata.delete_opstamp, 0);
 
         // Check actor state.
-        assert_eq!(delete_planner_executor_handle.state(), ActorState::Idle);
+        assert_eq!(delete_planner_handle.state(), ActorState::Idle);
 
         Ok(())
     }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -61,7 +61,7 @@ const NUM_STALE_SPLITS_TO_FETCH: usize = 1000;
 ///      there are more than `N` immature stale splits, the planner will plan no operations.
 ///      However, this is mitigated by the fact that a merge policy should consider "old split" as
 ///      mature and an index should not have many immature splits.
-///      See tracked issue https://github.com/quickwit-oss/quickwit/issues/2147
+///      See tracked issue <https://github.com/quickwit-oss/quickwit/issues/2147>.
 /// 3. If there is no stale splits, stop.
 /// 4. If there are stale splits, for each split, do:
 ///    - Get the list of delete queries to apply to this split.

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -30,6 +30,7 @@ pub mod actors;
 pub mod error;
 mod garbage_collection;
 mod janitor_service;
+mod metrics;
 mod retention_policy_execution;
 
 pub use janitor_service::JanitorService;

--- a/quickwit/quickwit-janitor/src/metrics.rs
+++ b/quickwit/quickwit-janitor/src/metrics.rs
@@ -17,16 +17,26 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use tantivy::{Directory, TrackedObject};
+use once_cell::sync::Lazy;
+use quickwit_common::metrics::{new_gauge_vec, IntGaugeVec};
 
-use crate::merge_policy::MergeOperation;
-use crate::models::ScratchDirectory;
-
-#[derive(Debug)]
-pub struct MergeScratch {
-    pub merge_operation: TrackedObject<MergeOperation>,
-    /// Scratch directory for computing the merge.
-    pub merge_scratch_directory: ScratchDirectory,
-    pub downloaded_splits_directory: ScratchDirectory,
-    pub tantivy_dirs: Vec<Box<dyn Directory>>,
+pub struct JanitorMetrics {
+    pub ongoing_num_delete_operations_total: IntGaugeVec,
 }
+
+impl Default for JanitorMetrics {
+    fn default() -> Self {
+        JanitorMetrics {
+            ongoing_num_delete_operations_total: new_gauge_vec(
+                "ongoing_num_delete_operations_total",
+                "Num of ongoing delete operations (per index).",
+                "quickwit_janitor",
+                &["index"],
+            ),
+        }
+    }
+}
+
+/// `JANTIOR_METRICS` exposes a bunch of related metrics through a prometheus
+/// endpoint.
+pub static JANITOR_METRICS: Lazy<JanitorMetrics> = Lazy::new(JanitorMetrics::default);

--- a/quickwit/quickwit-janitor/src/metrics.rs
+++ b/quickwit/quickwit-janitor/src/metrics.rs
@@ -37,6 +37,6 @@ impl Default for JanitorMetrics {
     }
 }
 
-/// `JANTIOR_METRICS` exposes a bunch of related metrics through a prometheus
+/// `JANITOR_METRICS` exposes a bunch of related metrics through a prometheus
 /// endpoint.
 pub static JANITOR_METRICS: Lazy<JanitorMetrics> = Lazy::new(JanitorMetrics::default);


### PR DESCRIPTION
Fix #2136

And:
- add gauges on the number of ongoing merge/delete operations
- add an observable state for merge planner and delete planner. I will add in a separated PR a REST endpoint to retrieve the ongoing delete operations, this can be helpful when checking what's the planner is doing.