### PR TITLE
Running the delete task creation handler on all nodes.

### DIFF
--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -17,18 +17,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::convert::Infallible;
 use std::sync::Arc;
 
-use quickwit_actors::Mailbox;
-use quickwit_janitor::actors::DeleteTaskService;
+use quickwit_config::{build_doc_mapper, IndexConfig};
+use quickwit_janitor::error::JanitorError;
 use quickwit_metastore::Metastore;
-use quickwit_proto::metastore_api::DeleteQuery;
+use quickwit_proto::metastore_api::{DeleteQuery, DeleteTask};
+use quickwit_proto::SearchRequest;
 use serde::Deserialize;
 use warp::{Filter, Rejection};
 
-use crate::format::{Format, FormatError};
-use crate::{require, with_arg};
+use crate::format::Format;
+use crate::with_arg;
 
 /// This struct represents the delete query passed to
 /// the rest API.
@@ -49,21 +49,17 @@ pub struct DeleteQueryRequest {
 /// Delete query API handlers.
 pub fn delete_task_api_handlers(
     metastore: Arc<dyn Metastore>,
-    delete_task_service_mailbox_opt: Option<Mailbox<DeleteTaskService>>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
-    get_delete_tasks_handler(metastore.clone(), delete_task_service_mailbox_opt.clone())
-        .or(post_delete_tasks_handler(delete_task_service_mailbox_opt))
+    get_delete_tasks_handler(metastore.clone()).or(post_delete_tasks_handler(metastore.clone()))
 }
 
 pub fn get_delete_tasks_handler(
     metastore: Arc<dyn Metastore>,
-    delete_task_service_mailbox: Option<Mailbox<DeleteTaskService>>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!(String / "delete-tasks")
         .and(warp::get())
         .and(with_arg(metastore))
-        .and(require(delete_task_service_mailbox))
-        .and_then(get_delete_tasks)
+        .then(get_delete_tasks)
 }
 
 // Returns delete tasks in json format for a given `index_id`.
@@ -71,30 +67,27 @@ pub fn get_delete_tasks_handler(
 // Explanation: we don't want to expose any delete tasks endpoints without a running
 // `DeleteTaskService`. This is ensured by requiring a `Mailbox<DeleteTaskService>` in
 // `get_delete_tasks_handler` and consequently we get the mailbox in `get_delete_tasks` signature.
-async fn get_delete_tasks(
-    index_id: String,
-    metastore: Arc<dyn Metastore>,
-    _delete_task_service_mailbox: Mailbox<DeleteTaskService>,
-) -> Result<impl warp::Reply, Infallible> {
+async fn get_delete_tasks(index_id: String, metastore: Arc<dyn Metastore>) -> impl warp::Reply {
     let delete_tasks = metastore.list_delete_tasks(&index_id, 0).await;
-    Ok(Format::PrettyJson.make_rest_reply(delete_tasks))
+    Format::PrettyJson.make_rest_reply(delete_tasks)
 }
 
 pub fn post_delete_tasks_handler(
-    delete_task_service_mailbox: Option<Mailbox<DeleteTaskService>>,
+    metastore: Arc<dyn Metastore>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!(String / "delete-tasks")
         .and(warp::body::json())
         .and(warp::post())
-        .and(require(delete_task_service_mailbox))
-        .and_then(post_delete_request)
+        .and(with_arg(metastore))
+        .then(post_delete_request)
+        .map(|create_delete_res| Format::PrettyJson.make_rest_reply(create_delete_res))
 }
 
 async fn post_delete_request(
     index_id: String,
     delete_request: DeleteQueryRequest,
-    delete_task_service_mailbox: Mailbox<DeleteTaskService>,
-) -> Result<impl warp::Reply, Infallible> {
+    metastore: Arc<dyn Metastore>,
+) -> Result<DeleteTask, JanitorError> {
     let delete_query = DeleteQuery {
         index_id: index_id.clone(),
         start_timestamp: delete_request.start_timestamp,
@@ -102,23 +95,26 @@ async fn post_delete_request(
         query: delete_request.query,
         search_fields: delete_request.search_fields,
     };
-    let create_delete_task_reply = delete_task_service_mailbox
-        .ask_for_res(delete_query)
-        .await
-        .map_err(FormatError::wrap);
-    Ok(Format::PrettyJson.make_rest_reply(create_delete_task_reply))
+    let index_config: IndexConfig = metastore
+        .index_metadata(&delete_query.index_id)
+        .await?
+        .into_index_config();
+    // TODO should it be something else than a JanitorError?
+    let doc_mapper = build_doc_mapper(&index_config.doc_mapping, &index_config.search_settings)
+        .map_err(|error| JanitorError::InternalError(error.to_string()))?;
+    let delete_search_request = SearchRequest::from(delete_query.clone());
+    // Validate the delete query.
+    doc_mapper
+        .query(doc_mapper.schema(), &delete_search_request)
+        .map_err(|error| JanitorError::InvalidDeleteQuery(error.to_string()))?;
+    let delete_task = metastore.create_delete_task(delete_query).await?;
+    Ok(delete_task)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use quickwit_actors::Universe;
     use quickwit_indexing::TestSandbox;
-    use quickwit_janitor::actors::DeleteTaskService;
     use quickwit_proto::metastore_api::DeleteTask;
-    use quickwit_search::{MockSearchService, SearchClientPool};
-    use quickwit_storage::StorageUriResolver;
     use warp::Filter;
 
     use crate::rest::recover_fn;
@@ -139,26 +135,8 @@ mod tests {
             .await
             .unwrap();
         let metastore = test_sandbox.metastore();
-        let mock_search_service = MockSearchService::new();
-        let client_pool = SearchClientPool::from_mocks(vec![Arc::new(mock_search_service)])
-            .await
-            .unwrap();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let data_dir_path = temp_dir.path().to_path_buf();
-        let delete_task_service = DeleteTaskService::new(
-            metastore.clone(),
-            client_pool,
-            StorageUriResolver::for_test(),
-            data_dir_path,
-            4,
-        );
-        let universe = Universe::new();
-        let (delete_task_service_mailbox, _delete_task_service_handler) =
-            universe.spawn_builder().spawn(delete_task_service);
-
         let delete_query_api_handlers =
-            super::delete_task_api_handlers(metastore, Some(delete_task_service_mailbox))
-                .recover(recover_fn);
+            super::delete_task_api_handlers(metastore).recover(recover_fn);
         let resp = warp::test::request()
             .path("/test-delete-task-rest/delete-tasks")
             .method("POST")

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -72,7 +72,7 @@ fn get_indexes_metadatas_handler(
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!("indexes")
         .and(warp::get())
-        .and(warp::path::end().map(move || index_service.clone()))
+        .and(with_arg(index_service))
         .then(get_indexes_metadatas)
         .map(format_response)
 }
@@ -90,7 +90,7 @@ fn get_all_splits_handler(
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!("indexes" / String / "splits")
         .and(warp::get())
-        .and(warp::path::end().map(move || index_service.clone()))
+        .and(with_arg(index_service))
         .then(get_all_splits)
         .map(format_response)
 }
@@ -113,8 +113,8 @@ fn create_index_handler(
         // TODO: add a filter on the content type, we support only json.
         .and(warp::post())
         .and(warp::filters::body::bytes())
-        .and(warp::path::end().map(move || index_service.clone()))
-        .and(warp::path::end().map(move || quickwit_config.clone()))
+        .and(with_arg(index_service))
+        .and(with_arg(quickwit_config))
         .then(create_index)
         .map(format_response)
 }
@@ -143,7 +143,7 @@ fn delete_index_handler(
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!("indexes" / String)
         .and(warp::delete())
-        .and(warp::path::end().map(move || index_service.clone()))
+        .and(with_arg(index_service))
         .then(delete_index)
         .map(format_response)
 }
@@ -162,7 +162,7 @@ fn create_source_handler(
     warp::path!("indexes" / String / "sources")
         .and(warp::post())
         .and(json_body())
-        .and(warp::path::end().map(move || index_service.clone()))
+        .and(with_arg(index_service))
         .then(create_source)
         .map(format_response)
 }
@@ -181,7 +181,7 @@ fn delete_source_handler(
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
     warp::path!("indexes" / String / "sources" / String)
         .and(warp::delete())
-        .and(warp::path::end().map(move || index_service.clone()))
+        .and(with_arg(index_service))
         .then(delete_source)
         .map(format_response)
 }

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -212,7 +212,7 @@ pub async fn serve_quickwit(config: QuickwitConfig) -> anyhow::Result<()> {
         services,
     };
     let grpc_server = grpc::start_grpc_server(grpc_listen_addr, &quickwit_services);
-    let rest_server = rest::start_rest_server(rest_listen_addr, &universe, &quickwit_services);
+    let rest_server = rest::start_rest_server(rest_listen_addr, &quickwit_services);
     tokio::try_join!(grpc_server, rest_server)?;
     Ok(())
 }


### PR DESCRIPTION
    Running the delete task creation handler on all nodes.
    
    The delete task creation/list handlers where needlessly requiring
    or were executed on the DeleteTaskService but were
    simply interacting with the Metastore.
    
    After the modification, the handler runs on all rest API
    and discuss directly with the Metastore.
    
    Closes #2507
