### PR TITLE
Instrument OTLP trace service

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "689894c2db1ea643a50834b999abf1c110887402542955ff5451dab8f861f9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1178,15 +1178,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4137,7 +4137,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yaml 0.9.16",
+ "serde_yaml 0.9.17",
  "tokio",
  "toml",
  "tracing",
@@ -4199,7 +4199,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "serde_yaml 0.9.16",
+ "serde_yaml 0.9.17",
  "tantivy",
  "tempfile",
  "thiserror",
@@ -4473,7 +4473,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
+ "once_cell",
+ "prost",
  "quickwit-actors",
+ "quickwit-common",
  "quickwit-ingest-api",
  "quickwit-proto",
  "serde",
@@ -5550,9 +5553,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
 dependencies = [
  "indexmap",
  "itoa 1.0.5",
@@ -6563,9 +6566,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -6859,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -7498,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -159,7 +159,7 @@ time = { version = "0.3.17", features = ["std", "formatting", "macros"] }
 tokio = { version = "1.24", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["full"] }
-toml = "0.5.10"
+toml = "0.5.11"
 tonic = { version = "0.8.3", features = ["gzip"] }
 tonic-build = "0.8.4"
 tower = "0.4.13"

--- a/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
@@ -27,9 +27,9 @@ use crate::{IndexMetadata, ListSplitsQuery, Metastore, MetastoreResult, Split, S
 
 macro_rules! instrument {
     ($expr:expr, [$operation:ident, $($label:expr),*]) => {
+        let start = std::time::Instant::now();
         let labels = [stringify!($operation), $($label,)*];
         crate::metrics::METASTORE_METRICS.requests_total.with_label_values(labels).inc();
-        let start = std::time::Instant::now();
         let (res, is_error) = match $expr {
             ok @ Ok(_) => {
                 (ok, "false")
@@ -83,7 +83,6 @@ impl Metastore for InstrumentedMetastore {
     }
 
     // Index API
-
     async fn create_index(&self, index_config: IndexConfig) -> MetastoreResult<()> {
         let index_id = index_config.index_id.to_string();
         instrument!(

--- a/quickwit/quickwit-opentelemetry/Cargo.toml
+++ b/quickwit/quickwit-opentelemetry/Cargo.toml
@@ -13,6 +13,8 @@ documentation = "https://quickwit.io/docs/"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+once_cell = { workspace = true }
+prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
@@ -20,6 +22,7 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 
 quickwit-actors = { workspace = true }
+quickwit-common = { workspace = true }
 quickwit-ingest-api = { workspace = true }
 quickwit-proto = { workspace = true }
 

--- a/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
@@ -20,37 +20,50 @@
 use once_cell::sync::Lazy;
 use quickwit_common::metrics::{new_counter_vec, new_histogram_vec, HistogramVec, IntCounterVec};
 
-pub struct MetastoreMetrics {
-    pub requests_total: IntCounterVec<2>,
-    pub request_errors_total: IntCounterVec<2>,
-    pub request_duration_seconds: HistogramVec<3>,
+pub struct OtlpServiceMetrics {
+    pub requests_total: IntCounterVec<4>,
+    pub request_errors_total: IntCounterVec<4>,
+    pub request_duration_seconds: HistogramVec<5>,
+    pub ingested_spans_total: IntCounterVec<4>,
+    pub ingested_bytes_total: IntCounterVec<4>,
 }
 
-impl Default for MetastoreMetrics {
+impl Default for OtlpServiceMetrics {
     fn default() -> Self {
         Self {
             requests_total: new_counter_vec(
                 "requests_total",
                 "Number of requests",
-                "quickwit_metastore",
-                ["operation", "index"],
+                "quickwit_otel",
+                ["service", "index", "transport", "format"],
             ),
             request_errors_total: new_counter_vec(
                 "request_errors_total",
                 "Number of failed requests",
-                "quickwit_metastore",
-                ["operation", "index"],
+                "quickwit_otel",
+                ["service", "index", "transport", "format"],
             ),
             request_duration_seconds: new_histogram_vec(
                 "request_duration_seconds",
                 "Duration of requests",
-                "quickwit_metastore",
-                ["operation", "index", "error"],
+                "quickwit_otel",
+                ["service", "index", "transport", "format", "error"],
+            ),
+            ingested_spans_total: new_counter_vec(
+                "ingested_spans_total",
+                "Number of spans ingested",
+                "quickwit_otel",
+                ["service", "index", "transport", "format"],
+            ),
+            ingested_bytes_total: new_counter_vec(
+                "ingested_bytes_total",
+                "Number of bytes ingested",
+                "quickwit_otel",
+                ["service", "index", "transport", "format"],
             ),
         }
     }
 }
 
-/// `METASTORE_METRICS` exposes a bunch of metastore-related metrics through a Prometheus
-/// endpoint.
-pub static METASTORE_METRICS: Lazy<MetastoreMetrics> = Lazy::new(MetastoreMetrics::default);
+/// `OTLP_SERVICE_METRICS` exposes metrics for each OTLP service.
+pub static OTLP_SERVICE_METRICS: Lazy<OtlpServiceMetrics> = Lazy::new(OtlpServiceMetrics::default);

--- a/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
@@ -25,6 +25,7 @@ use serde_json::{Number as JsonNumber, Value as JsonValue};
 use tracing::warn;
 
 mod logs;
+mod metrics;
 mod trace;
 
 pub use logs::OtlpGrpcLogsService;


### PR DESCRIPTION
### Description
Per title.

### How was this PR tested?
```
QW_ENABLE_JAEGER_SERVICE=true \
QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER=true \
QW_ENABLE_OPENTELEMETRY_OTLP_SERVICE=true \
OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:7281 \
RUST_BACKTRACE=1 \
RUST_LOG=info,quickwit=info,quickwit_jaeger=debug \
cargo run --manifest-path quickwit/Cargo.toml --all-features -- run
```
