### PR TITLE
quickwit-aws time mocking

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "futures",
  "hyper-rustls",
  "once_cell",
+ "quickwit-actors",
  "rand 0.8.5",
  "rusoto_core",
  "rusoto_kinesis",

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -24,5 +24,8 @@ rusoto_sts = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+quickwit-actors = { workspace = true }
+
 [features]
 kinesis = ["rusoto_kinesis"]


### PR DESCRIPTION
 Accelerates time in the aws retry unit test using quickwit-actors's time mocker.
