### PR TITLE
Use a randomized partition id for the ingest api #2310 

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ulid",
 ]
 
 [[package]]

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -357,8 +357,8 @@ impl IndexingPipeline {
             .source_checkpoint(source_id)
             .cloned()
             .unwrap_or_default(); // TODO Have a stricter check.
-        let source = quickwit_supported_sources()
-            .load_source(
+        let source = ctx
+            .protect_future(quickwit_supported_sources().load_source(
                 Arc::new(SourceExecutionContext {
                     metastore: self.params.metastore.clone(),
                     index_id: self.params.pipeline_id.index_id.clone(),
@@ -366,7 +366,7 @@ impl IndexingPipeline {
                     source_config: self.params.source_config.clone(),
                 }),
                 source_checkpoint,
-            )
+            ))
             .await?;
         let actor_source = SourceActor {
             source,

--- a/quickwit/quickwit-indexing/src/source/source_factory.rs
+++ b/quickwit/quickwit-indexing/src/source/source_factory.rs
@@ -98,7 +98,6 @@ impl SourceLoader {
     ) -> Result<Box<dyn Source>, SourceLoaderError> {
         let source_type = ctx.source_config.source_type().to_string();
         let source_id = ctx.source_config.source_id.clone();
-
         let source_factory = self
             .type_to_factory
             .get(ctx.source_config.source_type())

--- a/quickwit/quickwit-ingest-api/Cargo.toml
+++ b/quickwit/quickwit-ingest-api/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+ulid = {workspace = true}
 
 quickwit-actors = { workspace = true }
 quickwit-common = { workspace = true }

--- a/quickwit/quickwit-ingest-api/src/lib.rs
+++ b/quickwit/quickwit-ingest-api/src/lib.rs
@@ -31,7 +31,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context};
 pub use errors::IngestApiError;
 use errors::Result;
-pub use ingest_api_service::IngestApiService;
+pub use ingest_api_service::{GetPartitionId, IngestApiService};
 use metrics::INGEST_METRICS;
 use once_cell::sync::OnceCell;
 pub use position::Position;

--- a/quickwit/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit/quickwit-metastore/src/checkpoint.rs
@@ -525,6 +525,11 @@ impl SourceCheckpointDelta {
         self.per_partition.len()
     }
 
+    /// Returns an iterator over the partition_ids.
+    pub fn partitions(&self) -> impl Iterator<Item = &PartitionId> {
+        self.per_partition.keys()
+    }
+
     /// Returns `true` if the checkpoint delta is empty.
     pub fn is_empty(&self) -> bool {
         self.per_partition.is_empty()


### PR DESCRIPTION
```
    Random `partition_id` for the ingest API source.
    
    This PR changes the partition_id used in the ingest API.
    After this changes, we use a randomly generated partition_ID,
    and save it in RocksDB.
    
    This solves two problems that we have.
    
    We can then have two nodes running the ingest_api
    as a duct tape distributed model. That way, their
    checkpoint won't interfere.
    
    Closes #2291
    
    It also makes it possible to behave less poorly if the
    rocksdb data dir is lost (for instance, when using a
    ephemeral volume).
    
    Before the change, the ingest API would add
    give the new message auto increment positions starting at
    0.
    The source checkpoint in the metastore would prevent quicwit
    from indexing any document until the previous position
    is reached.
    
    Closes #2310

```
