### PR TITLE
Refactor cluster sandbox wait_for methods

### DIFF
--- a/quickwit/quickwit-integration-tests/src/test_utils/mod.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/mod.rs
@@ -19,4 +19,4 @@
 
 mod cluster_sandbox;
 
-pub use cluster_sandbox::{build_node_configs, ClusterSandbox};
+pub use cluster_sandbox::{build_node_configs, ingest_with_retry, ClusterSandbox};

--- a/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
@@ -28,7 +28,7 @@ use quickwit_rest_client::models::IngestSource;
 use quickwit_rest_client::rest_client::CommitType;
 use quickwit_serve::SearchRequestQueryString;
 
-use crate::test_utils::ClusterSandbox;
+use crate::test_utils::{ingest_with_retry, ClusterSandbox};
 
 fn get_ndjson_filepath(ndjson_dataset_filename: &str) -> String {
     format!(
@@ -223,16 +223,14 @@ async fn test_multi_nodes_cluster() {
     // Check that ingest request send to searcher is forwarded to indexer and thus indexed.
     let ndjson_filepath = get_ndjson_filepath("documents_to_ingest.json");
     let ingest_source = IngestSource::File(PathBuf::from_str(&ndjson_filepath).unwrap());
-    sandbox
-        .searcher_rest_client
-        .ingest(
-            "my-new-multi-node-index",
-            ingest_source,
-            None,
-            CommitType::Auto,
-        )
-        .await
-        .unwrap();
+    ingest_with_retry(
+        &sandbox.searcher_rest_client,
+        "my-new-multi-node-index",
+        ingest_source,
+        CommitType::Auto,
+    )
+    .await
+    .unwrap();
     // Wait until split is commited and search.
     tokio::time::sleep(Duration::from_secs(4)).await;
     let search_response_one_hit = sandbox

--- a/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
@@ -17,8 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
-
 use bytes::Bytes;
 use quickwit_metastore::SplitState;
 use quickwit_rest_client::rest_client::CommitType;

--- a/quickwit/quickwit-rest-client/src/models.rs
+++ b/quickwit/quickwit-rest-client/src/models.rs
@@ -71,6 +71,7 @@ impl ApiResponse {
     }
 }
 
+#[derive(Clone)]
 pub enum IngestSource {
     Bytes(Bytes),
     File(PathBuf),


### PR DESCRIPTION
### Description

Switches retry logic in cluster sandbox wait_for methods to use quickwit_common::test_utils::wait_for_server_ready. It also adds a retry logic for the first ingest commands after an index creation to make tests more reliable. Checking the number of running pipelines doesn't seem to do that trick.

Fixes #3230
Fixes #3214

### How was this PR tested?

It is refactoring tests.
