### PR TITLE
Improve scheduling triggers. Fix #2659.

### DIFF
--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -626,7 +626,7 @@ mod tests {
             .unwrap(),
         );
         let mut random_generator = rand::thread_rng();
-        let indexing_tasks = (0..10_000)
+        let indexing_tasks = (0..1_000)
             .map(|_| {
                 let index_id = random_generator.gen_range(0..=10_000);
                 let source_id = random_generator.gen_range(0..=100);
@@ -705,12 +705,14 @@ mod tests {
         cluster: Arc<Cluster>,
         gossip_public_address: SocketAddr,
         indexing_tasks: Vec<IndexingTask>,
-    ) -> anyhow::Result<bool> {
+    ) -> bool {
         let members = cluster.ready_members_from_chitchat_state().await;
-        let node = members
+        let node_opt = members
             .iter()
-            .find(|member| member.gossip_advertise_addr == gossip_public_address)
-            .ok_or_else(|| anyhow!("no cluster member"))?;
+            .find(|member| member.gossip_advertise_addr == gossip_public_address);
+        let Some(node) = node_opt else {
+            return false;
+        };
         let node_grouped_tasks: HashMap<IndexingTask, usize> = node
             .indexing_tasks
             .iter()
@@ -724,7 +726,7 @@ mod tests {
             .into_iter()
             .map(|(key, group)| (key, group.count()))
             .collect();
-        Ok(node_grouped_tasks == grouped_tasks)
+        node_grouped_tasks == grouped_tasks
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -448,7 +448,7 @@ pub async fn create_cluster_for_test_with_id(
 /// Creates a failure detector config for tests.
 fn create_failure_detector_config_for_test() -> FailureDetectorConfig {
     FailureDetectorConfig {
-        phi_threshold: 6.0,
+        phi_threshold: 3.0,
         initial_interval: GOSSIP_INTERVAL,
         ..Default::default()
     }

--- a/quickwit/quickwit-common/src/test_utils.rs
+++ b/quickwit/quickwit-common/src/test_utils.rs
@@ -31,11 +31,11 @@ pub async fn wait_until_predicate<Fut>(
     retry_interval: Duration,
 ) -> Result<(), Elapsed>
 where
-    Fut: Future<Output = Result<bool, anyhow::Error>>,
+    Fut: Future<Output = bool>,
 {
     tokio::time::timeout(timeout, async move {
         loop {
-            if predicate().await.is_ok() {
+            if predicate().await {
                 break;
             }
             tokio::time::sleep(retry_interval).await

--- a/quickwit/quickwit-control-plane/Cargo.toml
+++ b/quickwit/quickwit-control-plane/Cargo.toml
@@ -43,6 +43,7 @@ proptest = { workspace = true }
 rand = { workspace = true }
 
 quickwit-actors = { workspace = true, features = ["testsuite"] }
+quickwit-common = { workspace = true, features = ["testsuite"] }
 quickwit-config = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-storage = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-control-plane/src/grpc_adapter.rs
+++ b/quickwit/quickwit-control-plane/src/grpc_adapter.rs
@@ -1,0 +1,140 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use async_trait::async_trait;
+use quickwit_actors::Mailbox;
+use quickwit_proto::control_plane_api::control_plane_service_server::{self as grpc};
+use quickwit_proto::control_plane_api::{NotifyIndexChangeRequest, NotifyIndexChangeResponse};
+use quickwit_proto::tonic;
+
+use crate::scheduler::IndexingScheduler;
+
+#[allow(missing_docs)]
+#[derive(Clone)]
+pub struct GrpcControlPlaneAdapter(Mailbox<IndexingScheduler>);
+
+impl From<Mailbox<IndexingScheduler>> for GrpcControlPlaneAdapter {
+    fn from(indexing_scheduler: Mailbox<IndexingScheduler>) -> Self {
+        Self(indexing_scheduler)
+    }
+}
+
+#[async_trait]
+impl grpc::ControlPlaneService for GrpcControlPlaneAdapter {
+    async fn notify_index_change(
+        &self,
+        request: tonic::Request<NotifyIndexChangeRequest>,
+    ) -> Result<tonic::Response<NotifyIndexChangeResponse>, tonic::Status> {
+        let index_event_request = request.into_inner();
+        let create_index_reply = self
+            .0
+            .ask(index_event_request)
+            .await
+            .map(|_| NotifyIndexChangeResponse {})
+            .map_err(|send_error| {
+                quickwit_proto::tonic::Status::new(tonic::Code::Internal, send_error.to_string())
+            })?;
+        Ok(tonic::Response::new(create_index_reply))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    use chitchat::transport::ChannelTransport;
+    use quickwit_actors::{Mailbox, Universe};
+    use quickwit_cluster::{create_cluster_for_test, ClusterMember};
+    use quickwit_config::service::QuickwitService;
+    use quickwit_grpc_clients::service_client_pool::ServiceClientPool;
+    use quickwit_grpc_clients::ControlPlaneGrpcClient;
+    use quickwit_metastore::MockMetastore;
+    use quickwit_proto::control_plane_api::control_plane_service_server::ControlPlaneServiceServer;
+    use quickwit_proto::tonic::transport::Server;
+    use tokio::sync::watch;
+    use tokio_stream::wrappers::WatchStream;
+
+    use super::GrpcControlPlaneAdapter;
+    use crate::scheduler::IndexingScheduler;
+
+    async fn start_grpc_server(
+        address: SocketAddr,
+        indexing_scheduler: Mailbox<IndexingScheduler>,
+    ) -> anyhow::Result<()> {
+        let grpc_adapter = GrpcControlPlaneAdapter::from(indexing_scheduler);
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(ControlPlaneServiceServer::new(grpc_adapter))
+                .serve(address)
+                .await?;
+            Result::<_, anyhow::Error>::Ok(())
+        });
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_control_plane_grpc_client() -> anyhow::Result<()> {
+        quickwit_common::setup_logging_for_tests();
+        let universe = Universe::with_accelerated_time();
+        let mut metastore = MockMetastore::default();
+        metastore
+            .expect_list_indexes_metadatas()
+            .returning(move || Ok(Vec::new()));
+        let transport = ChannelTransport::default();
+        let cluster = Arc::new(
+            create_cluster_for_test(Vec::new(), &["control_plane", "indexer"], &transport, true)
+                .await
+                .unwrap(),
+        );
+        let scheduler = IndexingScheduler::new(
+            cluster,
+            Arc::new(metastore),
+            ServiceClientPool::new(HashMap::new()),
+        );
+        let (_, scheduler_handler) = universe.spawn_builder().spawn(scheduler);
+        let control_plane_grpc_addr_port = quickwit_common::net::find_available_tcp_port().unwrap();
+        let control_plane_grpc_addr: SocketAddr =
+            ([127, 0, 0, 1], control_plane_grpc_addr_port).into();
+        start_grpc_server(control_plane_grpc_addr, scheduler_handler.mailbox().clone()).await?;
+        let control_plane_service_member = ClusterMember::new(
+            "1".to_string(),
+            0,
+            HashSet::from([QuickwitService::ControlPlane]),
+            control_plane_grpc_addr,
+            control_plane_grpc_addr,
+            Vec::new(),
+        );
+        let (_members_tx, members_rx) =
+            watch::channel::<Vec<ClusterMember>>(vec![control_plane_service_member.clone()]);
+        let watch_members = WatchStream::new(members_rx);
+        let mut control_plane_client =
+            ControlPlaneGrpcClient::create_and_update_from_members(watch_members)
+                .await
+                .unwrap();
+        let result = control_plane_client.notify_index_change().await;
+        assert!(result.is_ok());
+        let scheduler_state = scheduler_handler.process_pending_and_observe().await;
+        assert_eq!(scheduler_state.num_applied_physical_indexing_plan, 1);
+        universe.assert_quit().await;
+
+        Ok(())
+    }
+}

--- a/quickwit/quickwit-control-plane/src/scheduler.rs
+++ b/quickwit/quickwit-control-plane/src/scheduler.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
@@ -45,10 +46,9 @@ use crate::{NotifyIndexChangeRequest, NotifyIndexChangeResponse};
 const REFRESH_PLAN_LOOP_INTERVAL: Duration = if cfg!(any(test, feature = "testsuite")) {
     Duration::from_secs(3)
 } else {
-    Duration::from_secs(60)
+    Duration::from_secs(60 * 5)
 };
 
-// TODO: replace the value 0 by 1 once time warping is correctly handle by the actor framework.
 const MIN_DURATION_BETWEEN_SCHEDULING_SECS: u64 = if cfg!(any(test, feature = "testsuite")) {
     0
 } else {
@@ -58,6 +58,7 @@ const MIN_DURATION_BETWEEN_SCHEDULING_SECS: u64 = if cfg!(any(test, feature = "t
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct IndexingSchedulerState {
     pub num_applied_physical_indexing_plan: usize,
+    pub num_schedule_indexing_plan: usize,
     pub last_applied_physical_plan: Option<PhysicalIndexingPlan>,
     pub last_applied_plan_timestamp: Option<i64>,
 }
@@ -89,7 +90,9 @@ pub struct IndexingSchedulerState {
 /// - [`ControlPlanLoop`]: this event is scheduled every [`HEARTBEAT`] and control if the `desired
 ///   plan`, that is the last applied [`PhysicalIndexingPlan`] by the scheduler, and the `running
 ///   plan`, that is the indexing tasks running on all indexers and retrieved from the chitchat
-///   state, are the same. If not, the scheduler will trigger a scheduling.
+///   state, are the same:
+///   - if node IDs are different, the scheduler will trigger a scheduling.
+///   - if indexing tasks are different, the scheduler will apply again the last applied plan.
 ///
 /// Finally, in order to give the time for each indexer to run their indexing tasks, the control
 /// phase will wait at least [`MIN_DURATION_BETWEEN_SCHEDULING_SECS`] before comparing the desired
@@ -147,13 +150,10 @@ impl IndexingScheduler {
         }
     }
 
-    async fn schedule_indexing_plan(&mut self) -> anyhow::Result<()> {
+    async fn schedule_indexing_plan_if_needed(&mut self) -> anyhow::Result<()> {
         let indexers: Vec<ClusterMember> = self.get_indexers_from_cluster_state().await;
         if indexers.is_empty() {
-            warn!("No indexer available, set an empty physical indexing plan.");
-            self.state.last_applied_physical_plan = Some(PhysicalIndexingPlan::default());
-            self.state.last_applied_plan_timestamp =
-                Some(OffsetDateTime::now_utc().unix_timestamp());
+            warn!("No indexer available, cannot schedule an indexing plan.");
             return Ok(());
         };
         let source_configs: HashMap<IndexSourceId, SourceConfig> =
@@ -161,8 +161,19 @@ impl IndexingScheduler {
         let indexing_tasks = build_indexing_plan(&indexers, &source_configs);
         let new_physical_plan =
             build_physical_indexing_plan(&indexers, &source_configs, indexing_tasks);
+        if let Some(last_applied_plan) = self.state.last_applied_physical_plan.as_ref() {
+            let plans_diff = get_indexing_plans_diff(
+                last_applied_plan.indexing_tasks_per_node(),
+                new_physical_plan.indexing_tasks_per_node(),
+            );
+            if plans_diff.is_empty() {
+                info!("plan diff emtpy, do nothing");
+                return Ok(());
+            }
+        }
         self.apply_physical_indexing_plan(&indexers, new_physical_plan)
             .await;
+        self.state.num_schedule_indexing_plan += 1;
         Ok(())
     }
 
@@ -190,44 +201,47 @@ impl IndexingScheduler {
 
     /// Checks if the last applied plan corresponds to the running indexing tasks present in the
     /// chitchat cluster state. If true, do nothing.
-    /// If false, schedule a new indexing plan.
+    /// If node IDs differ, schedule a new indexing plan.
+    /// If indexing tasks differ, apply again the last plan.
     async fn control_running_plan(&mut self) -> anyhow::Result<()> {
         let last_applied_plan =
             if let Some(last_applied_plan) = self.state.last_applied_physical_plan.as_ref() {
                 last_applied_plan
             } else {
+                // If there is no plan, the node is probably starting and the scheduler did not find
+                // indexers yet. In this case, we want to schedule as soon as possible to find new
+                // indexers.
+                self.schedule_indexing_plan_if_needed().await?;
                 return Ok(());
             };
 
-        // TODO(fmassot): once the actor framekwork can correctly simulate time advance, change
-        // `MIN_DURATION_BETWEEN_SCHEDULING_SECS` value for test and correctly test it. Currently, I
-        // put its value 0 to make test simple.
         if let Some(last_applied_plan_timestamp) = self.state.last_applied_plan_timestamp.as_ref() {
-            // If the last applied plan is empty, the node is probably starting and did not find
-            // indexers yet. In this case, we dont want to wait
-            // `MIN_DURATION_BETWEEN_SCHEDULING_SECS` for checking if new indexers are
-            // there.
-            if !last_applied_plan.is_empty()
-                && (OffsetDateTime::now_utc().unix_timestamp() - last_applied_plan_timestamp)
-                    < MIN_DURATION_BETWEEN_SCHEDULING_SECS as i64
+            if (OffsetDateTime::now_utc().unix_timestamp() - last_applied_plan_timestamp)
+                < MIN_DURATION_BETWEEN_SCHEDULING_SECS as i64
             {
                 return Ok(());
             }
         }
+
         let indexers = self.get_indexers_from_cluster_state().await;
         let running_indexing_tasks_by_node_id: HashMap<String, Vec<IndexingTask>> = indexers
+            .clone()
             .into_iter()
             .map(|cluster_member| (cluster_member.node_id, cluster_member.indexing_tasks))
             .collect();
-        // TODO(fmassot): in the case where we have the same set of nodes in the two plans, a
-        // rescheduling is not needed, we probably should just reapply the same plan on the
-        // indexers.
-        if !are_indexing_plans_equal(
+
+        let indexing_plans_diff = get_indexing_plans_diff(
             &running_indexing_tasks_by_node_id,
             last_applied_plan.indexing_tasks_per_node(),
-        ) {
-            info!("Running plan and last applied plan differs: schedule an indexing plan.");
-            self.schedule_indexing_plan().await?;
+        );
+        if !indexing_plans_diff.has_same_nodes() {
+            info!(plans_diff=?indexing_plans_diff, "Running plan and last applied plan node IDs differ: schedule an indexing plan.");
+            self.schedule_indexing_plan_if_needed().await?;
+        } else if !indexing_plans_diff.has_same_tasks() {
+            // Some nodes may have not received their tasks, apply it again.
+            info!(plans_diff=?indexing_plans_diff, "Running tasks and last applied tasks differ: reapply last plan.");
+            self.apply_physical_indexing_plan(&indexers, last_applied_plan.clone())
+                .await;
         }
         Ok(())
     }
@@ -271,6 +285,10 @@ impl IndexingScheduler {
             }
         }
         self.state.num_applied_physical_indexing_plan += 1;
+        info!(
+            "num applied plan {}",
+            self.state.num_applied_physical_indexing_plan
+        );
         self.state.last_applied_plan_timestamp = Some(OffsetDateTime::now_utc().unix_timestamp());
         self.state.last_applied_physical_plan = Some(new_physical_plan);
     }
@@ -285,8 +303,8 @@ impl Handler<NotifyIndexChangeRequest> for IndexingScheduler {
         _: NotifyIndexChangeRequest,
         _: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        info!("Index change notification: schedule indexing plan.");
-        self.schedule_indexing_plan()
+        info!("Index change notification: shedule indexing plan.");
+        self.schedule_indexing_plan_if_needed()
             .await
             .context("Error when scheduling indexing plan")?;
         Ok(Ok(NotifyIndexChangeResponse {}))
@@ -325,7 +343,7 @@ impl Handler<RefreshPlanLoop> for IndexingScheduler {
         _message: RefreshPlanLoop,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        if let Err(error) = self.schedule_indexing_plan().await {
+        if let Err(error) = self.schedule_indexing_plan_if_needed().await {
             error!("Error when scheduling indexing plan: `{}`.", error);
         }
         ctx.schedule_self_msg(REFRESH_PLAN_LOOP_INTERVAL, RefreshPlanLoop)
@@ -334,17 +352,72 @@ impl Handler<RefreshPlanLoop> for IndexingScheduler {
     }
 }
 
-/// Compares the `running_plan` retrieved from the chitchat state and
-/// the last plan applied by the scheduler and returns
-/// - true if plans are equal. Plans are considered equal if they have the same node IDs and if each
-///   node has the same running tasks.
-/// - false if not and logs the difference between plans.
-fn are_indexing_plans_equal(
-    running_plan: &HashMap<String, Vec<IndexingTask>>,
-    last_applied_plan: &HashMap<String, Vec<IndexingTask>>,
-) -> bool {
-    let mut plans_are_equal = true;
-    // Compare node IDs with at least one task.
+struct IndexingPlanDiff<'a> {
+    pub missing_node_ids: HashSet<&'a str>,
+    pub unplanned_node_ids: HashSet<&'a str>,
+    pub missing_tasks_by_node_id: HashMap<&'a str, Vec<&'a IndexingTask>>,
+    pub unplanned_tasks_by_node_id: HashMap<&'a str, Vec<&'a IndexingTask>>,
+}
+
+impl<'a> IndexingPlanDiff<'a> {
+    pub fn has_same_nodes(&self) -> bool {
+        self.missing_node_ids.is_empty() && self.unplanned_node_ids.is_empty()
+    }
+
+    pub fn has_same_tasks(&self) -> bool {
+        self.missing_tasks_by_node_id.is_empty() && self.unplanned_tasks_by_node_id.is_empty()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.has_same_nodes() && self.has_same_tasks()
+    }
+}
+
+impl<'a> fmt::Debug for IndexingPlanDiff<'a> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.has_same_nodes() && self.has_same_tasks() {
+            return write!(formatter, "EmptyIndexingPlanDiff");
+        }
+        write!(formatter, "IndexingPlanDiff(")?;
+        let mut separator = "";
+        if !self.missing_node_ids.is_empty() {
+            write!(formatter, "missing_node_ids={:?}, ", self.missing_node_ids)?;
+            separator = ", "
+        }
+        if !self.unplanned_node_ids.is_empty() {
+            write!(
+                formatter,
+                "{separator}unplanned_node_ids={:?}",
+                self.unplanned_node_ids
+            )?;
+            separator = ", "
+        }
+        if !self.missing_tasks_by_node_id.is_empty() {
+            write!(
+                formatter,
+                "{separator}missing_tasks_by_node_id={:?}, ",
+                self.missing_tasks_by_node_id
+            )?;
+            separator = ", "
+        }
+        if !self.unplanned_tasks_by_node_id.is_empty() {
+            write!(
+                formatter,
+                "{separator}unplanned_tasks_by_node_id={:?}",
+                self.unplanned_tasks_by_node_id
+            )?;
+        }
+        write!(formatter, ")")
+    }
+}
+
+/// Returns the difference between the `running_plan` retrieved from the chitchat state and
+/// the last plan applied by the scheduler.
+fn get_indexing_plans_diff<'a>(
+    running_plan: &'a HashMap<String, Vec<IndexingTask>>,
+    last_applied_plan: &'a HashMap<String, Vec<IndexingTask>>,
+) -> IndexingPlanDiff<'a> {
+    // Nodes diff.
     let running_node_ids: HashSet<&str> = running_plan
         .iter()
         .map(|(node_id, _)| node_id.as_str())
@@ -354,88 +427,116 @@ fn are_indexing_plans_equal(
         .map(|(node_id, _)| node_id.as_str())
         .collect();
     let common_node_ids = running_node_ids.intersection(&planned_node_ids);
-    let missing_planned_node_ids = planned_node_ids.difference(&running_node_ids).collect_vec();
-    let unplanned_node_ids = running_node_ids.difference(&planned_node_ids);
-
-    for unplanned_node_id in unplanned_node_ids {
-        plans_are_equal = false;
-        let running_tasks = running_plan
-            .get(*unplanned_node_id)
-            .map(Vec::as_slice)
-            .unwrap_or_default();
-        if running_tasks.is_empty() {
-            // An new indexer may have joined the cluster.
-            info!("The indexer `{unplanned_node_id}` is not part of the last applied plan.")
-        } else {
-            info!(
-                "The indexer `{unplanned_node_id}`, which is not part of the last applied plan, \
-                 has some running tasks: {running_tasks:?}."
-            );
-        }
-    }
-
-    for missing_planned_node_id in missing_planned_node_ids {
-        // An indexer may have left the cluster.
-        plans_are_equal = false;
-        let planned_tasks = last_applied_plan
-            .get(*missing_planned_node_id)
-            .map(Vec::as_slice)
-            .unwrap_or_default();
-        info!(
-            "The indexer `{missing_planned_node_id}` is not part of the the running plan, none of \
-             his tasks are running: {planned_tasks:?}."
-        );
-    }
-
-    // Compare indexing tasks for each common node ID.
+    let missing_node_ids: HashSet<&str> = planned_node_ids
+        .difference(&running_node_ids)
+        .copied()
+        .collect();
+    let unplanned_node_ids: HashSet<&str> = running_node_ids
+        .difference(&planned_node_ids)
+        .copied()
+        .collect();
+    // Tasks diff.
+    // Note(fmassot): the diff code is too complex...
+    let mut missing_tasks_by_node_id: HashMap<&str, Vec<&IndexingTask>> = HashMap::new();
+    let mut unplanned_tasks_by_node_id: HashMap<&str, Vec<&IndexingTask>> = HashMap::new();
     for common_node_id in common_node_ids {
-        let running_tasks: HashSet<_> = running_plan
+        let grouped_running_tasks: HashMap<&IndexingTask, usize> = running_plan
             .get(*common_node_id)
-            .map(|tasks| HashSet::from_iter(tasks.iter()))
+            .map(|tasks| {
+                tasks
+                    .iter()
+                    .group_by(|&task| task)
+                    .into_iter()
+                    .map(|(key, group)| (key, group.count()))
+                    .collect::<HashMap<_, _>>()
+            })
             .unwrap_or_default();
-        let desired_tasks: HashSet<_> = last_applied_plan
+        let grouped_desired_tasks: HashMap<&IndexingTask, usize> = last_applied_plan
             .get(*common_node_id)
-            .map(|tasks| HashSet::from_iter(tasks.iter()))
+            .map(|tasks| {
+                tasks
+                    .iter()
+                    .group_by(|&task| task)
+                    .into_iter()
+                    .map(|(key, group)| (key, group.count()))
+                    .collect::<HashMap<_, _>>()
+            })
             .unwrap_or_default();
-        let missing_desired_tasks = desired_tasks.difference(&running_tasks).collect_vec();
-        let non_desired_tasks = running_tasks.difference(&desired_tasks).collect_vec();
-
-        if !missing_desired_tasks.is_empty() {
-            plans_are_equal = false;
-            info!(
-                "Indexer `{common_node_id}` does not run the desired indexing tasks: \
-                 `{missing_desired_tasks:?}`"
-            );
-        }
-        if !non_desired_tasks.is_empty() {
-            plans_are_equal = false;
-            info!(
-                "Indexer `{common_node_id}` is running non desired indexing tasks: \
-                 `{non_desired_tasks:?}`"
-            );
+        let all_tasks: HashSet<&IndexingTask> = grouped_running_tasks
+            .keys()
+            .copied()
+            .chain(grouped_desired_tasks.keys().copied())
+            .collect();
+        for task in all_tasks {
+            let running_task_count = grouped_running_tasks.get(task).unwrap_or(&0);
+            let desired_task_count = grouped_desired_tasks.get(task).unwrap_or(&0);
+            match running_task_count.cmp(desired_task_count) {
+                Ordering::Greater => {
+                    let unplanned_tasks = unplanned_tasks_by_node_id
+                        .entry(common_node_id)
+                        .or_default();
+                    (0..running_task_count - desired_task_count).for_each(|_| {
+                        unplanned_tasks.push(task);
+                    });
+                }
+                Ordering::Less => {
+                    let missing_tasks = missing_tasks_by_node_id.entry(common_node_id).or_default();
+                    (0..desired_task_count - running_task_count).for_each(|_| {
+                        missing_tasks.push(task);
+                    });
+                }
+                _ => {}
+            }
         }
     }
-
-    plans_are_equal
+    for missing_node_id in missing_node_ids.iter() {
+        if let Some(missing_tasks) = last_applied_plan.get(*missing_node_id) {
+            if !missing_tasks.is_empty() {
+                missing_tasks_by_node_id
+                    .insert(missing_node_id, missing_tasks.iter().collect_vec());
+            }
+        }
+    }
+    for unplanned_node_id in unplanned_node_ids.iter() {
+        if let Some(unplanned_tasks) = running_plan.get(*unplanned_node_id) {
+            if !unplanned_tasks.is_empty() {
+                unplanned_tasks_by_node_id
+                    .insert(unplanned_node_id, unplanned_tasks.iter().collect_vec());
+            }
+        }
+    }
+    IndexingPlanDiff {
+        missing_node_ids,
+        unplanned_node_ids,
+        missing_tasks_by_node_id,
+        unplanned_tasks_by_node_id,
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::num::NonZeroUsize;
+    use std::collections::{HashMap, HashSet};
+    use std::future::Future;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use chitchat::transport::ChannelTransport;
-    use quickwit_actors::Universe;
-    use quickwit_cluster::{create_cluster_for_test, grpc_addr_from_listen_addr_for_test};
+    use quickwit_actors::{ActorHandle, Inbox, Universe, HEARTBEAT};
+    use quickwit_cluster::{
+        create_cluster_for_test, grpc_addr_from_listen_addr_for_test, Cluster,
+    };
     use quickwit_config::{KafkaSourceParams, SourceConfig, SourceParams};
     use quickwit_grpc_clients::service_client_pool::ServiceClientPool;
     use quickwit_indexing::indexing_client::IndexingServiceClient;
+    use quickwit_indexing::IndexingService;
     use quickwit_metastore::{IndexMetadata, MockMetastore};
     use quickwit_proto::indexing_api::{ApplyIndexingPlanRequest, IndexingTask};
     use serde_json::json;
+    use tokio::time::error::Elapsed;
 
-    use super::{are_indexing_plans_equal, IndexingScheduler};
+    use super::IndexingScheduler;
+    use crate::scheduler::{get_indexing_plans_diff, REFRESH_PLAN_LOOP_INTERVAL};
 
     fn index_metadata_for_test(
         index_id: &str,
@@ -466,9 +567,11 @@ mod tests {
         index_metadata
     }
 
-    #[tokio::test]
-    async fn test_scheduler_scheduling_and_control_loop() {
-        quickwit_common::setup_logging_for_tests();
+    async fn start_scheduler(
+        cluster: Arc<Cluster>,
+        indexers: &[&Cluster],
+        universe: &Universe,
+    ) -> (Vec<Inbox<IndexingService>>, ActorHandle<IndexingScheduler>) {
         let index_1 = "test-indexing-plan-1";
         let source_1 = "source-1";
         let index_2 = "test-indexing-plan-2";
@@ -480,6 +583,26 @@ mod tests {
         metastore
             .expect_list_indexes_metadatas()
             .returning(move || Ok(vec![index_metadata_2.clone(), index_metadata_1.clone()]));
+        let mut indexer_inboxes = Vec::new();
+        let mut indexing_clients = Vec::new();
+        for indexer in indexers {
+            let (indexing_service_mailbox, indexing_service_inbox) = universe.create_test_mailbox();
+            let client_grpc_addr = grpc_addr_from_listen_addr_for_test(indexer.gossip_listen_addr);
+            let indexing_client =
+                IndexingServiceClient::from_service(indexing_service_mailbox, client_grpc_addr);
+            indexing_clients.push(indexing_client);
+            indexer_inboxes.push(indexing_service_inbox);
+        }
+        let indexing_client_pool = ServiceClientPool::for_clients_list(indexing_clients);
+        let indexing_scheduler =
+            IndexingScheduler::new(cluster, Arc::new(metastore), indexing_client_pool);
+        let (_, scheduler_handler) = universe.spawn_builder().spawn(indexing_scheduler);
+        (indexer_inboxes, scheduler_handler)
+    }
+
+    #[tokio::test]
+    async fn test_scheduler_scheduling_and_control_loop_apply_plan_again() {
+        quickwit_common::setup_logging_for_tests();
         let transport = ChannelTransport::default();
         let cluster = Arc::new(
             create_cluster_for_test(Vec::new(), &["indexer", "control_plane"], &transport, true)
@@ -487,29 +610,26 @@ mod tests {
                 .unwrap(),
         );
         let universe = Universe::with_accelerated_time();
-        let (indexing_service_mailbox, indexing_service_inbox) = universe.create_test_mailbox();
-        let client_grpc_addr = grpc_addr_from_listen_addr_for_test(cluster.gossip_listen_addr);
-        let indexing_client =
-            IndexingServiceClient::from_service(indexing_service_mailbox, client_grpc_addr);
-        let indexing_client_pool = ServiceClientPool::for_clients_list(vec![indexing_client]);
-        let indexing_scheduler =
-            IndexingScheduler::new(cluster.clone(), Arc::new(metastore), indexing_client_pool);
-        let (_, scheduler_handler) = universe.spawn_builder().spawn(indexing_scheduler);
-
+        let (indexing_service_inboxes, scheduler_handler) =
+            start_scheduler(cluster.clone(), &[&cluster.clone()], &universe).await;
+        let indexing_service_inbox = indexing_service_inboxes[0].clone();
         let scheduler_state = scheduler_handler.process_pending_and_observe().await;
         let indexing_service_inbox_messages =
             indexing_service_inbox.drain_for_test_typed::<ApplyIndexingPlanRequest>();
         assert_eq!(scheduler_state.num_applied_physical_indexing_plan, 1);
+        assert_eq!(scheduler_state.num_schedule_indexing_plan, 1);
         assert!(scheduler_state.last_applied_physical_plan.is_some());
         assert_eq!(indexing_service_inbox_messages.len(), 1);
 
         // After a HEARTBEAT, the control loop will check if the desired plan is running on the
-        // indexer. As the chitchat state of the indexer is not updated (we did not instantiate a
-        // indexing service for that), the control loop will trigger a new scheduling.
-        scheduler_handler.process_pending_and_observe().await;
+        // indexer. As chitchat state of the indexer is not updated (we did not
+        // instantiate a indexing service for that), the control loop will apply again the
+        // same plan.
+        universe.sleep(HEARTBEAT).await;
         let scheduler_state = scheduler_handler.process_pending_and_observe().await;
         let indexing_service_inbox_messages =
             indexing_service_inbox.drain_for_test_typed::<ApplyIndexingPlanRequest>();
+        assert_eq!(scheduler_state.num_schedule_indexing_plan, 1);
         assert_eq!(scheduler_state.num_applied_physical_indexing_plan, 2);
         assert_eq!(indexing_service_inbox_messages.len(), 1);
         let indexing_tasks = indexing_service_inbox_messages
@@ -536,6 +656,7 @@ mod tests {
             .update_self_node_indexing_tasks(&[indexing_tasks[0].clone()])
             .await
             .unwrap();
+        universe.sleep(HEARTBEAT).await;
         let scheduler_state = scheduler_handler.process_pending_and_observe().await;
         assert_eq!(scheduler_state.num_applied_physical_indexing_plan, 3);
         let indexing_service_inbox_messages =
@@ -544,8 +665,46 @@ mod tests {
         universe.assert_quit().await;
     }
 
+    #[tokio::test]
+    async fn test_scheduler_scheduling_no_indexer() {
+        quickwit_common::setup_logging_for_tests();
+        let transport = ChannelTransport::default();
+        let cluster = Arc::new(
+            create_cluster_for_test(Vec::new(), &["control_plane"], &transport, true)
+                .await
+                .unwrap(),
+        );
+        let universe = Universe::with_accelerated_time();
+        let (indexing_service_inboxes, scheduler_handler) =
+            start_scheduler(cluster.clone(), &[&cluster.clone()], &universe).await;
+        let indexing_service_inbox = indexing_service_inboxes[0].clone();
+
+        // No indexer.
+        universe.sleep(HEARTBEAT).await;
+        let scheduler_state = scheduler_handler.process_pending_and_observe().await;
+        let indexing_service_inbox_messages =
+            indexing_service_inbox.drain_for_test_typed::<ApplyIndexingPlanRequest>();
+        assert_eq!(scheduler_state.num_applied_physical_indexing_plan, 0);
+        assert_eq!(scheduler_state.num_schedule_indexing_plan, 0);
+        assert!(scheduler_state.last_applied_physical_plan.is_none());
+        assert_eq!(indexing_service_inbox_messages.len(), 0);
+
+        // Wait REFRESH_PLAN_LOOP_INTERVAL * 2, as there is no indexer, we should observe no
+        // scheduling.
+        universe.sleep(REFRESH_PLAN_LOOP_INTERVAL * 2).await;
+        let scheduler_state = scheduler_handler.process_pending_and_observe().await;
+        let indexing_service_inbox_messages =
+            indexing_service_inbox.drain_for_test_typed::<ApplyIndexingPlanRequest>();
+        assert_eq!(scheduler_state.num_applied_physical_indexing_plan, 0);
+        assert_eq!(scheduler_state.num_schedule_indexing_plan, 0);
+        assert!(scheduler_state.last_applied_physical_plan.is_none());
+        assert_eq!(indexing_service_inbox_messages.len(), 0);
+        universe.assert_quit().await;
+    }
+
+    
     #[test]
-    fn test_are_indexing_plans_equal() {
+    fn test_indexing_plans_diff() {
         {
             let mut running_plan = HashMap::new();
             let mut desired_plan = HashMap::new();
@@ -565,8 +724,8 @@ mod tests {
                 "indexer-1".to_string(),
                 vec![task_2, task_1.clone(), task_1],
             );
-
-            assert!(are_indexing_plans_equal(&running_plan, &desired_plan));
+            let indexing_plans_diff = get_indexing_plans_diff(&running_plan, &desired_plan);
+            assert!(indexing_plans_diff.is_empty());
         }
         {
             let mut running_plan = HashMap::new();
@@ -579,14 +738,21 @@ mod tests {
                 index_id: "index-1".to_string(),
                 source_id: "source-2".to_string(),
             };
-            running_plan.insert("indexer-1".to_string(), vec![task_1]);
-            desired_plan.insert("indexer-1".to_string(), vec![]);
+            running_plan.insert("indexer-1".to_string(), vec![task_1.clone()]);
+            desired_plan.insert("indexer-1".to_string(), vec![task_2.clone()]);
 
-            assert!(!are_indexing_plans_equal(&running_plan, &desired_plan));
-
-            desired_plan.insert("indexer-1".to_string(), vec![task_2]);
-
-            assert!(!are_indexing_plans_equal(&running_plan, &desired_plan));
+            let indexing_plans_diff = get_indexing_plans_diff(&running_plan, &desired_plan);
+            assert!(!indexing_plans_diff.is_empty());
+            assert!(indexing_plans_diff.has_same_nodes());
+            assert!(!indexing_plans_diff.has_same_tasks());
+            assert_eq!(
+                indexing_plans_diff.unplanned_tasks_by_node_id,
+                HashMap::from_iter([("indexer-1", vec![&task_1])])
+            );
+            assert_eq!(
+                indexing_plans_diff.missing_tasks_by_node_id,
+                HashMap::from_iter([("indexer-1", vec![&task_2])])
+            );
         }
         {
             let mut running_plan = HashMap::new();
@@ -596,23 +762,66 @@ mod tests {
                 source_id: "source-1".to_string(),
             };
             running_plan.insert("indexer-2".to_string(), vec![]);
-            desired_plan.insert("indexer-1".to_string(), vec![task_1]);
+            desired_plan.insert("indexer-1".to_string(), vec![task_1.clone()]);
 
-            assert!(!are_indexing_plans_equal(&running_plan, &desired_plan));
+            let indexing_plans_diff = get_indexing_plans_diff(&running_plan, &desired_plan);
+            assert!(!indexing_plans_diff.is_empty());
+            assert!(!indexing_plans_diff.has_same_nodes());
+            assert!(!indexing_plans_diff.has_same_tasks());
+            assert_eq!(
+                indexing_plans_diff.missing_node_ids,
+                HashSet::from_iter(["indexer-1"])
+            );
+            assert_eq!(
+                indexing_plans_diff.unplanned_node_ids,
+                HashSet::from_iter(["indexer-2"])
+            );
+            assert_eq!(
+                indexing_plans_diff.missing_tasks_by_node_id,
+                HashMap::from_iter([("indexer-1", vec![&task_1])])
+            );
         }
         {
             let mut running_plan = HashMap::new();
-            let desired_plan = HashMap::new();
-            running_plan.insert("indexer-1".to_string(), Vec::new());
-
-            assert!(!are_indexing_plans_equal(&running_plan, &desired_plan));
-        }
-        {
-            let running_plan = HashMap::new();
             let mut desired_plan = HashMap::new();
-            desired_plan.insert("indexer-1".to_string(), Vec::new());
+            let task_1 = IndexingTask {
+                index_id: "index-1".to_string(),
+                source_id: "source-1".to_string(),
+            };
+            running_plan.insert("indexer-1".to_string(), vec![task_1.clone()]);
+            desired_plan.insert(
+                "indexer-1".to_string(),
+                vec![task_1.clone(), task_1.clone(), task_1.clone()],
+            );
 
-            assert!(!are_indexing_plans_equal(&running_plan, &desired_plan));
+            let indexing_plans_diff = get_indexing_plans_diff(&running_plan, &desired_plan);
+            assert!(!indexing_plans_diff.is_empty());
+            assert!(indexing_plans_diff.has_same_nodes());
+            assert!(!indexing_plans_diff.has_same_tasks());
+            assert_eq!(
+                indexing_plans_diff.missing_tasks_by_node_id,
+                HashMap::from_iter([("indexer-1", vec![&task_1, &task_1])])
+            );
         }
+    }
+
+    // TODO(fmassot): remove when this function is available in quickwit-common.
+    pub async fn wait_until_predicate<Fut>(
+        predicate: impl Fn() -> Fut,
+        timeout: Duration,
+        retry_interval: Duration,
+    ) -> Result<(), Elapsed>
+    where
+        Fut: Future<Output = bool>,
+    {
+        tokio::time::timeout(timeout, async move {
+            loop {
+                if predicate().await {
+                    break;
+                }
+                tokio::time::sleep(retry_interval).await
+            }
+        })
+        .await
     }
 }

--- a/quickwit/quickwit-control-plane/src/scheduler.rs
+++ b/quickwit/quickwit-control-plane/src/scheduler.rs
@@ -95,7 +95,7 @@ pub struct IndexingSchedulerState {
 ///   - if indexing tasks are different, the scheduler will apply again the last applied plan.
 ///
 /// Finally, in order to give the time for each indexer to run their indexing tasks, the control
-/// phase will wait at least [`MIN_DURATION_BETWEEN_SCHEDULING_SECS`] before comparing the desired
+/// phase will wait at least [`MIN_DURATION_BETWEEN_SCHEDULING`] before comparing the desired
 /// plan with the running plan.
 pub struct IndexingScheduler {
     cluster: Arc<Cluster>,

--- a/quickwit/quickwit-control-plane/src/scheduler.rs
+++ b/quickwit/quickwit-control-plane/src/scheduler.rs
@@ -815,6 +815,12 @@ mod tests {
     #[test]
     fn test_indexing_plans_diff() {
         {
+            let running_plan = HashMap::new();
+            let desired_plan = HashMap::new();
+            let indexing_plans_diff = get_indexing_plans_diff(&running_plan, &desired_plan);
+            assert!(indexing_plans_diff.is_empty());
+        }
+        {
             let mut running_plan = HashMap::new();
             let mut desired_plan = HashMap::new();
             let task_1 = IndexingTask {
@@ -864,13 +870,18 @@ mod tests {
             );
         }
         {
+            // Task assigned to indexer-1 in desired plan but another one running.
             let mut running_plan = HashMap::new();
             let mut desired_plan = HashMap::new();
             let task_1 = IndexingTask {
                 index_id: "index-1".to_string(),
                 source_id: "source-1".to_string(),
             };
-            running_plan.insert("indexer-2".to_string(), vec![]);
+            let task_2 = IndexingTask {
+                index_id: "index-2".to_string(),
+                source_id: "source-2".to_string(),
+            };
+            running_plan.insert("indexer-2".to_string(), vec![task_2.clone()]);
             desired_plan.insert("indexer-1".to_string(), vec![task_1.clone()]);
 
             let indexing_plans_diff = get_indexing_plans_diff(&running_plan, &desired_plan);
@@ -889,8 +900,13 @@ mod tests {
                 indexing_plans_diff.missing_tasks_by_node_id,
                 HashMap::from_iter([("indexer-1", vec![&task_1]), ("indexer-2", Vec::new())])
             );
+            assert_eq!(
+                indexing_plans_diff.unplanned_tasks_by_node_id,
+                HashMap::from_iter([("indexer-2", vec![&task_2]), ("indexer-1", Vec::new())])
+            );
         }
         {
+            // Diff with 3 same tasks running but only one on the desired plan.
             let mut running_plan = HashMap::new();
             let mut desired_plan = HashMap::new();
             let task_1 = IndexingTask {
@@ -909,6 +925,29 @@ mod tests {
             assert!(!indexing_plans_diff.has_same_tasks());
             assert_eq!(
                 indexing_plans_diff.missing_tasks_by_node_id,
+                HashMap::from_iter([("indexer-1", vec![&task_1, &task_1])])
+            );
+        }
+        {
+            // Diff with 3 same tasks on desired plan but only one running.
+            let mut running_plan = HashMap::new();
+            let mut desired_plan = HashMap::new();
+            let task_1 = IndexingTask {
+                index_id: "index-1".to_string(),
+                source_id: "source-1".to_string(),
+            };
+            running_plan.insert(
+                "indexer-1".to_string(),
+                vec![task_1.clone(), task_1.clone(), task_1.clone()],
+            );
+            desired_plan.insert("indexer-1".to_string(), vec![task_1.clone()]);
+
+            let indexing_plans_diff = get_indexing_plans_diff(&running_plan, &desired_plan);
+            assert!(!indexing_plans_diff.is_empty());
+            assert!(indexing_plans_diff.has_same_nodes());
+            assert!(!indexing_plans_diff.has_same_tasks());
+            assert_eq!(
+                indexing_plans_diff.unplanned_tasks_by_node_id,
                 HashMap::from_iter([("indexer-1", vec![&task_1, &task_1])])
             );
         }

--- a/quickwit/quickwit-control-plane/src/scheduler.rs
+++ b/quickwit/quickwit-control-plane/src/scheduler.rs
@@ -513,8 +513,8 @@ fn get_indexing_tasks_diff<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
     use std::collections::{HashMap, HashSet};
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
     use std::time::Duration;
 

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -1311,7 +1311,6 @@ mod tests {
                 .await;
             assert_eq!(resp.status(), 400);
             let body = from_utf8_lossy(resp.body());
-            println!("{}", body);
             assert!(body
                 .contains("Quickwit currently supports multiple pipelines only for Kafka sources"));
         }


### PR DESCRIPTION
# Description

Several improvements were made:
- [x] Avoid scheduling if the difference between the last applied plan and the running plan is a difference between tasks only.
- [x] Avoid scheduling if the last applied plan is the same as the newly built plan.
- [x] I removed the usage of an empty plan when there is no indexer, the code was confusing.
- [x] The diff between plans is fixed (it was wrong...). The current code is ugly, I still want to improve it...

# How this PR was tested
- [x] New tests have been added, so the coverage is way better.
- [x] Add a test to check no plan is scheduled during the `MIN_DURATION_BETWEEN_SCHEDULING_SECS` period.
- [x] Add unit test on indexing tasks diff.