### PR TITLE
Retry on LimitExceeded errors and ignore some Kinesis tests

### DIFF
--- a/quickwit/quickwit-aws/src/error.rs
+++ b/quickwit/quickwit-aws/src/error.rs
@@ -157,48 +157,48 @@ impl Retryable for GetShardIteratorError {
 #[cfg(feature = "kinesis")]
 impl Retryable for ListShardsError {
     fn is_retryable(&self) -> bool {
-        false
+        matches!(self, ListShardsError::LimitExceeded(_))
     }
 }
 
 #[cfg(feature = "kinesis")]
 impl Retryable for CreateStreamError {
     fn is_retryable(&self) -> bool {
-        false
+        matches!(self, CreateStreamError::LimitExceeded(_))
     }
 }
 
 #[cfg(feature = "kinesis")]
 impl Retryable for DeleteStreamError {
     fn is_retryable(&self) -> bool {
-        false
+        matches!(self, DeleteStreamError::LimitExceeded(_))
     }
 }
 
 #[cfg(feature = "kinesis")]
 impl Retryable for DescribeStreamError {
     fn is_retryable(&self) -> bool {
-        false
+        matches!(self, DescribeStreamError::LimitExceeded(_))
     }
 }
 
 #[cfg(feature = "kinesis")]
 impl Retryable for ListStreamsError {
     fn is_retryable(&self) -> bool {
-        false
+        matches!(self, ListStreamsError::LimitExceeded(_))
     }
 }
 
 #[cfg(feature = "kinesis")]
 impl Retryable for MergeShardsError {
     fn is_retryable(&self) -> bool {
-        false
+        matches!(self, MergeShardsError::LimitExceeded(_))
     }
 }
 
 #[cfg(feature = "kinesis")]
 impl Retryable for SplitShardError {
     fn is_retryable(&self) -> bool {
-        false
+        matches!(self, SplitShardError::LimitExceeded(_))
     }
 }

--- a/quickwit/quickwit-aws/src/retry.rs
+++ b/quickwit/quickwit-aws/src/retry.rs
@@ -25,8 +25,8 @@ use rand::Rng;
 use tracing::{debug, warn};
 
 const DEFAULT_MAX_RETRY_ATTEMPTS: usize = 30;
-const DEFAULT_BASE_DELAY: Duration = Duration::from_millis(if cfg!(test) { 1 } else { 250 });
-const DEFAULT_MAX_DELAY: Duration = Duration::from_millis(if cfg!(test) { 1 } else { 20_000 });
+const DEFAULT_BASE_DELAY: Duration = Duration::from_millis(if cfg!(test) { 50 } else { 250 });
+const DEFAULT_MAX_DELAY: Duration = Duration::from_millis(if cfg!(test) { 1_000 } else { 20_000 });
 
 pub trait Retryable {
     fn is_retryable(&self) -> bool {

--- a/quickwit/quickwit-indexing/src/source/kinesis/api.rs
+++ b/quickwit/quickwit-indexing/src/source/kinesis/api.rs
@@ -395,6 +395,8 @@ mod kinesis_localstack_tests {
         Ok(())
     }
 
+    // Ignoring this test because the localstack implementation of Kinesis is bogus.
+    #[ignore]
     #[tokio::test]
     async fn test_get_shard_iterator() -> anyhow::Result<()> {
         let (kinesis_client, stream_name) = setup("test-get-shard-iterator", 2).await?;

--- a/quickwit/quickwit-indexing/src/source/kinesis/shard_consumer.rs
+++ b/quickwit/quickwit-indexing/src/source/kinesis/shard_consumer.rs
@@ -355,6 +355,8 @@ mod tests {
         Ok(())
     }
 
+    // Ignoring this test because the localstack implementation of Kinesis is bogus.
+    #[ignore]
     #[tokio::test]
     async fn test_start_after_sequence_number() -> anyhow::Result<()> {
         let universe = Universe::new();
@@ -413,8 +415,7 @@ mod tests {
         Ok(())
     }
 
-    // This test fails when run against the Localstack Kinesis providers `kinesis-mock` or
-    // `kinesalite` since they do not properly implement the `ChildShards` API.
+    // Ignoring this test because the localstack implementation of Kinesis is bogus.
     #[ignore]
     #[tokio::test]
     async fn test_merge_shards() -> anyhow::Result<()> {
@@ -476,8 +477,7 @@ mod tests {
         Ok(())
     }
 
-    // This test fails when run against the Localstack Kinesis providers `kinesis-mock` or
-    // `kinesalite` since they do not properly implement the `ChildShards` API.
+    // Ignoring this test because the localstack implementation of Kinesis is bogus.
     #[ignore]
     #[tokio::test]
     async fn test_split_shard() -> anyhow::Result<()> {


### PR DESCRIPTION
### Description
Localstack updated the mock library they use for Kinesis, which improves a few things and makes some other worse.

### How was this PR tested?
Ran Kinesis test suite locally.