### PR TITLE
Fixes the merge planner.

### DIFF
--- a/quickwit/quickwit-actors/src/actor.rs
+++ b/quickwit/quickwit-actors/src/actor.rs
@@ -40,6 +40,7 @@ use crate::spawn_builder::SpawnBuilder;
 use crate::Universe;
 use crate::{
     AskError, Command, KillSwitch, Mailbox, Progress, ProtectedZoneGuard, QueueCapacity, SendError,
+    TrySendError,
 };
 
 /// The actor exit status represents the outcome of the execution of an actor,
@@ -467,7 +468,7 @@ impl<A: Actor> ActorContext<A> {
         &self,
         mailbox: &Mailbox<DestActor>,
         msg: M,
-    ) -> Result<oneshot::Receiver<DestActor::Reply>, crate::SendError>
+    ) -> Result<oneshot::Receiver<DestActor::Reply>, SendError>
     where
         DestActor: Handler<M>,
         M: 'static + Send + Sync + fmt::Debug,
@@ -521,24 +522,42 @@ impl<A: Actor> ActorContext<A> {
     pub async fn send_exit_with_success<Dest: Actor>(
         &self,
         mailbox: &Mailbox<Dest>,
-    ) -> Result<(), crate::SendError> {
+    ) -> Result<(), SendError> {
         let _guard = self.protect_zone();
         debug!(from=%self.self_mailbox.actor_instance_id(), to=%mailbox.actor_instance_id(), "success");
         mailbox.send_message(Command::ExitWithSuccess).await?;
         Ok(())
     }
 
-    /// `async` version of `send_self_message`.
+    /// Sends a message to an actor's own mailbox.
+    ///
+    /// Warning: This method is dangerous as it can very easily
+    /// cause a deadlock.
     pub async fn send_self_message<M>(
         &self,
         msg: M,
-    ) -> Result<oneshot::Receiver<A::Reply>, crate::SendError>
+    ) -> Result<oneshot::Receiver<A::Reply>, SendError>
     where
         A: Handler<M>,
         M: 'static + Sync + Send + fmt::Debug,
     {
         debug!(self=%self.self_mailbox.actor_instance_id(), msg=?msg, "self_send");
         self.self_mailbox.send_message(msg).await
+    }
+
+    /// Attempts to send a message to itself.
+    ///
+    /// Warning: This method will always fail if
+    /// an actor has a capacity of 0.
+    pub fn try_send_self_message<M>(
+        &self,
+        msg: M,
+    ) -> Result<oneshot::Receiver<A::Reply>, TrySendError<M>>
+    where
+        A: Handler<M>,
+        M: 'static + Sync + Send + fmt::Debug,
+    {
+        self.self_mailbox.try_send_message(msg)
     }
 
     pub async fn schedule_self_msg<M>(&self, after_duration: Duration, message: M)

--- a/quickwit/quickwit-actors/src/actor.rs
+++ b/quickwit/quickwit-actors/src/actor.rs
@@ -346,6 +346,11 @@ impl<A: Actor> ActorContext<A> {
         future.await
     }
 
+    /// Cooperatively yields, while keeping the actor protected.
+    pub async fn yield_now(&self) {
+        self.protect_future(tokio::task::yield_now()).await;
+    }
+
     /// Gets a copy of the actor kill switch.
     /// This should rarely be used.
     ///

--- a/quickwit/quickwit-actors/src/lib.rs
+++ b/quickwit/quickwit-actors/src/lib.rs
@@ -60,7 +60,7 @@ pub use universe::Universe;
 
 pub use self::actor::ActorContext;
 pub use self::actor_state::ActorState;
-pub use self::channel_with_priority::{QueueCapacity, RecvError, SendError};
+pub use self::channel_with_priority::{QueueCapacity, RecvError, SendError, TrySendError};
 pub use self::mailbox::{create_mailbox, create_test_mailbox, Inbox, Mailbox};
 pub use self::registry::ActorObservation;
 pub use self::supervisor::{Supervisor, SupervisorState};

--- a/quickwit/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit/quickwit-actors/src/spawn_builder.rs
@@ -223,7 +223,7 @@ impl<A: Actor> ActorExecutionEnv<A> {
             return Err(ActorExitStatus::Killed);
         }
         if self.actor.yield_after_each_message() {
-            self.ctx.protect_future(tokio::task::yield_now()).await;
+            self.ctx.yield_now().await;
             if self.ctx.kill_switch().is_dead() {
                 return Err(ActorExitStatus::Killed);
             }

--- a/quickwit/quickwit-indexing/README.md
+++ b/quickwit/quickwit-indexing/README.md
@@ -18,6 +18,6 @@ flowchart LR
         merge_uploader[MergeUploader] --inf--> merge_publisher
     end
     merge_planner[MergePlanner] --1--> merge_downloader
-    merge_publisher[MergePublisher] --0--> merge_planner
-    publisher[Publisher] --0--> merge_planner
+    merge_publisher[MergePublisher] --1--> merge_planner
+    publisher[Publisher] --1--> merge_planner
 ```

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -17,11 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use itertools::Itertools;
+use quickwit_actors::channel_with_priority::TrySendError;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
 use quickwit_metastore::SplitMetadata;
 use serde::Serialize;
@@ -73,9 +75,22 @@ impl Actor for MergePlanner {
     }
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
-        let target_partition_ids = self.partitioned_young_splits.keys().cloned().collect_vec();
         self.handle(RefreshMetric, ctx).await?;
-        self.send_merge_ops(ctx, &target_partition_ids).await?;
+        self.send_merge_ops(ctx).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<PlanMerge> for MergePlanner {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _: PlanMerge,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        self.send_merge_ops(ctx).await?;
         Ok(())
     }
 }
@@ -86,56 +101,29 @@ impl Handler<NewSplits> for MergePlanner {
 
     async fn handle(
         &mut self,
-        message: NewSplits,
+        new_splits: NewSplits,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        let mut target_partition_ids = Vec::new();
-
-        let partitioned_new_young_splits = message
-            .new_splits
-            .into_iter()
-            .filter(|split| {
-                let is_immature = !self.merge_policy.is_mature(split);
-                if !is_immature {
-                    info!(
-                        split_id=%split.split_id(),
-                        index_id=%self.pipeline_id.index_id,
-                        source_id=%split.source_id,
-                        num_docs=split.num_docs,
-                        num_bytes=split.uncompressed_docs_size_in_bytes,
-                        "Split is mature."
-                    );
-                }
-                is_immature
-            })
-            .group_by(|split| split.partition_id);
-
-        for (partition_id, new_young_splits) in &partitioned_new_young_splits {
-            let young_splits = self
-                .partitioned_young_splits
-                .entry(partition_id)
-                .or_default();
-            for new_young_split in new_young_splits {
-                // Due to the recycling of the mailbox of the merge planner, it is possible for
-                // a split already in store to be received.
-                let split_already_known = young_splits
-                    .iter()
-                    .any(|split| split.split_id() == new_young_split.split_id());
-                if split_already_known {
-                    continue;
-                }
-                young_splits.push(new_young_split);
-            }
-            target_partition_ids.push(partition_id);
-        }
-        self.send_merge_ops(ctx, &target_partition_ids).await?;
+        self.record_splits(new_splits.new_splits);
+        self.send_merge_ops(ctx).await?;
         Ok(())
     }
 }
 
+fn max_merge_ops(merge_op: &MergeOperation) -> usize {
+    merge_op
+        .splits_as_slice()
+        .iter()
+        .map(|split_metadata| split_metadata.num_merge_ops)
+        .max()
+        .unwrap_or(0)
+}
+
 impl MergePlanner {
     pub fn queue_capacity() -> QueueCapacity {
-        QueueCapacity::Bounded(0)
+        // We cannot have a Queue capacity of 0 here because `try_send_self`
+        // would never succeed.
+        QueueCapacity::Bounded(1)
     }
 
     pub fn new(
@@ -144,46 +132,121 @@ impl MergePlanner {
         merge_policy: Arc<dyn MergePolicy>,
         merge_split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
     ) -> MergePlanner {
-        let mut partitioned_young_splits: HashMap<u64, Vec<SplitMetadata>> = HashMap::new();
-        for split in published_splits {
-            if !belongs_to_pipeline(&pipeline_id, &split) || merge_policy.is_mature(&split) {
-                continue;
-            }
-            partitioned_young_splits
-                .entry(split.partition_id)
-                .or_default()
-                .push(split);
-        }
-        MergePlanner {
+        let mut merge_planner = MergePlanner {
             pipeline_id,
-            partitioned_young_splits,
+            partitioned_young_splits: Default::default(),
             merge_policy,
             merge_split_downloader_mailbox,
             ongoing_merge_operations_inventory: Inventory::default(),
+        };
+        merge_planner.record_splits(published_splits);
+        merge_planner
+    }
+
+    fn record_split(&mut self, new_split: SplitMetadata) {
+        if !belongs_to_pipeline(&self.pipeline_id, &new_split)
+            || self.merge_policy.is_mature(&new_split)
+        {
+            return;
+        }
+        let splits_for_partition: &mut Vec<SplitMetadata> = self
+            .partitioned_young_splits
+            .entry(new_split.partition_id)
+            .or_default();
+        // Due to the recycling of the mailbox of the merge planner, it is possible for
+        // a split already in store to be received.
+        if splits_for_partition
+            .iter()
+            .any(|split| split.split_id() == new_split.split_id())
+        {
+            return;
+        }
+        splits_for_partition.push(new_split);
+    }
+
+    // Records a list of splits.
+    //
+    // Internally this function will detect and avoid adding the split
+    // that are:
+    // - already known
+    // - mature
+    // - do not belong to the current timeline.
+    fn record_splits(&mut self, split_metadatas: Vec<SplitMetadata>) {
+        for new_split in split_metadatas {
+            self.record_split(new_split);
         }
     }
 
-    async fn send_merge_ops(
+    async fn compute_merge_ops(
         &mut self,
         ctx: &ActorContext<Self>,
-        target_partition_ids: &[u64],
-    ) -> Result<(), ActorExitStatus> {
-        for partition_id in target_partition_ids {
-            if let Some(young_splits) = self.partitioned_young_splits.get_mut(partition_id) {
-                let merge_operations = self.merge_policy.operations(young_splits);
+    ) -> Result<Vec<MergeOperation>, ActorExitStatus> {
+        let mut merge_operations = Vec::new();
+        for young_splits in self.partitioned_young_splits.values_mut() {
+            if !young_splits.is_empty() {
+                merge_operations.extend(self.merge_policy.operations(young_splits));
+            }
+            ctx.record_progress();
+            tokio::task::yield_now().await;
+        }
+        self.partitioned_young_splits
+            .retain(|_, splits| !splits.is_empty());
+        Ok(merge_operations)
+    }
 
-                for merge_operation in merge_operations {
-                    info!(merge_operation=?merge_operation, "Planned merge operation.");
-                    let tracked_merge_operations = self
-                        .ongoing_merge_operations_inventory
-                        .track(merge_operation);
-                    ctx.send_message(
-                        &self.merge_split_downloader_mailbox,
-                        tracked_merge_operations,
-                    )
-                    .await?;
+    async fn send_merge_ops(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
+        // We do not want to simply schedule all available merge operations here.
+        //
+        // The reason is that in presence of partitioning, it is very possible
+        // to receive a set of splits opening the opportunity to run a lot "large" merge
+        // operations at the same time.
+        //
+        // These large merge operation will in turn prevent small merge operations
+        // from being executed, when in fact small merge operations should be executed
+        // in priority.
+        //
+        // As an alternative approach, this function push merge operations until it starts
+        // experience some push back, and then just "loops".
+        let mut merge_ops = self.compute_merge_ops(ctx).await?;
+        // We run smaller merges in priority.
+        merge_ops.sort_by_cached_key(|merge_op| Reverse(max_merge_ops(merge_op)));
+        while let Some(merge_operation) = merge_ops.pop() {
+            info!(merge_operation=?merge_operation, "Planned merge operation.");
+            let tracked_merge_operation = self
+                .ongoing_merge_operations_inventory
+                .track(merge_operation);
+            if let Err(try_send_err) = self
+                .merge_split_downloader_mailbox
+                .try_send_message(tracked_merge_operation)
+            {
+                match try_send_err {
+                    TrySendError::Disconnected => {
+                        return Err(ActorExitStatus::DownstreamClosed);
+                    }
+                    TrySendError::Full(merge_op) => {
+                        ctx.send_message(&self.merge_split_downloader_mailbox, merge_op)
+                            .await?;
+                        break;
+                    }
                 }
             }
+        }
+        if !merge_ops.is_empty() {
+            // We experienced some push back and decided to stop queueing too
+            // many merge operation. (For more detail see #2348)
+            //
+            // We need to re-record the related split, so that we
+            // perform a merge in the future.
+            for merge_op in merge_ops {
+                self.record_splits(merge_op.splits);
+            }
+            // We try_self_send a `PlanMerge` message in order to ensure that
+            // progress on our merges.
+            //
+            // If `try_send_self_message` returns an error, it means that the
+            // the self queue is full, which means that the `PlanMerge`
+            // message is not really needed anyway.
+            let _ignored_result = ctx.try_send_self_message(PlanMerge);
         }
         Ok(())
     }
@@ -198,6 +261,9 @@ fn belongs_to_pipeline(pipeline_id: &IndexingPipelineId, split: &SplitMetadata) 
 
 #[derive(Debug)]
 struct RefreshMetric;
+
+#[derive(Debug)]
+struct PlanMerge;
 
 #[async_trait]
 impl Handler<RefreshMetric> for MergePlanner {
@@ -221,24 +287,35 @@ impl Handler<RefreshMetric> for MergePlanner {
     }
 }
 
+#[derive(Clone, Debug, Serialize)]
+pub struct MergePlannerState {
+    ongoing_merge_operations: Vec<MergeOperation>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use itertools::Itertools;
     use quickwit_actors::{create_mailbox, QueueCapacity, Universe};
-    use quickwit_config::merge_policy_config::StableLogMergePolicyConfig;
+    use quickwit_config::merge_policy_config::{
+        ConstWriteAmplificationMergePolicyConfig, MergePolicyConfig, StableLogMergePolicyConfig,
+    };
+    use quickwit_config::IndexingSettings;
     use quickwit_metastore::SplitMetadata;
     use tantivy::TrackedObject;
 
     use crate::actors::MergePlanner;
-    use crate::merge_policy::{MergeOperation, StableLogMergePolicy};
+    use crate::merge_policy::{
+        merge_policy_from_settings, MergeOperation, MergePolicy, StableLogMergePolicy,
+    };
     use crate::models::{IndexingPipelineId, NewSplits};
 
     fn split_metadata_for_test(
         split_id: &str,
         partition_id: u64,
         num_docs: usize,
+        num_merge_ops: usize,
     ) -> SplitMetadata {
         SplitMetadata {
             split_id: split_id.to_string(),
@@ -247,6 +324,7 @@ mod tests {
             node_id: "test-node".to_string(),
             num_docs,
             partition_id,
+            num_merge_ops,
             ..Default::default()
         }
     }
@@ -283,8 +361,8 @@ mod tests {
             // send one split
             let message = NewSplits {
                 new_splits: vec![
-                    split_metadata_for_test("1_1", 1, 2500),
-                    split_metadata_for_test("1_2", 2, 3000),
+                    split_metadata_for_test("1_1", 1, 2500, 0),
+                    split_metadata_for_test("1_2", 2, 3000, 0),
                 ],
             };
             merge_planner_mailbox.send_message(message).await?;
@@ -296,8 +374,8 @@ mod tests {
             // send two splits with a duplicate
             let message = NewSplits {
                 new_splits: vec![
-                    split_metadata_for_test("2_1", 1, 2000),
-                    split_metadata_for_test("1_2", 2, 3000),
+                    split_metadata_for_test("2_1", 1, 2000, 0),
+                    split_metadata_for_test("1_2", 2, 3000, 0),
                 ],
             };
             merge_planner_mailbox.send_message(message).await?;
@@ -309,10 +387,10 @@ mod tests {
             // send four more splits to generate merge
             let message = NewSplits {
                 new_splits: vec![
-                    split_metadata_for_test("3_1", 1, 1500),
-                    split_metadata_for_test("4_1", 1, 1000),
-                    split_metadata_for_test("2_2", 2, 2000),
-                    split_metadata_for_test("3_2", 2, 4000),
+                    split_metadata_for_test("3_1", 1, 1500, 0),
+                    split_metadata_for_test("4_1", 1, 1000, 0),
+                    split_metadata_for_test("2_2", 2, 2000, 0),
+                    split_metadata_for_test("3_2", 2, 4000, 0),
                 ],
             };
             merge_planner_mailbox.send_message(message).await?;
@@ -334,9 +412,144 @@ mod tests {
 
         Ok(())
     }
-}
 
-#[derive(Clone, Debug, Serialize)]
-pub struct MergePlannerState {
-    ongoing_merge_operations: Vec<MergeOperation>,
+    #[tokio::test]
+    async fn test_merge_planner_priority() -> anyhow::Result<()> {
+        let (merge_split_downloader_mailbox, merge_split_downloader_inbox) =
+            create_mailbox("MergeSplitDownloader".to_string(), QueueCapacity::Unbounded);
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
+        let merge_policy_config = ConstWriteAmplificationMergePolicyConfig {
+            merge_factor: 2,
+            max_merge_factor: 2,
+            max_merge_ops: 3,
+        };
+        let indexing_settings = IndexingSettings {
+            merge_policy: MergePolicyConfig::ConstWriteAmplification(merge_policy_config),
+            ..Default::default()
+        };
+        let merge_policy: Arc<dyn MergePolicy> = merge_policy_from_settings(&indexing_settings);
+        let merge_planner = MergePlanner::new(
+            pipeline_id,
+            Vec::new(),
+            merge_policy,
+            merge_split_downloader_mailbox,
+        );
+        let universe = Universe::new();
+        let (merge_planner_mailbox, merge_planner_handle) =
+            universe.spawn_builder().spawn(merge_planner);
+        // send 4 splits, offering 2 merge opportunities.
+        let message = NewSplits {
+            new_splits: vec![
+                split_metadata_for_test("2_a", 2, 100, 2),
+                split_metadata_for_test("2_b", 2, 100, 2),
+                split_metadata_for_test("1_a", 1, 10, 1),
+                split_metadata_for_test("1_b", 1, 10, 1),
+            ],
+        };
+        merge_planner_mailbox.send_message(message).await?;
+        merge_planner_handle.process_pending_and_observe().await;
+        let merge_ops: Vec<TrackedObject<MergeOperation>> =
+            merge_split_downloader_inbox.drain_for_test_typed();
+        assert_eq!(merge_ops.len(), 2);
+        assert_eq!(merge_ops[0].splits_as_slice()[0].num_merge_ops, 1);
+        assert_eq!(merge_ops[1].splits_as_slice()[0].num_merge_ops, 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_merge_planner_priority_only_queue_up_to_capacity() {
+        let (merge_split_downloader_mailbox, merge_split_downloader_inbox) = create_mailbox(
+            "MergeSplitDownloader".to_string(),
+            QueueCapacity::Bounded(2),
+        );
+        let pipeline_id = IndexingPipelineId {
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
+            pipeline_ord: 0,
+        };
+        let merge_policy_config = ConstWriteAmplificationMergePolicyConfig {
+            merge_factor: 2,
+            max_merge_factor: 2,
+            max_merge_ops: 3,
+        };
+        let indexing_settings = IndexingSettings {
+            merge_policy: MergePolicyConfig::ConstWriteAmplification(merge_policy_config),
+            ..Default::default()
+        };
+        let merge_policy: Arc<dyn MergePolicy> = merge_policy_from_settings(&indexing_settings);
+        let merge_planner = MergePlanner::new(
+            pipeline_id,
+            Vec::new(),
+            merge_policy,
+            merge_split_downloader_mailbox,
+        );
+        let universe = Universe::new();
+        let (merge_planner_mailbox, _) = universe.spawn_builder().spawn(merge_planner);
+        tokio::task::spawn(async move {
+            // Sending 200 splits offering 100 split opportunities
+            let messages_with_merge_ops2 = NewSplits {
+                new_splits: (0..10)
+                    .flat_map(|partition_id| {
+                        [
+                            split_metadata_for_test(
+                                &format!("{partition_id}_a_large"),
+                                2,
+                                1_000_000,
+                                2,
+                            ),
+                            split_metadata_for_test(
+                                &format!("{partition_id}_b_large"),
+                                2,
+                                1_000_000,
+                                2,
+                            ),
+                        ]
+                    })
+                    .collect(),
+            };
+            merge_planner_mailbox
+                .send_message(messages_with_merge_ops2)
+                .await
+                .unwrap();
+            let messages_with_merge_ops1 = NewSplits {
+                new_splits: (0..10)
+                    .flat_map(|partition_id| {
+                        [
+                            split_metadata_for_test(
+                                &format!("{partition_id}_a_small"),
+                                2,
+                                100_000,
+                                1,
+                            ),
+                            split_metadata_for_test(
+                                &format!("{partition_id}_b_small"),
+                                2,
+                                100_000,
+                                1,
+                            ),
+                        ]
+                    })
+                    .collect(),
+            };
+            merge_planner_mailbox
+                .send_message(messages_with_merge_ops1)
+                .await
+                .unwrap();
+        });
+        tokio::task::spawn(async move {
+            let mut merge_ops: Vec<TrackedObject<MergeOperation>> = Vec::new();
+            while merge_ops.len() < 20 {
+                merge_ops.extend(merge_split_downloader_inbox.drain_for_test_typed());
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
 }

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -24,6 +24,7 @@ mod stable_log_merge_policy;
 use std::fmt;
 use std::sync::Arc;
 
+pub(crate) use const_write_amplification::ConstWriteAmplificationMergePolicy;
 use itertools::Itertools;
 pub use nop_merge_policy::NopMergePolicy;
 use quickwit_config::merge_policy_config::MergePolicyConfig;
@@ -33,7 +34,6 @@ use serde::Serialize;
 pub(crate) use stable_log_merge_policy::StableLogMergePolicy;
 use tracing::{info_span, Span};
 
-use crate::merge_policy::const_write_amplification::ConstWriteAmplificationMergePolicy;
 use crate::new_split_id;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -397,6 +397,9 @@ pub mod tests {
             create_timestamp: 0,
             tags: BTreeSet::from_iter(vec!["tenant_id:1".to_string(), "tenant_id:2".to_string()]),
             footer_offsets: 0..100,
+            index_id: "test-index".to_string(),
+            source_id: "test-source".to_string(),
+            node_id: "test-node".to_string(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Fixes the merge planner.
    
This PR tweaks the way the merge planner schedules its merge operation
in a subtle way to avoid adding a lot of large merge operations at the
same time... Hence stalling smaller, with a larger bang-for-the-buck
merge operations.
    
This is done by stopping queue merge operations as soon as push back is
experienced.
    


Closes #2348
