### PR TITLE
Add support of toml and yaml on index/source creation.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2142,7 +2142,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -3632,9 +3632,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3642,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3652,9 +3652,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3665,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
 dependencies = [
  "once_cell",
  "pest",
@@ -5402,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c321ee4e17d2b7abe12b5d20c1231db708dd36185c8a21e9de5fed6da4dbe9"
+checksum = "7fe32e8c89834541077a5c5bbe5691aa69324361e27e6aeb3552a737db4a70c8"
 dependencies = [
  "arrayvec 0.7.2",
  "borsh",
@@ -6923,9 +6923,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
 dependencies = [
  "indexmap",
  "nom8",

--- a/quickwit/quickwit-serve/src/index_api/mod.rs
+++ b/quickwit/quickwit-serve/src/index_api/mod.rs
@@ -19,4 +19,4 @@
 
 mod rest_handler;
 
-pub use self::rest_handler::{index_management_handlers, IndexApi};
+pub use self::rest_handler::{index_management_handlers, IndexApi, UnsupportedContentType};

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -20,12 +20,13 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use hyper::header::CONTENT_TYPE;
 use quickwit_config::{ConfigFormat, QuickwitConfig, SourceConfig};
 use quickwit_core::{IndexService, IndexServiceError};
 use quickwit_janitor::FileEntry;
 use quickwit_metastore::{IndexMetadata, Split};
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use thiserror::Error;
 use tracing::info;
 use warp::{Filter, Rejection, Reply};
 
@@ -59,6 +60,33 @@ pub fn index_management_handlers(
 
 fn format_response<T: Serialize>(result: Result<T, IndexServiceError>) -> impl Reply {
     Format::default().make_rest_reply_non_serializable_error(result)
+}
+
+#[derive(Debug, Error)]
+#[error(
+    "Unsupported content-type header. Choices are application/json, application/toml and \
+     application/yaml."
+)]
+pub struct UnsupportedContentType;
+impl warp::reject::Reject for UnsupportedContentType {}
+
+pub fn config_format_filter() -> impl Filter<Extract = (ConfigFormat,), Error = Rejection> + Copy {
+    warp::filters::header::optional::<mime_guess::Mime>(CONTENT_TYPE.as_str()).and_then(
+        |mime_opt: Option<mime_guess::Mime>| {
+            if let Some(mime) = mime_opt {
+                let config_format = match mime.subtype().as_str() {
+                    "json" => ConfigFormat::Json,
+                    "yaml" => ConfigFormat::Yaml,
+                    "toml" => ConfigFormat::Toml,
+                    _ => {
+                        return futures::future::err(warp::reject::custom(UnsupportedContentType));
+                    }
+                };
+                return futures::future::ok(config_format);
+            }
+            futures::future::ok(ConfigFormat::Json)
+        },
+    )
 }
 
 fn get_index_metadata_handler(
@@ -144,18 +172,14 @@ fn create_index_handler(
     quickwit_config: Arc<QuickwitConfig>,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     warp::path!("indexes")
-        // TODO: add a filter on the content type, we support only json.
         .and(warp::post())
+        .and(config_format_filter())
+        .and(warp::body::content_length_limit(1024 * 1024))
         .and(warp::filters::body::bytes())
         .and(with_arg(index_service))
         .and(with_arg(quickwit_config))
         .then(create_index)
         .map(format_response)
-}
-
-fn json_body<T: DeserializeOwned + Send>(
-) -> impl Filter<Extract = (T,), Error = warp::Rejection> + Clone {
-    warp::body::content_length_limit(1024 * 1024).and(warp::body::json())
 }
 
 #[utoipa::path(
@@ -170,12 +194,13 @@ fn json_body<T: DeserializeOwned + Send>(
 )]
 /// Create Index
 async fn create_index(
+    config_format: ConfigFormat,
     index_config_bytes: Bytes,
     index_service: Arc<IndexService>,
     quickwit_config: Arc<QuickwitConfig>,
 ) -> Result<IndexMetadata, IndexServiceError> {
     let index_config = quickwit_config::load_index_config_from_user_config(
-        ConfigFormat::Json,
+        config_format,
         &index_config_bytes,
         &quickwit_config.default_index_root_uri,
     )
@@ -219,7 +244,9 @@ fn create_source_handler(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     warp::path!("indexes" / String / "sources")
         .and(warp::post())
-        .and(json_body())
+        .and(config_format_filter())
+        .and(warp::body::content_length_limit(1024 * 1024))
+        .and(warp::filters::body::bytes())
         .and(with_arg(index_service))
         .then(create_source)
         .map(format_response)
@@ -241,9 +268,13 @@ fn create_source_handler(
 /// Create Source
 async fn create_source(
     index_id: String,
-    source_config: SourceConfig,
+    config_format: ConfigFormat,
+    source_config_bytes: Bytes,
     index_service: Arc<IndexService>,
 ) -> Result<SourceConfig, IndexServiceError> {
+    let source_config: SourceConfig = config_format
+        .parse(&source_config_bytes)
+        .map_err(IndexServiceError::InvalidConfig)?;
     info!(index_id = %index_id, source_id = %source_config.source_id, "create-source");
     index_service.create_source(&index_id, source_config).await
 }
@@ -599,6 +630,104 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rest_create_index_and_source_with_yaml() {
+        let metastore = build_metastore_for_test().await;
+        let index_service = IndexService::new(metastore.clone(), StorageUriResolver::for_test());
+        let mut quickwit_config = QuickwitConfig::for_test();
+        quickwit_config.default_index_root_uri =
+            Uri::from_well_formed("file:///default-index-root-uri");
+        let index_management_handler =
+            super::index_management_handlers(Arc::new(index_service), Arc::new(quickwit_config))
+                .recover(recover_fn);
+        let resp = warp::test::request()
+            .path("/indexes")
+            .method("POST")
+            .header("content-type", "application/yaml")
+            .body(
+                r#"
+            version: 0.4
+            index_id: hdfs-logs
+            doc_mapping:
+              field_mappings:
+                - name: timestamp
+                  type: i64
+                  fast: true
+                  indexed: true
+            "#,
+            )
+            .reply(&index_management_handler)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let resp_json: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        let expected_response_json = serde_json::json!({
+            "index_config": {
+                "index_id": "hdfs-logs",
+                "index_uri": "file:///default-index-root-uri/hdfs-logs",
+            }
+        });
+        assert_json_include!(actual: resp_json, expected: expected_response_json);
+    }
+
+    #[tokio::test]
+    async fn test_rest_create_index_and_source_with_toml() {
+        let metastore = build_metastore_for_test().await;
+        let index_service = IndexService::new(metastore.clone(), StorageUriResolver::for_test());
+        let mut quickwit_config = QuickwitConfig::for_test();
+        quickwit_config.default_index_root_uri =
+            Uri::from_well_formed("file:///default-index-root-uri");
+        let index_management_handler =
+            super::index_management_handlers(Arc::new(index_service), Arc::new(quickwit_config))
+                .recover(recover_fn);
+        let resp = warp::test::request()
+            .path("/indexes")
+            .method("POST")
+            .header("content-type", "application/toml")
+            .body(
+                r#"
+            version = "0.4"
+            index_id = "hdfs-logs"
+            [doc_mapping]
+            field_mappings = [
+                { name = "timestamp", type = "i64", fast = true, indexed = true}
+            ]
+            "#,
+            )
+            .reply(&index_management_handler)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let resp_json: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        let expected_response_json = serde_json::json!({
+            "index_config": {
+                "index_id": "hdfs-logs",
+                "index_uri": "file:///default-index-root-uri/hdfs-logs",
+            }
+        });
+        assert_json_include!(actual: resp_json, expected: expected_response_json);
+    }
+
+    #[tokio::test]
+    async fn test_rest_create_index_with_wrong_content_type() {
+        let metastore = build_metastore_for_test().await;
+        let index_service = IndexService::new(metastore.clone(), StorageUriResolver::for_test());
+        let mut quickwit_config = QuickwitConfig::for_test();
+        quickwit_config.default_index_root_uri =
+            Uri::from_well_formed("file:///default-index-root-uri");
+        let index_management_handler =
+            super::index_management_handlers(Arc::new(index_service), Arc::new(quickwit_config))
+                .recover(recover_fn);
+        let resp = warp::test::request()
+            .path("/indexes")
+            .method("POST")
+            .header("content-type", "application/yoml")
+            .body(r#""#)
+            .reply(&index_management_handler)
+            .await;
+        assert_eq!(resp.status(), 415);
+        let body = from_utf8_lossy(resp.body());
+        assert!(body.contains("Unsupported content-type header. Choices are"));
+    }
+
+    #[tokio::test]
     async fn test_rest_create_index_with_bad_config() -> anyhow::Result<()> {
         let metastore = MockMetastore::new();
         let index_service = IndexService::new(Arc::new(metastore), StorageUriResolver::for_test());
@@ -637,12 +766,11 @@ mod tests {
             .path("/indexes/my-index/sources")
             .method("POST")
             .json(&true)
-            .body(r#"{"version": 0.4, "source_id": "file-source""#)
+            .body(r#"{"version": 0.4, "source_id": "file-source"}"#)
             .reply(&index_management_handler)
             .await;
         assert_eq!(resp.status(), 400);
         let body = from_utf8_lossy(resp.body());
-        println!("{}", body);
         assert!(body.contains("invalid type: floating point `0.4`"));
         Ok(())
     }


### PR DESCRIPTION
Preparing #2717. We should do the toml/yaml parsing on the server side.