### PR TITLE
Fix handling of commit parameters in rest client

### DIFF
--- a/quickwit/quickwit-ingest/src/lib.rs
+++ b/quickwit/quickwit-ingest/src/lib.rs
@@ -137,11 +137,11 @@ impl From<u32> for CommitType {
 }
 
 impl CommitType {
-    pub fn to_query_parameter(&self) -> Option<&'static str> {
+    pub fn to_query_parameter(&self) -> Option<&'static [(&'static str, &'static str)]> {
         match self {
             CommitType::Auto => None,
-            CommitType::WaitFor => Some("commit=wait_for"),
-            CommitType::Force => Some("commit=force"),
+            CommitType::WaitFor => Some(&[("commit", "wait_for")]),
+            CommitType::Force => Some(&[("commit", "force")]),
         }
     }
 }


### PR DESCRIPTION
### Description

Fixes handling of CommitType::Force and CommitType::WaitFor in the rest client.

Fixes #3196

### How was this PR tested?

Added 2 unit tests. I discovered the issue while working on #2984, so integration tests are almost ready, but I will push them as another PR.
