### PR TITLE
Universe shouldn't panic if thread is panicking

### DIFF
--- a/quickwit/quickwit-actors/src/universe.rs
+++ b/quickwit/quickwit-actors/src/universe.rs
@@ -139,7 +139,10 @@ impl Universe {
 
 impl Drop for Universe {
     fn drop(&mut self) {
-        if cfg!(any(test, feature = "testsuite")) && !self.spawn_ctx.registry.is_empty() && !thread::panicking() {
+        if cfg!(any(test, feature = "testsuite"))
+            && !self.spawn_ctx.registry.is_empty()
+            && !thread::panicking()
+        {
             panic!(
                 "There are still running actors at the end of the test. Did you call \
                  universe.assert_quit()?"

--- a/quickwit/quickwit-actors/src/universe.rs
+++ b/quickwit/quickwit-actors/src/universe.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::thread;
 use std::time::Duration;
 
 use crate::mailbox::create_mailbox;
@@ -138,7 +139,7 @@ impl Universe {
 
 impl Drop for Universe {
     fn drop(&mut self) {
-        if cfg!(any(test, feature = "testsuite")) && !self.spawn_ctx.registry.is_empty() {
+        if cfg!(any(test, feature = "testsuite")) && !self.spawn_ctx.registry.is_empty() && !thread::panicking() {
             panic!(
                 "There are still running actors at the end of the test. Did you call \
                  universe.assert_quit()?"

--- a/quickwit/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit/quickwit-indexing/failpoints/mod.rs
@@ -40,7 +40,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use fail::FailScenario;
-use quickwit_actors::{ActorExitStatus, Universe};
+use quickwit_actors::ActorExitStatus;
 use quickwit_common::io::IoControls;
 use quickwit_common::rand::append_random_suffix;
 use quickwit_common::split_file;


### PR DESCRIPTION
### Description

If test fails with panic and universe drop is called it kills the test runner instead of displaying the first panic.

### How was this PR tested?

By manually breaking a test.

Relates to #2766
