### PR TITLE
Fixes BackPressure.

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use byte_unit::Byte;
 use quickwit_actors::{
     create_mailbox, Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, Health, Inbox,
-    Mailbox, QueueCapacity, Supervisable,
+    Mailbox, Supervisable,
 };
 use quickwit_common::io::IoControls;
 use quickwit_common::KillSwitch;
@@ -91,8 +91,10 @@ impl Actor for MergePipeline {
 
 impl MergePipeline {
     pub fn new(params: MergePipelineParams) -> Self {
-        let (merge_planner_mailbox, merge_planner_inbox) =
-            create_mailbox::<MergePlanner>("MergePlanner".to_string(), QueueCapacity::Unbounded);
+        let (merge_planner_mailbox, merge_planner_inbox) = create_mailbox::<MergePlanner>(
+            "MergePlanner".to_string(),
+            MergePlanner::queue_capacity(),
+        );
         Self {
             params,
             previous_generations_statistics: Default::default(),

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -69,7 +69,7 @@ impl Actor for MergePlanner {
     }
 
     fn queue_capacity(&self) -> QueueCapacity {
-        QueueCapacity::Bounded(0)
+        MergePlanner::queue_capacity()
     }
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
@@ -134,6 +134,10 @@ impl Handler<NewSplits> for MergePlanner {
 }
 
 impl MergePlanner {
+    pub fn queue_capacity() -> QueueCapacity {
+        QueueCapacity::Bounded(0)
+    }
+
     pub fn new(
         pipeline_id: IndexingPipelineId,
         published_splits: Vec<SplitMetadata>,


### PR DESCRIPTION
The mailbox created for the MergePlanner was ignoring the actor defined QueueCapacity, and using an unbounded QueueCapacity.
