### PR TITLE
Minor changes meant to simplify the UX of tracing

### DIFF
--- a/docs/distributed-tracing/index.md
+++ b/docs/distributed-tracing/index.md
@@ -23,11 +23,11 @@ Quickwit implements a gRPC service compatible with Jaeger UI. All you need is to
 
 We made a tutorial on [how to analyze Quickwit traces in Jaeger UI](use-jaeger-to-analyze-quickwit-traces.md) that will guide you through the process.
 
-## Disabling the OpenTelemetry endpoint
+## OpenTelemetry service
 
-Quickwit natively supports the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/reference/specification/protocol/otlp/) and provides a gRPC endpoint to receive spans from an OpenTelemetry collector. This endpoint is enabled by default.
+Quickwit natively supports the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/reference/specification/protocol/otlp/) and provides a gRPC endpoint to receive spans from an OpenTelemetry collector, or from your application directly, via an exporter. This endpoint is enabled by default.
 
-If it is not explicitly disable, Quickwit will start the gRPC service ready to receive spans from an OpenTelemetry collector. The spans are indexed on  the `otel-trace-v0` index, and this index will be automatically created if not present. The index doc mapping is described in the next [section](#trace-and-span-data-model).
+When enabled, Quickwit will start the gRPC service ready to receive spans from an OpenTelemetry collector. The spans are indexed on  the `otel-trace-v0` index, and this index will be automatically created if not present. The index doc mapping is described in the next [section](#trace-and-span-data-model).
 
 If for any reason, you want to disable this endpoint, you can:
 - Set the `QW_ENABLE_OTLP_ENDPOINT` environment variable to `false` when starting Quickwit.

--- a/docs/distributed-tracing/index.md
+++ b/docs/distributed-tracing/index.md
@@ -23,21 +23,21 @@ Quickwit implements a gRPC service compatible with Jaeger UI. All you need is to
 
 We made a tutorial on [how to analyze Quickwit traces in Jaeger UI](use-jaeger-to-analyze-quickwit-traces.md) that will guide you through the process.
 
-## Enabling OpenTelemetry service
+## Disabling the OpenTelemetry endpoint
 
 Quickwit natively supports the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/reference/specification/protocol/otlp/) and provides a gRPC endpoint to receive spans from an OpenTelemetry collector. This endpoint is enabled by default.
 
-You can enable/disable it by:
-- Set `QW_ENABLE_OTLP_ENDPOINT` environment variable to `true`/`false` when starting Quickwit.
-- Or [configure the node config](/docs/configuration/node-config.md) by setting the indexer setting `enable_otlp_endpoint` to `true`/`false`:
+If it is not explicitly disable, Quickwit will start the gRPC service ready to receive spans from an OpenTelemetry collector. The spans are indexed on  the `otel-trace-v0` index, and this index will be automatically created if not present. The index doc mapping is described in the next [section](#trace-and-span-data-model).
+
+If for any reason, you want to disable this endpoint, you can:
+- Set the `QW_ENABLE_OTLP_ENDPOINT` environment variable to `false` when starting Quickwit.
+- Or [configure the node config](/docs/configuration/node-config.md) by setting the indexer setting `enable_otlp_endpoint` to `false`.
 
 ```yaml title=node-config.yaml
 # ... Indexer configuration ...
 indexer:
-    enable_otlp_endpoint: true
+    enable_otlp_endpoint: false
 ```
-
-When starting Quickwit with `enable_otlp_endpoint: true`, Quickwit will start the gRPC service ready to receive spans from an OpenTelemetry collector. The spans are indexed on  the `otel-trace-v0` index, this index will be automatically created if not present. The index doc mapping is described in the next [section](#trace-and-span-data-model).
 
 ## Trace and span data model
 

--- a/docs/distributed-tracing/instrument-python-and-send-traces-to-quickwit.md
+++ b/docs/distributed-tracing/instrument-python-and-send-traces-to-quickwit.md
@@ -21,7 +21,7 @@ In this tutorial, we will show you how to instrument a Python [Flask](https://fl
 [Install Quickwit](/docs/get-started/installation.md) and start a Quickwit instance with OTLP service enabled:
 
 ```bash
-QW_ENABLE_OTLP_ENDPOINT=true ./quickwit run
+./quickwit run
 ```
 
 ## Start Jaeger UI

--- a/docs/distributed-tracing/instrument-python-and-send-traces-to-quickwit.md
+++ b/docs/distributed-tracing/instrument-python-and-send-traces-to-quickwit.md
@@ -18,7 +18,7 @@ In this tutorial, we will show you how to instrument a Python [Flask](https://fl
 
 ## Start a Quickwit instance
 
-[Install Quickwit](/docs/get-started/installation.md) and start a Quickwit instance with OTLP service enabled:
+[Install Quickwit](/docs/get-started/installation.md) and start a Quickwit instance:
 
 ```bash
 ./quickwit run
@@ -26,9 +26,9 @@ In this tutorial, we will show you how to instrument a Python [Flask](https://fl
 
 ## Start Jaeger UI
 
-Let's start a Jaeger UI instance with docker. Here we want to connect inform jaeger that it should use quickwit as its backend.
-Due to some idiosyncracy associated with networking with containers, you will need a different approach on MacOS & Windows on one side,
-and Linux on the other side.
+Let's start a Jaeger UI instance with docker. Here we need to inform jaeger that it should use quickwit as its backend.
+
+Due to some idiosyncracy associated with networking with containers, we will have to use a different approach on MacOS & Windows on one side, and Linux on the other side.
 
 ### MacOS & Windows
 

--- a/docs/distributed-tracing/instrument-python-and-send-traces-to-quickwit.md
+++ b/docs/distributed-tracing/instrument-python-and-send-traces-to-quickwit.md
@@ -26,7 +26,13 @@ In this tutorial, we will show you how to instrument a Python [Flask](https://fl
 
 ## Start Jaeger UI
 
-Let's start a Jaeger UI instance with docker
+Let's start a Jaeger UI instance with docker. Here we want to connect inform jaeger that it should use quickwit as its backend.
+Due to some idiosyncracy associated with networking with containers, you will need a different approach on MacOS & Windows on one side,
+and Linux on the other side.
+
+### MacOS & Windows
+
+We can rely on `host.docker.internal` to get the docker bridge ip address, pointing to our quickwit server.
 
 ```bash
 docker run --rm --name jaeger-qw \
@@ -34,6 +40,21 @@ docker run --rm --name jaeger-qw \
     -e GRPC_STORAGE_SERVER=host.docker.internal:7281 \
     -p 16686:16686 \
     jaegertracing/jaeger-query:latest
+```
+
+### Linux
+
+By default, quickwit is listening to `127.0.0.1`, and will not respond to request directed
+to the docker bridge (`172.17.0.1`). There are different ways to solve this problem.
+The easiest is probably to use host network mode.
+
+```bash
+docker run --rm --name jaeger-qw  --network=host \
+    -e SPAN_STORAGE_TYPE=grpc-plugin \
+    -e GRPC_STORAGE_SERVER=127.0.0.1:7281 \
+    -p 16686:16686 \
+    jaegertracing/jaeger-query:latest
+
 ```
 
 ## Run a simple Flask app

--- a/docs/distributed-tracing/use-jaeger-to-analyze-quickwit-traces.md
+++ b/docs/distributed-tracing/use-jaeger-to-analyze-quickwit-traces.md
@@ -13,7 +13,6 @@ In this tutorial, we will show you how Quickwit can eat its own dog food: we wil
 First, start a [Quickwit instance](../get-started/installation.md) with the OTLP service enabled:
 
 ```bash
-QW_ENABLE_OTLP_ENDPOINT=true \
 QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER=true \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:7281 \
 quickwit run
@@ -35,7 +34,7 @@ docker run --rm --name jaeger-qw \
 
 ## Search traces in Jaeger UI
 
-As Quickwit is indexing its own traces, you should be able to see them in Jaeger UI after 30 seconds (the time it takes for Quickwit to do its first commit). 
+As Quickwit is indexing its own traces, you should be able to see them in Jaeger UI after 30 seconds (the time it takes for Quickwit to do its first commit).
 
 Open the Jaeger UI at [http://localhost:16686](http://localhost:16686) and search for traces! By executing search queries, you will then see Quickwit's own traces:
 

--- a/docs/distributed-tracing/use-jaeger-to-analyze-quickwit-traces.md
+++ b/docs/distributed-tracing/use-jaeger-to-analyze-quickwit-traces.md
@@ -22,14 +22,36 @@ We also set `QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER` and `OTEL_EXPORTER_OTLP_ENDP
 
 ## Start Jaeger UI
 
-Let's use docker to quickstart the Jaeger UI:
+Let's start a Jaeger UI instance with docker. Here we want to connect inform jaeger that it should use quickwit as its backend.
+Due to some idiosyncracy associated with networking with containers, you will need a different approach on MacOS & Windows on one side,
+and Linux on the other side.
+
+### MacOS & Windows
+
+We can rely on `host.docker.internal` to get the docker bridge ip address, pointing to our quickwit server.
 
 ```bash
+
 docker run --rm --name jaeger-qw \
     -e SPAN_STORAGE_TYPE=grpc-plugin \
     -e GRPC_STORAGE_SERVER=host.docker.internal:7281 \
     -p 16686:16686 \
     jaegertracing/jaeger-query:latest
+```
+
+### Linux
+
+By default, quickwit is listening to `127.0.0.1`, and will not respond to request directed
+to the docker bridge (`172.17.0.1`). There are different ways to solve this problem.
+The easiest is probably to use host network mode.
+
+```bash
+docker run --rm --name jaeger-qw  --network=host \
+    -e SPAN_STORAGE_TYPE=grpc-plugin \
+    -e GRPC_STORAGE_SERVER=127.0.0.1:7281 \
+    -p 16686:16686 \
+    jaegertracing/jaeger-query:latest
+
 ```
 
 ## Search traces in Jaeger UI

--- a/docs/distributed-tracing/use-jaeger-to-analyze-quickwit-traces.md
+++ b/docs/distributed-tracing/use-jaeger-to-analyze-quickwit-traces.md
@@ -15,23 +15,22 @@ First, start a [Quickwit instance](../get-started/installation.md) with the OTLP
 ```bash
 QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER=true \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:7281 \
-quickwit run
+./quickwit run
 ```
 
 We also set `QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER` and `OTEL_EXPORTER_OTLP_ENDPOINT` environment variables so that Quickwit will send its own traces to itself.
 
 ## Start Jaeger UI
 
-Let's start a Jaeger UI instance with docker. Here we want to connect inform jaeger that it should use quickwit as its backend.
-Due to some idiosyncracy associated with networking with containers, you will need a different approach on MacOS & Windows on one side,
-and Linux on the other side.
+Let's start a Jaeger UI instance with docker. Here we need to inform jaeger that it should use quickwit as its backend.
+
+Due to some idiosyncracy associated with networking with containers, we will have to use a different approach on MacOS & Windows on one side, and Linux on the other side.
 
 ### MacOS & Windows
 
 We can rely on `host.docker.internal` to get the docker bridge ip address, pointing to our quickwit server.
 
 ```bash
-
 docker run --rm --name jaeger-qw \
     -e SPAN_STORAGE_TYPE=grpc-plugin \
     -e GRPC_STORAGE_SERVER=host.docker.internal:7281 \
@@ -56,7 +55,7 @@ docker run --rm --name jaeger-qw  --network=host \
 
 ## Search traces in Jaeger UI
 
-As Quickwit is indexing its own traces, you should be able to see them in Jaeger UI after 30 seconds (the time it takes for Quickwit to do its first commit).
+As Quickwit is indexing its own traces, you should be able to see them in Jaeger UI after 5 seconds (the time it takes for Quickwit to do its first commit).
 
 Open the Jaeger UI at [http://localhost:16686](http://localhost:16686) and search for traces! By executing search queries, you will then see Quickwit's own traces:
 

--- a/docs/log-management/index.md
+++ b/docs/log-management/index.md
@@ -66,6 +66,22 @@ The logs received by this endpoint are indexed on  the `otel-logs-v0` index. Thi
 
 You can also send your logs directly to this index by using the [ingest API](/docs/reference/rest-api.md#ingest-data-into-an-index).
 
+## OpenTelemetry service
+
+Quickwit natively supports the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/reference/specification/protocol/otlp/) and provides a gRPC endpoint to receive spans from an OpenTelemetry collector. This endpoint is enabled by default.
+
+When enabled, Quickwit will start the gRPC service ready to receive spans from an OpenTelemetry collector. The spans are indexed on  the `otel-trace-v0` index, and this index will be automatically created if not present. The index doc mapping is described in the next [section](#trace-and-span-data-model).
+
+If for any reason, you want to disable this endpoint, you can:
+- Set the `QW_ENABLE_OTLP_ENDPOINT` environment variable to `false` when starting Quickwit.
+- Or [configure the node config](/docs/configuration/node-config.md) by setting the indexer setting `enable_otlp_endpoint` to `false`.
+
+```yaml title=node-config.yaml
+# ... Indexer configuration ...
+indexer:
+    enable_otlp_endpoint: false
+```
+
 ## OpenTelemetry logs data model
 
 Quickwit sends OpenTelemetry logs into the `otel-logs-v0` index which is automatically created if you enable the OpenTelemetry service.
@@ -154,7 +170,7 @@ search_settings:
 Currently, Quickwit provides a simplistic UI to get basic information from the cluster, indexes and search documents.
 If a simple UI is not sufficient for you and you need additional features, Grafana and Elasticsearch query API support are planned for Q2 2023, stay tuned!
 
-You can also send traces to Quickwit that you can visualize in Jaeger UI, as explained in the following [tutorial](./use-jaeger-to-analyze-quickwit-traces).
+You can also send traces to Quickwit that you can visualize in Jaeger UI, as explained in the following [tutorial](./distributed-tracing/instrument-python-and-send-traces-to-quickwit).
 
 
 ## Known limitations

--- a/docs/log-management/index.md
+++ b/docs/log-management/index.md
@@ -60,21 +60,9 @@ Currently, we have tested the following HTTP-based agents:
 - FluentD (tutorial coming soon)
 - Logstash: Quickwit does not support the Elasticsearch output. However, it's possible to send logs with the HTTP output but with `json` [format](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html) only.
 
-## Enabling/disabling the OpenTelemetry service
+Quickwit natively supports the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/reference/specification/protocol/otlp/) and provides a gRPC endpoint to receive logs from an OpenTelemetry collector by default.
 
-Quickwit natively supports the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/reference/specification/protocol/otlp/) and provides a gRPC endpoint to receive logs from an OpenTelemetry collector. This endpoint is enabled by default.
-
-You can enable/disable it by:
-- Set `QW_ENABLE_OTLP_ENDPOINT` environment variable to `true`/`false` when starting Quickwit.
-- Or [configure the node config](/docs/configuration/node-config.md) by setting the indexer setting `enable_otlp_endpoint` to `true`/`false`:
-
-```yaml title=node-config.yaml
-# ... Indexer configuration ...
-indexer:
-    enable_otlp_endpoint: true
-```
-
-When starting Quickwit with `enable_otlp_endpoint: true`, Quickwit will start the gRPC service ready to receive logs from an OpenTelemetry collector. The logs are indexed on  the `otel-logs-v0` index, this index will be automatically created if not present. The index doc mapping is described in this [section](#opentelemetry-logs-data-model).
+The logs received by this endpoint are indexed on  the `otel-logs-v0` index. This index will be automatically created if not present. The index doc mapping is described in this [section](#opentelemetry-logs-data-model).
 
 You can also send your logs directly to this index by using the [ingest API](/docs/reference/rest-api.md#ingest-data-into-an-index).
 
@@ -166,7 +154,8 @@ search_settings:
 Currently, Quickwit provides a simplistic UI to get basic information from the cluster, indexes and search documents.
 If a simple UI is not sufficient for you and you need additional features, Grafana and Elasticsearch query API support are planned for Q2 2023, stay tuned!
 
-You can also send traces to Quickwit that you can visualize in Jaeger UI. Tutorial coming soon.
+You can also send traces to Quickwit that you can visualize in Jaeger UI, as explained in the following [tutorial](./use-jaeger-to-analyze-quickwit-traces).
+
 
 ## Known limitations
 

--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -108,8 +108,8 @@ doc_mapping:
 
   timestamp_field: timestamp_secs
 
-  partition_key: hash_mod(service_name, 100)
-  tag_fields: [service_name]
+  # partition_key: hash_mod(service_name, 100)
+  # tag_fields: [service_name]
 
 indexing_settings:
   commit_timeout_secs: 5

--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -112,7 +112,7 @@ doc_mapping:
   tag_fields: [service_name]
 
 indexing_settings:
-  commit_timeout_secs: 30
+  commit_timeout_secs: 5
 
 search_settings:
   default_search_fields: []

--- a/quickwit/quickwit-opentelemetry/src/otlp/trace.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/trace.rs
@@ -139,8 +139,8 @@ doc_mapping:
 
   timestamp_field: span_start_timestamp_secs
 
-  partition_key: hash_mod(service_name, 100)
-  tag_fields: [service_name]
+  # partition_key: hash_mod(service_name, 100)
+  # tag_fields: [service_name]
 
 indexing_settings:
   commit_timeout_secs: 5

--- a/quickwit/quickwit-opentelemetry/src/otlp/trace.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/trace.rs
@@ -143,7 +143,7 @@ doc_mapping:
   tag_fields: [service_name]
 
 indexing_settings:
-  commit_timeout_secs: 30
+  commit_timeout_secs: 5
 
 search_settings:
   default_search_fields: []


### PR DESCRIPTION
- tracing commits every 5s by default
- removes QW_ENABLE_OTLP_ENDPOINT=true as it is the default
- we only talk about disabling that endpoint in one place and link that information somewhere else.
- adding a link to the tracing tutorial.
- Fixed instruction for linux


I could not test the changes so leaving as draft for the moment.