### PR TITLE
Differentiate serde_json-value from tantivy-value

### DIFF
--- a/quickwit/quickwit-actors/src/registry.rs
+++ b/quickwit/quickwit-actors/src/registry.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::future;
 use serde::Serialize;
+use serde_json::Value as JsonValue;
 use tokio::sync::oneshot;
 
 use crate::mailbox::WeakMailbox;
@@ -40,7 +41,7 @@ trait JsonObservable: Sync + Send {
     fn is_disconnected(&self) -> bool;
     fn any(&self) -> &dyn Any;
     fn actor_instance_id(&self) -> &str;
-    async fn observe(&self) -> Option<serde_json::Value>;
+    async fn observe(&self) -> Option<JsonValue>;
 }
 
 #[async_trait]
@@ -57,7 +58,7 @@ impl<A: Actor> JsonObservable for TypedJsonObservable<A> {
     fn actor_instance_id(&self) -> &str {
         self.actor_instance_id.as_str()
     }
-    async fn observe(&self) -> Option<serde_json::Value> {
+    async fn observe(&self) -> Option<JsonValue> {
         let mailbox = self.weak_mailbox.upgrade()?;
         let (oneshot_tx, oneshot_rx) = oneshot::channel::<Box<dyn Any + Send>>();
         mailbox
@@ -104,7 +105,7 @@ impl ActorRegistryForSpecificType {
 pub struct ActorObservation {
     pub type_name: &'static str,
     pub instance_id: String,
-    pub obs: Option<serde_json::Value>,
+    pub obs: Option<JsonValue>,
 }
 
 impl ActorRegistry {

--- a/quickwit/quickwit-common/src/net.rs
+++ b/quickwit/quickwit-common/src/net.rs
@@ -353,6 +353,7 @@ mod tests {
     use std::net::Ipv6Addr;
 
     use pnet::ipnetwork::{Ipv4Network, Ipv6Network};
+    use serde_json::Value as JsonValue;
 
     use super::*;
 
@@ -392,15 +393,15 @@ mod tests {
     fn test_serialize_host() {
         assert_eq!(
             serde_json::to_value(Host::from(Ipv4Addr::LOCALHOST)).unwrap(),
-            serde_json::Value::String("127.0.0.1".to_string())
+            JsonValue::String("127.0.0.1".to_string())
         );
         assert_eq!(
             serde_json::to_value(Host::from(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))).unwrap(),
-            serde_json::Value::String("::1".to_string())
+            JsonValue::String("::1".to_string())
         );
         assert_eq!(
             serde_json::to_value(Host::Hostname("localhost".to_string())).unwrap(),
-            serde_json::Value::String("localhost".to_string())
+            JsonValue::String("localhost".to_string())
         );
     }
 

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -46,6 +46,7 @@ pub use index_config::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde_json::Value as JsonValue;
 pub use source_config::{
     FileSourceParams, KafkaSourceParams, KinesisSourceParams, RegionOrEndpoint, SourceConfig,
     SourceParams, VecSourceParams, VoidSourceParams, CLI_INGEST_SOURCE_ID, INGEST_API_SOURCE_ID,
@@ -119,12 +120,12 @@ impl ConfigFormat {
     where T: DeserializeOwned {
         match self {
             ConfigFormat::Json => {
-                let mut json_value: serde_json::Value =
+                let mut json_value: JsonValue =
                     serde_json::from_reader(StripComments::new(payload))?;
                 let version_value = json_value.get_mut("version").context("Missing version.")?;
                 if let Some(version_number) = version_value.as_u64() {
                     warn!("`version` is supposed to be a string.");
-                    *version_value = serde_json::Value::String(version_number.to_string());
+                    *version_value = JsonValue::String(version_number.to_string());
                 }
                 serde_json::from_value(json_value).context("Failed to read JSON file.")
             }

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -25,6 +25,7 @@ use std::str::FromStr;
 use quickwit_common::uri::Uri;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value as JsonValue;
 // For backward compatibility.
 use serialize::VersionedSourceConfig;
 
@@ -73,7 +74,7 @@ impl SourceConfig {
     }
 
     // TODO: Remove after source factory refactor.
-    pub fn params(&self) -> serde_json::Value {
+    pub fn params(&self) -> JsonValue {
         match &self.source_params {
             SourceParams::File(params) => serde_json::to_value(params),
             SourceParams::Kafka(params) => serde_json::to_value(params),
@@ -199,7 +200,7 @@ pub struct KafkaSourceParams {
     /// Kafka client configuration parameters.
     #[serde(default = "serde_json::Value::default")]
     #[serde(skip_serializing_if = "serde_json::Value::is_null")]
-    pub client_params: serde_json::Value,
+    pub client_params: JsonValue,
     /// When backfill mode is enabled, the source exits after reaching the end of the topic.
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]

--- a/quickwit/quickwit-doc-mapper/src/routing_expression/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/routing_expression/mod.rs
@@ -23,6 +23,7 @@ use std::num::NonZeroU64;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use serde_json::Value as JsonValue;
 use siphasher::sip::SipHasher;
 
 pub trait RoutingExprContext {
@@ -33,32 +34,32 @@ pub trait RoutingExprContext {
 /// This is a bit overkill but this function has the merit of
 /// ensuring that the data that is sent to the hasher is unique
 /// to the value, so we do not lose injectivity there.
-fn hash_json_val<H: Hasher>(json_val: &serde_json::Value, hasher: &mut H) {
+fn hash_json_val<H: Hasher>(json_val: &JsonValue, hasher: &mut H) {
     match json_val {
-        serde_json::Value::Null => {
+        JsonValue::Null => {
             hasher.write_u8(0u8);
         }
-        serde_json::Value::Bool(bool_val) => {
+        JsonValue::Bool(bool_val) => {
             hasher.write_u8(1u8);
             bool_val.hash(hasher);
         }
-        serde_json::Value::Number(num) => {
+        JsonValue::Number(num) => {
             hasher.write_u8(2u8);
             num.hash(hasher);
         }
-        serde_json::Value::String(s) => {
+        JsonValue::String(s) => {
             hasher.write_u8(3u8);
             hasher.write_usize(s.len());
             hasher.write(s.as_bytes());
         }
-        serde_json::Value::Array(arr) => {
+        JsonValue::Array(arr) => {
             hasher.write_u8(4u8);
             hasher.write_usize(arr.len());
             for el in arr {
                 hash_json_val(el, hasher);
             }
         }
-        serde_json::Value::Object(obj) => {
+        JsonValue::Object(obj) => {
             hasher.write_u8(5u8);
             hasher.write_usize(obj.len());
             for (key, val) in obj.iter() {
@@ -70,7 +71,7 @@ fn hash_json_val<H: Hasher>(json_val: &serde_json::Value, hasher: &mut H) {
     }
 }
 
-impl RoutingExprContext for serde_json::Map<String, serde_json::Value> {
+impl RoutingExprContext for serde_json::Map<String, JsonValue> {
     fn hash_attribute<H: Hasher>(&self, attr_name: &str, hasher: &mut H) {
         if let Some(json_val) = self.get(attr_name) {
             hasher.write_u8(1u8);
@@ -268,7 +269,7 @@ mod tests {
     #[test]
     fn test_routing_expr_empty_hashes_to_0() {
         let expr = RoutingExpr::new("", NonZeroU64::new(10).unwrap()).unwrap();
-        let ctx: serde_json::Map<String, serde_json::Value> = Default::default();
+        let ctx: serde_json::Map<String, JsonValue> = Default::default();
         assert_eq!(expr.eval_hash(&ctx), 0u64);
     }
 
@@ -288,9 +289,9 @@ mod tests {
     fn test_routing_expr_depends_on_both_expr_and_value() {
         let routing_expr = RoutingExpr::new("tenant_id", MAX_NUM_PARTITIONS).unwrap();
         let routing_expr2 = RoutingExpr::new("app", MAX_NUM_PARTITIONS).unwrap();
-        let ctx: serde_json::Map<String, serde_json::Value> =
+        let ctx: serde_json::Map<String, JsonValue> =
             serde_json::from_str(r#"{"tenant_id": "happy", "app": "happy"}"#).unwrap();
-        let ctx2: serde_json::Map<String, serde_json::Value> =
+        let ctx2: serde_json::Map<String, JsonValue> =
             serde_json::from_str(r#"{"tenant_id": "happy2"}"#).unwrap();
         // This assert is important.
         assert_ne!(routing_expr.eval_hash(&ctx), routing_expr2.eval_hash(&ctx),);
@@ -302,7 +303,7 @@ mod tests {
     #[test]
     fn test_routing_expr_change_detection() {
         let routing_expr = RoutingExpr::new("tenant_id", MAX_NUM_PARTITIONS).unwrap();
-        let ctx: serde_json::Map<String, serde_json::Value> =
+        let ctx: serde_json::Map<String, JsonValue> =
             serde_json::from_str(r#"{"tenant_id": "happy-tenant", "app": "happy"}"#).unwrap();
         assert_eq!(routing_expr.eval_hash(&ctx), 9u64);
     }

--- a/quickwit/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit/quickwit-indexing/failpoints/mod.rs
@@ -49,6 +49,7 @@ use quickwit_indexing::merge_policy::MergeOperation;
 use quickwit_indexing::models::{IndexingPipelineId, MergeScratch, ScratchDirectory};
 use quickwit_indexing::{get_tantivy_directory_from_split_bundle, TestSandbox};
 use quickwit_metastore::{ListSplitsQuery, Split, SplitMetadata, SplitState};
+use serde_json::Value as JsonValue;
 use tantivy::{Directory, Inventory};
 
 #[tokio::test]
@@ -175,11 +176,11 @@ async fn aux_test_failpoints() -> anyhow::Result<()> {
         &search_fields,
     )
     .await?;
-    let batch_1: Vec<serde_json::Value> = vec![
+    let batch_1: Vec<JsonValue> = vec![
         serde_json::json!({"body ": "1", "ts": 1629889530 }),
         serde_json::json!({"body ": "2", "ts": 1629889531 }),
     ];
-    let batch_2: Vec<serde_json::Value> = vec![
+    let batch_2: Vec<JsonValue> = vec![
         serde_json::json!({"body ": "3", "ts": 1629889532 }),
         serde_json::json!({"body ": "4", "ts": 1629889533 }),
     ];
@@ -245,7 +246,7 @@ async fn test_merge_executor_controlled_directory_kill_switch() -> anyhow::Resul
     .await?;
 
     let doc_mapper = test_index_builder.doc_mapper();
-    let batch: Vec<serde_json::Value> =
+    let batch: Vec<JsonValue> =
         std::iter::repeat_with(|| serde_json::json!({"body ": TEST_TEXT, "ts": 1631072713 }))
             .take(500)
             .collect();

--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -306,6 +306,7 @@ mod tests {
     use quickwit_actors::{create_test_mailbox, Universe};
     use quickwit_doc_mapper::{default_doc_mapper_for_test, DefaultDocMapper};
     use quickwit_metastore::checkpoint::SourceCheckpointDelta;
+    use serde_json::Value as JsonValue;
 
     use super::*;
     use crate::models::{PublishLock, RawDocBatch};
@@ -364,7 +365,7 @@ mod tests {
         assert_eq!(batch.checkpoint_delta, checkpoint_delta);
 
         let schema = doc_mapper.schema();
-        let doc_json: serde_json::Value =
+        let doc_json: JsonValue =
             serde_json::from_str(&schema.to_json(&batch.docs[0].doc)).unwrap();
         assert_eq!(
             doc_json,

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -507,6 +507,7 @@ mod tests {
     use quickwit_common::split_file;
     use quickwit_metastore::SplitMetadata;
     use quickwit_proto::metastore_api::DeleteQuery;
+    use serde_json::Value as JsonValue;
     use tantivy::{Inventory, ReloadPolicy};
 
     use super::*;
@@ -636,9 +637,9 @@ mod tests {
 
     async fn aux_test_delete_and_merge_executor(
         index_id: &str,
-        docs: Vec<serde_json::Value>,
+        docs: Vec<JsonValue>,
         delete_query: &str,
-        result_docs: Vec<serde_json::Value>,
+        result_docs: Vec<JsonValue>,
     ) -> anyhow::Result<()> {
         quickwit_common::setup_logging_for_tests();
         let pipeline_id = IndexingPipelineId {
@@ -771,7 +772,7 @@ mod tests {
                 let doc_json = searcher.schema().to_json(&doc);
                 serde_json::from_str(&doc_json).unwrap()
             })
-            .collect::<Vec<serde_json::Value>>();
+            .collect::<Vec<JsonValue>>();
 
         assert_eq!(documents_left.len(), result_docs.len());
         for doc in &documents_left {

--- a/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
@@ -31,6 +31,7 @@ use quickwit_proto::ingest_api::{
     CreateQueueIfNotExistsRequest, FetchRequest, FetchResponse, SuggestTruncateRequest,
 };
 use serde::Serialize;
+use serde_json::Value as JsonValue;
 
 use super::{Source, SourceActor, SourceContext, TypedSourceFactory};
 use crate::actors::DocProcessor;
@@ -191,7 +192,7 @@ impl Source for IngestApiSource {
         "IngestApiSource".to_string()
     }
 
-    fn observable_state(&self) -> serde_json::Value {
+    fn observable_state(&self) -> JsonValue {
         serde_json::to_value(&self.counters).unwrap()
     }
 }

--- a/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -34,7 +34,7 @@ use quickwit_metastore::checkpoint::{
 };
 use rusoto_core::Region;
 use rusoto_kinesis::KinesisClient;
-use serde_json::json;
+use serde_json::{json, Value as JsonValue};
 use tokio::sync::mpsc;
 use tokio::time;
 use tracing::{info, warn};
@@ -326,7 +326,7 @@ impl Source for KinesisSource {
         format!("KinesisSource{{source_id={}}}", self.source_id)
     }
 
-    fn observable_state(&self) -> serde_json::Value {
+    fn observable_state(&self) -> JsonValue {
         let shard_consumer_positions: Vec<(&ShardId, &str)> = self
             .state
             .shard_consumers

--- a/quickwit/quickwit-indexing/src/source/kinesis/shard_consumer.rs
+++ b/quickwit/quickwit-indexing/src/source/kinesis/shard_consumer.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, Mailbox};
 use quickwit_aws::retry::RetryParams;
 use rusoto_kinesis::{KinesisClient, Record};
-use serde_json::json;
+use serde_json::{json, Value as JsonValue};
 use tokio::sync::mpsc;
 
 use crate::source::kinesis::api::{get_records, get_shard_iterator};
@@ -137,7 +137,7 @@ pub(super) struct Loop;
 
 #[async_trait]
 impl Actor for ShardConsumer {
-    type ObservableState = serde_json::Value;
+    type ObservableState = JsonValue;
 
     fn name(&self) -> String {
         "KinesisShardConsumer".to_string()
@@ -243,6 +243,7 @@ impl Handler<Loop> for ShardConsumer {
 #[cfg(all(test, feature = "kinesis-localstack-tests"))]
 mod tests {
     use quickwit_actors::Universe;
+    use serde_json::Value as JsonValue;
 
     use super::*;
     use crate::source::kinesis::api::tests::{merge_shards, split_shard};
@@ -289,7 +290,7 @@ mod tests {
         let expected_state = json!({
             "stream_name": stream_name,
             "shard_id": shard_id_0,
-            "current_sequence_number": serde_json::Value::Null,
+            "current_sequence_number": JsonValue::Null,
             "lag_millis": 0,
             "num_bytes_processed": 0,
             "num_records_processed": 0,

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -84,6 +84,7 @@ use quickwit_common::runtimes::RuntimeType;
 use quickwit_config::{SourceConfig, SourceParams};
 use quickwit_metastore::checkpoint::SourceCheckpoint;
 use quickwit_metastore::Metastore;
+use serde_json::Value as JsonValue;
 pub use source_factory::{SourceFactory, SourceLoader, TypedSourceFactory};
 use tokio::runtime::Handle;
 use tracing::error;
@@ -209,7 +210,7 @@ pub trait Source: Send + Sync + 'static {
     ///
     /// This object is simply a json object, and its content may vary depending on the
     /// source.
-    fn observable_state(&self) -> serde_json::Value;
+    fn observable_state(&self) -> JsonValue;
 }
 
 /// The SourceActor acts as a thin wrapper over a source trait object to execute.
@@ -225,7 +226,7 @@ struct Loop;
 
 #[async_trait]
 impl Actor for SourceActor {
-    type ObservableState = serde_json::Value;
+    type ObservableState = JsonValue;
 
     fn name(&self) -> String {
         self.source.name()

--- a/quickwit/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit/quickwit-indexing/src/source/vec_source.rs
@@ -27,6 +27,7 @@ use quickwit_config::VecSourceParams;
 use quickwit_metastore::checkpoint::{
     PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
 };
+use serde_json::Value as JsonValue;
 use tracing::info;
 
 use crate::actors::DocProcessor;
@@ -113,7 +114,7 @@ impl Source for VecSource {
         format!("VecSource {{ source_id={} }}", self.source_id)
     }
 
-    fn observable_state(&self) -> serde_json::Value {
+    fn observable_state(&self) -> JsonValue {
         serde_json::json!({
             "next_item_idx": self.next_item_idx,
         })

--- a/quickwit/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit/quickwit-indexing/src/source/void_source.rs
@@ -24,6 +24,7 @@ use async_trait::async_trait;
 use quickwit_actors::{ActorExitStatus, Mailbox, HEARTBEAT};
 use quickwit_config::VoidSourceParams;
 use quickwit_metastore::checkpoint::SourceCheckpoint;
+use serde_json::Value as JsonValue;
 
 use crate::actors::DocProcessor;
 use crate::source::{Source, SourceContext, SourceExecutionContext, TypedSourceFactory};
@@ -45,8 +46,8 @@ impl Source for VoidSource {
         "VoidSource".to_string()
     }
 
-    fn observable_state(&self) -> serde_json::Value {
-        serde_json::Value::Object(Default::default())
+    fn observable_state(&self) -> JsonValue {
+        JsonValue::Object(Default::default())
     }
 }
 

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -33,6 +33,7 @@ use quickwit_metastore::{
     IndexMetadata, Metastore, MetastoreUriResolver, Split, SplitMetadata, SplitState,
 };
 use quickwit_storage::{Storage, StorageUriResolver};
+use serde_json::Value as JsonValue;
 
 use crate::actors::IndexingService;
 use crate::models::{DetachPipeline, IndexingStatistics, SpawnPipeline};
@@ -124,11 +125,11 @@ impl TestSandbox {
 
     /// Adds documents.
     ///
-    /// The documents are expected to be `serde_json::Value`.
+    /// The documents are expected to be `JsonValue`.
     /// They can be created using the `serde_json::json!` macro.
     pub async fn add_documents<I>(&self, split_docs: I) -> anyhow::Result<IndexingStatistics>
     where
-        I: IntoIterator<Item = serde_json::Value> + 'static,
+        I: IntoIterator<Item = JsonValue> + 'static,
         I::IntoIter: Send,
     {
         let docs: Vec<String> = split_docs

--- a/quickwit/quickwit-metastore/src/backward_compatibility_tests/mod.rs
+++ b/quickwit/quickwit-metastore/src/backward_compatibility_tests/mod.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use anyhow::{bail, Context};
 use quickwit_config::TestableForRegression;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 use crate::file_backed_metastore::file_backed_index::FileBackedIndex;
 use crate::{IndexMetadata, SplitMetadata};
@@ -96,9 +97,8 @@ where T: TestableForRegression {
 fn test_and_update_expected_files_single_case<T>(expected_path: &Path) -> anyhow::Result<bool>
 where for<'a> T: Serialize + Deserialize<'a> {
     let expected: T = deserialize_json_file(Path::new(&expected_path))?;
-    let expected_old_json_value: serde_json::Value =
-        deserialize_json_file(Path::new(&expected_path))?;
-    let expected_new_json_value: serde_json::Value = serde_json::to_value(&expected)?;
+    let expected_old_json_value: JsonValue = deserialize_json_file(Path::new(&expected_path))?;
+    let expected_new_json_value: JsonValue = serde_json::to_value(&expected)?;
     // We compare json Value, so we don't detect format change like a change in the field order.
     if expected_old_json_value == expected_new_json_value {
         // No modification

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -24,8 +24,8 @@ use quickwit_config::SearcherConfig;
 use quickwit_doc_mapper::DefaultDocMapper;
 use quickwit_indexing::TestSandbox;
 use quickwit_proto::{SearchRequest, SortOrder};
-use serde_json::json;
-use tantivy::schema::Value;
+use serde_json::{json, Value as JsonValue};
+use tantivy::schema::Value as TantivyValue;
 use tantivy::time::OffsetDateTime;
 
 use super::*;
@@ -69,8 +69,8 @@ async fn test_single_node_simple() -> anyhow::Result<()> {
     .await?;
     assert_eq!(single_node_result.num_hits, 1);
     assert_eq!(single_node_result.hits.len(), 1);
-    let hit_json: serde_json::Value = serde_json::from_str(&single_node_result.hits[0].json)?;
-    let expected_json: serde_json::Value = json!({"title": "snoopy", "body": "Snoopy is an anthropomorphic beagle[5] in the comic strip...", "url": "http://snoopy", "binary": "dGhpcyBpcyBhIHRlc3Qu"});
+    let hit_json: JsonValue = serde_json::from_str(&single_node_result.hits[0].json)?;
+    let expected_json: JsonValue = json!({"title": "snoopy", "body": "Snoopy is an anthropomorphic beagle[5] in the comic strip...", "url": "http://snoopy", "binary": "dGhpcyBpcyBhIHRlc3Qu"});
     assert_json_include!(actual: hit_json, expected: expected_json);
     assert!(single_node_result.elapsed_time_micros > 10);
     assert!(single_node_result.elapsed_time_micros < 1_000_000);
@@ -114,8 +114,8 @@ async fn test_single_node_termset() -> anyhow::Result<()> {
     .await?;
     assert_eq!(single_node_result.num_hits, 1);
     assert_eq!(single_node_result.hits.len(), 1);
-    let hit_json: serde_json::Value = serde_json::from_str(&single_node_result.hits[0].json)?;
-    let expected_json: serde_json::Value = json!({"title": "beagle", "body": "The beagle is a breed of small scent hound, similar in appearance to the much larger foxhound.", "url": "http://beagle", "binary": "bWFkZSB5b3UgbG9vay4="});
+    let hit_json: JsonValue = serde_json::from_str(&single_node_result.hits[0].json)?;
+    let expected_json: JsonValue = json!({"title": "beagle", "body": "The beagle is a breed of small scent hound, similar in appearance to the much larger foxhound.", "url": "http://beagle", "binary": "bWFkZSB5b3UgbG9vay4="});
     assert_json_include!(actual: hit_json, expected: expected_json);
     assert!(single_node_result.elapsed_time_micros > 10);
     assert!(single_node_result.elapsed_time_micros < 1_000_000);
@@ -159,14 +159,14 @@ async fn test_single_search_with_snippet() -> anyhow::Result<()> {
     assert_eq!(single_node_result.num_hits, 2);
     assert_eq!(single_node_result.hits.len(), 2);
 
-    let highlight_json: serde_json::Value =
+    let highlight_json: JsonValue =
         serde_json::from_str(single_node_result.hits[0].snippet.as_ref().unwrap())?;
-    let expected_json: serde_json::Value = json!({"title": [], "body": ["Snoopy is an anthropomorphic <b>beagle</b> in the comic strip"]});
+    let expected_json: JsonValue = json!({"title": [], "body": ["Snoopy is an anthropomorphic <b>beagle</b> in the comic strip"]});
     assert_json_eq!(highlight_json, expected_json);
 
-    let highlight_json: serde_json::Value =
+    let highlight_json: JsonValue =
         serde_json::from_str(single_node_result.hits[1].snippet.as_ref().unwrap())?;
-    let expected_json: serde_json::Value = json!({
+    let expected_json: JsonValue = json!({
         "title": ["<b>beagle</b>"],
         "body": ["The <b>beagle</b> is a breed of small scent hound"]
     });
@@ -782,26 +782,25 @@ async fn test_search_dynamic_mode_do_not_expand_dots() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn json_to_named_field_doc(doc_json: serde_json::Value) -> NamedFieldDocument {
+fn json_to_named_field_doc(doc_json: JsonValue) -> NamedFieldDocument {
     assert!(doc_json.is_object());
-    let mut doc_map: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+    let mut doc_map: BTreeMap<String, Vec<TantivyValue>> = BTreeMap::new();
     for (key, value) in doc_json.as_object().unwrap().clone() {
         doc_map.insert(key, json_value_to_tantivy_value(value));
     }
     NamedFieldDocument(doc_map)
 }
 
-fn json_value_to_tantivy_value(value: serde_json::Value) -> Vec<Value> {
-    use serde_json::Value as JsonValue;
+fn json_value_to_tantivy_value(value: JsonValue) -> Vec<TantivyValue> {
     match value {
-        JsonValue::Bool(val) => vec![Value::Bool(val)],
-        JsonValue::String(val) => vec![Value::Str(val)],
+        JsonValue::Bool(val) => vec![TantivyValue::Bool(val)],
+        JsonValue::String(val) => vec![TantivyValue::Str(val)],
         JsonValue::Array(values) => values
             .into_iter()
             .flat_map(json_value_to_tantivy_value)
             .collect(),
         JsonValue::Object(object) => {
-            vec![Value::JsonObject(object)]
+            vec![TantivyValue::JsonObject(object)]
         }
         JsonValue::Null => vec![],
         value => vec![value.into()],
@@ -810,16 +809,16 @@ fn json_value_to_tantivy_value(value: serde_json::Value) -> Vec<Value> {
 
 #[track_caller]
 fn test_convert_leaf_hit_aux(
-    default_doc_mapper_json: serde_json::Value,
-    document_json: serde_json::Value,
-    expected_hit_json: serde_json::Value,
+    default_doc_mapper_json: JsonValue,
+    document_json: JsonValue,
+    expected_hit_json: JsonValue,
 ) {
     let default_doc_mapper: DefaultDocMapper =
         serde_json::from_value(default_doc_mapper_json).unwrap();
     let named_field_doc = json_to_named_field_doc(document_json);
     let hit_json_str =
         convert_document_to_json_string(named_field_doc, &default_doc_mapper).unwrap();
-    let hit_json: serde_json::Value = serde_json::from_str(&hit_json_str).unwrap();
+    let hit_json: JsonValue = serde_json::from_str(&hit_json_str).unwrap();
     assert_eq!(hit_json, expected_hit_json);
 }
 
@@ -1001,8 +1000,7 @@ async fn test_single_node_aggregation() -> anyhow::Result<()> {
         test_sandbox.storage_uri_resolver(),
     )
     .await?;
-    let agg_res_json: serde_json::Value =
-        serde_json::from_str(&single_node_result.aggregation.unwrap())?;
+    let agg_res_json: JsonValue = serde_json::from_str(&single_node_result.aggregation.unwrap())?;
     assert_eq!(
         agg_res_json["expensive_colors"]["buckets"][0]["key"],
         "white"
@@ -1141,9 +1139,8 @@ async fn test_single_node_with_ip_field() -> anyhow::Result<()> {
         .await?;
         assert_eq!(single_node_result.num_hits, 1);
         assert_eq!(single_node_result.hits.len(), 1);
-        let hit_json: serde_json::Value = serde_json::from_str(&single_node_result.hits[0].json)?;
-        let expected_json: serde_json::Value =
-            json!({"log": "Request successful", "host": "10.10.11.125"});
+        let hit_json: JsonValue = serde_json::from_str(&single_node_result.hits[0].json)?;
+        let expected_json: JsonValue = json!({"log": "Request successful", "host": "10.10.11.125"});
         assert_json_include!(actual: hit_json, expected: expected_json);
         Ok(())
     }

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -146,6 +146,7 @@ mod tests {
     use quickwit_indexing::mock_split;
     use quickwit_metastore::{IndexMetadata, MockMetastore};
     use quickwit_storage::StorageUriResolver;
+    use serde_json::Value as JsonValue;
 
     use super::*;
     use crate::recover_fn;
@@ -169,7 +170,7 @@ mod tests {
             .reply(&index_management_handler)
             .await;
         assert_eq!(resp.status(), 200);
-        let actual_response_json: serde_json::Value = serde_json::from_slice(resp.body())?;
+        let actual_response_json: JsonValue = serde_json::from_slice(resp.body())?;
         let expected_response_json = serde_json::json!({
             "index_id": "test-index",
             "index_uri": "ram:///indexes/test-index",
@@ -195,7 +196,7 @@ mod tests {
             .reply(&index_management_handler)
             .await;
         assert_eq!(resp.status(), 200);
-        let actual_response_json: serde_json::Value = serde_json::from_slice(resp.body())?;
+        let actual_response_json: JsonValue = serde_json::from_slice(resp.body())?;
         let expected_response_json = serde_json::json!([{
             "create_timestamp": 0,
             "split_id": "split_1",
@@ -224,10 +225,10 @@ mod tests {
             .reply(&index_management_handler)
             .await;
         assert_eq!(resp.status(), 200);
-        let actual_response_json: serde_json::Value = serde_json::from_slice(resp.body())?;
-        let actual_response_arr: &Vec<serde_json::Value> = actual_response_json.as_array().unwrap();
+        let actual_response_json: JsonValue = serde_json::from_slice(resp.body())?;
+        let actual_response_arr: &Vec<JsonValue> = actual_response_json.as_array().unwrap();
         assert_eq!(actual_response_arr.len(), 1);
-        let actual_index_metadata_json: &serde_json::Value = &actual_response_arr[0];
+        let actual_index_metadata_json: &JsonValue = &actual_response_arr[0];
         let expected_response_json = serde_json::json!({
             "index_id": "test-index",
             "index_uri": "ram:///indexes/test-index",

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -25,7 +25,7 @@ use quickwit_actors::Mailbox;
 use quickwit_ingest_api::{add_doc, IngestApiService};
 use quickwit_proto::ingest_api::{DocBatch, IngestRequest, TailRequest};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::Value as JsonValue;
 use thiserror::Error;
 use warp::{reject, Filter, Rejection};
 
@@ -193,7 +193,7 @@ async fn elastic_ingest(
                 BulkApiError::InvalidSource("Expected source for the action.".to_string())
             })
             .and_then(|source| {
-                serde_json::from_str::<Value>(source)
+                serde_json::from_str::<JsonValue>(source)
                     .map_err(|err| BulkApiError::InvalidSource(err.to_string()))
             })?;
 

--- a/quickwit/quickwit-serve/src/node_info_handler.rs
+++ b/quickwit/quickwit-serve/src/node_info_handler.rs
@@ -67,6 +67,7 @@ async fn get_config(config: Arc<QuickwitConfig>) -> Result<impl warp::Reply, Rej
 #[cfg(test)]
 mod tests {
     use assert_json_diff::assert_json_include;
+    use serde_json::Value as JsonValue;
 
     use super::*;
     use crate::{quickwit_build_info, recover_fn};
@@ -80,7 +81,7 @@ mod tests {
             super::node_info_handler(build_info, Arc::new(config.clone())).recover(recover_fn);
         let resp = warp::test::request().path("/version").reply(&handler).await;
         assert_eq!(resp.status(), 200);
-        let resp_build_info_json: serde_json::Value = serde_json::from_slice(resp.body())?;
+        let resp_build_info_json: JsonValue = serde_json::from_slice(resp.body())?;
         let expected_build_json = serde_json::json!({
             "commit_date": build_info.commit_date,
             "version": build_info.version,
@@ -89,7 +90,7 @@ mod tests {
 
         let resp = warp::test::request().path("/config").reply(&handler).await;
         assert_eq!(resp.status(), 200);
-        let resp_json: serde_json::Value = serde_json::from_slice(resp.body())?;
+        let resp_json: JsonValue = serde_json::from_slice(resp.body())?;
         let expected_response_json = serde_json::json!({
             "node_id": config.node_id,
             "metastore_uri": "postgresql://username:***redacted***@db",


### PR DESCRIPTION
Make a  clear difference `serde_json::Value` from `tantivy::schema::Value`

Closes https://github.com/quickwit-oss/quickwit/issues/2338