### PR TITLE
delete segment when last document get deleted

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -366,11 +366,20 @@ impl MergeExecutor {
         ctx.record_progress();
 
         // Compute merged split attributes.
-        let merged_segment = merged_index
-            .searchable_segments()?
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow!("Delete operation should output one segment."))?;
+        let merged_segment =
+            if let Some(segment) = merged_index.searchable_segments()?.into_iter().next() {
+                segment
+            } else {
+                info!(
+                    "All document from split `{}` were deleted.",
+                    split.split_id()
+                );
+                self.metastore
+                    .mark_splits_for_deletion(&split.index_id, &[split.split_id()])
+                    .await?;
+                return Ok(None);
+            };
+
         let merged_segment_reader = SegmentReader::open(&merged_segment)?;
         let num_docs = merged_segment_reader.num_docs() as u64;
         let uncompressed_docs_size_in_bytes = (num_docs as f32
@@ -484,6 +493,11 @@ impl MergeExecutor {
 
         // A merge is useless if there is no delete and only one segment.
         if num_delete_tasks == 0 && segment_ids.len() <= 1 {
+            return Ok(output_directory);
+        }
+
+        // If after deletion there is no longer any document, don't try to merge.
+        if num_delete_tasks != 0 && segment_ids.is_empty() {
             return Ok(output_directory);
         }
 
@@ -742,43 +756,55 @@ mod tests {
             .await;
 
         let packager_msgs: Vec<IndexedSplitBatch> = merge_packager_inbox.drain_for_test_typed();
-        assert_eq!(packager_msgs.len(), 1);
-        let split = &packager_msgs[0].splits[0];
-        assert_eq!(split.split_attrs.num_docs, result_docs.len() as u64);
-        assert_eq!(split.split_attrs.delete_opstamp, 1);
-        // Delete operations do not update the num_merge_ops value.
-        assert_eq!(split.split_attrs.num_merge_ops, 1);
-        assert_eq!(
-            split.split_attrs.uncompressed_docs_size_in_bytes,
-            expected_uncompressed_docs_size_in_bytes,
-        );
-        let reader = split
-            .index
-            .reader_builder()
-            .reload_policy(ReloadPolicy::Manual)
-            .try_into()?;
-        let searcher = reader.searcher();
-        assert_eq!(searcher.segment_readers().len(), 1);
+        if !result_docs.is_empty() {
+            assert_eq!(packager_msgs.len(), 1);
+            let split = &packager_msgs[0].splits[0];
+            assert_eq!(split.split_attrs.num_docs, result_docs.len() as u64);
+            assert_eq!(split.split_attrs.delete_opstamp, 1);
+            // Delete operations do not update the num_merge_ops value.
+            assert_eq!(split.split_attrs.num_merge_ops, 1);
+            assert_eq!(
+                split.split_attrs.uncompressed_docs_size_in_bytes,
+                expected_uncompressed_docs_size_in_bytes,
+            );
+            let reader = split
+                .index
+                .reader_builder()
+                .reload_policy(ReloadPolicy::Manual)
+                .try_into()?;
+            let searcher = reader.searcher();
+            assert_eq!(searcher.segment_readers().len(), 1);
 
-        let documents_left = searcher
-            .search(
-                &tantivy::query::AllQuery,
-                &tantivy::collector::TopDocs::with_limit(result_docs.len() + 1),
-            )?
-            .into_iter()
-            .map(|(_, doc_address)| {
-                let doc = searcher.doc(doc_address).unwrap();
-                let doc_json = searcher.schema().to_json(&doc);
-                serde_json::from_str(&doc_json).unwrap()
-            })
-            .collect::<Vec<serde_json::Value>>();
+            let documents_left = searcher
+                .search(
+                    &tantivy::query::AllQuery,
+                    &tantivy::collector::TopDocs::with_limit(result_docs.len() + 1),
+                )?
+                .into_iter()
+                .map(|(_, doc_address)| {
+                    let doc = searcher.doc(doc_address).unwrap();
+                    let doc_json = searcher.schema().to_json(&doc);
+                    serde_json::from_str(&doc_json).unwrap()
+                })
+                .collect::<Vec<serde_json::Value>>();
 
-        assert_eq!(documents_left.len(), result_docs.len());
-        for doc in &documents_left {
-            assert!(result_docs.contains(dbg!(doc)));
-        }
-        for doc in &result_docs {
-            assert!(documents_left.contains(doc));
+            assert_eq!(documents_left.len(), result_docs.len());
+            for doc in &documents_left {
+                assert!(result_docs.contains(dbg!(doc)));
+            }
+            for doc in &result_docs {
+                assert!(documents_left.contains(doc));
+            }
+        } else {
+            assert!(packager_msgs.is_empty());
+            let metastore = test_sandbox.metastore();
+            assert!(metastore
+                .list_all_splits(index_id)
+                .await?
+                .into_iter()
+                .all(
+                    |split| split.split_state == quickwit_metastore::SplitState::MarkedForDeletion
+                ));
         }
 
         Ok(())
@@ -813,6 +839,20 @@ mod tests {
                 serde_json::json!({"body": ["info"], "ts": ["2021-06-29T00:56:48Z"] }),
                 serde_json::json!({"body": ["info"], "ts": ["2021-06-29T00:56:49Z"] }),
             ],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_delete_all() -> anyhow::Result<()> {
+        aux_test_delete_and_merge_executor(
+            "test-delete-all",
+            vec![
+                serde_json::json!({"body": "delete", "ts": 1634928208 }),
+                serde_json::json!({"body": "delete", "ts": 1634928209 }),
+            ],
+            "body:delete",
+            vec![],
         )
         .await
     }

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -371,7 +371,7 @@ impl MergeExecutor {
                 segment
             } else {
                 info!(
-                    "All document from split `{}` were deleted.",
+                    "All documents from split `{}` were deleted.",
                     split.split_id()
                 );
                 self.metastore


### PR DESCRIPTION
### Description

fix #1960 

### How was this PR tested?

I created an index with a single document repeated thousands of times and one other document. On delete, the split containing only repeated document get marked for deletion, the split with one document left is... left with one document.