### PR TITLE
add support for forcing commit or waiting for a commit on file ingest…

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4945,6 +4945,7 @@ dependencies = [
  "quickwit-common",
  "quickwit-config",
  "quickwit-indexing",
+ "quickwit-ingest",
  "quickwit-metastore",
  "quickwit-search",
  "quickwit-serve",

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -129,7 +129,7 @@ pub fn build_index_command<'a>() -> Command<'a> {
                     Arg::new("force")
                         .long("force")
                         .short('f')
-                        .help("Force a commit after the last document is sent, and wait for all documents to be commited .nd available before exiting")
+                        .help("Force a commit after the last document is sent, and wait for all documents to be committed and available for search before exiting")
                         .takes_value(false)
                         .conflicts_with("wait"),
                 ])

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -28,7 +28,7 @@ use std::{fmt, io};
 use anyhow::{bail, Context};
 use byte_unit::Byte;
 use bytes::Bytes;
-use clap::{arg, ArgMatches, Command};
+use clap::{arg, Arg, ArgMatches, Command};
 use colored::{ColoredString, Colorize};
 use humantime::format_duration;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -42,7 +42,7 @@ use quickwit_indexing::IndexingPipeline;
 use quickwit_metastore::{IndexMetadata, Split, SplitState};
 use quickwit_proto::SortOrder;
 use quickwit_rest_client::models::IngestSource;
-use quickwit_rest_client::rest_client::{IngestEvent, QuickwitClient, Transport};
+use quickwit_rest_client::rest_client::{CommitType, IngestEvent, QuickwitClient, Transport};
 use quickwit_search::SearchResponseRest;
 use quickwit_serve::{ListSplitsQueryParams, SearchRequestQueryString, SortByField};
 use quickwit_storage::load_file;
@@ -121,6 +121,16 @@ pub fn build_index_command<'a>() -> Command<'a> {
                         .display_order(1),
                     arg!(--"input-path" <INPUT_PATH> "Location of the input file.")
                         .required(false),
+                    Arg::new("wait")
+                        .long("wait")
+                        .short('w')
+                        .help("Enable waiting after the last document is sent")
+                        .takes_value(false),
+                    Arg::new("force")
+                        .long("force")
+                        .short('f')
+                        .help("Force a commit after the last document is sent")
+                        .takes_value(false),
                 ])
             )
         .subcommand(
@@ -182,6 +192,7 @@ pub struct IngestDocsArgs {
     pub cluster_endpoint: Url,
     pub index_id: String,
     pub input_path_opt: Option<PathBuf>,
+    pub commit_type: CommitType,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -323,11 +334,18 @@ impl IndexCliCommand {
         } else {
             None
         };
+        let commit_type = match (matches.is_present("wait"), matches.is_present("force")) {
+            (false, false) => CommitType::Auto,
+            (false, true) => CommitType::Force,
+            (true, false) => CommitType::WaitFor,
+            (true, true) => bail!("Can't specify both --wait and --force"),
+        };
 
         Ok(Self::Ingest(IngestDocsArgs {
             cluster_endpoint,
             index_id,
             input_path_opt,
+            commit_type,
         }))
     }
 
@@ -784,7 +802,12 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
         None => IngestSource::Stdin,
     };
     qw_client
-        .ingest(&args.index_id, ingest_source, Some(&update_progress_bar))
+        .ingest(
+            &args.index_id,
+            ingest_source,
+            Some(&update_progress_bar),
+            args.commit_type,
+        )
         .await?;
     progress_bar.finish();
     println!(

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -124,13 +124,14 @@ pub fn build_index_command<'a>() -> Command<'a> {
                     Arg::new("wait")
                         .long("wait")
                         .short('w')
-                        .help("Wait for a document to be commited before exiting")
+                        .help("Wait for all documents to be commited and available for search before exiting")
                         .takes_value(false),
                     Arg::new("force")
                         .long("force")
                         .short('f')
-                        .help("Force a commit after the last document is sent, and wait for the commit to finish")
-                        .takes_value(false),
+                        .help("Force a commit after the last document is sent, and wait for all documents to be commited .nd available before exiting")
+                        .takes_value(false)
+                        .conflicts_with("wait"),
                 ])
             )
         .subcommand(

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -124,12 +124,12 @@ pub fn build_index_command<'a>() -> Command<'a> {
                     Arg::new("wait")
                         .long("wait")
                         .short('w')
-                        .help("Enable waiting after the last document is sent")
+                        .help("Wait for a document to be commited before exiting")
                         .takes_value(false),
                     Arg::new("force")
                         .long("force")
                         .short('f')
-                        .help("Force a commit after the last document is sent")
+                        .help("Force a commit after the last document is sent, and wait for the commit to finish")
                         .takes_value(false),
                 ])
             )

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -186,6 +186,7 @@ mod tests {
         ExtractSplitArgs, GarbageCollectIndexArgs, LocalIngestDocsArgs, MergeArgs, ToolCliCommand,
     };
     use quickwit_common::uri::Uri;
+    use quickwit_rest_client::rest_client::CommitType;
     use reqwest::Url;
 
     #[test]
@@ -278,12 +279,14 @@ mod tests {
                     cluster_endpoint,
                     index_id,
                     input_path_opt: None,
+                    commit_type: CommitType::Auto,
                 })) if &index_id == "wikipedia"
                        && cluster_endpoint == Url::from_str("http://127.0.0.1:8000").unwrap()
         ));
 
         let app = build_cli().no_binary_name(true);
-        let matches = app.try_get_matches_from(["index", "ingest", "--index", "wikipedia"])?;
+        let matches =
+            app.try_get_matches_from(["index", "ingest", "--index", "wikipedia", "--force"])?;
         let command = CliCommand::parse_cli_args(&matches)?;
         assert!(matches!(
             command,
@@ -292,9 +295,37 @@ mod tests {
                     cluster_endpoint,
                     index_id,
                     input_path_opt: None,
+                    commit_type: CommitType::Force,
                 })) if &index_id == "wikipedia"
                         && cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
         ));
+
+        let app = build_cli().no_binary_name(true);
+        let matches =
+            app.try_get_matches_from(["index", "ingest", "--index", "wikipedia", "--wait"])?;
+        let command = CliCommand::parse_cli_args(&matches)?;
+        assert!(matches!(
+            command,
+            CliCommand::Index(IndexCliCommand::Ingest(
+                IngestDocsArgs {
+                    cluster_endpoint,
+                    index_id,
+                    input_path_opt: None,
+                    commit_type: CommitType::WaitFor,
+                })) if &index_id == "wikipedia"
+                        && cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
+        ));
+
+        let app = build_cli().no_binary_name(true);
+        let matches = app.try_get_matches_from([
+            "index",
+            "ingest",
+            "--index",
+            "wikipedia",
+            "--wait",
+            "--force",
+        ])?;
+        assert!(CliCommand::parse_cli_args(&matches).is_err());
         Ok(())
     }
 

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -317,15 +317,19 @@ mod tests {
         ));
 
         let app = build_cli().no_binary_name(true);
-        let matches = app.try_get_matches_from([
-            "index",
-            "ingest",
-            "--index",
-            "wikipedia",
-            "--wait",
-            "--force",
-        ])?;
-        assert!(CliCommand::parse_cli_args(&matches).is_err());
+        assert_eq!(
+            app.try_get_matches_from([
+                "index",
+                "ingest",
+                "--index",
+                "wikipedia",
+                "--wait",
+                "--force",
+            ])
+            .unwrap_err()
+            .kind(),
+            clap::ErrorKind::ArgumentConflict
+        );
         Ok(())
     }
 

--- a/quickwit/quickwit-ingest/src/lib.rs
+++ b/quickwit/quickwit-ingest/src/lib.rs
@@ -115,7 +115,7 @@ pub async fn start_ingest_api_service(
 }
 
 #[repr(u32)]
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all(deserialize = "snake_case"))]
 #[derive(Default)]
 pub enum CommitType {
@@ -132,6 +132,16 @@ impl From<u32> for CommitType {
             1 => CommitType::WaitFor,
             2 => CommitType::Force,
             _ => panic!("Unknown commit type {value}"),
+        }
+    }
+}
+
+impl CommitType {
+    pub fn to_query_parameter(&self) -> Option<&'static str> {
+        match self {
+            CommitType::Auto => None,
+            CommitType::WaitFor => Some("commit=wait_for"),
+            CommitType::Force => Some("commit=force"),
         }
     }
 }

--- a/quickwit/quickwit-rest-client/Cargo.toml
+++ b/quickwit/quickwit-rest-client/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 
 quickwit-common = { workspace = true }
 quickwit-config = { workspace = true }
+quickwit-ingest = { workspace = true }
 quickwit-metastore = { workspace = true }
 quickwit-search = { workspace = true }
 quickwit-serve = { workspace = true }

--- a/quickwit/quickwit-rest-client/src/lib.rs
+++ b/quickwit/quickwit-rest-client/src/lib.rs
@@ -35,6 +35,7 @@ pub(crate) struct BatchLineReader {
     alloc_num_bytes: usize,
     max_batch_num_bytes: usize,
     num_lines: usize,
+    has_next: bool,
 }
 
 impl BatchLineReader {
@@ -58,6 +59,7 @@ impl BatchLineReader {
             alloc_num_bytes,
             max_batch_num_bytes,
             num_lines: 0,
+            has_next: true,
         }
     }
 
@@ -86,6 +88,7 @@ impl BatchLineReader {
                 return Ok(Some(Bytes::from(batch)));
             }
             if line_num_bytes == 0 {
+                self.has_next = false;
                 if self.buffer.is_empty() {
                     return Ok(None);
                 }
@@ -94,6 +97,14 @@ impl BatchLineReader {
             }
             self.num_lines += 1;
         }
+    }
+
+    /// Returns whether there is still data available
+    ///
+    /// This can spuriously return `true` when there was no data
+    /// to send at all.
+    pub fn has_next(&self) -> bool {
+        self.has_next
     }
 
     #[cfg(any(test, feature = "testsuite"))]

--- a/quickwit/quickwit-rest-client/src/rest_client.rs
+++ b/quickwit/quickwit-rest-client/src/rest_client.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use quickwit_common::FileEntry;
 use quickwit_config::{ConfigFormat, SourceConfig};
+pub use quickwit_ingest::CommitType;
 use quickwit_metastore::{IndexMetadata, Split};
 use quickwit_search::SearchResponseRest;
 use quickwit_serve::{ListSplitsQueryParams, SearchRequestQueryString};
@@ -144,6 +145,7 @@ impl QuickwitClient {
         index_id: &str,
         ingest_source: IngestSource,
         on_ingest_event: Option<&dyn Fn(IngestEvent)>,
+        last_block_commit: CommitType,
     ) -> Result<(), Error> {
         let ingest_path = format!("{index_id}/ingest");
         let mut batch_reader = match ingest_source {
@@ -154,10 +156,24 @@ impl QuickwitClient {
         };
         while let Some(batch) = batch_reader.next_batch().await? {
             loop {
-                let response = self
-                    .transport
-                    .send::<()>(Method::POST, &ingest_path, None, None, Some(batch.clone()))
-                    .await?;
+                let response = if let (Some(query_param), false) = (
+                    last_block_commit.to_query_parameter(),
+                    batch_reader.has_next(),
+                ) {
+                    self.transport
+                        .send::<()>(
+                            Method::POST,
+                            &format!("{ingest_path}?{query_param}"),
+                            None,
+                            None,
+                            Some(batch.clone()),
+                        )
+                        .await?
+                } else {
+                    self.transport
+                        .send::<()>(Method::POST, &ingest_path, None, None, Some(batch.clone()))
+                        .await?
+                };
 
                 if response.status_code() == StatusCode::TOO_MANY_REQUESTS {
                     if let Some(event_fn) = &on_ingest_event {
@@ -422,6 +438,7 @@ mod test {
     use bytes::Bytes;
     use quickwit_config::{ConfigFormat, SourceConfig};
     use quickwit_indexing::mock_split;
+    use quickwit_ingest::CommitType;
     use quickwit_metastore::IndexMetadata;
     use quickwit_search::SearchResponseRest;
     use quickwit_serve::{ListSplitsQueryParams, SearchRequestQueryString};
@@ -529,7 +546,7 @@ mod test {
             .await;
         let ingest_source = IngestSource::File(PathBuf::from_str(&ndjson_filepath).unwrap());
         qw_client
-            .ingest("my-index", ingest_source, None)
+            .ingest("my-index", ingest_source, None, CommitType::Auto)
             .await
             .unwrap();
     }
@@ -558,7 +575,7 @@ mod test {
             .await;
         let ingest_source = IngestSource::File(PathBuf::from_str(&ndjson_filepath).unwrap());
         let error = qw_client
-            .ingest("my-index", ingest_source, None)
+            .ingest("my-index", ingest_source, None, CommitType::Auto)
             .await
             .unwrap_err();
         assert!(matches!(error, Error::Api(_)));


### PR DESCRIPTION
### Description

add command line arguments to wait for/force a commit when ingesting from the cli

### How was this PR tested?

setting a very high commit timeout, and verifying a commit get trigger at the end of the ingestion

in practice it almost always hit [this timeout](https://github.com/quickwit-oss/quickwit/pull/3049/files#diff-4c0fcf5f3d94686949a73e623bde2f115360207eb410946a969fefae1605feceR83). It should be made much bigger for `commit=wait_for/force`, but maybe not for `commit=auto`