### PR TITLE
Fix search rest response (snippet)

### DIFF
--- a/quickwit/quickwit-search/src/search_response_rest.rs
+++ b/quickwit/quickwit-search/src/search_response_rest.rs
@@ -20,8 +20,9 @@
 use std::convert::TryFrom;
 
 use quickwit_common::truncate_str;
+use quickwit_proto::SearchResponse;
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 use crate::error::SearchError;
 
@@ -32,50 +33,52 @@ pub struct SearchResponseRest {
     /// Overall number of documents matching the query.
     pub num_hits: u64,
     /// List of hits returned.
-    pub hits: Vec<serde_json::Value>,
+    pub hits: Vec<Value>,
+    /// List of snippets
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snippets: Option<Vec<Value>>,
     /// Elapsed time.
     pub elapsed_time_micros: u64,
     /// Search errors.
     pub errors: Vec<String>,
     /// Aggregations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub aggregations: Option<serde_json::Value>,
+    pub aggregations: Option<Value>,
 }
 
-impl TryFrom<quickwit_proto::SearchResponse> for SearchResponseRest {
+impl TryFrom<SearchResponse> for SearchResponseRest {
     type Error = SearchError;
 
-    fn try_from(search_response: quickwit_proto::SearchResponse) -> Result<Self, Self::Error> {
-        let hits = search_response
-            .hits
-            .into_iter()
-            .map(|hit| {
-                let mut hit_value = Map::with_capacity(2);
-                let document: serde_json::Value =
-                    serde_json::from_str(&hit.json).map_err(|err| {
-                        SearchError::InternalError(format!(
-                            "Failed to serialize document `{}` to JSON: `{}`.",
-                            truncate_str(&hit.json, 100),
-                            err
-                        ))
-                    })?;
-                hit_value.insert("document".to_string(), document);
-
-                if let Some(snippet_json) = &hit.snippet {
-                    let snippet: Value = serde_json::from_str(snippet_json).map_err(|err| {
+    fn try_from(search_response: SearchResponse) -> Result<Self, Self::Error> {
+        let hits_with_snippet_iter = search_response.hits.into_iter().map(|hit| {
+            let document: Value = serde_json::from_str(&hit.json).map_err(|err| {
+                SearchError::InternalError(format!(
+                    "Failed to serialize document `{}` to JSON: `{}`.",
+                    truncate_str(&hit.json, 100),
+                    err
+                ))
+            })?;
+            let snippet_opt = hit
+                .snippet
+                .map(|snippet_json| {
+                    serde_json::from_str::<Value>(&snippet_json).map_err(|err| {
                         SearchError::InternalError(format!(
                             "Failed to serialize snippet `{}` to JSON: `{}`.",
                             snippet_json, err
                         ))
-                    })?;
-                    hit_value.insert("snippet".to_string(), snippet);
-                }
-                Ok(Value::Object(hit_value))
-            })
-            .collect::<crate::Result<Vec<serde_json::Value>>>()?;
+                    })
+                })
+                .transpose()?;
+            Result::<_, SearchError>::Ok((document, snippet_opt))
+        });
+        let (hits, snippets) = itertools::process_results(hits_with_snippet_iter, |iter| {
+            iter.unzip::<_, _, Vec<_>, Vec<_>>()
+        })?;
+
         Ok(SearchResponseRest {
             num_hits: search_response.num_hits,
             hits,
+            snippets: snippets.into_iter().collect(),
             elapsed_time_micros: search_response.elapsed_time_micros,
             errors: search_response.errors,
             aggregations: search_response

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -356,6 +356,7 @@ mod tests {
         let search_response = SearchResponseRest {
             num_hits: 55,
             hits: Vec::new(),
+            snippets: None,
             elapsed_time_micros: 0u64,
             errors: Vec::new(),
             aggregations: None,
@@ -824,10 +825,8 @@ mod tests {
         let resp_json: serde_json::Value = serde_json::from_slice(resp.body())?;
         let expected_response_json = serde_json::json!({
             "num_hits": 1,
-            "hits": [{
-                "document": {"title": "foo", "body": "foo bar baz"},
-                "snippet": {"title": [], "body": ["foo <em>bar</em> baz"]}
-            }],
+            "hits": [{"title": "foo", "body": "foo bar baz"}],
+            "snippets": [{"title": [], "body": ["foo <em>bar</em> baz"]}],
             "elapsed_time_micros": 16,
             "errors": [],
         });


### PR DESCRIPTION
Hoisted snippets field at the top level  of the search rest response.

Closes https://github.com/quickwit-oss/quickwit/issues/2052
