### PR TITLE
Check sort-by-score CLI

### DIFF
--- a/quickwit/quickwit-codegen-example/src/error.rs
+++ b/quickwit/quickwit-codegen-example/src/error.rs
@@ -44,6 +44,6 @@ impl<E> From<AskError<E>> for HelloError
 where E: fmt::Debug
 {
     fn from(error: AskError<E>) -> Self {
-        HelloError::InternalError(format!("{:?}", error))
+        HelloError::InternalError(format!("{error:?}"))
     }
 }

--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -198,7 +198,7 @@ mod tests {
             .reply(&delete_query_api_handlers)
             .await;
         assert_eq!(resp.status(), 400);
-        assert!(String::from_utf8_lossy(resp.body()).contains("InvalidDeleteQuery"));
+        assert!(String::from_utf8_lossy(resp.body()).contains("Invalid delete query"));
 
         // GET delete tasks.
         let resp = warp::test::request()

--- a/quickwit/quickwit-serve/src/format.rs
+++ b/quickwit/quickwit-serve/src/format.rs
@@ -117,7 +117,10 @@ impl Format {
                     }
                 }
             }
-            Err(err) => self.make_reply_for_err(err),
+            Err(err) => self.make_reply_for_err(FormatError {
+                code: err.status_code(),
+                error: err.to_string(),
+            }),
         }
     }
 


### PR DESCRIPTION
Make use of FormatError in make rest reply to display a more meaningful error message in CLI upon SearApiError

Closes https://github.com/quickwit-oss/quickwit/issues/2790
