### PR TITLE
Move `/api/v1/health` routes to `/health`

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
@@ -49,7 +49,6 @@ use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tokio_stream::StreamExt;
 use tower::discover::Change;
-use tower::service_fn;
 use tower::timeout::error::Elapsed;
 use tower::timeout::Timeout;
 use tracing::{error, info};
@@ -125,7 +124,7 @@ impl MetastoreGrpcClient {
     pub async fn from_duplex_stream(client: tokio::io::DuplexStream) -> anyhow::Result<Self> {
         let mut client = Some(client);
         let channel = Endpoint::try_from("http://test.server")?
-            .connect_with_connector(service_fn(move |_: Uri| {
+            .connect_with_connector(tower::service_fn(move |_: Uri| {
                 let client = client.take();
                 async move {
                     client.ok_or_else(|| {

--- a/quickwit/quickwit-serve/src/health_check_api/handler.rs
+++ b/quickwit/quickwit-serve/src/health_check_api/handler.rs
@@ -32,7 +32,7 @@ use warp::{Filter, Rejection};
 use crate::with_arg;
 
 /// Health check handlers.
-pub fn health_check_handlers(
+pub(crate) fn health_check_handlers(
     cluster: Arc<Cluster>,
     indexer_service_opt: Option<Mailbox<IndexingService>>,
     janitor_service_opt: Option<Mailbox<JanitorService>>,
@@ -40,23 +40,21 @@ pub fn health_check_handlers(
     liveness_handler(indexer_service_opt, janitor_service_opt).or(readiness_handler(cluster))
 }
 
-pub fn liveness_handler(
+fn liveness_handler(
     indexer_service_opt: Option<Mailbox<IndexingService>>,
     janitor_service_opt: Option<Mailbox<JanitorService>>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!("health" / "livez")
-        .and(warp::path::end())
         .and(warp::get())
         .and(with_arg(indexer_service_opt))
         .and(with_arg(janitor_service_opt))
         .and_then(get_liveness)
 }
 
-pub fn readiness_handler(
+fn readiness_handler(
     cluster: Arc<Cluster>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!("health" / "readyz")
-        .and(warp::path::end())
         .and(warp::get())
         .and(with_arg(cluster))
         .and_then(get_readiness)

--- a/quickwit/quickwit-serve/src/health_check_api/mod.rs
+++ b/quickwit/quickwit-serve/src/health_check_api/mod.rs
@@ -19,4 +19,4 @@
 
 mod handler;
 
-pub use handler::health_check_handlers;
+pub(crate) use handler::health_check_handlers;

--- a/quickwit/quickwit-serve/src/test_utils/rest_client.rs
+++ b/quickwit/quickwit-serve/src/test_utils/rest_client.rs
@@ -28,7 +28,7 @@ use serde::de::DeserializeOwned;
 use tokio_stream::StreamExt;
 
 pub struct QuickwitRestClient {
-    api_root: String,
+    root_url: String,
     client: hyper::Client<HttpConnector, Body>,
 }
 
@@ -38,12 +38,12 @@ impl QuickwitRestClient {
             .pool_idle_timeout(Duration::from_secs(30))
             .http2_only(true)
             .build_http();
-        let api_root = format!("http://{}/api/v1", addr);
-        Self { api_root, client }
+        let root_url = format!("http://{}", addr);
+        Self { root_url, client }
     }
 
     pub async fn cluster_snapshot(&self) -> anyhow::Result<ClusterSnapshot> {
-        let uri = format!("{}/cluster", self.api_root)
+        let uri = format!("{}/api/v1/cluster", self.root_url)
             .parse::<hyper::Uri>()
             .unwrap();
         let response = self.client.get(uri).await?;
@@ -52,7 +52,7 @@ impl QuickwitRestClient {
     }
 
     pub async fn indexing_service_counters(&self) -> anyhow::Result<IndexingServiceCounters> {
-        let uri = format!("{}/indexing", self.api_root)
+        let uri = format!("{}/api/v1/indexing", self.root_url)
             .parse::<hyper::Uri>()
             .unwrap();
         let response = self.client.get(uri).await?;
@@ -61,7 +61,7 @@ impl QuickwitRestClient {
     }
 
     pub async fn is_live(&self) -> anyhow::Result<bool> {
-        let uri = format!("{}/health/livez", self.api_root)
+        let uri = format!("{}/health/livez", self.root_url)
             .parse::<hyper::Uri>()
             .unwrap();
         let response = self.client.get(uri).await?;
@@ -72,7 +72,7 @@ impl QuickwitRestClient {
     }
 
     pub async fn is_ready(&self) -> anyhow::Result<bool> {
-        let uri = format!("{}/health/readyz", self.api_root)
+        let uri = format!("{}/health/readyz", self.root_url)
             .parse::<hyper::Uri>()
             .unwrap();
         let response = self.client.get(uri).await?;


### PR DESCRIPTION
### Description
Per title.

### How was this PR tested?
Ran `quickwit run` locally and `curl`ed the two health endpoints.
