### PR TITLE
Fix control plane notifications

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/metastore_event_publisher.rs
+++ b/quickwit/quickwit-metastore/src/metastore/metastore_event_publisher.rs
@@ -25,6 +25,7 @@ use quickwit_common::pubsub::{Event, EventBroker};
 use quickwit_common::uri::Uri;
 use quickwit_config::{IndexConfig, SourceConfig};
 use quickwit_proto::metastore_api::{DeleteQuery, DeleteTask};
+use tracing::info;
 
 use crate::checkpoint::IndexCheckpointDelta;
 use crate::{IndexMetadata, ListSplitsQuery, Metastore, MetastoreResult, Split, SplitMetadata};
@@ -186,6 +187,7 @@ impl Metastore for MetastoreEventPublisher {
             index_id: index_id.to_string(),
             source_config: source.clone(),
         };
+        info!("add source {index_id}, {source:?}");
         self.underlying.add_source(index_id, source).await?;
         self.event_broker.publish(event);
         Ok(())

--- a/quickwit/quickwit-serve/src/grpc.rs
+++ b/quickwit/quickwit-serve/src/grpc.rs
@@ -72,7 +72,7 @@ pub(crate) async fn start_grpc_server(
     };
     // Mount gRPC control plane service if `QuickwitService::ControlPlane` is enabled on node.
     let control_plane_grpc_service = if services.services.contains(&QuickwitService::ControlPlane) {
-        if let Some(control_plane_client) = &services.control_plane_client {
+        if let Some(control_plane_client) = &services.control_plane_service {
             enabled_grpc_services.insert("control-plane");
             let adapter = ControlPlaneServiceGrpcServerAdapter::new(control_plane_client.clone());
             Some(ControlPlaneServiceGrpcServer::new(adapter))

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -18,10 +18,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::net::SocketAddr;
-use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::Future;
 use hyper::header::CONTENT_TYPE;
 use hyper::{http, Response, StatusCode, Uri};
 use quickwit_common::metrics;
@@ -133,23 +131,23 @@ pub(crate) async fn start_rest_server(
         .with(request_counter)
         .recover(recover_fn);
 
-    // let warp_service = warp::service(rest_routes);
-    // let compression_predicate =
-    //     DefaultPredicate::new().and(SizeAbove::new(MINIMUM_RESPONSE_COMPRESSION_SIZE));
+    let warp_service = warp::service(rest_routes);
+    let compression_predicate =
+        DefaultPredicate::new().and(SizeAbove::new(MINIMUM_RESPONSE_COMPRESSION_SIZE));
 
-    // let service = ServiceBuilder::new()
-    //     .layer(
-    //         CompressionLayer::new()
-    //             .gzip(true)
-    //             .compress_when(compression_predicate),
-    //     )
-    //     .service(warp_service);
+    let service = ServiceBuilder::new()
+        .layer(
+            CompressionLayer::new()
+                .gzip(true)
+                .compress_when(compression_predicate),
+        )
+        .service(warp_service);
 
     info!("Searcher ready to accept requests at http://{rest_listen_addr}/");
 
-    let rest_server: Pin<Box<dyn Future<Output = ()> + Send>> =
-        Box::pin(warp::serve(rest_routes).run(rest_listen_addr));
-    rest_server.await;
+    hyper::Server::bind(&rest_listen_addr)
+        .serve(Shared::new(service))
+        .await?;
     Ok(())
 }
 

--- a/quickwit/quickwit-serve/src/test_utils/rest_client.rs
+++ b/quickwit/quickwit-serve/src/test_utils/rest_client.rs
@@ -21,7 +21,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use hyper::client::HttpConnector;
-use hyper::{Body, Response, StatusCode};
+use hyper::{Body, Request, Response, StatusCode};
 use quickwit_cluster::ClusterSnapshot;
 use quickwit_indexing::actors::IndexingServiceCounters;
 use serde::de::DeserializeOwned;
@@ -40,6 +40,25 @@ impl QuickwitRestClient {
             .build_http();
         let root_url = format!("http://{addr}");
         Self { root_url, client }
+    }
+
+    pub async fn create_index(&self, index_config_yaml: &str) -> anyhow::Result<()> {
+        let uri = format!("{}/api/v1/indexes", self.root_url)
+            .parse::<hyper::Uri>()
+            .unwrap();
+        let request = Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header("content-type", "application/yaml")
+            .body(Body::from(index_config_yaml.to_string()))
+            .unwrap();
+        let response = self.client.request(request).await.unwrap();
+        if response.status() == StatusCode::OK {
+            return Ok(());
+        }
+        let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body_string = String::from_utf8(body_bytes.to_vec()).unwrap();
+        Err(anyhow::anyhow!("error when creating index: {body_string}"))
     }
 
     pub async fn cluster_snapshot(&self) -> anyhow::Result<ClusterSnapshot> {


### PR DESCRIPTION
### Description

The control plane notifications are not working for 2 reasons:
- one is described in #2981
- in a cluster mode, the control plane is not notified as we don't instantiate the control plane client to send the notifications, so nothing is sent!

### How was this PR tested?

- [x] add a test on control plane notification on a standalone server
- [x] add a test on control plane notification on a multi-node cluster
