### PR TITLE
 Refactor `ClusterMember` and `Cluster::new`

### DIFF
--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -43,18 +43,18 @@ fn unix_timestamp() -> u64 {
 
 pub async fn start_cluster_service(
     quickwit_config: &QuickwitConfig,
-    services: &HashSet<QuickwitService>,
+    enabled_services: &HashSet<QuickwitService>,
 ) -> anyhow::Result<Arc<Cluster>> {
-    let member = ClusterMember::new(
+    let self_node = ClusterMember::new(
         quickwit_config.node_id.clone(),
         unix_timestamp(),
+        enabled_services.clone(),
         quickwit_config.gossip_advertise_addr,
-        services.clone(),
         quickwit_config.grpc_advertise_addr,
     );
 
     let cluster = Cluster::join(
-        member,
+        self_node,
         quickwit_config.gossip_listen_addr,
         quickwit_config.cluster_id.clone(),
         quickwit_config.peer_seed_addrs().await?,

--- a/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
@@ -541,7 +541,7 @@ fn get_metastore_grpc_addresses(members: &[ClusterMember]) -> HashSet<SocketAddr
         .iter()
         .filter(|member| {
             member
-                .available_services
+                .enabled_services
                 .contains(&QuickwitService::Metastore)
         })
         .map(|member| member.grpc_advertise_addr)
@@ -735,15 +735,15 @@ mod tests {
         let metastore_service_member = ClusterMember::new(
             "1".to_string(),
             0,
-            metastore_service_grpc_addr,
             HashSet::from([QuickwitService::Metastore, QuickwitService::Indexer]),
+            metastore_service_grpc_addr,
             metastore_service_grpc_addr,
         );
         let searcher_member = ClusterMember::new(
             "2".to_string(),
             0,
-            searcher_grpc_addr,
             HashSet::from([QuickwitService::Searcher]),
+            searcher_grpc_addr,
             searcher_grpc_addr,
         );
         let (members_tx, members_rx) =
@@ -808,22 +808,22 @@ mod tests {
         let metastore_member_1 = ClusterMember::new(
             "1".to_string(),
             0,
-            grpc_addr_1,
             HashSet::from([QuickwitService::Metastore]),
+            grpc_addr_1,
             grpc_addr_1,
         );
         let metastore_member_2 = ClusterMember::new(
             "2".to_string(),
             0,
-            grpc_addr_2,
             HashSet::from([QuickwitService::Metastore]),
+            grpc_addr_2,
             grpc_addr_2,
         );
         let metastore_member_3 = ClusterMember::new(
             "3".to_string(),
             0,
-            grpc_addr_3,
             HashSet::from([QuickwitService::Metastore]),
+            grpc_addr_3,
             grpc_addr_3,
         );
         let (members_tx, members_rx) =

--- a/quickwit/quickwit-search/src/search_client_pool.rs
+++ b/quickwit/quickwit-search/src/search_client_pool.rs
@@ -134,11 +134,7 @@ impl SearchClientPool {
     async fn update_members(&self, cluster_members: &[ClusterMember]) {
         let members_grpc_addrs = cluster_members
             .iter()
-            .filter(|member| {
-                member
-                    .available_services
-                    .contains(&QuickwitService::Searcher)
-            })
+            .filter(|member| member.enabled_services.contains(&QuickwitService::Searcher))
             .map(|member| member.grpc_advertise_addr)
             .collect_vec();
         let mut new_clients = self.clients();

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -93,7 +93,7 @@ struct QuickwitServices {
 fn has_node_with_metastore_service(members: &[ClusterMember]) -> bool {
     members.iter().any(|member| {
         member
-            .available_services
+            .enabled_services
             .contains(&QuickwitService::Metastore)
     })
 }


### PR DESCRIPTION
### Description
For the umpteenth time this year, I got confused between `node_id`, `node_unique_id`, `NodeId`, `generation`. `enabled_services` vs `available_services` in the cluster code, so I renamed a few attributes and added some comments here and there to hopefully make things easier to read and understand.

### How was this PR tested?
Test suite
