### PR TITLE
QW-2281: Fix timestamp filters for PSQL

### DIFF
--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -1517,7 +1517,7 @@ pub mod test_suite {
         let _ = tracing_subscriber::fmt::try_init();
         let metastore = MetastoreToTest::default_for_test().await;
 
-        let initial_timestamp = OffsetDateTime::now_utc().unix_timestamp();
+        let current_timestamp = OffsetDateTime::now_utc().unix_timestamp();
 
         let index_id = "list-splits-index";
         let index_uri = format!("ram://indexes/{index_id}");
@@ -1532,8 +1532,8 @@ pub mod test_suite {
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(0..=99),
+            create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:foo", "tag:bar"]),
-            create_timestamp: initial_timestamp,
             delete_opstamp: 3,
             ..Default::default()
         };
@@ -1546,8 +1546,8 @@ pub mod test_suite {
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(100..=199),
+            create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:bar"]),
-            create_timestamp: initial_timestamp,
             delete_opstamp: 1,
             ..Default::default()
         };
@@ -1560,8 +1560,8 @@ pub mod test_suite {
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(200..=299),
+            create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:foo", "tag:baz"]),
-            create_timestamp: initial_timestamp,
             delete_opstamp: 5,
             ..Default::default()
         };
@@ -1587,8 +1587,8 @@ pub mod test_suite {
             num_docs: 1,
             uncompressed_docs_size_in_bytes: 2,
             time_range: None,
+            create_timestamp: current_timestamp,
             tags: to_set(&["tag!", "tag:baz", "tag:biz"]),
-            create_timestamp: initial_timestamp,
             delete_opstamp: 9,
             ..Default::default()
         };
@@ -2072,7 +2072,7 @@ pub mod test_suite {
             );
 
             let query =
-                ListSplitsQuery::for_index(index_id).with_update_timestamp_gte(initial_timestamp);
+                ListSplitsQuery::for_index(index_id).with_update_timestamp_gte(current_timestamp);
             let splits = metastore.list_splits(query).await.unwrap();
             let split_ids: HashSet<String> = splits
                 .into_iter()

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2092,6 +2092,15 @@ pub mod test_suite {
 
             let select_timestamp = OffsetDateTime::now_utc().unix_timestamp() - 1;
             let query =
+                ListSplitsQuery::for_index(index_id).with_update_timestamp_gte(select_timestamp);
+            let splits = metastore.list_splits(query).await.unwrap();
+            let split_ids: HashSet<String> = splits
+                .into_iter()
+                .map(|meta| meta.split_id().to_string())
+                .collect();
+            assert_eq!(split_ids, to_hash_set(&["list-splits-six"]));
+
+            let query =
                 ListSplitsQuery::for_index(index_id).with_create_timestamp_lte(select_timestamp);
             let splits = metastore.list_splits(query).await.unwrap();
             let split_ids: HashSet<String> = splits

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -1533,6 +1533,7 @@ pub mod test_suite {
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(0..=99),
             tags: to_set(&["tag!", "tag:foo", "tag:bar"]),
+            create_timestamp: initial_timestamp,
             delete_opstamp: 3,
             ..Default::default()
         };
@@ -1546,6 +1547,7 @@ pub mod test_suite {
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(100..=199),
             tags: to_set(&["tag!", "tag:bar"]),
+            create_timestamp: initial_timestamp,
             delete_opstamp: 1,
             ..Default::default()
         };
@@ -1559,6 +1561,7 @@ pub mod test_suite {
             uncompressed_docs_size_in_bytes: 2,
             time_range: Some(200..=299),
             tags: to_set(&["tag!", "tag:foo", "tag:baz"]),
+            create_timestamp: initial_timestamp,
             delete_opstamp: 5,
             ..Default::default()
         };
@@ -1585,6 +1588,7 @@ pub mod test_suite {
             uncompressed_docs_size_in_bytes: 2,
             time_range: None,
             tags: to_set(&["tag!", "tag:baz", "tag:biz"]),
+            create_timestamp: initial_timestamp,
             delete_opstamp: 9,
             ..Default::default()
         };
@@ -2006,6 +2010,8 @@ pub mod test_suite {
                 .collect();
             assert_eq!(split_ids, to_hash_set(&["list-splits-five"]));
 
+            // Artificially increase the create_timestamp
+            sleep(Duration::from_secs(2)).await;
             // add a split without tag
             let split_metadata_6 = SplitMetadata {
                 footer_offsets: 1000..2000,
@@ -2015,11 +2021,10 @@ pub mod test_suite {
                 num_docs: 1,
                 uncompressed_docs_size_in_bytes: 2,
                 time_range: None,
+                create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
                 tags: to_set(&[]),
                 ..Default::default()
             };
-            // Artificially increase the create_timestamp
-            sleep(Duration::from_secs_f64(1.5)).await;
             metastore
                 .stage_split(index_id, split_metadata_6.clone())
                 .await


### PR DESCRIPTION
Fixes #2281 

This fixes the bug introduced by #2152 and adds unit tests to prevent this error from re-occurring. 
