### PR TITLE
QW-2308: Adjust indexing service to let CLI detach merge pipeline.

### DIFF
--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -41,7 +41,7 @@ use quickwit_config::{
 use quickwit_core::{
     clear_cache_directory, remove_indexing_directory, validate_storage_uri, IndexService,
 };
-use quickwit_indexing::actors::{IndexingService, MergePipelineId};
+use quickwit_indexing::actors::IndexingService;
 use quickwit_indexing::models::{
     DetachIndexingPipeline, DetachMergePipeline, IndexingPipelineId, IndexingStatistics,
     SpawnMergePipeline, SpawnPipeline,
@@ -938,7 +938,7 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
         .await?;
     let merge_pipeline_handle = indexing_server_mailbox
         .ask_for_res(DetachMergePipeline {
-            pipeline_id: MergePipelineId::from(&pipeline_id),
+            pipeline_id: pipeline_id.clone(),
         })
         .await?;
     let indexing_pipeline_handle = indexing_server_mailbox

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -959,7 +959,7 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
     let statistics =
         start_statistics_reporting_loop(indexing_pipeline_handle, args.input_path_opt.is_none())
             .await?;
-    merge_pipeline_handle.kill().await;
+    merge_pipeline_handle.quit().await;
     // Shutdown the indexing server.
     universe
         .send_exit_with_success(&indexing_server_mailbox)

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -866,7 +866,7 @@ mod tests {
         assert_eq!(observation.num_running_merge_pipelines, 1);
 
         // Test `detach_merge_pipeline`
-        let pipeline = indexing_server_mailbox
+        let _pipeline = indexing_server_mailbox
             .ask_for_res(DetachMergePipeline {
                 pipeline_id: MergePipelineId::from(&pipeline_id),
             })

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -27,9 +27,7 @@ use quickwit_actors::{
     Observation,
 };
 use quickwit_common::fs::get_cache_directory_path;
-use quickwit_config::{
-    build_doc_mapper, IndexConfig, IndexerConfig, SourceConfig, SourceParams, VecSourceParams,
-};
+use quickwit_config::{build_doc_mapper, IndexConfig, IndexerConfig, SourceConfig};
 use quickwit_ingest_api::QUEUES_DIR_NAME;
 use quickwit_metastore::{IndexMetadata, Metastore, MetastoreError};
 use quickwit_proto::{ServiceError, ServiceErrorCode};
@@ -42,8 +40,8 @@ use super::merge_pipeline::{MergePipeline, MergePipelineParams};
 use super::MergePlanner;
 use crate::models::{
     DetachIndexingPipeline, DetachMergePipeline, IndexingDirectory, IndexingPipelineId, Observe,
-    ObservePipeline, ShutdownPipeline, ShutdownPipelines, SpawnMergePipeline, SpawnPipeline,
-    SpawnPipelines, WeakIndexingDirectory,
+    ObservePipeline, ShutdownPipeline, ShutdownPipelines, SpawnPipeline, SpawnPipelines,
+    WeakIndexingDirectory,
 };
 use crate::split_store::{LocalSplitStore, SplitStoreQuota};
 use crate::{IndexingPipeline, IndexingPipelineParams, IndexingSplitStore, IndexingStatistics};
@@ -96,8 +94,8 @@ pub struct IndexingServiceCounters {
 type IndexId = String;
 type SourceId = String;
 
-#[derive(Clone, Hash, Eq, PartialEq)]
-struct MergePipelineId {
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct MergePipelineId {
     index_id: String,
     source_id: String,
 }
@@ -347,26 +345,6 @@ impl IndexingService {
         Ok(())
     }
 
-    async fn spawn_merge_pipeline(
-        &mut self,
-        ctx: &ActorContext<Self>,
-        pipeline_id: IndexingPipelineId,
-    ) -> Result<IndexingPipelineId, IndexingServiceError> {
-        let index_config = self
-            .index_metadata(ctx, &pipeline_id.index_id)
-            .await?
-            .into_index_config();
-        let source_config = SourceConfig {
-            source_id: pipeline_id.source_id.clone(),
-            num_pipelines: 1,
-            enabled: true,
-            source_params: SourceParams::Vec(VecSourceParams::default()),
-        };
-        self.spawn_pipeline_inner(ctx, pipeline_id.clone(), index_config, source_config)
-            .await?;
-        Ok(pipeline_id)
-    }
-
     async fn index_metadata(
         &self,
         ctx: &ActorContext<Self>,
@@ -526,9 +504,7 @@ impl Handler<DetachMergePipeline> for IndexingService {
         msg: DetachMergePipeline,
         _ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        Ok(self
-            .detach_merge_pipeline(&MergePipelineId::from(&msg.pipeline_id))
-            .await)
+        Ok(self.detach_merge_pipeline(&msg.pipeline_id).await)
     }
 }
 
@@ -561,18 +537,6 @@ impl Actor for IndexingService {
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
         self.handle(SuperviseLoop, ctx).await
-    }
-}
-
-#[async_trait]
-impl Handler<SpawnMergePipeline> for IndexingService {
-    type Reply = Result<IndexingPipelineId, IndexingServiceError>;
-    async fn handle(
-        &mut self,
-        message: SpawnMergePipeline,
-        ctx: &ActorContext<Self>,
-    ) -> Result<Self::Reply, ActorExitStatus> {
-        Ok(self.spawn_merge_pipeline(ctx, message.pipeline_id).await)
     }
 }
 
@@ -689,7 +653,7 @@ mod tests {
     use quickwit_actors::{Health, ObservationType, Supervisable, Universe, HEARTBEAT};
     use quickwit_common::rand::append_random_suffix;
     use quickwit_common::uri::Uri;
-    use quickwit_config::{SourceConfig, VecSourceParams};
+    use quickwit_config::{SourceConfig, SourceParams, VecSourceParams};
     use quickwit_ingest_api::init_ingest_api;
     use quickwit_metastore::{quickwit_metastore_uri_resolver, MockMetastore};
 
@@ -877,22 +841,29 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(
-            indexing_server_handle.observe().await.num_running_pipelines,
-            0
-        );
+        let observation = indexing_server_handle.process_pending_and_observe().await;
+        assert_eq!(observation.num_running_pipelines, 0);
+
+        // Let the service cleanup the merge pipelines.
+        universe.simulate_time_shift(HEARTBEAT).await;
 
         // Test `spawn_merge_pipeline`.
         indexing_server_mailbox
-            .ask_for_res(SpawnMergePipeline {
-                pipeline_id: pipeline_id_0,
+            .ask_for_res(SpawnPipeline {
+                index_id: index_id.clone(),
+                source_config: SourceConfig {
+                    source_id: source_config_0.source_id,
+                    num_pipelines: 1,
+                    enabled: true,
+                    source_params: SourceParams::Vec(VecSourceParams::default()),
+                },
+                pipeline_ord: 0,
             })
             .await
             .unwrap();
-        assert_eq!(
-            indexing_server_handle.observe().await.num_running_pipelines,
-            1
-        );
+        let observation = indexing_server_handle.process_pending_and_observe().await;
+        assert_eq!(observation.num_running_pipelines, 1);
+        assert_eq!(observation.num_running_merge_pipelines, 1);
 
         // Test `supervise_pipelines`
         let source_config_3 = SourceConfig {
@@ -977,6 +948,7 @@ mod tests {
         assert_eq!(observation.num_running_pipelines, 1);
         assert_eq!(observation.num_failed_pipelines, 0);
         assert_eq!(observation.num_successful_pipelines, 0);
+        assert_eq!(observation.num_running_merge_pipelines, 1);
 
         // Test `shutdown_pipeline`
         indexing_server_mailbox
@@ -986,17 +958,13 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(
-            indexing_server_handle.observe().await.num_running_pipelines,
-            0
-        );
-        assert_eq!(
-            indexing_server_handle
-                .observe()
-                .await
-                .num_running_merge_pipelines,
-            0
-        );
+
+        // Let the service cleanup the merge pipelines.
+        universe.simulate_time_shift(HEARTBEAT).await;
+
+        let observation = indexing_server_handle.process_pending_and_observe().await;
+        assert_eq!(observation.num_running_pipelines, 0);
+        assert_eq!(observation.num_running_merge_pipelines, 0);
         universe.simulate_time_shift(HEARTBEAT).await;
         // Check that the merge pipeline is also shut down as they are no more indexing pipeilne on
         // the index.

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -96,8 +96,8 @@ pub struct IndexingServiceCounters {
 type IndexId = String;
 type SourceId = String;
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct MergePipelineId {
+#[derive(Clone, Hash, Eq, PartialEq)]
+struct MergePipelineId {
     index_id: String,
     source_id: String,
 }
@@ -526,7 +526,9 @@ impl Handler<DetachMergePipeline> for IndexingService {
         msg: DetachMergePipeline,
         _ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        Ok(self.detach_merge_pipeline(&msg.pipeline_id).await)
+        Ok(self
+            .detach_merge_pipeline(&MergePipelineId::from(&msg.pipeline_id))
+            .await)
     }
 }
 

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -184,7 +184,7 @@ impl IndexingService {
                 index_id: pipeline_id.index_id.clone(),
                 source_id: pipeline_id.source_id.clone(),
             })?;
-        self.counters.num_running_merge_pipelines = 1;
+        self.counters.num_running_merge_pipelines -= 1;
         Ok(pipeline_handle.handle)
     }
 

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -32,7 +32,8 @@ mod uploader;
 
 pub use indexing_pipeline::{IndexingPipeline, IndexingPipelineHandles, IndexingPipelineParams};
 pub use indexing_service::{
-    IndexingService, IndexingServiceCounters, IndexingServiceError, INDEXING_DIR_NAME,
+    IndexingService, IndexingServiceCounters, IndexingServiceError, MergePipelineId,
+    INDEXING_DIR_NAME,
 };
 pub use sequencer::Sequencer;
 mod merge_executor;

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -32,8 +32,7 @@ mod uploader;
 
 pub use indexing_pipeline::{IndexingPipeline, IndexingPipelineHandles, IndexingPipelineParams};
 pub use indexing_service::{
-    IndexingService, IndexingServiceCounters, IndexingServiceError, MergePipelineId,
-    INDEXING_DIR_NAME,
+    IndexingService, IndexingServiceCounters, IndexingServiceError, INDEXING_DIR_NAME,
 };
 pub use sequencer::Sequencer;
 mod merge_executor;

--- a/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
+++ b/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
@@ -20,6 +20,7 @@
 use quickwit_config::SourceConfig;
 
 use super::IndexingPipelineId;
+use crate::actors::MergePipelineId;
 
 #[derive(Debug)]
 pub struct SpawnPipelines {
@@ -52,8 +53,16 @@ pub struct ShutdownPipeline {
 /// server. This is mostly useful for ad-hoc indexing pipelines launched with `quickwit index
 /// ingest ..` and testing.
 #[derive(Debug)]
-pub struct DetachPipeline {
+pub struct DetachIndexingPipeline {
     pub pipeline_id: IndexingPipelineId,
+}
+
+#[derive(Debug)]
+/// Detaches a merge pipeline from the indexing service. The pipeline is no longer managed by the
+/// server. This is mostly useful for preventing the server killing an existing merge pipeline
+/// if a indexing pipeline is detached.
+pub struct DetachMergePipeline {
+    pub pipeline_id: MergePipelineId,
 }
 
 #[derive(Debug)]

--- a/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
+++ b/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
@@ -20,6 +20,7 @@
 use quickwit_config::SourceConfig;
 
 use super::IndexingPipelineId;
+use crate::actors::MergePipelineId;
 
 #[derive(Debug)]
 pub struct SpawnPipelines {
@@ -61,15 +62,10 @@ pub struct DetachIndexingPipeline {
 /// server. This is mostly useful for preventing the server killing an existing merge pipeline
 /// if a indexing pipeline is detached.
 pub struct DetachMergePipeline {
-    pub pipeline_id: IndexingPipelineId,
+    pub pipeline_id: MergePipelineId,
 }
 
 #[derive(Debug)]
 pub struct ObservePipeline {
-    pub pipeline_id: IndexingPipelineId,
-}
-
-#[derive(Debug)]
-pub struct SpawnMergePipeline {
     pub pipeline_id: IndexingPipelineId,
 }

--- a/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
+++ b/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
@@ -20,7 +20,6 @@
 use quickwit_config::SourceConfig;
 
 use super::IndexingPipelineId;
-use crate::actors::MergePipelineId;
 
 #[derive(Debug)]
 pub struct SpawnPipelines {
@@ -62,7 +61,7 @@ pub struct DetachIndexingPipeline {
 /// server. This is mostly useful for preventing the server killing an existing merge pipeline
 /// if a indexing pipeline is detached.
 pub struct DetachMergePipeline {
-    pub pipeline_id: MergePipelineId,
+    pub pipeline_id: IndexingPipelineId,
 }
 
 #[derive(Debug)]

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -40,7 +40,7 @@ pub use indexing_directory::{IndexingDirectory, WeakIndexingDirectory};
 pub use indexing_pipeline_id::IndexingPipelineId;
 pub use indexing_service_message::{
     DetachIndexingPipeline, DetachMergePipeline, ObservePipeline, ShutdownPipeline,
-    ShutdownPipelines, SpawnMergePipeline, SpawnPipeline, SpawnPipelines,
+    ShutdownPipelines, SpawnPipeline, SpawnPipelines,
 };
 pub use indexing_statistics::IndexingStatistics;
 pub use merge_planner_message::NewSplits;

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -39,8 +39,8 @@ pub use indexed_split::{
 pub use indexing_directory::{IndexingDirectory, WeakIndexingDirectory};
 pub use indexing_pipeline_id::IndexingPipelineId;
 pub use indexing_service_message::{
-    DetachPipeline, ObservePipeline, ShutdownPipeline, ShutdownPipelines, SpawnMergePipeline,
-    SpawnPipeline, SpawnPipelines,
+    DetachIndexingPipeline, DetachMergePipeline, ObservePipeline, ShutdownPipeline,
+    ShutdownPipelines, SpawnMergePipeline, SpawnPipeline, SpawnPipelines,
 };
 pub use indexing_statistics::IndexingStatistics;
 pub use merge_planner_message::NewSplits;

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -35,7 +35,7 @@ use quickwit_metastore::{
 use quickwit_storage::{Storage, StorageUriResolver};
 
 use crate::actors::IndexingService;
-use crate::models::{DetachPipeline, IndexingStatistics, SpawnPipeline};
+use crate::models::{DetachIndexingPipeline, IndexingStatistics, SpawnPipeline};
 
 /// Creates a Test environment.
 ///
@@ -156,7 +156,7 @@ impl TestSandbox {
             .await?;
         let pipeline_handle = self
             .indexing_service
-            .ask_for_res(DetachPipeline { pipeline_id })
+            .ask_for_res(DetachIndexingPipeline { pipeline_id })
             .await?;
         let (_pipeline_exit_status, pipeline_statistics) = pipeline_handle.join().await;
         Ok(pipeline_statistics)


### PR DESCRIPTION
Closes #2308 

### Description
This adds a new handler for detaching a given merge pipeline, which lets us detach both the indexing and merge pipelines to avoid the indexing service from killing the merge pipeline.

This also inadvertently fixed a small bug where merge pipeline counters were not set until the actor tries to clean them up.

### How was this PR tested?
Existing tests have been adjusted to use the new way of spawning merge pipelines, and the new handler has got a test.
