### PR TITLE
Control plane now control the last applied plan after each heartbeat …

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_plan.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_plan.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 /// each indexer, identified by its node ID, should run.
 /// TODO(fmassot): a metastore version number will be attached to the plan
 /// to identify if the plan is up to date with the metastore.
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Default)]
 pub struct PhysicalIndexingPlan {
     indexing_tasks_per_node_id: HashMap<String, Vec<IndexingTask>>,
 }
@@ -46,6 +46,10 @@ impl PhysicalIndexingPlan {
         Self {
             indexing_tasks_per_node_id,
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.indexing_tasks_per_node_id.is_empty()
     }
 
     /// Returns the number of indexing tasks for the given node ID.


### PR DESCRIPTION
…if it is empty.

Tested locally. 

```
2023-02-12T23:36:19.731Z  WARN quickwit_control_plane::scheduler: No indexer available, set an empty physical indexing plan.
2023-02-12T23:36:19.732Z  INFO quickwit_serve::grpc: Starting gRPC server. enabled_grpc_services={"control_plane", "indexing", "jaeger", "metastore", "otlp-log", "otlp-trace", "search"} grpc_listen_addr=127.0.0.1:7281
2023-02-12T23:36:19.732Z  INFO quickwit_serve::rest: Starting REST server. rest_listen_addr=127.0.0.1:7280
2023-02-12T23:36:19.732Z  INFO quickwit_serve::rest: Searcher ready to accept requests at http://127.0.0.1:7280/
2023-02-12T23:36:19.733Z  INFO quickwit_janitor::actors::garbage_collector: Garbage collecting indexes. index_ids=otel-trace-v0
2023-02-12T23:36:19.734Z  INFO quickwit_janitor::actors::delete_task_pipeline: Spawning delete tasks pipeline. index_id=otel-trace-v0 root_dir=/Users/francois.massot@contentsquare-ext.com/Documents/quickwit/repos/quickwit/quickwit/qwdata/delete_task_service
2023-02-12T23:36:19.737Z  INFO quickwit_janitor::actors::delete_task_planner: index_id="otel-trace-v0" last_delete_opstamp=0 num_stale_splits=0
2023-02-12T23:36:22.733Z  INFO quickwit_control_plane::scheduler: The indexer `node-black-FTcd` is not part of the last applied plan.
2023-02-12T23:36:22.734Z  INFO quickwit_control_plane::scheduler: Running plan and last applied plan differs: schedule an indexing plan.
2023-02-12T23:36:22.746Z  INFO quickwit_indexing::actors::indexing_service: Spawning indexing pipeline. pipeline_id=IndexingPipelineId { index_id: "otel-trace-v0", source_id: "_ingest-api-source", node_id: "node-black-FTcd", pipeline_ord: 0 }
```