### PR TITLE
Add Jaeger config

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4372,6 +4372,7 @@ dependencies = [
  "prost",
  "prost-types",
  "quickwit-common",
+ "quickwit-config",
  "quickwit-opentelemetry",
  "quickwit-proto",
  "quickwit-search",

--- a/quickwit/quickwit-actors/src/universe.rs
+++ b/quickwit/quickwit-actors/src/universe.rs
@@ -56,7 +56,7 @@ impl Universe {
     ///
     /// The time "jumps" only happen when no actor is processing any message,
     /// running initialization or finalize.
-    #[cfg(any(tests, feature = "testsuite"))]
+    #[cfg(any(test, feature = "testsuite"))]
     pub fn with_accelerated_time() -> Universe {
         let universe = Universe::new();
         universe.spawn_ctx().scheduler_client.accelerate_time();

--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -116,6 +116,11 @@ pub fn is_disjoint(left: &Range<i64>, right: &RangeInclusive<i64>) -> bool {
     left.end <= *right.start() || *right.end() < left.start
 }
 
+/// For use with the `skip_serializing_if` serde attribute.
+pub fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 pub fn no_color() -> bool {
     matches!(env::var("NO_COLOR"), Ok(value) if !value.is_empty())
 }

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -31,9 +31,9 @@
         "max_num_concurrent_split_searches": 150
     },
     "jaeger": {
-        "enable_service": false,
+        "enable_endpoint": false,
         "lookback_period_hours": 24,
         "max_trace_duration_secs": 600,
-        "max_retrieve_spans": 1000
+        "max_fetch_spans": 1000
     }
 }

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -29,5 +29,11 @@
         "split_footer_cache_capacity": "1G",
         "max_num_concurrent_split_streams": 120,
         "max_num_concurrent_split_searches": 150
+    },
+    "jaeger": {
+        "enable_service": false,
+        "lookback_period_hours": 24,
+        "max_trace_duration_secs": 600,
+        "max_retrieve_spans": 1000
     }
 }

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -23,9 +23,8 @@ split_footer_cache_capacity = "1G"
 max_num_concurrent_split_streams = 120
 max_num_concurrent_split_searches = 150
 
-
 [jaeger]
-enable_service = false
+enable_endpoint = false
 lookback_period_hours = 24
 max_trace_duration_secs = 600
-max_retrieve_spans = 1_000
+max_fetch_spans = 1_000

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -23,3 +23,9 @@ split_footer_cache_capacity = "1G"
 max_num_concurrent_split_streams = 120
 max_num_concurrent_split_searches = 150
 
+
+[jaeger]
+enable_service = false
+lookback_period_hours = 24
+max_trace_duration_secs = 600
+max_retrieve_spans = 1_000

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -15,12 +15,20 @@ peer_seeds:
 data_dir: /opt/quickwit/data
 metastore_uri: postgres://username:password@host:port/db
 default_index_root_uri: s3://quickwit-indexes
+
 indexer:
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000
   max_concurrent_split_uploads: 8
+
 searcher:
   fast_field_cache_capacity: 10G
   split_footer_cache_capacity: 1G
   max_num_concurrent_split_streams: 120
   max_num_concurrent_split_searches: 150
+
+jaeger:
+  enable_service: false
+  lookback_period_hours: 24
+  max_trace_duration_secs: 60
+  max_retrieve_spans: 1000

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -28,7 +28,7 @@ searcher:
   max_num_concurrent_split_searches: 150
 
 jaeger:
-  enable_service: false
+  enable_endpoint: false
   lookback_period_hours: 24
   max_trace_duration_secs: 60
-  max_retrieve_spans: 1000
+  max_fetch_spans: 1000

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -57,7 +57,8 @@ use crate::merge_policy_config::{
     ConstWriteAmplificationMergePolicyConfig, MergePolicyConfig, StableLogMergePolicyConfig,
 };
 pub use crate::quickwit_config::{
-    IndexerConfig, IngestApiConfig, QuickwitConfig, SearcherConfig, DEFAULT_QW_CONFIG_PATH,
+    IndexerConfig, IngestApiConfig, JaegerConfig, QuickwitConfig, SearcherConfig,
+    DEFAULT_QW_CONFIG_PATH,
 };
 use crate::source_config::serialize::{SourceConfigV0_4, VersionedSourceConfig};
 
@@ -83,10 +84,6 @@ use crate::source_config::serialize::{SourceConfigV0_4, VersionedSourceConfig};
 )))]
 /// Schema used for the OpenAPI generation which are apart of this crate.
 pub struct ConfigApiSchemas;
-
-fn is_false(val: &bool) -> bool {
-    !*val
-}
 
 /// Checks whether an identifier conforms to Quickwit object naming conventions.
 pub fn validate_identifier(label: &str, value: &str) -> anyhow::Result<()> {

--- a/quickwit/quickwit-config/src/quickwit_config/mod.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/mod.rs
@@ -22,7 +22,9 @@ mod serialize;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::net::SocketAddr;
+use std::num::NonZeroU64;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::bail;
 use byte_unit::Byte;
@@ -40,20 +42,20 @@ pub const DEFAULT_QW_CONFIG_PATH: &str = "config/quickwit.yaml";
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct IndexerConfig {
-    #[doc(hidden)]
-    #[serde(default = "IndexerConfig::default_enable_opentelemetry_otlp_service")]
-    pub enable_opentelemetry_otlp_service: bool,
     #[serde(default = "IndexerConfig::default_split_store_max_num_bytes")]
     pub split_store_max_num_bytes: Byte,
     #[serde(default = "IndexerConfig::default_split_store_max_num_splits")]
     pub split_store_max_num_splits: usize,
     #[serde(default = "IndexerConfig::default_max_concurrent_split_uploads")]
     pub max_concurrent_split_uploads: usize,
+    #[doc(hidden)]
+    #[serde(default = "IndexerConfig::default_enable_opentelemetry_otlp_service")]
+    pub enable_opentelemetry_otlp_service: bool,
 }
 
 impl IndexerConfig {
     fn default_enable_opentelemetry_otlp_service() -> bool {
-        false
+        !(cfg!(feature = "test") || cfg!(feature = "testsuite"))
     }
 
     fn default_max_concurrent_split_uploads() -> usize {
@@ -94,9 +96,6 @@ impl Default for IndexerConfig {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SearcherConfig {
-    #[doc(hidden)]
-    #[serde(default = "SearcherConfig::default_enable_jaeger_service")]
-    pub enable_jaeger_service: bool,
     #[serde(default = "SearcherConfig::default_fast_field_cache_capacity")]
     pub fast_field_cache_capacity: Byte,
     #[serde(default = "SearcherConfig::default_split_footer_cache_capacity")]
@@ -108,10 +107,6 @@ pub struct SearcherConfig {
 }
 
 impl SearcherConfig {
-    fn default_enable_jaeger_service() -> bool {
-        false
-    }
-
     fn default_fast_field_cache_capacity() -> Byte {
         Byte::from_bytes(1_000_000_000) // 1G
     }
@@ -132,7 +127,6 @@ impl SearcherConfig {
 impl Default for SearcherConfig {
     fn default() -> Self {
         Self {
-            enable_jaeger_service: Self::default_enable_jaeger_service(),
             fast_field_cache_capacity: Self::default_fast_field_cache_capacity(),
             split_footer_cache_capacity: Self::default_split_footer_cache_capacity(),
             max_num_concurrent_split_streams: Self::default_max_num_concurrent_split_streams(),
@@ -169,6 +163,56 @@ impl Default for IngestApiConfig {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JaegerConfig {
+    #[serde(default = "JaegerConfig::default_enable_jaeger_service")]
+    pub enable_service: bool,
+    #[serde(default = "JaegerConfig::default_lookback_period_hours")]
+    lookback_period_hours: NonZeroU64,
+    #[serde(default = "JaegerConfig::default_max_trace_duration_secs")]
+    max_trace_duration_secs: NonZeroU64,
+    #[serde(default = "JaegerConfig::default_max_retrieve_spans")]
+    pub max_retrieve_spans: NonZeroU64,
+}
+
+impl JaegerConfig {
+    pub fn lookback_period(&self) -> Duration {
+        Duration::from_secs(self.lookback_period_hours.get() * 3600)
+    }
+
+    pub fn max_trace_duration(&self) -> Duration {
+        Duration::from_secs(self.max_trace_duration_secs.get())
+    }
+
+    fn default_enable_jaeger_service() -> bool {
+        !(cfg!(feature = "test") || cfg!(feature = "testsuite"))
+    }
+
+    fn default_lookback_period_hours() -> NonZeroU64 {
+        NonZeroU64::new(72).unwrap() // 3 days
+    }
+
+    fn default_max_trace_duration_secs() -> NonZeroU64 {
+        NonZeroU64::new(3600).unwrap() // 1 hour
+    }
+
+    fn default_max_retrieve_spans() -> NonZeroU64 {
+        NonZeroU64::new(10_000).unwrap() // 10k spans
+    }
+}
+
+impl Default for JaegerConfig {
+    fn default() -> Self {
+        Self {
+            enable_service: Self::default_enable_jaeger_service(),
+            lookback_period_hours: Self::default_lookback_period_hours(),
+            max_trace_duration_secs: Self::default_max_trace_duration_secs(),
+            max_retrieve_spans: Self::default_max_retrieve_spans(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct QuickwitConfig {
     pub cluster_id: String,
@@ -186,6 +230,7 @@ pub struct QuickwitConfig {
     pub indexer_config: IndexerConfig,
     pub searcher_config: SearcherConfig,
     pub ingest_api_config: IngestApiConfig,
+    pub jaeger_config: JaegerConfig,
 }
 
 impl QuickwitConfig {

--- a/quickwit/quickwit-config/src/quickwit_config/serialize.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/serialize.rs
@@ -33,8 +33,8 @@ use crate::qw_env_vars::*;
 use crate::service::QuickwitService;
 use crate::templating::render_config;
 use crate::{
-    validate_identifier, ConfigFormat, IndexerConfig, IngestApiConfig, QuickwitConfig,
-    SearcherConfig,
+    validate_identifier, ConfigFormat, IndexerConfig, IngestApiConfig, JaegerConfig,
+    QuickwitConfig, SearcherConfig,
 };
 
 pub const DEFAULT_CLUSTER_ID: &str = "quickwit-default-cluster";
@@ -175,6 +175,9 @@ struct QuickwitConfigBuilder {
     #[serde(rename = "ingest_api")]
     #[serde(default)]
     ingest_api_config: IngestApiConfig,
+    #[serde(rename = "jaeger")]
+    #[serde(default)]
+    jaeger_config: JaegerConfig,
 }
 
 impl QuickwitConfigBuilder {
@@ -255,6 +258,7 @@ impl QuickwitConfigBuilder {
             indexer_config: self.indexer_config,
             searcher_config: self.searcher_config,
             ingest_api_config: self.ingest_api_config,
+            jaeger_config: self.jaeger_config,
         };
 
         validate(&quickwit_config)?;
@@ -296,6 +300,7 @@ impl Default for QuickwitConfigBuilder {
             indexer_config: IndexerConfig::default(),
             searcher_config: SearcherConfig::default(),
             ingest_api_config: IngestApiConfig::default(),
+            jaeger_config: JaegerConfig::default(),
         }
     }
 }
@@ -346,6 +351,7 @@ pub fn quickwit_config_for_test() -> QuickwitConfig {
         indexer_config: IndexerConfig::default(),
         searcher_config: SearcherConfig::default(),
         ingest_api_config: IngestApiConfig::default(),
+        jaeger_config: JaegerConfig::default(),
     }
 }
 
@@ -353,6 +359,7 @@ pub fn quickwit_config_for_test() -> QuickwitConfig {
 mod tests {
     use std::env;
     use std::net::Ipv4Addr;
+    use std::num::NonZeroU64;
     use std::path::Path;
 
     use byte_unit::Byte;
@@ -429,11 +436,19 @@ mod tests {
         assert_eq!(
             config.searcher_config,
             SearcherConfig {
-                enable_jaeger_service: false,
                 fast_field_cache_capacity: Byte::from_str("10G").unwrap(),
                 split_footer_cache_capacity: Byte::from_str("1G").unwrap(),
                 max_num_concurrent_split_searches: 150,
                 max_num_concurrent_split_streams: 120,
+            }
+        );
+        assert_eq!(
+            config.jaeger_config,
+            JaegerConfig {
+                enable_service: false,
+                lookback_period_hours: NonZeroU64::new(24).unwrap(),
+                max_trace_duration_secs: NonZeroU64::new(600).unwrap(),
+                max_retrieve_spans: NonZeroU64::new(1_000).unwrap(),
             }
         );
         Ok(())
@@ -473,18 +488,6 @@ mod tests {
         .unwrap_err();
         assert!(format!("{parsing_error:?}")
             .contains("unknown field `max_num_concurrent_split_searchs`"));
-    }
-
-    #[test]
-    fn test_indexer_config_default_values() {
-        let indexer_config = serde_yaml::from_str::<IndexerConfig>("{}").unwrap();
-        assert_eq!(indexer_config, IndexerConfig::default());
-    }
-
-    #[test]
-    fn test_searcher_config_default_values() {
-        let searcher_config = serde_yaml::from_str::<SearcherConfig>("{}").unwrap();
-        assert_eq!(searcher_config, SearcherConfig::default());
     }
 
     #[tokio::test]
@@ -658,6 +661,8 @@ mod tests {
         );
         assert_eq!(config.indexer_config, IndexerConfig::default());
         assert_eq!(config.searcher_config, SearcherConfig::default());
+        assert_eq!(config.ingest_api_config, IngestApiConfig::default());
+        assert_eq!(config.jaeger_config, JaegerConfig::default());
     }
 
     #[tokio::test]
@@ -805,10 +810,10 @@ mod tests {
     async fn test_load_config_with_validation_error() {
         let config_filepath = get_config_filepath("quickwit.yaml");
         let file = std::fs::read_to_string(&config_filepath).unwrap();
-        let config = QuickwitConfig::load(ConfigFormat::Yaml, file.as_bytes())
+        let error = QuickwitConfig::load(ConfigFormat::Yaml, file.as_bytes())
             .await
             .unwrap_err();
-        assert!(config.to_string().contains("Data dir"));
+        assert!(error.to_string().contains("Data dir"));
     }
 
     #[tokio::test]
@@ -888,5 +893,17 @@ mod tests {
             .unwrap_err();
             assert!(error.to_string().contains("Data dir must be located"));
         }
+    }
+
+    #[test]
+    fn test_jaeger_config_rejects_null_values() {
+        let jaeger_config_yaml = r#"
+            enable_service: true
+            max_trace_duration_secs: 0
+        "#;
+        let error = serde_yaml::from_str::<JaegerConfig>(jaeger_config_yaml).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("max_trace_duration_secs: invalid value: integer `0`"))
     }
 }

--- a/quickwit/quickwit-config/src/quickwit_config/serialize.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/serialize.rs
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(
             config.indexer_config,
             IndexerConfig {
-                enable_opentelemetry_otlp_service: false,
+                enable_otlp_endpoint: false,
                 split_store_max_num_bytes: Byte::from_str("1T").unwrap(),
                 split_store_max_num_splits: 10_000,
                 max_concurrent_split_uploads: 8,
@@ -445,10 +445,10 @@ mod tests {
         assert_eq!(
             config.jaeger_config,
             JaegerConfig {
-                enable_service: false,
+                enable_endpoint: false,
                 lookback_period_hours: NonZeroU64::new(24).unwrap(),
                 max_trace_duration_secs: NonZeroU64::new(600).unwrap(),
-                max_retrieve_spans: NonZeroU64::new(1_000).unwrap(),
+                max_fetch_spans: NonZeroU64::new(1_000).unwrap(),
             }
         );
         Ok(())
@@ -898,7 +898,7 @@ mod tests {
     #[test]
     fn test_jaeger_config_rejects_null_values() {
         let jaeger_config_yaml = r#"
-            enable_service: true
+            enable_endpoint: true
             max_trace_duration_secs: 0
         "#;
         let error = serde_yaml::from_str::<JaegerConfig>(jaeger_config_yaml).unwrap_err();

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -23,8 +23,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{bail, Context};
-use quickwit_common::no_color;
 use quickwit_common::uri::Uri;
+use quickwit_common::{is_false, no_color};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
@@ -34,7 +34,7 @@ use tracing::warn;
 use vrl::diagnostic::Formatter;
 use vrl::{CompilationResult, Program, TimeZone};
 
-use crate::{is_false, ConfigFormat, TestableForRegression};
+use crate::{ConfigFormat, TestableForRegression};
 
 /// Reserved source ID for the `quickwit index ingest` CLI command.
 pub const CLI_INGEST_SOURCE_ID: &str = "_ingest-cli-source";

--- a/quickwit/quickwit-jaeger/Cargo.toml
+++ b/quickwit/quickwit-jaeger/Cargo.toml
@@ -26,6 +26,7 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 
 quickwit-common = { workspace = true }
+quickwit-config = { workspace = true }
 quickwit-opentelemetry = { workspace = true }
 quickwit-proto = { workspace = true }
 quickwit-search = { workspace = true }

--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -22,13 +22,14 @@ use std::fmt::Write;
 use std::mem;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use base64::prelude::{Engine, BASE64_STANDARD};
 use itertools::Itertools;
 use prost::Message;
 use prost_types::{Duration as WellKnownDuration, Timestamp as WellKnownTimestamp};
+use quickwit_config::JaegerConfig;
 use quickwit_opentelemetry::otlp::{
     Event as QwEvent, Link as QwLink, Span as QwSpan, SpanStatus as QwSpanStatus,
     OTEL_TRACE_INDEX_ID,
@@ -74,18 +75,18 @@ type SpanStream = ReceiverStream<Result<SpansResponseChunk, Status>>;
 
 pub struct JaegerService {
     search_service: Arc<dyn SearchService>,
-    lookback_period: Duration,
-    max_trace_duration: Duration,
-    max_retrieved_spans: u64,
+    lookback_period_secs: i64,
+    max_trace_duration_secs: i64,
+    max_retrieve_spans: u64,
 }
 
 impl JaegerService {
-    pub fn new(search_service: Arc<dyn SearchService>) -> Self {
+    pub fn new(config: JaegerConfig, search_service: Arc<dyn SearchService>) -> Self {
         Self {
+            lookback_period_secs: config.lookback_period().as_secs() as i64,
+            max_trace_duration_secs: config.max_trace_duration().as_secs() as i64,
+            max_retrieve_spans: config.max_retrieve_spans.get(),
             search_service,
-            lookback_period: Duration::from_secs(3 * 24 * 3600),
-            max_trace_duration: Duration::from_secs(3600),
-            max_retrieved_spans: 10_000,
         }
     }
 
@@ -99,7 +100,8 @@ impl JaegerService {
         let index_id = TRACE_INDEX_ID.to_string();
         let query = "*".to_string();
         let max_hits = 1_000;
-        let start_timestamp = Some(OffsetDateTime::now_utc().unix_timestamp() - 24 * 3600); // 24-hour lookback
+        let start_timestamp =
+            Some(OffsetDateTime::now_utc().unix_timestamp() - self.lookback_period_secs);
 
         let search_request = SearchRequest {
             index_id,
@@ -150,7 +152,8 @@ impl JaegerService {
             None,
         );
         let max_hits = 1_000;
-        let start_timestamp = Some(OffsetDateTime::now_utc().unix_timestamp() - 24 * 3600); // 24-hour lookback
+        let start_timestamp =
+            Some(OffsetDateTime::now_utc().unix_timestamp() - self.lookback_period_secs);
 
         let search_request = SearchRequest {
             index_id,
@@ -220,8 +223,8 @@ impl JaegerService {
             .query
             .ok_or_else(|| Status::invalid_argument("Trace query is empty."))?;
         let (trace_ids, span_timestamps_range) = self.find_trace_ids(trace_query).await?;
-        let start = span_timestamps_range.start() - self.max_trace_duration.as_secs() as i64;
-        let end = span_timestamps_range.end() + self.max_trace_duration.as_secs() as i64;
+        let start = span_timestamps_range.start() - self.max_trace_duration_secs;
+        let end = span_timestamps_range.end() + self.max_trace_duration_secs;
         let search_window = start..=end;
         let response = self
             .stream_spans(&trace_ids, search_window, operation_name, request_start)
@@ -239,7 +242,7 @@ impl JaegerService {
         debug!(request=?request, "`get_trace` request");
         let trace_id = BASE64_STANDARD.encode(request.trace_id);
         let end = OffsetDateTime::now_utc().unix_timestamp();
-        let start = end - self.lookback_period.as_secs() as i64;
+        let start = end - self.lookback_period_secs;
         let search_window = start..=end;
         let response = self
             .stream_spans(&[trace_id], search_window, operation_name, request_start)
@@ -325,7 +328,7 @@ impl JaegerService {
             search_fields: Vec::new(),
             start_timestamp: Some(*search_window.start()),
             end_timestamp: Some(*search_window.end()),
-            max_hits: self.max_retrieved_spans,
+            max_hits: self.max_retrieve_spans,
             start_offset: 0,
             sort_order: None,
             sort_by_field: None,

--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -77,16 +77,16 @@ pub struct JaegerService {
     search_service: Arc<dyn SearchService>,
     lookback_period_secs: i64,
     max_trace_duration_secs: i64,
-    max_retrieve_spans: u64,
+    max_fetch_spans: u64,
 }
 
 impl JaegerService {
     pub fn new(config: JaegerConfig, search_service: Arc<dyn SearchService>) -> Self {
         Self {
+            search_service,
             lookback_period_secs: config.lookback_period().as_secs() as i64,
             max_trace_duration_secs: config.max_trace_duration().as_secs() as i64,
-            max_retrieve_spans: config.max_retrieve_spans.get(),
-            search_service,
+            max_fetch_spans: config.max_fetch_spans.get(),
         }
     }
 
@@ -328,7 +328,7 @@ impl JaegerService {
             search_fields: Vec::new(),
             start_timestamp: Some(*search_window.start()),
             end_timestamp: Some(*search_window.end()),
-            max_hits: self.max_retrieve_spans,
+            max_hits: self.max_fetch_spans,
             start_offset: 0,
             sort_order: None,
             sort_by_field: None,

--- a/quickwit/quickwit-serve/src/grpc.rs
+++ b/quickwit/quickwit-serve/src/grpc.rs
@@ -125,18 +125,18 @@ pub(crate) async fn start_grpc_server(
     } else {
         None
     };
-    let enable_jaeger_service = services.config.searcher_config.enable_jaeger_service;
+    let enable_jaeger_service = services.config.jaeger_config.enable_service;
     let jaeger_grpc_service =
         if enable_jaeger_service && services.services.contains(&QuickwitService::Searcher) {
             enabled_grpc_services.insert("jaeger");
             let search_service = services.search_service.clone();
             Some(SpanReaderPluginServer::new(JaegerService::new(
+                services.config.jaeger_config.clone(),
                 search_service,
             )))
         } else {
             None
         };
-
     let server_router = server
         .add_optional_service(metastore_grpc_service)
         .add_optional_service(control_plane_grpc_service)

--- a/quickwit/quickwit-serve/src/grpc.rs
+++ b/quickwit/quickwit-serve/src/grpc.rs
@@ -84,10 +84,8 @@ pub(crate) async fn start_grpc_server(
         None
     };
     // Mount gRPC OpenTelemetry OTLP trace service if `QuickwitService::Indexer` is enabled on node.
-    let enable_opentelemetry_otlp_grpc_service = services
-        .config
-        .indexer_config
-        .enable_opentelemetry_otlp_service;
+    let enable_opentelemetry_otlp_grpc_service =
+        services.config.indexer_config.enable_otlp_endpoint;
     let otlp_trace_service = if enable_opentelemetry_otlp_grpc_service
         && services.services.contains(&QuickwitService::Indexer)
     {
@@ -125,9 +123,9 @@ pub(crate) async fn start_grpc_server(
     } else {
         None
     };
-    let enable_jaeger_service = services.config.jaeger_config.enable_service;
+    let enable_jaeger_endpoint = services.config.jaeger_config.enable_endpoint;
     let jaeger_grpc_service =
-        if enable_jaeger_service && services.services.contains(&QuickwitService::Searcher) {
+        if enable_jaeger_endpoint && services.services.contains(&QuickwitService::Searcher) {
             enabled_grpc_services.insert("jaeger");
             let search_service = services.search_service.clone();
             Some(SpanReaderPluginServer::new(JaegerService::new(

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -181,7 +181,7 @@ pub async fn serve_quickwit(config: QuickwitConfig) -> anyhow::Result<()> {
         let ingest_api_service =
             start_ingest_api_service(&universe, &config.data_dir_path, &config.ingest_api_config)
                 .await?;
-        if config.indexer_config.enable_opentelemetry_otlp_service {
+        if config.indexer_config.enable_otlp_endpoint {
             let index_config = load_index_config_from_user_config(
                 ConfigFormat::Yaml,
                 OTEL_TRACE_INDEX_CONFIG.as_bytes(),


### PR DESCRIPTION
### Description
- [x] add Jaeger config to set parameters such as `lookback_period`, `max_trace_duration`, or `max_retrieve_spans`
- [x] enable OTel OTLP trace service by default
- [x] enable Jaeger service by default
- [x] document config 

### How was this PR tested?
`make test-all`
