### PR TITLE
Fix `test_metastore_list_splits` flaky test

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
@@ -63,7 +63,7 @@ use crate::{
 const CLIENT_TIMEOUT_DURATION: Duration = if cfg!(test) {
     Duration::from_millis(100)
 } else {
-    Duration::from_secs(5)
+    Duration::from_secs(30)
 };
 
 /// The [`MetastoreGrpcClient`] sends gRPC requests to cluster members running a [`Metastore`]

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2821,9 +2821,7 @@ macro_rules! metastore_test_suite {
             #[tokio::test]
             async fn test_metastore_list_splits() {
                 let _ = tracing_subscriber::fmt::try_init();
-                for _ in 0..100 {
-                    crate::tests::test_suite::test_metastore_list_splits::<$metastore_type>().await;
-                }
+                crate::tests::test_suite::test_metastore_list_splits::<$metastore_type>().await;
             }
 
             #[tokio::test]

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2015,7 +2015,7 @@ pub mod test_suite {
             assert_eq!(split_ids, to_hash_set(&["list-splits-five"]));
 
             // Artificially increase the create_timestamp
-            sleep(Duration::from_secs(3)).await;
+            sleep(Duration::from_secs(1)).await;
             // add a split without tag
             let split_metadata_6 = SplitMetadata {
                 footer_offsets: 1000..2000,
@@ -2094,9 +2094,8 @@ pub mod test_suite {
                 ])
             );
 
-            let select_timestamp = OffsetDateTime::now_utc().unix_timestamp() - 1;
-            let query =
-                ListSplitsQuery::for_index(index_id).with_update_timestamp_gte(select_timestamp);
+            let query = ListSplitsQuery::for_index(index_id)
+                .with_update_timestamp_gte(split_metadata_6.create_timestamp);
             let splits = metastore.list_splits(query).await.unwrap();
             let split_ids: HashSet<String> = splits
                 .into_iter()
@@ -2105,7 +2104,7 @@ pub mod test_suite {
             assert_eq!(split_ids, to_hash_set(&["list-splits-six"]));
 
             let query = ListSplitsQuery::for_index(index_id)
-                .with_create_timestamp_lte(select_timestamp - 1);
+                .with_create_timestamp_lt(split_metadata_6.create_timestamp);
             let splits = metastore.list_splits(query).await.unwrap();
             let split_ids: HashSet<String> = splits
                 .into_iter()

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2015,7 +2015,7 @@ pub mod test_suite {
             assert_eq!(split_ids, to_hash_set(&["list-splits-five"]));
 
             // Artificially increase the create_timestamp
-            sleep(Duration::from_secs(2)).await;
+            sleep(Duration::from_secs(3)).await;
             // add a split without tag
             let split_metadata_6 = SplitMetadata {
                 footer_offsets: 1000..2000,

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2104,8 +2104,8 @@ pub mod test_suite {
                 .collect();
             assert_eq!(split_ids, to_hash_set(&["list-splits-six"]));
 
-            let query =
-                ListSplitsQuery::for_index(index_id).with_create_timestamp_lte(select_timestamp);
+            let query = ListSplitsQuery::for_index(index_id)
+                .with_create_timestamp_lte(select_timestamp - 1);
             let splits = metastore.list_splits(query).await.unwrap();
             let split_ids: HashSet<String> = splits
                 .into_iter()


### PR DESCRIPTION
This PR adjusts the metastore test so that we're more forgiving towards the potential of network latency and similar affecting the GRPC metastore tests.

The flaky-ness of this test is due to the fact that we're comparing timestamps in a relatively short time frame while we're only accurate to 1 second.
This means under the right amount of network latency and time, it's possible for the sixth split to be within the range we're filtering out (which it shouldn't do).
The solution to this is to extend the time we wait for by another second (making it `3` seconds) and then filtering out splits which are older than `2` seconds ago so that there is no potential overlap between the sixth split's timestamp and the selection timestamp.

I've ran this several times now in loops and haven't observed this behaviour anymore after adjusting this.