### PR TITLE
Fix typo in test_config_contains_wrong_values.

### DIFF
--- a/quickwit/quickwit-config/src/quickwit_config/serialize.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/serialize.rs
@@ -486,7 +486,7 @@ mod tests {
         .await
         .unwrap_err();
         assert!(format!("{parsing_error:?}")
-            .contains("unknown field `max_num_concurrent_split_searches_with_typo`"));
+            .contains("unknown field `max_num_concurrent_split_searchs_with_typo`"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

This test is failing on my local laptop and failed also on [coverage](https://github.com/quickwit-oss/quickwit/actions/runs/4320005920/jobs/7539796621#step:13:1235)

### How was this PR tested?

Tested locally.
