### PR TITLE
Various tracing enhancements

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -951,7 +951,7 @@ mod tests {
         let metastore = Arc::new(FileBackedMetastore::default_for_test().await);
         let mut index_ids = Vec::new();
         for idx in 0..10 {
-            let index_id = format!("test-index-{}", idx);
+            let index_id = format!("test-index-{idx}");
             let index_config = IndexConfig::for_test(&index_id, "ram:///indexes/test-index");
             metastore.create_index(index_config).await.unwrap();
             index_ids.push(index_id);

--- a/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
@@ -30,8 +30,8 @@ mod trace;
 
 pub use logs::OtlpGrpcLogsService;
 pub use trace::{
-    Base64, Event, Link, OtlpGrpcTraceService, Span, SpanStatus, OTEL_TRACE_INDEX_CONFIG,
-    OTEL_TRACE_INDEX_ID,
+    Base64, Event, Link, OtlpGrpcTraceService, Span, SpanFingerprint, SpanKind, SpanStatus,
+    OTEL_TRACE_INDEX_CONFIG, OTEL_TRACE_INDEX_ID,
 };
 
 pub(crate) fn extract_attributes(attributes: Vec<KeyValue>) -> HashMap<String, JsonValue> {

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -267,7 +267,7 @@ pub async fn start_searcher_service(
     Ok(search_service)
 }
 
-/// Create a Term from a &str
+/// Creates a tantivy Term from a &str.
 #[cfg(any(test, feature = "testsuite"))]
 #[macro_export]
 macro_rules! encode_term_for_test {


### PR DESCRIPTION
### Description
- Use `service_name` as tag field to prune splits
- Sort spans within a batch by trace ID and timestamp to improve compression and efficiency of trace IDs collector (upcoming PR)
- Partition trace index by service name % 100
- Use list terms query to list operations
- Filter operations by span kind

### How was this PR tested?
Ingested some traces and displayed them in Jaeger UI