### PR TITLE
Increase grpc metastore timeout for production usage.

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
@@ -63,7 +63,7 @@ use crate::{
 const CLIENT_TIMEOUT_DURATION: Duration = if cfg!(test) {
     Duration::from_millis(100)
 } else {
-    Duration::from_secs(5)
+    Duration::from_secs(30)
 };
 
 /// The [`MetastoreGrpcClient`] sends gRPC requests to cluster members running a [`Metastore`]


### PR DESCRIPTION
Set to 30 seconds.

We are monitoring slow operations on the metastore via logs and metrics so I think it's fine to increase the timeout to a greater value to:
- avoid stopping all the indexing pipeline for one slow operation (this happens a few times on my use case but there is not need to stop)
- avoid repetitive failures when the database is slow or on a query that is retrieving a lot of splits, this can happen if quickwit did not run correctly during a few hours. For example, the merge pipeline has stopped and we have possibly more than 100 000 small splits in the db. Queries can be quite slow and a low timeout will not let Quickwit return in to a normal mode.
