### PR TITLE
QW-2897: Update pulsar message ID comment

### DIFF
--- a/quickwit/quickwit-indexing/src/source/pulsar_source.rs
+++ b/quickwit/quickwit-indexing/src/source/pulsar_source.rs
@@ -376,7 +376,16 @@ async fn create_pulsar_consumer(
 fn msg_id_to_position(msg: &MessageIdData) -> Position {
     // The order of these fields are important as they affect the sorting
     // of the checkpoint positions.
-    // TODO: Confirm this layout is correct?
+    //
+    // The key parts of the ID used for ordering are:
+    // - The ledger ID which is a sequentially increasing ID.
+    // - The entry ID the unique ID of the message within the ledger.
+    // - The batch position for the current chunk of messages.
+    //
+    // The remaining keys are not required for sorting but are required
+    // in order to re-construct the message ID in order to send back to pulsar.
+    // The ledger_id, entry_id and the batch_index form a unique composite key which will
+    // prevent the remaining parts of the ID from interfering with the sorting.
     let id_str = format!(
         "{:0>20},{:0>20},{},{},{}",
         msg.ledger_id,


### PR DESCRIPTION
Closes #2897 

Confirms the layout of the position ID for pulsar message IDs and adds an explanation as to why the order is what it is.
