### PR TITLE
Display source enabled in source describe/list commands.

### DIFF
--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -35,7 +35,7 @@ use quickwit_metastore::quickwit_metastore_uri_resolver;
 use quickwit_storage::{load_file, quickwit_storage_uri_resolver};
 use regex::Regex;
 use tabled::object::Rows;
-use tabled::{Alignment, Header, Modify, Rotate, Style, Table, Tabled};
+use tabled::{Alignment, Header, Modify, Style, Table, Tabled};
 use tracing::info;
 
 pub mod cli;
@@ -139,15 +139,20 @@ pub async fn run_index_checklist(
 pub fn make_table<T: Tabled>(
     header: &str,
     rows: impl IntoIterator<Item = T>,
-    rotate: bool,
+    transpose: bool,
 ) -> Table {
-    let mut table = Table::new(rows)
-        .with(Modify::new(Rows::new(1..)).with(Alignment::left()))
-        .with(Style::ascii());
-    if rotate {
-        table = table.with(Rotate::Left)
-    }
+    let table = if transpose {
+        let mut index_builder = Table::builder(rows).index();
+        index_builder.set_index(0);
+        index_builder.transpose();
+        index_builder.build()
+    } else {
+        Table::builder(rows).build()
+    };
+
     table
+        .with(Modify::new(Rows::new(1..)).with(Alignment::left()))
+        .with(Style::ascii())
         .with(Header(header))
         .with(Modify::new(Rows::single(0)).with(Alignment::center()))
 }

--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -422,6 +422,7 @@ where
     let source_rows = vec![SourceRow {
         source_id: source.source_id.clone(),
         source_type: source.source_type().to_string(),
+        enabled: source.enabled.to_string(),
     }];
     let source_table = make_table("Source", source_rows, true);
 
@@ -457,6 +458,7 @@ where I: IntoIterator<Item = SourceConfig> {
         .map(|source| SourceRow {
             source_type: source.source_type().to_string(),
             source_id: source.source_id,
+            enabled: source.enabled.to_string(),
         })
         .sorted_by(|left, right| left.source_id.cmp(&right.source_id));
     make_table("Sources", rows, false)
@@ -464,10 +466,12 @@ where I: IntoIterator<Item = SourceConfig> {
 
 #[derive(Tabled)]
 struct SourceRow {
-    #[tabled(rename = "Type")]
-    source_type: String,
     #[tabled(rename = "ID")]
     source_id: String,
+    #[tabled(rename = "Type")]
+    source_type: String,
+    #[tabled(rename = "Enabled")]
+    enabled: String,
 }
 
 #[derive(Tabled)]
@@ -742,6 +746,7 @@ mod tests {
         let expected_source = vec![SourceRow {
             source_id: "foo-source".to_string(),
             source_type: "file".to_string(),
+            enabled: "true".to_string(),
         }];
         let expected_params = vec![ParamsRow {
             key: "filepath".to_string(),
@@ -814,10 +819,12 @@ mod tests {
             SourceRow {
                 source_id: "bar-source".to_string(),
                 source_type: "file".to_string(),
+                enabled: "true".to_string(),
             },
             SourceRow {
                 source_id: "foo-source".to_string(),
                 source_type: "file".to_string(),
+                enabled: "true".to_string(),
             },
         ];
         assert_eq!(


### PR DESCRIPTION
Fix #2197

Note: I used transpose to keep the same order of columns/rows.

Output:

```
quickwit source list --index wikipedia  --config ../config/quickwit.yaml

+-------------+------------+---------+
|              Sources               |
+-------------+------------+---------+
| ID          | Type       | Enabled |
+-------------+------------+---------+
| _ingest-api | ingest-api | true    |
+-------------+------------+---------+
```


```
quickwit describe --source _ingest-api --index wikipedia  --config ../config/quickwit.yaml

+---------+-------------+
|        Source         |
+---------+-------------+
| ID      | _ingest-api |
+---------+-------------+
| Type    | ingest-api  |
+---------+-------------+
| Enabled | true        |
+---------+-------------+

+-----+-------+
| Parameters  |
+-----+-------+
| Key | Value |
+-----+-------+
|     | null  |
+-----+-------+

+--------------+----------------------+
|             Checkpoint              |
+--------------+----------------------+
| Partition ID | Offset               |
+--------------+----------------------+
| wikipedia    | 00000000000000000001 |
+--------------+----------------------+

```