### PR TITLE
Update installation page.

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 Quickwit compiles to a single binary and we provide different methods to install it:
 
-- Linux/MacOS binaries that you can[download manually](#download) or with the [isntall script](#install-script)
+- Linux/MacOS binaries that you can[download manually](#download) or with the [install script](#install-script)
 - [Docker image](#use-the-docker-image)
 - [Helm chart](/docs/deployment/kubernetes.md)
 
@@ -21,8 +21,7 @@ Support of aarch64 is currently experimental.
 
 ## Download
 
-<<<<<<< HEAD
-version: 0.5.0 - [Release note](https://github.com/quickwit-oss/quickwit/releases/tag/v0.4.0)
+version: 0.5.0 - [Release note](https://github.com/quickwit-oss/quickwit/releases/tag/v0.5.0)
 License: [AGPL V3](https://github.com/quickwit-oss/quickwit/blob/main/LICENSE.md)
 Downloads `.tar.gz`:
 - [Linux ARM64](https://github.com/quickwit-oss/quickwit/releases/download/v0.5.0/quickwit-v0.5.0-aarch64-unknown-linux-gnu.tar.gz)

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -6,7 +6,11 @@ sidebar_position: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Quickwit compiles to a single binary, we provide different methods to install it.
+Quickwit compiles to a single binary and we provide different methods to install it:
+
+- Linux/MacOS binaries that you can[download manually](#download) or with the [isntall script](#install-script)
+- [Docker image](#use-the-docker-image)
+- [Helm chart](/docs/deployment/kubernetes.md)
 
 ## Prerequisites
 
@@ -17,12 +21,14 @@ Support of aarch64 is currently experimental.
 
 ## Download
 
+<<<<<<< HEAD
 version: 0.5.0 - [Release note](https://github.com/quickwit-oss/quickwit/releases/tag/v0.4.0)
 License: [AGPL V3](https://github.com/quickwit-oss/quickwit/blob/main/LICENSE.md)
 Downloads `.tar.gz`:
-- [Linux ARM64](https://github.com/quickwit-oss/quickwit/releases/download/v0.4.0/quickwit-v0.4.0-aarch64-unknown-linux-gnu.tar.gz)
-- [Linux x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.4.0/quickwit-v0.4.0-x86_64-unknown-linux-gnu.tar.gz)
-- [macOS x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.4.0/quickwit-v0.4.0-x86_64-apple-darwin.tar.gz)
+- [Linux ARM64](https://github.com/quickwit-oss/quickwit/releases/download/v0.5.0/quickwit-v0.5.0-aarch64-unknown-linux-gnu.tar.gz)
+- [Linux x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.5.0/quickwit-v0.5.0-x86_64-unknown-linux-gnu.tar.gz)
+- [macOS aarch64](https://github.com/quickwit-oss/quickwit/releases/download/v0.5.0/quickwit-v0.5.0-aarch64-apple-darwin.tar.gz)
+- [macOS x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.5.0/quickwit-v0.5.0-x86_64-apple-darwin.tar.gz)
 
 
 Check out the available builds in greater detail on [GitHub](https://github.com/quickwit-oss/quickwit/releases)
@@ -104,8 +110,6 @@ pacman -S clang protobuf openssl pkg-config cmake make
 
 </Tabs>
 
-
-
 ## Install script
 
 To easily install Quickwit on your machine, just run the command below from your preferred shell.
@@ -138,38 +142,14 @@ quickwit-{version}
 
 If you use Docker, this might be one of the quickest way to get going.
 The following command will pull the image from [Docker Hub](https://hub.docker.com/r/quickwit/quickwit)
-and gets you right in the shell of the running container ready to execute Quickwit commands.
-Note that we are also mounting the working directory as volume. This is useful when you already have your dataset ready on your machine and want to work with Quickwit Docker image.
+and start a container ready to execute Quickwit commands.
 
 ```bash
-docker run -it -v "$(pwd)":"/quickwit/files" --entrypoint bash quickwit/quickwit
-quickwit --version
+docker run --rm quickwit/quickwit --version
+
+# If you are using Apple silicon based macOS system you might need to specify the platform.
+# You can also safely ignore jemalloc warnings.
+docker run --rm --platform linux/amd64 quickwit/quickwit --version
 ```
 
-To get the full gist of this, let's run a minified version of the - [Quickstart guide](./quickstart.md).
-
-```bash
-# let's create a `data` directory
-mkdir data && cd data
-
-# download wikipedia dataset files
-curl -o wikipedia_index_config.yaml https://raw.githubusercontent.com/quickwit-oss/quickwit/main/config/tutorials/wikipedia/index-config.yaml
-curl -o wiki-articles-10000.json https://quickwit-datasets-public.s3.amazonaws.com/wiki-articles-10000.json
-
-# create, index and search using the container
-docker run -v "$(pwd)":"/quickwit/qwdata" quickwit/quickwit index create --index-config ./qwdata/wikipedia_index_config.yaml
-
-docker run -v "$(pwd)":"/quickwit/qwdata" quickwit/quickwit index ingest --index wikipedia --input-path ./qwdata/wiki-articles-10000.json
-
-docker run -v "$(pwd)":"/quickwit/qwdata" quickwit/quickwit index search --index wikipedia --query "barack obama"
-
-docker run -v "$(pwd)":"/quickwit/qwdata" --expose 7280 -p 7280:7280 quickwit/quickwit run --service searcher
-```
-
-Now you can make HTTP requests to the searcher service API.
-
-```bash
-curl http://127.0.0.1:7280/api/v1/wikipedia/search?query=obama
-```
-
-Alternatively, you can run a container shell session with your `data` folder mounted and execute the commands from within that session.
+To get the full gist of this, follow the [Quickstart guide](./quickstart.md).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -13,12 +13,12 @@ Data collection are opt-out. To disable them, just set the environment variable 
 export QW_DISABLE_TELEMETRY=1
 ```
 
-Look at `quickwit help` command output to check whether telemetry is enabled or not:
+Look at `c` command output to check whether telemetry is enabled or not:
 ```bash
-quickwit help
-Quickwit 0.1.0
-Quickwit, Inc. <hello@quickwit.io>
-Indexing your large dataset on object storage & making it searchable from the command line.
+quickwit --help
+Quickwit 0.5.0
+Index and search your data on object storage at any scale
+
 Telemetry enabled
 ```
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -13,11 +13,12 @@ Data collection are opt-out. To disable them, just set the environment variable 
 export QW_DISABLE_TELEMETRY=1
 ```
 
-Look at `c` command output to check whether telemetry is enabled or not:
+Look at `--help` command output to check whether telemetry is enabled or not:
 ```bash
 quickwit --help
 Quickwit 0.5.0
-Index and search your data on object storage at any scale
+Sub-second search & analytics engine on cloud storage.
+  Find more information at https://quickwit.io/docs
 
 Telemetry enabled
 ```

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -162,7 +162,7 @@ async fn main() -> anyhow::Result<()> {
 /// Return the about text with telemetry info.
 fn about_text() -> String {
     let mut about_text = String::from(
-        "Index your dataset on object storage & make it searchable from the command line.\n  Find more information at https://quickwit.io/docs\n\n",
+        "Index and search your data on object storage at any scale.\nFind more information at https://quickwit.io/docs\n\n",
     );
     if quickwit_telemetry::is_telemetry_enabled() {
         about_text += "Telemetry: enabled";

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -162,7 +162,7 @@ async fn main() -> anyhow::Result<()> {
 /// Return the about text with telemetry info.
 fn about_text() -> String {
     let mut about_text = String::from(
-        "Sub-second search & analytics engine on cloud storage.\nFind more information at https://quickwit.io/docs\n\n",
+        "Sub-second search & analytics engine on cloud storage.\n  Find more information at https://quickwit.io/docs\n\n",
     );
     if quickwit_telemetry::is_telemetry_enabled() {
         about_text += "Telemetry: enabled";

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -162,7 +162,7 @@ async fn main() -> anyhow::Result<()> {
 /// Return the about text with telemetry info.
 fn about_text() -> String {
     let mut about_text = String::from(
-        "Index and search your data on object storage at any scale.\nFind more information at https://quickwit.io/docs\n\n",
+        "Sub-second search & analytics engine on cloud storage.\nFind more information at https://quickwit.io/docs\n\n",
     );
     if quickwit_telemetry::is_telemetry_enabled() {
         about_text += "Telemetry: enabled";


### PR DESCRIPTION
### Description

- Small intro to present the 3 ways to install quickwit
- addition of macOS aarch64 binary link
- remove the small tutorial at the end, the link to the quickstart should be sufficient
- update telemetry doc
- change CLI tagline

```
Quickwit 0.4.0-nightly (5d57148 2023-02-25T10:11:11Z)
Index and search your data on object storage at any scale.
Find more information at https://quickwit.io/docs

Telemetry: enabled
```

### How was this PR tested?

- [x] Check docker command
- [x] Check rendering on website

