### PR TITLE
Select index for update

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -142,6 +142,7 @@ where E: sqlx::Executor<'a, Database = Postgres> {
         SELECT *
         FROM indexes
         WHERE index_id = $1
+        FOR UPDATE
         "#,
     )
     .bind(index_id)


### PR DESCRIPTION
### Description
Inside a transaction, this will lock the index row for an upcoming update.

### How was this PR tested?
Added a test. The test does fail without the fix.
