### PR TITLE
Use byte for ingest api config params.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4759,6 +4759,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "byte-unit",
  "flume",
  "futures",
  "mrecordlog",

--- a/quickwit/quickwit-config/src/quickwit_config/mod.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/mod.rs
@@ -140,18 +140,18 @@ impl Default for SearcherConfig {
 #[serde(deny_unknown_fields)]
 pub struct IngestApiConfig {
     #[serde(default = "IngestApiConfig::default_max_queue_memory_usage")]
-    pub max_queue_memory_usage: usize,
+    pub max_queue_memory_usage: Byte,
     #[serde(default = "IngestApiConfig::default_max_queue_disk_usage")]
-    pub max_queue_disk_usage: usize,
+    pub max_queue_disk_usage: Byte,
 }
 
 impl IngestApiConfig {
-    fn default_max_queue_memory_usage() -> usize {
-        2 * 1024 * 1024 * 1024 // 2 GiB // TODO maybe we want more?
+    fn default_max_queue_memory_usage() -> Byte {
+        Byte::from_bytes(2 * 1024 * 1024 * 1024) // 2 GiB // TODO maybe we want more?
     }
 
-    fn default_max_queue_disk_usage() -> usize {
-        4 * 1024 * 1024 * 1024 // 4 GiB // TODO maybe we want more?
+    fn default_max_queue_disk_usage() -> Byte {
+        Byte::from_bytes(4 * 1024 * 1024 * 1024) // 4 GiB // TODO maybe we want more?
     }
 }
 

--- a/quickwit/quickwit-ingest-api/Cargo.toml
+++ b/quickwit/quickwit-ingest-api/Cargo.toml
@@ -8,6 +8,7 @@ description = "Quickwit is a cost-efficient search engine."
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+byte-unit = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 mrecordlog = { workspace = true }

--- a/quickwit/quickwit-ingest-api/src/lib.rs
+++ b/quickwit/quickwit-ingest-api/src/lib.rs
@@ -63,8 +63,8 @@ pub async fn init_ingest_api(
     }
     let ingest_api_actor = IngestApiService::with_queues_dir(
         queues_dir_path,
-        config.max_queue_memory_usage,
-        config.max_queue_disk_usage,
+        config.max_queue_memory_usage.get_bytes() as usize,
+        config.max_queue_disk_usage.get_bytes() as usize,
     )
     .await
     .with_context(|| {
@@ -132,6 +132,7 @@ pub fn iter_doc_payloads(doc_batch: &DocBatch) -> impl Iterator<Item = &[u8]> {
 #[cfg(test)]
 mod tests {
 
+    use byte_unit::Byte;
     use quickwit_actors::AskError;
     use quickwit_proto::ingest_api::{CreateQueueRequest, IngestRequest, SuggestTruncateRequest};
 
@@ -182,8 +183,8 @@ mod tests {
             &universe,
             &queues_dir_path,
             &IngestApiConfig {
-                max_queue_memory_usage: 1024,
-                max_queue_disk_usage: 1024 * 1024 * 256,
+                max_queue_memory_usage: Byte::from_bytes(1024),
+                max_queue_disk_usage: Byte::from_bytes(1024 * 1024 * 256),
             },
         )
         .await


### PR DESCRIPTION
### Description

Just use byte for ingest api config params. It's consistent with other params expressing bytes and it will make it easier to configure.

Fixes #2846 



