### PR TITLE
Set default env variables for main node config parameters

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -974,17 +974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,7 +3271,6 @@ dependencies = [
  "byte-unit",
  "chrono",
  "cron",
- "derivative",
  "enum-iterator",
  "humantime",
  "itertools",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -47,7 +47,6 @@ colored = "2.0.0"
 console-subscriber = "0.1.0"
 criterion = { version = "0.4", features = ["async_tokio"] }
 cron = "0.11.0"
-derivative = "2.2.0"
 dialoguer = "0.10.2"
 dotenv = "0.15"
 dyn-clone = "1.0.4"

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{bail, Context};
@@ -89,13 +88,9 @@ pub fn start_actor_runtimes(services: &HashSet<QuickwitService>) -> anyhow::Resu
     Ok(())
 }
 
-async fn load_quickwit_config(
-    config_uri: &Uri,
-    data_dir_path_opt: Option<PathBuf>,
-) -> anyhow::Result<QuickwitConfig> {
+async fn load_quickwit_config(config_uri: &Uri) -> anyhow::Result<QuickwitConfig> {
     let config_content = load_file(config_uri).await?;
-    let config =
-        QuickwitConfig::load(config_uri, config_content.as_slice(), data_dir_path_opt).await?;
+    let config = QuickwitConfig::load(config_uri, config_content.as_slice()).await?;
     info!(config_uri=%config_uri, config=?config, "Loaded Quickwit config.");
     Ok(config)
 }

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -239,7 +239,6 @@ mod tests {
             config_uri: Uri::try_new("file:///config.yaml").unwrap(),
             index_config_uri: expected_index_config_uri.clone(),
             overwrite: false,
-            data_dir: None,
             assume_yes: false,
         }));
         assert_eq!(command, expected_cmd);
@@ -259,7 +258,6 @@ mod tests {
             config_uri: Uri::try_new("file:///config.yaml").unwrap(),
             index_config_uri: expected_index_config_uri,
             overwrite: true,
-            data_dir: None,
             assume_yes: false,
         }));
         assert_eq!(command, expected_cmd);
@@ -287,7 +285,6 @@ mod tests {
                     index_id,
                     input_path_opt: None,
                     overwrite: false,
-                    data_dir: None,
                     clear_cache: true,
                 })) if &index_id == "wikipedia"
                        && config_uri == Uri::try_new("file:///config.yaml").unwrap()
@@ -313,7 +310,6 @@ mod tests {
                     index_id,
                     input_path_opt: None,
                     overwrite: true,
-                    data_dir: None,
                     clear_cache: false
                 })) if &index_id == "wikipedia"
                         && config_uri == Uri::try_new("file:///config.yaml").unwrap()
@@ -390,7 +386,6 @@ mod tests {
                 start_timestamp: Some(0),
                 end_timestamp: Some(1),
                 config_uri: _config_uri,
-                data_dir: None,
                 sort_by_score: false,
             })) if &index_id == "wikipedia"
                   && query == "Barack Obama"
@@ -486,7 +481,6 @@ mod tests {
                 grace_period,
                 config_uri,
                 dry_run: true,
-                data_dir: None,
             })) if &index_id == "wikipedia" && grace_period == Duration::from_secs(5 * 60) && config_uri == expected_config_uri
         ));
         Ok(())

--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use clap::{arg, ArgMatches, Command};
@@ -35,23 +34,8 @@ pub fn build_run_command<'a>() -> Command<'a> {
     Command::new("run")
         .about("Runs quickwit services. By default, `metastore`, `indexer` and `searcher` are started.")
         .args(&[
-            arg!(--"data-dir" <DATA_DIR> "Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.")
-                .env("QW_DATA_DIR")
-                .required(false),
-            arg!(--"service" <SERVICE> "Services (searcher|indexer|metastore) to run. If unspecified all services `metastore`, `searcher` and `indexer` are started.")
+            arg!(--"service" <SERVICE> "Services (indexer|searcher|janitor|metastore) to run. If unspecified, all the supported services are started.")
                 .multiple_occurrences(true)
-                .required(false),
-            arg!(--"metastore-uri" <METASTORE_URI> "Metastore URI. Override the `metastore_uri` parameter defined in the config file. Defaults to file-backed, but could be Amazon S3 or PostgreSQL.")
-                .env("QW_METASTORE_URI")
-                .required(false),
-            arg!(--"cluster-id" <CLUSTER_ID> "ID of the cluster to connect to.")
-                .env("QW_CLUSTER_ID")
-                .required(false),
-            arg!(--"node-id" <NODE_ID> "Node ID identifying uniquely the node in the cluster.")
-                .env("QW_NODE_ID")
-                .required(false),
-            arg!(--"peer-seeds" <PEER_SEEDS> "Comma-separated list of peer seeds to connect to in order to join a cluster.")
-                .env("QW_PEER_SEEDS")
                 .required(false),
         ])
 }
@@ -59,12 +43,7 @@ pub fn build_run_command<'a>() -> Command<'a> {
 #[derive(Debug, Eq, PartialEq)]
 pub struct RunCliCommand {
     pub config_uri: Uri,
-    pub data_dir_path: Option<PathBuf>,
     pub services: Option<HashSet<QuickwitService>>,
-    pub metastore_uri: Option<Uri>,
-    pub cluster_id: Option<String>,
-    pub node_id: Option<String>,
-    pub peer_seeds: Option<Vec<String>>,
 }
 
 impl RunCliCommand {
@@ -73,7 +52,6 @@ impl RunCliCommand {
             .value_of("config")
             .map(Uri::try_new)
             .expect("`config` is a required arg.")?;
-        let data_dir_path = matches.value_of("data-dir").map(PathBuf::from);
         let services = matches
             .values_of("service")
             .map(|values| {
@@ -82,61 +60,22 @@ impl RunCliCommand {
                 services
             })
             .transpose()?;
-        let metastore_uri = matches
-            .value_of("metastore-uri")
-            .map(Uri::try_new)
-            .transpose()?;
-        let cluster_id = matches.value_of("cluster-id").map(String::from);
-        let node_id = matches.value_of("node-id").map(String::from);
-        let peer_seeds = matches
-            .value_of("peer-seeds")
-            .map(|peer_seeds_str| peer_seeds_str.split(',').map(String::from).collect());
         Ok(RunCliCommand {
             config_uri,
-            data_dir_path,
             services,
-            metastore_uri,
-            cluster_id,
-            node_id,
-            peer_seeds,
         })
     }
 
     pub async fn execute(&self) -> anyhow::Result<()> {
         debug!(args = ?self, "run-service");
-        let service_str = self
-            .services
-            .iter()
-            .map(|service| format!("{service:?}"))
-            .join(",");
-        let telemetry_event = TelemetryEvent::RunService(service_str);
-        quickwit_telemetry::send_telemetry_event(telemetry_event).await;
+        let mut config = load_quickwit_config(&self.config_uri).await?;
 
-        let mut config = load_quickwit_config(&self.config_uri, self.data_dir_path.clone()).await?;
-
-        // TODO: Remove these overrides when #1011 lands.
-        if let Some(metastore_uri) = &self.metastore_uri {
-            tracing::info!(metastore_uri = %metastore_uri, "Setting metastore URI from override.");
-            config.metastore_uri = metastore_uri.clone();
-        }
-        if let Some(cluster_id) = &self.cluster_id {
-            tracing::info!(cluster_id = %cluster_id, "Setting cluster ID from override.");
-            config.cluster_id = cluster_id.clone();
-        }
-        if let Some(node_id) = &self.node_id {
-            tracing::info!(node_id = %node_id, "Setting node ID from override.");
-            config.node_id = node_id.clone();
-        }
-        if let Some(peer_seeds) = &self.peer_seeds {
-            tracing::info!(peer_seeds = %peer_seeds.join(", "), "Setting peer seeds from override.");
-            config.peer_seeds = peer_seeds.clone();
-        }
         if let Some(services) = &self.services {
             tracing::info!(services = %services.iter().join(", "), "Setting services from override.");
             config.enabled_services = services.clone();
         }
-        // Revalidate config because of overrides.
-        config.validate()?;
+        let telemetry_event = TelemetryEvent::RunService(config.enabled_services.iter().join(","));
+        quickwit_telemetry::send_telemetry_event(telemetry_event).await;
         // TODO move in serve quickwit?
         start_actor_runtimes(&config.enabled_services)?;
         serve_quickwit(config).await?;
@@ -160,7 +99,6 @@ mod tests {
             command,
             CliCommand::Run(RunCliCommand {
                 config_uri,
-                data_dir_path: None,
                 services,
                 ..
             })
@@ -174,10 +112,10 @@ mod tests {
         let command = build_cli().no_binary_name(true);
         let matches = command.try_get_matches_from(vec![
             "run",
-            "--service",
-            "indexer",
             "--config",
             "/config.yaml",
+            "--service",
+            "indexer",
         ])?;
         let command = CliCommand::parse_cli_args(&matches)?;
         let expected_config_uri = Uri::try_new("file:///config.yaml").unwrap();
@@ -185,7 +123,6 @@ mod tests {
             command,
             CliCommand::Run(RunCliCommand {
                 config_uri,
-                data_dir_path: None,
                 services,
                 ..
             })
@@ -199,12 +136,12 @@ mod tests {
         let command = build_cli().no_binary_name(true);
         let matches = command.try_get_matches_from(vec![
             "run",
+            "--config",
+            "/config.yaml",
             "--service",
             "searcher",
             "--service",
             "metastore",
-            "--config",
-            "/config.yaml",
         ])?;
         let command = CliCommand::parse_cli_args(&matches).unwrap();
         let expected_config_uri = Uri::try_new("file:///config.yaml").unwrap();
@@ -214,7 +151,6 @@ mod tests {
             command,
             CliCommand::Run(RunCliCommand {
                 config_uri,
-                data_dir_path: None,
                 services,
                 ..
             })
@@ -228,10 +164,10 @@ mod tests {
         let command = build_cli().no_binary_name(true);
         let matches = command.try_get_matches_from(vec![
             "run",
-            "--service",
-            "indexer",
             "--config",
             "/config.yaml",
+            "--service",
+            "indexer",
         ])?;
         let command = CliCommand::parse_cli_args(&matches)?;
         let expected_config_uri = Uri::try_new("file:///config.yaml").unwrap();
@@ -239,7 +175,6 @@ mod tests {
             command,
             CliCommand::Run(RunCliCommand {
                 config_uri,
-                data_dir_path: None,
                 services,
                 ..
             })

--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -312,7 +312,7 @@ impl SourceCliCommand {
 }
 
 async fn create_source_cli(args: CreateSourceArgs) -> anyhow::Result<()> {
-    let qw_config = load_quickwit_config(&args.config_uri, None).await?;
+    let qw_config = load_quickwit_config(&args.config_uri).await?;
     let metastore = quickwit_metastore_uri_resolver()
         .resolve(&qw_config.metastore_uri)
         .await?;
@@ -341,7 +341,7 @@ async fn create_source_cli(args: CreateSourceArgs) -> anyhow::Result<()> {
 }
 
 async fn toggle_source_cli(args: ToggleSourceArgs) -> anyhow::Result<()> {
-    let config = load_quickwit_config(&args.config_uri, None).await?;
+    let config = load_quickwit_config(&args.config_uri).await?;
     let metastore = quickwit_metastore_uri_resolver()
         .resolve(&config.metastore_uri)
         .await?;
@@ -366,7 +366,7 @@ async fn toggle_source_cli(args: ToggleSourceArgs) -> anyhow::Result<()> {
 }
 
 async fn delete_source_cli(args: DeleteSourceArgs) -> anyhow::Result<()> {
-    let config = load_quickwit_config(&args.config_uri, None).await?;
+    let config = load_quickwit_config(&args.config_uri).await?;
     let metastore = quickwit_metastore_uri_resolver()
         .resolve(&config.metastore_uri)
         .await?;
@@ -390,7 +390,7 @@ async fn delete_source_cli(args: DeleteSourceArgs) -> anyhow::Result<()> {
 }
 
 async fn describe_source_cli(args: DescribeSourceArgs) -> anyhow::Result<()> {
-    let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
+    let quickwit_config = load_quickwit_config(&args.config_uri).await?;
     let index_metadata = resolve_index(&quickwit_config.metastore_uri, &args.index_id).await?;
     let source_checkpoint = index_metadata
         .checkpoint
@@ -444,7 +444,7 @@ where
 }
 
 async fn list_sources_cli(args: ListSourcesArgs) -> anyhow::Result<()> {
-    let quickwit_config = load_quickwit_config(&args.config_uri, None).await?;
+    let quickwit_config = load_quickwit_config(&args.config_uri).await?;
     let index_metadata = resolve_index(&quickwit_config.metastore_uri, &args.index_id).await?;
     let table = make_list_sources_table(index_metadata.sources.into_values());
     display_tables(&[table]);
@@ -525,7 +525,7 @@ fn flatten_json(value: Value) -> Vec<(String, Value)> {
 }
 
 async fn reset_checkpoint_cli(args: ResetCheckpointArgs) -> anyhow::Result<()> {
-    let config = load_quickwit_config(&args.config_uri, None).await?;
+    let config = load_quickwit_config(&args.config_uri).await?;
     let metastore = quickwit_metastore_uri_resolver()
         .resolve(&config.metastore_uri)
         .await?;

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -158,7 +158,6 @@ async fn test_cmd_create_on_existing_index() {
     let args = CreateIndexArgs {
         config_uri: test_env.config_uri,
         index_config_uri: test_env.index_config_uri,
-        data_dir: None,
         overwrite: false,
         assume_yes: false,
     };
@@ -179,7 +178,6 @@ async fn test_cmd_ingest_on_non_existing_index() {
         config_uri: test_env.config_uri,
         index_id: "index-does-not-exist".to_string(),
         input_path_opt: Some(test_env.resource_files["logs"].clone()),
-        data_dir: None,
         overwrite: false,
         clear_cache: true,
     };
@@ -204,7 +202,6 @@ async fn test_cmd_ingest_on_non_existing_file() {
         config_uri: test_env.config_uri,
         index_id: test_env.index_id,
         input_path_opt: Some(test_env.data_dir_path.join("file-does-not-exist.json")),
-        data_dir: None,
         overwrite: false,
         clear_cache: true,
     };
@@ -229,7 +226,6 @@ async fn test_ingest_docs_cli_keep_cache() {
         config_uri: test_env.config_uri,
         index_id,
         input_path_opt: Some(test_env.resource_files["logs"].clone()),
-        data_dir: None,
         overwrite: false,
         clear_cache: false,
     };
@@ -250,7 +246,6 @@ async fn test_ingest_docs_cli() {
         config_uri: test_env.config_uri.clone(),
         index_id: index_id.clone(),
         input_path_opt: Some(test_env.resource_files["logs"].clone()),
-        data_dir: None,
         overwrite: false,
         clear_cache: true,
     };
@@ -309,7 +304,6 @@ async fn test_cmd_search_aggregation() -> Result<()> {
         start_timestamp: None,
         end_timestamp: None,
         config_uri: Uri::try_new(&test_env.resource_files["config"].display().to_string()).unwrap(),
-        data_dir: None,
         sort_by_score: false,
     };
     let search_response = search_index(args).await?;
@@ -384,7 +378,6 @@ async fn test_cmd_search_with_snippets() -> Result<()> {
         start_timestamp: None,
         end_timestamp: None,
         config_uri: Uri::try_new(&test_env.resource_files["config"].display().to_string()).unwrap(),
-        data_dir: None,
         sort_by_score: false,
     };
     let search_response = search_index(args).await?;
@@ -420,7 +413,6 @@ async fn test_search_index_cli() {
         snippet_fields: None,
         start_timestamp: None,
         end_timestamp: None,
-        data_dir: None,
         sort_by_score: false,
     };
 
@@ -467,7 +459,6 @@ async fn test_delete_index_cli_dry_run() {
         config_uri: test_env.config_uri.clone(),
         index_id: index_id.clone(),
         dry_run,
-        data_dir: None,
     };
 
     let metastore = quickwit_metastore_uri_resolver()
@@ -513,7 +504,6 @@ async fn test_delete_index_cli() {
         config_uri: test_env.config_uri.clone(),
         index_id: index_id.clone(),
         dry_run: false,
-        data_dir: None,
     };
 
     delete_index_cli(args).await.unwrap();
@@ -561,7 +551,6 @@ async fn test_garbage_collect_cli_no_grace() {
         index_id: index_id.clone(),
         grace_period: Duration::from_secs(3600),
         dry_run,
-        data_dir: None,
     };
 
     let splits = metastore.list_all_splits(&test_env.index_id).await.unwrap();
@@ -618,7 +607,6 @@ async fn test_garbage_collect_cli_no_grace() {
         config_uri: test_env.config_uri.clone(),
         index_id,
         dry_run: false,
-        data_dir: None,
     };
 
     delete_index_cli(args).await.unwrap();
@@ -888,7 +876,6 @@ async fn test_all_with_s3_localstack_cli() {
         snippet_fields: None,
         start_timestamp: None,
         end_timestamp: None,
-        data_dir: None,
         sort_by_score: false,
     };
 
@@ -899,17 +886,11 @@ async fn test_all_with_s3_localstack_cli() {
     // TODO: ditto.
     let run_cli_command = RunCliCommand {
         config_uri: test_env.config_uri.clone(),
-        data_dir_path: None,
         services: Some(HashSet::from([
             QuickwitService::Searcher,
             QuickwitService::Metastore,
         ])),
-        metastore_uri: None,
-        cluster_id: None,
-        node_id: None,
-        peer_seeds: None,
     };
-
     let service_task = tokio::spawn(async move { run_cli_command.execute().await.unwrap() });
 
     wait_port_ready(test_env.rest_listen_port).await.unwrap();
@@ -934,7 +915,6 @@ async fn test_all_with_s3_localstack_cli() {
         config_uri: test_env.config_uri.clone(),
         index_id: index_id.clone(),
         dry_run: false,
-        data_dir: None,
     };
 
     delete_index_cli(args).await.unwrap();

--- a/quickwit/quickwit-config/Cargo.toml
+++ b/quickwit/quickwit-config/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = { workspace = true }
 byte-unit = { workspace = true }
 chrono = { workspace = true }
 cron = { workspace = true }
-derivative = { workspace = true }
 enum-iterator = { workspace = true }
 humantime = { workspace = true }
 itertools = { workspace = true }

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -3,14 +3,22 @@
     "version": 0,
     "cluster_id": "quickwit-cluster",
     "node_id": "my-unique-node-id",
-    "metastore_uri": "postgres://username:password@host:port/db",
-    "data_dir": "/opt/quickwit/data",
+    "enabled_services": [
+        "janitor",
+        "metastore"
+    ],
     "listen_address": "0.0.0.0",
+    "advertise_address": "172.0.0.12",
     "rest_listen_port": 1111,
+    "gossip_listen_port": 2222,
+    "grpc_listen_port": 3333,
     "peer_seeds": [
         "quickwit-searcher-0.local",
         "quickwit-searcher-1.local"
     ],
+    "data_dir": "/opt/quickwit/data",
+    "metastore_uri": "postgres://username:password@host:port/db",
+    "default_index_root_uri": "s3://quickwit-indexes",
     "indexer": {
         "split_store_max_num_bytes": "1T",
         "split_store_max_num_splits": 10000,

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -1,11 +1,16 @@
 version = 0
 cluster_id = "quickwit-cluster"
 node_id = "my-unique-node-id"
+enabled_services = [ "janitor", "metastore" ]
 listen_address = "0.0.0.0"
+advertise_address = "172.0.0.12"
 rest_listen_port = 1111
+gossip_listen_port = 2222
+grpc_listen_port = 3333
 peer_seeds = [ "quickwit-searcher-0.local", "quickwit-searcher-1.local" ]
-metastore_uri = "postgres://username:password@host:port/db"
 data_dir = "/opt/quickwit/data"
+metastore_uri = "postgres://username:password@host:port/db"
+default_index_root_uri = "s3://quickwit-indexes"
 
 [indexer]
 split_store_max_num_bytes = "1T"

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -1,13 +1,20 @@
 version: 0
 cluster_id: quickwit-cluster
 node_id: my-unique-node-id
+enabled_services:
+  - janitor
+  - metastore
 listen_address: 0.0.0.0
+advertise_address: 172.0.0.12
 rest_listen_port: 1111
+gossip_listen_port: 2222
+grpc_listen_port: 3333
 peer_seeds:
   - quickwit-searcher-0.local
   - quickwit-searcher-1.local
-metastore_uri: postgres://username:password@host:port/db
 data_dir: /opt/quickwit/data
+metastore_uri: postgres://username:password@host:port/db
+default_index_root_uri: s3://quickwit-indexes
 indexer:
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000

--- a/quickwit/quickwit-config/src/config_value.rs
+++ b/quickwit/quickwit-config/src/config_value.rs
@@ -71,8 +71,6 @@ where
         self,
         env_vars: &HashMap<String, String>,
     ) -> anyhow::Result<Option<T>> {
-        assert_eq!(QW_NONE, 0);
-
         // QW env vars take precedence over the config file values.
         if E > QW_NONE {
             if let Some(env_var_key) = QW_ENV_VARS.get(&E) {

--- a/quickwit/quickwit-config/src/config_value.rs
+++ b/quickwit/quickwit-config/src/config_value.rs
@@ -1,0 +1,247 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::{any, fmt};
+
+use anyhow::{self, Context};
+use serde::{Deserialize, Deserializer};
+
+use crate::qw_env_vars::{QW_ENV_VARS, QW_NONE};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ConfigValue<T, const E: usize> {
+    /// Value provided by the user in a config file.
+    provided: Option<T>,
+    /// Value provided by Quickwit as default.
+    default: Option<T>,
+}
+
+impl<T, const E: usize> ConfigValue<T, E>
+where
+    T: FromStr,
+    <T as FromStr>::Err: fmt::Debug,
+{
+    pub(crate) fn with_default(value: T) -> Self {
+        Self {
+            provided: None,
+            default: Some(value),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(value: T) -> Self {
+        Self {
+            provided: Some(value),
+            default: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn none() -> Self {
+        Self {
+            provided: None,
+            default: None,
+        }
+    }
+
+    #[cfg(any(test, feature = "testsuite"))]
+    pub(crate) fn unwrap(self) -> T {
+        self.provided.or(self.default).unwrap()
+    }
+
+    pub(crate) fn resolve_optional(
+        self,
+        env_vars: &HashMap<String, String>,
+    ) -> anyhow::Result<Option<T>> {
+        assert_eq!(QW_NONE, 0);
+
+        // QW env vars take precedence over the config file values.
+        if E > QW_NONE {
+            if let Some(env_var_key) = QW_ENV_VARS.get(&E) {
+                if let Some(env_var_value) = env_vars.get(*env_var_key) {
+                    let value = env_var_value.parse::<T>().map_err(|error| {
+                        anyhow::anyhow!(
+                            "Failed to convert value `{env_var_value}` read from environment \
+                             variable `{env_var_key}` to type `{}`: {error:?}",
+                            any::type_name::<T>(),
+                        )
+                    })?;
+                    return Ok(Some(value));
+                }
+            }
+        }
+        Ok(self.provided.or(self.default))
+    }
+
+    pub(crate) fn resolve(self, env_vars: &HashMap<String, String>) -> anyhow::Result<T> {
+        self.resolve_optional(env_vars)?.context(
+            "Failed to resolve field value: no value was provided via environment variable or \
+             config file, and the field has no default.",
+        )
+    }
+}
+
+impl<T, const E: usize> Default for ConfigValue<T, E>
+where T: Default
+{
+    fn default() -> Self {
+        Self {
+            provided: None,
+            default: Some(T::default()),
+        }
+    }
+}
+
+impl<'de, T, const E: usize> Deserialize<'de> for ConfigValue<T, E>
+where T: Deserialize<'de>
+{
+    fn deserialize<D>(deserializer: D) -> Result<ConfigValue<T, E>, D::Error>
+    where D: Deserializer<'de> {
+        let value: Option<T> = Deserialize::deserialize(deserializer)?;
+        Ok(ConfigValue {
+            provided: value,
+            default: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qw_env_vars::{
+        QW_CLUSTER_ID, QW_GOSSIP_LISTEN_PORT, QW_NODE_ID, QW_REST_LISTEN_PORT,
+    };
+
+    #[test]
+    fn test_config_value_resolve_optional() {
+        {
+            let env_vars = HashMap::new();
+            let rest_listen_port = ConfigValue::<usize, QW_REST_LISTEN_PORT>::none();
+            assert!(rest_listen_port
+                .resolve_optional(&env_vars)
+                .unwrap()
+                .is_none());
+        }
+        {
+            let env_vars = HashMap::new();
+            let rest_listen_port = ConfigValue::<usize, QW_REST_LISTEN_PORT>::with_default(7280);
+            assert_eq!(
+                rest_listen_port
+                    .resolve_optional(&env_vars)
+                    .unwrap()
+                    .unwrap(),
+                7280
+            );
+        }
+        {
+            let env_vars = HashMap::new();
+            let rest_listen_port = ConfigValue::<usize, QW_REST_LISTEN_PORT> {
+                provided: Some(5678),
+                default: Some(7820),
+            };
+            assert_eq!(
+                rest_listen_port
+                    .resolve_optional(&env_vars)
+                    .unwrap()
+                    .unwrap(),
+                5678
+            );
+        }
+        {
+            let mut env_vars = HashMap::new();
+            env_vars.insert("QW_REST_LISTEN_PORT".to_string(), "foobar".to_string());
+            let rest_listen_port = ConfigValue::<usize, QW_REST_LISTEN_PORT> {
+                provided: Some(5678),
+                default: Some(7820),
+            };
+            rest_listen_port.resolve_optional(&env_vars).unwrap_err();
+        }
+        {
+            let mut env_vars = HashMap::new();
+            env_vars.insert("QW_REST_LISTEN_PORT".to_string(), "1234".to_string());
+            let rest_listen_port = ConfigValue::<usize, QW_REST_LISTEN_PORT> {
+                provided: Some(5678),
+                default: Some(7820),
+            };
+            assert_eq!(
+                rest_listen_port
+                    .resolve_optional(&env_vars)
+                    .unwrap()
+                    .unwrap(),
+                1234
+            );
+        }
+    }
+
+    #[test]
+    fn test_config_value_resolve() {
+        let env_vars = HashMap::new();
+        let rest_listen_port = ConfigValue::<usize, QW_REST_LISTEN_PORT>::none();
+        rest_listen_port.resolve(&env_vars).unwrap_err();
+    }
+
+    #[test]
+    fn test_config_value_deserialize() {
+        fn default_cluster_id() -> ConfigValue<String, QW_CLUSTER_ID> {
+            ConfigValue::with_default("default-cluster".to_string())
+        }
+
+        fn default_node_id() -> ConfigValue<String, QW_NODE_ID> {
+            ConfigValue::with_default("default-node".to_string())
+        }
+
+        fn default_rest_listen_port() -> ConfigValue<usize, QW_REST_LISTEN_PORT> {
+            ConfigValue::with_default(7280)
+        }
+
+        #[derive(Deserialize)]
+        struct Config {
+            #[serde(default)]
+            version: ConfigValue<usize, QW_NONE>,
+            #[serde(default = "default_cluster_id")]
+            cluster_id: ConfigValue<String, QW_CLUSTER_ID>,
+            #[serde(default = "default_node_id")]
+            node_id: ConfigValue<String, QW_NODE_ID>,
+            #[serde(default = "default_rest_listen_port")]
+            rest_listen_port: ConfigValue<usize, QW_REST_LISTEN_PORT>,
+            gossip_listen_port: ConfigValue<String, QW_GOSSIP_LISTEN_PORT>,
+        }
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+            cluster_id: qw-cluster
+            "#,
+        )
+        .unwrap();
+
+        let mut env_vars = HashMap::new();
+        env_vars.insert("QW_REST_LISTEN_PORT".to_string(), "1234".to_string());
+
+        assert_eq!(config.version.resolve(&env_vars).unwrap(), 0);
+        assert_eq!(config.cluster_id.resolve(&env_vars).unwrap(), "qw-cluster");
+        assert_eq!(config.node_id.resolve(&env_vars).unwrap(), "default-node");
+        assert_eq!(config.rest_listen_port.resolve(&env_vars).unwrap(), 1234);
+        assert!(config
+            .gossip_listen_port
+            .resolve_optional(&env_vars)
+            .unwrap()
+            .is_none());
+    }
+}

--- a/quickwit/quickwit-config/src/index_config.rs
+++ b/quickwit/quickwit-config/src/index_config.rs
@@ -34,8 +34,8 @@ use quickwit_doc_mapper::{
     DefaultDocMapper, DefaultDocMapperBuilder, DocMapper, FieldMappingEntry, ModeType,
     QuickwitJsonOptions, SortBy, SortByConfig, SortOrder,
 };
-use serde::de::{Error, IgnoredAny};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::de::IgnoredAny;
+use serde::{Deserialize, Serialize};
 
 use crate::merge_policy_config::{MergePolicyConfig, StableLogMergePolicyConfig};
 use crate::source_config::SourceConfig;
@@ -433,7 +433,6 @@ pub struct IndexConfig {
     pub version: usize,
     pub index_id: String,
     #[serde(default)]
-    #[serde(deserialize_with = "deser_and_validate_uri")]
     pub index_uri: Option<Uri>,
     pub doc_mapping: DocMapping,
     #[serde(default)]
@@ -559,16 +558,6 @@ pub fn build_doc_mapper(
         max_num_partitions: doc_mapping.max_num_partitions,
     };
     Ok(Arc::new(builder.try_build()?))
-}
-
-/// Deserializes and validates a [`Uri`].
-fn deser_and_validate_uri<'de, D>(deserializer: D) -> Result<Option<Uri>, D::Error>
-where D: Deserializer<'de> {
-    let uri_opt: Option<String> = Deserialize::deserialize(deserializer)?;
-    uri_opt
-        .map(|uri| Uri::try_new(&uri))
-        .transpose()
-        .map_err(D::Error::custom)
 }
 
 #[cfg(test)]
@@ -829,7 +818,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "URI is empty.")]
+    #[should_panic(expected = "empty URI")]
     fn test_config_validates_uris() {
         let config_yaml = r#"
             version: 0

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -22,8 +22,10 @@ use once_cell::sync::OnceCell;
 use regex::Regex;
 
 mod config;
+mod config_value;
 mod index_config;
 pub mod merge_policy_config;
+mod qw_env_vars;
 pub mod service;
 mod source_config;
 mod templating;

--- a/quickwit/quickwit-config/src/qw_env_vars.rs
+++ b/quickwit/quickwit-config/src/qw_env_vars.rs
@@ -34,7 +34,7 @@ macro_rules! qw_env_vars {
     };
 
     ($($ident:ident),*) => {
-        qw_env_vars!(@step 1usize, $($ident,)*);
+        qw_env_vars!(@step 0usize, $($ident,)*);
 
         pub(crate) static QW_ENV_VARS: Lazy<HashMap<usize, &'static str>> = Lazy::new(|| {
             let mut env_vars = HashMap::new();
@@ -44,9 +44,10 @@ macro_rules! qw_env_vars {
     }
 }
 
-pub(crate) const QW_NONE: usize = 0;
-
+// These environment variable keys can be declared in any order with the exception of `QW_NONE`,
+// which must be declared first.
 qw_env_vars!(
+    QW_NONE,
     QW_CLUSTER_ID,
     QW_NODE_ID,
     QW_ENABLED_SERVICES,
@@ -68,6 +69,8 @@ mod tests {
 
     #[test]
     fn test_qw_env_vars_expansion() {
+        assert_eq!(QW_NONE, 0);
+
         assert_eq!(QW_CLUSTER_ID, 1);
         assert_eq!(QW_ENV_VARS.get(&QW_CLUSTER_ID).unwrap(), &"QW_CLUSTER_ID");
 

--- a/quickwit/quickwit-config/src/qw_env_vars.rs
+++ b/quickwit/quickwit-config/src/qw_env_vars.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+
+/// Expands the list of QW environment variables into constants of the form `const <ENV_VAR_KEY>:
+/// usize = <env var index>;` and builds the map `QW_EN_VARS` of environment variable index to
+/// environment variable key.
+macro_rules! qw_env_vars {
+    (@step $idx:expr,) => {};
+
+    (@step $idx:expr, $head:ident, $($tail:ident,)*) => {
+        pub(crate) const $head: usize = $idx;
+
+        qw_env_vars!(@step $idx + 1usize, $($tail,)*);
+    };
+
+    ($($ident:ident),*) => {
+        qw_env_vars!(@step 1usize, $($ident,)*);
+
+        pub(crate) static QW_ENV_VARS: Lazy<HashMap<usize, &'static str>> = Lazy::new(|| {
+            let mut env_vars = HashMap::new();
+            $(env_vars.insert($ident, stringify!($ident));)*
+            env_vars
+        });
+    }
+}
+
+pub(crate) const QW_NONE: usize = 0;
+
+qw_env_vars!(
+    QW_CLUSTER_ID,
+    QW_NODE_ID,
+    QW_ENABLED_SERVICES,
+    QW_LISTEN_ADDRESS,
+    QW_ADVERTISE_ADDRESS,
+    QW_REST_LISTEN_PORT,
+    QW_GOSSIP_LISTEN_PORT,
+    QW_GRPC_LISTEN_PORT,
+    QW_PEER_SEEDS,
+    QW_DATA_DIR,
+    QW_METASTORE_URI,
+    QW_DEFAULT_INDEX_ROOT_URI
+);
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_qw_env_vars_expansion() {
+        assert_eq!(QW_CLUSTER_ID, 1);
+        assert_eq!(QW_ENV_VARS.get(&QW_CLUSTER_ID).unwrap(), &"QW_CLUSTER_ID");
+
+        assert_eq!(QW_ENV_VARS.get(&QW_NODE_ID).unwrap(), &"QW_NODE_ID");
+        assert_eq!(QW_NODE_ID, 2);
+    }
+}

--- a/quickwit/quickwit-config/src/service.rs
+++ b/quickwit/quickwit-config/src/service.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 
@@ -42,7 +43,8 @@ impl QuickwitService {
             QuickwitService::Metastore => "metastore",
         }
     }
-    pub fn supported_services() -> Vec<QuickwitService> {
+
+    pub fn supported_services() -> HashSet<QuickwitService> {
         all::<QuickwitService>().into_iter().collect()
     }
 }
@@ -64,8 +66,8 @@ impl FromStr for QuickwitService {
             "metastore" => Ok(QuickwitService::Metastore),
             _ => {
                 bail!(
-                    "Failed to parse service `{service_str}`. Supported services are: {}",
-                    QuickwitService::supported_services().iter().join(", ")
+                    "Failed to parse service `{service_str}`. Supported services are: `{}`.",
+                    QuickwitService::supported_services().iter().join("`, `")
                 )
             }
         }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_format.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_format.rs
@@ -148,9 +148,8 @@ impl Serialize for DateTimeFormat {
 impl<'de> Deserialize<'de> for DateTimeFormat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
-        let date_time_format_str = String::deserialize(deserializer)?;
-        let date_time_format =
-            DateTimeFormat::from_str(&date_time_format_str).map_err(D::Error::custom)?;
+        let date_time_format_str: String = Deserialize::deserialize(deserializer)?;
+        let date_time_format = date_time_format_str.parse().map_err(D::Error::custom)?;
         Ok(date_time_format)
     }
 }


### PR DESCRIPTION
### Description
Set default env variables for main node config parameters such `QW_CLUSTER_ID`, `QW_NODE_ID`. The values are loaded independently from the CLI parameters when the config object is built.

### How was this PR tested?
Added a bunch of unit tests.

Try it yourself:

```sh
> QW_CLUSTER_ID="dev-cluster" \
  QW_NODE_ID="node-0" \
  QW_ENABLED_SERVICES="indexer,searcher,metastore" \
  QW_DATA_DIR="qwdata/node-0" \
  QW_METASTORE_URI="qwdata/indexes#polling_interval=5s" \
  QW_DEFAULT_INDEX_ROOT_URI="qwdata/indexes" \
  cargo run --manifest-path quickwit/Cargo.toml --all-features -- run
```
