### PR TITLE
Fix duplicate fields in editor auto-completion

### DIFF
--- a/quickwit/quickwit-ui/src/components/QueryEditor/QueryEditor.tsx
+++ b/quickwit/quickwit-ui/src/components/QueryEditor/QueryEditor.tsx
@@ -61,7 +61,7 @@ export function QueryEditor(props: SearchComponentProps) {
     const updatedLanguageId = getLanguageId(props.searchRequest.indexId);
     if (monacoRef.current !== null && updatedLanguageId !== '' && props.index !== null) {
       const monaco = monacoRef.current;
-      if (!monaco.languages.getLanguages().some(({ id }: {id :string }) => id === languageId)) {
+      if (!monaco.languages.getLanguages().some(({ id }: {id :string }) => id === updatedLanguageId)) {
         console.log('register language', updatedLanguageId);
         monaco.languages.register({'id': updatedLanguageId});
         monaco.languages.setMonarchTokensProvider(updatedLanguageId, LanguageFeatures())


### PR DESCRIPTION
Ensure an index is registered in the query editor component (Monaco editor) only once.

Manually reproduced and tested.
Closes https://github.com/quickwit-oss/quickwit/issues/2615
