### PR TITLE
QW-2273: Add the ability to disable ANSI terminal codes in logging.

### DIFF
--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -40,9 +40,12 @@ pub fn build_cli<'a>() -> Command<'a> {
         )
         .arg(
             Arg::new("no-ansi")
-                .long("no-ansi-logging")
-                .help("Disable ANSI terminal codes being injected into the logging output")
-                .env("QW_NO_ANSI_LOGGING")
+                .long("no-color")
+                .help(
+                    "Disable ANSI terminal codes (colors, etc...) being injected into the logging \
+                     output",
+                )
+                .env("NO_COLOR")
                 .global(true)
                 .display_order(2)
                 .takes_value(false),

--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -41,10 +41,7 @@ pub fn build_cli<'a>() -> Command<'a> {
         .arg(
             Arg::new("no-ansi")
                 .long("no-ansi-logging")
-                .help(
-                    "Disable ANSI terminal codes. This is useful for logging to a file, reducing \
-                     noise",
-                )
+                .help("Disable ANSI terminal codes being injected into the logging output")
                 .env("QW_NO_ANSI_LOGGING")
                 .global(true)
                 .display_order(2)

--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -39,7 +39,7 @@ pub fn build_cli<'a>() -> Command<'a> {
                 .display_order(1),
         )
         .arg(
-            Arg::new("no-ansi")
+            Arg::new("no-color")
                 .long("no-color")
                 .help(
                     "Disable ANSI terminal codes (colors, etc...) being injected into the logging \

--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -40,7 +40,7 @@ pub fn build_cli<'a>() -> Command<'a> {
         )
         .arg(
             Arg::new("no-ansi")
-                .long("no-ansi")
+                .long("no-ansi-logging")
                 .help(
                     "Disable ANSI terminal codes. This is useful for logging to a file, reducing \
                      noise",

--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -38,6 +38,18 @@ pub fn build_cli<'a>() -> Command<'a> {
                 .global(true)
                 .display_order(1),
         )
+        .arg(
+            Arg::new("no-ansi")
+                .long("no-ansi")
+                .help(
+                    "Disable ANSI terminal codes. This is useful for logging to a file, reducing \
+                     noise",
+                )
+                .env("QW_NO_ANSI_LOGGING")
+                .global(true)
+                .display_order(2)
+                .takes_value(false),
+        )
         .subcommand(build_run_command().display_order(1))
         .subcommand(build_index_command().display_order(2))
         .subcommand(build_source_command().display_order(3))

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -38,7 +38,11 @@ use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
-fn setup_logging_and_tracing(level: Level, build_info: &QuickwitBuildInfo) -> anyhow::Result<()> {
+fn setup_logging_and_tracing(
+    level: Level,
+    ansi: bool,
+    build_info: &QuickwitBuildInfo,
+) -> anyhow::Result<()> {
     #[cfg(feature = "tokio-console")]
     {
         if std::env::var_os(quickwit_cli::QW_ENABLE_TOKIO_CONSOLE_ENV_KEY).is_some() {
@@ -54,6 +58,7 @@ fn setup_logging_and_tracing(level: Level, build_info: &QuickwitBuildInfo) -> an
     let registry = tracing_subscriber::registry().with(env_filter);
     let event_format = tracing_subscriber::fmt::format()
         .with_target(true)
+        .with_ansi(ansi)
         .with_timer(
             // We do not rely on the Rfc3339 implementation, because it has a nanosecond precision.
             // See discussion here: https://github.com/time-rs/time/discussions/418
@@ -130,7 +135,11 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "jemalloc")]
     start_jemalloc_metrics_loop();
 
-    setup_logging_and_tracing(command.default_log_level(), &build_info)?;
+    setup_logging_and_tracing(
+        command.default_log_level(),
+        !matches.is_present("no-ansi"),
+        &build_info,
+    )?;
     info!(
         version = build_info.version,
         commit = build_info.commit_short_hash,

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -137,7 +137,7 @@ async fn main() -> anyhow::Result<()> {
 
     setup_logging_and_tracing(
         command.default_log_level(),
-        !matches.is_present("no-ansi"),
+        !matches.is_present("no-color"),
         &build_info,
     )?;
     info!(


### PR DESCRIPTION
This adds the ability to pass a `--no-ansi-logging` flag or `QW_NO_ANSI_LOGGING` environment variable in order to disable tracing_subscriber from injecting ANSI terminal codes, reducing the noise when logging to things like files which do not support rendering the codes. 