### PR TITLE
File-backed metastore check connectivity with existence of indexes st…

### DIFF
--- a/quickwit/quickwit-metastore/Cargo.toml
+++ b/quickwit/quickwit-metastore/Cargo.toml
@@ -47,6 +47,7 @@ md5 = { workspace = true }
 mockall = { workspace = true }
 rand = { workspace = true }
 tracing-subscriber = { workspace = true }
+tempfile = { workspace = true }
 
 quickwit-config = { workspace = true, features = ["testsuite"] }
 quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -42,7 +42,7 @@ use self::file_backed_index::FileBackedIndex;
 pub use self::file_backed_metastore_factory::FileBackedMetastoreFactory;
 use self::lazy_file_backed_index::LazyFileBackedIndex;
 use self::store_operations::{
-    check_indexes_states_exist, delete_index, fetch_and_build_indexes_states, fetch_index,
+    check_indexes_states_exist, delete_index, fetch_index, fetch_or_init_indexes_states,
     index_exists, put_index, put_indexes_states,
 };
 use crate::checkpoint::IndexCheckpointDelta;
@@ -130,7 +130,7 @@ impl FileBackedMetastore {
         polling_interval_opt: Option<Duration>,
     ) -> MetastoreResult<Self> {
         let indexes_map =
-            fetch_and_build_indexes_states(storage.clone(), polling_interval_opt).await?;
+            fetch_or_init_indexes_states(storage.clone(), polling_interval_opt).await?;
         let per_index_metastores = Arc::new(RwLock::new(indexes_map));
         Ok(Self {
             storage,
@@ -655,7 +655,7 @@ mod tests {
 
     use super::lazy_file_backed_index::LazyFileBackedIndex;
     use super::store_operations::{
-        fetch_and_build_indexes_states, meta_path, put_index_given_index_id, put_indexes_states,
+        fetch_or_init_indexes_states, meta_path, put_index_given_index_id, put_indexes_states,
     };
     use super::{FileBackedIndex, FileBackedMetastore, IndexState};
     use crate::tests::test_suite::DefaultForTest;
@@ -1087,7 +1087,7 @@ mod tests {
         ));
         // Check index state is in `Creating` in the states file.
         let index_states =
-            fetch_and_build_indexes_states(Arc::new(ram_storage_clone_2.clone()), None)
+            fetch_or_init_indexes_states(Arc::new(ram_storage_clone_2.clone()), None)
                 .await
                 .unwrap();
         assert!(matches!(
@@ -1100,7 +1100,7 @@ mod tests {
             deleted_index_error,
             MetastoreError::IndexDoesNotExist { .. }
         ));
-        let index_states = fetch_and_build_indexes_states(Arc::new(ram_storage_clone_2), None)
+        let index_states = fetch_or_init_indexes_states(Arc::new(ram_storage_clone_2), None)
             .await
             .unwrap();
         assert!(index_states.get(index_id).is_none());

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
@@ -73,7 +73,7 @@ fn convert_error(index_id: &str, storage_err: StorageError) -> MetastoreError {
     }
 }
 
-/// Check if `INDEXES_STATES_FILENAME` file exists.
+/// Checks whether `INDEXES_STATES_FILENAME` file exists.
 pub(crate) async fn check_indexes_states_exist(storage: Arc<dyn Storage>) -> anyhow::Result<()> {
     let indexes_list_path = Path::new(INDEXES_STATES_FILENAME);
     storage.exists(indexes_list_path).await?;

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
@@ -81,8 +81,8 @@ pub(crate) async fn check_indexes_states_exist(storage: Arc<dyn Storage>) -> any
 }
 
 /// Fetch `INDEXES_STATES_FILENAME` file and build the map (index, state).
-/// If the file does not exist, return an empty map.
-pub(crate) async fn fetch_and_build_indexes_states(
+/// If the file does not exist, it will create it and return an empty map.
+pub(crate) async fn fetch_or_init_indexes_states(
     storage: Arc<dyn Storage>,
     polling_interval_opt: Option<Duration>,
 ) -> MetastoreResult<HashMap<String, IndexState>> {

--- a/quickwit/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit/quickwit-metastore/src/metastore_resolver.rs
@@ -148,17 +148,19 @@ impl MetastoreUriResolver {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use quickwit_common::uri::Uri;
 
     use crate::quickwit_metastore_uri_resolver;
 
     #[tokio::test]
-    async fn test_metastore_resolver_should_not_raise_errors_on_file() -> anyhow::Result<()> {
+    async fn test_metastore_resolver_should_not_raise_errors_on_file() {
         let metastore_resolver = quickwit_metastore_uri_resolver();
-        metastore_resolver
-            .resolve(&Uri::from_well_formed("file://"))
-            .await?;
-        Ok(())
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let metastore_filepath = format!("file://{}/metastore", tmp_dir.path().display());
+        let metastore_uri = Uri::from_str(&metastore_filepath).unwrap();
+        metastore_resolver.resolve(&metastore_uri).await.unwrap();
     }
 
     #[cfg(feature = "postgres")]


### PR DESCRIPTION
…ates file.

### Description

Fix #3088 

The check connectivity is now using the existence of indexes states file. To make this work, the file-backed metastore is now creating this file in `try_new` if it does not exist.

### How was this PR tested?

Test added.
