### PR TITLE
Fix vector configuration in tutorial

### DIFF
--- a/docs/get-started/tutorials/send-logs-from-vector-to-quickwit.md
+++ b/docs/get-started/tutorials/send-logs-from-vector-to-quickwit.md
@@ -163,6 +163,7 @@ source = '''
 
 [sinks.quickwit_logs]
 type = "http"
+method = "post"
 inputs = ["remap_syslog"]
 encoding.codec = "json"
 framing.method = "newline_delimited"


### PR DESCRIPTION
### Description

In the tutorial for sending logs to the vector. There is an error on the vector configuration that causes an error, by default the sink vector `http` uses the HTTP method `GET` and quickwit responds with an HTTP 405 error when ingesting logs.

We need to explicitly define the use of the `POST` method.

Error in vector logs:

```
vector::internal_events::http_client: HTTP response. status=405 Method Not Allowed version=HTTP/1.1 ...
```

### How was this PR tested?

PR changes only documentation file.
