### PR TITLE
Add progress bar on ingest CLI command.

### DIFF
--- a/quickwit/quickwit-rest-client/src/rest_client.rs
+++ b/quickwit/quickwit-rest-client/src/rest_client.rs
@@ -160,8 +160,8 @@ impl QuickwitClient {
                     .await?;
 
                 if response.status_code() == StatusCode::TOO_MANY_REQUESTS {
-                    if let Some(f) = on_ingest_event.as_ref() {
-                        f(IngestEvent::Sleep)
+                    if let Some(event_fn) = &on_ingest_event {
+                        event_fn(IngestEvent::Sleep)
                     }
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 } else {
@@ -169,8 +169,8 @@ impl QuickwitClient {
                     break;
                 }
             }
-            if let Some(f) = on_ingest_event.as_ref() {
-                f(IngestEvent::IngestedNumBytes(batch.len()))
+            if let Some(event_fn) = on_ingest_event.as_ref() {
+                event_fn(IngestEvent::IngestedDocBatch(batch.len()))
             }
         }
         Ok(())
@@ -178,7 +178,7 @@ impl QuickwitClient {
 }
 
 pub enum IngestEvent {
-    IngestedNumBytes(usize),
+    IngestedDocBatch(usize),
     Sleep,
 }
 


### PR DESCRIPTION
Adding a progress bar to the ingest API.

- Tested with an input file
- Tested with stdin source
- The progress bar is hidden when the stdout is not a tty.

![Capture d’écran 2023-02-23 à 21 21 55](https://user-images.githubusercontent.com/653704/221021457-654555c8-3fdb-498e-8233-12134be51280.png)


