### PR TITLE
Add codegen for actor mailbox

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4496,6 +4496,7 @@ dependencies = [
  "dyn-clone",
  "mockall",
  "prost",
+ "quickwit-actors",
  "quickwit-codegen",
  "serde",
  "thiserror",

--- a/quickwit/quickwit-actors/src/actor.rs
+++ b/quickwit/quickwit-actors/src/actor.rs
@@ -195,7 +195,7 @@ pub trait Actor: Send + Sync + Sized + 'static {
 
 #[async_trait::async_trait]
 pub trait Handler<M>: Actor {
-    type Reply: 'static + Send;
+    type Reply: Send + 'static;
 
     /// Processes a message.
     ///

--- a/quickwit/quickwit-actors/src/actor_context.rs
+++ b/quickwit/quickwit-actors/src/actor_context.rs
@@ -273,14 +273,15 @@ impl<A: Actor> ActorContext<A> {
 
     /// Similar to `send_message`, except this method
     /// waits asynchronously for the actor reply.
-    pub async fn ask_for_res<DestActor: Actor, M, T, E: fmt::Debug>(
+    pub async fn ask_for_res<DestActor: Actor, M, T, E>(
         &self,
         mailbox: &Mailbox<DestActor>,
         msg: M,
     ) -> Result<T, AskError<E>>
     where
         DestActor: Handler<M, Reply = Result<T, E>>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + Sync + 'static,
+        E: fmt::Debug,
     {
         let _guard = self.protect_zone();
         debug!(from=%self.self_mailbox.actor_instance_id(), send=%mailbox.actor_instance_id(), msg=?msg, "ask");

--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -328,10 +328,11 @@ impl<A: Actor> Mailbox<A> {
     /// waits asynchronously for the actor reply.
     ///
     /// From an actor context, use the `ActorContext::ask` method instead.
-    pub async fn ask_for_res<M, T, E: fmt::Debug>(&self, message: M) -> Result<T, AskError<E>>
+    pub async fn ask_for_res<M, T, E>(&self, message: M) -> Result<T, AskError<E>>
     where
         A: Handler<M, Reply = Result<T, E>>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + Sync + 'static,
+        E: fmt::Debug,
     {
         self.send_message(message)
             .await

--- a/quickwit/quickwit-codegen-example/Cargo.toml
+++ b/quickwit/quickwit-codegen-example/Cargo.toml
@@ -20,8 +20,12 @@ tonic = { workspace = true }
 tower = { workspace = true }
 utoipa = { workspace = true }
 
+quickwit-actors = { workspace = true }
+
 [dev-dependencies]
-mockall = { workspace = true }
+mockall = { workspace = true}
+
+quickwit-actors = { workspace = true, features = ["testsuite"] }
 
 [build-dependencies]
 quickwit-codegen = { workspace = true }

--- a/quickwit/quickwit-codegen-example/src/error.rs
+++ b/quickwit/quickwit-codegen-example/src/error.rs
@@ -17,6 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt;
+
+use quickwit_actors::AskError;
+
 // Service errors have to be handwritten before codegen.
 #[derive(Debug, thiserror::Error)]
 pub enum HelloError {
@@ -28,10 +32,18 @@ pub enum HelloError {
 
 // Service errors must implement `From<tonic::Status>` and `Into<tonic::Status>`.
 impl From<HelloError> for tonic::Status {
-    fn from(val: HelloError) -> Self {
-        match val {
+    fn from(error: HelloError) -> Self {
+        match error {
             HelloError::InternalError(message) => tonic::Status::internal(message),
             HelloError::TransportError(status) => status,
         }
+    }
+}
+
+impl<E> From<AskError<E>> for HelloError
+where E: fmt::Debug
+{
+    fn from(error: AskError<E>) -> Self {
+        HelloError::InternalError(format!("{:?}", error))
     }
 }


### PR DESCRIPTION
### Description
Generate the boiler code necessary to use an actor's mailbox as a Tower service. That means that we can implement an endpoint as `fn hello<T>(message: HelloRequest) where T: tower::Service<HelloRequest>` and provide whichever Tower service implementation.

Under the hood, the call can be routed to a local implementation (actor or not) or a remote implementation via gRPC.

### How was this PR tested?
- Updated unit test