### PR TITLE
Update cross image version with clang 3.9

### DIFF
--- a/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
@@ -9,8 +9,8 @@ ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \
-    apt-get install -y clang \
-        libclang-dev \
+    apt-get install -y clang-3.9 \
+        libclang-3.9-dev \
         binutils-aarch64-linux-gnu \
         libsasl2-dev:arm64 \
         unzip && \

--- a/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.4
 
 ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip"
 

--- a/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
@@ -3,8 +3,8 @@ FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4
 ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip"
 
 RUN apt-get update && \
-    apt-get install -y clang \
-        libclang-dev \
+    apt-get install -y clang-3.9 \
+        libclang-3.9-dev \
         libsasl2-dev \
         unzip && \
     rm -rf /var/lib/apt/lists/*

--- a/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4
 
 ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip"
 


### PR DESCRIPTION
Needed to compile rocksdb.