### PR TITLE
Remove sed commands from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,7 @@ RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CAR
     && mkdir -p /quickwit/bin \
     && find target/$CARGO_PROFILE -maxdepth 1 -perm /a+x -type f -exec mv {} /quickwit/bin \;
 
-# Change the default configuration file in order to make the REST,
-# gRPC, and gossip services accessible outside of Docker container.
 COPY config/quickwit.yaml /quickwit/config/quickwit.yaml
-RUN sed -i 's/#[ ]*listen_address: 127.0.0.1/listen_address: 0.0.0.0/g' config/quickwit.yaml
 
 
 FROM debian:bullseye-slim AS quickwit
@@ -69,6 +66,7 @@ COPY --from=builder /quickwit/config/quickwit.yaml /quickwit/config/quickwit.yam
 
 ENV QW_CONFIG=/quickwit/config/quickwit.yaml
 ENV QW_DATA_DIR=/quickwit/qwdata
+ENV QW_LISTEN_ADDRESS=0.0.0.0
 
 RUN quickwit --version
 

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -5,10 +5,6 @@ RUN tar -xzf quickwit-*-$(cat /etc/apk/arch)-unknown-linux-musl.tar.gz
 RUN mv ./quickwit-*/* ./
 RUN chmod 744 ./quickwit
 
-# Change the default configuration file in order to make the REST,
-# gRPC and gossip services accessible outside of Docker.
-RUN sed -i 's/#listen_address: 127.0.0.1/listen_address: 0.0.0.0/g' ./config/quickwit.yaml
-
 
 FROM alpine:3
 
@@ -24,5 +20,6 @@ COPY --from=builder /config/quickwit.yaml /quickwit/config/quickwit.yaml
 
 ENV QW_CONFIG=/quickwit/config/quickwit.yaml
 ENV QW_DATA_DIR=/quickwit/qwdata
+ENV QW_LISTEN_ADDRESS=0.0.0.0
 
 ENTRYPOINT ["/usr/local/bin/quickwit"]


### PR DESCRIPTION
### Description
Remove sed commands from Dockerfiles. We can use `QW_LISTEN_ADDRESS` directly.

### How was this PR tested?
```
docker build -t quickwit/quickwit:guilload .
docker run -it quickwit/quickwit:guilload run
2022-11-08T21:19:22.426Z  INFO quickwit_cli: Loaded Quickwit config. config_uri=file:///quickwit/config/quickwit.yaml config=QuickwitConfig { version: 0, cluster_id: "quickwit-default-cluster", node_id: "node-broken-VAOu", enabled_services: {Indexer, Searcher, Janitor, Metastore}, rest_listen_addr: 0.0.0.0:7280
```
