### PR TITLE
Rename `Supervisable::health` method to `harvest_health`

### DIFF
--- a/quickwit/quickwit-actors/src/actor_handle.rs
+++ b/quickwit/quickwit-actors/src/actor_handle.rs
@@ -64,7 +64,7 @@ impl<A: Actor> fmt::Debug for ActorHandle<A> {
 
 pub trait Supervisable {
     fn name(&self) -> &str;
-    fn health(&self) -> Health;
+    fn harvest_health(&self) -> Health;
 }
 
 impl<A: Actor> Supervisable for ActorHandle<A> {
@@ -72,7 +72,11 @@ impl<A: Actor> Supervisable for ActorHandle<A> {
         self.actor_context.actor_instance_id()
     }
 
-    fn health(&self) -> Health {
+    /// Harvests the health of the actor by checking its state (see [`ActorState`]) and/or progress
+    /// (see `Progress`). When the actor is running, calling this method resets its progress state
+    /// to "no update" (see `ProgressState`). As a consequence, only one supervisor or probe
+    /// should periodically invoke this method during the lifetime of the actor.
+    fn harvest_health(&self) -> Health {
         let actor_state = self.state();
         if actor_state == ActorState::Success {
             Health::Success

--- a/quickwit/quickwit-actors/src/supervisor.rs
+++ b/quickwit/quickwit-actors/src/supervisor.rs
@@ -112,7 +112,12 @@ impl<A: Actor> Supervisor<A> {
         &mut self,
         ctx: &ActorContext<Supervisor<A>>,
     ) -> Result<(), ActorExitStatus> {
-        match self.handle_opt.as_ref().unwrap().health() {
+        match self
+            .handle_opt
+            .as_ref()
+            .expect("The actor handle should always be set.")
+            .harvest_health()
+        {
             Health::Healthy => {
                 return Ok(());
             }

--- a/quickwit/quickwit-actors/src/tests.rs
+++ b/quickwit/quickwit-actors/src/tests.rs
@@ -275,15 +275,15 @@ async fn test_timeouting_actor() {
     );
     assert!(buggy_mailbox.send_message(Block).await.is_ok());
 
-    assert_eq!(buggy_handle.health(), Health::Healthy);
+    assert_eq!(buggy_handle.harvest_health(), Health::Healthy);
     assert_eq!(
         buggy_handle.process_pending_and_observe().await.obs_type,
         ObservationType::Timeout
     );
-    assert_eq!(buggy_handle.health(), Health::Healthy);
+    assert_eq!(buggy_handle.harvest_health(), Health::Healthy);
     tokio::time::sleep(crate::HEARTBEAT).await;
     tokio::time::sleep(crate::HEARTBEAT).await;
-    assert_eq!(buggy_handle.health(), Health::FailureOrUnhealthy);
+    assert_eq!(buggy_handle.harvest_health(), Health::FailureOrUnhealthy);
 }
 
 #[tokio::test]

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -184,7 +184,7 @@ impl IndexingPipeline {
         let mut failure_or_unhealthy_actors: Vec<&str> = Default::default();
         let mut success_actors: Vec<&str> = Default::default();
         for supervisable in self.supervisables() {
-            match supervisable.health() {
+            match supervisable.harvest_health() {
                 Health::Healthy => {
                     // At least one other actor is running.
                     healthy_actors.push(supervisable.name());
@@ -796,7 +796,7 @@ mod tests {
         // Check indexing pipeline has restarted.
         assert_eq!(indexing_pipeline_handler.observe().await.generation, 2);
         // Check that the merge pipeline is still up.
-        assert_eq!(merge_pipeline_handler.health(), Health::Healthy);
+        assert_eq!(merge_pipeline_handler.harvest_health(), Health::Healthy);
         Ok(())
     }
 }

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -1001,7 +1001,7 @@ mod tests {
                 .indexing_pipeline_handles
                 .get(&message.0)
                 .unwrap()
-                .health())
+                .harvest_health())
         }
     }
 

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -133,7 +133,7 @@ impl MergePipeline {
         let mut failure_or_unhealthy_actors: Vec<&str> = Default::default();
         let mut success_actors: Vec<&str> = Default::default();
         for supervisable in self.supervisables() {
-            match supervisable.health() {
+            match supervisable.harvest_health() {
                 Health::Healthy => {
                     // At least one other actor is running.
                     healthy_actors.push(supervisable.name());

--- a/quickwit/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit/quickwit-indexing/src/source/void_source.rs
@@ -129,7 +129,7 @@ mod tests {
         };
         let universe = Universe::new();
         let (_, void_source_handle) = universe.spawn_builder().spawn(void_source_actor);
-        matches!(void_source_handle.health(), Health::Healthy);
+        matches!(void_source_handle.harvest_health(), Health::Healthy);
         let (actor_termination, observed_state) = void_source_handle.quit().await;
         assert_eq!(observed_state, json!({}));
         matches!(actor_termination, ActorExitStatus::Quit);

--- a/quickwit/quickwit-janitor/src/janitor_service.rs
+++ b/quickwit/quickwit-janitor/src/janitor_service.rs
@@ -43,6 +43,29 @@ impl JanitorService {
             retention_policy_executor_handle,
         }
     }
+
+    fn supervisables(&self) -> Vec<&dyn Supervisable> {
+        vec![
+            &self.delete_task_service_handle,
+            &self.garbage_collector_handle,
+            &self.retention_policy_executor_handle,
+        ]
+    }
+
+    // CAUTION: if you ever add a supervisor to this actor, make sure the healthz probe no longer
+    // calls this method and share the health via a watch channel instead.
+    fn harvest_health(&self) -> Health {
+        let mut janitor_health = Health::Healthy;
+
+        for supervisable in self.supervisables() {
+            let actor_health = supervisable.harvest_health();
+
+            if actor_health != Health::Healthy {
+                janitor_health = actor_health;
+            }
+        }
+        janitor_health
+    }
 }
 
 #[async_trait]
@@ -67,14 +90,6 @@ impl Handler<Healthz> for JanitorService {
         _message: Healthz,
         _ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        let all_healthy = [
-            self.delete_task_service_handle.health(),
-            self.garbage_collector_handle.health(),
-            self.retention_policy_executor_handle.health(),
-        ]
-        .iter()
-        .all(|health| *health == Health::Healthy);
-
-        Ok(all_healthy)
+        Ok(self.harvest_health() == Health::Healthy)
     }
 }


### PR DESCRIPTION
### Description
Rename `Supervisable::health` to `harvest_health` to inform the caller that the method performs a side-effect. 

### How was this PR tested?
`cargo test --manifest-path quickwit/Cargo.toml --all-features --no-run` (the test suite is broken)
