### PR TITLE
Fix database migrations

### DIFF
--- a/quickwit/quickwit-metastore/migrations/postgresql/2_create-splits.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/2_create-splits.up.sql
@@ -12,6 +12,29 @@ CREATE TABLE IF NOT EXISTS splits (
     FOREIGN KEY(index_id) REFERENCES indexes(index_id)
 );
 
+DROP TRIGGER IF EXISTS quickwit_set_index_update_timestamp_on_split_change ON splits CASCADE;
+CREATE TRIGGER quickwit_set_index_update_timestamp_on_split_change
+    AFTER INSERT OR DELETE OR UPDATE ON splits
+    FOR EACH ROW
+    EXECUTE PROCEDURE set_index_update_timestamp_for_split();
+
+-- We also want to update an index `update_timestamp` field whenever a related split
+-- is modified.
+CREATE OR REPLACE FUNCTION set_index_update_timestamp_for_split() RETURNS trigger AS $$
+BEGIN
+    IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') THEN
+        UPDATE indexes SET update_timestamp = NEW.update_timestamp
+        WHERE indexes.index_id = NEW.index_id;
+    ELSIF (TG_OP = 'DELETE') THEN
+        UPDATE indexes SET update_timestamp = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+        WHERE indexes.index_id = OLD.index_id;
+    END IF;
+    RETURN NULL;
+END;
+
+$$ LANGUAGE plpgsql;
+
+
 -- apply the trigger to the `splits` table
 SELECT quickwit_manage_update_timestamp('splits');
 

--- a/quickwit/quickwit-metastore/migrations/postgresql/6_delete-update-index-update-timestamp-on-split-update-trigger.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/6_delete-update-index-update-timestamp-on-split-update-trigger.up.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER IF EXISTS quickwit_set_index_update_timestamp_on_split_change ON splits CASCADE;


### PR DESCRIPTION
### Description
Restore the initial migration file and drop the trigger in another migration.

### How was this PR tested?
Ran the up migration on an erroring database.
