### PR TITLE
Set up build info in Docker env

### DIFF
--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -3,10 +3,12 @@ name: Build and publish Docker images
 on:
   push:
     branches:
-      - "main"
+      - main
     tags:
-      - "v*"
-      - "happy-plazza"
+      - airmail
+      - happy-plazza
+      - qw*
+      - v*
 
 jobs:
   docker:
@@ -45,10 +47,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
+      - name: Retrieve commit date, hash, and tags
+        run: |
+          echo "QW_COMMIT_DATE=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+          echo "QW_COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "QW_COMMIT_TAGS=$(git tag --points-at HEAD | tr '\n' ',')" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
+          build-args: |
+            QW_COMMIT_DATE=${{ env.QW_COMMIT_DATE }}
+            QW_COMMIT_HASH=${{ env.QW_COMMIT_HASH }}
+            QW_COMMIT_TAGS=${{ env.QW_COMMIT_TAGS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,14 @@ FROM rust:bullseye AS builder
 
 ARG CARGO_FEATURES=release-feature-set
 ARG CARGO_PROFILE=release
+ARG QW_COMMIT_DATE
+ARG QW_COMMIT_HASH
+ARG QW_COMMIT_TAGS
+
+ENV QW_COMMIT_DATE=$QW_COMMIT_DATE
+ENV QW_COMMIT_HASH=$QW_COMMIT_HASH
+ENV QW_COMMIT_TAGS=$QW_COMMIT_TAGS
+
 
 RUN echo "Adding Node.js PPA" \
     && curl -s https://deb.nodesource.com/setup_16.x | bash

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,20 @@ QUICKWIT_SRC = quickwit
 help:
 	@grep '^[^\.#[:space:]].*:' Makefile
 
+
+IMAGE_TAG := $(shell git branch --show-current | tr '\#/' '-')
+
+QW_COMMIT_DATE := $(shell TZ=UTC0 git log -1 --format=%cd --date=format-local:'%Y-%m-%dT%H:%M:%SZ')
+QW_COMMIT_HASH := $(shell git rev-parse HEAD)
+QW_COMMIT_TAGS := $(shell git tag --points-at HEAD | tr '\n' ',')
+
+docker-build:
+	@docker build \
+		--build-arg QW_COMMIT_DATE=$(QW_COMMIT_DATE) \
+		--build-arg QW_COMMIT_HASH=$(QW_COMMIT_HASH) \
+		--build-arg QW_COMMIT_TAGS=$(QW_COMMIT_TAGS) \
+		-t quickwit/quickwit:$(IMAGE_TAG) .
+
 # Usage:
 # `make docker-compose-up` starts all the services.
 # `make docker-compose-up DOCKER_SERVICES='jaeger,localstack'` starts the subset of services matching the profiles.
@@ -19,10 +33,10 @@ docker-compose-logs:
 	docker compose logs -f -t
 
 fmt:
-	$(MAKE) -C $(QUICKWIT_SRC) fmt
+	@$(MAKE) -C $(QUICKWIT_SRC) fmt
 
-fix: fmt
-	$(MAKE) -C $(QUICKWIT_SRC) fix
+fix:
+	@$(MAKE) -C $(QUICKWIT_SRC) fix
 
 # Usage:
 # `make test-all` starts the Docker services and runs all the tests.

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3642,6 +3642,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
+ "time 0.3.15",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -151,7 +151,7 @@ thiserror = "1"
 thousands = "0.2.0"
 tikv-jemalloc-ctl = "0.5"
 tikv-jemallocator = "0.5"
-time = { version = "0.3.7", features = ["std", "macros"] }
+time = { version = "0.3.7", features = ["std", "formatting", "macros"] }
 tokio = { version = "^1.21", features = ["full", "test-util"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["full"] }

--- a/quickwit/Makefile
+++ b/quickwit/Makefile
@@ -9,7 +9,7 @@ fmt:
 
 fix: fmt
 	@echo "Running cargo clippy --fix"
-	cargo clippy --fix --all-features --allow-dirty --allow-staged
+	@cargo clippy --fix --all-features --allow-dirty --allow-staged
 
 # Usage:
 # `make test-all` starts the Docker services and runs all the tests.

--- a/quickwit/quickwit-cli/src/generate_markdown.rs
+++ b/quickwit/quickwit-cli/src/generate_markdown.rs
@@ -19,12 +19,12 @@
 
 use clap::Command;
 use quickwit_cli::cli::build_cli;
-use quickwit_serve::build_quickwit_build_info;
+use quickwit_serve::quickwit_build_info;
 use toml::Value;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let build_info = build_quickwit_build_info();
+    let build_info = quickwit_build_info();
     let version_text = format!(
         "{} ({} {})",
         build_info.cargo_pkg_version, build_info.cargo_pkg_version, build_info.commit_date,

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -30,7 +30,7 @@ use quickwit_cli::jemalloc::start_jemalloc_metrics_loop;
 use quickwit_cli::{
     QW_ENABLE_JAEGER_EXPORTER_ENV_KEY, QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER_ENV_KEY,
 };
-use quickwit_serve::{build_quickwit_build_info, QuickwitBuildInfo};
+use quickwit_serve::{quickwit_build_info, QuickwitBuildInfo};
 use quickwit_telemetry::payload::TelemetryEvent;
 use tonic::metadata::MetadataMap;
 use tracing::{info, Level};
@@ -117,11 +117,11 @@ async fn main() -> anyhow::Result<()> {
 
     let telemetry_handle = quickwit_telemetry::start_telemetry_loop();
     let about_text = about_text();
-    let build_info = build_quickwit_build_info();
+    let build_info = quickwit_build_info();
 
     let app = build_cli()
         .about(about_text.as_str())
-        .version(build_info.version);
+        .version(build_info.version.as_str());
     let matches = app.get_matches();
 
     let command = match CliCommand::parse_cli_args(&matches) {
@@ -138,7 +138,7 @@ async fn main() -> anyhow::Result<()> {
     setup_logging_and_tracing(
         command.default_log_level(),
         !matches.is_present("no-color"),
-        &build_info,
+        build_info,
     )?;
     info!(
         version = build_info.version,

--- a/quickwit/quickwit-serve/Cargo.toml
+++ b/quickwit/quickwit-serve/Cargo.toml
@@ -50,6 +50,9 @@ quickwit-proto = { workspace = true }
 quickwit-search = { workspace = true }
 quickwit-storage = { workspace = true }
 
+[build-dependencies]
+time = { workspace = true }
+
 [dev-dependencies]
 assert-json-diff = { workspace = true }
 chitchat = { workspace = true }

--- a/quickwit/quickwit-serve/build.rs
+++ b/quickwit/quickwit-serve/build.rs
@@ -20,26 +20,38 @@
 use std::env;
 use std::process::Command;
 
-const NONE: &str = "none";
-
-const UNKNOWN: &str = "unknown";
+use time::macros::format_description;
+use time::OffsetDateTime;
 
 fn main() {
-    commit_info();
     println!(
-        "cargo:rustc-env=CARGO_BUILD_TARGET={}",
+        "cargo:rustc-env=BUILD_DATE={}",
+        OffsetDateTime::now_utc()
+            .format(format_description!(
+                "[year]-[month]-[day]T[hour]:[minute]:[second]Z"
+            ))
+            .unwrap()
+    );
+    println!(
+        "cargo:rustc-env=BUILD_PROFILE={}",
+        env::var("PROFILE").unwrap()
+    );
+    println!(
+        "cargo:rustc-env=BUILD_TARGET={}",
         env::var("TARGET").unwrap()
     );
+    commit_info();
 }
 
+/// Extracts commit date, hash, and tags
 fn commit_info() {
-    // Extract commit hash and date
+    // Extract commit date and hash.
     let output_bytes = match Command::new("git")
         .arg("log")
         .arg("-1")
-        .arg("--date=short")
-        .arg("--format=%H %h %cd")
-        .arg("--abbrev=9")
+        .arg("--format=%cd %H")
+        .arg("--date=format-local:%Y-%m-%dT%H:%M:%SZ")
+        .env("TZ", "UTC0")
         .output()
     {
         Ok(output) if output.status.success() => output.stdout,
@@ -47,12 +59,15 @@ fn commit_info() {
     };
     let output = String::from_utf8(output_bytes).unwrap();
     let mut parts = output.split_whitespace();
-    let mut next = || parts.next().unwrap_or(UNKNOWN);
-    println!("cargo:rustc-env=QW_COMMIT_HASH={}", next());
-    println!("cargo:rustc-env=QW_COMMIT_SHORT_HASH={}", next());
-    println!("cargo:rustc-env=QW_COMMIT_DATE={}", next());
 
-    // Extract commit version tag
+    if let Some(commit_date) = parts.next() {
+        println!("cargo:rustc-env=QW_COMMIT_DATE={commit_date}");
+    }
+    if let Some(commit_hash) = parts.next() {
+        println!("cargo:rustc-env=QW_COMMIT_HASH={commit_hash}");
+    }
+
+    // Extract commit tags.
     let output_bytes = match Command::new("git")
         .arg("tag")
         .arg("--points-at")
@@ -63,9 +78,8 @@ fn commit_info() {
         _ => Vec::new(),
     };
     let output = String::from_utf8(output_bytes).unwrap();
-    let version_tag = output
-        .split_whitespace()
-        .find(|tag| tag.ends_with(env!("CARGO_PKG_VERSION")))
-        .unwrap_or(NONE);
-    println!("cargo:rustc-env=QW_COMMIT_VERSION_TAG={}", version_tag);
+    let tags = output.lines().collect::<Vec<_>>();
+    if !tags.is_empty() {
+        println!("cargo:rustc-env=QW_COMMIT_TAGS={}", tags.join(","));
+    }
 }

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -52,7 +52,7 @@ pub(crate) async fn start_rest_server(
     let api_v1_root_url = warp::path!("api" / "v1" / ..);
     let api_v1_routes = cluster_handler(quickwit_services.cluster.clone())
         .or(node_info_handler(
-            quickwit_services.build_info.clone(),
+            quickwit_services.build_info,
             quickwit_services.config.clone(),
         ))
         .or(indexing_get_handler(


### PR DESCRIPTION
### Description
- Allow propagation of commit info to Docker via build args
- Set commit info in CI env and pass to Docker

### How was this PR tested?
Ran `make docker-build` locally, launched container, and got following build info:
```json
{
  "build_date": "2022-11-12T20:03:31Z",
  "build_profile": "release",
  "build_target": "aarch64-unknown-linux-gnu",
  "cargo_pkg_version": "0.3.1",
  "commit_date": "2022-11-12T19:47:59Z",
  "commit_hash": "3c5996f75ac08f4711f5ab89e695fbd0e69bde12",
  "commit_short_hash": "3c5996f",
  "commit_tags": [
    "guilload"
  ],
  "version": "0.3.1-nightly"
}
```