### PR TITLE
Instrument metastore calls

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -672,6 +672,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "concat-idents"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe0e1d9f7de897d18e590a7496b5facbe87813f746cf4b8db596ba77e07e832"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3521,6 +3531,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "byte-unit",
+ "concat-idents",
  "dotenv",
  "futures",
  "http",
@@ -4859,9 +4870,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -45,6 +45,7 @@ chitchat = { git = "https://github.com/quickwit-oss/chitchat", rev = "cd568ba" }
 chrono = "0.4.19"
 clap = { version = "= 3.1", features = ["env"] }
 colored = "2.0.0"
+concat-idents = "1.1.4"
 console-subscriber = "0.1.0"
 criterion = { version = "0.4", features = ["async_tokio"] }
 cron = "0.11.0"

--- a/quickwit/quickwit-common/src/metrics.rs
+++ b/quickwit/quickwit-common/src/metrics.rs
@@ -18,7 +18,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use prometheus::{Encoder, HistogramOpts, Opts, TextEncoder};
-pub use prometheus::{Histogram, HistogramTimer, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+pub use prometheus::{
+    Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+};
 
 pub fn new_counter(name: &str, description: &str, namespace: &str) -> IntCounter {
     let counter_opts = Opts::new(name, description).namespace(namespace);
@@ -34,16 +36,30 @@ pub fn new_counter_vec(
     labels: &[&str],
 ) -> IntCounterVec {
     let counter_opts = Opts::new(name, description).namespace(namespace);
-    let counter_vec = IntCounterVec::new(counter_opts, labels).expect("Failed to create counter");
+    let counter_vec =
+        IntCounterVec::new(counter_opts, labels).expect("Failed to create counter vec");
     prometheus::register(Box::new(counter_vec.clone())).expect("Failed to register counter");
     counter_vec
 }
 
 pub fn new_histogram(name: &str, description: &str, namespace: &str) -> Histogram {
     let histogram_opts = HistogramOpts::new(name, description).namespace(namespace);
-    let histogram = Histogram::with_opts(histogram_opts).expect("Failed to create counter");
+    let histogram = Histogram::with_opts(histogram_opts).expect("Failed to create histogram");
     prometheus::register(Box::new(histogram.clone())).expect("Failed to register counter");
     histogram
+}
+
+pub fn new_histogram_vec(
+    name: &str,
+    description: &str,
+    namespace: &str,
+    labels: &[&str],
+) -> HistogramVec {
+    let histogram_opts = HistogramOpts::new(name, description).namespace(namespace);
+    let histogram_vec =
+        HistogramVec::new(histogram_opts, labels).expect("Failed to create histogram vec");
+    prometheus::register(Box::new(histogram_vec.clone())).expect("Failed to register counter");
+    histogram_vec
 }
 
 pub fn new_gauge(name: &str, description: &str, namespace: &str) -> IntGauge {

--- a/quickwit/quickwit-metastore/Cargo.toml
+++ b/quickwit/quickwit-metastore/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://quickwit.io/docs/"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 byte-unit = { workspace = true }
+concat-idents = { workspace = true }
 sqlx = { workspace = true, optional = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/quickwit/quickwit-metastore/src/lib.rs
+++ b/quickwit/quickwit-metastore/src/lib.rs
@@ -27,14 +27,14 @@
 
 #[macro_use]
 mod tests;
-mod split_metadata;
-mod split_metadata_version;
-
 #[allow(missing_docs)]
 pub mod checkpoint;
 mod error;
 mod metastore;
 mod metastore_resolver;
+mod metrics;
+mod split_metadata;
+mod split_metadata_version;
 
 use std::ops::Range;
 

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
@@ -29,6 +29,7 @@ use regex::Regex;
 use tokio::sync::Mutex;
 use tracing::debug;
 
+use crate::metastore::instrumented_metastore::InstrumentedMetastore;
 use crate::{
     FileBackedMetastore, Metastore, MetastoreError, MetastoreFactory, MetastoreResolverError,
 };
@@ -130,8 +131,9 @@ impl MetastoreFactory for FileBackedMetastoreFactory {
         let file_backed_metastore = FileBackedMetastore::try_new(storage, polling_interval_opt)
             .await
             .map_err(MetastoreResolverError::FailedToOpenMetastore)?;
+        let instrumented_metastore = InstrumentedMetastore::new(Box::new(file_backed_metastore));
         let unique_metastore_for_uri = self
-            .cache_metastore(uri, Arc::new(file_backed_metastore))
+            .cache_metastore(uri, Arc::new(instrumented_metastore))
             .await;
         Ok(unique_metastore_for_uri)
     }

--- a/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
@@ -1,0 +1,334 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::ops::Range;
+
+use async_trait::async_trait;
+use concat_idents::concat_idents;
+use quickwit_common::uri::Uri;
+use quickwit_config::SourceConfig;
+use quickwit_doc_mapper::tag_pruning::TagFilterAst;
+use quickwit_proto::metastore_api::{DeleteQuery, DeleteTask};
+
+use crate::checkpoint::IndexCheckpointDelta;
+use crate::{IndexMetadata, Metastore, MetastoreResult, Split, SplitMetadata, SplitState};
+
+macro_rules! instrument {
+    ($method_name:ident, $expr:expr, $($label:expr),*) => {
+        let labels = &[$($label,)*];
+        concat_idents!(metric_name = $method_name, _requests_total {
+            crate::metrics::METASTORE_METRICS.metric_name.with_label_values(labels).inc();
+        });
+        let start = std::time::Instant::now();
+        let (res, is_error) = match $expr {
+            ok @ Ok(_) => {
+                (ok, "false")
+            },
+            err @ Err(_) => {
+                concat_idents!(metric_name = $method_name, _errors_total {
+                    crate::metrics::METASTORE_METRICS.metric_name.with_label_values(labels).inc();
+                });
+                (err, "true")
+            },
+        };
+        let elapsed = start.elapsed();
+        let labels = &[$($label,)* is_error];
+        concat_idents!(metric_name = $method_name, _duration_seconds {
+            crate::metrics::METASTORE_METRICS.metric_name.with_label_values(labels).observe(elapsed.as_secs_f64());
+        });
+        if elapsed.as_secs() > 1 {
+            let index_id = if labels.len() > 1 {
+                labels[0]
+            } else {
+                ""
+            };
+            tracing::warn!(
+                operation=stringify!($method_name),
+                duration_millis=elapsed.as_millis(),
+                index_id=index_id,
+                "Slow metastore operation"
+            );
+        }
+        return res;
+    };
+}
+
+pub(crate) struct InstrumentedMetastore {
+    underlying: Box<dyn Metastore>,
+}
+
+impl InstrumentedMetastore {
+    pub fn new(metastore: Box<dyn Metastore>) -> Self {
+        Self {
+            underlying: metastore,
+        }
+    }
+}
+
+#[async_trait]
+impl Metastore for InstrumentedMetastore {
+    fn uri(&self) -> &Uri {
+        self.underlying.uri()
+    }
+
+    async fn check_connectivity(&self) -> anyhow::Result<()> {
+        self.underlying.check_connectivity().await
+    }
+
+    // Index API
+
+    async fn create_index(&self, index_metadata: IndexMetadata) -> MetastoreResult<()> {
+        let index_id = index_metadata.index_id.clone();
+        instrument!(
+            create_index,
+            self.underlying.create_index(index_metadata).await,
+            index_id.as_ref()
+        );
+    }
+
+    async fn index_exists(&self, index_id: &str) -> MetastoreResult<bool> {
+        instrument!(
+            index_exists,
+            self.underlying.index_exists(index_id).await,
+            index_id
+        );
+    }
+
+    async fn index_metadata(&self, index_id: &str) -> MetastoreResult<IndexMetadata> {
+        instrument!(
+            index_metadata,
+            self.underlying.index_metadata(index_id).await,
+            index_id
+        );
+    }
+
+    async fn list_indexes_metadatas(&self) -> MetastoreResult<Vec<IndexMetadata>> {
+        instrument!(
+            list_indexes_metadatas,
+            self.underlying.list_indexes_metadatas().await,
+        );
+    }
+
+    async fn delete_index(&self, index_id: &str) -> MetastoreResult<()> {
+        instrument!(
+            delete_index,
+            self.underlying.delete_index(index_id).await,
+            index_id
+        );
+    }
+
+    // Split API
+
+    async fn stage_split(
+        &self,
+        index_id: &str,
+        split_metadata: SplitMetadata,
+    ) -> MetastoreResult<()> {
+        instrument!(
+            stage_split,
+            self.underlying.stage_split(index_id, split_metadata).await,
+            index_id
+        );
+    }
+
+    async fn publish_splits<'a>(
+        &self,
+        index_id: &str,
+        split_ids: &[&'a str],
+        replaced_split_ids: &[&'a str],
+        checkpoint_delta_opt: Option<IndexCheckpointDelta>,
+    ) -> MetastoreResult<()> {
+        instrument!(
+            publish_splits,
+            self.underlying
+                .publish_splits(
+                    index_id,
+                    split_ids,
+                    replaced_split_ids,
+                    checkpoint_delta_opt,
+                )
+                .await,
+            index_id
+        );
+    }
+
+    async fn list_splits(
+        &self,
+        index_id: &str,
+        split_state: SplitState,
+        time_range: Option<Range<i64>>,
+        tags: Option<TagFilterAst>,
+    ) -> MetastoreResult<Vec<Split>> {
+        instrument!(
+            list_splits,
+            self.underlying
+                .list_splits(index_id, split_state, time_range, tags)
+                .await,
+            index_id
+        );
+    }
+
+    async fn list_all_splits(&self, index_id: &str) -> MetastoreResult<Vec<Split>> {
+        instrument!(
+            list_all_splits,
+            self.underlying.list_all_splits(index_id).await,
+            index_id
+        );
+    }
+
+    async fn mark_splits_for_deletion<'a>(
+        &self,
+        index_id: &str,
+        split_ids: &[&'a str],
+    ) -> MetastoreResult<()> {
+        instrument!(
+            mark_splits_for_deletion,
+            self.underlying
+                .mark_splits_for_deletion(index_id, split_ids)
+                .await,
+            index_id
+        );
+    }
+
+    async fn delete_splits<'a>(
+        &self,
+        index_id: &str,
+        split_ids: &[&'a str],
+    ) -> MetastoreResult<()> {
+        instrument!(
+            delete_splits,
+            self.underlying.delete_splits(index_id, split_ids).await,
+            index_id
+        );
+    }
+
+    // Source API
+
+    async fn add_source(&self, index_id: &str, source: SourceConfig) -> MetastoreResult<()> {
+        let source_id = source.source_id.clone();
+        instrument!(
+            add_source,
+            self.underlying.add_source(index_id, source).await,
+            index_id,
+            source_id.as_ref()
+        );
+    }
+
+    async fn toggle_source(
+        &self,
+        index_id: &str,
+        source_id: &str,
+        enable: bool,
+    ) -> MetastoreResult<()> {
+        instrument!(
+            toggle_source,
+            self.underlying
+                .toggle_source(index_id, source_id, enable)
+                .await,
+            index_id,
+            source_id
+        );
+    }
+
+    async fn reset_source_checkpoint(
+        &self,
+        index_id: &str,
+        source_id: &str,
+    ) -> MetastoreResult<()> {
+        instrument!(
+            reset_source_checkpoint,
+            self.underlying
+                .reset_source_checkpoint(index_id, source_id)
+                .await,
+            index_id,
+            source_id
+        );
+    }
+
+    async fn delete_source(&self, index_id: &str, source_id: &str) -> MetastoreResult<()> {
+        instrument!(
+            delete_source,
+            self.underlying.delete_source(index_id, source_id).await,
+            index_id,
+            source_id
+        );
+    }
+
+    // Delete tasks API
+    async fn create_delete_task(&self, delete_query: DeleteQuery) -> MetastoreResult<DeleteTask> {
+        let index_id = delete_query.index_id.clone();
+        instrument!(
+            create_delete_task,
+            self.underlying.create_delete_task(delete_query).await,
+            index_id.as_ref()
+        );
+    }
+
+    async fn list_delete_tasks(
+        &self,
+        index_id: &str,
+        opstamp_start: u64,
+    ) -> MetastoreResult<Vec<DeleteTask>> {
+        instrument!(
+            list_delete_tasks,
+            self.underlying
+                .list_delete_tasks(index_id, opstamp_start)
+                .await,
+            index_id
+        );
+    }
+
+    async fn last_delete_opstamp(&self, index_id: &str) -> MetastoreResult<u64> {
+        instrument!(
+            last_delete_opstamp,
+            self.underlying.last_delete_opstamp(index_id).await,
+            index_id
+        );
+    }
+
+    async fn update_splits_delete_opstamp<'a>(
+        &self,
+        index_id: &str,
+        split_ids: &[&'a str],
+        delete_opstamp: u64,
+    ) -> MetastoreResult<()> {
+        instrument!(
+            update_splits_delete_opstamp,
+            self.underlying
+                .update_splits_delete_opstamp(index_id, split_ids, delete_opstamp)
+                .await,
+            index_id
+        );
+    }
+
+    async fn list_stale_splits(
+        &self,
+        index_id: &str,
+        delete_opstamp: u64,
+        num_splits: usize,
+    ) -> MetastoreResult<Vec<Split>> {
+        instrument!(
+            list_stale_splits,
+            self.underlying
+                .list_stale_splits(index_id, delete_opstamp, num_splits)
+                .await,
+            index_id
+        );
+    }
+}

--- a/quickwit/quickwit-metastore/src/metrics.rs
+++ b/quickwit/quickwit-metastore/src/metrics.rs
@@ -1,0 +1,497 @@
+// Copyright (C) 2022 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use once_cell::sync::Lazy;
+use quickwit_common::metrics::{new_counter_vec, new_histogram_vec, HistogramVec, IntCounterVec};
+
+pub struct MetastoreMetrics {
+    // Index API
+    pub create_index_requests_total: IntCounterVec,
+    pub create_index_errors_total: IntCounterVec,
+    pub create_index_duration_seconds: HistogramVec,
+
+    pub index_exists_requests_total: IntCounterVec,
+    pub index_exists_errors_total: IntCounterVec,
+    pub index_exists_duration_seconds: HistogramVec,
+
+    pub index_metadata_requests_total: IntCounterVec,
+    pub index_metadata_errors_total: IntCounterVec,
+    pub index_metadata_duration_seconds: HistogramVec,
+
+    pub list_indexes_metadatas_requests_total: IntCounterVec,
+    pub list_indexes_metadatas_errors_total: IntCounterVec,
+    pub list_indexes_metadatas_duration_seconds: HistogramVec,
+
+    pub delete_index_requests_total: IntCounterVec,
+    pub delete_index_errors_total: IntCounterVec,
+    pub delete_index_duration_seconds: HistogramVec,
+
+    // Split API
+    pub stage_split_requests_total: IntCounterVec,
+    pub stage_split_errors_total: IntCounterVec,
+    pub stage_split_duration_seconds: HistogramVec,
+
+    pub publish_splits_requests_total: IntCounterVec,
+    pub publish_splits_errors_total: IntCounterVec,
+    pub publish_splits_duration_seconds: HistogramVec,
+
+    pub list_splits_requests_total: IntCounterVec,
+    pub list_splits_errors_total: IntCounterVec,
+    pub list_splits_duration_seconds: HistogramVec,
+
+    pub list_all_splits_requests_total: IntCounterVec,
+    pub list_all_splits_errors_total: IntCounterVec,
+    pub list_all_splits_duration_seconds: HistogramVec,
+
+    pub mark_splits_for_deletion_requests_total: IntCounterVec,
+    pub mark_splits_for_deletion_errors_total: IntCounterVec,
+    pub mark_splits_for_deletion_duration_seconds: HistogramVec,
+
+    pub delete_splits_requests_total: IntCounterVec,
+    pub delete_splits_errors_total: IntCounterVec,
+    pub delete_splits_duration_seconds: HistogramVec,
+
+    // Source API
+    pub add_source_requests_total: IntCounterVec,
+    pub add_source_errors_total: IntCounterVec,
+    pub add_source_duration_seconds: HistogramVec,
+
+    pub toggle_source_requests_total: IntCounterVec,
+    pub toggle_source_errors_total: IntCounterVec,
+    pub toggle_source_duration_seconds: HistogramVec,
+
+    pub reset_source_checkpoint_requests_total: IntCounterVec,
+    pub reset_source_checkpoint_errors_total: IntCounterVec,
+    pub reset_source_checkpoint_duration_seconds: HistogramVec,
+
+    pub delete_source_requests_total: IntCounterVec,
+    pub delete_source_errors_total: IntCounterVec,
+    pub delete_source_duration_seconds: HistogramVec,
+
+    // Delete tasks API
+    pub create_delete_task_requests_total: IntCounterVec,
+    pub create_delete_task_errors_total: IntCounterVec,
+    pub create_delete_task_duration_seconds: HistogramVec,
+
+    pub list_delete_tasks_requests_total: IntCounterVec,
+    pub list_delete_tasks_errors_total: IntCounterVec,
+    pub list_delete_tasks_duration_seconds: HistogramVec,
+
+    pub last_delete_opstamp_requests_total: IntCounterVec,
+    pub last_delete_opstamp_errors_total: IntCounterVec,
+    pub last_delete_opstamp_duration_seconds: HistogramVec,
+
+    pub update_splits_delete_opstamp_requests_total: IntCounterVec,
+    pub update_splits_delete_opstamp_errors_total: IntCounterVec,
+    pub update_splits_delete_opstamp_duration_seconds: HistogramVec,
+
+    pub list_stale_splits_requests_total: IntCounterVec,
+    pub list_stale_splits_errors_total: IntCounterVec,
+    pub list_stale_splits_duration_seconds: HistogramVec,
+}
+
+impl Default for MetastoreMetrics {
+    fn default() -> Self {
+        MetastoreMetrics {
+            create_index_requests_total: new_counter_vec(
+                "create_index_requests_total",
+                "Number of create index requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            create_index_errors_total: new_counter_vec(
+                "create_index_errors_total",
+                "Number of failed create index requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            create_index_duration_seconds: new_histogram_vec(
+                "create_index_duration_seconds",
+                "Duration of create index requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            index_exists_requests_total: new_counter_vec(
+                "index_exists_requests_total",
+                "Number of index exists requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            index_exists_errors_total: new_counter_vec(
+                "index_exists_errors_total",
+                "Number of failed index exists requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            index_exists_duration_seconds: new_histogram_vec(
+                "index_exists_duration_seconds",
+                "Duration of a index exists requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            index_metadata_requests_total: new_counter_vec(
+                "index_metadata_requests_total",
+                "Number of index metadata requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            index_metadata_errors_total: new_counter_vec(
+                "index_metadata_errors_total",
+                "Number of failed index metadata requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            index_metadata_duration_seconds: new_histogram_vec(
+                "index_metadata_duration_seconds",
+                "Duration of index metadata requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            list_indexes_metadatas_requests_total: new_counter_vec(
+                "list_indexes_metadatas_requests_total",
+                "Number of list indexes metadatas requests",
+                "quickwit_metastore",
+                &[],
+            ),
+            list_indexes_metadatas_errors_total: new_counter_vec(
+                "list_indexes_metadatas_errors_total",
+                "Number of failed list indexes metadatas requests",
+                "quickwit_metastore",
+                &[],
+            ),
+            list_indexes_metadatas_duration_seconds: new_histogram_vec(
+                "list_indexes_metadatas_duration_seconds",
+                "Duration of list indexes metadatas requests",
+                "quickwit_metastore",
+                &["error"],
+            ),
+
+            delete_index_requests_total: new_counter_vec(
+                "delete_index_requests_total",
+                "Number of delete index requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            delete_index_errors_total: new_counter_vec(
+                "delete_index_errors_total",
+                "Number of failed delete index requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            delete_index_duration_seconds: new_histogram_vec(
+                "delete_index_duration_seconds",
+                "Duration of delete index requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            stage_split_requests_total: new_counter_vec(
+                "stage_split_requests_total",
+                "Number of stage split requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            stage_split_errors_total: new_counter_vec(
+                "stage_split_errors_total",
+                "Number of failed stage split requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            stage_split_duration_seconds: new_histogram_vec(
+                "stage_split_duration_seconds",
+                "Duration of stage split requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            publish_splits_requests_total: new_counter_vec(
+                "publish_splits_requests_total",
+                "Number of publish splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            publish_splits_errors_total: new_counter_vec(
+                "publish_splits_errors_total",
+                "Number of failed publish splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            publish_splits_duration_seconds: new_histogram_vec(
+                "publish_splits_duration_seconds",
+                "Duration of publish splits requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            list_splits_requests_total: new_counter_vec(
+                "list_splits_requests_total",
+                "Number of list splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_splits_errors_total: new_counter_vec(
+                "list_splits_errors_total",
+                "Number of failed list splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_splits_duration_seconds: new_histogram_vec(
+                "list_splits_duration_seconds",
+                "Duration of list splits requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            list_all_splits_requests_total: new_counter_vec(
+                "list_all_splits_requests_total",
+                "Number of list all splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_all_splits_errors_total: new_counter_vec(
+                "list_all_splits_errors_total",
+                "Number of failed list all splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_all_splits_duration_seconds: new_histogram_vec(
+                "list_all_splits_duration_seconds",
+                "Duration of list all splits requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            mark_splits_for_deletion_requests_total: new_counter_vec(
+                "mark_splits_for_deletion_requests_total",
+                "Number of mark splits for deletion requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            mark_splits_for_deletion_errors_total: new_counter_vec(
+                "mark_splits_for_deletion_errors_total",
+                "Number of failed mark splits for deletion requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            mark_splits_for_deletion_duration_seconds: new_histogram_vec(
+                "mark_splits_for_deletion_duration_seconds",
+                "Duration of mark splits for deletion requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            delete_splits_requests_total: new_counter_vec(
+                "delete_splits_requests_total",
+                "Number of delete splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            delete_splits_errors_total: new_counter_vec(
+                "delete_splits_errors_total",
+                "Number of failed delete splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            delete_splits_duration_seconds: new_histogram_vec(
+                "delete_splits_duration_seconds",
+                "Duration of delete splits requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            add_source_requests_total: new_counter_vec(
+                "add_source_requests_total",
+                "Number of add source requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            add_source_errors_total: new_counter_vec(
+                "add_source_errors_total",
+                "Number of failed add source requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            add_source_duration_seconds: new_histogram_vec(
+                "add_source_duration_seconds",
+                "Duration of a add source requests",
+                "quickwit_metastore",
+                &["index", "source", "error"],
+            ),
+
+            toggle_source_requests_total: new_counter_vec(
+                "toggle_source_requests_total",
+                "Number of toggle source requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            toggle_source_errors_total: new_counter_vec(
+                "toggle_source_errors_total",
+                "Number of failed toggle source requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            toggle_source_duration_seconds: new_histogram_vec(
+                "toggle_source_duration_seconds",
+                "Duration of toggle source requests",
+                "quickwit_metastore",
+                &["index", "source", "error"],
+            ),
+
+            reset_source_checkpoint_requests_total: new_counter_vec(
+                "reset_source_checkpoint_requests_total",
+                "Number of reset source checkpoint requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            reset_source_checkpoint_errors_total: new_counter_vec(
+                "reset_source_checkpoint_errors_total",
+                "Number of failed reset source checkpoint requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            reset_source_checkpoint_duration_seconds: new_histogram_vec(
+                "reset_source_checkpoint_duration_seconds",
+                "Duration of reset source checkpoint requests",
+                "quickwit_metastore",
+                &["index", "source", "error"],
+            ),
+
+            delete_source_requests_total: new_counter_vec(
+                "delete_source_requests_total",
+                "Number of delete source requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            delete_source_errors_total: new_counter_vec(
+                "delete_source_errors_total",
+                "Number of failed delete source requests",
+                "quickwit_metastore",
+                &["index", "source"],
+            ),
+            delete_source_duration_seconds: new_histogram_vec(
+                "delete_source_duration_seconds",
+                "Duration of delete source requests",
+                "quickwit_metastore",
+                &["index", "source", "error"],
+            ),
+
+            create_delete_task_requests_total: new_counter_vec(
+                "create_delete_task_requests_total",
+                "Number of create delete task requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            create_delete_task_errors_total: new_counter_vec(
+                "create_delete_task_errors_total",
+                "Number of failed create delete task requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            create_delete_task_duration_seconds: new_histogram_vec(
+                "create_delete_task_duration_seconds",
+                "Duration of create delete task requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            list_delete_tasks_requests_total: new_counter_vec(
+                "list_delete_tasks_requests_total",
+                "Number of list delete tasks requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_delete_tasks_errors_total: new_counter_vec(
+                "list_delete_tasks_errors_total",
+                "Number of failed list delete tasks requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_delete_tasks_duration_seconds: new_histogram_vec(
+                "list_delete_tasks_duration_seconds",
+                "Duration of list delete tasks requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            last_delete_opstamp_requests_total: new_counter_vec(
+                "last_delete_opstamp_requests_total",
+                "Number of last delete opstamp requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            last_delete_opstamp_errors_total: new_counter_vec(
+                "last_delete_opstamp_errors_total",
+                "Number of failed last delete opstamp requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            last_delete_opstamp_duration_seconds: new_histogram_vec(
+                "last_delete_opstamp_duration_seconds",
+                "Duration of last delete opstamp requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            update_splits_delete_opstamp_requests_total: new_counter_vec(
+                "update_splits_delete_opstamp_requests_total",
+                "Number of update splits delete opstamp requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            update_splits_delete_opstamp_errors_total: new_counter_vec(
+                "update_splits_delete_opstamp_errors_total",
+                "Number of failed update splits delete opstamp requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            update_splits_delete_opstamp_duration_seconds: new_histogram_vec(
+                "update_splits_delete_opstamp_duration_seconds",
+                "Duration of a update splits delete opstamp requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+
+            list_stale_splits_requests_total: new_counter_vec(
+                "list_stale_splits_requests_total",
+                "Number of list stale splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_stale_splits_errors_total: new_counter_vec(
+                "list_stale_splits_errors_total",
+                "Number of failed list stale splits requests",
+                "quickwit_metastore",
+                &["index"],
+            ),
+            list_stale_splits_duration_seconds: new_histogram_vec(
+                "list_stale_splits_duration_seconds",
+                "Duration of list stale splits requests",
+                "quickwit_metastore",
+                &["index", "error"],
+            ),
+        }
+    }
+}
+
+/// `METASTORE_METRICS` exposes a bunch of metastore-related metrics through a Prometheus
+/// endpoint.
+pub static METASTORE_METRICS: Lazy<MetastoreMetrics> = Lazy::new(MetastoreMetrics::default);


### PR DESCRIPTION
### Description
- Counts the number of requests for each metastore call.
- Counts the number of failed calls
- Records the duration of the calls.
- Warn on slow call (1s threshold)

### How was this PR tested?
- Launched quickwit and visited `http://localhost:7280/metrics`
- Introduced some sleep statements here and there to test the slow call warning
- Introduced some errors to hit the error code path

```
2022-11-03T16:03:46.899Z  WARN quickwit_metastore::metastore::instrumented_metastore: Slow metastore operation. operation="index_metadata" duration_millis=5002 index_id="otel-trace-v0"
```