### PR TITLE
add fastfield range queries to warmup

### DIFF
--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -237,10 +237,11 @@ fn get_fastfield_cardinality(field_type: &FieldType) -> Option<Cardinality> {
         | FieldType::F64(options)
         | FieldType::Bool(options) => options.get_fastfield_cardinality(),
         FieldType::Date(options) => options.get_fastfield_cardinality(),
+        FieldType::IpAddr(options) => options.get_fastfield_cardinality(),
         FieldType::Facet(_) => Some(Cardinality::MultiValues),
         FieldType::Bytes(options) if options.is_fast() => Some(Cardinality::MultiValues),
         FieldType::Str(options) if options.is_fast() => Some(Cardinality::MultiValues),
-        _ => None,
+        FieldType::JsonObject(_) | FieldType::Bytes(_) | FieldType::Str(_) => None,
     }
 }
 


### PR DESCRIPTION
### Description

add fastfield range queries to warmup. add ip field handling to `get_fastfield_cardinality`

### How was this PR tested?
```
➜  quickwit-indices quickwit index search --index ip_minimal --config ./quickwit.yaml --query "ip:[192.168.0.3 TO 192.168.0.5]"
{
  "num_hits": 2,
  "hits": [
    {
      "ip": "192.168.0.5",
      "severity_text": "INFO",
      "timestamp": 1501471920
    },
    {
      "ip": "192.168.0.5",
      "severity_text": "INFO",
      "timestamp": 1501471920
    }
  ],
  "elapsed_time_micros": 1693,
  "errors": []
}
```
