### PR TITLE
Replace prettyjson by pretty_json to be consistent everywhere.

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -617,7 +617,7 @@ quickwit split list
 `--create-date` Selects the splits whose creation dates are before this date. \
 `--start-date` Selects the splits that contain documents after this date (time-series indexes only). \
 `--end-date` Selects the splits that contain documents before this date (time-series indexes only). \
-`--output-format` Output format. Possible values are `table`, `json`, and `prettyjson`. \
+`--output-format` Output format. Possible values are `table`, `json`, and `pretty_json`. \
 ### split describe
 
 Displays metadata about a split.  

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -63,7 +63,7 @@ POST api/v1/<index id>/search
 | **search_field**    | `[String]` | Fields to search on if no field name is specified in the query. Comma-separated list, e.g. "field1,field2"                                             | index_config.search_settings.default_search_fields |
 | **snippet_fields**  | `[String]` | Fields to extract snippet on. Comma-separated list, e.g. "field1,field2"                                                                               |                                                    |
 | **sort_by_field**   | `String`   | Field to sort query results by. You can sort by a field (must be a fast field) and by BM25 `_score`. By default, hits are sorted by their document ID. |                                                    |
-| **format**          | `Enum`     | The output format. Allowed values are "json" or "prettyjson"                                                                                           | `prettyjson`                                       |
+| **format**          | `Enum`     | The output format. Allowed values are "json" or "pretty_json"                                                                                           | `pretty_json`                                       |
 | **aggs**            | `JSON`     | The aggregations request. See the [aggregations doc](aggregation.md) for supported aggregations.                                                       |                                                    |
 
 :::info
@@ -402,14 +402,14 @@ Delete source of ID `<source id>`.
 This endpoint lets you check the state of the cluster from the point of view of the node handling the request.
 
 ```
-GET api/v1/cluster?format=prettyjson
+GET api/v1/cluster?format=pretty_json
 ```
 
 #### Parameters
 
 Name | Type | Description | Default value
 --- | --- | --- | ---
-**format** | `String` | The output format requested for the response: `json` or `prettyjson` | `prettyjson`
+**format** | `String` | The output format requested for the response: `json` or `pretty_json` | `pretty_json`
 
 
 ## Delete API

--- a/quickwit/quickwit-cli/src/split.rs
+++ b/quickwit/quickwit-cli/src/split.rs
@@ -63,7 +63,7 @@ pub fn build_split_command<'a>() -> Command<'a> {
                     //     .display_order(6)
                     //     .required(false)
                     //     .use_value_delimiter(true),
-                    arg!(--"output-format" <OUTPUT_FORMAT> "Output format. Possible values are `table`, `json`, and `prettyjson`.")
+                    arg!(--"output-format" <OUTPUT_FORMAT> "Output format. Possible values are `table`, `json`, and `pretty_json`.")
                         .alias("format")
                         .display_order(7)
                         .required(false)
@@ -114,10 +114,10 @@ impl FromStr for OutputFormat {
         match output_format_str {
             "table" => Ok(OutputFormat::Table),
             "json" => Ok(OutputFormat::Json),
-            "prettyjson" => Ok(OutputFormat::PrettyJson),
+            "pretty_json" => Ok(OutputFormat::PrettyJson),
             _ => bail!(
                 "Failed to parse output format `{output_format_str}`. Supported formats are: \
-                 `table`, `json`, and `prettyjson`."
+                 `table`, `json`, and `pretty_json`."
             ),
         }
     }


### PR DESCRIPTION
TLDR.

Tested with `cargo run -- split list --index airmail-logs --output-format pretty_json`

