### PR TITLE
Fix the delete index user confirmation

### DIFF
--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -866,6 +866,13 @@ pub async fn search_index_cli(args: SearchIndexArgs) -> anyhow::Result<()> {
 pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
     debug!(args=?args, "delete-index");
     println!("❯ Deleting index...");
+    if !args.dry_run && !args.assume_yes {
+        let prompt = "This operation will delete the index. Do you want to proceed?".to_string();
+        if !prompt_confirmation(&prompt, false) {
+            return Ok(());
+        }
+    }
+
     quickwit_telemetry::send_telemetry_event(TelemetryEvent::Delete).await;
     let endpoint =
         Url::parse(args.cluster_endpoint.as_str()).context("Failed to parse cluster endpoint.")?;
@@ -875,12 +882,7 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
         .indexes()
         .delete(&args.index_id, args.dry_run)
         .await?;
-    if !args.dry_run && !args.assume_yes {
-        let prompt = "This operation will delete the index. Do you want to proceed?".to_string();
-        if !prompt_confirmation(&prompt, false) {
-            return Ok(());
-        }
-    }
+
     if args.dry_run {
         if affected_files.is_empty() {
             println!("Only the index will be deleted since it does not contains any data file.");

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -865,7 +865,6 @@ pub async fn search_index_cli(args: SearchIndexArgs) -> anyhow::Result<()> {
 
 pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
     debug!(args=?args, "delete-index");
-    println!("❯ Deleting index...");
     if !args.dry_run && !args.assume_yes {
         let prompt = "This operation will delete the index. Do you want to proceed?".to_string();
         if !prompt_confirmation(&prompt, false) {
@@ -873,6 +872,7 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
         }
     }
 
+    println!("❯ Deleting index...");
     quickwit_telemetry::send_telemetry_event(TelemetryEvent::Delete).await;
     let endpoint =
         Url::parse(args.cluster_endpoint.as_str()).context("Failed to parse cluster endpoint.")?;


### PR DESCRIPTION
### Description

Ensure that when a user answer `no` the index will not be deleted, this is done by moving the actual delete logic after confirming with the user.

### How was this PR tested?

The test suite was run locally and the following command were run to confirm the changes in behavior.

```sh
cargo r index create --index-config ../config/tutorials/hdfs-logs/index-config.yaml

cargo r index create --index-config ../config/tutorials/hdfs-logs/index-config.yaml # Answered no.

cargo r index describe --index hdfs-logs # return the information about the index.

cargo r index create --index-config ../config/tutorials/hdfs-logs/index-config.yaml # Answered yes.

cargo r index describe --index hdfs-logs # return 404 not found
```

I've looked at the test suite, we seem to run all the CLI test with `assume_yes` and skipping any prompt. 
Maybe we should also validate the confirmation flow, I am not sure  how to add it to the test suite, I am not familiar enough with the code base.

Fixes: #3147
