### PR TITLE
WIP: QW-2597: Initial `quickwit init` command implementation.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4141,6 +4141,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "promptea"
+version = "0.1.0"
+source = "git+https://github.com/quickwit-oss/promptea.git?rev=29a6310#29a631086e49f196e69dd7220c1cf197b180d9e4"
+dependencies = [
+ "Inflector",
+ "console",
+ "dialoguer",
+ "indexmap",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "proptest"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4392,6 +4406,7 @@ dependencies = [
  "quickwit-directories",
  "quickwit-doc-mapper",
  "quickwit-indexing",
+ "quickwit-init",
  "quickwit-metastore",
  "quickwit-proto",
  "quickwit-rest-client",
@@ -4769,6 +4784,15 @@ dependencies = [
  "tracing",
  "ulid",
  "utoipa",
+]
+
+[[package]]
+name = "quickwit-init"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "promptea",
+ "serde_yaml 0.9.19",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "quickwit-grpc-clients",
   "quickwit-indexing",
   "quickwit-ingest-api",
+  "quickwit-init",
   "quickwit-jaeger",
   "quickwit-janitor",
   "quickwit-metastore",
@@ -105,6 +106,7 @@ predicates = "2"
 prettyplease = "0.1.23"
 proc-macro2 = "1.0.50"
 prometheus = { version = "0.13", features = ["process"] }
+promptea = { git = "https://github.com/quickwit-oss/promptea.git", rev = "29a6310" }
 proptest = "1"
 prost = { version = "0.11.6", default-features = false, features = [
   "prost-derive",
@@ -207,6 +209,7 @@ quickwit_elastic_api_generation = { git = "https://github.com/quickwit-oss/elast
 quickwit-grpc-clients = { version = "0.4.0", path = "./quickwit-grpc-clients" }
 quickwit-indexing = { version = "0.4.0", path = "./quickwit-indexing" }
 quickwit-ingest-api = { version = "0.4.0", path = "./quickwit-ingest-api" }
+quickwit-init = { version = "0.4.0", path = "./quickwit-init" }
 quickwit-jaeger = { version = "0.4.0", path = "./quickwit-jaeger" }
 quickwit-janitor = { version = "0.4.0", path = "./quickwit-janitor" }
 quickwit-metastore = { version = "0.4.0", path = "./quickwit-metastore" }

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -70,6 +70,7 @@ quickwit-search = { workspace = true }
 quickwit-serve = { workspace = true }
 quickwit-storage = { workspace = true }
 quickwit-telemetry = { workspace = true }
+quickwit-init = { workspace = true }
 
 [dev-dependencies]
 predicates = { workspace = true }

--- a/quickwit/quickwit-cli/src/init.rs
+++ b/quickwit/quickwit-cli/src/init.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use anyhow::bail;
 use clap::{Arg, ArgMatches, Command};
 use quickwit_init::InitOption;

--- a/quickwit/quickwit-cli/src/init.rs
+++ b/quickwit/quickwit-cli/src/init.rs
@@ -1,0 +1,57 @@
+use anyhow::bail;
+use clap::{Arg, ArgMatches, Command};
+use quickwit_init::InitOption;
+
+pub fn build_init_command<'a>() -> Command<'a> {
+    Command::new("init")
+        .about(
+            "The one stop shop for setting up Quickwit configs, projects and more with a helpful \
+             walkthrough prompt.",
+        )
+        .arg(
+            Arg::new("quiet")
+                .long("quiet")
+                .short('q')
+                .required(false)
+                .takes_value(false)
+                .help(
+                    "Hide the additional help text for each parameter to reduce noise in the \
+                     terminal.",
+                ),
+        )
+        .subcommand(
+            Command::new("index")
+                .display_order(1)
+                .about("Create a new Quickwit index config using the prompt-base walkthrough."),
+        )
+        .subcommand(
+            Command::new("source")
+                .display_order(2)
+                .about("Create a new Quickwit source config using the prompt-base walkthrough."),
+        )
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct InitCliCommand {
+    pub option: InitOption,
+    pub quiet: bool,
+}
+
+impl InitCliCommand {
+    pub fn parse_cli_args(matches: &ArgMatches) -> anyhow::Result<Self> {
+        let quiet = matches.is_present("quiet");
+        let subcommand = matches.subcommand();
+        let option = match subcommand.map(|v| v.0) {
+            Some("index") => InitOption::Index,
+            Some("source") => InitOption::Source,
+            None => InitOption::Quickwit,
+            Some(other) => bail!("Init subcommand `{other}` is not implemented."),
+        };
+
+        Ok(Self { option, quiet })
+    }
+
+    pub fn execute(self) -> anyhow::Result<()> {
+        quickwit_init::init(self.option, self.quiet)
+    }
+}

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -42,6 +42,7 @@ use tracing::info;
 
 pub mod cli;
 pub mod index;
+pub mod init;
 #[cfg(feature = "jemalloc")]
 pub mod jemalloc;
 pub mod service;

--- a/quickwit/quickwit-init/Cargo.toml
+++ b/quickwit/quickwit-init/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quickwit-init"
 version = "0.4.0"
 edition = "2021"
+license = "AGPL-3.0-or-later"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/quickwit/quickwit-init/Cargo.toml
+++ b/quickwit/quickwit-init/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "quickwit-init"
+version = "0.4.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+promptea = { workspace = true }
+serde_yaml = { workspace = true }
+anyhow = { workspace = true }

--- a/quickwit/quickwit-init/schemas/source.yaml
+++ b/quickwit/quickwit-init/schemas/source.yaml
@@ -1,0 +1,178 @@
+
+fields:
+  source_id:
+    type: string
+    display_name: "Source ID"
+    description: |
+      The source ID is a string that uniquely identifies the source within an index.\n
+      It may only contain uppercase or lowercase ASCII letters, digits, hyphens (-), and underscores (_).\n
+      Finally, it must start with a letter and contain at least 3 characters but no more than 255.\n
+      Find out more: https://quickwit.io/docs/configuration/source-config
+    max_length: 255
+    min_length: 3
+    regex: "^[a-zA-Z][a-zA-Z0-9-_]{2,254}$"
+  source_type:
+    type: select
+    display_name: "Source Type"
+    description: |
+      The source type designates the kind of source being configured.
+      As of version 0.3, available source types are `file`, `kafka`, `pulsar` and `kinesis`.
+    items:
+      - file
+      - kafka
+      - kinesis
+      - pulsar
+    then:
+      insert_at_root: true
+      if:
+        - picked: file
+          fields:
+            params:
+              type: object
+              display_name: "File Parameters"
+              description: |
+                Please follow the steps for creating a file source.
+                
+                Read more: https://quickwit.io/docs/configuration/source-config#file-source
+              fields:
+                filepath:
+                  display_name: "File Path"
+                  prompt: "Path"
+                  description: |
+                    Path to a local file consisting of JSON objects separated by a newline.	
+                    This is relative to the indexer itself running the source rather than your
+                    local machine.
+                  type: string
+                  # TODO: add regex validation
+        - picked: kafka
+          fields:
+            params:
+              type: object
+              display_name: "Kafka Parameters"
+              description: |
+                Please follow the steps for creating a Kafka source.
+                
+                Read more: https://quickwit.io/docs/configuration/source-config#kafka-source
+              fields:
+                topic:
+                  type: string
+                  prompt: "Topic Name"
+                  description: Name of the topic to consume.
+                client_log_level:
+                  type: select
+                  prompt: "Client Log Level (leave blank to skip)"
+                  description: |
+                    librdkafka client log level.
+                  items:
+                    - info
+                    - warn
+                    - debug
+                    - error
+                enable_backfill_mode:
+                  type: bool
+                  prompt: "Enable Backfill Mode (y/n)"
+                  description: |
+                    Backfill mode stops the source after reaching the end of the topic.
+        - picked: kinesis
+          fields:
+            params:
+              type: object
+              display_name: "Kinesis Parameters"
+              description: |
+                Please follow the steps for creating a Kinesis source.
+                
+                Read more: https://quickwit.io/docs/configuration/source-config#kinesis-source
+              fields:
+                stream_name:
+                  type: string
+                  prompt: "Stream Name"
+                  description: Name of the Kinesis stream to consume.
+                region:
+                  type: string
+                  prompt: "Region (leave blank to skip)"
+                  description: |
+                    The AWS region of the stream. Mutually exclusive with endpoint.
+                    Defaults to `us-east-1`.
+                  can_skip: true
+                endpoint:
+                  type: string
+                  prompt: "Endpoint (leave blank to skip)"
+                  description: |
+                    Custom endpoint for use with AWS-compatible Kinesis service. 
+                    Mutually exclusive with `region`.
+                  can_skip: true
+        - picked: pulsar
+          fields:
+            params:
+              type: object
+              display_name: "Pulsar Parameters"
+              description: |
+                Please follow the steps for creating a Pulsar source.
+                
+                Read more: https://quickwit.io/docs/configuration/source-config#pulsar-source
+              fields:
+                topics:
+                  type: string[]
+                  prompt: "Topic"
+                  description: |
+                    You can create a Pulsar source consuming from several
+                    topics at once, you need to provide at least 1 topic by default.
+                    Learn more: https://pulsar.apache.org/docs/2.11.x/concepts-messaging/#topics
+                  min_items: 1
+                address:
+                  type: string
+                  description: |
+                    The address used for connecting to the Pulsar broker.
+                    This address must start with `pulsar://`.
+                  regex: "^pulsar:\/\/.+$"  # TODO: Better validator may be useful
+                consumer_name:
+                  type: string
+                  prompt: "Consumer Name (leave blank to skip)"
+                  description: |
+                    You can customise the consumer name used when Quickwit connects to Pulsar,
+                    by default this is `quickwit`.
+                  can_skip: true
+                authentication:
+                  type: select
+                  prompt: "Authentication (press `q` or ESC to skip)"
+                  can_skip: true
+                  description: |
+                    You can provide optional authentication, both token and Oauth2 
+                    authentication is supported.
+                    Read more about Pulsar authentication: https://pulsar.apache.org/docs/2.11.x/security-overview/
+                  items:
+                    - token
+                    - oauth2
+                  then:
+                    if:
+                      - picked: token
+                        fields:
+                          token:
+                            type: string
+                            display_name: "JWT Token"
+                            prompt: "Token"
+                            description: |
+                              The Pulsar JWT token.
+                              For more information see: https://pulsar.apache.org/docs/2.11.x/security-jwt/
+                      - picked: oauth2
+                        fields:
+                          oauth2:
+                            type: object
+                            fields:
+                              issuer_url:
+                                type: string
+                                display_name: "Issuer URL"
+                              credentials_url:
+                                type: string
+                                display_name: "Credentials URL"
+                              audience:
+                                type: string
+                                can_skip: true
+                                display_name: "Audience"
+                                prompt: "Audience (leave blank to skip)"
+                              scope:
+                                type: string
+                                can_skip: true
+                                display_name: "Scope"
+                                prompt: "Scope (leave blank to skip)"
+

--- a/quickwit/quickwit-init/src/lib.rs
+++ b/quickwit/quickwit-init/src/lib.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::fmt::{Display, Formatter};
 
 use anyhow::Context;

--- a/quickwit/quickwit-init/src/lib.rs
+++ b/quickwit/quickwit-init/src/lib.rs
@@ -1,0 +1,68 @@
+use std::fmt::{Display, Formatter};
+
+use anyhow::Context;
+use promptea::{BlankValidator, PromptValue, Schema};
+
+/// The main entry point for Quickwit init.
+///
+/// The system will create a set of prompts for a user
+/// in order to create a given config/project based on
+/// the input [InitOption].
+///
+/// Additionally, `quiet` can be passed in order to disable
+/// the prompts from displaying the additional description
+/// for each field.
+pub fn init(option: InitOption, quiet: bool) -> anyhow::Result<()> {
+    let schema = option.as_schema();
+
+    let input_data = schema
+        .prompt(quiet)
+        .context("Failed to get user input and complete init process.")?;
+
+    let path = format!("./new-{option}-config.yaml");
+    let msg = format!("Where should this config be exported? (Leave blank for {path})");
+    let output_path = String::prompt(msg, Some(BlankValidator), true)
+        .context("Could not get output path from user input.")?
+        .unwrap_or(path);
+
+    let exported_data =
+        serde_yaml::to_string(&input_data).context("Could not serialize input data to yaml.")?;
+
+    std::fs::write(output_path, exported_data).context("Failed to write config to file.")?;
+
+    Ok(())
+}
+
+#[derive(Debug, Eq, PartialEq)]
+/// The selected config schema to prompt the user with.
+pub enum InitOption {
+    /// Create a new source config.
+    Source,
+    /// Create a new index config.
+    Index,
+    /// Create a new Quickwit config.
+    Quickwit,
+}
+
+impl Display for InitOption {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InitOption::Source => write!(f, "source"),
+            InitOption::Index => write!(f, "index"),
+            InitOption::Quickwit => write!(f, "quickwit"),
+        }
+    }
+}
+
+impl InitOption {
+    fn as_schema(&self) -> Schema {
+        match self {
+            InitOption::Source => {
+                let schema_yaml = include_str!("../schemas/source.yaml");
+                serde_yaml::from_str(schema_yaml).expect("Schema should be valid yaml.")
+            }
+            InitOption::Index => unimplemented!("Index schema not yet implemented."),
+            InitOption::Quickwit => unimplemented!("Quickwit schema not yet implemented."),
+        }
+    }
+}


### PR DESCRIPTION
### Description
This will add the initial `quickwit init` command, designed to make creating configs and setting up Quickwit as simple and as pain-free as possible.

The system reads a schema defined as a yaml which describes the various properties of the config (validation, nested objects, selects, etc...) and walks the user through populating the config with descriptions to match.

This initial PR focuses on the main configs and currently doesn't intend to implement the templating logic that we want further down the line.

**Command Goals:**
- `quickwit init` - Sets up the base Quickwit config itself for when you're first setting up a node.
- `quickwit init index` - Sets up an index config.
- `quickwit init source` - Sets up a source config.

**Checklist:**
- [x] Implement data source schema.
- [ ] Implement index schema.
- [ ] Implement Quickwit config schema.

Originally this was going to be written as a derived macro but it very quickly became apparent that it would be way too much time to implement and test vs going with the yaml approach, either way, they save writing hundreds of lines of rust code to prompt the user for each config.

**Preview**:
![image](https://user-images.githubusercontent.com/57491488/224116208-2214feb3-19d6-4d33-99fb-6825486c4c71.png)


### How was this PR tested?

Currently, there is not testing, I'm still trying to work out how best to go about unit testing something which takes input from stdin.