### PR TITLE
Remove transaction from `stage_split`

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -112,20 +112,25 @@ impl PostgresqlMetastore {
         })
     }
 
+    /// This function attempts to update an index update timestamp. Since we call this method after
+    /// a successful update of splits or delete tasks, we never return an error to not mislead the
+    /// clients into believing that the update failed. We log the error instead.
     #[instrument(skip(self))]
-    async fn update_index_update_timestamp(&self, index_id: &str) -> MetastoreResult<()> {
-        let mut conn = self.connection_pool.acquire().await?;
-        sqlx::query(
+    async fn update_index_update_timestamp(&self, index_id: &str) {
+        let update_res = sqlx::query(
             r#"
-                UPDATE indexes
+            UPDATE indexes
             SET update_timestamp = current_timestamp
             WHERE index_id = $1;
             "#,
         )
         .bind(index_id)
-        .execute(&mut conn)
-        .await?;
-        Ok(())
+        .execute(&self.connection_pool)
+        .await;
+
+        if let Err(error) = update_res {
+            warn!(error=?error, "Failed to update index update timestamp.");
+        }
     }
 }
 
@@ -636,7 +641,7 @@ impl Metastore for PostgresqlMetastore {
             debug!(index_id=?index_id, split_id=?split_id, "The split has been staged");
             Ok(())
         })?;
-        self.update_index_update_timestamp(index_id).await?;
+        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -702,7 +707,7 @@ impl Metastore for PostgresqlMetastore {
             }
             Ok(())
         })?;
-        self.update_index_update_timestamp(index_id).await?;
+        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -743,7 +748,7 @@ impl Metastore for PostgresqlMetastore {
                 cause: "".to_string(),
             })
         })?;
-        self.update_index_update_timestamp(index_id).await?;
+        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -785,7 +790,7 @@ impl Metastore for PostgresqlMetastore {
                 split_ids: not_deletable_ids,
             })
         })?;
-        self.update_index_update_timestamp(index_id).await?;
+        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -946,7 +951,7 @@ impl Metastore for PostgresqlMetastore {
             }
             Ok(())
         })?;
-        self.update_index_update_timestamp(index_id).await?;
+        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 


### PR DESCRIPTION
### Description
- Remove transaction from `stage_split`
- Fix `update_index_update_timestamp`

### How was this PR tested?
Replayed gRPC requests and observed a 20-15s second improvement (70-75s vs. 90-100s)
