### PR TITLE
Update tantivy to fix json path search escaping '.'

### DIFF
--- a/docs/reference/query-language.md
+++ b/docs/reference/query-language.md
@@ -26,7 +26,7 @@ Note that a query like `title:barack obama` will find only `barack` in the title
 ### Searching structures nested in documents.
 
 Quickwit is designed to index structured data.
-If you search into some object nested into your document, whether it is an `object`, a `json` object, or a whether it was caught through the `dynamic` mode, the query language is the same. You simply need to chain the different steps to reach your value from the root of the document.
+If you search into some object nested into your document, whether it is an `object`, a `json` object, or whether it was caught through the `dynamic` mode, the query language is the same. You simply need to chain the different steps to reach your value from the root of the document.
 
 For instance, the document `{"product": {"attributes": {color": "red"}}}` is returned if you query `product.attributes.color:red`.
 If a dot `.` exists in one of the key of your object, you need to escape it.

--- a/docs/reference/query-language.md
+++ b/docs/reference/query-language.md
@@ -23,6 +23,15 @@ title:"barack obama" AND president
 
 Note that a query like `title:barack obama` will find only `barack` in the title and `obama` in the default fields. If no default field has been set on the index, this will result in an error.
 
+### Searching structures nested in documents.
+
+Quickwit is designed to index structured data.
+If you search into some object nested into your document, whether it is an `object`, a `json` object, or a whether it was caught through the `dynamic` mode, the query language is the same. You simply need to chain the different steps to reach your value from the root of the document.
+
+For instance, the document `{"product": {"attributes": {color": "red"}}}` is returned if you query `product.attributes.color:red`.
+If a dot `.` exists in one of the key of your object, you need to escape it.
+For instance, the document `{"attributes": {"server.name": "elephant"}}` is returned if you query `attributes:server\.name:elephant`.
+
 ### Boolean Operators
 
 Quickwit supports `AND`, `+`, `OR`, `NOT` and `-` as Boolean operators (case sensitive). By default, the `AND` is chosen, this means that if you omit it in a query like `title:"barack obama" president` Quickwit will interpret the query as `title:"barack obama" AND president`.
@@ -46,7 +55,7 @@ Slop queries can only be used on field indexed with the [record option](./../con
 #### Examples:
 
 With the following corpus:
-```json 
+```json
 [
     {"id": 1, "body": "a red bike"},
     {"id": 2, "body": "a small blue bike"},
@@ -55,14 +64,14 @@ With the following corpus:
     {"id": 5, "body": "a tiny shelter"}
 ]
 ```
-The following queries will output: 
+The following queries will output:
 
 - `body:"small bird"~2`: no match []
 - `body:"red bike"~2`: matches [1]
 - `body:"small blue bike"~3`: matches [2]
 - `body:"small bike"`: matches [4]
 - `body:"small bike"~1`: matches [2, 4]
-- `body:"small bike"~2`: matches [2, 4] 
+- `body:"small bike"~2`: matches [2, 4]
 - `body:"small bike"~3`: matches [2, 3, 4]
 
 ### Escaping Special Characters

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1220,7 +1220,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=55a9d80#55a9d808d444a39d6522749feee470f0410a1676"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2a39289#2a39289a1b0cb4e1a064552ce8c224f3ebee28a8"
 dependencies = [
  "fastdivide",
  "itertools",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=55a9d80#55a9d808d444a39d6522749feee470f0410a1676"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2a39289#2a39289a1b0cb4e1a064552ce8c224f3ebee28a8"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.19.0-dev"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=55a9d80#55a9d808d444a39d6522749feee470f0410a1676"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2a39289#2a39289a1b0cb4e1a064552ce8c224f3ebee28a8"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5003,12 +5003,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=55a9d80#55a9d808d444a39d6522749feee470f0410a1676"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2a39289#2a39289a1b0cb4e1a064552ce8c224f3ebee28a8"
 
 [[package]]
 name = "tantivy-common"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=55a9d80#55a9d808d444a39d6522749feee470f0410a1676"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2a39289#2a39289a1b0cb4e1a064552ce8c224f3ebee28a8"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -5028,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=55a9d80#55a9d808d444a39d6522749feee470f0410a1676"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2a39289#2a39289a1b0cb4e1a064552ce8c224f3ebee28a8"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -193,14 +193,14 @@ quickwit-serve = { version = "0.3.1", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.3.1", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.3.1", path = "./quickwit-telemetry" }
 
-fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "55a9d80" }
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "55a9d80", default-features = false, features = [
+fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "2a39289" }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "2a39289", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",
   "quickwit",
 ] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "55a9d80" }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "2a39289" }
 
 # This is actually not used directly the goal is to fix the version
 # used by reqwest. 0.8.30 has an unclear license.


### PR DESCRIPTION
Also updated documentation, to explain how nested structure can be searched.

Closes #2312

Tested on quickiwt by indexing a single document 
`{"resource": {"k8s.container.name": "prometheus"}}`
and searched it with quickwit.

![test_escape](https://user-images.githubusercontent.com/1021506/202060840-46dcc4ae-930a-4d3f-b0ec-8e64abae0653.png)
