### PR TITLE
Remove transaction from `delete_splits`

### DIFF
--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -126,6 +126,34 @@ macro_rules! ignore_error_kind {
     };
 }
 
+pub struct PrettySample<'a, T>(&'a [T], usize);
+
+impl<'a, T> PrettySample<'a, T> {
+    pub fn new(slice: &'a [T], sample_size: usize) -> Self {
+        Self(slice, sample_size)
+    }
+}
+
+impl<T> Debug for PrettySample<'_, T>
+where T: Debug
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "[")?;
+        for (i, item) in self.0.iter().enumerate() {
+            if i == self.1 {
+                write!(formatter, ", ...")?;
+                break;
+            }
+            if i > 0 {
+                write!(formatter, ", ")?;
+            }
+            write!(formatter, "{:?}", item)?;
+        }
+        write!(formatter, "]")?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::ErrorKind;
@@ -162,5 +190,19 @@ mod tests {
             std::fs::remove_file("file-does-not-exist")
         )
         .unwrap();
+    }
+
+    #[test]
+    fn test_pretty_sample() {
+        assert_eq!(
+            format!("{:?}", PrettySample::<'_, usize>::new(&[], 2)),
+            "[]"
+        );
+        assert_eq!(format!("{:?}", PrettySample::new(&[1], 2)), "[1]");
+        assert_eq!(format!("{:?}", PrettySample::new(&[1, 2], 2)), "[1, 2]");
+        assert_eq!(
+            format!("{:?}", PrettySample::new(&[1, 2, 3], 2)),
+            "[1, 2, ...]"
+        );
     }
 }

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -27,11 +27,13 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use itertools::Itertools;
+use quickwit_common::PrettySample;
 use quickwit_config::{SourceConfig, TestableForRegression};
 use quickwit_proto::metastore_api::{DeleteQuery, DeleteTask};
 use serde::{Deserialize, Serialize};
 use serialize::VersionedFileBackedIndex;
 use time::OffsetDateTime;
+use tracing::{info, warn};
 
 use crate::checkpoint::IndexCheckpointDelta;
 use crate::{
@@ -113,7 +115,8 @@ impl From<IndexMetadata> for FileBackedIndex {
 enum DeleteSplitOutcome {
     Success,
     SplitNotFound,
-    ForbiddenBecausePublished,
+    // The split is in another state than marked for deletion.
+    Forbidden,
 }
 
 impl FileBackedIndex {
@@ -323,12 +326,11 @@ impl FileBackedIndex {
     /// Deletes a split.
     fn delete_split(&mut self, split_id: &str) -> DeleteSplitOutcome {
         match self.splits.get(split_id).map(|split| split.split_state) {
-            // Only `Staged` and `MarkedForDeletion` splits can be deleted
-            Some(SplitState::Staged | SplitState::MarkedForDeletion) => {
+            Some(SplitState::MarkedForDeletion) => {
                 self.splits.remove(split_id);
                 DeleteSplitOutcome::Success
             }
-            Some(SplitState::Published) => DeleteSplitOutcome::ForbiddenBecausePublished,
+            Some(SplitState::Staged | SplitState::Published) => DeleteSplitOutcome::Forbidden,
             None => DeleteSplitOutcome::SplitNotFound,
         }
     }
@@ -342,22 +344,27 @@ impl FileBackedIndex {
             match self.delete_split(split_id) {
                 DeleteSplitOutcome::Success => {}
                 DeleteSplitOutcome::SplitNotFound => {
-                    split_not_found_ids.push(split_id.to_string());
+                    split_not_found_ids.push(split_id);
                 }
-                DeleteSplitOutcome::ForbiddenBecausePublished => {
+                DeleteSplitOutcome::Forbidden => {
                     split_not_deletable_ids.push(split_id.to_string());
                 }
             }
-        }
-        if !split_not_found_ids.is_empty() {
-            return Err(MetastoreError::SplitsDoNotExist {
-                split_ids: split_not_found_ids,
-            });
         }
         if !split_not_deletable_ids.is_empty() {
             return Err(MetastoreError::SplitsNotDeletable {
                 split_ids: split_not_deletable_ids,
             });
+        }
+        info!(index_id=%self.index_id(), "Deleted {} splits from index.", split_ids.len());
+
+        if !split_not_found_ids.is_empty() {
+            warn!(
+                index_id=%self.index_id(),
+                split_ids=?PrettySample::new(&split_not_found_ids, 5),
+                "{} splits were not found and could not be deleted.",
+                split_not_found_ids.len()
+            );
         }
         Ok(())
     }

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use itertools::Itertools;
 use quickwit_common::uri::Uri;
+use quickwit_common::PrettySample;
 use quickwit_config::SourceConfig;
 use quickwit_doc_mapper::tag_pruning::TagFilterAst;
 use quickwit_proto::metastore_api::{DeleteQuery, DeleteTask};
@@ -36,7 +37,7 @@ use sqlx::postgres::{PgConnectOptions, PgDatabaseError, PgPoolOptions};
 use sqlx::{ConnectOptions, Pool, Postgres, Transaction};
 use tokio::sync::Mutex;
 use tracing::log::LevelFilter;
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use crate::checkpoint::IndexCheckpointDelta;
 use crate::metastore::instrumented_metastore::InstrumentedMetastore;
@@ -741,37 +742,76 @@ impl Metastore for PostgresqlMetastore {
         index_id: &str,
         split_ids: &[&'a str],
     ) -> MetastoreResult<()> {
-        run_with_tx!(self.connection_pool, tx, {
-            let deletable_states = [
-                SplitState::Staged.as_str(),
-                SplitState::MarkedForDeletion.as_str(),
-            ];
-            let deleted_split_ids: Vec<String> = sqlx::query_scalar(
-                r#"
+        const DELETE_SPLITS_QUERY: &str = r#"
+            -- Select the splits to delete, regardless of their state.
+            -- The left join make it possible to identify the splits that do not exist.
+            WITH input_splits AS (
+                SELECT input_splits.split_id, splits.split_state
+                FROM UNNEST($2) AS input_splits(split_id)
+                LEFT JOIN (
+                    SELECT split_id, split_state
+                    FROM splits
+                    WHERE
+                        index_id = $1
+                        AND split_id = ANY($2)
+                    FOR UPDATE
+                    ) AS splits
+                USING (split_id)
+            ),
+            -- Delete the splits if and only if all the splits are marked for deletion.
+            deleted_splits AS (
                 DELETE FROM splits
+                USING input_splits
                 WHERE
-                        split_id = ANY($1)
-                    AND split_state = ANY($2)
-                RETURNING split_id
-            "#,
+                    splits.index_id = $1
+                    AND splits.split_id = input_splits.split_id
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM input_splits
+                        WHERE
+                            split_state IN ('Staged', 'Published')
+                    )
             )
+            -- Report the outcome of the delete query.
+            SELECT
+                COUNT(split_state),
+                COUNT(1) FILTER (WHERE split_state = 'MarkedForDeletion'),
+                COALESCE(ARRAY_AGG(split_id) FILTER (WHERE split_state IN ('Staged', 'Published')), ARRAY[]::TEXT[]),
+                COALESCE(ARRAY_AGG(split_id) FILTER (WHERE split_state IS NULL), ARRAY[]::TEXT[])
+                FROM input_splits
+        "#;
+        let (num_found_splits, num_deleted_splits, not_deletable_split_ids, not_found_split_ids): (
+            i64,
+            i64,
+            Vec<String>,
+            Vec<String>,
+        ) = sqlx::query_as(DELETE_SPLITS_QUERY)
+            .bind(index_id)
             .bind(split_ids)
-            .bind(&deletable_states[..])
-            .fetch_all(&mut *tx)
-            .await?;
+            .fetch_one(&self.connection_pool)
+            .await
+            .map_err(|error| convert_sqlx_err(index_id, error))?;
 
-            if deleted_split_ids.len() == split_ids.len() {
-                return Ok(());
-            }
-            // There is an error, but we want to investigate and return a meaningful error.
-            // From this point, we always have to return `Err` to abort the transaction.
-            let not_deletable_ids =
-                get_splits_with_invalid_state(tx, index_id, split_ids, &deleted_split_ids).await?;
+        if num_found_splits == 0 && index_opt(&self.connection_pool, index_id).await?.is_none() {
+            return Err(MetastoreError::IndexDoesNotExist {
+                index_id: index_id.to_string(),
+            });
+        }
+        if !not_deletable_split_ids.is_empty() {
+            return Err(MetastoreError::SplitsNotDeletable {
+                split_ids: not_deletable_split_ids,
+            });
+        }
+        info!(index_id=%index_id, "Deleted {} splits from index.", num_deleted_splits);
 
-            Err(MetastoreError::SplitsNotDeletable {
-                split_ids: not_deletable_ids,
-            })
-        })?;
+        if !not_found_split_ids.is_empty() {
+            warn!(
+                index_id=%index_id,
+                split_ids=?PrettySample::new(&not_found_split_ids, 5),
+                "{} splits were not found and could not be deleted.",
+                not_found_split_ids.len()
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
### Description
Remove transaction from `delete_splits` and update index update timestamp in the same query. 

In addition, I have modified the behavior of the method:
- Attempting to delete staged splits returns an error
- We no longer return an error when some splits are not found (but we log a warning)

### How was this PR tested?
Updated unit test.