### PR TITLE
Fix attempt to `try_send` before `send`

### DIFF
--- a/quickwit/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit/quickwit-indexing/failpoints/mod.rs
@@ -40,7 +40,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use fail::FailScenario;
-use quickwit_actors::{ActorExitStatus, Universe};
+use quickwit_actors::ActorExitStatus;
 use quickwit_common::io::IoControls;
 use quickwit_common::rand::append_random_suffix;
 use quickwit_common::split_file;


### PR DESCRIPTION
### Description
The code path was different depending on whether a backpressure counter was set or not. However, I believe we always want to `try_send` before `send`:

Before:
```rust
if let Some(backpressure_micros_counter) = backpressure_micros_counter_opt {
    match self.inner.tx.try_send_low_priority(envelope) {
        Ok(()) => Ok(response_rx),
        Err(TrySendError::Full(msg)) => {
            let now = Instant::now();
            self.inner.tx.send_low_priority(msg).await?;
            let elapsed = now.elapsed();
            backpressure_micros_counter.inc_by(elapsed.as_micros() as u64);
            Ok(response_rx)
        }
        Err(TrySendError::Disconnected) => Err(SendError::Disconnected),
    }
} else {
    self.inner.tx.send_low_priority(envelope).await?;
    Ok(response_rx)
}
```

After:
```rust
match self.inner.tx.try_send_low_priority(envelope) {
    Ok(()) => Ok(response_rx),
    Err(TrySendError::Full(envelope)) => {
        if let Some(backpressure_micros_counter) = backpressure_micros_counter_opt {
            let now = Instant::now();
            self.inner.tx.send_low_priority(envelope).await?;
            let elapsed = now.elapsed();
            backpressure_micros_counter.inc_by(elapsed.as_micros() as u64);
        } else {
            self.inner.tx.send_low_priority(envelope).await?;
        }
        Ok(response_rx)
    }
    Err(TrySendError::Disconnected) => Err(SendError::Disconnected),
}
```

### How was this PR tested?
- Ran test suite
