### PR TITLE
Update tantivy and integrate the Columnar work

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3578,7 +3578,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6687,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6740,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "bitpacking",
 ]
@@ -6748,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "fastdivide",
  "fnv",
@@ -6764,7 +6764,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6787,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "combine",
  "once_cell",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "tantivy-common",
  "tantivy-fst",
@@ -6806,7 +6806,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "byteorder",
  "murmurhash32",
@@ -6816,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=059fc767e#059fc767ea854c5dd6dfa819ff0f2514dd606859"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3578,7 +3578,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6687,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6740,12 +6740,15 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
+dependencies = [
+ "bitpacking",
+]
 
 [[package]]
 name = "tantivy-columnar"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "fastdivide",
  "fnv",
@@ -6761,7 +6764,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6784,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "combine",
  "once_cell",
@@ -6794,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "tantivy-common",
  "tantivy-fst",
@@ -6803,7 +6806,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "byteorder",
  "murmurhash32",
@@ -6813,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=694a05625#694a056255b966fb63839cabdb47dc99eb19d008"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -283,13 +283,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -951,7 +951,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
- "encode_unicode 0.3.6",
+ "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
@@ -1057,9 +1057,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1239,12 +1239,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote 1.0.26",
- "syn 1.0.109",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1280,24 +1280,24 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.26",
  "scratch",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -1674,12 +1674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,21 +1780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 
 [[package]]
-name = "fastfield_codecs"
-version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
-dependencies = [
- "fastdivide",
- "itertools",
- "log",
- "measure_time",
- "prettytable-rs",
- "rand 0.8.5",
- "tantivy-bitpacker",
- "tantivy-common",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,12 +1875,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "8ea55201cc351fdb478217c0fb641b59813da9b4efe4c414a9d8f989a657d149"
 dependencies = [
  "libc",
+ "rustix 0.35.13",
  "winapi 0.3.9",
 ]
 
@@ -2081,7 +2061,7 @@ checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -2485,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -2520,13 +2500,13 @@ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "inherent"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c03e372fd0ed313db7e83f37bbc15218ba94f08a462998a590bae6de3dcdbc"
+checksum = "20cc83c51f04b1ad3b24cbac53d2ec1a138d699caabe05d315cb8538e8624d01"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -2559,13 +2539,19 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "inventory"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498ae1c9c329c7972b917506239b557a60386839192f1cf0ca034f345b65db99"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
 dependencies = [
  "ctor",
  "ghost",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
 name = "io-lifetimes"
@@ -2600,8 +2586,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 1.0.9",
+ "rustix 0.36.11",
  "windows-sys 0.45.0",
 ]
 
@@ -2670,15 +2656,15 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+checksum = "f34313ec00c2eb5c3c87ca6732ea02dcf3af99c3ff7a8fb622ffb99c9d860a87"
 dependencies = [
  "ascii-canvas",
- "atty",
  "bit-set",
  "diff",
  "ena",
+ "is-terminal",
  "itertools",
  "lalrpop-util",
  "petgraph",
@@ -2693,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+checksum = "e5c1f7869c94d214466c5fd432dfed12c379fd87786768d36455892d46b18edd"
 dependencies = [
  "regex",
 ]
@@ -2750,6 +2736,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2811,6 +2803,15 @@ name = "lru"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
  "hashbrown 0.13.2",
 ]
@@ -2995,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -3010,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -3061,12 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "murmurhash32"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d736ff882f0e85fe9689fb23db229616c4c00aee2b3ac282f666d8f20eb25d4a"
-dependencies = [
- "byteorder",
-]
+checksum = "d9380db4c04d219ac5c51d14996bbf2c2e9a15229771b53f8671eb6c83cf44df"
 
 [[package]]
 name = "nanorand"
@@ -3580,7 +3578,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4031,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.11"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28f53e8b192565862cf99343194579a022eb9c7dd3a8d03134734803c7b3125"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -4041,26 +4039,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4508c0eff4d1e708551034de4bddd61bf8bda8c7b5ae72bd844cf68ea21117ac"
+checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
  "proc-macro2",
- "syn 2.0.8",
-]
-
-[[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode 1.0.0",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -4114,9 +4098,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -4131,7 +4115,7 @@ dependencies = [
  "byteorder",
  "hex",
  "lazy_static",
- "rustix",
+ "rustix 0.36.11",
 ]
 
 [[package]]
@@ -4195,7 +4179,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease 0.1.11",
+ "prettyplease 0.1.25",
  "prost",
  "prost-types",
  "regex",
@@ -4459,13 +4443,13 @@ dependencies = [
  "async-trait",
  "dyn-clone",
  "mockall",
- "prettyplease 0.2.0",
+ "prettyplease 0.2.4",
  "proc-macro2",
  "prost",
  "prost-build",
  "quote 1.0.26",
  "serde",
- "syn 2.0.8",
+ "syn 2.0.10",
  "thiserror",
  "tokio",
  "tonic",
@@ -4666,7 +4650,6 @@ dependencies = [
  "serde_json",
  "siphasher",
  "tantivy",
- "tantivy-query-grammar",
  "thiserror",
  "time 0.3.20",
  "time-fmt",
@@ -4965,13 +4948,12 @@ dependencies = [
  "async-trait",
  "bytes",
  "chitchat",
- "fastfield_codecs",
  "fnv",
  "futures",
  "http",
  "hyper",
  "itertools",
- "lru",
+ "lru 0.9.0",
  "mockall",
  "once_cell",
  "opentelemetry",
@@ -5073,7 +5055,7 @@ dependencies = [
  "bytes",
  "fnv",
  "futures",
- "lru",
+ "lru 0.9.0",
  "md5",
  "mockall",
  "once_cell",
@@ -5324,9 +5306,9 @@ checksum = "feff7c275fbc4a96ccdc240a5a180487a61a31baffaff6cdd4fb2c8e9e0a2ecd"
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5582,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "6.6.0"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb133b9a38b5543fad3807fb2028ea47c5f2b566f4f5e28a11902f1a358348b6"
+checksum = "1b68543d5527e158213414a92832d2aab11a84d2571a5eb021ebe22c43aab066"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -5626,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.29.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1b21b8760b0ef8ae5b43d40913ff711a2053cb7ff892a34facff7a6365375a"
+checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
 dependencies = [
  "arrayvec 0.7.2",
  "borsh",
@@ -5668,15 +5650,29 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.5",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 1.0.9",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
 ]
 
@@ -5957,7 +5953,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -6629,9 +6625,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
@@ -6690,8 +6686,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.19.1-quickwit"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+version = "0.19.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6705,13 +6701,12 @@ dependencies = [
  "downcast-rs",
  "fail",
  "fastdivide",
- "fastfield_codecs",
- "fs2",
+ "fs4",
  "htmlescape",
  "itertools",
  "levenshtein_automata",
  "log",
- "lru",
+ "lru 0.10.0",
  "lz4_flex",
  "measure_time",
  "memmap2",
@@ -6727,6 +6722,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tantivy-bitpacker",
+ "tantivy-columnar",
  "tantivy-common",
  "tantivy-fst",
  "tantivy-query-grammar",
@@ -6744,16 +6740,34 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.1.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
+dependencies = [
+ "fastdivide",
+ "fnv",
+ "itertools",
+ "log",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
 
 [[package]]
 name = "tantivy-common"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
 dependencies = [
  "async-trait",
  "byteorder",
  "ownedbytes",
+ "serde",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -6770,7 +6784,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
 dependencies = [
  "combine",
  "once_cell",
@@ -6780,10 +6794,8 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
 dependencies = [
- "ciborium",
- "serde",
  "tantivy-common",
  "tantivy-fst",
 ]
@@ -6791,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
 dependencies = [
  "byteorder",
  "murmurhash32",
@@ -6801,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?tag=quickwit-0.5-rev#7ce8a65619280e7e804cc8d0d3e6581503b27739"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2b6a4da64#2b6a4da64075b2c8195047cd0b987b64b8481627"
 dependencies = [
  "serde",
 ]
@@ -6826,7 +6838,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.36.11",
  "windows-sys 0.42.0",
 ]
 
@@ -6888,7 +6900,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -7286,7 +7298,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
- "prettyplease 0.1.11",
+ "prettyplease 0.1.25",
  "proc-macro2",
  "prost-build",
  "quote 1.0.26",
@@ -7495,7 +7507,7 @@ checksum = "bb01b60fcc3f5e17babb1a9956263f3ccd2cadc3e52908400231441683283c1d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -8358,9 +8370,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
@@ -8438,9 +8450,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zip"

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -219,14 +219,12 @@ quickwit-serve = { version = "0.5.0", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.5.0", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.5.0", path = "./quickwit-telemetry" }
 
-fastfield_codecs = { git = "https://github.com/quickwit-oss/tantivy/", tag = "quickwit-0.5-rev" }
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", tag = "quickwit-0.5-rev", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "2b6a4da64", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",
   "quickwit",
 ] }
-tantivy-query-grammar = { git = "https://github.com/quickwit-oss/tantivy/", tag = "quickwit-0.5-rev" }
 
 # This is actually not used directly the goal is to fix the version
 # used by reqwest. 0.8.30 has an unclear license.

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -219,7 +219,7 @@ quickwit-serve = { version = "0.5.0", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.5.0", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.5.0", path = "./quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "2b6a4da64", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "694a05625", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -219,7 +219,7 @@ quickwit-serve = { version = "0.5.0", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.5.0", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.5.0", path = "./quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "694a05625", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "059fc767e", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -68,7 +68,6 @@ async fn local_ingest_docs(input_path: &Path, test_env: &TestEnv) -> anyhow::Res
         clear_cache: true,
         vrl_script: None,
     };
-
     local_ingest_docs_cli(args).await
 }
 

--- a/quickwit/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit/quickwit-doc-mapper/Cargo.toml
@@ -24,7 +24,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 siphasher = { workspace = true }
 tantivy = { workspace = true }
-tantivy-query-grammar = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 time-fmt = "0.3.8"

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_type.rs
@@ -144,12 +144,11 @@ impl<'de> Deserialize<'de> for InputFormats {
 #[cfg(test)]
 mod tests {
 
-    use tantivy::schema::Cardinality;
     use time::macros::datetime;
 
     use super::*;
     use crate::default_doc_mapper::FieldMappingType;
-    use crate::FieldMappingEntry;
+    use crate::{Cardinality, FieldMappingEntry};
 
     #[test]
     fn test_date_time_options_single_value_deser() {

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -175,14 +175,17 @@ fn validate_timestamp_field_if_any(builder: &DefaultDocMapperBuilder) -> anyhow:
     {
         if cardinality != &Cardinality::SingleValue {
             bail!(
-                "Multiple values are forbidden for  the timestamp field (`{timestamp_field_name}`)."
+                "Multiple values are forbidden for  the timestamp field \
+                 (`{timestamp_field_name}`)."
             );
         }
         if !date_time_option.fast {
             bail!("The timestamp field `{timestamp_field_name}`is required to be a fast field.");
         }
     } else {
-        bail!("The timestamp field `{timestamp_field_name}` is required to have the datetime type.");
+        bail!(
+            "The timestamp field `{timestamp_field_name}` is required to have the datetime type."
+        );
     }
     Ok(())
 }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -25,19 +25,20 @@ use quickwit_proto::SearchRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Value as JsonValue};
 use tantivy::query::Query;
-use tantivy::schema::{Cardinality, Field, FieldType, Schema, Value as TantivyValue, STORED};
+use tantivy::schema::{Field, FieldType, Schema, Value as TantivyValue, STORED};
 use tantivy::Document;
 
 use super::field_mapping_entry::QuickwitTextTokenizer;
 use super::DefaultDocMapperBuilder;
 use crate::default_doc_mapper::mapping_tree::{build_mapping_tree, MappingNode, MappingTree};
+use crate::default_doc_mapper::FieldMappingType;
 pub use crate::default_doc_mapper::QuickwitJsonOptions;
 use crate::doc_mapper::{JsonObject, Partition};
 use crate::query_builder::build_query;
 use crate::routing_expression::RoutingExpr;
 use crate::{
-    DocMapper, DocParsingError, ModeType, QueryParserError, WarmupInfo, DYNAMIC_FIELD_NAME,
-    SOURCE_FIELD_NAME,
+    Cardinality, DocMapper, DocParsingError, ModeType, QueryParserError, WarmupInfo,
+    DYNAMIC_FIELD_NAME, SOURCE_FIELD_NAME,
 };
 
 /// Defines how an unmapped field should be handled.
@@ -160,41 +161,28 @@ fn list_required_fields(field_mappings: &MappingTree) -> Vec<Field> {
     }
 }
 
-fn resolve_timestamp_field(
-    timestamp_field_name_opt: Option<&String>,
-    schema: &Schema,
-) -> anyhow::Result<()> {
-    if let Some(ref timestamp_field_name) = timestamp_field_name_opt {
-        let timestamp_field = schema
-            .get_field(timestamp_field_name)
-            .with_context(|| format!("Unknown timestamp field: `{timestamp_field_name}`"))?;
-
-        let timestamp_field_entry = schema.get_field_entry(timestamp_field);
-        if !timestamp_field_entry.is_fast() {
+fn validate_timestamp_field_if_any(builder: &DefaultDocMapperBuilder) -> anyhow::Result<()> {
+    let Some(timestamp_field_name) = builder.timestamp_field.as_ref() else {
+        return Ok(());
+    };
+    let Some(timestamp_field_entry) = builder.field_mappings.iter().find(|mapping| {
+                &mapping.name == timestamp_field_name
+            }) else {
+                bail!("Missing timestamp field in field mappings: `{}`", timestamp_field_name);
+            };
+    if let FieldMappingType::DateTime(date_time_option, cardinality) =
+        &timestamp_field_entry.mapping_type
+    {
+        if cardinality != &Cardinality::SingleValue {
             bail!(
-                "Timestamp field must be a fast field, please add the fast property to your field \
-                 `{}`.",
-                timestamp_field_name
-            )
+                "Multiple values are forbidden for  the timestamp field (`{timestamp_field_name}`)."
+            );
         }
-        match timestamp_field_entry.field_type() {
-            FieldType::Date(options) => {
-                if options.get_fastfield_cardinality() == Some(Cardinality::MultiValues) {
-                    bail!(
-                        "Timestamp field cannot be an array, please change your field `{}` from \
-                         an array to a single value.",
-                        timestamp_field_name
-                    )
-                }
-            }
-            _ => {
-                bail!(
-                    "Timestamp field must be of type datetime, please change your field type `{}` \
-                     to datetime.",
-                    timestamp_field_name
-                )
-            }
+        if !date_time_option.fast {
+            bail!("The timestamp field `{timestamp_field_name}`is required to be a fast field.");
         }
+    } else {
+        bail!("The timestamp field `{timestamp_field_name}` is required to have the datetime type.");
     }
     Ok(())
 }
@@ -211,6 +199,8 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
         } else {
             None
         };
+
+        validate_timestamp_field_if_any(&builder)?;
 
         let dynamic_field = if let Mode::Dynamic(json_options) = &mode {
             Some(schema_builder.add_json_field(DYNAMIC_FIELD_NAME, json_options.clone()))
@@ -234,8 +224,6 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
                 .with_context(|| format!("Unknown default search field: `{field_name}`"))?;
             default_search_field_names.push(field_name.clone());
         }
-
-        resolve_timestamp_field(builder.timestamp_field.as_ref(), &schema)?;
 
         // Resolve tag fields
         let mut tag_field_names: BTreeSet<String> = Default::default();
@@ -271,7 +259,7 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
 impl From<DefaultDocMapper> for DefaultDocMapperBuilder {
     fn from(default_doc_mapper: DefaultDocMapper) -> Self {
         let mode = default_doc_mapper.mode.mode_type();
-        let dynamic_mapping = match &default_doc_mapper.mode {
+        let dynamic_mapping: Option<QuickwitJsonOptions> = match &default_doc_mapper.mode {
             Mode::Dynamic(mapping_options) => Some(mapping_options.clone()),
             _ => None,
         };
@@ -596,7 +584,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fail_to_build_doc_mapper_with_non_fast_timestamp_field() -> anyhow::Result<()> {
+    fn test_fail_to_build_doc_mapper_with_non_datetime_timestamp_field() {
         let doc_mapper = r#"{
             "default_search_fields": [],
             "timestamp_field": "timestamp",
@@ -608,16 +596,32 @@ mod tests {
                 }
             ]
         }"#;
-        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper)?;
-        let expected_msg = "Timestamp field must be a fast field, please add the fast property to \
-                            your field `timestamp`."
-            .to_string();
-        assert_eq!(builder.try_build().unwrap_err().to_string(), expected_msg);
-        Ok(())
+        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
+        let expected_msg = "The timestamp field `timestamp` is required to have the datetime type.";
+        assert_eq!(&builder.try_build().unwrap_err().to_string(), &expected_msg);
     }
 
     #[test]
-    fn test_fail_to_build_doc_mapper_with_duplicate_fields() -> anyhow::Result<()> {
+    fn test_fail_to_build_doc_mapper_with_non_fast_timestamp_field() {
+        let doc_mapper = r#"{
+            "default_search_fields": [],
+            "timestamp_field": "timestamp",
+            "tag_fields": [],
+            "field_mappings": [
+                {
+                    "name": "timestamp",
+                    "type": "datetime",
+                    "fast": false
+                }
+            ]
+        }"#;
+        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
+        let expected_msg = "The timestamp field `timestamp`is required to be a fast field.";
+        assert_eq!(&builder.try_build().unwrap_err().to_string(), &expected_msg);
+    }
+
+    #[test]
+    fn test_fail_to_build_doc_mapper_with_duplicate_fields() {
         {
             let doc_mapper = r#"{
                 "field_mappings": [
@@ -625,9 +629,9 @@ mod tests {
                     {"name": "body","type": "bytes"}
                 ]
             }"#;
-            let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper)?;
-            let expected_msg = "Duplicated field definition `body`.".to_string();
-            assert_eq!(builder.try_build().unwrap_err().to_string(), expected_msg);
+            let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
+            let expected_msg = "Duplicated field definition `body`.";
+            assert_eq!(&builder.try_build().unwrap_err().to_string(), expected_msg);
         }
 
         {
@@ -644,16 +648,14 @@ mod tests {
                     {"type": "text", "name": "body"}
                 ]
             }"#;
-            let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper)?;
-            let expected_msg = "Duplicated field definition `username`.".to_string();
-            assert_eq!(builder.try_build().unwrap_err().to_string(), expected_msg);
+            let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
+            let expected_msg = "Duplicated field definition `username`.";
+            assert_eq!(&builder.try_build().unwrap_err().to_string(), expected_msg);
         }
-        Ok(())
     }
 
     #[test]
-    fn test_should_build_doc_mapper_with_duplicate_fields_at_different_level() -> anyhow::Result<()>
-    {
+    fn test_should_build_doc_mapper_with_duplicate_fields_at_different_level() {
         let doc_mapper = r#"{
             "field_mappings": [
                 {
@@ -667,13 +669,12 @@ mod tests {
                 {"type": "text", "name": "body"}
             ]
         }"#;
-        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper)?;
+        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
         assert!(builder.try_build().is_ok());
-        Ok(())
     }
 
     #[test]
-    fn test_fail_to_build_doc_mapper_with_multivalued_timestamp_field() -> anyhow::Result<()> {
+    fn test_fail_to_build_doc_mapper_with_multivalued_timestamp_field() {
         let doc_mapper = r#"{
             "default_search_fields": [],
             "timestamp_field": "timestamp",
@@ -687,12 +688,9 @@ mod tests {
             ]
         }"#;
 
-        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper)?;
-        let expected_msg = "Timestamp field cannot be an array, please change your field \
-                            `timestamp` from an array to a single value."
-            .to_string();
-        assert_eq!(builder.try_build().unwrap_err().to_string(), expected_msg);
-        Ok(())
+        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
+        let expected_msg = "Multiple values are forbidden for  the timestamp field (`timestamp`).";
+        assert_eq!(&builder.try_build().unwrap_err().to_string(), expected_msg);
     }
 
     #[test]

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
@@ -90,6 +90,14 @@ impl Default for DefaultDocMapperBuilder {
     }
 }
 
+// By default, in dynamic mode, all fields are fast fields.
+fn default_dynamic_mapping() -> QuickwitJsonOptions {
+    QuickwitJsonOptions {
+        fast: true,
+        ..Default::default()
+    }
+}
+
 impl DefaultDocMapperBuilder {
     pub(crate) fn mode(&self) -> anyhow::Result<Mode> {
         if self.mode != ModeType::Dynamic && self.dynamic_mapping.is_some() {
@@ -101,7 +109,11 @@ impl DefaultDocMapperBuilder {
         Ok(match self.mode {
             ModeType::Lenient => Mode::Lenient,
             ModeType::Strict => Mode::Strict,
-            ModeType::Dynamic => Mode::Dynamic(self.dynamic_mapping.clone().unwrap_or_default()),
+            ModeType::Dynamic => Mode::Dynamic(
+                self.dynamic_mapping
+                    .clone()
+                    .unwrap_or_else(default_dynamic_mapping),
+            ),
         })
     }
 

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_type.rs
@@ -17,18 +17,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use tantivy::schema::{Cardinality, Type};
+use tantivy::schema::Type;
 
 use super::date_time_type::QuickwitDateTimeOptions;
 use crate::default_doc_mapper::field_mapping_entry::{
     QuickwitIpAddrOptions, QuickwitJsonOptions, QuickwitNumericOptions, QuickwitObjectOptions,
     QuickwitTextOptions,
 };
+use crate::Cardinality;
 
 /// A `FieldMappingType` defines the type and indexing options
 /// of a mapping field.
 #[derive(Clone, Debug, PartialEq)]
-pub enum FieldMappingType {
+pub(crate) enum FieldMappingType {
     /// String mapping type configuration.
     Text(QuickwitTextOptions, Cardinality),
     /// Signed 64-bit integer mapping type configuration.

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
@@ -27,8 +27,8 @@ use base64::prelude::{Engine, BASE64_STANDARD};
 use itertools::Itertools;
 use serde_json::Value as JsonValue;
 use tantivy::schema::{
-    BytesOptions, Cardinality, Field, IntoIpv6Addr, IpAddrOptions, JsonObjectOptions,
-    NumericOptions, SchemaBuilder, TextOptions, Value as TantivyValue,
+    BytesOptions, Field, IntoIpv6Addr, IpAddrOptions, JsonObjectOptions, NumericOptions,
+    SchemaBuilder, TextOptions, Value as TantivyValue,
 };
 use tantivy::{DateOptions, Document};
 use tracing::warn;
@@ -38,7 +38,7 @@ use crate::default_doc_mapper::field_mapping_entry::{
     QuickwitIpAddrOptions, QuickwitNumericOptions, QuickwitObjectOptions, QuickwitTextOptions,
 };
 use crate::default_doc_mapper::{FieldMappingType, QuickwitJsonOptions};
-use crate::{DocParsingError, FieldMappingEntry, ModeType};
+use crate::{Cardinality, DocParsingError, FieldMappingEntry, ModeType};
 
 #[derive(Clone, Debug)]
 pub enum LeafType {
@@ -505,10 +505,7 @@ fn build_mapping_tree_from_entries<'a>(
     Ok(mapping_node)
 }
 
-fn get_numeric_options(
-    quickwit_numeric_options: &QuickwitNumericOptions,
-    cardinality: Cardinality,
-) -> NumericOptions {
+fn get_numeric_options(quickwit_numeric_options: &QuickwitNumericOptions) -> NumericOptions {
     let mut numeric_options = NumericOptions::default();
     if quickwit_numeric_options.stored {
         numeric_options = numeric_options.set_stored();
@@ -517,15 +514,12 @@ fn get_numeric_options(
         numeric_options = numeric_options.set_indexed();
     }
     if quickwit_numeric_options.fast {
-        numeric_options = numeric_options.set_fast(cardinality);
+        numeric_options = numeric_options.set_fast();
     }
     numeric_options
 }
 
-fn get_date_time_options(
-    quickwit_date_time_options: &QuickwitDateTimeOptions,
-    cardinality: Cardinality,
-) -> DateOptions {
+fn get_date_time_options(quickwit_date_time_options: &QuickwitDateTimeOptions) -> DateOptions {
     let mut date_time_options = DateOptions::default();
     if quickwit_date_time_options.stored {
         date_time_options = date_time_options.set_stored();
@@ -534,7 +528,7 @@ fn get_date_time_options(
         date_time_options = date_time_options.set_indexed();
     }
     if quickwit_date_time_options.fast {
-        date_time_options = date_time_options.set_fast(cardinality);
+        date_time_options = date_time_options.set_fast();
     }
     date_time_options.set_precision(quickwit_date_time_options.precision)
 }
@@ -553,10 +547,7 @@ fn get_bytes_options(quickwit_numeric_options: &QuickwitNumericOptions) -> Bytes
     bytes_options
 }
 
-fn get_ip_address_options(
-    quickwit_ip_address_options: &QuickwitIpAddrOptions,
-    cardinality: Cardinality,
-) -> IpAddrOptions {
+fn get_ip_address_options(quickwit_ip_address_options: &QuickwitIpAddrOptions) -> IpAddrOptions {
     let mut ip_address_options = IpAddrOptions::default();
     if quickwit_ip_address_options.stored {
         ip_address_options = ip_address_options.set_stored();
@@ -565,7 +556,7 @@ fn get_ip_address_options(
         ip_address_options = ip_address_options.set_indexed();
     }
     if quickwit_ip_address_options.fast {
-        ip_address_options = ip_address_options.set_fast(cardinality);
+        ip_address_options = ip_address_options.set_fast();
     }
     ip_address_options
 }
@@ -612,7 +603,7 @@ fn build_mapping_from_field_type<'a>(
             Ok(MappingTree::Leaf(mapping_leaf))
         }
         FieldMappingType::I64(options, cardinality) => {
-            let numeric_options = get_numeric_options(options, *cardinality);
+            let numeric_options = get_numeric_options(options);
             let field = schema_builder.add_i64_field(&field_name, numeric_options);
             let mapping_leaf = MappingLeaf {
                 field,
@@ -622,7 +613,7 @@ fn build_mapping_from_field_type<'a>(
             Ok(MappingTree::Leaf(mapping_leaf))
         }
         FieldMappingType::U64(options, cardinality) => {
-            let numeric_options = get_numeric_options(options, *cardinality);
+            let numeric_options = get_numeric_options(options);
             let field = schema_builder.add_u64_field(&field_name, numeric_options);
             let mapping_leaf = MappingLeaf {
                 field,
@@ -632,7 +623,7 @@ fn build_mapping_from_field_type<'a>(
             Ok(MappingTree::Leaf(mapping_leaf))
         }
         FieldMappingType::F64(options, cardinality) => {
-            let numeric_options = get_numeric_options(options, *cardinality);
+            let numeric_options = get_numeric_options(options);
             let field = schema_builder.add_f64_field(&field_name, numeric_options);
             let mapping_leaf = MappingLeaf {
                 field,
@@ -642,7 +633,7 @@ fn build_mapping_from_field_type<'a>(
             Ok(MappingTree::Leaf(mapping_leaf))
         }
         FieldMappingType::Bool(options, cardinality) => {
-            let numeric_options = get_numeric_options(options, *cardinality);
+            let numeric_options = get_numeric_options(options);
             let field = schema_builder.add_bool_field(&field_name, numeric_options);
             let mapping_leaf = MappingLeaf {
                 field,
@@ -652,7 +643,7 @@ fn build_mapping_from_field_type<'a>(
             Ok(MappingTree::Leaf(mapping_leaf))
         }
         FieldMappingType::IpAddr(options, cardinality) => {
-            let ip_addr_options = get_ip_address_options(options, *cardinality);
+            let ip_addr_options = get_ip_address_options(options);
             let field = schema_builder.add_ip_addr_field(&field_name, ip_addr_options);
             let mapping_leaf = MappingLeaf {
                 field,
@@ -662,7 +653,7 @@ fn build_mapping_from_field_type<'a>(
             Ok(MappingTree::Leaf(mapping_leaf))
         }
         FieldMappingType::DateTime(options, cardinality) => {
-            let date_time_options = get_date_time_options(options, *cardinality);
+            let date_time_options = get_date_time_options(options);
             let field = schema_builder.add_date_field(&field_name, date_time_options);
             let mapping_leaf = MappingLeaf {
                 field,
@@ -706,7 +697,7 @@ mod tests {
     use std::net::IpAddr;
 
     use serde_json::{json, Value as JsonValue};
-    use tantivy::schema::{Cardinality, Field, IntoIpv6Addr, Value as TantivyValue};
+    use tantivy::schema::{Field, IntoIpv6Addr, Value as TantivyValue};
     use tantivy::{DateTime, Document};
     use time::macros::datetime;
 
@@ -715,6 +706,7 @@ mod tests {
     use crate::default_doc_mapper::field_mapping_entry::{
         QuickwitIpAddrOptions, QuickwitNumericOptions, QuickwitTextOptions,
     };
+    use crate::Cardinality;
 
     #[test]
     fn test_field_name_from_field_path() {

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -38,7 +38,7 @@ pub use self::field_mapping_entry::{
 pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,
 };
-pub use self::field_mapping_type::FieldMappingType;
+pub(crate) use self::field_mapping_type::FieldMappingType;
 use crate::QW_RESERVED_FIELD_NAMES;
 
 /// Regular expression validating a field mapping name.

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper.rs
@@ -196,12 +196,12 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use quickwit_proto::SearchRequest;
-    use tantivy::schema::{Cardinality, Field, FieldType, Term};
+    use tantivy::schema::{Field, FieldType, Term};
 
     use crate::default_doc_mapper::{FieldMappingType, QuickwitJsonOptions, QuickwitTextOptions};
     use crate::{
-        DefaultDocMapperBuilder, DocMapper, DocParsingError, FieldMappingEntry, WarmupInfo,
-        DYNAMIC_FIELD_NAME,
+        Cardinality, DefaultDocMapperBuilder, DocMapper, DocParsingError, FieldMappingEntry,
+        WarmupInfo, DYNAMIC_FIELD_NAME,
     };
 
     const JSON_DEFAULT_DOC_MAPPER: &str = r#"

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -54,6 +54,12 @@ pub const DYNAMIC_FIELD_NAME: &str = "_dynamic";
 /// Quickwit reserved field names.
 const QW_RESERVED_FIELD_NAMES: &[&str] = &[SOURCE_FIELD_NAME, DYNAMIC_FIELD_NAME];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum Cardinality {
+    SingleValue,
+    MultiValues,
+}
+
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(
     QuickwitJsonOptions,

--- a/quickwit/quickwit-doc-mapper/src/query_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/query_builder.rs
@@ -22,8 +22,8 @@ use std::collections::{HashMap, HashSet};
 use anyhow::{bail, Context};
 use quickwit_proto::SearchRequest;
 use tantivy::query::{Query, QueryParser, QueryParserError as TantivyQueryParserError};
+use tantivy::query_grammar::{UserInputAst, UserInputLeaf, UserInputLiteral};
 use tantivy::schema::{Field, FieldEntry, FieldType, Schema};
-use tantivy_query_grammar::{UserInputAst, UserInputLeaf, UserInputLiteral};
 
 use crate::{QueryParserError, WarmupInfo, DYNAMIC_FIELD_NAME, QUICKWIT_TOKENIZER_MANAGER};
 
@@ -33,7 +33,7 @@ pub(crate) fn build_query(
     request: &SearchRequest,
     default_field_names: &[String],
 ) -> Result<(Box<dyn Query>, WarmupInfo), QueryParserError> {
-    let user_input_ast = tantivy_query_grammar::parse_query(&request.query)
+    let user_input_ast = tantivy::query_grammar::parse_query(&request.query)
         .map_err(|_| TantivyQueryParserError::SyntaxError(request.query.to_string()))?;
 
     let fast_field_names: HashSet<String> = extract_field_with_ranges(&schema, &user_input_ast)?;
@@ -303,9 +303,7 @@ fn validate_sort_by_score(
 mod test {
     use quickwit_proto::SearchRequest;
     use tantivy::query::QueryParserError;
-    use tantivy::schema::{
-        Cardinality, DateOptions, IpAddrOptions, Schema, FAST, INDEXED, STORED, TEXT,
-    };
+    use tantivy::schema::{Schema, FAST, INDEXED, STORED, TEXT};
 
     use super::{build_query, validate_requested_snippet_fields};
     use crate::{DYNAMIC_FIELD_NAME, SOURCE_FIELD_NAME};
@@ -325,15 +323,9 @@ mod test {
         schema_builder.add_text_field(SOURCE_FIELD_NAME, TEXT);
         schema_builder.add_json_field(DYNAMIC_FIELD_NAME, TEXT);
         schema_builder.add_ip_addr_field("ip", FAST | STORED);
-        schema_builder.add_ip_addr_field(
-            "ips",
-            IpAddrOptions::default().set_fast(Cardinality::MultiValues),
-        );
+        schema_builder.add_ip_addr_field("ips", FAST);
         schema_builder.add_ip_addr_field("ip_notff", STORED);
-        schema_builder.add_date_field(
-            "dt",
-            DateOptions::default().set_fast(Cardinality::SingleValue),
-        );
+        schema_builder.add_date_field("dt", FAST);
         schema_builder.add_u64_field("u64_fast", FAST | STORED);
         schema_builder.add_i64_field("i64_fast", FAST | STORED);
         schema_builder.add_f64_field("f64_fast", FAST | STORED);
@@ -346,7 +338,7 @@ mod test {
         search_fields: Vec<String>,
         default_search_fields: Option<Vec<String>>,
         expected: TestExpectation,
-    ) -> anyhow::Result<()> {
+    ) {
         let request = SearchRequest {
             aggregation_request: None,
             index_id: "test_index".to_string(),
@@ -390,27 +382,23 @@ mod test {
                 );
             }
         }
-
-        Ok(())
     }
 
     #[test]
     fn test_build_query() {
-        check_build_query("*", vec![], None, TestExpectation::Ok("All")).unwrap();
+        check_build_query("*", vec![], None, TestExpectation::Ok("All"));
         check_build_query(
             "foo:bar",
             vec![],
             None,
             TestExpectation::Err("Field does not exist: 'foo'"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "server.type:hpc server.mem:4GB",
             vec![],
             None,
             TestExpectation::Err("Field does not exist: 'server.type'"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "title:[a TO b]",
             vec![],
@@ -419,8 +407,7 @@ mod test {
                 "Field `title` is of type `Str`. Range queries are only supported on boolean, \
                  datetime, IP, and numeric fields",
             ),
-        )
-        .unwrap();
+        );
         check_build_query(
             "title:{a TO b} desc:foo",
             vec![],
@@ -429,8 +416,7 @@ mod test {
                 "Field `title` is of type `Str`. Range queries are only supported on boolean, \
                  datetime, IP, and numeric fields",
             ),
-        )
-        .unwrap();
+        );
         check_build_query(
             "title:>foo",
             vec![],
@@ -439,78 +425,67 @@ mod test {
                 "Field `title` is of type `Str`. Range queries are only supported on boolean, \
                  datetime, IP, and numeric fields",
             ),
-        )
-        .unwrap();
+        );
         check_build_query(
             "title:foo desc:bar _source:baz",
             vec![],
             None,
             TestExpectation::Ok("TermQuery"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "title:foo desc:bar",
             vec!["url".to_string()],
             None,
             TestExpectation::Err("field does not exist: 'url'"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "server.name:\".bar:\" server.mem:4GB",
             vec!["server.name".to_string()],
             None,
             TestExpectation::Ok("TermQuery"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "server.name:\"for.bar:b\" server.mem:4GB",
             vec![],
             None,
             TestExpectation::Ok("TermQuery"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "foo",
             vec![],
             Some(vec![]),
             TestExpectation::Err("No default field declared and no field specified in query."),
-        )
-        .unwrap();
+        );
         check_build_query(
             "bar",
             vec![],
             Some(vec![DYNAMIC_FIELD_NAME.to_string()]),
             TestExpectation::Err("No default field declared and no field specified in query."),
-        )
-        .unwrap();
+        );
         check_build_query(
             "title:hello AND (Jane OR desc:world)",
             vec![],
             Some(vec![DYNAMIC_FIELD_NAME.to_string()]),
             TestExpectation::Err("No default field declared and no field specified in query."),
-        )
-        .unwrap();
+        );
         check_build_query(
             "server.running:true",
             vec![],
             None,
             TestExpectation::Ok("TermQuery"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "title: IN [hello]",
             vec![],
             None,
             TestExpectation::Ok("TermSetQuery"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "IN [hello]",
             vec![],
             None,
             TestExpectation::Err("Unsupported query: Set query need to target a specific field."),
-        )
-        .unwrap();
+        );
     }
 
     #[test]
@@ -520,15 +495,13 @@ mod test {
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"dt\", value_type: Date"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "dt:<2023-01-10T15:13:35Z",
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"dt\", value_type: Date"),
-        )
-        .unwrap();
+        );
     }
 
     #[test]
@@ -540,20 +513,18 @@ mod test {
             TestExpectation::Ok(
                 "RangeQuery { field: \"ip\", value_type: IpAddr, left_bound: Included([0, 0, 0, \
                  0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1]), right_bound: Included([0, 0, 0, \
-                 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 1, 1, 1]) }",
+                 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 1, 1, 1])",
             ),
-        )
-        .unwrap();
+        );
         check_build_query(
             "ip:>127.0.0.1",
             Vec::new(),
             None,
             TestExpectation::Ok(
                 "RangeQuery { field: \"ip\", value_type: IpAddr, left_bound: Excluded([0, 0, 0, \
-                 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1]), right_bound: Unbounded }",
+                 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1]), right_bound: Unbounded",
             ),
-        )
-        .unwrap();
+        );
     }
 
     #[test]
@@ -563,15 +534,13 @@ mod test {
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"f64_fast\", value_type: F64"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "f64_fast:>7",
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"f64_fast\", value_type: F64"),
-        )
-        .unwrap();
+        );
     }
 
     #[test]
@@ -581,15 +550,13 @@ mod test {
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"i64_fast\", value_type: I64"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "i64_fast:>7",
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"i64_fast\", value_type: I64"),
-        )
-        .unwrap();
+        );
     }
 
     #[test]
@@ -599,15 +566,13 @@ mod test {
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"u64_fast\", value_type: U64"),
-        )
-        .unwrap();
+        );
         check_build_query(
             "u64_fast:>7",
             Vec::new(),
             None,
             TestExpectation::Ok("RangeQuery { field: \"u64_fast\", value_type: U64"),
-        )
-        .unwrap();
+        );
     }
 
     #[test]
@@ -619,10 +584,9 @@ mod test {
             TestExpectation::Ok(
                 "RangeQuery { field: \"ips\", value_type: IpAddr, left_bound: Included([0, 0, 0, \
                  0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1]), right_bound: Included([0, 0, 0, \
-                 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 1, 1, 1]) }",
+                 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 1, 1, 1])",
             ),
-        )
-        .unwrap();
+        );
     }
 
     #[test]
@@ -632,8 +596,7 @@ mod test {
             Vec::new(),
             None,
             TestExpectation::Err("field `ip_notff` is not declared as a fast field"),
-        )
-        .unwrap();
+        );
     }
 
     #[track_caller]
@@ -657,7 +620,7 @@ mod test {
             sort_order: None,
             sort_by_field: None,
         };
-        let user_input_ast = tantivy_query_grammar::parse_query(&request.query)
+        let user_input_ast = tantivy::query_grammar::parse_query(&request.query)
             .map_err(|_| QueryParserError::SyntaxError(request.query.clone()))
             .unwrap();
         let default_field_names =
@@ -667,15 +630,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "provided string was not `true` or `false`")]
     fn test_build_query_not_bool_should_fail() {
         check_build_query(
             "server.running:not a bool",
             vec![],
             None,
-            TestExpectation::Err("Expected a success when parsing TermQuery, but got error"),
-        )
-        .unwrap();
+            TestExpectation::Err("Expected a bool value: 'ParseBoolError'"),
+        );
     }
 
     #[test]

--- a/quickwit/quickwit-doc-mapper/src/tag_pruning.rs
+++ b/quickwit/quickwit-doc-mapper/src/tag_pruning.rs
@@ -22,7 +22,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use tantivy::query::QueryParserError as TantivyQueryParserError;
-use tantivy_query_grammar::{Occur, UserInputAst, UserInputLeaf, UserInputLiteral};
+use tantivy::query_grammar::{Occur, UserInputAst, UserInputLeaf, UserInputLiteral};
 
 use crate::QueryParserError;
 
@@ -46,7 +46,7 @@ pub fn match_tag_field_name(field_name: &str, tag: &str) -> bool {
 /// associated with a split, we are guaranteed that no documents
 /// in the split matches the query.
 pub fn extract_tags_from_query(user_query: &str) -> Result<Option<TagFilterAst>, QueryParserError> {
-    let user_input_ast = tantivy_query_grammar::parse_query(user_query)
+    let user_input_ast = tantivy::query_grammar::parse_query(user_query)
         .map_err(|_| TantivyQueryParserError::SyntaxError(user_query.to_string()))?;
     Ok(user_input_ast_to_tags_filter_ast(user_input_ast))
 }

--- a/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
@@ -152,17 +152,6 @@ impl From<B64TraceId> for TraceId {
     }
 }
 
-impl TryFrom<&[u8]> for B64TraceId {
-    type Error = TryFromB64TraceIdError;
-
-    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        let trace_id = slice
-            .try_into()
-            .map_err(|_| TryFromB64TraceIdError(slice.len()))?;
-        Ok(B64TraceId(trace_id))
-    }
-}
-
 impl TryFrom<Vec<u8>> for B64TraceId {
     type Error = TryFromB64TraceIdError;
 
@@ -177,8 +166,12 @@ impl TryFrom<Vec<u8>> for B64TraceId {
 impl FromStr for B64TraceId {
     type Err = TryFromB64TraceIdError;
 
-    fn from_str(trace_id: &str) -> Result<Self, Self::Err> {
-        trace_id.as_bytes().try_into()
+    fn from_str(b64_trace_id_str: &str) -> Result<Self, Self::Err> {
+        let trace_id = b64_trace_id_str
+            .as_bytes()
+            .try_into()
+            .map_err(|_| TryFromB64TraceIdError(b64_trace_id_str.len()))?;
+        Ok(B64TraceId(trace_id))
     }
 }
 

--- a/quickwit/quickwit-search/Cargo.toml
+++ b/quickwit/quickwit-search/Cargo.toml
@@ -16,7 +16,6 @@ bytes = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
-fastfield_codecs = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
 lru = { workspace = true }

--- a/quickwit/quickwit-search/src/filters.rs
+++ b/quickwit/quickwit-search/src/filters.rs
@@ -18,9 +18,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::ops::{Bound, RangeBounds, RangeInclusive};
-use std::sync::Arc;
 
-use fastfield_codecs::Column;
+use tantivy::fastfield::Column;
 use tantivy::{DateTime, DocId, SegmentReader};
 
 /// A filter that only retains docs within a time range.
@@ -29,14 +28,16 @@ pub struct TimestampFilter {
     /// The time range represented as (lower_bound, upper_bound).
     // TODO replace this with a RangeInclusive<DateTime> if it improves perf?
     time_range: (Bound<DateTime>, Bound<DateTime>),
-    /// The timestamp fast field reader.
-    time_column: Arc<dyn Column<DateTime>>,
+    timestamp_column: Column<DateTime>,
 }
 
 impl TimestampFilter {
     pub fn is_within_range(&self, doc_id: DocId) -> bool {
-        let timestamp_value: DateTime = self.time_column.get_val(doc_id);
-        self.time_range.contains(&timestamp_value)
+        if let Some(ts) = self.timestamp_column.first(doc_id) {
+            self.time_range.contains(&ts)
+        } else {
+            false
+        }
     }
 }
 
@@ -86,22 +87,27 @@ impl TimestampFilterBuilder {
         }
     }
 
+    /// None means that all
     pub fn build(
         &self,
         segment_reader: &SegmentReader,
     ) -> tantivy::Result<Option<TimestampFilter>> {
-        let timestamp_field_reader = segment_reader
-            .fast_fields()
-            .date(&self.timestamp_field_name)?;
+        let timestamp_column_opt: Option<Column<DateTime>> =
+            segment_reader
+                .fast_fields()
+                .column_opt::<DateTime>(&self.timestamp_field_name)?;
+        let Some(timestamp_column) = timestamp_column_opt else {
+            return Ok(None);
+        };
         let segment_range: RangeInclusive<DateTime> =
-            timestamp_field_reader.min_value()..=timestamp_field_reader.max_value();
+            timestamp_column.min_value()..=timestamp_column.max_value();
         let time_range = (self.start_timestamp, self.end_timestamp);
         if is_segment_always_within_timestamp_range(segment_range, time_range) {
             return Ok(None);
         }
         Ok(Some(TimestampFilter {
             time_range,
-            time_column: timestamp_field_reader,
+            timestamp_column,
         }))
     }
 }

--- a/quickwit/quickwit-search/src/find_trace_ids_collector.rs
+++ b/quickwit/quickwit-search/src/find_trace_ids_collector.rs
@@ -20,15 +20,15 @@
 use std::cmp::{Ord, Ordering};
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 use fnv::{FnvHashMap, FnvHashSet};
 use itertools::Itertools;
 use quickwit_opentelemetry::otlp::B64TraceId;
 use serde::{Deserialize, Serialize};
 use tantivy::collector::{Collector, SegmentCollector};
-use tantivy::fastfield::{Column, MultiValuedFastFieldReader};
-use tantivy::{DateTime, DocId, InvertedIndexReader, Score, SegmentReader};
+use tantivy::columnar::StrColumn;
+use tantivy::fastfield::Column;
+use tantivy::{DateTime, DocId, Score, SegmentReader};
 
 type TermOrd = u64;
 
@@ -152,20 +152,22 @@ impl Collector for FindTraceIdsCollector {
         _segment_local_id: u32,
         segment_reader: &SegmentReader,
     ) -> tantivy::Result<Self::Child> {
-        let trace_id_ff_reader = segment_reader
+        let trace_id_column = segment_reader
             .fast_fields()
-            .u64s(&self.trace_id_field_name)?;
-        let span_timestamp_column = segment_reader
+            .str(&self.trace_id_field_name)?
+            .ok_or_else(|| {
+                let err_msg = format!(
+                    "Failed to find column for trace_id field `{}`",
+                    self.trace_id_field_name
+                );
+                tantivy::TantivyError::InternalError(err_msg)
+            })?;
+        let span_timestamp_column: Column<DateTime> = segment_reader
             .fast_fields()
             .date(&self.span_timestamp_field_name)?;
-        let trace_id_field = segment_reader
-            .schema()
-            .get_field(&self.trace_id_field_name)?;
-        let inverted_index_reader = segment_reader.inverted_index(trace_id_field)?;
-        Ok(Self::Child {
-            trace_id_ff_reader,
+        Ok(FindTraceIdsSegmentCollector {
+            trace_id_column,
             span_timestamp_column,
-            inverted_index_reader,
             select_trace_ids: SelectTraceIds::new(self.num_traces),
         })
     }
@@ -203,21 +205,21 @@ fn merge_segment_fruits(mut segment_fruits: Vec<Vec<Span>>, num_traces: usize) -
 }
 
 pub struct FindTraceIdsSegmentCollector {
-    trace_id_ff_reader: MultiValuedFastFieldReader<u64>,
-    span_timestamp_column: Arc<dyn Column<DateTime>>,
-    inverted_index_reader: Arc<InvertedIndexReader>,
+    trace_id_column: StrColumn,
+    span_timestamp_column: Column<DateTime>,
     select_trace_ids: SelectTraceIds,
 }
 
 impl FindTraceIdsSegmentCollector {
     fn trace_id_term_ord(&self, doc: DocId) -> TermOrd {
-        self.trace_id_ff_reader
-            .get_first_val(doc)
-            .expect("There should be exactly one trace ID per span.")
+        self.trace_id_column
+            .term_ords(doc)
+            .next()
+            .unwrap_or_default()
     }
 
     fn span_timestamp(&self, doc: DocId) -> DateTime {
-        self.span_timestamp_column.get_val(doc)
+        self.span_timestamp_column.first(doc).unwrap_or_default()
     }
 }
 
@@ -231,25 +233,20 @@ impl SegmentCollector for FindTraceIdsSegmentCollector {
     }
 
     fn harvest(self) -> Self::Fruit {
-        let mut buffer = Vec::with_capacity(24);
-
+        let mut buffer = String::with_capacity(24);
         self.select_trace_ids
             .harvest()
             .into_iter()
-            .map(|trace_id| {
-                let span_timestamp = trace_id.span_timestamp;
-
+            .map(|trace_id_term_ord| {
+                let span_timestamp = trace_id_term_ord.span_timestamp;
                 let found_term = self
-                    .inverted_index_reader
-                    .terms()
-                    .ord_to_term(trace_id.term_ord, &mut buffer)
-                    .expect("The term ord should exist in the term dict.");
-
+                    .trace_id_column
+                    .ord_to_str(trace_id_term_ord.term_ord, &mut buffer)
+                    .expect("Failed to lookup in the trace id column term dictionary");
                 debug_assert!(found_term);
                 debug_assert_eq!(buffer.len(), 24);
-
                 let trace_id = buffer[..]
-                    .try_into()
+                    .parse()
                     .expect("The term dict should store Base64 trace IDs.");
                 Span::new(trace_id, span_timestamp)
             })

--- a/quickwit/quickwit-search/src/find_trace_ids_collector.rs
+++ b/quickwit/quickwit-search/src/find_trace_ids_collector.rs
@@ -242,7 +242,7 @@ impl SegmentCollector for FindTraceIdsSegmentCollector {
                 let found_term = self
                     .trace_id_column
                     .ord_to_str(trace_id_term_ord.term_ord, &mut buffer)
-                    .expect("Failed to lookup in the trace id column term dictionary");
+                    .expect("Failed to lookup trace ID in the column term dictionary");
                 debug_assert!(found_term);
                 debug_assert_eq!(buffer.len(), 24);
                 let trace_id = buffer[..]

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -18,15 +18,12 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{HashMap, HashSet};
-use std::io;
 use std::ops::Bound;
 use std::path::PathBuf;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::Context;
 use futures::future::try_join_all;
-use futures::Future;
 use itertools::{Either, Itertools};
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_doc_mapper::{DocMapper, WarmupInfo, QUICKWIT_TOKENIZER_MANAGER};
@@ -39,7 +36,8 @@ use quickwit_storage::{
 };
 use tantivy::collector::Collector;
 use tantivy::directory::FileSlice;
-use tantivy::schema::{Cardinality, Field, FieldType};
+use tantivy::fastfield::FastFieldReaders;
+use tantivy::schema::{Field, FieldType};
 use tantivy::{Index, ReloadPolicy, Searcher, Term};
 use tokio::task::spawn_blocking;
 use tracing::*;
@@ -181,7 +179,10 @@ async fn warm_up_term_dict_fields(
             .schema()
             .get_field(term_dict_field_name)
             .with_context(|| {
-                format!("Couldn't get field named {term_dict_field_name:?} from schema.")
+                format!(
+                    "Couldn't get field named `{term_dict_field_name}` from schema to warm up \
+                     term dicts."
+                )
             })?;
 
         term_dict_fields.push(term_dict_field);
@@ -207,10 +208,9 @@ async fn warm_up_postings(
 ) -> anyhow::Result<()> {
     let mut fields = Vec::new();
     for field_name in field_names.iter() {
-        let field = searcher
-            .schema()
-            .get_field(field_name)
-            .with_context(|| format!("Couldn't get field named {field_name:?} from schema."))?;
+        let field = searcher.schema().get_field(field_name).with_context(|| {
+            format!("Couldn't get field named `{field_name}` from schema to warm up postings.")
+        })?;
 
         fields.push(field);
     }
@@ -226,85 +226,37 @@ async fn warm_up_postings(
     Ok(())
 }
 
-// The field cardinality is not the same as the fast field cardinality.
-//
-// E.g. a single valued bytes field has a multivalued fast field cardinality.
-fn get_fastfield_cardinality(field_type: &FieldType) -> Option<Cardinality> {
-    match field_type {
-        FieldType::U64(options)
-        | FieldType::I64(options)
-        | FieldType::F64(options)
-        | FieldType::Bool(options) => options.get_fastfield_cardinality(),
-        FieldType::Date(options) => options.get_fastfield_cardinality(),
-        FieldType::Facet(_) => Some(Cardinality::MultiValues),
-        FieldType::Bytes(options) => {
-            if options.is_fast() {
-                Some(Cardinality::MultiValues)
-            } else {
-                None
-            }
-        }
-        FieldType::Str(options) => {
-            if options.is_fast() {
-                Some(Cardinality::MultiValues)
-            } else {
-                None
-            }
-        }
-        FieldType::IpAddr(options) => options.get_fastfield_cardinality(),
-        FieldType::JsonObject(_options) => None,
-    }
+async fn warm_up_fastfield(
+    fast_field_reader: &FastFieldReaders,
+    fast_field_name: &str,
+) -> anyhow::Result<()> {
+    let columns = fast_field_reader
+        .list_dynamic_column_handles(fast_field_name)
+        .await?;
+    futures::future::try_join_all(
+        columns
+            .into_iter()
+            .map(|col| async move { col.file_slice().read_bytes_async().await }),
+    )
+    .await?;
+    Ok(())
 }
 
-fn fast_field_idxs(fast_field_cardinality: Cardinality) -> &'static [usize] {
-    match fast_field_cardinality {
-        Cardinality::SingleValue => &[0],
-        Cardinality::MultiValues => &[0, 1],
-    }
-}
-
+/// Populate the short-lived cache with the data for
+/// all of the fast field passed in argument.
 async fn warm_up_fastfields(
     searcher: &Searcher,
     fast_field_names: &HashSet<String>,
 ) -> anyhow::Result<()> {
-    let mut fast_fields = Vec::new();
-    for fast_field_name in fast_field_names.iter() {
-        let fast_field = searcher
-            .schema()
-            .get_field(fast_field_name)
-            .with_context(|| {
-                format!("Couldn't get field named {fast_field_name:?} from schema.")
-            })?;
-
-        let field_entry = searcher.schema().get_field_entry(fast_field);
-        if !field_entry.is_fast() {
-            anyhow::bail!("Field {:?} is not a fast field.", fast_field_name);
-        }
-        let cardinality =
-            get_fastfield_cardinality(field_entry.field_type()).with_context(|| {
-                format!(
-                    "Couldn't get field cardinality {fast_field_name:?} from type {field_entry:?}."
-                )
-            })?;
-
-        fast_fields.push((fast_field, cardinality));
-    }
-
-    type SendableFuture = dyn Future<Output = io::Result<OwnedBytes>> + Send;
-    let mut warm_up_futures: Vec<Pin<Box<SendableFuture>>> = Vec::new();
-    for (field, cardinality) in fast_fields {
-        for segment_reader in searcher.segment_readers() {
-            for &fast_field_idx in fast_field_idxs(cardinality) {
-                let fast_field_slice = segment_reader
-                    .fast_fields()
-                    .fast_field_data(field, fast_field_idx)?;
-                warm_up_futures.push(Box::pin(async move {
-                    fast_field_slice.read_bytes_async().await
-                }));
-            }
+    let mut warm_up_futures = Vec::new();
+    for segment_reader in searcher.segment_readers() {
+        let fast_field_reader = segment_reader.fast_fields();
+        for fast_field_name in fast_field_names {
+            let warm_up_fut = warm_up_fastfield(fast_field_reader, fast_field_name);
+            warm_up_futures.push(Box::pin(warm_up_fut));
         }
     }
-    try_join_all(warm_up_futures).await?;
+    futures::future::try_join_all(warm_up_futures).await?;
     Ok(())
 }
 
@@ -478,7 +430,7 @@ async fn leaf_list_terms_single_split(
         .get_field(&search_request.field)
         .with_context(|| {
             format!(
-                "Couldn't get field named {:?} from schema.",
+                "Couldn't get field named {:?} from schema to list terms.",
                 search_request.field
             )
         })?;

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -242,8 +242,8 @@ async fn warm_up_fastfield(
     Ok(())
 }
 
-/// Populate the short-lived cache with the data for
-/// all of the fast field passed in argument.
+/// Populates the short-lived cache with the data for
+/// all of the fast fields passed as argument.
 async fn warm_up_fastfields(
     searcher: &Searcher,
     fast_field_names: &HashSet<String>,

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -47,6 +47,7 @@ use metrics::SEARCH_METRICS;
 use quickwit_doc_mapper::DocMapper;
 use root::validate_request;
 use service::SearcherContext;
+use tantivy::aggregation::AggregationLimits;
 use tantivy::schema::NamedFieldDocument;
 
 /// Refer to this as `crate::Result<T>`.
@@ -205,7 +206,6 @@ pub async fn single_node_search(
     } else {
         None
     };
-    let schema = doc_mapper.schema();
 
     let fetch_docs_response = fetch_docs(
         searcher_context.clone(),
@@ -244,7 +244,7 @@ pub async fn single_node_search(
                 let res: IntermediateAggregationResults =
                     serde_json::from_str(&intermediate_aggregation_result)?;
                 let res: AggregationResults =
-                    res.into_final_bucket_result(aggregations, &schema)?;
+                    res.into_final_bucket_result(aggregations, &AggregationLimits::default())?;
                 Some(serde_json::to_string(&res)?)
             }
         }

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -31,6 +31,7 @@ use quickwit_proto::{
 };
 use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
+use tantivy::aggregation::AggregationLimits;
 use tantivy::collector::Collector;
 use tantivy::TantivyError;
 use tokio::task::spawn_blocking;
@@ -305,7 +306,7 @@ pub async fn root_search(
                 let res: IntermediateAggregationResults =
                     serde_json::from_str(&intermediate_aggregation_result)?;
                 let res: AggregationResults =
-                    res.into_final_bucket_result(aggregations, &doc_mapper.schema())?;
+                    res.into_final_bucket_result(aggregations, &AggregationLimits::default())?;
                 Some(serde_json::to_string(&res)?)
             }
         }


### PR DESCRIPTION
Update tantivy and integrate the Columnar work

- Fast field readers become `Column`. Column dynamically handle
  cardinality.
- Aggregation is getting an aggregation limits object.
- Minor changes.

Closes https://github.com/quickwit-oss/quickwit/issues/1548