### PR TITLE
Refactor helpers in CLI test suite

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -127,20 +127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
-dependencies = [
- "bstr",
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,12 +1054,6 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenv"
@@ -3186,7 +3166,6 @@ name = "quickwit-cli"
 version = "0.3.1"
 dependencies = [
  "anyhow",
- "assert_cmd",
  "async-trait",
  "atty",
  "byte-unit",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -30,7 +30,6 @@ debug = 0
 anyhow = "1"
 arc-swap = "1.4"
 assert-json-diff = "2"
-assert_cmd = "2"
 async-speed-limit = "0.4"
 async-trait = "0.1"
 atty = "0.2"

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -68,7 +68,6 @@ quickwit-storage = { workspace = true }
 quickwit-telemetry = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = { workspace = true }
 predicates = { workspace = true }
 reqwest = { workspace = true }
 serial_test = { workspace = true }

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -73,12 +73,12 @@ async fn ingest_docs(input_path: &Path, test_env: &TestEnv) -> anyhow::Result<()
 #[test]
 fn test_cmd_help() {
     let cmd = build_cli();
-    let result = cmd
+    let error = cmd
         .clone()
-        .try_get_matches_from(vec![PACKAGE_BIN_NAME, "--help"]);
-    assert!(result.is_err());
+        .try_get_matches_from(vec![PACKAGE_BIN_NAME, "--help"])
+        .unwrap_err();
     // on `--help` clap returns an error.
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::DisplayHelp);
+    assert_eq!(error.kind(), ErrorKind::DisplayHelp);
 }
 
 #[tokio::test]
@@ -105,7 +105,7 @@ async fn test_cmd_create() {
 
     let index_metadata = test_env.index_metadata().await.unwrap();
     assert_eq!(index_metadata.index_id, test_env.index_id);
-    assert_eq!(index_metadata.index_uri, test_env.index_uri.as_ref());
+    assert_eq!(index_metadata.index_uri, test_env.index_uri);
 
     // Create non existing index with --overwrite.
     let index_id = append_random_suffix("test-create-non-existing-index-with-overwrite");
@@ -123,11 +123,11 @@ async fn test_cmd_create() {
 
     let index_metadata = test_env.index_metadata().await.unwrap();
     assert_eq!(index_metadata.index_id, test_env.index_id);
-    assert_eq!(index_metadata.index_uri, test_env.index_uri.as_ref());
+    assert_eq!(index_metadata.index_uri, test_env.index_uri);
 
     // Attempt to create with ill-formed new command.
-    let cmd = build_cli();
-    let result = cmd.try_get_matches_from(vec![PACKAGE_BIN_NAME, "index", "create"]);
+    let app = build_cli();
+    let result = app.try_get_matches_from(vec![PACKAGE_BIN_NAME, "index", "create"]);
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().kind(),

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -26,8 +26,9 @@ use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::Result;
+use clap::ErrorKind;
 use helpers::{TestEnv, TestStorageType};
-use predicates::prelude::*;
+use quickwit_cli::cli::build_cli;
 use quickwit_cli::index::{
     create_index_cli, delete_index_cli, garbage_collect_index_cli, ingest_docs_cli, search_index,
     CreateIndexArgs, DeleteIndexArgs, GarbageCollectIndexArgs, IngestDocsArgs, SearchIndexArgs,
@@ -44,116 +45,101 @@ use quickwit_metastore::{quickwit_metastore_uri_resolver, Metastore, MetastoreEr
 use serde_json::{json, Number, Value};
 use tokio::time::{sleep, Duration};
 
-use crate::helpers::{create_test_env, make_command, wait_port_ready};
+use crate::helpers::{create_test_env, wait_port_ready, PACKAGE_BIN_NAME};
 
-fn create_logs_index(test_env: &TestEnv) {
-    make_command(
-        format!(
-            "index create --index-config {} --config {}",
-            test_env.resource_files["index_config"].display(),
-            test_env.resource_files["config"].display(),
-        )
-        .as_str(),
-    )
-    .assert()
-    .success();
+async fn create_logs_index(test_env: &TestEnv) -> anyhow::Result<()> {
+    let args = CreateIndexArgs {
+        config_uri: test_env.config_uri.clone(),
+        index_config_uri: test_env.index_config_uri.clone(),
+        overwrite: false,
+        assume_yes: true,
+    };
+
+    create_index_cli(args).await
 }
 
-fn ingest_docs_with_options(input_path: &Path, test_env: &TestEnv, options: &str) {
-    make_command(
-        format!(
-            "index ingest --index {} --input-path {} --config {} {}",
-            test_env.index_id,
-            input_path.display(),
-            test_env.resource_files["config"].display(),
-            options
-        )
-        .as_str(),
-    )
-    .assert()
-    .success()
-    .stdout(predicate::str::contains("Indexed"))
-    .stdout(predicate::str::contains("documents in"))
-    .stdout(predicate::str::contains(
-        "Now, you can query the index with",
-    ));
-}
+async fn ingest_docs(input_path: &Path, test_env: &TestEnv) -> anyhow::Result<()> {
+    let args = IngestDocsArgs {
+        config_uri: test_env.config_uri.clone(),
+        index_id: test_env.index_id.clone(),
+        input_path_opt: Some(input_path.to_path_buf()),
+        overwrite: false,
+        clear_cache: true,
+    };
 
-fn ingest_docs(input_path: &Path, test_env: &TestEnv) {
-    ingest_docs_with_options(input_path, test_env, "");
+    ingest_docs_cli(args).await
 }
 
 #[test]
-fn test_cmd_help() -> anyhow::Result<()> {
-    let mut cmd = make_command("--help");
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("USAGE"));
-    Ok(())
+fn test_cmd_help() {
+    let cmd = build_cli();
+    let result = cmd
+        .clone()
+        .try_get_matches_from(vec![PACKAGE_BIN_NAME, "--help"]);
+    assert!(result.is_err());
+    // on `--help` clap returns an error.
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[tokio::test]
-async fn test_cmd_create() -> Result<()> {
+async fn test_cmd_create() {
     let index_id = append_random_suffix("test-create-cmd");
-    let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
-    create_logs_index(&test_env);
-    let index_metadata = test_env
-        .metastore()
-        .await?
-        .index_metadata(&test_env.index_id)
-        .await
-        .unwrap();
+    let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem).unwrap();
+    create_logs_index(&test_env).await.unwrap();
+    let index_metadata = test_env.index_metadata().await.unwrap();
     assert_eq!(index_metadata.index_id, test_env.index_id);
 
     // Create without giving `index-uri`.
     let index_id = append_random_suffix("test-create-cmd-no-index-uri");
-    let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
-    make_command(
-        format!(
-            "index create --index-config {} --config {}",
-            test_env.resource_files["index_config_without_uri"].display(),
-            test_env.resource_files["config"].display(),
-        )
-        .as_str(),
-    )
-    .assert()
-    .success();
-    let index_metadata = test_env
-        .metastore()
-        .await?
-        .index_metadata(&test_env.index_id)
-        .await
-        .unwrap();
+    let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem).unwrap();
+
+    let index_config_without_uri = Uri::from_str(&test_env.index_config_without_uri()).unwrap();
+    let args = CreateIndexArgs {
+        config_uri: test_env.config_uri.clone(),
+        index_config_uri: index_config_without_uri,
+        overwrite: false,
+        assume_yes: true,
+    };
+
+    create_index_cli(args).await.unwrap();
+
+    let index_metadata = test_env.index_metadata().await.unwrap();
     assert_eq!(index_metadata.index_id, test_env.index_id);
     assert_eq!(index_metadata.index_uri, test_env.index_uri.as_ref());
 
     // Create non existing index with --overwrite.
     let index_id = append_random_suffix("test-create-non-existing-index-with-overwrite");
-    let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
-    make_command(
-        format!(
-            "index create --index-config {} --config {} --overwrite -y",
-            test_env.resource_files["index_config_without_uri"].display(),
-            test_env.resource_files["config"].display(),
-        )
-        .as_str(),
-    )
-    .assert()
-    .success();
+    let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem).unwrap();
+
+    let index_config_without_uri = Uri::from_str(&test_env.index_config_without_uri()).unwrap();
+    let args = CreateIndexArgs {
+        config_uri: test_env.config_uri.clone(),
+        index_config_uri: index_config_without_uri,
+        overwrite: true,
+        assume_yes: true,
+    };
+
+    create_index_cli(args).await.unwrap();
+
+    let index_metadata = test_env.index_metadata().await.unwrap();
+    assert_eq!(index_metadata.index_id, test_env.index_id);
+    assert_eq!(index_metadata.index_uri, test_env.index_uri.as_ref());
 
     // Attempt to create with ill-formed new command.
-    make_command("index create")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("--index-config <INDEX_CONFIG>"));
-    Ok(())
+    let cmd = build_cli();
+    let result = cmd.try_get_matches_from(vec![PACKAGE_BIN_NAME, "index", "create"]);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().kind(),
+        ErrorKind::MissingRequiredArgument
+    );
 }
 
 #[tokio::test]
 async fn test_cmd_create_on_existing_index() {
     let index_id = append_random_suffix("test-create-cmd--index-already-exists");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
     let args = CreateIndexArgs {
         config_uri: test_env.config_uri,
@@ -196,7 +182,7 @@ async fn test_cmd_ingest_on_non_existing_index() {
 async fn test_cmd_ingest_on_non_existing_file() {
     let index_id = append_random_suffix("test-new-cmd--file-does-not-exist");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
     let args = IngestDocsArgs {
         config_uri: test_env.config_uri,
@@ -220,7 +206,7 @@ async fn test_cmd_ingest_on_non_existing_file() {
 async fn test_ingest_docs_cli_keep_cache() {
     let index_id = append_random_suffix("test-index-keep-cache");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
     let args = IngestDocsArgs {
         config_uri: test_env.config_uri,
@@ -240,7 +226,7 @@ async fn test_ingest_docs_cli_keep_cache() {
 async fn test_ingest_docs_cli() {
     let index_id = append_random_suffix("test-index-simple");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
     let args = IngestDocsArgs {
         config_uri: test_env.config_uri.clone(),
@@ -273,9 +259,11 @@ async fn test_ingest_docs_cli() {
 async fn test_cmd_search_aggregation() -> Result<()> {
     let index_id = append_random_suffix("test-search-cmd");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     let aggregation: Value = json!(
     {
@@ -363,9 +351,11 @@ async fn test_cmd_search_aggregation() -> Result<()> {
 async fn test_cmd_search_with_snippets() -> Result<()> {
     let index_id = append_random_suffix("test-search-cmd");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     // search with snippets
     let args = SearchIndexArgs {
@@ -402,7 +392,7 @@ async fn test_cmd_search_with_snippets() -> Result<()> {
 async fn test_search_index_cli() {
     let index_id = append_random_suffix("test-search-cmd");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
     let create_search_args = |query: &str| SearchIndexArgs {
         config_uri: test_env.config_uri.clone(),
@@ -418,7 +408,9 @@ async fn test_search_index_cli() {
         sort_by_score: false,
     };
 
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     let args = create_search_args("level:info");
 
@@ -445,7 +437,7 @@ async fn test_search_index_cli() {
 async fn test_delete_index_cli_dry_run() {
     let index_id = append_random_suffix("test-delete-cmd--dry-run");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
     let refresh_metastore = |metastore| {
         // In this test we rely on the file backed metastore
@@ -477,7 +469,9 @@ async fn test_delete_index_cli_dry_run() {
     let metastore = refresh_metastore(metastore).await.unwrap();
     assert!(metastore.index_exists(&index_id).await.unwrap());
 
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     // On non-empty index
     let args = create_delete_args(true);
@@ -498,9 +492,11 @@ async fn test_delete_index_cli_dry_run() {
 async fn test_delete_index_cli() {
     let index_id = append_random_suffix("test-delete-cmd");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     let args = DeleteIndexArgs {
         config_uri: test_env.config_uri.clone(),
@@ -530,8 +526,10 @@ async fn test_delete_index_cli() {
 async fn test_garbage_collect_cli_no_grace() {
     let index_id = append_random_suffix("test-gc-cmd--no-grace-period");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    create_logs_index(&test_env).await.unwrap();
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     let metastore = quickwit_metastore_uri_resolver()
         .resolve(&test_env.metastore_uri)
@@ -620,8 +618,10 @@ async fn test_garbage_collect_cli_no_grace() {
 async fn test_garbage_collect_index_cli() {
     let index_id = append_random_suffix("test-gc-cmd");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    create_logs_index(&test_env).await.unwrap();
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     let refresh_metastore = |metastore| {
         // In this test we rely on the file backed metastore and
@@ -716,7 +716,7 @@ async fn test_all_local_index() {
     quickwit_common::setup_logging_for_tests();
     let index_id = append_random_suffix("test-all");
     let test_env = create_test_env(index_id.clone(), TestStorageType::LocalFileSystem).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
     let metadata_file_exists = test_env
         .storage
@@ -725,7 +725,9 @@ async fn test_all_local_index() {
         .unwrap();
     assert!(metadata_file_exists);
 
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     // serve & api-search
     let run_cli_command = RunCliCommand {
@@ -790,9 +792,11 @@ async fn test_all_local_index() {
 async fn test_all_with_s3_localstack_cli() {
     let index_id = append_random_suffix("test-all--cli-s3-localstack");
     let test_env = create_test_env(index_id.clone(), TestStorageType::S3).unwrap();
-    create_logs_index(&test_env);
+    create_logs_index(&test_env).await.unwrap();
 
-    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
+        .await
+        .unwrap();
 
     // Cli search
     let args = SearchIndexArgs {


### PR DESCRIPTION
This PR finalizes the CLI test suite. With this PR, tests no longer spawn separate processes.

- Refactored `create_logs_index` and `ingest_docs` to run CLI functions.
- Refactored `test_cmd_create`
- Refactored `test_cmd_help`
- Added some helper methods to `TestEnv`
- Removed `assert_cmd` dependency
