### PR TITLE
Quickwit json expand dot options

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -175,7 +175,7 @@ The `datetime` type handles dates and datetimes. Quickwit supports multiple inpu
 
 - `unix_timestamp`: parse Unix timestamp values. Timestamp values come in different precision, namely: `seconds`, `milliseconds`, `microseconds`, or `nanoseconds`. Quickwit is capable of inferring the precision from the value. Because of this feature, Quickwit only supports timestamp values ranging from `13 Apr 1972 23:59:55` to `16 Mar 2242 12:56:31`.
 
-The `precision` parameter indicates the precision used to truncate the values before encoding and compressing them. The `precision` parameter can take the following values: `seconds`, `milliseconds`, `microseconds`. It only affects what is stored in fast fields when a `datetime` field is marked as fast field. 
+The `precision` parameter indicates the precision used to truncate the values before encoding and compressing them. The `precision` parameter can take the following values: `seconds`, `milliseconds`, `microseconds`. It only affects what is stored in fast fields when a `datetime` field is marked as fast field.
 
 :::info
 When specifying multiple input formats, the corresponding parsers are attempted in the order they are declared.
@@ -299,6 +299,7 @@ type: json
 stored: true
 indexed: true
 tokenizer: "default"
+expand_dots: false
 ```
 
 **Parameters for JSON field**
@@ -310,6 +311,7 @@ tokenizer: "default"
 | `indexed`   | Whether value is indexed | `true` |
 | `tokenizer` | **Only affects strings in the json object**. Name of the `Tokenizer`, choices between `raw`, `default`, `en_stem` and `chinese_compatible` | `default` |
 | `record`    | **Only affects strings in the json object**. Describes the amount of information indexed, choices between `basic`, `freq` and `position` | `basic` |
+| `expand_dots`    | If true, json keys containing a `.` should be expanded. For instance, if `expand_dots` is set to true, `{"k8s.node.id": "node-2"}` will be indexed as if it was `{"k8s": {"node": {"id": "node2"}}}`. The benefit is that escaping the `.` will not be required at query time. In other words, `k8s.node.id:node2` will match the document. This does not impact the way the document is stored.  | `true` |
 
 Note that the `tokenizer` and the `record` have the same definition and the same effect as for the text field.
 
@@ -372,6 +374,7 @@ Quickwit offers you three different modes:
 - stored: true
 - tokenizer: raw
 - record: basic
+- expand_dots: true
 ```
 
 The `dynamic` mode makes it possible to operate Quickwit in a schemaless manner, or with a partial schema.

--- a/docs/reference/query-language.md
+++ b/docs/reference/query-language.md
@@ -34,9 +34,9 @@ If a dot `.` exists in one of the key of your object, the above syntax has some 
 For instance, by default, `{"k8s.component.name": "quickwit"}` will be matched by `k8s.component.name:quickwit`.
 
 It is possible to remove the ambiguity by setting `expand_dots` in the json field configuration.
-In that case, it will be necessary to escpae the `.` in the query to match this document.
+In that case, it will be necessary to escape the `.` in the query to match this document.
 
-For instance, the above document, will match the query `k8s\.component\.name:quickwit`.
+For instance, the above document will match the query `k8s\.component\.name:quickwit`.
 
 ### Boolean Operators
 

--- a/docs/reference/query-language.md
+++ b/docs/reference/query-language.md
@@ -29,8 +29,14 @@ Quickwit is designed to index structured data.
 If you search into some object nested into your document, whether it is an `object`, a `json` object, or whether it was caught through the `dynamic` mode, the query language is the same. You simply need to chain the different steps to reach your value from the root of the document.
 
 For instance, the document `{"product": {"attributes": {color": "red"}}}` is returned if you query `product.attributes.color:red`.
-If a dot `.` exists in one of the key of your object, you need to escape it.
-For instance, the document `{"attributes": {"server.name": "elephant"}}` is returned if you query `attributes:server\.name:elephant`.
+
+If a dot `.` exists in one of the key of your object, the above syntax has some ambiguity.
+For instance, by default, `{"k8s.component.name": "quickwit"}` will be matched by `k8s.component.name:quickwit`.
+
+It is possible to remove the ambiguity by setting `expand_dots` in the json field configuration.
+In that case, it will be necessary to escpae the `.` in the query to match this document.
+
+For instance, the above document, will match the query `k8s\.component\.name:quickwit`.
 
 ### Boolean Operators
 

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1220,7 +1220,7 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 [[package]]
 name = "fastfield_codecs"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e758080#e758080465fee5cd9dfdb032a345fd7988df8914"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=0b40a7fe#0b40a7fe4350ea4e361486881d27441aa33257f5"
 dependencies = [
  "fastdivide",
  "itertools",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e758080#e758080465fee5cd9dfdb032a345fd7988df8914"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=0b40a7fe#0b40a7fe4350ea4e361486881d27441aa33257f5"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.19.0-dev"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e758080#e758080465fee5cd9dfdb032a345fd7988df8914"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=0b40a7fe#0b40a7fe4350ea4e361486881d27441aa33257f5"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5003,12 +5003,12 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e758080#e758080465fee5cd9dfdb032a345fd7988df8914"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=0b40a7fe#0b40a7fe4350ea4e361486881d27441aa33257f5"
 
 [[package]]
 name = "tantivy-common"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e758080#e758080465fee5cd9dfdb032a345fd7988df8914"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=0b40a7fe#0b40a7fe4350ea4e361486881d27441aa33257f5"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -5028,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.18.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=e758080#e758080465fee5cd9dfdb032a345fd7988df8914"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=0b40a7fe#0b40a7fe4350ea4e361486881d27441aa33257f5"
 dependencies = [
  "combine",
  "once_cell",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -193,14 +193,14 @@ quickwit-serve = { version = "0.3.1", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.3.1", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.3.1", path = "./quickwit-telemetry" }
 
-fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e758080" }
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e758080", default-features = false, features = [
+fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", rev = "0b40a7fe" }
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "0b40a7fe", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",
   "quickwit",
 ] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "e758080" }
+tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", rev = "0b40a7fe" }
 
 # This is actually not used directly the goal is to fix the version
 # used by reqwest. 0.8.30 has an unclear license.


### PR DESCRIPTION
Adds an expand_dot option (defaults to true) allowing`k8s.component.id:quickwit` to match 
`{"k8s.component.id:"quickwit"}`... Hence removing the need for escaping.

Closes #2345