### PR TITLE
More info in app version

### DIFF
--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -119,10 +119,11 @@ async fn main() -> anyhow::Result<()> {
     let telemetry_handle = quickwit_telemetry::start_telemetry_loop();
     let about_text = about_text();
     let build_info = quickwit_build_info();
+    let version_text = format!("{} ({} {})", build_info.version, build_info.commit_short_hash, build_info.build_date);
 
     let app = build_cli()
         .about(about_text.as_str())
-        .version(build_info.version.as_str());
+        .version(version_text.as_str());
     let matches = app.get_matches();
 
     let command = match CliCommand::parse_cli_args(&matches) {

--- a/quickwit/quickwit-ui/src/views/NodeInfoView.tsx
+++ b/quickwit/quickwit-ui/src/views/NodeInfoView.tsx
@@ -44,7 +44,7 @@ function NodeInfoView() {
 
   const urlByTab: Record<string, string> = {
     '1': 'api/v1/config',
-    '2': 'api/v1/build',
+    '2': 'api/v1/version',
   }
 
   const handleTabIndexChange = (_: React.SyntheticEvent, newValue: string) => {


### PR DESCRIPTION
- Added more info in the app version display like: `Quickwit 0.4.0-nightly (586a6f8 2022-12-02T03:00:00Z)`
- Fixed build info API URL.