### PR TITLE
Fix tokio runtime error in code coverage

### DIFF
--- a/quickwit/quickwit-common/src/runtimes.rs
+++ b/quickwit/quickwit-common/src/runtimes.rs
@@ -20,7 +20,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use anyhow::bail;
 use once_cell::sync::OnceCell;
 use tokio::runtime::Runtime;
 use tracing::warn;
@@ -119,10 +118,9 @@ fn start_runtimes(config: RuntimesConfiguration) -> HashMap<RuntimeType, Runtime
 }
 
 pub fn initialize_runtimes(runtime_config: RuntimesConfiguration) -> anyhow::Result<()> {
-    let runtimes = start_runtimes(runtime_config);
-    if RUNTIMES.set(runtimes).is_err() {
-        bail!("Runtimes have already been initialized.");
-    }
+    RUNTIMES.get_or_init(|| {
+        start_runtimes(runtime_config)
+    });
     Ok(())
 }
 

--- a/quickwit/quickwit-common/src/runtimes.rs
+++ b/quickwit/quickwit-common/src/runtimes.rs
@@ -118,9 +118,7 @@ fn start_runtimes(config: RuntimesConfiguration) -> HashMap<RuntimeType, Runtime
 }
 
 pub fn initialize_runtimes(runtime_config: RuntimesConfiguration) -> anyhow::Result<()> {
-    RUNTIMES.get_or_init(|| {
-        start_runtimes(runtime_config)
-    });
+    RUNTIMES.get_or_init(|| start_runtimes(runtime_config));
     Ok(())
 }
 


### PR DESCRIPTION
Our code coverage CI has been failing for a while, and installing `libsasl2` did not solve the issue. The current issue is one of the tests I refactored was throwing an error like this: 
```
test test_ingest_docs_cli ...  Num docs       5 Parse errs     0 PublSplits   1 Input size     0MB Thrghput  0.00MB/s Time 00:00:02
 Num docs       5 Parse errs     0 PublSplits   1 Input size     0MB Thrghput  0.00MB/s Time 00:00:03
 Num docs       5 Parse errs     0 PublSplits   1 Input size     0MB Thrghput  0.00MB/s Time 00:00:04
ok
test test_ingest_docs_cli_keep_cache ... FAILED

failures:

---- test_ingest_docs_cli_keep_cache stdout ----

---------------------------------------------------
 Connectivity checklist 
 ✔ metastore
 ✔ storage
 ✔ _cli-ingest-source

thread 'main' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/blocking/shutdown.rs:51:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_ingest_docs_cli_keep_cache
```
The error is not helpful at first because we don't hold any runtime handles in the test, and we are not dropping any. Also, the other tests that call the same CLI functions do not panic. 

The backtrace was *really* hard to read. (to me, at least):
```
test test_cmd_garbage_collect_spares_files_within_grace_period ... ok

failures:

---- test_ingest_docs_cli_keep_cache stdout ----

---------------------------------------------------
 Connectivity checklist
 ✔ metastore
 ✔ storage
 ✔ _cli-ingest-source

thread 'test_ingest_docs_cli_keep_cache' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.', /home/aimless/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.2/src/runtime/blocking/shutdown.rs:51:21
stack backtrace:
   0: std::panicking::begin_panic::<&str>
   1: <tokio::runtime::blocking::shutdown::Receiver>::wait
   2: <tokio::runtime::blocking::pool::BlockingPool>::shutdown
   3: <tokio::runtime::blocking::pool::BlockingPool as core::ops::drop::Drop>::drop
   4: core::ptr::drop_in_place::<tokio::runtime::blocking::pool::BlockingPool>
   5: core::ptr::drop_in_place::<tokio::runtime::Runtime>
   6: core::ptr::drop_in_place::<(quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime)>
   7: <hashbrown::raw::Bucket<(quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime)>>::drop
   8: <hashbrown::raw::RawTable<(quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime)>>::drop_elements
   9: <hashbrown::raw::RawTable<(quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime)> as core::ops::drop::Drop>::drop
  10: core::ptr::drop_in_place::<hashbrown::raw::RawTable<(quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime)>>
  11: core::ptr::drop_in_place::<hashbrown::map::HashMap<quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime, std::collections::hash::map::RandomState>>
  12: core::ptr::drop_in_place::<std::collections::hash::map::HashMap<quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime>>
  13: core::ptr::drop_in_place::<core::result::Result<(), std::collections::hash::map::HashMap<quickwit_common::runtimes::RuntimeType, tokio::runtime::Runtime>>>
  14: quickwit_common::runtimes::initialize_runtimes
  15: quickwit_cli::start_actor_runtimes
  16: __covrec_9B216AE819355724
  17: __covrec_6D0347CC9C63AC3D
  18: __covrec_53D826159CCEA8Fu
  19: <unknown>
  20: __covrec_2F3159ADF2F57101u
  21: __covrec_EE8F315740AB72FAu
  22: __covrec_B040EAECBDFB93F4u
  23: __covrec_AC7BF7093685AAF5u
  24: __covrec_D2AAF6C0A90CDB0B
  25: __covrec_C5FA7E3B61CD5C51u
  26: __covrec_BB2BF6001F6F750Fu
  27: __covrec_EF2C1D5AB70D5EB0u
  28: <tokio::runtime::scheduler::current_thread::CoreGuard>::enter::<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut core::future::from_generator::GenFuture<cli::test_ingest_docs_cli_keep_cache::{closure#0}>>>::{closure#0}, core::option::Option<()>>::{closure#0}
  29: __covrec_6572EDA7065767A8
  30: __covrec_36CAAB2846B4C6E8u
  31: __covrec_63C695904B220A13u
  32: __covrec_E202529AC0B64808u
  33: __covrec_9B2E69EE1A1DDDB8
  34: __covrec_BAE9DA3AF058A5E5u
  35: cli::test_ingest_docs_cli_keep_cache::{closure#0}
  36: <cli::test_ingest_docs_cli_keep_cache::{closure#0} as core::ops::function::FnOnce<()>>::call_once
  37: core::ops::function::FnOnce::call_once
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    test_ingest_docs_cli_keep_cache
```

So, we are dropping multiple runtimes? `HashMap<RuntimeType, Runtime>`? oh, OH
It calls `quickwit_cli::start_actor_runtimes`, and that calls `quickwit_common::runtimes::initialize_runtimes`.
And `initialize_runtimes()` looks like this: 
```rust
pub fn initialize_runtimes(runtime_config: RuntimesConfiguration) -> anyhow::Result<()> {
    let runtimes = start_runtimes(runtime_config);
    if RUNTIMES.set(runtimes).is_err() {  // <--- RUNTIME.set() takes the ownership
        bail!("Runtimes have already been initialized.");
    }
    Ok(())
}
```
But we are only dropping the `runtimes` if `RUNTIMES` is already initialized. But in that case, shouldn't we get the error `Runtimes have already been initialized.` first? Well, we don't because code panics right away, unable to reach the `bail!` line. Refactoring it to this actually throws the error.
```rust
pub fn initialize_runtimes(runtime_config: RuntimesConfiguration) -> anyhow::Result<()> {
    let current_runtimes = RUNTIMES.get();
    if let Some(_) = current_runtimes {
        bail!("Runtimes have already been initialized.");
    }
    /* ... */
    Ok(())
}
```
But then all of the CLI tests fail because we try to re-initialize the runtimes in the tests. :sob: 

@fmassot suggested that we can log a warn message.

*Note: It was painful to debug this.*