### PR TITLE
Add REST endpoints for creating/deleting for index/source resources.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3440,6 +3440,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "byte-unit",
+ "bytes",
  "futures",
  "futures-util",
  "mockall",

--- a/quickwit/quickwit-core/Cargo.toml
+++ b/quickwit/quickwit-core/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://quickwit.io/docs/"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 byte-unit = { workspace = true }
+bytes = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 rand = { workspace = true }

--- a/quickwit/quickwit-core/src/lib.rs
+++ b/quickwit/quickwit-core/src/lib.rs
@@ -30,6 +30,7 @@ pub use index::{
 mod tests {
     use std::path::Path;
 
+    use quickwit_common::uri::Uri;
     use quickwit_indexing::TestSandbox;
     use quickwit_janitor::FileEntry;
     use quickwit_storage::StorageUriResolver;
@@ -70,8 +71,11 @@ mod tests {
             assert_eq!(split_num_bytes, file_entry.file_size_in_bytes);
         }
         // Now delete the index.
-        let index_service =
-            IndexService::new(test_sandbox.metastore(), StorageUriResolver::for_test());
+        let index_service = IndexService::new(
+            test_sandbox.metastore(),
+            Uri::from_well_formed("file:///default-index-root-uri"),
+            StorageUriResolver::for_test(),
+        );
         let deleted_file_entries = index_service.delete_index(index_id, false).await?;
         assert_eq!(deleted_file_entries.len(), 1);
         Ok(())

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -193,7 +193,11 @@ pub async fn serve_quickwit(config: QuickwitConfig) -> anyhow::Result<()> {
     .await?;
 
     // Always instantiate index management service.
-    let index_service = Arc::new(IndexService::new(metastore.clone(), storage_resolver));
+    let index_service = Arc::new(IndexService::new(
+        metastore.clone(),
+        config.default_index_root_uri.clone(),
+        storage_resolver,
+    ));
 
     let grpc_listen_addr = config.grpc_listen_addr;
     let rest_listen_addr = config.rest_listen_addr;


### PR DESCRIPTION
Add REST endpoints for creating/deleting for index/source resources.

Some remarks:
- all nodes can respond. A node that does not run the metastore service will send the gRPC request to the metastore node. 
- creating a file source is somewhat broken. We only support indexing a local file, this means that the file needs to be on the indexer...
- when we create a source, we do a connectivity check, this is done by the node receiving the request. This means that this must be able to connect to kinesis, kafka or have access to the file if it's a file source.

 
If this PR is ok, I'm going to add an update index endpoint in a separate PR. We can authorize the update on the merge pocliy / retention policy and on some indexing settings.

