### PR TITLE
QW-2404: Fix merge CLI command.

### DIFF
--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -1089,8 +1089,9 @@ pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
         }
     }
 
-    let (pipeline_exit_status, _pipeline_statistics) = pipeline_handle.join().await;
+    let (pipeline_exit_status, _pipeline_statistics) = pipeline_handle.quit().await;
     indexing_service_handle.quit().await;
+    // TODO: This is nearly always an error because we call `quit()`, alternatives?
     if !pipeline_exit_status.is_success() {
         bail!(pipeline_exit_status);
     }

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -56,7 +56,7 @@ use quickwit_telemetry::payload::TelemetryEvent;
 use tabled::object::{Columns, Segment};
 use tabled::{Alignment, Concat, Format, Modify, Panel, Rotate, Style, Table, Tabled};
 use thousands::Separable;
-use tracing::{debug, warn, Level};
+use tracing::{debug, info, warn, Level};
 
 use crate::stats::{mean, percentile, std_deviation};
 use crate::{
@@ -1082,10 +1082,12 @@ pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
         let observation = pipeline_handle.observe().await;
 
         if observation.num_ongoing_merges == 0 {
+            info!("Merge pipeline has no more ongoing merges, Exiting.");
             break;
         }
 
         if observation.obs_type == ObservationType::PostMortem {
+            info!("Merge pipeline has exited, Exiting.");
             break;
         }
     }

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -56,7 +56,6 @@ use quickwit_telemetry::payload::TelemetryEvent;
 use tabled::object::{Columns, Segment};
 use tabled::{Alignment, Concat, Format, Modify, Panel, Rotate, Style, Table, Tabled};
 use thousands::Separable;
-use tokio::time::interval;
 use tracing::{debug, warn, Level};
 
 use crate::stats::{mean, percentile, std_deviation};
@@ -1076,9 +1075,9 @@ pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
         })
         .await?;
 
-    let mut interval = interval(Duration::from_secs(1));
+    let mut check_interval = tokio::time::interval(Duration::from_secs(1));
     loop {
-        interval.tick().await;
+        check_interval.tick().await;
 
         let observation = pipeline_handle.observe().await;
 

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -345,11 +345,7 @@ impl Handler<Observe> for MergePipeline {
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         if let Some(handles) = &self.handles {
-            let (
-                merge_planner_state,
-                merge_uploader_counters,
-                merge_publisher_counters,
-            ) = join!(
+            let (merge_planner_state, merge_uploader_counters, merge_publisher_counters) = join!(
                 handles.merge_planner.observe(),
                 handles.merge_uploader.observe(),
                 handles.merge_publisher.observe(),

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -345,7 +345,12 @@ impl Handler<Observe> for MergePipeline {
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         if let Some(handles) = &self.handles {
-            let (merge_uploader_counters, merge_publisher_counters) = join!(
+            let (
+                merge_planner_state,
+                merge_uploader_counters,
+                merge_publisher_counters,
+            ) = join!(
+                handles.merge_planner.observe(),
                 handles.merge_uploader.observe(),
                 handles.merge_publisher.observe(),
             );
@@ -354,7 +359,8 @@ impl Handler<Observe> for MergePipeline {
                 .clone()
                 .add_actor_counters(&merge_uploader_counters, &merge_publisher_counters)
                 .set_generation(self.statistics.generation)
-                .set_num_spawn_attempts(self.statistics.num_spawn_attempts);
+                .set_num_spawn_attempts(self.statistics.num_spawn_attempts)
+                .set_ongoing_merges(merge_planner_state.ongoing_merge_operations.len());
         }
         ctx.schedule_self_msg(Duration::from_secs(1), Observe).await;
         Ok(())

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -291,7 +291,7 @@ impl Handler<RefreshMetric> for MergePlanner {
 
 #[derive(Clone, Debug, Serialize)]
 pub struct MergePlannerState {
-    ongoing_merge_operations: Vec<MergeOperation>,
+    pub(crate) ongoing_merge_operations: Vec<MergeOperation>,
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -46,8 +46,8 @@ pub use self::indexer::{Indexer, IndexerCounters};
 pub use self::ingest_api_garbage_collector::{
     IngestApiGarbageCollector, IngestApiGarbageCollectorCounters,
 };
-pub use self::merge_pipeline::MergePipeline;
 pub use self::merge_executor::{combine_partition_ids, merge_split_attrs, MergeExecutor};
+pub use self::merge_pipeline::MergePipeline;
 pub use self::merge_planner::MergePlanner;
 pub use self::merge_split_downloader::MergeSplitDownloader;
 pub use self::packager::Packager;

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -46,6 +46,7 @@ pub use self::indexer::{Indexer, IndexerCounters};
 pub use self::ingest_api_garbage_collector::{
     IngestApiGarbageCollector, IngestApiGarbageCollectorCounters,
 };
+pub use self::merge_pipeline::MergePipeline;
 pub use self::merge_executor::{combine_partition_ids, merge_split_attrs, MergeExecutor};
 pub use self::merge_planner::MergePlanner;
 pub use self::merge_split_downloader::MergeSplitDownloader;

--- a/quickwit/quickwit-indexing/src/models/merge_statistics.rs
+++ b/quickwit/quickwit-indexing/src/models/merge_statistics.rs
@@ -34,6 +34,8 @@ pub struct MergeStatistics {
     pub generation: usize,
     /// Number of successive pipeline spawn attempts.
     pub num_spawn_attempts: usize,
+    /// Number of merges currently in progress.
+    pub num_ongoing_merges: usize,
 }
 
 impl MergeStatistics {
@@ -54,6 +56,11 @@ impl MergeStatistics {
 
     pub fn set_generation(mut self, generation: usize) -> Self {
         self.generation = generation;
+        self
+    }
+
+    pub fn set_ongoing_merges(mut self, n: usize) -> Self {
+        self.num_ongoing_merges = n;
         self
     }
 }


### PR DESCRIPTION
### Description
Fixes how we run the merge CLI command to use the new ability to detach the merge pipeline itself.

We then check the number of ongoing merges and wait until that number has reached `0` or the actor has exited.

### How was this PR tested?

Describe how you tested this PR.
