### PR TITLE
Fix flaky CLI test and add `--retries` to nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             command: cargo doc --no-deps --all-features --document-private-items
             cache: true
           - name: cargo nextest
-            command: cargo nextest run --features=postgres --profile ci
+            command: cargo nextest run --features=postgres --profile ci --retries 1
             cache: true
           - name: License headers check
             command: bash scripts/check_license_headers.sh

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -686,7 +686,7 @@ async fn test_garbage_collect_index_cli() {
     let splits = metastore.list_all_splits(&test_env.index_id).await.unwrap();
     assert_eq!(splits[0].split_state, SplitState::Staged);
 
-    let args = create_gc_args(1);
+    let args = create_gc_args(3600);
 
     garbage_collect_index_cli(args).await.unwrap();
 


### PR DESCRIPTION
On slow runs, grace period passes for the staged splits. I did not notice it while refactoring x(
