### PR TITLE
Prevent test_indexing_pipeline_all_failures_handling form hanging

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -858,7 +858,6 @@ mod tests {
                             .ends_with(":(00000000000000000000..00000000000000001030])")
                 },
             )
-            .times(1)
             .returning(|_, _, _, _| Ok(()));
         let universe = Universe::with_accelerated_time();
         let node_id = "test-node";


### PR DESCRIPTION
### Description

Removes the condition that has been causing
test_indexing_pipeline_all_failures_handling to hang in case of pipeline initialization failure. The test will still fail if the pipeline fails to start the first time, but it will not longer make the test to hang.

See #3206

### How was this PR tested?

It is fixing a test.
