### PR TITLE
Set connection timeout to 5s on various clients

### DIFF
--- a/quickwit/quickwit-grpc-clients/src/balance_channel.rs
+++ b/quickwit/quickwit-grpc-clients/src/balance_channel.rs
@@ -74,6 +74,7 @@ pub async fn create_balance_channel_from_watched_members(
                 {
                     // If it fails, just log an error and stop the loop.
                     error!("Failed to update balance channel endpoints: {error:?}");
+                    break;
                 };
                 current_grpc_address_pool = new_grpc_address_pool;
                 // TODO: Expose number of metastore servers in the pool as a Prometheus metric.
@@ -138,7 +139,8 @@ async fn update_channel_endpoints(
                 .path_and_query("/")
                 .build()
                 .expect("Failed to build URI. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.");
-            let new_grpc_endpoint = Endpoint::from(new_grpc_uri);
+            let new_grpc_endpoint =
+                Endpoint::from(new_grpc_uri).connect_timeout(Duration::from_secs(5));
             channel_endpoint_tx
                 .send(Change::Insert(new_grpc_address, new_grpc_endpoint))
                 .await?;

--- a/quickwit/quickwit-indexing/src/indexing_client.rs
+++ b/quickwit/quickwit-indexing/src/indexing_client.rs
@@ -19,6 +19,7 @@
 
 use std::fmt;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use quickwit_actors::Mailbox;
@@ -118,7 +119,9 @@ pub async fn create_indexing_service_client(
         .authority(grpc_addr.to_string().as_str())
         .path_and_query("/")
         .build()?;
-    let channel = Endpoint::from(uri).connect_lazy();
+    let channel = Endpoint::from(uri)
+        .connect_timeout(Duration::from_secs(5))
+        .connect_lazy();
     let client = IndexingServiceClient::from_grpc_client(
         quickwit_proto::indexing_api::indexing_service_client::IndexingServiceClient::new(channel),
         grpc_addr,

--- a/quickwit/quickwit-search/src/client.rs
+++ b/quickwit/quickwit-search/src/client.rs
@@ -20,6 +20,7 @@
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::{StreamExt, TryStreamExt};
@@ -250,7 +251,9 @@ pub async fn create_search_service_client(
         .path_and_query("/")
         .build()?;
     // Create a channel with connect_lazy to automatically reconnect to the node.
-    let channel = Endpoint::from(uri).connect_lazy();
+    let channel = Endpoint::from(uri)
+        .connect_timeout(Duration::from_secs(5))
+        .connect_lazy();
     let client = quickwit_proto::search_service_client::SearchServiceClient::with_interceptor(
         channel,
         SpanContextInterceptor,


### PR DESCRIPTION
### Description
This is a temporary fix until we land #2706.

### How was this PR tested?
- Ran `make test-all`
- Launched Quickwit a few times and I no longer observe the noisy connection error on startup.