### PR TITLE
Fixes Bug in FileStorage

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/lazy_file_backed_index.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/lazy_file_backed_index.rs
@@ -87,10 +87,14 @@ async fn poll_index_metadata_once(
     index_id: &str,
     metadata_mutex: &Mutex<FileBackedIndex>,
 ) {
+    let mut metadata_lock = metadata_mutex.lock().await;
+    if metadata_lock.flip_recently_modified_down() {
+        return;
+    }
     let index_fetch_res = fetch_index(storage, index_id).await;
     match index_fetch_res {
         Ok(index) => {
-            *metadata_mutex.lock().await = index;
+            *metadata_lock = index;
         }
         Err(fetch_error) => {
             error!(error=?fetch_error, "fetch-metadata-error");

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -150,7 +150,7 @@ impl FileBackedMetastore {
         if !mutation_occurred {
             return Ok(false);
         }
-
+        locked_index.set_recently_modified();
         let put_result = put_index(&*self.storage, &index).await;
         match put_result {
             Ok(()) => {


### PR DESCRIPTION
Writing in the file storage was not atomic.

So if some other process was polling the file storage for instance, it could end up reading some version of the meta file that was partially written, and therefore invalid JSON.

This is the bug that was observed in #2304.

This PR also prevents the file metastore from reloading the data due to the polling loop, if it is the process acactually writing the metastore.

Closes #2304