### PR TITLE
Auto tagging of partition key fields

### DIFF
--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -427,7 +427,7 @@ impl TestableForRegression for IndexConfig {
             store_source: true,
             mode: ModeType::Dynamic,
             dynamic_mapping: None,
-            partition_key: Some("tenant".to_string()),
+            partition_key: Some("tenant_id".to_string()),
             max_num_partitions: NonZeroU32::new(100).unwrap(),
             timestamp_field: Some("timestamp".to_string()),
         };

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -117,31 +117,6 @@ impl DefaultDocMapper {
     }
 }
 
-fn validate_tag_fields(tag_fields: &[String], schema: &Schema) -> anyhow::Result<()> {
-    for tag_field in tag_fields {
-        let field = schema.get_field(tag_field)?;
-        let field_type = schema.get_field_entry(field).field_type();
-        match field_type {
-            FieldType::Str(options) => {
-                let tokenizer_opt = options
-                    .get_indexing_options()
-                    .map(|text_options| text_options.tokenizer());
-
-                if tokenizer_opt != Some(QuickwitTextTokenizer::Raw.get_name()) {
-                    bail!(
-                        "Tags collection is only allowed on text fields with the `raw` tokenizer."
-                    );
-                }
-            }
-            FieldType::Bytes(_) => {
-                bail!("Tags collection is not allowed on `bytes` fields.")
-            }
-            _ => (),
-        }
-    }
-    Ok(())
-}
-
 fn validate_timestamp_field_if_any(builder: &DefaultDocMapperBuilder) -> anyhow::Result<()> {
     let Some(timestamp_field_name) = builder.timestamp_field.as_ref() else {
         return Ok(());
@@ -194,9 +169,6 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
 
         let schema = schema_builder.build();
 
-        // validate fast fields
-        validate_tag_fields(&builder.tag_fields, &schema)?;
-
         // Resolve default search fields
         let mut default_search_field_names = Vec::new();
         for field_name in &builder.default_search_fields {
@@ -212,18 +184,19 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
         // Resolve tag fields
         let mut tag_field_names: BTreeSet<String> = Default::default();
         for tag_field_name in &builder.tag_fields {
-            if tag_field_names.contains(tag_field_name) {
-                bail!("Duplicated tag field: `{}`", tag_field_name)
+            validate_tag_and_insert(tag_field_name, &mut tag_field_names, &schema)?;
+        }
+
+        let partition_key = RoutingExpr::new(builder.partition_key.as_deref().unwrap_or(""))
+            .context("Failed to interpret the partition key.")?;
+        // partition key fields should be considered as tags
+        for partition_key_field in &partition_key.field_names() {
+            if !tag_field_names.contains(partition_key_field) {
+                validate_tag_and_insert(partition_key_field, &mut tag_field_names, &schema)?;
             }
-            schema
-                .get_field(tag_field_name)
-                .with_context(|| format!("Unknown tag field: `{tag_field_name}`"))?;
-            tag_field_names.insert(tag_field_name.clone());
         }
 
         let required_fields = Vec::new();
-        let partition_key = RoutingExpr::new(builder.partition_key.as_deref().unwrap_or(""))
-            .context("Failed to interpret the partition key.")?;
         Ok(DefaultDocMapper {
             schema,
             source_field,
@@ -238,6 +211,37 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
             mode,
         })
     }
+}
+
+fn validate_tag_and_insert(
+    tag_field_name: &String,
+    tag_field_names: &mut BTreeSet<String>,
+    schema: &Schema,
+) -> Result<(), anyhow::Error> {
+    if tag_field_names.contains(tag_field_name) {
+        bail!("Duplicated tag field: `{}`", tag_field_name)
+    }
+    let field = schema
+        .get_field(tag_field_name)
+        .with_context(|| format!("Unknown tag field: `{tag_field_name}`"))?;
+    let field_type = schema.get_field_entry(field).field_type();
+    match field_type {
+        FieldType::Str(options) => {
+            let tokenizer_opt = options
+                .get_indexing_options()
+                .map(|text_options| text_options.tokenizer());
+
+            if tokenizer_opt != Some(QuickwitTextTokenizer::Raw.get_name()) {
+                bail!("Tags collection is only allowed on text fields with the `raw` tokenizer.");
+            }
+        }
+        FieldType::Bytes(_) => {
+            bail!("Tags collection is not allowed on `bytes` fields.")
+        }
+        _ => (),
+    }
+    tag_field_names.insert(tag_field_name.clone());
+    Ok(())
 }
 
 impl From<DefaultDocMapper> for DefaultDocMapperBuilder {

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -771,6 +771,77 @@ mod tests {
     }
 
     #[test]
+    fn test_partion_key_in_tags() {
+        let doc_mapper = r#"{
+            "default_search_fields": [],
+            "timestamp_field": null,
+            "tag_fields": ["city"],
+            "store_source": true,
+            "partition_key": "hash_mod((service,division,city), 50)",
+            "field_mappings": [
+                {
+                    "name": "city",
+                    "type": "text",
+                    "stored": true,
+                    "tokenizer": "raw"
+                },
+                {
+                    "name": "division",
+                    "type": "text",
+                    "stored": true,
+                    "tokenizer": "raw"
+                },
+                {
+                    "name": "service",
+                    "type": "text",
+                    "stored": true,
+                    "tokenizer": "raw"
+                }
+            ]
+        }"#;
+
+        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
+        let doc_mapper = builder.try_build().unwrap();
+        let tag_fields: Vec<_> = doc_mapper.tag_field_names.into_iter().collect();
+        assert_eq!(tag_fields, vec!["city", "division", "service",]);
+    }
+
+    #[test]
+    fn test_partion_key_in_tags_without_explicit_tags() {
+        let doc_mapper = r#"{
+            "default_search_fields": [],
+            "timestamp_field": null,
+            "store_source": true,
+            "partition_key": "service,hash_mod((division,city), 50)",
+            "field_mappings": [
+                {
+                    "name": "city",
+                    "type": "text",
+                    "stored": true,
+                    "tokenizer": "raw"
+                },
+                {
+                    "name": "division",
+                    "type": "text",
+                    "stored": true,
+                    "tokenizer": "raw"
+                },
+                {
+                    "name": "service",
+                    "type": "text",
+                    "stored": true,
+                    "tokenizer": "raw"
+                }
+            ]
+        }"#;
+
+        let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
+        let doc_mapper = builder.try_build().unwrap();
+        let tag_fields: Vec<_> = doc_mapper.tag_field_names.into_iter().collect();
+        assert_eq!(tag_fields, vec!["city", "division", "service",]);
+    }
+
+    #[test]
     fn test_fail_to_build_doc_mapper_with_wrong_tag_fields_types() -> anyhow::Result<()> {
         let doc_mapper_one = r#"{
             "default_search_fields": [],

--- a/quickwit/quickwit-doc-mapper/src/routing_expression/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/routing_expression/mod.rs
@@ -123,6 +123,14 @@ impl RoutingExpr {
             0u64
         }
     }
+
+    pub fn field_names(&self) -> Vec<String> {
+        if let Some(inner) = self.inner_opt.as_ref() {
+            inner.field_names()
+        } else {
+            vec![]
+        }
+    }
 }
 
 impl Display for RoutingExpr {
@@ -130,7 +138,7 @@ impl Display for RoutingExpr {
         if let Some(inner_expr) = self.inner_opt.as_ref() {
             inner_expr.fmt(f)
         } else {
-            write!(f, "EmptyRoutingExpr")
+            write!(f, "")
         }
     }
 }
@@ -163,6 +171,21 @@ impl InnerRoutingExpr {
                 inner_expr.eval_hash(ctx, &mut sub_hasher);
                 hasher.write_u64(sub_hasher.finish() % modulo);
             }
+        }
+    }
+
+    // return all fields in a vector
+    fn field_names(&self) -> Vec<String> {
+        match self {
+            InnerRoutingExpr::Field(field_name) => vec![field_name.to_string()],
+            InnerRoutingExpr::Composite(children) => {
+                let mut fields = vec![];
+                for child in children {
+                    fields.extend(child.field_names());
+                }
+                fields
+            }
+            InnerRoutingExpr::Modulo(inner_expr, _) => inner_expr.field_names(),
         }
     }
 }

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-1cfee07237d8cbbe9240d5a883bf98c2.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-1cfee07237d8cbbe9240d5a883bf98c2.expected.json
@@ -62,7 +62,7 @@
         ],
         "max_num_partitions": 100,
         "mode": "dynamic",
-        "partition_key": "tenant",
+        "partition_key": "tenant_id",
         "store_source": true,
         "tag_fields": [
           "log_level",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-1cfee07237d8cbbe9240d5a883bf98c2.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-1cfee07237d8cbbe9240d5a883bf98c2.json
@@ -62,7 +62,7 @@
         ],
         "max_num_partitions": 100,
         "mode": "dynamic",
-        "partition_key": "tenant",
+        "partition_key": "tenant_id",
         "store_source": true,
         "tag_fields": [
           "log_level",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-333b645a318ab8f1dac4fd5b5162a638.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-333b645a318ab8f1dac4fd5b5162a638.expected.json
@@ -62,7 +62,7 @@
         ],
         "max_num_partitions": 100,
         "mode": "dynamic",
-        "partition_key": "tenant",
+        "partition_key": "tenant_id",
         "store_source": true,
         "tag_fields": [
           "log_level",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-333b645a318ab8f1dac4fd5b5162a638.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4-333b645a318ab8f1dac4fd5b5162a638.json
@@ -62,7 +62,7 @@
         ],
         "max_num_partitions": 100,
         "mode": "dynamic",
-        "partition_key": "tenant",
+        "partition_key": "tenant_id",
         "store_source": true,
         "tag_fields": [
           "log_level",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-7b8e4fe4e8bd3b08d453edc75d04a418.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-7b8e4fe4e8bd3b08d453edc75d04a418.expected.json
@@ -1,0 +1,152 @@
+{
+  "delete_tasks": [
+    {
+      "create_timestamp": 0,
+      "delete_query": {
+        "index_id": "index",
+        "query": "Harry Potter",
+        "search_fields": []
+      },
+      "opstamp": 10
+    }
+  ],
+  "index": {
+    "checkpoint": {
+      "kafka-source": {
+        "00000000000000000000": "00000000000000000042"
+      }
+    },
+    "create_timestamp": 1789,
+    "index_config": {
+      "doc_mapping": {
+        "field_mappings": [
+          {
+            "fast": true,
+            "indexed": true,
+            "name": "tenant_id",
+            "stored": true,
+            "type": "u64"
+          },
+          {
+            "fast": true,
+            "indexed": true,
+            "input_formats": [
+              "rfc3339",
+              "unix_timestamp"
+            ],
+            "name": "timestamp",
+            "output_format": "rfc3339",
+            "precision": "seconds",
+            "stored": true,
+            "type": "datetime"
+          },
+          {
+            "fast": false,
+            "fieldnorms": false,
+            "indexed": true,
+            "name": "log_level",
+            "stored": true,
+            "tokenizer": "raw",
+            "type": "text"
+          },
+          {
+            "fast": false,
+            "fieldnorms": false,
+            "indexed": true,
+            "name": "message",
+            "record": "position",
+            "stored": true,
+            "tokenizer": "default",
+            "type": "text"
+          }
+        ],
+        "max_num_partitions": 100,
+        "mode": "dynamic",
+        "partition_key": "tenant_id",
+        "store_source": true,
+        "tag_fields": [
+          "log_level",
+          "tenant_id"
+        ],
+        "timestamp_field": "timestamp"
+      },
+      "index_id": "my-index",
+      "index_uri": "s3://quickwit-indexes/my-index",
+      "indexing_settings": {
+        "commit_timeout_secs": 301,
+        "docstore_blocksize": 1000000,
+        "docstore_compression_level": 8,
+        "merge_policy": {
+          "maturation_period": "2days",
+          "max_merge_factor": 11,
+          "merge_factor": 9,
+          "min_level_num_docs": 100000,
+          "type": "stable_log"
+        },
+        "resources": {
+          "heap_size": 3
+        },
+        "split_num_docs_target": 10000001
+      },
+      "retention": {
+        "period": "90 days",
+        "schedule": "daily"
+      },
+      "search_settings": {
+        "default_search_fields": [
+          "message"
+        ]
+      },
+      "version": "0.5"
+    },
+    "sources": [
+      {
+        "desired_num_pipelines": 2,
+        "enabled": true,
+        "max_num_pipelines_per_indexer": 2,
+        "params": {
+          "client_params": {},
+          "topic": "kafka-topic"
+        },
+        "source_id": "kafka-source",
+        "source_type": "kafka",
+        "transform": {
+          "script": ".message = downcase(string!(.message))"
+        },
+        "version": "0.5"
+      }
+    ],
+    "version": "0.5"
+  },
+  "splits": [
+    {
+      "create_timestamp": 3,
+      "delete_opstamp": 10,
+      "footer_offsets": {
+        "end": 2000,
+        "start": 1000
+      },
+      "index_id": "my-index",
+      "node_id": "node",
+      "num_docs": 12303,
+      "num_merge_ops": 3,
+      "partition_id": 7,
+      "publish_timestamp": 1789,
+      "source_id": "source",
+      "split_id": "split",
+      "split_state": "Published",
+      "tags": [
+        "234",
+        "aaa"
+      ],
+      "time_range": {
+        "end": 130198,
+        "start": 121000
+      },
+      "uncompressed_docs_size_in_bytes": 234234,
+      "update_timestamp": 1789,
+      "version": "0.5"
+    }
+  ],
+  "version": "0.5"
+}

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-7b8e4fe4e8bd3b08d453edc75d04a418.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-7b8e4fe4e8bd3b08d453edc75d04a418.json
@@ -1,0 +1,152 @@
+{
+  "delete_tasks": [
+    {
+      "create_timestamp": 0,
+      "delete_query": {
+        "index_id": "index",
+        "query": "Harry Potter",
+        "search_fields": []
+      },
+      "opstamp": 10
+    }
+  ],
+  "index": {
+    "checkpoint": {
+      "kafka-source": {
+        "00000000000000000000": "00000000000000000042"
+      }
+    },
+    "create_timestamp": 1789,
+    "index_config": {
+      "doc_mapping": {
+        "field_mappings": [
+          {
+            "fast": true,
+            "indexed": true,
+            "name": "tenant_id",
+            "stored": true,
+            "type": "u64"
+          },
+          {
+            "fast": true,
+            "indexed": true,
+            "input_formats": [
+              "rfc3339",
+              "unix_timestamp"
+            ],
+            "name": "timestamp",
+            "output_format": "rfc3339",
+            "precision": "seconds",
+            "stored": true,
+            "type": "datetime"
+          },
+          {
+            "fast": false,
+            "fieldnorms": false,
+            "indexed": true,
+            "name": "log_level",
+            "stored": true,
+            "tokenizer": "raw",
+            "type": "text"
+          },
+          {
+            "fast": false,
+            "fieldnorms": false,
+            "indexed": true,
+            "name": "message",
+            "record": "position",
+            "stored": true,
+            "tokenizer": "default",
+            "type": "text"
+          }
+        ],
+        "max_num_partitions": 100,
+        "mode": "dynamic",
+        "partition_key": "tenant_id",
+        "store_source": true,
+        "tag_fields": [
+          "log_level",
+          "tenant_id"
+        ],
+        "timestamp_field": "timestamp"
+      },
+      "index_id": "my-index",
+      "index_uri": "s3://quickwit-indexes/my-index",
+      "indexing_settings": {
+        "commit_timeout_secs": 301,
+        "docstore_blocksize": 1000000,
+        "docstore_compression_level": 8,
+        "merge_policy": {
+          "maturation_period": "2days",
+          "max_merge_factor": 11,
+          "merge_factor": 9,
+          "min_level_num_docs": 100000,
+          "type": "stable_log"
+        },
+        "resources": {
+          "heap_size": 3
+        },
+        "split_num_docs_target": 10000001
+      },
+      "retention": {
+        "period": "90 days",
+        "schedule": "daily"
+      },
+      "search_settings": {
+        "default_search_fields": [
+          "message"
+        ]
+      },
+      "version": "0.5"
+    },
+    "sources": [
+      {
+        "desired_num_pipelines": 2,
+        "enabled": true,
+        "max_num_pipelines_per_indexer": 2,
+        "params": {
+          "client_params": {},
+          "topic": "kafka-topic"
+        },
+        "source_id": "kafka-source",
+        "source_type": "kafka",
+        "transform": {
+          "script": ".message = downcase(string!(.message))"
+        },
+        "version": "0.5"
+      }
+    ],
+    "version": "0.5"
+  },
+  "splits": [
+    {
+      "create_timestamp": 3,
+      "delete_opstamp": 10,
+      "footer_offsets": {
+        "end": 2000,
+        "start": 1000
+      },
+      "index_id": "my-index",
+      "node_id": "node",
+      "num_docs": 12303,
+      "num_merge_ops": 3,
+      "partition_id": 7,
+      "publish_timestamp": 1789,
+      "source_id": "source",
+      "split_id": "split",
+      "split_state": "Published",
+      "tags": [
+        "234",
+        "aaa"
+      ],
+      "time_range": {
+        "end": 130198,
+        "start": 121000
+      },
+      "uncompressed_docs_size_in_bytes": 234234,
+      "update_timestamp": 1789,
+      "version": "0.5"
+    }
+  ],
+  "version": "0.5"
+}

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-8ee262f0219f8e823ae6cbaf9681548e.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-8ee262f0219f8e823ae6cbaf9681548e.expected.json
@@ -62,7 +62,7 @@
         ],
         "max_num_partitions": 100,
         "mode": "dynamic",
-        "partition_key": "tenant",
+        "partition_key": "tenant_id",
         "store_source": true,
         "tag_fields": [
           "log_level",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-8ee262f0219f8e823ae6cbaf9681548e.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5-8ee262f0219f8e823ae6cbaf9681548e.json
@@ -62,7 +62,7 @@
         ],
         "max_num_partitions": 100,
         "mode": "dynamic",
-        "partition_key": "tenant",
+        "partition_key": "tenant_id",
         "store_source": true,
         "tag_fields": [
           "log_level",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-88352b53d5d5b2c92127761d39e17d7a.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-88352b53d5d5b2c92127761d39e17d7a.expected.json
@@ -50,7 +50,7 @@
       ],
       "max_num_partitions": 100,
       "mode": "dynamic",
-      "partition_key": "tenant",
+      "partition_key": "tenant_id",
       "store_source": true,
       "tag_fields": [
         "log_level",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-88352b53d5d5b2c92127761d39e17d7a.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-88352b53d5d5b2c92127761d39e17d7a.json
@@ -50,7 +50,7 @@
       ],
       "max_num_partitions": 100,
       "mode": "dynamic",
-      "partition_key": "tenant",
+      "partition_key": "tenant_id",
       "store_source": true,
       "tag_fields": [
         "log_level",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-b5e855552221fc7a3d31f4751a9348e3.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-b5e855552221fc7a3d31f4751a9348e3.expected.json
@@ -50,7 +50,7 @@
       ],
       "max_num_partitions": 100,
       "mode": "dynamic",
-      "partition_key": "tenant",
+      "partition_key": "tenant_id",
       "store_source": true,
       "tag_fields": [
         "log_level",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-b5e855552221fc7a3d31f4751a9348e3.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4-b5e855552221fc7a3d31f4751a9348e3.json
@@ -50,7 +50,7 @@
       ],
       "max_num_partitions": 100,
       "mode": "dynamic",
-      "partition_key": "tenant",
+      "partition_key": "tenant_id",
       "store_source": true,
       "tag_fields": [
         "log_level",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-1a77cc5755c53213debe38b455a499a5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-1a77cc5755c53213debe38b455a499a5.expected.json
@@ -50,7 +50,7 @@
       ],
       "max_num_partitions": 100,
       "mode": "dynamic",
-      "partition_key": "tenant",
+      "partition_key": "tenant_id",
       "store_source": true,
       "tag_fields": [
         "log_level",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-1a77cc5755c53213debe38b455a499a5.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-1a77cc5755c53213debe38b455a499a5.json
@@ -50,7 +50,7 @@
       ],
       "max_num_partitions": 100,
       "mode": "dynamic",
-      "partition_key": "tenant",
+      "partition_key": "tenant_id",
       "store_source": true,
       "tag_fields": [
         "log_level",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-f6ee019f1fd27b9958b7344f39752eaa.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-f6ee019f1fd27b9958b7344f39752eaa.expected.json
@@ -1,0 +1,108 @@
+{
+  "checkpoint": {
+    "kafka-source": {
+      "00000000000000000000": "00000000000000000042"
+    }
+  },
+  "create_timestamp": 1789,
+  "index_config": {
+    "doc_mapping": {
+      "field_mappings": [
+        {
+          "fast": true,
+          "indexed": true,
+          "name": "tenant_id",
+          "stored": true,
+          "type": "u64"
+        },
+        {
+          "fast": true,
+          "indexed": true,
+          "input_formats": [
+            "rfc3339",
+            "unix_timestamp"
+          ],
+          "name": "timestamp",
+          "output_format": "rfc3339",
+          "precision": "seconds",
+          "stored": true,
+          "type": "datetime"
+        },
+        {
+          "fast": false,
+          "fieldnorms": false,
+          "indexed": true,
+          "name": "log_level",
+          "stored": true,
+          "tokenizer": "raw",
+          "type": "text"
+        },
+        {
+          "fast": false,
+          "fieldnorms": false,
+          "indexed": true,
+          "name": "message",
+          "record": "position",
+          "stored": true,
+          "tokenizer": "default",
+          "type": "text"
+        }
+      ],
+      "max_num_partitions": 100,
+      "mode": "dynamic",
+      "partition_key": "tenant_id",
+      "store_source": true,
+      "tag_fields": [
+        "log_level",
+        "tenant_id"
+      ],
+      "timestamp_field": "timestamp"
+    },
+    "index_id": "my-index",
+    "index_uri": "s3://quickwit-indexes/my-index",
+    "indexing_settings": {
+      "commit_timeout_secs": 301,
+      "docstore_blocksize": 1000000,
+      "docstore_compression_level": 8,
+      "merge_policy": {
+        "maturation_period": "2days",
+        "max_merge_factor": 11,
+        "merge_factor": 9,
+        "min_level_num_docs": 100000,
+        "type": "stable_log"
+      },
+      "resources": {
+        "heap_size": 3
+      },
+      "split_num_docs_target": 10000001
+    },
+    "retention": {
+      "period": "90 days",
+      "schedule": "daily"
+    },
+    "search_settings": {
+      "default_search_fields": [
+        "message"
+      ]
+    },
+    "version": "0.5"
+  },
+  "sources": [
+    {
+      "desired_num_pipelines": 2,
+      "enabled": true,
+      "max_num_pipelines_per_indexer": 2,
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
+      "source_id": "kafka-source",
+      "source_type": "kafka",
+      "transform": {
+        "script": ".message = downcase(string!(.message))"
+      },
+      "version": "0.5"
+    }
+  ],
+  "version": "0.5"
+}

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-f6ee019f1fd27b9958b7344f39752eaa.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.5-f6ee019f1fd27b9958b7344f39752eaa.json
@@ -1,0 +1,108 @@
+{
+  "checkpoint": {
+    "kafka-source": {
+      "00000000000000000000": "00000000000000000042"
+    }
+  },
+  "create_timestamp": 1789,
+  "index_config": {
+    "doc_mapping": {
+      "field_mappings": [
+        {
+          "fast": true,
+          "indexed": true,
+          "name": "tenant_id",
+          "stored": true,
+          "type": "u64"
+        },
+        {
+          "fast": true,
+          "indexed": true,
+          "input_formats": [
+            "rfc3339",
+            "unix_timestamp"
+          ],
+          "name": "timestamp",
+          "output_format": "rfc3339",
+          "precision": "seconds",
+          "stored": true,
+          "type": "datetime"
+        },
+        {
+          "fast": false,
+          "fieldnorms": false,
+          "indexed": true,
+          "name": "log_level",
+          "stored": true,
+          "tokenizer": "raw",
+          "type": "text"
+        },
+        {
+          "fast": false,
+          "fieldnorms": false,
+          "indexed": true,
+          "name": "message",
+          "record": "position",
+          "stored": true,
+          "tokenizer": "default",
+          "type": "text"
+        }
+      ],
+      "max_num_partitions": 100,
+      "mode": "dynamic",
+      "partition_key": "tenant_id",
+      "store_source": true,
+      "tag_fields": [
+        "log_level",
+        "tenant_id"
+      ],
+      "timestamp_field": "timestamp"
+    },
+    "index_id": "my-index",
+    "index_uri": "s3://quickwit-indexes/my-index",
+    "indexing_settings": {
+      "commit_timeout_secs": 301,
+      "docstore_blocksize": 1000000,
+      "docstore_compression_level": 8,
+      "merge_policy": {
+        "maturation_period": "2days",
+        "max_merge_factor": 11,
+        "merge_factor": 9,
+        "min_level_num_docs": 100000,
+        "type": "stable_log"
+      },
+      "resources": {
+        "heap_size": 3
+      },
+      "split_num_docs_target": 10000001
+    },
+    "retention": {
+      "period": "90 days",
+      "schedule": "daily"
+    },
+    "search_settings": {
+      "default_search_fields": [
+        "message"
+      ]
+    },
+    "version": "0.5"
+  },
+  "sources": [
+    {
+      "desired_num_pipelines": 2,
+      "enabled": true,
+      "max_num_pipelines_per_indexer": 2,
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
+      "source_id": "kafka-source",
+      "source_type": "kafka",
+      "transform": {
+        "script": ".message = downcase(string!(.message))"
+      },
+      "version": "0.5"
+    }
+  ],
+  "version": "0.5"
+}


### PR DESCRIPTION
Refs #3000

### Description

Partition key fields are added to tag fields.

:warning: Fails retrocompatibility tests where the partition key is not defined in the field mappings, hence cannot be validated as a tag. Cf third commit. Is this ok or not? 

### How was this PR tested?

UT.
