### PR TITLE
Implement grpc metatastore uri method.

### DIFF
--- a/quickwit/quickwit-common/src/uri.rs
+++ b/quickwit/quickwit-common/src/uri.rs
@@ -38,6 +38,7 @@ pub enum Protocol {
     PostgreSQL,
     Ram,
     S3,
+    Grpc,
 }
 
 impl Protocol {
@@ -48,6 +49,7 @@ impl Protocol {
             Protocol::PostgreSQL => "postgresql",
             Protocol::Ram => "ram",
             Protocol::S3 => "s3",
+            Protocol::Grpc => "grpc",
         }
     }
 
@@ -82,6 +84,10 @@ impl Protocol {
     pub fn is_database(&self) -> bool {
         matches!(&self, Protocol::PostgreSQL)
     }
+
+    pub fn is_grpc(&self) -> bool {
+        matches!(&self, Protocol::Grpc)
+    }
 }
 
 impl Display for Protocol {
@@ -100,6 +106,7 @@ impl FromStr for Protocol {
             "postgres" | "postgresql" => Ok(Protocol::PostgreSQL),
             "ram" => Ok(Protocol::Ram),
             "s3" => Ok(Protocol::S3),
+            "grpc" => Ok(Protocol::Grpc),
             _ => bail!("Unknown URI protocol `{}`.", protocol),
         }
     }
@@ -492,6 +499,10 @@ mod tests {
         assert_eq!(
             Uri::for_test("postgresql://localhost:5432/metastore").protocol(),
             Protocol::PostgreSQL
+        );
+        assert_eq!(
+            Uri::for_test("grpc://localhost:5432/metastore").protocol(),
+            Protocol::Grpc
         );
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -500,8 +500,8 @@ impl Metastore for FileBackedMetastore {
         .await
     }
 
-    fn uri(&self) -> &Uri {
-        self.storage.uri()
+    fn uri(&self) -> Uri {
+        self.storage.uri().clone()
     }
 
     async fn check_connectivity(&self) -> anyhow::Result<()> {

--- a/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
@@ -74,7 +74,7 @@ impl InstrumentedMetastore {
 
 #[async_trait]
 impl Metastore for InstrumentedMetastore {
-    fn uri(&self) -> &Uri {
+    fn uri(&self) -> Uri {
         self.underlying.uri()
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -89,7 +89,7 @@ use crate::{MetastoreError, MetastoreResult, Split, SplitMetadata, SplitState};
 #[async_trait]
 pub trait Metastore: Send + Sync + 'static {
     /// Returns the metastore's uri.
-    fn uri(&self) -> &Uri;
+    fn uri(&self) -> Uri;
 
     /// Checks whether the metastore is available.
     async fn check_connectivity(&self) -> anyhow::Result<()>;

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -867,8 +867,8 @@ impl Metastore for PostgresqlMetastore {
         })
     }
 
-    fn uri(&self) -> &Uri {
-        &self.uri
+    fn uri(&self) -> Uri {
+        self.uri.clone()
     }
 
     /// Retrieves the last delete opstamp for a given `index_id`.

--- a/quickwit/quickwit-metastore/src/metastore/retrying_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/retrying_metastore/mod.rs
@@ -55,7 +55,7 @@ impl RetryingMetastore {
 
 #[async_trait]
 impl Metastore for RetryingMetastore {
-    fn uri(&self) -> &Uri {
+    fn uri(&self) -> Uri {
         self.inner.uri()
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/retrying_metastore/test.rs
+++ b/quickwit/quickwit-metastore/src/metastore/retrying_metastore/test.rs
@@ -72,7 +72,7 @@ impl RetryTestMetastore {
 
 #[async_trait]
 impl Metastore for RetryTestMetastore {
-    fn uri(&self) -> &Uri {
+    fn uri(&self) -> Uri {
         unimplemented!()
     }
 


### PR DESCRIPTION
Two main things here:
- I was forced to change the metastore uri  signature `uri() -> &Uri` into `uri() -> Uri` to implement it for the gRPC metastore. This gRPC metastore holds a `watch::Receiver<HashSet<QuickwitUri>>` to keep the current metastore URIs and returns the first element `uri()` is called. And we cannot return a value referencing a temporary value created in the `uri` method.
- I decided to add a `grpc` protocol variant to use it in`Uri`. I hesitated with an `http` variant which seems too broad when you look at the existing variants: `postgresql`, `s3`. I found grpc a bit more consistent.