### PR TITLE
Add OpenAPI schema resolver unit test

### DIFF
--- a/quickwit/quickwit-serve/src/openapi.rs
+++ b/quickwit/quickwit-serve/src/openapi.rs
@@ -130,6 +130,11 @@ impl OpenApiMerger for utoipa::openapi::OpenApi {
     fn with_path_prefix(mut self, prefix: &str) -> Self {
         let paths = mem::take(&mut self.paths.paths);
         for (path, detail) in paths {
+            if !path.starts_with('/') {
+                // We can panic here as I will be raised during unit tests.
+                panic!("Path {path:?} does not start with `/`.");
+            }
+
             let adjusted_path = if path != "/" {
                 format!("{prefix}{path}")
             } else {
@@ -143,7 +148,7 @@ impl OpenApiMerger for utoipa::openapi::OpenApi {
 }
 
 #[cfg(test)]
-mod openapi_schema_resolver_tests {
+mod openapi_schema_tests {
     use std::collections::{BTreeSet, VecDeque};
 
     use itertools::Itertools;

--- a/quickwit/quickwit-serve/src/openapi.rs
+++ b/quickwit/quickwit-serve/src/openapi.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::mem;
 use quickwit_common::metrics::MetricsApi;
 use quickwit_config::ConfigApiSchemas;
 use quickwit_doc_mapper::DocMapperApiSchemas;
@@ -122,9 +123,10 @@ impl OpenApiMerger for utoipa::openapi::OpenApi {
         }
     }
 
-    fn with_path_prefix(mut self, path: &str) -> Self {
-        for details in self.paths.paths.values_mut() {
-            details.servers = Some(vec![Server::new(path)]);
+    fn with_path_prefix(mut self, prefix: &str) -> Self {
+        let paths = mem::take(&mut self.paths.paths);
+        for (path, detail) in paths {
+            self.paths.paths.insert(format!("{prefix}{path}"), detail);
         }
 
         self


### PR DESCRIPTION
This adds a unit test that attempts to resolve the paths of all schemas defined within the generated OpenAPI doc.

This comes out of how little validation Utoipa does to produce a correct schema, which is often missed during PRs and is very easy to break and very hard to notice unless you open every single request on the docs.

This also adds some other minor changes like making it clearer what the base path is for each request, and ensuring paths start with `/`