### PR TITLE
QW-2972: Add validator to pulsar address

### DIFF
--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -361,25 +361,14 @@ fn pulsar_uri<'de, D>(deserializer: D) -> Result<String, D::Error>
 where D: Deserializer<'de> {
     let uri: String = Deserialize::deserialize(deserializer)?;
 
-    let remaining = uri
-        .strip_prefix("pulsar://")
-        .ok_or_else(|| Error::custom("Pulsar uri must start with `pulsar://`."))?;
-
     let err_msg = format!(
         "Invalid Pulsar uri provided, must be in the format of `pulsar://host:port/path`. Got: \
          `{uri}`"
     );
-    let (_host, port_and_path) = remaining
-        .split_once(':')
-        .ok_or_else(|| Error::custom(&err_msg))?;
-    let port = port_and_path
-        .split_once('/')
-        .map(|(port, _)| port)
-        .unwrap_or(port_and_path);
 
-    let _port = port
-        .parse::<u16>()
-        .map_err(|_| Error::custom("Invalid port provided for Pulsar address. Got: `{port}`"))?;
+    let _remaining = uri
+        .strip_prefix("pulsar://")
+        .ok_or_else(|| Error::custom(err_msg))?;
 
     Ok(uri)
 }
@@ -950,26 +939,6 @@ mod tests {
             let yaml = r#"
                     topics:
                         - my-topic
-                    address: pulsar://invalid-address
-                "#;
-            serde_yaml::from_str::<PulsarSourceParams>(yaml)
-                .expect_err("Pulsar config should reject invalid address");
-        }
-
-        {
-            let yaml = r#"
-                    topics:
-                        - my-topic
-                    address: pulsar://some-host:invalid-port/
-                "#;
-            serde_yaml::from_str::<PulsarSourceParams>(yaml)
-                .expect_err("Pulsar config should reject invalid address");
-        }
-
-        {
-            let yaml = r#"
-                    topics:
-                        - my-topic
                     address: pulsar://some-host:80/valid-path
                 "#;
             assert_eq!(
@@ -977,6 +946,24 @@ mod tests {
                 PulsarSourceParams {
                     topics: vec!["my-topic".to_string()],
                     address: "pulsar://some-host:80/valid-path".to_string(),
+                    consumer_name: default_consumer_name(),
+                    authentication: None,
+                }
+            );
+        }
+
+        {
+            let yaml = r#"
+                    topics:
+                        - my-topic
+                    address: pulsar://2345:0425:2CA1:0000:0000:0567:5673:23b5:80/valid-path
+                "#;
+            assert_eq!(
+                serde_yaml::from_str::<PulsarSourceParams>(yaml).unwrap(),
+                PulsarSourceParams {
+                    topics: vec!["my-topic".to_string()],
+                    address: "pulsar://2345:0425:2CA1:0000:0000:0567:5673:23b5:80/valid-path"
+                        .to_string(),
                     consumer_name: default_consumer_name(),
                     authentication: None,
                 }

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -328,6 +328,7 @@ pub struct VoidSourceParams;
 pub struct PulsarSourceParams {
     /// List of the topics that the source consumes.
     pub topics: Vec<String>,
+    #[serde(deserialize_with = "pulsar_uri")]
     /// The connection URI for pulsar.
     pub address: String,
     #[schema(default = "quickwit")]
@@ -353,6 +354,18 @@ pub enum PulsarSourceAuth {
         audience: Option<String>,
         scope: Option<String>,
     },
+}
+
+// Deserializing a string into an pulsar uri.
+fn pulsar_uri<'de, D>(deserializer: D) -> Result<String, D::Error>
+where D: Deserializer<'de> {
+    let uri: String = Deserialize::deserialize(deserializer)?;
+
+    if !uri.starts_with("pulsar://") {
+        return Err(Error::custom("Pulsar uri must start with `pulsar://`."))
+    }
+
+    Ok(uri)
 }
 
 fn default_consumer_name() -> String {

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -361,14 +361,12 @@ fn pulsar_uri<'de, D>(deserializer: D) -> Result<String, D::Error>
 where D: Deserializer<'de> {
     let uri: String = Deserialize::deserialize(deserializer)?;
 
-    let err_msg = format!(
-        "Invalid Pulsar uri provided, must be in the format of `pulsar://host:port/path`. Got: \
-         `{uri}`"
-    );
-
-    let _remaining = uri
-        .strip_prefix("pulsar://")
-        .ok_or_else(|| Error::custom(err_msg))?;
+    if uri.strip_prefix("pulsar://").is_none() {
+        return Err(Error::custom(format!(
+            "Invalid Pulsar uri provided, must be in the format of `pulsar://host:port/path`. \
+             Got: `{uri}`"
+        )));
+    }
 
     Ok(uri)
 }


### PR DESCRIPTION
Closes #2972 

Adds the missing validator check to ensure the pulsar address starts with `pulsar://`.

This adds about as much validation as is possible with the limited amount of documentation available.