### PR TITLE
QW-2409: Ditch `update_timestamp` from index metadata.

### DIFF
--- a/quickwit/quickwit-metastore/migrations/postgresql/8_delete-update-timestamp-on-indexes-table.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/8_delete-update-timestamp-on-indexes-table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE indexes DROP COLUMN IF EXISTS update_timestamp;

--- a/quickwit/quickwit-metastore/migrations/postgresql/8_delete-update-timestamp-on-indexes-table.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/8_delete-update-timestamp-on-indexes-table.up.sql
@@ -1,1 +1,2 @@
 ALTER TABLE indexes DROP COLUMN IF EXISTS update_timestamp;
+DROP TRIGGER IF EXISTS set_update_timestamp ON indexes;

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -188,7 +188,6 @@ impl FileBackedIndex {
 
         self.splits
             .insert(metadata.split_id().to_string(), metadata);
-        self.metadata.update_timestamp = now_timestamp;
         Ok(())
     }
 
@@ -234,9 +233,6 @@ impl FileBackedIndex {
             return Err(MetastoreError::SplitsNotDeletable {
                 split_ids: non_deletable_split_ids,
             });
-        }
-        if is_modified {
-            self.metadata.update_timestamp = now_timestamp;
         }
         Ok(is_modified)
     }
@@ -289,7 +285,6 @@ impl FileBackedIndex {
             });
         }
 
-        self.metadata.update_timestamp = now_timestamp;
         Ok(())
     }
 
@@ -364,7 +359,6 @@ impl FileBackedIndex {
                 split_ids: split_not_deletable_ids,
             });
         }
-        self.metadata.update_timestamp = OffsetDateTime::now_utc().unix_timestamp();
         Ok(())
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
@@ -44,8 +44,6 @@ pub struct IndexMetadata {
     pub checkpoint: IndexCheckpoint,
     /// Time at which the index was created.
     pub create_timestamp: i64,
-    /// Time at which the index was last updated.
-    pub update_timestamp: i64,
     /// Sources
     pub sources: HashMap<String, SourceConfig>,
 }
@@ -57,7 +55,6 @@ impl IndexMetadata {
             index_config,
             checkpoint: Default::default(),
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            update_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
             sources: HashMap::default(),
         }
     }
@@ -144,7 +141,6 @@ impl TestableForRegression for IndexMetadata {
             index_config,
             checkpoint,
             create_timestamp: 1789,
-            update_timestamp: 1789,
             sources: Default::default(),
         };
         index_metadata
@@ -156,7 +152,6 @@ impl TestableForRegression for IndexMetadata {
     fn test_equality(&self, other: &Self) {
         self.index_config().test_equality(other.index_config());
         assert_eq!(self.checkpoint, other.checkpoint);
-        assert_eq!(self.update_timestamp, other.update_timestamp);
         assert_eq!(self.create_timestamp, other.create_timestamp);
         assert_eq!(self.sources, other.sources);
     }

--- a/quickwit/quickwit-metastore/src/metastore/index_metadata/serialize.rs
+++ b/quickwit/quickwit-metastore/src/metastore/index_metadata/serialize.rs
@@ -58,7 +58,6 @@ impl From<IndexMetadata> for IndexMetadataV0_4 {
             index_config: index_metadata.index_config,
             checkpoint: index_metadata.checkpoint,
             create_timestamp: index_metadata.create_timestamp,
-            update_timestamp: index_metadata.update_timestamp,
             sources,
         }
     }
@@ -70,8 +69,6 @@ pub(crate) struct IndexMetadataV0_4 {
     pub checkpoint: IndexCheckpoint,
     #[serde(default = "utc_now_timestamp")]
     pub create_timestamp: i64,
-    #[serde(default = "utc_now_timestamp")]
-    pub update_timestamp: i64,
     pub sources: Vec<SourceConfig>,
 }
 
@@ -90,7 +87,6 @@ impl TryFrom<IndexMetadataV0_4> for IndexMetadata {
             index_config: v0_4.index_config,
             checkpoint: v0_4.checkpoint,
             create_timestamp: v0_4.create_timestamp,
-            update_timestamp: v0_4.update_timestamp,
             sources,
         })
     }

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -111,27 +111,6 @@ impl PostgresqlMetastore {
             connection_pool,
         })
     }
-
-    /// This function attempts to update an index update timestamp. Since we call this method after
-    /// a successful update of splits or delete tasks, we never return an error to not mislead the
-    /// clients into believing that the update failed. We log the error instead.
-    #[instrument(skip(self))]
-    async fn update_index_update_timestamp(&self, index_id: &str) {
-        let update_res = sqlx::query(
-            r#"
-            UPDATE indexes
-            SET update_timestamp = current_timestamp
-            WHERE index_id = $1;
-            "#,
-        )
-        .bind(index_id)
-        .execute(&self.connection_pool)
-        .await;
-
-        if let Err(error) = update_res {
-            warn!(error=?error, "Failed to update index update timestamp.");
-        }
-    }
 }
 
 /// Returns an Index object given an index_id or None if it does not exists.
@@ -628,7 +607,6 @@ impl Metastore for PostgresqlMetastore {
 
         debug!(index_id=%index_id, split_id=%split_metadata.split_id, "Split successfully staged.");
 
-        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -694,7 +672,6 @@ impl Metastore for PostgresqlMetastore {
             }
             Ok(())
         })?;
-        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -754,7 +731,6 @@ impl Metastore for PostgresqlMetastore {
                 cause: "".to_string(),
             })
         })?;
-        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -795,7 +771,6 @@ impl Metastore for PostgresqlMetastore {
                 split_ids: not_deletable_ids,
             })
         })?;
-        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 
@@ -960,7 +935,6 @@ impl Metastore for PostgresqlMetastore {
                 index_id: index_id.to_string(),
             });
         }
-        self.update_index_update_timestamp(index_id).await;
         Ok(())
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
@@ -43,8 +43,6 @@ pub struct Index {
     pub index_metadata_json: String,
     /// Timestamp for tracking when the split was created.
     pub create_timestamp: sqlx::types::time::PrimitiveDateTime,
-    /// Timestamp for tracking when the split was last updated.
-    pub update_timestamp: sqlx::types::time::PrimitiveDateTime,
 }
 
 impl Index {
@@ -64,7 +62,6 @@ impl Index {
         // duplicated in [`IndexMetadata`]. We must override the duplicates with the authentic
         // values upon deserialization.
         index_metadata.create_timestamp = self.create_timestamp.assume_utc().unix_timestamp();
-        index_metadata.update_timestamp = self.update_timestamp.assume_utc().unix_timestamp();
         Ok(index_metadata)
     }
 }

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -101,10 +101,6 @@ pub mod test_suite {
 
         assert_eq!(index_metadata.index_id(), index_id);
         assert_eq!(index_metadata.index_uri(), &index_uri);
-        assert_eq!(
-            index_metadata.create_timestamp,
-            index_metadata.update_timestamp
-        );
 
         let error = metastore.create_index(index_metadata).await.unwrap_err();
         assert!(matches!(error, MetastoreError::IndexAlreadyExists { .. }));
@@ -2270,14 +2266,6 @@ pub mod test_suite {
         let split_meta = metastore.list_all_splits(index_id).await.unwrap()[0].clone();
         assert!(split_meta.update_timestamp > current_timestamp);
         assert!(split_meta.publish_timestamp.is_none());
-        assert!(
-            metastore
-                .index_metadata(index_id)
-                .await
-                .unwrap()
-                .update_timestamp
-                > current_timestamp
-        );
 
         current_timestamp = split_meta.update_timestamp;
 
@@ -2301,14 +2289,6 @@ pub mod test_suite {
         assert_eq!(
             split_meta.publish_timestamp,
             Some(split_meta.update_timestamp)
-        );
-        assert!(
-            metastore
-                .index_metadata(index_id)
-                .await
-                .unwrap()
-                .update_timestamp
-                > current_timestamp
         );
 
         // wait a sec & re-publish and check publish_timestamp has not changed
@@ -2341,14 +2321,6 @@ pub mod test_suite {
         let split_meta = metastore.list_all_splits(index_id).await.unwrap()[0].clone();
         assert!(split_meta.update_timestamp > current_timestamp);
         assert!(split_meta.publish_timestamp.is_some());
-        assert!(
-            metastore
-                .index_metadata(index_id)
-                .await
-                .unwrap()
-                .update_timestamp
-                > current_timestamp
-        );
 
         current_timestamp = split_meta.update_timestamp;
 
@@ -2358,14 +2330,8 @@ pub mod test_suite {
             .delete_splits(index_id, &[split_id])
             .await
             .unwrap();
-        assert!(
-            metastore
-                .index_metadata(index_id)
-                .await
-                .unwrap()
-                .update_timestamp
-                > current_timestamp
-        );
+
+        // TODO add new check?
 
         cleanup_index(&metastore, index_id).await;
     }

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2322,8 +2322,6 @@ pub mod test_suite {
         assert!(split_meta.update_timestamp > current_timestamp);
         assert!(split_meta.publish_timestamp.is_some());
 
-        current_timestamp = split_meta.update_timestamp;
-
         // wait for 1s, delete split & check the index `update_timestamp`
         sleep(Duration::from_secs(1)).await;
         metastore

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-6c9e39c3826b9ca97f8a9760f50ee0f6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-6c9e39c3826b9ca97f8a9760f50ee0f6.expected.json
@@ -107,7 +107,6 @@
         "version": "0.4"
       }
     ],
-    "update_timestamp": 1789,
     "version": "0.4"
   },
   "splits": [

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-6c9e39c3826b9ca97f8a9760f50ee0f6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-6c9e39c3826b9ca97f8a9760f50ee0f6.json
@@ -107,7 +107,6 @@
         "version": "0.4"
       }
     ],
-    "update_timestamp": 1789,
     "version": "0.4"
   },
   "splits": [

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-c5c7464b71b9edfa6ad4291b081212e5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-c5c7464b71b9edfa6ad4291b081212e5.expected.json
@@ -95,6 +95,5 @@
       "version": "0.4"
     }
   ],
-  "update_timestamp": 1789,
   "version": "0.4"
 }

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-c5c7464b71b9edfa6ad4291b081212e5.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-c5c7464b71b9edfa6ad4291b081212e5.json
@@ -95,6 +95,5 @@
       "version": "0.4"
     }
   ],
-  "update_timestamp": 1789,
   "version": "0.4"
 }


### PR DESCRIPTION
### Description
This drops the `update_timestamp` field as part of the index metadata and applies any migrations needed for PostgreSQL.

### How was this PR tested?

Tests involving the update_timestamp on the index have been adjusted.