### PR TITLE
Document timestamp pruning

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -272,7 +272,7 @@ quickwit index search
 `--sort-by-score` Setting this flag calculates and sorts documents by their BM25 score.
 
 :::warning
-The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the `datetime` field precision. The `datetime` field precision configured in doc mapping only specifies how the field is internally stored as fast-field, whereas the split timestamp on which the document filtering is done is always stored using seconds precision.
+The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the timestamp field precision. The timestamp field precision only affects the way it's stored as fast-fields, whereas the document filtering is always performed in seconds.
 :::
 
 *Examples*

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -267,9 +267,13 @@ quickwit index search
 `--start-offset` Offset in the global result set of the first hit returned. (default: 0) \
 `--search-fields` List of fields that Quickwit will search into if the user query does not explicitly target a field in the query. It overrides the default search fields defined in the index config. Space-separated list, e.g. "field1 field2". \
 `--snippet-fields` List of fields that Quickwit will extract snippet on. Space-separated list, e.g. "field1 field2". \
-`--start-timestamp` Filters out documents before that timestamp (time-series indexes only). \
-`--end-timestamp` Filters out documents after that timestamp (time-series indexes only). \
+`--start-timestamp` Filters out documents before that timestamp in seconds (time-series indexes only). \
+`--end-timestamp` Filters out documents after that timestamp in seconds (time-series indexes only). \
 `--sort-by-score` Setting this flag calculates and sorts documents by their BM25 score.
+
+:::warning
+The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the `datetime` field precision. The `datetime` field precision configured in doc mapping only specifies how the field is internally stored as fast-field, whereas the split timestamp on which the document filtering is done is always stored using seconds precision.
+:::
 
 *Examples*
 
@@ -389,8 +393,8 @@ quickwit split list
 
 `--index` ID of the target index. \
 `--states` Comma-separated list of split states to filter on. Possible values are `staged`, `published`, and `marked`. \
-`--start-date` Filters out splits containing documents from this timestamp onwards (time-series indexes only).  \
-`--end-date` Filters out splits containing documents before this timestamp (time-series indexes only).  \
+`--start-date` Filters out splits containing documents from this timestamp in seconds onwards (time-series indexes only). \
+`--end-date` Filters out splits containing documents before this timestamp in seconds (time-series indexes only). \
 `--tags` Comma-separated list of tags, only splits that contain all of the tags will be returned.  \
 `--config` Quickwit config file.  \
 `--data-dir` Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.  \

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -48,8 +48,8 @@ Search for documents matching a query in the given index `<index id>`. This endp
 | Variable                  | Type                 | Description                                                                                                | Default value                                                                                   |
 | ------------------------- | -------------------- | -------------------------------------------------------------------------------------------------          | ----------------------------------------------------------------------------------------------- |
 | **query**                 | `String`             | Query text. See the [query language doc](query-language.md) (mandatory)                                    |                                                                                                 |
-| **start_timestamp**       | `i64`                | If set, restrict search to documents with a `timestamp >= start_timestamp`                                 |                                                                                                 |
-| **end_timestamp**         | `i64`                | If set, restrict search to documents with a `timestamp < end_timestamp`                                    |                                                                                                 |
+| **start_timestamp**       | `i64`                | If set, restrict search to documents with a `timestamp >= start_timestamp`. The value must be in seconds.                                |                                                                                                 |
+| **end_timestamp**         | `i64`                | If set, restrict search to documents with a `timestamp < end_timestamp`. The value must be in seconds.                                   |                                                                                                 |
 | **start_offset**          | `Integer`            | Number of documents to skip                                                                                | `0`                                                                                             |
 | **max_hits**              | `Integer`            | Maximum number of hits to return (by default 20)                                                           | `20`                                                                                            |
 | **search_field**          | `[String]`           | Fields to search on if no field name is specified in the query. Comma-separated list, e.g. "field1,field2" | index_config.search_settings.default_search_fields                                              |
@@ -57,6 +57,10 @@ Search for documents matching a query in the given index `<index id>`. This endp
 | **sort_by_field**         | `String`             | Field to sort query results by. By default, documents are sorted by their document id. It is possible to sort by specific fast fields by passing the field name. Setting this value to `_score` calculates and sorts by BM25 score of the documents.         |                               |
 | **format**                | `Enum`               | The output format. Allowed values are "json" or "prettyjson"                                               | `prettyjson`                                                                                    |
 | **aggs**               | `JSON`               | The aggregations request. See the [aggregations doc](aggregation.md) for supported aggregations.      |
+
+:::warning
+The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the `datetime` field precision. The `datetime` field precision configured in doc mapping only specifies how the field is internally stored as fast-field, whereas the split timestamp on which the document filtering is done is always stored using seconds precision.
+:::
 
 #### Response
 
@@ -99,9 +103,13 @@ The endpoint will return 10 million values if 10 million documents match the que
 | **query**           | `String`   | Query text. See the [query language doc](query-language.md) (mandatory)                                          |                                                    |
 | **fast_field**      | `String`   | Name of a field to retrieve from documents. This field must be marked as "fast" in the index config. (mandatory) |                                                    |
 | **search_field**    | `[String]` | Fields to search on. Comma-separated list, e.g. "field1,field2"                                                  | index_config.search_settings.default_search_fields |
-| **start_timestamp** | `i64`      | If set, restrict search to documents with a `timestamp >= start_timestamp`                                       |                                                    |
-| **end_timestamp**   | `i64`      | If set, restrict search to documents with a `timestamp < end_timestamp`                                          |                                                    |
+| **start_timestamp** | `i64`      | If set, restrict search to documents with a `timestamp >= start_timestamp`. The value must be in seconds.                                   |                                                    |
+| **end_timestamp**   | `i64`      | If set, restrict search to documents with a `timestamp < end_timestamp`. The value must be in seconds.                                        |                                                    |
 | **output_format**   | `String`   | Response output format. `csv` or `clickHouseRowBinary`                                                           | `csv`                                              |
+
+:::warning
+The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the `datetime` field precision. The `datetime` field precision configured in doc mapping only specifies how the field is internally stored as fast-field, whereas the split timestamp on which the document filtering is done is always stored using seconds precision.
+:::
 
 #### Response
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -59,7 +59,7 @@ Search for documents matching a query in the given index `<index id>`. This endp
 | **aggs**               | `JSON`               | The aggregations request. See the [aggregations doc](aggregation.md) for supported aggregations.      |
 
 :::warning
-The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the `datetime` field precision. The `datetime` field precision configured in doc mapping only specifies how the field is internally stored as fast-field, whereas the split timestamp on which the document filtering is done is always stored using seconds precision.
+The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the timestamp field precision. The timestamp field precision only affects the way it's stored as fast-fields, whereas the document filtering is always performed in seconds.
 :::
 
 #### Response
@@ -108,8 +108,8 @@ The endpoint will return 10 million values if 10 million documents match the que
 | **output_format**   | `String`   | Response output format. `csv` or `clickHouseRowBinary`                                                           | `csv`                                              |
 
 :::warning
-The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the `datetime` field precision. The `datetime` field precision configured in doc mapping only specifies how the field is internally stored as fast-field, whereas the split timestamp on which the document filtering is done is always stored using seconds precision.
-:::
+The `start_timestamp` and `end_timestamp` should be specified in seconds regardless of the timestamp field precision. The timestamp field precision only affects the way it's stored as fast-fields, whereas the document filtering is always performed in seconds.
+::: 
 
 #### Response
 


### PR DESCRIPTION
Add documentation to stress that timestamps pruning should be specified in seconds and why.

Closes https://github.com/quickwit-oss/quickwit/issues/2140