### PR TITLE
add docs about required system dependencies

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -64,6 +64,10 @@ pacman -S openssl
 Additionally it requires a few more dependencies to compile it. These dependencies are not required on production system:
 - `clang`: used to compile some dependencies.
 - `protobuf-compiler`: used to compile protobuf definitions.
+- `libssl-dev`: headers for libssl.
+- `pkg-config`: used to locate libssl.
+- `cmake`: used to build librdkafka, for kafka support.
+- `libsasl2-dev`: required for sasl support in kafka.
 These dependencies can be installed on your system using the native package manager.
 You can install these dependencies using the following command:
 
@@ -72,7 +76,7 @@ You can install these dependencies using the following command:
 <TabItem value="ubuntu" label="Ubuntu">
 
 ```bash
-apt install -y clang protobuf-compiler
+apt install -y clang protobuf-compiler libssl-dev pkg-config cmake libsasl2-dev
 ```
 
 </TabItem>
@@ -80,10 +84,12 @@ apt install -y clang protobuf-compiler
 <TabItem value="aws-linux" label="AWS Linux">
 
 ```bash
-yum -y update && yum -y install clang
+yum -y update && yum -y install clang openssl-devel pkgconfig cmake3 cyrus-sasl-devel
 # amazonlinux only has protobuf-compiler 2.5, we need something much more up to date.
 wget https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip
 sudo unzip protoc-21.9-linux-x86_64.zip -d /usr/local
+# amazonlinux use cmake2 as cmake, we need cmake3
+ln -s /usr/bin/cmake3 /usr/bin/cmake
 ```
 
 </TabItem>
@@ -91,7 +97,7 @@ sudo unzip protoc-21.9-linux-x86_64.zip -d /usr/local
 <TabItem value="arch-linux" label="Arch Linux">
 
 ```bash
-pacman -S clang protobuf
+pacman -S clang protobuf openssl pkg-config cmake make libsasl
 ```
 
 </TabItem>

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -61,6 +61,44 @@ pacman -S openssl
 
 </Tabs>
 
+Additionally it requires a few more dependencies to compile it. These dependencies are not required on production system:
+- `clang`: used to compile some dependencies.
+- `protobuf-compiler`: used to compile protobuf definitions.
+These dependencies can be installed on your system using the native package manager.
+You can install these dependencies using the following command:
+
+<Tabs>
+
+<TabItem value="ubuntu" label="Ubuntu">
+
+```bash
+apt install -y clang protobuf-compiler
+```
+
+</TabItem>
+
+<TabItem value="aws-linux" label="AWS Linux">
+
+```bash
+yum -y update && yum -y install clang
+# amazonlinux only has protobuf-compiler 2.5, we need something much more up to date.
+wget https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip
+sudo unzip protoc-21.9-linux-x86_64.zip -d /usr/local
+```
+
+</TabItem>
+
+<TabItem value="arch-linux" label="Arch Linux">
+
+```bash
+pacman -S clang protobuf
+```
+
+</TabItem>
+
+</Tabs>
+
+
 
 ## Install script
 


### PR DESCRIPTION
### Description

fix #1775
I added only packages I actually needed to run quickwit. I got no complain about make/cmake/pkg-config on neither platform so I assume they are probably no longer needed.

### How was this PR tested?

install the dependencies in `ubuntu:latest`, `amazonlinux:latest` and `archlinux:latest` and verify `cargo run --release` print quickwit help message
