### PR TITLE
Fix license header checker

### DIFF
--- a/quickwit/scripts/check_license_headers.sh
+++ b/quickwit/scripts/check_license_headers.sh
@@ -9,7 +9,7 @@ for file in $(git ls-files | \
     grep -v "quickwit-proto/src" \
 )
 do
-    diff <(sed 's/{\\d+}/2022/' .license_header.txt) <(head -n 19 $file)
+    diff <(sed 's/{\\d+}/2023/' .license_header.txt) <(head -n 19 $file)
     DIFFRESULT=$?
     if [ $DIFFRESULT -ne 0 ]; then
         echo $DIFFRESULT


### PR DESCRIPTION
### Description

All headers were updated to 2023, so the license checker should also be updated.

Fixes #2767

### How was this PR tested?

By running `bash scripts/check_license_headers.sh`
