### PR TITLE
Switch to custom collector for aggregating trace IDs

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4916,6 +4916,7 @@ dependencies = [
  "bytes",
  "chitchat",
  "fastfield_codecs",
+ "fnv",
  "futures",
  "http",
  "hyper",

--- a/quickwit/quickwit-search/Cargo.toml
+++ b/quickwit/quickwit-search/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://quickwit.io/docs/"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
+fnv = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 fastfield_codecs = { workspace = true }

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use quickwit_doc_mapper::{DocMapper, WarmupInfo};
 use quickwit_proto::{LeafSearchResponse, PartialHit, SearchRequest, SortOrder};
+use serde::Deserialize;
 use tantivy::aggregation::agg_req::{
     get_fast_field_names, get_term_dict_field_names, Aggregations,
 };
@@ -35,6 +36,7 @@ use tantivy::schema::Schema;
 use tantivy::{DocId, Score, SegmentOrdinal, SegmentReader};
 
 use crate::filters::{TimestampFilter, TimestampFilterBuilder};
+use crate::jaeger_collector::{FindTraceIdsCollector, FindTraceIdsSegmentCollector};
 use crate::partial_hit_sorting_key;
 
 #[derive(Clone, Debug)]
@@ -161,6 +163,11 @@ impl PartialEq for PartialHitHeapItem {
 
 impl Eq for PartialHitHeapItem {}
 
+enum AggregationSegmentCollectors {
+    FindTraceIdsSegmentCollector(FindTraceIdsSegmentCollector),
+    TantivyAggregationSegmentCollector(AggregationSegmentCollector),
+}
+
 /// Quickwit collector working at the scale of the segment.
 pub struct QuickwitSegmentCollector {
     num_hits: u64,
@@ -170,7 +177,7 @@ pub struct QuickwitSegmentCollector {
     max_hits: usize,
     segment_ord: u32,
     timestamp_filter_opt: Option<TimestampFilter>,
-    aggregation: Option<AggregationSegmentCollector>,
+    aggregation: Option<AggregationSegmentCollectors>,
 }
 
 impl QuickwitSegmentCollector {
@@ -219,8 +226,15 @@ impl SegmentCollector for QuickwitSegmentCollector {
 
         self.num_hits += 1;
         self.collect_top_k(doc_id, score);
-        if let Some(aggregation_collector) = self.aggregation.as_mut() {
-            aggregation_collector.collect(doc_id, score);
+
+        match self.aggregation.as_mut() {
+            Some(AggregationSegmentCollectors::FindTraceIdsSegmentCollector(collector)) => {
+                collector.collect(doc_id, score)
+            }
+            Some(AggregationSegmentCollectors::TantivyAggregationSegmentCollector(collector)) => {
+                collector.collect(doc_id, score)
+            }
+            None => (),
         }
     }
 
@@ -240,15 +254,19 @@ impl SegmentCollector for QuickwitSegmentCollector {
             })
             .collect();
 
-        let intermediate_aggregation_result = if let Some(collector) = self.aggregation {
-            Some(
-                serde_json::to_string(&collector.harvest()?)
-                    .expect("could not serialize aggregation to json"),
-            )
-        } else {
-            None
+        let intermediate_aggregation_result = match self.aggregation {
+            Some(AggregationSegmentCollectors::FindTraceIdsSegmentCollector(collector)) => Some(
+                serde_json::to_string(&collector.harvest())
+                    .expect("Collector fruit should be JSON serializable."),
+            ),
+            Some(AggregationSegmentCollectors::TantivyAggregationSegmentCollector(collector)) => {
+                Some(
+                    serde_json::to_string(&collector.harvest()?)
+                        .expect("Collector fruit should be JSON serializable."),
+                )
+            }
+            None => None,
         };
-
         Ok(LeafSearchResponse {
             intermediate_aggregation_result,
             num_hits: self.num_hits,
@@ -256,6 +274,37 @@ impl SegmentCollector for QuickwitSegmentCollector {
             failed_splits: vec![],
             num_attempted_splits: 1,
         })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum QuickwitAggregations {
+    FindTraceIdsAggregation(FindTraceIdsCollector),
+    TantivyAggregations(Aggregations),
+}
+
+impl QuickwitAggregations {
+    fn fast_field_names(&self) -> HashSet<String> {
+        match self {
+            QuickwitAggregations::FindTraceIdsAggregation(collector) => {
+                collector.fast_field_names()
+            }
+            QuickwitAggregations::TantivyAggregations(aggregations) => {
+                get_fast_field_names(aggregations)
+            }
+        }
+    }
+
+    fn term_dict_field_names(&self) -> HashSet<String> {
+        match self {
+            QuickwitAggregations::FindTraceIdsAggregation(collector) => {
+                collector.term_dict_field_names()
+            }
+            QuickwitAggregations::TantivyAggregations(aggregations) => {
+                get_term_dict_field_names(aggregations)
+            }
+        }
     }
 }
 
@@ -270,7 +319,7 @@ pub(crate) struct QuickwitCollector {
     pub max_hits: usize,
     pub sort_by: SortBy,
     timestamp_filter_builder_opt: Option<TimestampFilterBuilder>,
-    pub aggregation: Option<Aggregations>,
+    pub aggregation: Option<QuickwitAggregations>,
 }
 
 impl QuickwitCollector {
@@ -282,21 +331,23 @@ impl QuickwitCollector {
                 fast_field_names.insert(field_name.clone());
             }
         }
-        if let Some(aggregate) = self.aggregation.as_ref() {
-            fast_field_names.extend(get_fast_field_names(aggregate));
+        if let Some(aggregations) = &self.aggregation {
+            fast_field_names.extend(aggregations.fast_field_names());
         }
         if let Some(timestamp_filter_builder) = &self.timestamp_filter_builder_opt {
             fast_field_names.insert(timestamp_filter_builder.timestamp_field_name.clone());
         }
         fast_field_names
     }
+
     pub fn term_dict_field_names(&self) -> HashSet<String> {
         let mut term_dict_field_names = HashSet::default();
-        if let Some(aggregate) = self.aggregation.as_ref() {
-            term_dict_field_names.extend(get_term_dict_field_names(aggregate));
+        if let Some(aggregations) = &self.aggregation {
+            term_dict_field_names.extend(aggregations.term_dict_field_names());
         }
         term_dict_field_names
     }
+
     pub fn warmup_info(&self) -> WarmupInfo {
         WarmupInfo {
             term_dict_field_names: self.term_dict_field_names(),
@@ -323,13 +374,27 @@ impl Collector for QuickwitCollector {
         // starting from 0 for every leaves.
         let leaf_max_hits = self.max_hits + self.start_offset;
 
-        let timestamp_filter_opt =
-            if let Some(timestamp_filter_builder) = &self.timestamp_filter_builder_opt {
-                timestamp_filter_builder.build(segment_reader)?
-            } else {
-                None
-            };
-
+        let timestamp_filter_opt = match &self.timestamp_filter_builder_opt {
+            Some(timestamp_filter_builder) => timestamp_filter_builder.build(segment_reader)?,
+            None => None,
+        };
+        let aggregation = match &self.aggregation {
+            Some(QuickwitAggregations::FindTraceIdsAggregation(collector)) => {
+                Some(AggregationSegmentCollectors::FindTraceIdsSegmentCollector(
+                    collector.for_segment(0, segment_reader)?,
+                ))
+            }
+            Some(QuickwitAggregations::TantivyAggregations(aggs)) => Some(
+                AggregationSegmentCollectors::TantivyAggregationSegmentCollector(
+                    AggregationSegmentCollector::from_agg_req_and_reader(
+                        aggs,
+                        segment_reader,
+                        AGGREGATION_BUCKET_LIMIT,
+                    )?,
+                ),
+            ),
+            None => None,
+        };
         Ok(QuickwitSegmentCollector {
             num_hits: 0u64,
             split_id: self.split_id.clone(),
@@ -338,17 +403,7 @@ impl Collector for QuickwitCollector {
             segment_ord,
             max_hits: leaf_max_hits,
             timestamp_filter_opt,
-            aggregation: self
-                .aggregation
-                .as_ref()
-                .map(|aggs| {
-                    AggregationSegmentCollector::from_agg_req_and_reader(
-                        aggs,
-                        segment_reader,
-                        AGGREGATION_BUCKET_LIMIT,
-                    )
-                })
-                .transpose()?,
+            aggregation,
         })
     }
 
@@ -372,7 +427,8 @@ impl Collector for QuickwitCollector {
         // All leaves will return their top [0..max_hits) documents.
         // We compute the overall [0..start_offset + max_hits) documents ...
         let num_hits = self.start_offset + self.max_hits;
-        let mut merged_leaf_response = merge_leaf_responses(segment_fruits?, num_hits)?;
+        let mut merged_leaf_response =
+            merge_leaf_responses(&self.aggregation, segment_fruits?, num_hits)?;
         // ... and drop the first [..start_offsets) hits.
         merged_leaf_response
             .partial_hits
@@ -388,6 +444,7 @@ impl Collector for QuickwitCollector {
 
 /// Merges a set of Leaf Results.
 fn merge_leaf_responses(
+    aggregations_opt: &Option<QuickwitAggregations>,
     leaf_responses: Vec<LeafSearchResponse>,
     max_hits: usize,
 ) -> tantivy::Result<LeafSearchResponse> {
@@ -395,24 +452,46 @@ fn merge_leaf_responses(
     if leaf_responses.len() == 1 {
         return Ok(leaf_responses.into_iter().next().unwrap_or_default()); //< default is actually never called
     }
-    let intermediate_aggregation_results = leaf_responses
-        .iter()
-        .flat_map(|leaf_response| {
-            leaf_response
-                .intermediate_aggregation_result
-                .as_ref()
-                .map(|res| serde_json::from_str(res))
-        })
-        .collect::<Result<Vec<IntermediateAggregationResults>, _>>()?;
+    let merged_intermediate_aggregation_result = match aggregations_opt {
+        Some(QuickwitAggregations::FindTraceIdsAggregation(collector)) => {
+            let fruits: Vec<
+                <<FindTraceIdsCollector as Collector>::Child as SegmentCollector>::Fruit,
+            > = leaf_responses
+                .iter()
+                .filter_map(|leaf_response| {
+                    leaf_response.intermediate_aggregation_result.as_ref().map(
+                        |intermediate_aggregation_result| {
+                            serde_json::from_str(intermediate_aggregation_result)
+                        },
+                    )
+                })
+                .collect::<Result<_, _>>()?;
+            let merged_fruit = collector.merge_fruits(fruits)?;
+            Some(serde_json::to_string(&merged_fruit)?)
+        }
+        Some(QuickwitAggregations::TantivyAggregations(_)) => {
+            let fruits: Vec<IntermediateAggregationResults> = leaf_responses
+                .iter()
+                .filter_map(|leaf_response| {
+                    leaf_response.intermediate_aggregation_result.as_ref().map(
+                        |intermediate_aggregation_result| {
+                            serde_json::from_str(intermediate_aggregation_result)
+                        },
+                    )
+                })
+                .collect::<Result<_, _>>()?;
 
-    let intermediate_aggregation_result =
-        intermediate_aggregation_results
-            .into_iter()
-            .reduce(|mut res1, res2| {
-                res1.merge_fruits(res2);
-                res1
-            });
-
+            fruits
+                .into_iter()
+                .reduce(|mut left, right| {
+                    left.merge_fruits(right);
+                    left
+                })
+                .map(|merged_fruit| serde_json::to_string(&merged_fruit))
+                .transpose()?
+        }
+        None => None,
+    };
     let num_attempted_splits = leaf_responses
         .iter()
         .map(|leaf_response| leaf_response.num_attempted_splits)
@@ -433,10 +512,7 @@ fn merge_leaf_responses(
     // TODO optimize
     let top_k_partial_hits = top_k_partial_hits(all_partial_hits, max_hits);
     Ok(LeafSearchResponse {
-        intermediate_aggregation_result: intermediate_aggregation_result
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()?,
+        intermediate_aggregation_result: merged_intermediate_aggregation_result,
         num_hits,
         partial_hits: top_k_partial_hits,
         failed_splits,
@@ -465,12 +541,10 @@ pub(crate) fn make_collector_for_split(
     search_request: &SearchRequest,
     split_schema: &Schema,
 ) -> crate::Result<QuickwitCollector> {
-    let aggregation = if let Some(agg) = &search_request.aggregation_request {
-        Some(serde_json::from_str(agg)?)
-    } else {
-        None
+    let aggregation = match &search_request.aggregation_request {
+        Some(aggregation) => Some(serde_json::from_str(aggregation)?),
+        None => None,
     };
-
     let timestamp_field_opt = doc_mapper.timestamp_field(split_schema);
     let timestamp_filter_builder_opt = TimestampFilterBuilder::new(
         doc_mapper.timestamp_field_name(),

--- a/quickwit/quickwit-search/src/jaeger_collector.rs
+++ b/quickwit/quickwit-search/src/jaeger_collector.rs
@@ -1,0 +1,215 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use fnv::FnvHashMap;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use tantivy::collector::{Collector, SegmentCollector};
+use tantivy::fastfield::{Column, MultiValuedFastFieldReader};
+use tantivy::{DateTime, DocId, InvertedIndexReader, Score, SegmentReader};
+
+type TraceId = Vec<u8>;
+type TraceIdTermOrd = u64;
+type SpanTimestamp = i64;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TraceIdSpanTimestamp {
+    pub trace_id: TraceId,
+    pub span_timestamp: SpanTimestamp,
+}
+
+impl TraceIdSpanTimestamp {
+    fn new(trace_id: TraceId, span_timestamp: i64) -> Self {
+        Self {
+            trace_id,
+            span_timestamp,
+        }
+    }
+}
+
+/// Finds the most recent trace ids among a set of matching spans. Multiple spans that belong to the
+/// same trace can be found in the document set. As a result, this problem is akin to finding the
+/// top k elements with duplicates
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FindTraceIdsCollector {
+    num_traces: usize,
+    trace_id_field_name: String,
+    span_timestamp_field_name: String,
+}
+
+impl FindTraceIdsCollector {
+    pub fn fast_field_names(&self) -> HashSet<String> {
+        HashSet::from_iter([
+            self.trace_id_field_name.clone(),
+            self.span_timestamp_field_name.clone(),
+        ])
+    }
+
+    pub fn term_dict_field_names(&self) -> HashSet<String> {
+        HashSet::from_iter([self.trace_id_field_name.clone()])
+    }
+}
+
+impl Collector for FindTraceIdsCollector {
+    type Fruit = Vec<TraceIdSpanTimestamp>;
+    type Child = FindTraceIdsSegmentCollector;
+
+    fn for_segment(
+        &self,
+        _segment_local_id: u32,
+        segment_reader: &SegmentReader,
+    ) -> tantivy::Result<Self::Child> {
+        let trace_id_ff_reader = segment_reader
+            .fast_fields()
+            .u64s(&self.trace_id_field_name)?;
+        let span_timestamp_column = segment_reader
+            .fast_fields()
+            .date(&self.span_timestamp_field_name)?;
+
+        let trace_id_field = segment_reader
+            .schema()
+            .get_field(&self.trace_id_field_name)?;
+        let inverted_index_reader = segment_reader.inverted_index(trace_id_field)?;
+
+        Ok(Self::Child {
+            num_traces: self.num_traces,
+            trace_id_ff_reader,
+            span_timestamp_column,
+            inverted_index_reader,
+            buckets: FnvHashMap::default(),
+        })
+    }
+
+    fn merge_fruits(
+        &self,
+        segment_fruits: Vec<<Self::Child as SegmentCollector>::Fruit>,
+    ) -> tantivy::Result<Self::Fruit> {
+        let mut buckets = FnvHashMap::default();
+        for segment_fruit in segment_fruits {
+            for fruit in segment_fruit {
+                buckets
+                    .entry(fruit.trace_id)
+                    .and_modify(|entry| {
+                        if *entry < fruit.span_timestamp {
+                            *entry = fruit.span_timestamp
+                        }
+                    })
+                    .or_insert(fruit.span_timestamp);
+            }
+        }
+        let merged_fruits = buckets
+            .into_iter()
+            .sorted_by_key(|(_, span_timestamp)| *span_timestamp)
+            .rev()
+            .take(self.num_traces)
+            .map(|(trace_id, span_timestamp)| TraceIdSpanTimestamp::new(trace_id, span_timestamp))
+            .collect();
+        Ok(merged_fruits)
+    }
+
+    fn requires_scoring(&self) -> bool {
+        false
+    }
+}
+
+/// This a naive implementation of a top k algorithm with duplicates. A more robust implementation
+/// will follow.
+pub struct FindTraceIdsSegmentCollector {
+    num_traces: usize,
+    trace_id_ff_reader: MultiValuedFastFieldReader<u64>,
+    span_timestamp_column: Arc<dyn Column<DateTime>>,
+    inverted_index_reader: Arc<InvertedIndexReader>,
+    buckets: FnvHashMap<TraceIdTermOrd, SpanTimestamp>,
+}
+
+impl FindTraceIdsSegmentCollector {
+    fn trace_id_term_ord(&self, doc: DocId) -> TraceIdTermOrd {
+        self.trace_id_ff_reader
+            .get_first_val(doc)
+            .expect("There should be exactly one trace ID per span.")
+    }
+
+    fn trace_id(&self, trace_id_term_ord: TraceIdTermOrd) -> TraceId {
+        let mut trace_id = vec![0u8; 16];
+        self.inverted_index_reader
+            .terms()
+            .ord_to_term(trace_id_term_ord, &mut trace_id)
+            .unwrap();
+        trace_id
+    }
+
+    fn span_timestamp(&self, doc: DocId) -> SpanTimestamp {
+        self.span_timestamp_column
+            .get_val(doc)
+            .into_timestamp_micros()
+    }
+}
+
+impl SegmentCollector for FindTraceIdsSegmentCollector {
+    type Fruit = Vec<TraceIdSpanTimestamp>;
+
+    fn collect(&mut self, doc: DocId, _score: Score) {
+        let trace_id_term_ord = self.trace_id_term_ord(doc);
+        let span_timestamp = self.span_timestamp(doc);
+        self.buckets
+            .entry(trace_id_term_ord)
+            .and_modify(|entry| {
+                if *entry < span_timestamp {
+                    *entry = span_timestamp
+                }
+            })
+            .or_insert(span_timestamp);
+    }
+
+    fn harvest(self) -> Self::Fruit {
+        self.buckets
+            .iter()
+            .take(self.num_traces)
+            .map(|(trace_id_term_ord, span_timestamp)| {
+                TraceIdSpanTimestamp::new(self.trace_id(*trace_id_term_ord), *span_timestamp)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collector::QuickwitAggregations;
+
+    #[test]
+    fn test_find_trace_ids_collector_serde() {
+        let collector_json = serde_json::to_string(&FindTraceIdsCollector {
+            num_traces: 10,
+            trace_id_field_name: "trace_id".to_string(),
+            span_timestamp_field_name: "span_timestamp".to_string(),
+        })
+        .unwrap();
+        let aggregation: QuickwitAggregations = serde_json::from_str(&collector_json).unwrap();
+        let QuickwitAggregations::FindTraceIdsAggregation(collector) = aggregation else {
+            panic!("Expected FindTraceIdsAggregation");
+        };
+        assert_eq!(collector.num_traces, 10);
+        assert_eq!(collector.trace_id_field_name, "trace_id");
+        assert_eq!(collector.span_timestamp_field_name, "span_timestamp");
+    }
+}

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -28,6 +28,7 @@ mod collector;
 mod error;
 mod fetch_docs;
 mod filters;
+mod jaeger_collector;
 mod leaf;
 mod retry;
 mod root;
@@ -41,6 +42,7 @@ mod metrics;
 #[cfg(test)]
 mod tests;
 
+use collector::QuickwitAggregations;
 use metrics::SEARCH_METRICS;
 use quickwit_doc_mapper::DocMapper;
 use root::validate_request;
@@ -60,7 +62,6 @@ use quickwit_doc_mapper::tag_pruning::extract_tags_from_query;
 use quickwit_metastore::{ListSplitsQuery, Metastore, SplitMetadata, SplitState};
 use quickwit_proto::{Hit, PartialHit, SearchRequest, SearchResponse, SplitIdAndFooterOffsets};
 use quickwit_storage::StorageUriResolver;
-use tantivy::aggregation::agg_req::Aggregations;
 use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use tantivy::DocAddress;
@@ -228,11 +229,24 @@ pub async fn single_node_search(
     let aggregation = if let Some(intermediate_aggregation_result) =
         leaf_search_response.intermediate_aggregation_result
     {
-        let res: IntermediateAggregationResults =
-            serde_json::from_str(&intermediate_aggregation_result)?;
-        let req: Aggregations = serde_json::from_str(search_request.aggregation_request())?;
-        let res: AggregationResults = res.into_final_bucket_result(req, &schema)?;
-        Some(serde_json::to_string(&res)?)
+        let aggregations: QuickwitAggregations =
+            serde_json::from_str(search_request.aggregation_request.as_ref().expect(
+                "Aggregation should be present since we are processing an intermediate \
+                 aggregation result.",
+            ))?;
+        match aggregations {
+            QuickwitAggregations::FindTraceIdsAggregation(_) => {
+                // There is nothing to merge here because there is only one leaf response.
+                Some(intermediate_aggregation_result)
+            }
+            QuickwitAggregations::TantivyAggregations(aggregations) => {
+                let res: IntermediateAggregationResults =
+                    serde_json::from_str(&intermediate_aggregation_result)?;
+                let res: AggregationResults =
+                    res.into_final_bucket_result(aggregations, &schema)?;
+                Some(serde_json::to_string(&res)?)
+            }
+        }
     } else {
         None
     };

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -29,7 +29,6 @@ use quickwit_proto::{
     LeafSearchRequest, LeafSearchResponse, ListTermsRequest, ListTermsResponse, PartialHit,
     SearchRequest, SearchResponse, SplitIdAndFooterOffsets,
 };
-use tantivy::aggregation::agg_req::Aggregations;
 use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use tantivy::collector::Collector;
@@ -38,7 +37,7 @@ use tokio::task::spawn_blocking;
 use tracing::{debug, error, instrument};
 
 use crate::cluster_client::ClusterClient;
-use crate::collector::make_merge_collector;
+use crate::collector::{make_merge_collector, QuickwitAggregations};
 use crate::search_job_placer::Job;
 use crate::{
     extract_split_and_footer_offsets, list_relevant_splits, SearchError, SearchJobPlacer,
@@ -113,7 +112,7 @@ impl From<FetchDocsJob> for SplitIdAndFooterOffsets {
 
 pub(crate) fn validate_request(search_request: &SearchRequest) -> crate::Result<()> {
     if let Some(agg) = search_request.aggregation_request.as_ref() {
-        let _agg: Aggregations = serde_json::from_str(agg)
+        let _aggs: QuickwitAggregations = serde_json::from_str(agg)
             .map_err(|err| SearchError::InvalidAggregationRequest(err.to_string()))?;
     };
 
@@ -202,6 +201,7 @@ pub async fn root_search(
 
     // Creates a collector which merges responses into one
     let merge_collector = make_merge_collector(search_request)?;
+    let aggregations = merge_collector.aggregation.clone();
 
     // Merging is a cpu-bound task.
     // It should be executed by Tokio's blocking threads.
@@ -293,11 +293,22 @@ pub async fn root_search(
     let aggregation = if let Some(intermediate_aggregation_result) =
         leaf_search_response.intermediate_aggregation_result
     {
-        let res: IntermediateAggregationResults =
-            serde_json::from_str(&intermediate_aggregation_result)?;
-        let req: Aggregations = serde_json::from_str(search_request.aggregation_request())?;
-        let res: AggregationResults = res.into_final_bucket_result(req, &doc_mapper.schema())?;
-        Some(serde_json::to_string(&res)?)
+        match aggregations.expect(
+            "Aggregation should be present since we are processing an intermediate aggregation \
+             result.",
+        ) {
+            QuickwitAggregations::FindTraceIdsAggregation(_) => {
+                // The merge collector has already merged the intermediate results.
+                Some(intermediate_aggregation_result)
+            }
+            QuickwitAggregations::TantivyAggregations(aggregations) => {
+                let res: IntermediateAggregationResults =
+                    serde_json::from_str(&intermediate_aggregation_result)?;
+                let res: AggregationResults =
+                    res.into_final_bucket_result(aggregations, &doc_mapper.schema())?;
+                Some(serde_json::to_string(&res)?)
+            }
+        }
     } else {
         None
     };
@@ -1474,7 +1485,7 @@ mod tests {
         assert_eq!(
             search_response.unwrap_err().to_string(),
             "Invalid aggregation request: data did not match any variant of untagged enum \
-             Aggregation at line 18 column 13",
+             QuickwitAggregations",
         );
         Ok(())
     }

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -30,6 +30,7 @@ use tantivy::time::OffsetDateTime;
 use tantivy::Term;
 
 use super::*;
+use crate::jaeger_collector::TraceIdSpanTimestamp;
 use crate::single_node_search;
 
 #[tokio::test]
@@ -1412,6 +1413,72 @@ async fn test_single_node_list_terms() -> anyhow::Result<()> {
         .unwrap();
         let terms = collect_str_terms(search_response);
         assert_eq!(terms, &["beagle"]);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_single_node_find_trace_ids_collector() -> anyhow::Result<()> {
+    let index_id = "single-node-find-trace-ids-collector";
+    let doc_mapping_yaml = r#"
+            field_mappings:
+              - name: trace_id
+                type: text
+                tokenizer: raw
+                fast: true
+              - name: span_timestamp_secs
+                type: datetime
+                fast: true
+                precision: seconds
+        "#;
+    let docs = vec![
+        json!({"trace_id": "foo", "span_timestamp_secs": "2023-01-10T15:13:35Z"}),
+        json!({"trace_id": "foo", "span_timestamp_secs": "2023-01-10T15:13:36Z"}),
+        json!({"trace_id": "foo", "span_timestamp_secs": "2023-01-10T15:13:37Z"}),
+        json!({"trace_id": "foo", "span_timestamp_secs": "2023-01-10T15:13:38Z"}),
+        json!({"trace_id": "foo", "span_timestamp_secs": "2023-01-10T15:13:39Z"}),
+        json!({"trace_id": "foo", "span_timestamp_secs": "2023-01-10T15:13:40Z"}),
+        json!({"trace_id": "bar", "span_timestamp_secs": "2024-01-10T15:13:35Z"}),
+        json!({"trace_id": "bar", "span_timestamp_secs": "2024-01-10T15:13:40Z"}),
+        json!({"trace_id": "qux", "span_timestamp_secs": "2025-01-10T15:13:40Z"}),
+        json!({"trace_id": "qux", "span_timestamp_secs": "2025-01-10T15:13:35Z"}),
+    ];
+    let test_sandbox = TestSandbox::create(index_id, doc_mapping_yaml, "{}", &[]).await?;
+    test_sandbox.add_documents(docs).await?;
+    {
+        let aggregations = r#"{
+            "num_traces": 5,
+            "trace_id_field_name": "trace_id",
+            "span_timestamp_field_name": "span_timestamp_secs"
+        }"#
+        .to_string();
+
+        let search_request = SearchRequest {
+            index_id: index_id.to_string(),
+            query: "*".to_string(),
+            aggregation_request: Some(aggregations),
+            search_fields: Vec::new(),
+            start_timestamp: None,
+            end_timestamp: None,
+            max_hits: 0,
+            start_offset: 0,
+            ..Default::default()
+        };
+        let single_node_result = single_node_search(
+            &search_request,
+            &*test_sandbox.metastore(),
+            test_sandbox.storage_uri_resolver(),
+        )
+        .await?;
+        let aggregation = single_node_result.aggregation.unwrap();
+        let trace_ids: Vec<TraceIdSpanTimestamp> = serde_json::from_str(&aggregation).unwrap();
+        assert_eq!(trace_ids.len(), 3);
+        assert_eq!(trace_ids[0].trace_id, "foo".as_bytes().to_vec());
+        assert_eq!(trace_ids[0].span_timestamp, 1673363620000000);
+        assert_eq!(trace_ids[1].trace_id, "bar".as_bytes().to_vec());
+        assert_eq!(trace_ids[1].span_timestamp, 1704899620000000);
+        assert_eq!(trace_ids[2].trace_id, "qux".as_bytes().to_vec());
+        assert_eq!(trace_ids[2].span_timestamp, 1736522020000000);
     }
     Ok(())
 }


### PR DESCRIPTION
### Description
Switch to a custom collector for aggregating trace IDs. This PR focuses on the plumbing part. I will follow up shortly with a second PR that implements an efficient algorithm.

### How was this PR tested?
- Added unit tests
- Tested with Jaeger
- Ran `make test-all`
