### PR TITLE
Run azurite in all profile in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
     ports:
         - "10000:10000" # Blob store port
     profiles:
+      - all
       - azurite
     volumes:
         - "${TMPDIR:-/tmp}/quickwit/services/azurite:/data"


### PR DESCRIPTION
### Description

Added azurite to run in the default ("all") profile in docker compose. Otherwise, it is not getting started when we try to start all services for testing.

### How was this PR tested?

By following instructions in CONTRIBUTING.md

Fixes #2751
