### PR TITLE
Yield before calling on drained callback

### DIFF
--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -356,6 +356,10 @@ impl<A: Actor> Clone for Inbox<A> {
 }
 
 impl<A: Actor> Inbox<A> {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.rx.is_empty()
+    }
+
     pub(crate) async fn recv(&self) -> Result<Envelope<A>, RecvError> {
         self.rx.recv().await
     }

--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -506,7 +506,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mailbox_send_with_backpressure_counter_no_backpressure_cleansheet() {
+    async fn test_mailbox_send_with_backpressure_counter_low_backpressure() {
         let universe = Universe::with_accelerated_time();
         let back_pressure_actor = BackPressureActor;
         let (mailbox, _handle) = universe.spawn_builder().spawn(back_pressure_actor);
@@ -527,9 +527,9 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(backpressure_micros_counter.get(), 0u64);
+        assert!(backpressure_micros_counter.get() < 500);
         processed.await.unwrap();
-        assert_eq!(backpressure_micros_counter.get(), 0u64);
+        assert!(backpressure_micros_counter.get() < 500);
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-actors/src/tests.rs
+++ b/quickwit/quickwit-actors/src/tests.rs
@@ -318,7 +318,8 @@ async fn test_actor_running_states() {
     }
     let obs = ping_handle.process_pending_and_observe().await;
     assert_eq!(*obs, 10);
-    assert_eq!(ping_handle.state(), ActorState::Idle);
+    universe.sleep(Duration::from_millis(1)).await;
+    assert!(ping_handle.state() == ActorState::Idle);
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -613,6 +614,7 @@ async fn test_drain_is_called() {
     mailbox.send_message(()).await.unwrap();
     mailbox.send_message(()).await.unwrap();
     handle.resume();
+    universe.sleep(Duration::from_millis(1)).await;
     assert_eq!(
         *handle.process_pending_and_observe().await,
         ProcessAndDrainCounts {
@@ -621,6 +623,7 @@ async fn test_drain_is_called() {
         }
     );
     mailbox.send_message(()).await.unwrap();
+    universe.sleep(Duration::from_millis(1)).await;
     assert_eq!(
         *handle.process_pending_and_observe().await,
         ProcessAndDrainCounts {

--- a/quickwit/quickwit-actors/src/universe.rs
+++ b/quickwit/quickwit-actors/src/universe.rs
@@ -19,8 +19,6 @@
 
 use std::time::Duration;
 
-use futures::Future;
-
 use crate::mailbox::create_mailbox;
 use crate::registry::ActorObservation;
 use crate::scheduler::start_scheduler;
@@ -104,19 +102,6 @@ impl Universe {
     /// universe.
     pub async fn sleep(&self, duration: Duration) {
         self.spawn_ctx.scheduler_client.sleep(duration).await;
-    }
-
-    /// This function acts as a drop-in replacement of
-    /// `tokio::time::sleep`.
-    ///
-    /// It can however be accelerated when using a time-accelerated
-    /// universe.
-    pub async fn timeout<O>(
-        &self,
-        duration: Duration,
-        fut: impl Future<Output = O>,
-    ) -> Result<O, ()> {
-        self.spawn_ctx.scheduler_client.timeout(duration, fut).await
     }
 
     pub fn spawn_builder<A: Actor>(&self) -> SpawnBuilder<A> {

--- a/quickwit/quickwit-actors/src/universe.rs
+++ b/quickwit/quickwit-actors/src/universe.rs
@@ -19,6 +19,8 @@
 
 use std::time::Duration;
 
+use futures::Future;
+
 use crate::mailbox::create_mailbox;
 use crate::registry::ActorObservation;
 use crate::scheduler::start_scheduler;
@@ -99,9 +101,22 @@ impl Universe {
     /// `tokio::time::sleep`.
     ///
     /// It can however be accelerated when using a time-accelerated
-    /// Universe.
+    /// universe.
     pub async fn sleep(&self, duration: Duration) {
         self.spawn_ctx.scheduler_client.sleep(duration).await;
+    }
+
+    /// This function acts as a drop-in replacement of
+    /// `tokio::time::sleep`.
+    ///
+    /// It can however be accelerated when using a time-accelerated
+    /// universe.
+    pub async fn timeout<O>(
+        &self,
+        duration: Duration,
+        fut: impl Future<Output = O>,
+    ) -> Result<O, ()> {
+        self.spawn_ctx.scheduler_client.timeout(duration, fut).await
     }
 
     pub fn spawn_builder<A: Actor>(&self) -> SpawnBuilder<A> {

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -398,7 +398,7 @@ impl Handler<PlanDeleteLoop> for DeleteTaskPlanner {
 
 #[cfg(test)]
 mod tests {
-    use quickwit_actors::{ActorState, Universe};
+    use quickwit_actors::Universe;
     use quickwit_config::build_doc_mapper;
     use quickwit_grpc_clients::service_client_pool::ServiceClientPool;
     use quickwit_indexing::merge_policy::{MergeOperation, NopMergePolicy};
@@ -562,10 +562,6 @@ mod tests {
         assert_eq!(all_splits[1].split_metadata.delete_opstamp, 2);
         // The last split has not yet its delete opstamp updated.
         assert_eq!(all_splits[2].split_metadata.delete_opstamp, 0);
-
-        // Check actor state.
-        assert_eq!(delete_planner_handle.state(), ActorState::Idle);
-
         Ok(())
     }
 }


### PR DESCRIPTION
### Description
`try_recv` returning `None` means that the channel is empty but not necessarily drained, i.e., an actor can exist at the other end of the channel waiting on `send`. The only way to find out is to yield and check whether the channel is empty when the task is scheduled again.

### How was this PR tested?
- Updated unit tests
- `make test-all`