### PR TITLE
Replace wikipedia with stackoverflow in quickstart

### DIFF
--- a/config/tutorials/stackoverflow/index-config.yaml
+++ b/config/tutorials/stackoverflow/index-config.yaml
@@ -1,0 +1,47 @@
+#
+# Index config file for stackoverflow dataset.
+#
+version: 0.4
+
+index_id: stackoverflow
+
+doc_mapping:
+  field_mappings:
+    - name: user
+      type: text
+      fast: true
+      tokenizer: raw
+    - name: tags
+      type: array<text>
+      fast: true
+      tokenizer: raw
+    - name: type
+      type: text
+      fast: true
+      tokenizer: raw
+    - name: title
+      type: text
+      tokenizer: default
+      record: position
+      stored: true
+    - name: body
+      type: text
+      tokenizer: default
+      record: position
+      stored: true
+    - name: questionId
+      type: u64
+    - name: answerId
+      type: u64
+    - name: acceptedAnswerId
+      type: u64
+    - name: creationDate
+      type: datetime
+      fast: true
+      input_formats:
+        - rfc3339
+      precision: seconds
+  timestamp_field: creationDate
+
+search_settings:
+  default_search_fields: [title, body]


### PR DESCRIPTION
### Description

Replaces wikipedia dataset in the quickstart guide with the stackoverflow dataset. This new dataset not only has a timestamp but also contains some interesting elements such as tags and record types to make getting started more fun.

Besides replacing the dataset it also adds instructions on how to use docker image on Apple silicon based macOS systems and adds --rm flag to all docker instructions. Without the rm flag docker creates and keeps a new container for every execution and we start a new container at least 6 times during this tutorial.

Closes #1618

### How was this PR tested?

I visually inspected the markdown. I am not really sure how to render it into HTML the same way as it is done on the web site. 

I manually ran both CLI and docker commands on x86_64 Ubuntu 22.04.1 to make sure that the flow describe in the guide really works. I also tested docker commands on arm64 macOS 13.1 machine (the CLI path fails on this machine due to #1928)
