### PR TITLE
Reduce attack surface on the FileStorage.

### DIFF
--- a/quickwit/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit/quickwit-storage/src/local_file_storage.rs
@@ -21,7 +21,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::io::{ErrorKind, SeekFrom};
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -56,6 +56,11 @@ impl fmt::Debug for LocalFileStorage {
 }
 
 impl LocalFileStorage {
+    fn full_path(&self, relative_path: &Path) -> crate::StorageResult<PathBuf> {
+        ensure_valid_relative_path(relative_path)?;
+        Ok(self.root.join(relative_path))
+    }
+
     /// Creates a local file storage instance given a URI.
     pub fn from_uri(uri: &Uri) -> Result<Self, StorageResolverError> {
         uri.filepath()
@@ -71,7 +76,7 @@ impl LocalFileStorage {
     /// Moves a file from a source to a destination.
     /// from here is an external path, and to is an internal path.
     pub async fn move_into(&self, from_external: &Path, to: &Path) -> crate::StorageResult<()> {
-        let to_full_path = self.root.join(to);
+        let to_full_path = self.full_path(to)?;
         fs::rename(from_external, to_full_path).await?;
         Ok(())
     }
@@ -79,15 +84,47 @@ impl LocalFileStorage {
     /// Moves a file from a source to a destination.
     /// from here is an internal path, and to is an external path.
     pub async fn move_out(&self, from_internal: &Path, to: &Path) -> crate::StorageResult<()> {
-        let from_full_path = self.root.join(from_internal);
+        let from_full_path = self.full_path(from_internal)?;
         fs::rename(from_full_path, to).await?;
+        Ok(())
+    }
+
+    async fn delete_single_file(&self, relative_path: &Path) -> StorageResult<()> {
+        let full_path = self.full_path(relative_path)?;
+        ignore_error_kind!(ErrorKind::NotFound, fs::remove_file(full_path).await)?;
         Ok(())
     }
 }
 
+/// Ensure that the path given does not include any ".." for security reasons.
+///
+/// In order to reduce the attack surface, we want to make sure the `FileStorage`
+/// only access/delete files that are children of its root_directory.
+fn ensure_valid_relative_path(path: &Path) -> StorageResult<()> {
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::ParentDir | Component::Prefix(_) => {
+                // We forbid `Path` components that are breaking the assumption that
+                // root.join(path) is a child of root (if we omit fs links).
+                return Err(StorageErrorKind::Unauthorized.with_error(anyhow::anyhow!(
+                    "Path `{}` is forbidden. Only simple relative path are allowed.",
+                    path.display()
+                )));
+            }
+            Component::CurDir | Component::Normal(_) => {
+                // we accept `./` and subdir/
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Delete empty directories starting from `{root}/{path}` directory and stopping at `{root}`
 /// directory. Note that the `{root}` directory is not deleted.
-fn delete_all_dirs<'a>(root: &'a Path, path: &'a Path) -> BoxFuture<'a, std::io::Result<()>> {
+fn delete_all_dirs_if_empty<'a>(
+    root: &'a Path,
+    path: &'a Path,
+) -> BoxFuture<'a, std::io::Result<()>> {
     async move {
         let full_path = root.join(path);
         let path_entries_result = full_path.read_dir();
@@ -117,7 +154,7 @@ fn delete_all_dirs<'a>(root: &'a Path, path: &'a Path) -> BoxFuture<'a, std::io:
                 if path == &Path::new("") || path == &Path::new(".") {
                     return Ok(());
                 }
-                delete_all_dirs(root, path).await?;
+                delete_all_dirs_if_empty(root, path).await?;
             }
             _ => return Ok(()),
         }
@@ -142,7 +179,7 @@ impl Storage for LocalFileStorage {
         path: &Path,
         payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
-        let full_path = self.root.join(path);
+        let full_path = self.full_path(path)?;
         if let Some(parent_dir) = full_path.parent() {
             fs::create_dir_all(parent_dir).await?;
         }
@@ -155,14 +192,14 @@ impl Storage for LocalFileStorage {
     }
 
     async fn copy_to(&self, path: &Path, output: &mut dyn SendableAsync) -> StorageResult<()> {
-        let full_path = self.root.join(path);
+        let full_path = self.full_path(path)?;
         let mut file = tokio::fs::File::open(&full_path).await?;
         tokio::io::copy(&mut file, output).await?;
         Ok(())
     }
 
     async fn get_slice(&self, path: &Path, range: Range<usize>) -> StorageResult<OwnedBytes> {
-        let full_path = self.root.join(path);
+        let full_path = self.full_path(path)?;
         let mut file = fs::File::open(full_path).await?;
         file.seek(SeekFrom::Start(range.start as u64)).await?;
         let mut content_bytes: Vec<u8> = vec![0u8; range.len()];
@@ -171,10 +208,9 @@ impl Storage for LocalFileStorage {
     }
 
     async fn delete(&self, path: &Path) -> StorageResult<()> {
-        let full_path = self.root.join(path);
-        ignore_error_kind!(ErrorKind::NotFound, fs::remove_file(full_path).await)?;
+        self.delete_single_file(path).await?;
         if let Some(parent) = path.parent() {
-            if let Err(error) = delete_all_dirs(&self.root, parent).await {
+            if let Err(error) = delete_all_dirs_if_empty(&self.root, parent).await {
                 warn!(error=?error, path=%path.display(), "Failed to delete directory.");
             }
         }
@@ -189,19 +225,18 @@ impl Storage for LocalFileStorage {
         let mut failures = HashMap::new();
         let mut parent_paths = BTreeSet::new();
 
-        let futures = paths
+        let remove_file_res_futures: Vec<_> = paths
             .iter()
             .map(|path| async move {
-                let full_path = self.root.join(path);
-                let delete_res =
-                    ignore_error_kind!(ErrorKind::NotFound, fs::remove_file(full_path).await);
-                (path, delete_res)
+                let remove_file_res = self.delete_single_file(path).await;
+                (path, remove_file_res)
             })
-            .collect::<Vec<_>>();
-        let mut stream = futures::stream::iter(futures).buffer_unordered(10);
+            .collect();
 
-        while let Some((path, delete_res)) = stream.next().await {
-            match delete_res {
+        let mut stream = futures::stream::iter(remove_file_res_futures).buffer_unordered(10);
+
+        while let Some((path, remove_file_res)) = stream.next().await {
+            match remove_file_res {
                 Ok(_) => {
                     successes.push(path.to_path_buf());
 
@@ -211,7 +246,7 @@ impl Storage for LocalFileStorage {
                 }
                 Err(error) => {
                     let failure = DeleteFailure {
-                        error: Some(error.into()),
+                        error: Some(error),
                         ..Default::default()
                     };
                     failures.insert(path.to_path_buf(), failure);
@@ -222,7 +257,7 @@ impl Storage for LocalFileStorage {
         // Traverse the parent directories in reverse order, so that we delete the deepest ones
         // first.
         for parent_path in parent_paths.into_iter().rev() {
-            if let Err(error) = delete_all_dirs(&self.root, parent_path).await {
+            if let Err(error) = delete_all_dirs_if_empty(&self.root, parent_path).await {
                 warn!(error=?error, path=%parent_path.display(), "Failed to delete directory.");
             }
         }
@@ -237,7 +272,7 @@ impl Storage for LocalFileStorage {
     }
 
     async fn get_all(&self, path: &Path) -> StorageResult<OwnedBytes> {
-        let full_path = self.root.join(path);
+        let full_path = self.full_path(path)?;
         let content_bytes = fs::read(full_path).await.map_err(|err| {
             StorageError::from(err).add_context(format!(
                 "Failed to read file {}/{}",
@@ -253,7 +288,7 @@ impl Storage for LocalFileStorage {
     }
 
     async fn file_num_bytes(&self, path: &Path) -> StorageResult<u64> {
-        let full_path = self.root.join(path);
+        let full_path = self.full_path(path)?;
         match fs::metadata(full_path).await {
             Ok(metadata) => {
                 if metadata.is_file() {
@@ -306,6 +341,25 @@ mod tests {
         let mut local_file_storage = LocalFileStorage::from_uri(&uri)?;
         storage_test_suite(&mut local_file_storage).await?;
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_local_file_storage_forbids_double_dot() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let uri = Uri::from_str(&format!("{}", tempdir.path().display())).unwrap();
+        let local_file_storage = LocalFileStorage::from_uri(&uri).unwrap();
+        assert_eq!(
+            local_file_storage
+                .exists(Path::new("hello/toto"))
+                .await
+                .unwrap(),
+            false
+        );
+        let exist_error = local_file_storage
+            .exists(Path::new("hello/../toto"))
+            .await
+            .unwrap_err();
+        assert_eq!(exist_error.kind(), StorageErrorKind::Unauthorized);
     }
 
     #[test]
@@ -366,7 +420,7 @@ mod tests {
 
         // check all empty directory
         assert_eq!(dir_path.exists(), true);
-        delete_all_dirs(&path_root, dir_path.as_path()).await?;
+        delete_all_dirs_if_empty(&path_root, dir_path.as_path()).await?;
         assert_eq!(dir_path.exists(), false);
         assert_eq!(dir_path.parent().unwrap().exists(), false);
 
@@ -376,13 +430,13 @@ mod tests {
         tokio::fs::File::create(intermediate_file.clone()).await?;
         assert_eq!(dir_path.exists(), true);
         assert_eq!(intermediate_file.exists(), true);
-        delete_all_dirs(&path_root, dir_path.as_path()).await?;
+        delete_all_dirs_if_empty(&path_root, dir_path.as_path()).await?;
         assert_eq!(dir_path.exists(), false);
         assert_eq!(dir_path.parent().unwrap().exists(), true);
 
         // make sure it does not go beyond the path
         tokio::fs::create_dir_all(path_root.join("home/foo/bar")).await?;
-        delete_all_dirs(&path_root.join("home/foo"), Path::new("bar")).await?;
+        delete_all_dirs_if_empty(&path_root.join("home/foo"), Path::new("bar")).await?;
         assert_eq!(path_root.join("home/foo").exists(), true);
 
         Ok(())


### PR DESCRIPTION
We prevent people from using relative path including a `..` in the FileStorage.

Closes #53

