### PR TITLE
Authorize field names that starts with underscore.

### DIFF
--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -713,10 +713,9 @@ mod tests {
         let deser_err = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper)
             .err()
             .unwrap();
-        assert_eq!(
-            deser_err.to_string(),
-            "Field name `_source` may not start by _ at line 9 column 13"
-        );
+        assert!(deser_err
+            .to_string()
+            .contains("The following fields are reserved for Quickwit internal usage"));
     }
 
     #[test]

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -54,6 +54,9 @@ pub const SOURCE_FIELD_NAME: &str = "_source";
 /// Field name reserved for storing the dynamically indexed fields.
 pub const DYNAMIC_FIELD_NAME: &str = "_dynamic";
 
+/// Quickwit reserved field names.
+const QW_RESERVED_FIELD_NAMES: &[&str] = &[SOURCE_FIELD_NAME, DYNAMIC_FIELD_NAME];
+
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(
     QuickwitJsonOptions,


### PR DESCRIPTION
Added tests to avoid clashes with field names used internally.

The main reason for this validation relaxation: `_my_field` seems quite common.