### PR TITLE
Fix failpoints / code cov

### DIFF
--- a/quickwit/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit/quickwit-indexing/failpoints/mod.rs
@@ -186,12 +186,8 @@ async fn aux_test_failpoints() -> anyhow::Result<()> {
     ];
     test_index_builder.add_documents(batch_1).await?;
     test_index_builder.add_documents(batch_2).await?;
-    let query = ListSplitsQuery::for_index(&index_id)
-        .with_split_state(SplitState::Published);
-    let mut splits = test_index_builder
-        .metastore()
-        .list_splits(query)
-        .await?;
+    let query = ListSplitsQuery::for_index(&index_id).with_split_state(SplitState::Published);
+    let mut splits = test_index_builder.metastore().list_splits(query).await?;
     splits.sort_by_key(|split| *split.split_metadata.time_range.clone().unwrap().start());
     assert_eq!(splits.len(), 2);
     assert_eq!(

--- a/quickwit/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit/quickwit-indexing/failpoints/mod.rs
@@ -48,7 +48,7 @@ use quickwit_indexing::actors::MergeExecutor;
 use quickwit_indexing::merge_policy::MergeOperation;
 use quickwit_indexing::models::{IndexingPipelineId, MergeScratch, ScratchDirectory};
 use quickwit_indexing::{get_tantivy_directory_from_split_bundle, TestSandbox};
-use quickwit_metastore::{Split, SplitMetadata, SplitState};
+use quickwit_metastore::{ListSplitsQuery, Split, SplitMetadata, SplitState};
 use tantivy::{Directory, Inventory};
 
 #[tokio::test]
@@ -186,9 +186,11 @@ async fn aux_test_failpoints() -> anyhow::Result<()> {
     ];
     test_index_builder.add_documents(batch_1).await?;
     test_index_builder.add_documents(batch_2).await?;
+    let query = ListSplitsQuery::for_index(&index_id)
+        .with_split_state(SplitState::Published);
     let mut splits = test_index_builder
         .metastore()
-        .list_splits(&index_id, SplitState::Published, None, None)
+        .list_splits(query)
         .await?;
     splits.sort_by_key(|split| *split.split_metadata.time_range.clone().unwrap().start());
     assert_eq!(splits.len(), 2);


### PR DESCRIPTION
The latest PR by me has inadvertently broken code cov because it uses the old version of `list_splits`, this wasn't picked up in CI because we don't seem to enable the feature. :(


