### PR TITLE
Remove all `splits` table triggers from the Postgres metastore. 

### DIFF
--- a/quickwit/quickwit-metastore/migrations/postgresql/7_delete-split-table-triggers.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/7_delete-split-table-triggers.up.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS set_split_publish_timestamp_on_split_publish ON splits CASCADE;
+DROP TRIGGER IF EXISTS set_update_timestamp ON splits CASCADE;

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -177,7 +177,10 @@ async fn mark_splits_as_published_helper(
     let published_split_ids: Vec<String> = sqlx::query(
         r#"
         UPDATE splits
-        SET split_state = $1
+        SET
+            split_state = $1,
+            update_timestamp = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+            publish_timestamp = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
         WHERE
                 index_id = $2
             AND split_id = ANY($3)

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -939,6 +939,7 @@ impl Metastore for PostgresqlMetastore {
                 UPDATE splits
                 SET
                     delete_opstamp = $1,
+                    -- The values we compare with are *before* the modification:
                     update_timestamp = CASE
                         WHEN delete_opstamp != $1 THEN (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
                         ELSE update_timestamp


### PR DESCRIPTION
While testing and profiling queries on a large database, I notice we still have a few triggers on the splits table that add some additional overhead to each update we perform on the table, although the overhead is not extreme, it is not minimal either.

This PR removes the triggers as we can perform all of the trigger's functions as part of the queries invoking the trigger, some of the logic with the `CASE` statements are probably unnecessary depending on the desired behaviour we want, but I thought it's best not to change the behaviour in this PR. 

