### PR TITLE
fix some issues found while investigating search latency

### DIFF
--- a/quickwit/quickwit-search/src/thread_pool.rs
+++ b/quickwit/quickwit-search/src/thread_pool.rs
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt;
+
 use once_cell::sync::OnceCell;
 use quickwit_common::metrics::create_gauge_guard;
 use tracing::error;
@@ -36,6 +38,14 @@ fn search_thread_pool() -> &'static rayon::ThreadPool {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Panicked;
+
+impl fmt::Display for Panicked {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Scheduled job panicked")
+    }
+}
+
+impl std::error::Error for Panicked {}
 
 /// Function similar to `tokio::spawn_blocking`.
 ///


### PR DESCRIPTION
### Description

related to #3146 
spawn a few futures, instrument some functions and use the cpu_intensive pool instead of tokio blocking pool

### How was this PR tested?
doing queries on a local node and seeing `elapsed_time_micros` is much smaller