### PR TITLE
Add last_indexed_doc_timestamp to split metadata.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3396,6 +3396,7 @@ dependencies = [
  "backoff",
  "byte-unit",
  "bytes",
+ "chrono",
  "fail",
  "flume",
  "fnv",

--- a/quickwit/quickwit-config/src/index_config.rs
+++ b/quickwit/quickwit-config/src/index_config.rs
@@ -157,6 +157,9 @@ pub struct IndexingSettings {
     #[serde(default = "IndexingSettings::default_split_num_docs_target")]
     pub split_num_docs_target: usize,
 
+    #[serde(default = "IndexingSettings::default_maturity_period")]
+    pub maturity_period: Option<Duration>,
+
     #[serde(default)]
     pub merge_policy: MergePolicyConfig,
     #[serde(default)]
@@ -216,6 +219,7 @@ impl From<IndexingSettingsLegacy> for IndexingSettings {
             docstore_compression_level: settings.docstore_compression_level,
             docstore_blocksize: settings.docstore_blocksize,
             split_num_docs_target: settings.split_num_docs_target,
+            maturity_period: None,
             merge_policy,
             resources: settings.resources,
         }
@@ -276,6 +280,11 @@ impl IndexingSettings {
         10_000_000
     }
 
+    pub fn default_maturity_period() -> Option<Duration> {
+        // 7 days.
+        Some(Duration::from_secs(3600 * 24 * 7))
+    }
+
     fn default_merge_enabled() -> bool {
         true
     }
@@ -307,6 +316,7 @@ impl Default for IndexingSettings {
             docstore_blocksize: Self::default_docstore_blocksize(),
             docstore_compression_level: Self::default_docstore_compression_level(),
             split_num_docs_target: Self::default_split_num_docs_target(),
+            maturity_period: Self::default_maturity_period(),
             merge_policy: MergePolicyConfig::default(),
             resources: IndexingResources::default(),
         }

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -15,6 +15,7 @@ arc-swap = { workspace = true }
 async-trait = { workspace = true }
 backoff = { workspace = true, optional = true }
 byte-unit = { workspace = true }
+chrono = { workspace = true }
 fail = { workspace = true }
 flume = { workspace = true }
 fnv = { workspace = true }

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -214,6 +214,7 @@ mod tests {
                 max_merge_factor: 5,
             },
             50_000,
+            None,
         ));
         let merge_planner = MergePlanner::new(
             pipeline_id,

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -320,6 +320,7 @@ fn u64_from_term_data(data: &[u8]) -> anyhow::Result<u64> {
 mod tests {
     use std::ops::RangeInclusive;
 
+    use chrono::Utc;
     use quickwit_actors::{create_test_mailbox, ObservationType, Universe};
     use quickwit_doc_mapper::QUICKWIT_TOKENIZER_MANAGER;
     use quickwit_metastore::checkpoint::IndexCheckpointDelta;
@@ -397,6 +398,7 @@ mod tests {
                 replaced_split_ids: Vec::new(),
                 delete_opstamp: 0,
                 num_merge_ops: 0,
+                last_indexed_doc_timestamp: Utc::now().timestamp(),
             },
             index,
             split_scratch_directory,

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -371,6 +371,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
+    use chrono::Utc;
     use quickwit_actors::{create_test_mailbox, ObservationType, Universe};
     use quickwit_metastore::checkpoint::{IndexCheckpointDelta, SourceCheckpointDelta};
     use quickwit_metastore::MockMetastore;
@@ -429,6 +430,7 @@ mod tests {
                         split_id: "test-split".to_string(),
                         delete_opstamp: 10,
                         num_merge_ops: 0,
+                        last_indexed_doc_timestamp: 0,
                     },
                     split_scratch_directory,
                     tags: Default::default(),
@@ -527,6 +529,7 @@ mod tests {
                 ],
                 delete_opstamp: 0,
                 num_merge_ops: 0,
+                last_indexed_doc_timestamp: Utc::now().timestamp(),
             },
             split_scratch_directory: split_scratch_directory_1,
             tags: Default::default(),
@@ -547,6 +550,7 @@ mod tests {
                 ],
                 delete_opstamp: 0,
                 num_merge_ops: 0,
+                last_indexed_doc_timestamp: Utc::now().timestamp(),
             },
             split_scratch_directory: split_scratch_directory_2,
             tags: Default::default(),
@@ -655,6 +659,7 @@ mod tests {
                         split_id: "test-split".to_string(),
                         delete_opstamp: 10,
                         num_merge_ops: 0,
+                        last_indexed_doc_timestamp: Utc::now().timestamp(),
                     },
                     split_scratch_directory,
                     tags: Default::default(),

--- a/quickwit/quickwit-indexing/src/models/split_attrs.rs
+++ b/quickwit/quickwit-indexing/src/models/split_attrs.rs
@@ -60,6 +60,9 @@ pub struct SplitAttrs {
 
     // Number of merge operation the split has been through so far.
     pub num_merge_ops: usize,
+
+    // TODO: add docs
+    pub last_indexed_doc_timestamp: i64,
 }
 
 impl fmt::Debug for SplitAttrs {
@@ -75,6 +78,10 @@ impl fmt::Debug for SplitAttrs {
             )
             .field("num_docs", &self.num_docs)
             .field("num_merge_ops", &self.num_merge_ops)
+            .field(
+                "last_indexed_doc_timestamp",
+                &self.last_indexed_doc_timestamp,
+            )
             .finish()
     }
 }
@@ -99,5 +106,6 @@ pub fn create_split_metadata(
         footer_offsets,
         delete_opstamp: split_attrs.delete_opstamp,
         num_merge_ops: split_attrs.num_merge_ops,
+        last_indexed_doc_timestamp: split_attrs.last_indexed_doc_timestamp,
     }
 }

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -242,6 +242,7 @@ mod tests {
     use std::sync::Arc;
 
     use byte_unit::Byte;
+    use chrono::Utc;
     use quickwit_metastore::SplitMetadata;
     use quickwit_storage::{RamStorage, SplitPayloadBuilder};
     use tempfile::tempdir;
@@ -255,6 +256,7 @@ mod tests {
     fn create_test_split_metadata(split_id: &str) -> SplitMetadata {
         SplitMetadata {
             split_id: split_id.to_string(),
+            last_indexed_doc_timestamp: Utc::now().timestamp(),
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-metastore/src/backward_compatibility_tests/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/backward_compatibility_tests/split_metadata.rs
@@ -37,6 +37,7 @@ pub(crate) fn sample_split_metadata_for_regression() -> SplitMetadata {
         tags: ["234".to_string(), "aaa".to_string()].into_iter().collect(),
         footer_offsets: 1000..2000,
         num_merge_ops: 3,
+        last_indexed_doc_timestamp: 4,
     }
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -665,10 +665,6 @@ impl Metastore for PostgresqlMetastore {
 
             update_index_update_timestamp(tx, index_id).await?;
 
-            if marked_split_ids.len() == split_ids.len() {
-                return Ok(());
-            }
-
             get_splits_with_invalid_state(tx, index_id, split_ids, &marked_split_ids).await?;
 
             let err_msg = format!("Failed to mark splits for deletion for index {index_id}.");

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
@@ -136,11 +136,12 @@ impl TryInto<QuickwitSplit> for Split {
 
     fn try_into(self) -> Result<QuickwitSplit, Self::Error> {
         let mut split_metadata = self.split_metadata()?;
-        // `create_timestamp` and `delete_opstamp` are duplicated in `SplitMetadata` and needs to be
+        // Those variables are duplicated in `SplitMetadata` and needs to be
         // overridden with the "true" value stored in a column.
         split_metadata.create_timestamp = self.create_timestamp.assume_utc().unix_timestamp();
         split_metadata.index_id = self.index_id.clone();
         split_metadata.delete_opstamp = self.delete_opstamp as u64;
+
         let split_state = self.split_state()?;
         let update_timestamp = self.update_timestamp.assume_utc().unix_timestamp();
         let publish_timestamp = self

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -125,6 +125,11 @@ pub struct SplitMetadata {
     /// Number of merge operations that was involved to create
     /// this split.
     pub num_merge_ops: usize,
+
+    /// Timestamp of the last document indexed in the split.
+    /// On the first split generation (before merges/delete), it corresponds to the created
+    /// timestamp. TODO: check when we set the created timestamp and udpate docs accordingly.
+    pub last_indexed_doc_timestamp: i64,
 }
 
 impl SplitMetadata {

--- a/quickwit/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata_version.rs
@@ -87,6 +87,7 @@ impl From<SplitMetadataAndFooterV0> for SplitMetadata {
             tags: v0.split_metadata.tags,
             index_id: "".to_string(),
             num_merge_ops: 0,
+            last_indexed_doc_timestamp: v0.split_metadata.create_timestamp,
         }
     }
 }
@@ -147,6 +148,9 @@ pub(crate) struct SplitMetadataV1 {
 
     #[serde(default)]
     num_merge_ops: usize,
+
+    #[serde(default = "utc_now_timestamp")]
+    pub last_indexed_doc_timestamp: i64,
 }
 
 impl From<SplitMetadataV1> for SplitMetadata {
@@ -181,6 +185,7 @@ impl From<SplitMetadataV1> for SplitMetadata {
             tags: v1.tags,
             footer_offsets: v1.footer_offsets,
             num_merge_ops: v1.num_merge_ops,
+            last_indexed_doc_timestamp: v1.last_indexed_doc_timestamp,
         }
     }
 }
@@ -201,6 +206,7 @@ impl From<SplitMetadata> for SplitMetadataV1 {
             tags: split.tags,
             footer_offsets: split.footer_offsets,
             num_merge_ops: split.num_merge_ops,
+            last_indexed_doc_timestamp: split.last_indexed_doc_timestamp,
         }
     }
 }


### PR DESCRIPTION
WIP. Follow up of the discussion #2147 where we don't persist the maturity in the metastore.

Existing merge policies use this timestamp to know whether the split is mature or not. 

Important Note: the namings are bad, I need to update them.