### PR TITLE
Change doc mapper signature

### DIFF
--- a/quickwit/quickwit-doc-mapper/benches/doc_to_json_bench.rs
+++ b/quickwit/quickwit-doc-mapper/benches/doc_to_json_bench.rs
@@ -49,7 +49,7 @@ pub fn simple_json_to_doc_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let lines: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
             for line in lines {
-                doc_mapper.doc_from_json(&line).unwrap();
+                doc_mapper.doc_from_json_str(&line).unwrap();
             }
         })
     });

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -32,7 +32,7 @@ use super::field_mapping_entry::QuickwitTextTokenizer;
 use super::DefaultDocMapperBuilder;
 use crate::default_doc_mapper::mapping_tree::{build_mapping_tree, MappingNode, MappingTree};
 pub use crate::default_doc_mapper::QuickwitJsonOptions;
-use crate::doc_mapper::Partition;
+use crate::doc_mapper::{JsonObject, Partition};
 use crate::query_builder::build_query;
 use crate::routing_expression::RoutingExpr;
 use crate::{
@@ -342,13 +342,10 @@ fn extract_single_obj(
 
 #[typetag::serde(name = "default")]
 impl DocMapper for DefaultDocMapper {
-    fn doc_from_json(&self, doc_json: &str) -> Result<(Partition, Document), DocParsingError> {
-        let json_obj: serde_json::Map<String, JsonValue> =
-            serde_json::from_str(doc_json).map_err(|_| {
-                let doc_json_sample = doc_json.chars().take(20).collect();
-                DocParsingError::NotJsonObject(doc_json_sample)
-            })?;
-
+    fn doc_from_json_obj(
+        &self,
+        json_obj: JsonObject,
+    ) -> Result<(Partition, Document), DocParsingError> {
         let partition: Partition = self.partition_key.eval_hash(&json_obj);
 
         let mut dynamic_json_obj = serde_json::Map::default();
@@ -492,9 +489,11 @@ mod tests {
 
     #[test]
     fn test_parsing_document() {
-        let doc_mapper = crate::default_doc_mapper_for_test();
         let json_doc = example_json_doc_value();
-        let (_, document) = doc_mapper.doc_from_json(&json_doc.to_string()).unwrap();
+        let doc_mapper = crate::default_doc_mapper_for_test();
+        let (_, document) = doc_mapper
+            .doc_from_json_obj(json_doc.as_object().unwrap().clone())
+            .unwrap();
         let schema = doc_mapper.schema();
         // 8 property entry + 1 field "_source" + two fields values for "tags" field
         // + 2 values inf "server.status" field + 2 values in "server.payload" field
@@ -534,7 +533,7 @@ mod tests {
     fn test_accept_parsing_document_with_unknown_fields_and_missing_fields() {
         let doc_mapper = crate::default_doc_mapper_for_test();
         doc_mapper
-            .doc_from_json(
+            .doc_from_json_str(
                 r#"{
                 "timestamp": 1586960586000,
                 "unknown_field": "20200415T072306-0700 INFO This is a great log",
@@ -549,7 +548,7 @@ mod tests {
     #[test]
     fn test_fail_parsing_document_with_missing_fast_field() {
         let doc_mapper = crate::default_doc_mapper_for_test();
-        let result = doc_mapper.doc_from_json(
+        let result = doc_mapper.doc_from_json_str(
             r#"{
                 "timestamp": 1586960586000,
                 "unknown_field": "20200415T072306-0700 INFO This is a great log",
@@ -568,7 +567,7 @@ mod tests {
     #[test]
     fn test_fail_to_parse_document_with_wrong_cardinality() -> anyhow::Result<()> {
         let doc_mapper = crate::default_doc_mapper_for_test();
-        let result = doc_mapper.doc_from_json(
+        let result = doc_mapper.doc_from_json_str(
             r#"{
                 "timestamp": 1586960586000,
                 "body": ["text 1", "text 2"]
@@ -586,7 +585,7 @@ mod tests {
     #[test]
     fn test_fail_to_parse_document_with_wrong_value() -> anyhow::Result<()> {
         let doc_mapper = crate::default_doc_mapper_for_test();
-        let result = doc_mapper.doc_from_json(
+        let result = doc_mapper.doc_from_json_str(
             r#"{
                 "timestamp": 1586960586000,
                 "body": 1
@@ -741,12 +740,12 @@ mod tests {
         }"#;
         let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper)?;
         let doc_mapper = builder.try_build()?;
-        let result = doc_mapper.doc_from_json(
+        let result = doc_mapper.doc_from_json_str(
             r#"{
             "image": "invalid base64 data"
         }"#,
         );
-        let expected_msg = "The field 'image' could not be parsed: Expected Base64 string, got \
+        let expected_msg = "The field `image` could not be parsed: Expected Base64 string, got \
                             `invalid base64 data`: Invalid byte 32, offset 7.";
         assert_eq!(result.unwrap_err().to_string(), expected_msg);
         Ok(())
@@ -782,7 +781,7 @@ mod tests {
             "image": "YWJj"
         });
         let (_, document) = doc_mapper
-            .doc_from_json(&json_doc_value.to_string())
+            .doc_from_json_obj(json_doc_value.as_object().unwrap().clone())
             .unwrap();
 
         // 2 properties, + 1 value for "_source"
@@ -926,7 +925,7 @@ mod tests {
         let default_doc_mapper: DefaultDocMapper =
             serde_json::from_str(r#"{ "mode": "strict" }"#).unwrap();
         let parsing_err = default_doc_mapper
-            .doc_from_json(r#"{ "a": { "b": 5, "c": 6 } }"#)
+            .doc_from_json_str(r#"{ "a": { "b": 5, "c": 6 } }"#)
             .err()
             .unwrap();
         assert!(
@@ -955,10 +954,10 @@ mod tests {
         )
         .unwrap();
         assert!(default_doc_mapper
-            .doc_from_json(r#"{ "some_obj": { "child_a": "hello" } }"#)
+            .doc_from_json_str(r#"{ "some_obj": { "child_a": "hello" } }"#)
             .is_ok());
         let parsing_err = default_doc_mapper
-            .doc_from_json(r#"{ "some_obj": { "child_a": "hello", "child_b": 6 } }"#)
+            .doc_from_json_str(r#"{ "some_obj": { "child_a": "hello", "child_b": 6 } }"#)
             .err()
             .unwrap();
         assert!(
@@ -971,7 +970,7 @@ mod tests {
         let default_doc_mapper: DefaultDocMapper =
             serde_json::from_str(r#"{ "mode": "lenient" }"#).unwrap();
         let (_, doc) = default_doc_mapper
-            .doc_from_json(r#"{ "a": { "b": 5, "c": 6 } }"#)
+            .doc_from_json_str(r#"{ "a": { "b": 5, "c": 6 } }"#)
             .unwrap();
         assert_eq!(doc.len(), 0);
     }
@@ -983,7 +982,7 @@ mod tests {
         let schema = default_doc_mapper.schema();
         let dynamic_field = schema.get_field(DYNAMIC_FIELD_NAME).unwrap();
         let (_, doc) = default_doc_mapper
-            .doc_from_json(r#"{ "a": { "b": 5, "c": 6 } }"#)
+            .doc_from_json_str(r#"{ "a": { "b": 5, "c": 6 } }"#)
             .unwrap();
         let vals: Vec<&TantivyValue> = doc.get_all(dynamic_field).collect();
         assert_eq!(vals.len(), 1);
@@ -1023,7 +1022,7 @@ mod tests {
         )
         .unwrap();
         let (_, doc) = default_doc_mapper
-            .doc_from_json(
+            .doc_from_json_str(
                 r#"{ "some_obj": { "child_a": "", "child_b": {"c": 3} }, "some_obj2": 4 }"#,
             )
             .unwrap();
@@ -1071,7 +1070,7 @@ mod tests {
         )
         .unwrap();
         let (_, doc) = default_doc_mapper
-            .doc_from_json(r#"{ "some_obj": { "json_obj": {"hello": 2} } }"#)
+            .doc_from_json_str(r#"{ "some_obj": { "json_obj": {"hello": 2} } }"#)
             .unwrap();
         let json_field = default_doc_mapper
             .schema()

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
@@ -986,7 +986,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             parse_err.to_string(),
-            "The field 'root.my_field' could not be parsed: Expected JSON number, got `[1,2]`."
+            "The field `root.my_field` could not be parsed: Expected JSON number, got `[1,2]`."
         );
     }
 

--- a/quickwit/quickwit-doc-mapper/src/error.rs
+++ b/quickwit/quickwit-doc-mapper/src/error.rs
@@ -35,11 +35,11 @@ impl From<tantivy::query::QueryParserError> for QueryParserError {
 /// a document from JSON.
 #[derive(Debug, Error, Eq, PartialEq)]
 pub enum DocParsingError {
-    /// The provided string is not valid JSON.
-    #[error("The provided string is not a valid JSON object. {0}")]
+    /// The provided string is not a syntactically valid JSON object.
+    #[error("The provided string is not a syntactically valid JSON object: {0}")]
     NotJsonObject(String),
     /// One of the value could not be parsed.
-    #[error("The field '{0}' could not be parsed: {1}")]
+    #[error("The field `{0}` could not be parsed: {1}")]
     ValueError(String, String),
     /// The json-document contains a field that is not declared in the schema.
     #[error("The document contains a field that is not declared in the schema: {0:?}")]

--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -171,7 +171,7 @@ impl DocProcessor {
         // Parse the document
         let _protect_guard = ctx.protect_zone();
         let num_bytes = doc_json.len();
-        let doc_parsing_result = self.doc_mapper.doc_from_json(doc_json);
+        let doc_parsing_result = self.doc_mapper.doc_from_json_str(doc_json);
         let (partition, doc) = doc_parsing_result.map_err(|doc_parsing_error| {
             warn!(err=?doc_parsing_error);
             match doc_parsing_error {


### PR DESCRIPTION
### Description
Use `serde_json::Map<String, JsonValue>` instead of `&str` as input of the doc mapper parsing method so we can use the doc mapper directly on docs that already have been parsed as part of the transform process.

Indeed, I'm working on finalizing the VRL PR, and I'm making some changes to the doc processor. The code looks like this:

```rust
let doc_res = if let Some(transform) = self.transform_opt {
    let vrl_value: VrlValue = transform.transform_doc(&json_doc)?;
    let json_value: JsonValue = serde_json::to_value(vrl_doc).map_err(...);
    let JsonValue::Object(json_obj) = json_value else ...
    doc_mapper.doc_from_json_obj(json_obj)
} else {
    doc_mapper.doc_from_json_str(&json_doc)
}
```

Without this change, we have to serialize the `VrlValue` to a JSON string and then back to a `JsonValue`. This is painfully slow.

### How was this PR tested?
`make test-all`