### PR TITLE
Remove mold usage in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,18 +88,6 @@ jobs:
         with:
           key: "v1-${{ matrix.task.name }}"
           workspaces: "./quickwit -> target"
-      - name: Install mold deps
-        run: | 
-          apt update
-          apt install wget -y
-          apt install jq -y
-      - name: Install mold
-        run: | 
-          version=latest
-          test $version = latest && version=$(wget -q -O- https://api.github.com/repos/rui314/mold/releases/latest | jq -r .tag_name | sed 's/^v//'); true
-          echo "mold $version"
-          wget -q -O- https://github.com/rui314/mold/releases/download/v$version/mold-$version-$(uname -m)-linux.tar.gz | tar -C /usr/local --strip-components=1 -xzf -
-          ln -sf /usr/local/bin/mold $(realpath /usr/bin/ld);
       - name: Install nextest
         if: matrix.task.name == 'cargo nextest'
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
The current CI code is referring to the latest version of a binary build on a mold's creator.
That's a recipe for breaking CI, exposing ourselves to change of API (unlikely for a linker but well), supply chain attack etc, change of licenses (for CI that's ok but for building our binares that would have been a disaster).

Let's stick to the stock linker.
