### PR TITLE
Remove transaction from marked splits for deletion

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -418,6 +418,7 @@ impl Metastore for FileBackedMetastore {
                     SplitState::Published,
                     SplitState::MarkedForDeletion,
                 ],
+                false,
             )
         })
         .await?;

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -709,30 +709,68 @@ impl Metastore for PostgresqlMetastore {
         index_id: &str,
         split_ids: &[&'a str],
     ) -> MetastoreResult<()> {
-        run_with_tx!(self.connection_pool, tx, {
-            let marked_split_ids: Vec<String> = mark_splits_for_deletion(
-                tx,
-                index_id,
-                split_ids,
-                &[
-                    SplitState::Staged.as_str(),
-                    SplitState::Published.as_str(),
-                    SplitState::MarkedForDeletion.as_str(),
-                ],
+        const MARK_SPLITS_FOR_DELETION_QUERY: &str = r#"
+            -- Select the splits to update, regardless of their state.
+            -- The left join make it possible to identify the splits that do not exist.
+            WITH input_splits AS (
+                SELECT input_splits.split_id, splits.split_state
+                FROM UNNEST($2) AS input_splits(split_id)
+                LEFT JOIN (
+                    SELECT split_id, split_state
+                    FROM splits
+                    WHERE
+                        index_id = $1
+                        AND split_id = ANY($2)
+                    FOR UPDATE
+                    ) AS splits
+                USING (split_id)
+            ),
+            -- Mark the staged and published splits for deletion.
+            marked_splits AS (
+                UPDATE splits
+                SET
+                    split_state = 'MarkedForDeletion',
+                    update_timestamp = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+                FROM input_splits
+                WHERE
+                    splits.index_id = $1
+                    AND splits.split_id = input_splits.split_id
+                    AND splits.split_state IN ('Staged', 'Published')
             )
-            .await?;
+            -- Report the outcome of the update query.
+            SELECT
+                COUNT(split_state),
+                COUNT(1) FILTER (WHERE split_state IN ('Staged', 'Published')),
+                COALESCE(ARRAY_AGG(split_id) FILTER (WHERE split_state IS NULL), ARRAY[]::TEXT[])
+                FROM input_splits
+        "#;
+        let (num_found_splits, num_marked_splits, not_found_split_ids): (i64, i64, Vec<String>) =
+            sqlx::query_as(MARK_SPLITS_FOR_DELETION_QUERY)
+                .bind(index_id)
+                .bind(split_ids)
+                .fetch_one(&self.connection_pool)
+                .await
+                .map_err(|error| convert_sqlx_err(index_id, error))?;
 
-            if marked_split_ids.len() == split_ids.len() {
-                return Ok(());
-            }
-            get_splits_with_invalid_state(tx, index_id, split_ids, &marked_split_ids).await?;
-
-            let err_msg = format!("Failed to mark splits for deletion for index {index_id}.");
-            Err(MetastoreError::InternalError {
-                message: err_msg,
-                cause: "".to_string(),
-            })
-        })?;
+        if num_found_splits == 0 && index_opt(&self.connection_pool, index_id).await?.is_none() {
+            return Err(MetastoreError::IndexDoesNotExist {
+                index_id: index_id.to_string(),
+            });
+        }
+        info!(
+            index_id=%index_id,
+            "Marked {} splits for deletion, among which {} were newly marked.",
+            split_ids.len() - not_found_split_ids.len(),
+            num_marked_splits
+        );
+        if !not_found_split_ids.is_empty() {
+            warn!(
+                index_id=%index_id,
+                split_ids=?PrettySample::new(&not_found_split_ids, 5),
+                "{} splits were not found and could not be marked for deletion.",
+                not_found_split_ids.len()
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
### Description
- Remove transaction from marked splits for deletion
- Display a warning when some splits are not found rather than returning an error

### How was this PR tested?
- Updated and completed unit test
- Ran `make test-all`
