### PR TITLE
Refactor quickwit-cluster

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "byte-unit"
@@ -641,11 +641,12 @@ dependencies = [
 [[package]]
 name = "chitchat"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/chitchat?rev=4973853#497385319d05eab8d4e77d1dcbb2e67fe1541206"
+source = "git+https://github.com/quickwit-oss/chitchat?rev=bc29598#bc295980ac2e00f389dfa7e87cf6dc7995061206"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "itertools",
  "rand 0.8.5",
  "serde",
  "tokio",
@@ -855,21 +856,21 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.9.2",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+checksum = "57ab2224a0311582eb03adba4caaf18644f7b1f10a760803a803b9b605187fc7"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -883,7 +884,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -3136,7 +3137,7 @@ dependencies = [
  "prost",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -3149,7 +3150,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "prost",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
 ]
 
@@ -3608,14 +3609,14 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
 dependencies = [
- "portable-atomic 1.3.1",
+ "portable-atomic 1.3.2",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bbda379e6e462c97ea6afe9f6233619b202bbc4968d7caa6917788d2070a044"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
 
 [[package]]
 name = "postcard"
@@ -3995,6 +3996,7 @@ dependencies = [
  "atty",
  "byte-unit",
  "bytes",
+ "chitchat",
  "clap 3.1.18",
  "colored",
  "console-subscriber",
@@ -4036,7 +4038,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.6.0",
- "tonic",
+ "tonic 0.8.3",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -4049,6 +4051,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chitchat",
+ "futures",
  "itertools",
  "quickwit-common",
  "quickwit-config",
@@ -4058,8 +4061,10 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "time 0.3.21",
  "tokio",
  "tokio-stream",
+ "tonic 0.8.3",
  "tracing",
  "ulid",
  "utoipa",
@@ -4086,6 +4091,8 @@ version = "0.5.0"
 dependencies = [
  "async-trait",
  "dyn-clone",
+ "http",
+ "hyper",
  "mockall",
  "prost",
  "quickwit-actors",
@@ -4094,7 +4101,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tower",
  "utoipa",
 ]
@@ -4113,6 +4120,7 @@ dependencies = [
  "futures",
  "home",
  "hostname",
+ "http",
  "hyper",
  "itertools",
  "num_cpus",
@@ -4128,6 +4136,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
+ "tonic 0.8.3",
  "tower",
  "tracing",
  "utoipa",
@@ -4172,6 +4182,8 @@ dependencies = [
  "async-trait",
  "chitchat",
  "dyn-clone",
+ "http",
+ "hyper",
  "itertools",
  "mockall",
  "proptest",
@@ -4193,7 +4205,7 @@ dependencies = [
  "time 0.3.21",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
  "tower",
  "tracing",
  "utoipa",
@@ -4289,6 +4301,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "itertools",
  "quickwit-cluster",
  "quickwit-common",
@@ -4296,7 +4309,7 @@ dependencies = [
  "quickwit-proto",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
  "tower",
  "tracing",
 ]
@@ -4368,6 +4381,8 @@ dependencies = [
  "dyn-clone",
  "flume",
  "futures",
+ "http",
+ "hyper",
  "mockall",
  "mrecordlog",
  "once_cell",
@@ -4384,7 +4399,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tower",
  "tracing",
  "ulid",
@@ -4443,7 +4458,7 @@ dependencies = [
  "time 0.3.21",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
  "tracing",
 ]
 
@@ -4569,7 +4584,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tracing",
 ]
 
@@ -4585,7 +4600,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
  "tracing",
  "tracing-opentelemetry",
@@ -6631,9 +6646,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -6824,6 +6839,34 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -43,14 +43,14 @@ assert-json-diff = "2"
 async-speed-limit = "0.4"
 async-trait = "0.1"
 atty = "0.2"
-azure_core = {version = "0.5.0", features = ["enable_reqwest_rustls"] }
-azure_storage = { version = "0.6.0", default-features = false, features = ["enable_reqwest_rustls"]}
-azure_storage_blobs = { version = "0.6.0", default-features = false, features = ["enable_reqwest_rustls"]}
+azure_core = { version = "0.5.0", features = ["enable_reqwest_rustls"] }
+azure_storage = { version = "0.6.0", default-features = false, features = ["enable_reqwest_rustls"] }
+azure_storage_blobs = { version = "0.6.0", default-features = false, features = ["enable_reqwest_rustls"] }
 backoff = { version = "0.4", features = ["tokio"] }
 base64 = "0.21"
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
 bytes = "1"
-chitchat = { git = "https://github.com/quickwit-oss/chitchat", rev = "4973853" }
+chitchat = { git = "https://github.com/quickwit-oss/chitchat", rev = "bc29598" }
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 clap = { version = "=3.1", features = ["env"] }
 colored = "2.0.0"
@@ -71,7 +71,7 @@ futures-util = { version = "0.3.25", default-features = false }
 heck = "0.4.1"
 home = "0.5.4"
 hostname = "0.3"
-http = "0.2"
+http = "0.2.9"
 humansize = "2.1.3"
 humantime = "2.1.0"
 hyper = { version = "0.14", features = [
@@ -177,7 +177,7 @@ tokio-util = { version = "0.7", features = ["full"] }
 toml = "0.6.0"
 tonic = { version = "0.8.3", features = ["gzip"] }
 tonic-build = "0.8.4"
-tower = { version = "0.4.13", features = ["buffer", "load", "util"] }
+tower = { version = "0.4.13", features = ["balance", "buffer", "load", "util"] }
 tower-http = { version = "0.4.0", features = ["compression-gzip", "cors"] }
 tracing = "0.1.37"
 tracing-opentelemetry = "0.18.0"

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = { workspace = true }
 atty = { workspace = true }
 bytes = { workspace = true }
 byte-unit = { workspace = true }
+chitchat = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
 console-subscriber = { workspace = true, optional = true }

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -22,21 +22,22 @@ use std::io::{stdout, Stdout, Write};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{env, fmt, io};
 
 use anyhow::{bail, Context};
+use chitchat::transport::ChannelTransport;
+use chitchat::FailureDetectorConfig;
 use clap::{arg, ArgMatches, Command};
 use colored::{ColoredString, Colorize};
 use humantime::format_duration;
 use quickwit_actors::{ActorExitStatus, ActorHandle, ObservationType, Universe};
-use quickwit_cluster::create_fake_cluster_for_cli;
+use quickwit_cluster::{Cluster, ClusterMember};
 use quickwit_common::uri::Uri;
 use quickwit_common::{GREEN_COLOR, RED_COLOR};
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{
-    IndexerConfig, SourceConfig, SourceParams, TransformConfig, VecSourceParams,
+    IndexerConfig, QuickwitConfig, SourceConfig, SourceParams, TransformConfig, VecSourceParams,
     CLI_INGEST_SOURCE_ID,
 };
 use quickwit_core::{clear_cache_directory, IndexService};
@@ -316,7 +317,7 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
     // The indexing service needs to update its cluster chitchat state so that the control plane is
     // aware of the running tasks. We thus create a fake cluster to instantiate the indexing service
     // and avoid impacting potential control plane running on the cluster.
-    let fake_cluster = create_fake_cluster_for_cli().await?;
+    let cluster = create_empty_cluster(&config).await?;
     let indexer_config = IndexerConfig {
         ..Default::default()
     };
@@ -325,7 +326,7 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
         config.node_id.clone(),
         config.data_dir_path.clone(),
         indexer_config,
-        Arc::new(fake_cluster),
+        cluster,
         metastore,
         None,
         quickwit_storage_uri_resolver().clone(),
@@ -405,7 +406,7 @@ pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
     // The indexing service needs to update its cluster chitchat state so that the control plane is
     // aware of the running tasks. We thus create a fake cluster to instantiate the indexing service
     // and avoid impacting potential control plane running on the cluster.
-    let fake_cluster = create_fake_cluster_for_cli().await?;
+    let cluster = create_empty_cluster(&config).await?;
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
         .resolve(&config.metastore_uri)
@@ -417,7 +418,7 @@ pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
         config.node_id,
         config.data_dir_path,
         indexer_config,
-        Arc::new(fake_cluster),
+        cluster,
         metastore,
         None,
         storage_resolver,
@@ -749,4 +750,26 @@ impl ThroughputCalculator {
     pub fn elapsed_time(&self) -> Duration {
         self.start_time.elapsed()
     }
+}
+
+async fn create_empty_cluster(config: &QuickwitConfig) -> anyhow::Result<Cluster> {
+    let self_node = ClusterMember::new(
+        config.node_id.clone(),
+        quickwit_cluster::GenerationId::now(),
+        false,
+        HashSet::new(),
+        config.gossip_advertise_addr,
+        config.grpc_advertise_addr,
+        Vec::new(),
+    );
+    let cluster = Cluster::join(
+        config.cluster_id.clone(),
+        self_node,
+        config.gossip_advertise_addr,
+        Vec::new(),
+        FailureDetectorConfig::default(),
+        &ChannelTransport::default(),
+    )
+    .await?;
+    Ok(cluster)
 }

--- a/quickwit/quickwit-cluster/Cargo.toml
+++ b/quickwit/quickwit-cluster/Cargo.toml
@@ -13,12 +13,15 @@ documentation = "https://quickwit.io/docs/"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 chitchat = { workspace = true }
+futures = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tonic = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }
 utoipa = { workspace = true }
@@ -31,6 +34,7 @@ quickwit-proto = { workspace = true }
 testsuite = []
 
 [dev-dependencies]
+chitchat = { workspace = true, features = ["testsuite"] }
 quickwit-common = { workspace = true, features = ["testsuite"] }
 
 rand = { workspace = true }

--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -1,0 +1,788 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+
+use chitchat::{ChitchatId, NodeState};
+use quickwit_common::sorted_iter::{KeyDiff, SortedByKeyIterator};
+use quickwit_common::tower::{make_channel, warmup_channel};
+use tracing::{info, warn};
+
+use crate::member::NodeStateExt;
+use crate::ClusterNode;
+
+#[derive(Debug, Clone)]
+pub enum ClusterChange {
+    Add(ClusterNode),
+    Update(ClusterNode),
+    Remove(ClusterNode),
+}
+
+/// Compares the digests of the previous and new set of lives nodes, identifies the changes that
+/// occurred in the cluster, and emits the corresponding events, focusing on ready nodes only.
+pub(crate) async fn compute_cluster_change_events(
+    cluster_id: &str,
+    self_chitchat_id: &ChitchatId,
+    previous_nodes: &mut BTreeMap<ChitchatId, ClusterNode>,
+    previous_node_states: &BTreeMap<ChitchatId, NodeState>,
+    new_node_states: &BTreeMap<ChitchatId, NodeState>,
+) -> Vec<ClusterChange> {
+    let mut events = Vec::new();
+
+    for key_diff in previous_node_states
+        .iter()
+        .diff_by_key(new_node_states.iter())
+    {
+        let event_opt = match key_diff {
+            // The node has joined the cluster.
+            KeyDiff::Added(chitchat_id, node_state) => {
+                compute_cluster_change_events_on_added(
+                    cluster_id,
+                    self_chitchat_id,
+                    chitchat_id,
+                    node_state,
+                    previous_nodes,
+                )
+                .await
+            }
+            // The node's state has changed.
+            KeyDiff::Unchanged(chitchat_id, previous_node_state, new_node_state)
+                if previous_node_state.max_version() != new_node_state.max_version() =>
+            {
+                compute_cluster_change_events_on_updated(
+                    cluster_id,
+                    self_chitchat_id,
+                    chitchat_id,
+                    new_node_state,
+                    previous_nodes,
+                )
+                .await
+            }
+            // The node's state has not changed.
+            KeyDiff::Unchanged(_chitchat_id, _previous_max_version, _new_max_version) => None,
+            // The node has left the cluster, i.e. it is considered dead by the failure detector.
+            KeyDiff::Removed(chitchat_id, _node_state) => compute_cluster_change_events_on_removed(
+                cluster_id,
+                self_chitchat_id,
+                chitchat_id,
+                previous_nodes,
+            ),
+        };
+        if let Some(event) = event_opt {
+            events.push(event);
+        }
+    }
+    events
+}
+
+async fn compute_cluster_change_events_on_added(
+    cluster_id: &str,
+    self_chitchat_id: &ChitchatId,
+    new_chitchat_id: &ChitchatId,
+    new_node_state: &NodeState,
+    previous_nodes: &mut BTreeMap<ChitchatId, ClusterNode>,
+) -> Option<ClusterChange> {
+    let is_self_node = self_chitchat_id == new_chitchat_id;
+    if !is_self_node {
+        info!(
+            cluster_id=%cluster_id,
+            node_id=%new_chitchat_id.node_id,
+            "Node `{}` has joined the cluster.",
+            new_chitchat_id.node_id
+        );
+    }
+    let grpc_advertise_addr = match new_node_state.grpc_advertise_addr() {
+        Ok(addr) => addr,
+        Err(error) => {
+            warn!(
+                cluster_id=%cluster_id,
+                node_id=%new_chitchat_id.node_id,
+                error=?error,
+                "Failed to read or parse gRPC advertise address."
+            );
+            return None;
+        }
+    };
+    let channel = make_channel(grpc_advertise_addr).await;
+    let new_node = match ClusterNode::try_new(
+        new_chitchat_id.clone(),
+        new_node_state,
+        channel,
+        is_self_node,
+    ) {
+        Ok(node) => node,
+        Err(error) => {
+            warn!(
+                cluster_id=%cluster_id,
+                node_id=%new_chitchat_id.node_id,
+                error=?error,
+                "Failed to create cluster node from Chitchat node state."
+            );
+            return None;
+        }
+    };
+    previous_nodes.insert(new_chitchat_id.clone(), new_node.clone());
+
+    if new_node.is_ready() {
+        warmup_channel(new_node.channel()).await;
+
+        if !is_self_node {
+            info!(
+                cluster_id=%cluster_id,
+                node_id=%new_chitchat_id.node_id,
+                "Node `{}` has transitioned to ready state.",
+                new_chitchat_id.node_id
+            );
+        }
+        return Some(ClusterChange::Add(new_node));
+    }
+    None
+}
+
+async fn compute_cluster_change_events_on_updated(
+    cluster_id: &str,
+    self_chitchat_id: &ChitchatId,
+    updated_chitchat_id: &ChitchatId,
+    updated_node_state: &NodeState,
+    previous_nodes: &mut BTreeMap<ChitchatId, ClusterNode>,
+) -> Option<ClusterChange> {
+    let previous_node = previous_nodes.get(updated_chitchat_id)?.clone();
+    let previous_channel = previous_node.channel();
+    let is_self_node = self_chitchat_id == updated_chitchat_id;
+    let updated_node = match ClusterNode::try_new(
+        updated_chitchat_id.clone(),
+        updated_node_state,
+        previous_channel,
+        is_self_node,
+    ) {
+        Ok(node) => node,
+        Err(error) => {
+            warn!(
+                cluster_id=%cluster_id,
+                node_id=%updated_chitchat_id.node_id,
+                error=?error,
+                "Failed to create cluster node from Chitchat node state."
+            );
+            return None;
+        }
+    };
+    previous_nodes.insert(updated_chitchat_id.clone(), updated_node.clone());
+
+    if !previous_node.is_ready() && updated_node.is_ready() {
+        warmup_channel(updated_node.channel()).await;
+
+        if !is_self_node {
+            info!(
+                cluster_id=%cluster_id,
+                node_id=%updated_chitchat_id.node_id,
+                "Node `{}` has transitioned to ready state.",
+                updated_chitchat_id.node_id
+            );
+        }
+        Some(ClusterChange::Add(updated_node))
+    } else if previous_node.is_ready() && !updated_node.is_ready() {
+        if !is_self_node {
+            info!(
+                cluster_id=%cluster_id,
+                node_id=%updated_chitchat_id.node_id,
+                "Node `{}` has transitioned out of ready state.",
+                updated_chitchat_id.node_id
+            );
+        }
+        Some(ClusterChange::Remove(updated_node))
+    } else if previous_node.is_ready() && updated_node.is_ready() {
+        Some(ClusterChange::Update(updated_node))
+    } else {
+        None
+    }
+}
+
+fn compute_cluster_change_events_on_removed(
+    cluster_id: &str,
+    self_chitchat_id: &ChitchatId,
+    removed_chitchat_id: &ChitchatId,
+    previous_nodes: &mut BTreeMap<ChitchatId, ClusterNode>,
+) -> Option<ClusterChange> {
+    if self_chitchat_id != removed_chitchat_id {
+        info!(
+            cluster_id=%cluster_id,
+            node_id=%removed_chitchat_id.node_id,
+            "Node `{}` has left the cluster.",
+            removed_chitchat_id.node_id
+        );
+    }
+    let previous_node = previous_nodes.remove(removed_chitchat_id)?;
+
+    if previous_node.is_ready() {
+        Some(ClusterChange::Remove(previous_node))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::net::SocketAddr;
+
+    use itertools::Itertools;
+    use quickwit_config::service::QuickwitService;
+    use tonic::transport::Channel;
+
+    use super::*;
+    use crate::member::{
+        ENABLED_SERVICES_KEY, GRPC_ADVERTISE_ADDR_KEY, READINESS_KEY, READINESS_VALUE_NOT_READY,
+        READINESS_VALUE_READY,
+    };
+
+    pub(crate) struct NodeStateBuilder {
+        enabled_services: HashSet<QuickwitService>,
+        grpc_advertise_addr: SocketAddr,
+        readiness: bool,
+        key_values: Vec<(String, String)>,
+    }
+
+    impl Default for NodeStateBuilder {
+        fn default() -> Self {
+            Self {
+                enabled_services: QuickwitService::supported_services(),
+                grpc_advertise_addr: "127.0.0.1:7281"
+                    .parse()
+                    .expect("`127.0.0.1:7281` should be a valid socket address."),
+                readiness: false,
+                key_values: Vec::new(),
+            }
+        }
+    }
+
+    impl NodeStateBuilder {
+        pub(crate) fn with_grpc_advertise_addr(mut self, grpc_advertise_addr: SocketAddr) -> Self {
+            self.grpc_advertise_addr = grpc_advertise_addr;
+            self
+        }
+
+        pub(crate) fn with_readiness(mut self, readiness: bool) -> Self {
+            self.readiness = readiness;
+            self
+        }
+
+        pub(crate) fn with_key_value(mut self, key: &str, value: &str) -> Self {
+            self.key_values.push((key.to_string(), value.to_string()));
+            self
+        }
+
+        pub(crate) fn build(self) -> NodeState {
+            let mut node_state = NodeState::default();
+
+            node_state.set(
+                ENABLED_SERVICES_KEY,
+                self.enabled_services
+                    .iter()
+                    .map(|service| service.as_str())
+                    .join(","),
+            );
+            node_state.set(
+                GRPC_ADVERTISE_ADDR_KEY,
+                self.grpc_advertise_addr.to_string(),
+            );
+            node_state.set(
+                READINESS_KEY,
+                if self.readiness {
+                    READINESS_VALUE_READY
+                } else {
+                    READINESS_VALUE_NOT_READY
+                },
+            );
+            for (key, value) in self.key_values {
+                node_state.set(key, value);
+            }
+            node_state
+        }
+    }
+
+    #[tokio::test]
+    async fn test_compute_cluster_change_events_on_added() {
+        let cluster_id = "test-cluster".to_string();
+        let self_port = 1234;
+        let self_chitchat_id = ChitchatId::for_local_test(self_port);
+        {
+            // New node joined the cluster with invalid gRPC advertise address.
+            let port = 1235;
+            let new_chitchat_id = ChitchatId::for_local_test(port);
+            let mut new_node_state = NodeStateBuilder::default().build();
+            new_node_state.set(GRPC_ADVERTISE_ADDR_KEY, "bogus-grpc-advertise-addr");
+            let mut previous_nodes = BTreeMap::new();
+
+            let event = compute_cluster_change_events_on_added(
+                &cluster_id,
+                &self_chitchat_id,
+                &new_chitchat_id,
+                &new_node_state,
+                &mut previous_nodes,
+            )
+            .await;
+            assert!(event.is_none());
+            assert!(previous_nodes.is_empty());
+        }
+        {
+            // New node joined the cluster but is not ready.
+            let port = 1235;
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
+            let new_chitchat_id = ChitchatId::for_local_test(port);
+            let new_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(false)
+                .build();
+            let mut previous_nodes = BTreeMap::new();
+
+            let event = compute_cluster_change_events_on_added(
+                &cluster_id,
+                &self_chitchat_id,
+                &new_chitchat_id,
+                &new_node_state,
+                &mut previous_nodes,
+            )
+            .await;
+            assert!(event.is_none());
+
+            let node = previous_nodes.get(&new_chitchat_id).unwrap();
+
+            assert_eq!(node.chitchat_id(), &new_chitchat_id);
+            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert!(!node.is_self_node());
+            assert!(!node.is_ready());
+        }
+        {
+            // New node joined the cluster and is ready.
+            let port = 1235;
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
+            let new_chitchat_id = ChitchatId::for_local_test(port);
+            let new_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(true)
+                .build();
+            let mut previous_nodes = BTreeMap::new();
+
+            let event = compute_cluster_change_events_on_added(
+                &cluster_id,
+                &self_chitchat_id,
+                &new_chitchat_id,
+                &new_node_state,
+                &mut previous_nodes,
+            )
+            .await
+            .unwrap();
+
+            let ClusterChange::Add(node) = event else {
+                panic!("Expected `ClusterChange::Add` event, got `{:?}`.", event);
+            };
+            assert_eq!(node.chitchat_id(), &new_chitchat_id);
+            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert!(!node.is_self_node());
+            assert!(node.is_ready());
+            assert_eq!(previous_nodes.get(&new_chitchat_id).unwrap(), &node);
+        }
+        {
+            // Self node joined the cluster and is ready.
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], self_port + 1).into();
+            let new_chitchat_id = self_chitchat_id.clone();
+            let new_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(true)
+                .build();
+            let mut previous_nodes = BTreeMap::new();
+
+            let event = compute_cluster_change_events_on_added(
+                &cluster_id,
+                &self_chitchat_id,
+                &new_chitchat_id,
+                &new_node_state,
+                &mut previous_nodes,
+            )
+            .await
+            .unwrap();
+
+            let ClusterChange::Add(node) = event else {
+                panic!("Expected `ClusterChange::Add` event, got `{:?}`.", event);
+            };
+            assert_eq!(node.chitchat_id(), &new_chitchat_id);
+            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert!(node.is_self_node());
+            assert!(node.is_ready());
+            assert_eq!(previous_nodes.get(&new_chitchat_id).unwrap(), &node);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_compute_cluster_change_events_on_updated() {
+        let cluster_id = "test-cluster".to_string();
+        let self_port = 1234;
+        let self_chitchat_id = ChitchatId::for_local_test(self_port);
+        {
+            // Node became ready.
+            let port = 1235;
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
+            let updated_chitchat_id = ChitchatId::for_local_test(port);
+            let previous_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(false)
+                .build();
+            let previous_channel = Channel::from_static("http://127.0.0.1:12345/").connect_lazy();
+            let is_self_node = true;
+            let previous_node = ClusterNode::try_new(
+                updated_chitchat_id.clone(),
+                &previous_node_state,
+                previous_channel,
+                is_self_node,
+            )
+            .unwrap();
+            let mut previous_nodes =
+                BTreeMap::from_iter([(updated_chitchat_id.clone(), previous_node)]);
+
+            let updated_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(true)
+                .with_key_value("my-key", "my-value")
+                .build();
+            let event = compute_cluster_change_events_on_updated(
+                &cluster_id,
+                &self_chitchat_id,
+                &updated_chitchat_id,
+                &updated_node_state,
+                &mut previous_nodes,
+            )
+            .await
+            .unwrap();
+            let ClusterChange::Add(node) = event else {
+                panic!("Expected `ClusterChange::Add` event, got `{:?}`.", event);
+            };
+            assert_eq!(node.chitchat_id(), &updated_chitchat_id);
+            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert!(node.is_ready());
+            assert!(!node.is_self_node());
+            assert_eq!(previous_nodes.get(&updated_chitchat_id).unwrap(), &node);
+        }
+        {
+            // Node changed.
+            let port = 1235;
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
+            let updated_chitchat_id = ChitchatId::for_local_test(port);
+            let previous_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(true)
+                .build();
+            let previous_channel = Channel::from_static("http://127.0.0.1:12345/").connect_lazy();
+            let is_self_node = true;
+            let previous_node = ClusterNode::try_new(
+                updated_chitchat_id.clone(),
+                &previous_node_state,
+                previous_channel,
+                is_self_node,
+            )
+            .unwrap();
+            let mut previous_nodes =
+                BTreeMap::from_iter([(updated_chitchat_id.clone(), previous_node)]);
+
+            let updated_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(true)
+                .with_key_value("my-key", "my-value")
+                .build();
+            let event = compute_cluster_change_events_on_updated(
+                &cluster_id,
+                &self_chitchat_id,
+                &updated_chitchat_id,
+                &updated_node_state,
+                &mut previous_nodes,
+            )
+            .await
+            .unwrap();
+            let ClusterChange::Update(node) = event else {
+                panic!("Expected `ClusterChange::Remove` event, got `{:?}`.", event);
+            };
+            assert_eq!(node.chitchat_id(), &updated_chitchat_id);
+            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert!(!node.is_self_node());
+            assert!(node.is_ready());
+            assert_eq!(previous_nodes.get(&updated_chitchat_id).unwrap(), &node);
+        }
+        {
+            // Node is no longer ready.
+            let port = 1235;
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
+            let updated_chitchat_id = ChitchatId::for_local_test(port);
+            let previous_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(true)
+                .build();
+            let previous_channel = Channel::from_static("http://127.0.0.1:12345/").connect_lazy();
+            let is_self_node = true;
+            let previous_node = ClusterNode::try_new(
+                updated_chitchat_id.clone(),
+                &previous_node_state,
+                previous_channel,
+                is_self_node,
+            )
+            .unwrap();
+            let mut previous_nodes =
+                BTreeMap::from_iter([(updated_chitchat_id.clone(), previous_node)]);
+
+            let updated_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(false)
+                .with_key_value("my-key", "my-value")
+                .build();
+            let event = compute_cluster_change_events_on_updated(
+                &cluster_id,
+                &self_chitchat_id,
+                &updated_chitchat_id,
+                &updated_node_state,
+                &mut previous_nodes,
+            )
+            .await
+            .unwrap();
+            let ClusterChange::Remove(node) = event else {
+                panic!("Expected `ClusterChange::Remove` event, got `{:?}`.", event);
+            };
+            assert_eq!(node.chitchat_id(), &updated_chitchat_id);
+            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert!(!node.is_self_node());
+            assert!(!node.is_ready());
+            assert_eq!(previous_nodes.get(&updated_chitchat_id).unwrap(), &node);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_compute_cluster_change_events_on_removed() {
+        let cluster_id = "test-cluster".to_string();
+        let self_port = 1234;
+        let self_chitchat_id = ChitchatId::for_local_test(self_port);
+        {
+            // Node left the cluster but it's missing from the previous live nodes.
+            let port = 1235;
+            let removed_chitchat_id = ChitchatId::for_local_test(port);
+            let mut previous_nodes = BTreeMap::default();
+
+            let event_opt = compute_cluster_change_events_on_removed(
+                &cluster_id,
+                &self_chitchat_id,
+                &removed_chitchat_id,
+                &mut previous_nodes,
+            );
+            assert!(event_opt.is_none());
+        }
+        {
+            // Node left the cluster in not ready state.
+            let port = 1235;
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
+            let removed_chitchat_id = ChitchatId::for_local_test(port);
+            let previous_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(false)
+                .build();
+            let previous_channel = Channel::from_static("http://127.0.0.1:12345/").connect_lazy();
+            let is_self_node = true;
+            let previous_node = ClusterNode::try_new(
+                removed_chitchat_id.clone(),
+                &previous_node_state,
+                previous_channel,
+                is_self_node,
+            )
+            .unwrap();
+            let mut previous_nodes =
+                BTreeMap::from_iter([(removed_chitchat_id.clone(), previous_node)]);
+
+            let event_opt = compute_cluster_change_events_on_removed(
+                &cluster_id,
+                &self_chitchat_id,
+                &removed_chitchat_id,
+                &mut previous_nodes,
+            );
+            assert!(event_opt.is_none());
+            assert!(!previous_nodes.contains_key(&removed_chitchat_id));
+        }
+        {
+            // Node left the cluster in ready state.
+            let port = 1235;
+            let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
+            let removed_chitchat_id = ChitchatId::for_local_test(port);
+            let new_node_state = NodeStateBuilder::default()
+                .with_grpc_advertise_addr(grpc_advertise_addr)
+                .with_readiness(true)
+                .build();
+            let channel = Channel::from_static("http://127.0.0.1:12345/").connect_lazy();
+            let node =
+                ClusterNode::try_new(removed_chitchat_id.clone(), &new_node_state, channel, false)
+                    .unwrap();
+            let mut previous_nodes = BTreeMap::from_iter([(removed_chitchat_id.clone(), node)]);
+
+            let event = compute_cluster_change_events_on_removed(
+                &cluster_id,
+                &self_chitchat_id,
+                &removed_chitchat_id,
+                &mut previous_nodes,
+            )
+            .unwrap();
+
+            let ClusterChange::Remove(node) = event else {
+                panic!("Expected `ClusterChange::Remove` event, got `{:?}`.", event);
+            };
+            assert_eq!(node.chitchat_id(), &removed_chitchat_id);
+            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert!(!node.is_self_node());
+            assert!(node.is_ready());
+            assert!(!previous_nodes.contains_key(&removed_chitchat_id));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_compute_cluster_change_events() {
+        let cluster_id = "test-cluster".to_string();
+        let self_port = 1234;
+        let self_chitchat_id = ChitchatId::for_local_test(self_port);
+        {
+            let mut previous_nodes = BTreeMap::default();
+            let previous_node_states = BTreeMap::default();
+            let new_node_states = BTreeMap::default();
+            let events = compute_cluster_change_events(
+                &cluster_id,
+                &self_chitchat_id,
+                &mut previous_nodes,
+                &previous_node_states,
+                &new_node_states,
+            )
+            .await;
+            assert!(events.is_empty());
+        }
+        {
+            // Node remained unchanged.
+            let previous_node_state = NodeStateBuilder::default().with_readiness(true).build();
+            let previous_channel = Channel::from_static("http://127.0.0.1:12345/").connect_lazy();
+            let is_self_node = true;
+            let previous_node = ClusterNode::try_new(
+                self_chitchat_id.clone(),
+                &previous_node_state,
+                previous_channel,
+                is_self_node,
+            )
+            .unwrap();
+            let mut previous_nodes =
+                BTreeMap::from_iter([(self_chitchat_id.clone(), previous_node)]);
+            let previous_node_states =
+                BTreeMap::from_iter([(self_chitchat_id.clone(), previous_node_state)]);
+
+            let new_node_state = NodeStateBuilder::default().with_readiness(true).build();
+            let new_node_states = BTreeMap::from_iter([(self_chitchat_id.clone(), new_node_state)]);
+
+            let events = compute_cluster_change_events(
+                &cluster_id,
+                &self_chitchat_id,
+                &mut previous_nodes,
+                &previous_node_states,
+                &new_node_states,
+            )
+            .await;
+            assert!(events.is_empty());
+        }
+        {
+            // Node joined the cluster.
+            let mut previous_nodes = BTreeMap::default();
+            let previous_node_states = BTreeMap::default();
+            let new_chitchat_id = ChitchatId::for_local_test(self_port + 1);
+            let new_node_state = NodeStateBuilder::default().with_readiness(true).build();
+            let new_node_states = BTreeMap::from_iter([(new_chitchat_id, new_node_state)]);
+            let events = compute_cluster_change_events(
+                &cluster_id,
+                &self_chitchat_id,
+                &mut previous_nodes,
+                &previous_node_states,
+                &new_node_states,
+            )
+            .await;
+            assert_eq!(events.len(), 1);
+
+            let ClusterChange::Add(_node) = events[0].clone() else {
+                panic!("Expected `ClusterChange::Add` event, got `{:?}`.", events[0]);
+            };
+
+            let events = compute_cluster_change_events(
+                &cluster_id,
+                &self_chitchat_id,
+                &mut previous_nodes,
+                &new_node_states,
+                &new_node_states,
+            )
+            .await;
+            assert_eq!(events.len(), 0);
+        }
+        {
+            // Node changed.
+            let previous_node_state = NodeStateBuilder::default().with_readiness(true).build();
+            let previous_channel = Channel::from_static("http://127.0.0.1:12345/").connect_lazy();
+            let is_self_node = true;
+            let previous_node = ClusterNode::try_new(
+                self_chitchat_id.clone(),
+                &previous_node_state,
+                previous_channel,
+                is_self_node,
+            )
+            .unwrap();
+            let mut previous_nodes =
+                BTreeMap::from_iter([(self_chitchat_id.clone(), previous_node)]);
+            let previous_node_states =
+                BTreeMap::from_iter([(self_chitchat_id.clone(), previous_node_state)]);
+
+            let new_node_state = NodeStateBuilder::default()
+                .with_readiness(true)
+                .with_key_value("my-key", "my-value")
+                .build();
+            let new_node_states = BTreeMap::from_iter([(self_chitchat_id.clone(), new_node_state)]);
+
+            let events = compute_cluster_change_events(
+                &cluster_id,
+                &self_chitchat_id,
+                &mut previous_nodes,
+                &previous_node_states,
+                &new_node_states,
+            )
+            .await;
+            assert_eq!(events.len(), 1);
+
+            let ClusterChange::Update(_node) = events[0].clone() else {
+                panic!("Expected `ClusterChange::Update` event, got `{:?}`.", events[0]);
+            };
+
+            // Node left the cluster.
+            let new_node_states = BTreeMap::default();
+            let events = compute_cluster_change_events(
+                &cluster_id,
+                &self_chitchat_id,
+                &mut previous_nodes,
+                &previous_node_states,
+                &new_node_states,
+            )
+            .await;
+            assert_eq!(events.len(), 1);
+
+            let ClusterChange::Remove(_node) = events[0].clone() else {
+                panic!("Expected `ClusterChange::Remove` event, got `{:?}`.", events[0]);
+            };
+        }
+    }
+}

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -17,34 +17,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
+use std::fmt::Debug;
 use std::net::SocketAddr;
-use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
-use chitchat::transport::{ChannelTransport, Transport};
+use anyhow::Context;
+use chitchat::transport::Transport;
 use chitchat::{
-    spawn_chitchat, ChitchatConfig, ChitchatHandle, ClusterStateSnapshot, FailureDetectorConfig,
-    NodeId, NodeState,
+    spawn_chitchat, Chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, ClusterStateSnapshot,
+    FailureDetectorConfig, NodeState,
 };
+use futures::Stream;
 use itertools::Itertools;
 use quickwit_proto::indexing_api::IndexingTask;
 use serde::{Deserialize, Serialize};
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch, Mutex, RwLock};
 use tokio::time::timeout;
-use tokio_stream::wrappers::WatchStream;
+use tokio_stream::wrappers::{UnboundedReceiverStream, WatchStream};
 use tokio_stream::StreamExt;
-use tracing::{debug, error, info};
+use tracing::{info, warn};
 
-use crate::error::{ClusterError, ClusterResult};
+use crate::change::{compute_cluster_change_events, ClusterChange};
 use crate::member::{
-    build_cluster_members, ClusterMember, ENABLED_SERVICES_KEY, GRPC_ADVERTISE_ADDR_KEY,
-    INDEXING_TASK_PREFIX,
+    build_cluster_member, ClusterMember, NodeStateExt, ENABLED_SERVICES_KEY,
+    GRPC_ADVERTISE_ADDR_KEY, INDEXING_TASK_PREFIX, READINESS_KEY, READINESS_VALUE_NOT_READY,
+    READINESS_VALUE_READY,
 };
-use crate::QuickwitService;
+use crate::ClusterNode;
 
 const GOSSIP_INTERVAL: Duration = if cfg!(any(test, feature = "testsuite")) {
     Duration::from_millis(25)
@@ -58,81 +59,81 @@ const MARKED_FOR_DELETION_GRACE_PERIOD: usize = if cfg!(any(test, feature = "tes
     5_000 // ~ HEARTBEAT * 5_000 ~ 4 hours.
 };
 
-// Health key and values used to store node's health in chitchat state.
-const HEALTH_KEY: &str = "health";
-const HEALTH_VALUE_READY: &str = "READY";
-const HEALTH_VALUE_NOT_READY: &str = "NOT_READY";
-
-/// This is an implementation of a cluster using Chitchat.
+#[derive(Clone)]
 pub struct Cluster {
-    /// ID of the cluster joined.
-    pub cluster_id: String,
-    /// Node ID.
-    pub node_id: NodeId,
-    /// A socket address that represents itself.
-    pub gossip_listen_addr: SocketAddr,
-
-    /// A handle to command Chitchat.
-    /// If it is dropped, the chitchat server will stop.
-    chitchat_handle: ChitchatHandle,
-
-    /// A watcher that receives ready members changes from chitchat.
-    members_rx: watch::Receiver<Vec<ClusterMember>>,
-
-    /// A stop flag of cluster monitoring task.
-    /// Once the cluster is created, a task to monitor cluster events will be started.
-    /// Nodes do not need to be monitored for events once they are detached from the cluster.
-    /// You need to update this value to get out of the task loop.
-    stop: Arc<AtomicBool>,
+    cluster_id: String,
+    self_chitchat_id: ChitchatId,
+    /// Socket address (UDP) the node listens on for receiving gossip messages.
+    gossip_listen_addr: SocketAddr,
+    inner: Arc<RwLock<InnerCluster>>,
 }
 
-fn is_ready_predicate(node_state: &NodeState) -> bool {
-    node_state
-        .get(HEALTH_KEY)
-        .map(|health_value| health_value == HEALTH_VALUE_READY)
-        .unwrap_or(false)
+impl Debug for Cluster {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Cluster")
+            .field("cluster_id", &self.cluster_id)
+            .field("self_node_id", &self.self_chitchat_id.node_id)
+            .field("gossip_listen_addr", &self.gossip_listen_addr)
+            .field(
+                "gossip_advertise_addr",
+                &self.self_chitchat_id.gossip_advertise_addr,
+            )
+            .finish()
+    }
 }
 
 impl Cluster {
-    /// Create a cluster given a host key and a listen address.
-    /// When a cluster is created, the thread that monitors cluster events
-    /// will be started at the same time.
+    pub fn cluster_id(&self) -> &str {
+        &self.cluster_id
+    }
+
+    pub fn self_chitchat_id(&self) -> &ChitchatId {
+        &self.self_chitchat_id
+    }
+
+    pub fn self_node_id(&self) -> &str {
+        &self.self_chitchat_id.node_id
+    }
+
+    pub fn gossip_listen_addr(&self) -> SocketAddr {
+        self.gossip_listen_addr
+    }
+
+    pub fn gossip_advertise_addr(&self) -> SocketAddr {
+        self.self_chitchat_id.gossip_advertise_addr
+    }
+
     pub async fn join(
+        cluster_id: String,
         self_node: ClusterMember,
         gossip_listen_addr: SocketAddr,
-        cluster_id: String,
         peer_seed_addrs: Vec<String>,
         failure_detector_config: FailureDetectorConfig,
         transport: &dyn Transport,
-    ) -> ClusterResult<Self> {
+    ) -> anyhow::Result<Self> {
         info!(
-            cluster_id = %cluster_id,
-            node_id = %self_node.node_id,
-            enabled_services = ?self_node.enabled_services,
-            gossip_listen_addr = %gossip_listen_addr,
-            gossip_advertise_addr = %self_node.gossip_advertise_addr,
-            grpc_advertise_addr = %self_node.grpc_advertise_addr,
-            peer_seed_addrs = %peer_seed_addrs.join(", "),
+            cluster_id=%cluster_id,
+            node_id=%self_node.node_id,
+            enabled_services=?self_node.enabled_services,
+            gossip_listen_addr=%gossip_listen_addr,
+            gossip_advertise_addr=%self_node.gossip_advertise_addr,
+            grpc_advertise_addr=%self_node.grpc_advertise_addr,
+            peer_seed_addrs=%peer_seed_addrs.join(", "),
             "Joining cluster."
         );
-        let self_node_id = NodeId::from(self_node.clone());
         let chitchat_config = ChitchatConfig {
             cluster_id: cluster_id.clone(),
-            node_id: self_node_id.clone(),
-            gossip_interval: GOSSIP_INTERVAL,
+            chitchat_id: self_node.chitchat_id(),
             listen_addr: gossip_listen_addr,
             seed_nodes: peer_seed_addrs,
             failure_detector_config,
-            is_ready_predicate: Some(Box::new(is_ready_predicate)),
+            gossip_interval: GOSSIP_INTERVAL,
             marked_for_deletion_grace_period: MARKED_FOR_DELETION_GRACE_PERIOD,
         };
         let chitchat_handle = spawn_chitchat(
             chitchat_config,
             vec![
-                (
-                    GRPC_ADVERTISE_ADDR_KEY.to_string(),
-                    self_node.grpc_advertise_addr.to_string(),
-                ),
                 (
                     ENABLED_SERVICES_KEY.to_string(),
                     self_node
@@ -141,152 +142,104 @@ impl Cluster {
                         .map(|service| service.as_str())
                         .join(","),
                 ),
-                (HEALTH_KEY.to_string(), HEALTH_VALUE_NOT_READY.to_string()),
+                (
+                    GRPC_ADVERTISE_ADDR_KEY.to_string(),
+                    self_node.grpc_advertise_addr.to_string(),
+                ),
+                (
+                    READINESS_KEY.to_string(),
+                    READINESS_VALUE_NOT_READY.to_string(),
+                ),
             ],
             transport,
         )
-        .await
-        .map_err(|cause| ClusterError::UDPPortBindingError {
-            listen_addr: gossip_listen_addr,
-            cause: cause.to_string(),
-        })?;
+        .await?;
+
         let chitchat = chitchat_handle.chitchat();
+        let live_nodes_stream = chitchat.lock().await.live_nodes_watcher();
+        let (ready_members_tx, ready_members_rx) = watch::channel(Vec::new());
 
-        let (members_sender, members_receiver) = watch::channel(Vec::new());
-
-        // Create cluster.
-        let cluster = Cluster {
+        spawn_ready_members_task(cluster_id.clone(), live_nodes_stream, ready_members_tx);
+        let inner = InnerCluster {
             cluster_id: cluster_id.clone(),
-            node_id: self_node_id.clone(),
-            gossip_listen_addr,
+            self_chitchat_id: self_node.chitchat_id(),
             chitchat_handle,
-            members_rx: members_receiver,
-            stop: Arc::new(AtomicBool::new(false)),
+            live_nodes: BTreeMap::new(),
+            change_stream_subscribers: Vec::new(),
+            ready_members_rx,
         };
-
-        // Add itself as the initial member of the cluster.
-        let initial_members: Vec<ClusterMember> = vec![self_node.clone()];
-        if members_sender.send(initial_members).is_err() {
-            error!("Failed to add itself as the initial member of the cluster.");
-        }
-
-        // Prepare to start a task that will monitor cluster events.
-        let task_stop = cluster.stop.clone();
-        tokio::task::spawn(async move {
-            let mut node_change_receiver = chitchat.lock().await.ready_nodes_watcher();
-
-            while let Some(mut members_set) = node_change_receiver.next().await {
-                let cluster_state_snapshot = chitchat.lock().await.state_snapshot();
-                // `members_set` does not contain `self`.
-                members_set.insert(self_node_id.clone());
-                let cluster_members = build_cluster_members(members_set, &cluster_state_snapshot);
-                if task_stop.load(Ordering::Relaxed) {
-                    debug!("Received a stop signal. Stopping.");
-                    break;
-                }
-
-                if members_sender.send(cluster_members).is_err() {
-                    // Somehow the cluster has been dropped.
-                    error!("Failed to send members list. Stopping.");
-                    break;
-                }
-            }
-            Result::<(), anyhow::Error>::Ok(())
-        });
-
+        let cluster = Cluster {
+            cluster_id,
+            self_chitchat_id: self_node.chitchat_id(),
+            gossip_listen_addr,
+            inner: Arc::new(RwLock::new(inner)),
+        };
+        spawn_ready_nodes_change_stream_task(cluster.clone()).await;
         Ok(cluster)
     }
 
-    /// Returns a [`WatchStream`] for monitoring change of ready `members`.
-    /// Note that it does not monitor changes of properties of members, this means
-    /// that a [`ClusterMember`] has no guarantee to have its properties up-to-date.
-    /// To get the latest properties of a [`ClusterMember`], use
-    /// `Self::ready_members_from_chitchat_state`.
-    pub fn ready_member_change_watcher(&self) -> WatchStream<Vec<ClusterMember>> {
-        WatchStream::new(self.members_rx.clone())
-    }
-
-    /// Returns the last [`ClusterMember`] sent by chitchat.
-    /// Note that a [`ClusterMember`] has no guarantee to have its properties up-to-date.
-    /// To get the latest properties of a [`ClusterMember`], use
-    /// `Self::ready_members_from_chitchat_state`.
+    /// Deprecated: this is going away soon.
     pub async fn ready_members(&self) -> Vec<ClusterMember> {
-        self.members_rx.borrow().clone()
+        self.inner.read().await.ready_members_rx.borrow().clone()
     }
 
-    /// Returns ready [`ClusterMember`]s built directly from the current chitchat state.
-    /// This guarantees to have members with up-to-date properties.
-    pub async fn ready_members_from_chitchat_state(&self) -> Vec<ClusterMember> {
-        let cluster_snapshot = self.snapshot().await;
-        let mut ready_nodes = cluster_snapshot.ready_nodes.clone();
-        let is_self_node_ready = cluster_snapshot
-            .chitchat_state_snapshot
-            .node_states
-            .get(&cluster_snapshot.self_node_id.id)
-            .map(is_ready_predicate)
-            .unwrap_or(false);
-        if is_self_node_ready {
-            ready_nodes.insert(cluster_snapshot.self_node_id.clone());
+    /// Deprecated: this is going away soon.
+    pub async fn ready_members_watcher(&self) -> WatchStream<Vec<ClusterMember>> {
+        WatchStream::new(self.inner.read().await.ready_members_rx.clone())
+    }
+
+    /// Returns a stream of changes affecting the set of ready nodes in the cluster.
+    pub async fn ready_nodes_change_stream(&self) -> impl Stream<Item = ClusterChange> {
+        // The subscriber channel must be unbounded because we do no want to block when sending the
+        // events.
+        let (change_stream_tx, change_stream_rx) = mpsc::unbounded_channel();
+        let mut inner = self.inner.write().await;
+        for node in inner.live_nodes.values() {
+            if node.is_ready() {
+                change_stream_tx
+                    .send(ClusterChange::Add(node.clone()))
+                    .expect("The receiver end of the channel should be open.");
+            }
         }
-        build_cluster_members(ready_nodes, &cluster_snapshot.chitchat_state_snapshot)
+        inner.change_stream_subscribers.push(change_stream_tx);
+        UnboundedReceiverStream::new(change_stream_rx)
     }
 
-    // Returns the gRPC addresses of the members providing the specified service. Used for testing.
-    #[cfg(test)]
-    pub fn members_grpc_advertise_addr_for_service(
+    /// Returns whether the self node is ready.
+    pub async fn is_self_node_ready(&self) -> bool {
+        self.chitchat()
+            .await
+            .lock()
+            .await
+            .node_state(&self.self_chitchat_id)
+            .expect("The self node should always be present in the set of live nodes.")
+            .is_ready()
+    }
+
+    /// Sets the self node's readiness.
+    pub async fn set_self_node_readiness(&self, readiness: bool) {
+        let readiness_value = if readiness {
+            READINESS_VALUE_READY
+        } else {
+            READINESS_VALUE_NOT_READY
+        };
+        self.set_self_key_value(READINESS_KEY, readiness_value)
+            .await
+    }
+
+    /// Sets a key-value pair on the cluster node's state.
+    pub async fn set_self_key_value<K: Into<String>, V: Into<String>>(&self, key: K, value: V) {
+        self.chitchat()
+            .await
+            .lock()
+            .await
+            .self_node_state()
+            .set(key, value);
+    }
+
+    /// Waits until the predicate holds true for the set of ready members.
+    pub async fn wait_for_ready_members<F>(
         &self,
-        service: &QuickwitService,
-    ) -> Vec<SocketAddr> {
-        self.members_rx
-            .borrow()
-            .iter()
-            .filter(|member| member.enabled_services.contains(service))
-            .map(|member| member.grpc_advertise_addr)
-            .collect_vec()
-    }
-
-    /// Set a key-value pair on the cluster node's state.
-    pub async fn set_key_value<K: ToString, V: ToString>(&self, key: K, value: V) {
-        let chitchat = self.chitchat_handle.chitchat();
-        let mut chitchat_guard = chitchat.lock().await;
-        chitchat_guard.self_node_state().set(key, value);
-    }
-
-    pub async fn snapshot(&self) -> ClusterSnapshot {
-        let chitchat = self.chitchat_handle.chitchat();
-        let chitchat_guard = chitchat.lock().await;
-
-        let chitchat_state_snapshot = chitchat_guard.state_snapshot();
-        let ready_nodes = chitchat_guard
-            .ready_nodes()
-            .cloned()
-            .collect::<HashSet<_>>();
-        let dead_nodes = chitchat_guard.dead_nodes().cloned().collect::<HashSet<_>>();
-        let live_nodes = chitchat_guard.live_nodes().cloned().collect::<HashSet<_>>();
-        ClusterSnapshot {
-            cluster_id: self.cluster_id.clone(),
-            self_node_id: self.node_id.clone(),
-            chitchat_state_snapshot,
-            ready_nodes,
-            live_nodes,
-            dead_nodes,
-        }
-    }
-
-    /// Leave the cluster.
-    pub async fn shutdown(self) {
-        info!(self_addr = ?self.gossip_listen_addr, "Shutting down chitchat.");
-        let result = self.chitchat_handle.shutdown().await;
-        if let Err(error) = result {
-            error!(self_addr = ?self.gossip_listen_addr, error = ?error, "Error while shutting down chitchat.");
-        }
-
-        self.stop.store(true, Ordering::Relaxed);
-    }
-
-    /// Waiting for the predicate to hold true for the cluster's members.
-    pub async fn wait_for_members<F>(
-        self: &Cluster,
         mut predicate: F,
         timeout_after: Duration,
     ) -> anyhow::Result<()>
@@ -295,31 +248,56 @@ impl Cluster {
     {
         timeout(
             timeout_after,
-            self.ready_member_change_watcher()
+            self.ready_members_watcher()
+                .await
                 .skip_while(|members| !predicate(members))
                 .next(),
         )
         .await
-        .map_err(|_| anyhow!("Waiting for members deadline has elapsed."))?;
+        .context("Deadline has passed before predicate held true.")?;
         Ok(())
     }
 
-    /// Set self readiness value.
-    pub async fn set_self_node_ready(&self, ready: bool) {
-        let health_value = if ready {
-            HEALTH_VALUE_READY
-        } else {
-            HEALTH_VALUE_NOT_READY
-        };
-        self.set_key_value(HEALTH_KEY, health_value).await
+    /// Returns a snapshot of the cluster state, including the underlying Chitchat state.
+    pub async fn snapshot(&self) -> ClusterSnapshot {
+        let chitchat = self.chitchat().await;
+        let chitchat_guard = chitchat.lock().await;
+        let chitchat_state_snapshot = chitchat_guard.state_snapshot();
+        let mut ready_nodes = HashSet::new();
+        let mut live_nodes = HashSet::new();
+
+        for chitchat_id in chitchat_guard.live_nodes().cloned() {
+            let node_state = chitchat_guard.node_state(&chitchat_id).expect(
+                "The node should always be present in the cluster state because we hold the \
+                 Chitchat mutex.",
+            );
+            if node_state.is_ready() {
+                ready_nodes.insert(chitchat_id);
+            } else {
+                live_nodes.insert(chitchat_id);
+            }
+        }
+        let dead_nodes = chitchat_guard.dead_nodes().cloned().collect::<HashSet<_>>();
+
+        ClusterSnapshot {
+            cluster_id: self.cluster_id.clone(),
+            self_node_id: self.self_chitchat_id.node_id.clone(),
+            ready_nodes,
+            live_nodes,
+            dead_nodes,
+            chitchat_state_snapshot,
+        }
     }
 
-    /// Returns true if self is ready.
-    pub async fn is_self_node_ready(&self) -> bool {
-        let chitchat = self.chitchat_handle.chitchat();
-        let mut chitchat_mutex = chitchat.lock().await;
-        let node_state = chitchat_mutex.self_node_state();
-        is_ready_predicate(node_state)
+    /// Leaves the cluster.
+    pub async fn shutdown(self) {
+        info!(
+            cluster_id=%self.cluster_id,
+            node_id=%self.self_chitchat_id.node_id,
+            "Leaving the cluster."
+        );
+        self.set_self_node_readiness(false).await;
+        tokio::time::sleep(GOSSIP_INTERVAL * 2).await;
     }
 
     /// Updates indexing tasks in chitchat state.
@@ -332,11 +310,11 @@ impl Cluster {
         &self,
         indexing_tasks: &[IndexingTask],
     ) -> anyhow::Result<()> {
-        let chitchat = self.chitchat_handle.chitchat();
+        let chitchat = self.chitchat().await;
         let mut chitchat_guard = chitchat.lock().await;
         let mut current_indexing_tasks_keys: HashSet<_> = chitchat_guard
             .self_node_state()
-            .iter_key_values(|key, _| key.starts_with(INDEXING_TASK_PREFIX))
+            .key_values(|key, _| key.starts_with(INDEXING_TASK_PREFIX))
             .map(|(key, _)| key.to_string())
             .collect();
         for (indexing_task, indexing_tasks_group) in
@@ -355,6 +333,98 @@ impl Cluster {
         }
         Ok(())
     }
+
+    async fn chitchat(&self) -> Arc<Mutex<Chitchat>> {
+        self.inner.read().await.chitchat_handle.chitchat()
+    }
+}
+
+/// Deprecated: this is going away soon.
+fn spawn_ready_members_task(
+    cluster_id: String,
+    mut live_nodes_stream: WatchStream<BTreeMap<ChitchatId, NodeState>>,
+    ready_members_tx: watch::Sender<Vec<ClusterMember>>,
+) {
+    let fut = async move {
+        while let Some(new_live_nodes) = live_nodes_stream.next().await {
+            let mut new_ready_members = Vec::with_capacity(new_live_nodes.len());
+
+            for (chitchat_id, node_state) in new_live_nodes {
+                let member = match build_cluster_member(chitchat_id, &node_state) {
+                    Ok(member) => member,
+                    Err(error) => {
+                        warn!(
+                            cluster_id=%cluster_id,
+                            error=?error,
+                            "Failed to build cluster member from Chitchat node state."
+                        );
+                        continue;
+                    }
+                };
+                if member.is_ready {
+                    new_ready_members.push(member);
+                }
+            }
+            if *ready_members_tx.borrow() != new_ready_members
+                && ready_members_tx.send(new_ready_members).is_err()
+            {
+                break;
+            }
+        }
+    };
+    tokio::spawn(fut);
+}
+
+async fn spawn_ready_nodes_change_stream_task(cluster: Cluster) {
+    let cluster_guard = cluster.inner.read().await;
+    let cluster_id = cluster_guard.cluster_id.clone();
+    let self_chitchat_id = cluster_guard.self_chitchat_id.clone();
+    let chitchat = cluster_guard.chitchat_handle.chitchat();
+    let weak_cluster = Arc::downgrade(&cluster.inner);
+    drop(cluster_guard);
+    drop(cluster);
+
+    let mut previous_live_node_states = BTreeMap::new();
+    let mut live_nodes_watcher = chitchat.lock().await.live_nodes_watcher();
+
+    let future = async move {
+        while let Some(new_live_node_states) = live_nodes_watcher.next().await {
+            let Some(cluster) = weak_cluster.upgrade() else {
+                break;
+            };
+            let mut cluster_guard = cluster.write().await;
+            let previous_live_nodes = &mut cluster_guard.live_nodes;
+
+            let events = compute_cluster_change_events(
+                &cluster_id,
+                &self_chitchat_id,
+                previous_live_nodes,
+                &previous_live_node_states,
+                &new_live_node_states,
+            )
+            .await;
+            if !events.is_empty() {
+                cluster_guard
+                    .change_stream_subscribers
+                    .retain(|change_stream_tx| {
+                        events
+                            .iter()
+                            .all(|event| change_stream_tx.send(event.clone()).is_ok())
+                    });
+            }
+            previous_live_node_states = new_live_node_states;
+        }
+    };
+    tokio::spawn(future);
+}
+
+struct InnerCluster {
+    cluster_id: String,
+    self_chitchat_id: ChitchatId,
+    chitchat_handle: ChitchatHandle,
+    live_nodes: BTreeMap<ChitchatId, ClusterNode>,
+    change_stream_subscribers: Vec<mpsc::UnboundedSender<ClusterChange>>,
+    ready_members_rx: watch::Receiver<Vec<ClusterMember>>,
 }
 
 // Not used within the code, used for documentation.
@@ -362,14 +432,18 @@ impl Cluster {
 pub struct NodeIdSchema {
     #[schema(example = "node-1")]
     /// The unique identifier of the node in the cluster.
-    pub id: String,
+    pub node_id: String,
+
+    #[schema(example = "1683736537", value_type = u64)]
+    /// A numeric identifier incremented every time the node leaves and rejoins the cluster.
+    pub generation_id: u64,
 
     #[schema(example = "127.0.0.1:8000", value_type = String)]
-    /// The SocketAddr other peers should use to communicate.
-    pub gossip_public_address: SocketAddr,
+    /// The socket address peers should use to gossip with the node.
+    pub gossip_advertise_addr: SocketAddr,
 }
 
-#[derive(Serialize, Deserialize, Debug, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ClusterSnapshot {
     #[schema(example = "qw-cluster-1")]
     /// The ID of the cluster that the node is a part of.
@@ -377,7 +451,19 @@ pub struct ClusterSnapshot {
 
     #[schema(value_type = NodeIdSchema)]
     /// The unique ID of the current node.
-    pub self_node_id: NodeId,
+    pub self_node_id: String,
+
+    #[schema(value_type  = Vec<NodeIdSchema>)]
+    /// The set of cluster node IDs that are ready to handle requests.
+    pub ready_nodes: HashSet<ChitchatId>,
+
+    #[schema(value_type  = Vec<NodeIdSchema>)]
+    /// The set of cluster node IDs that are alive but not ready.
+    pub live_nodes: HashSet<ChitchatId>,
+
+    #[schema(value_type  = Vec<NodeIdSchema>)]
+    /// The set of cluster node IDs flagged as dead or faulty.
+    pub dead_nodes: HashSet<ChitchatId>,
 
     #[schema(
         value_type = Object,
@@ -389,75 +475,74 @@ pub struct ClusterSnapshot {
             "max_version": 5,
         })
     )]
-    /// A snapshot of the current cluster state.
+    /// A complete snapshot of the Chitchat cluster state.
     pub chitchat_state_snapshot: ClusterStateSnapshot,
-
-    #[schema(value_type  = Vec<NodeIdSchema>)]
-    /// The set of node IDs that are ready to handle operations.
-    pub ready_nodes: HashSet<NodeId>,
-
-    #[schema(value_type  = Vec<NodeIdSchema>)]
-    /// The set of cluster node IDs that are alive.
-    pub live_nodes: HashSet<NodeId>,
-
-    #[schema(value_type  = Vec<NodeIdSchema>)]
-    /// The set of node IDs flagged as dead or faulty.
-    pub dead_nodes: HashSet<NodeId>,
 }
 
-/// Compute the gRPC port from the chitchat listen address for tests.
+/// Computes the gRPC port from the listen address for tests.
+#[cfg(any(test, feature = "testsuite"))]
 pub fn grpc_addr_from_listen_addr_for_test(listen_addr: SocketAddr) -> SocketAddr {
     let grpc_port = listen_addr.port() + 1u16;
     (listen_addr.ip(), grpc_port).into()
 }
 
+#[cfg(any(test, feature = "testsuite"))]
 pub async fn create_cluster_for_test_with_id(
     node_id: u16,
     cluster_id: String,
-    seeds: Vec<String>,
-    enabled_services: &HashSet<QuickwitService>,
+    peer_seed_addrs: Vec<String>,
+    enabled_services: &HashSet<quickwit_config::service::QuickwitService>,
     transport: &dyn Transport,
-    self_node_is_ready: bool,
+    self_node_readiness: bool,
 ) -> anyhow::Result<Cluster> {
     let gossip_advertise_addr: SocketAddr = ([127, 0, 0, 1], node_id).into();
     let node_id = format!("node_{node_id}");
+    let self_node = ClusterMember::new(
+        node_id,
+        crate::GenerationId(1),
+        self_node_readiness,
+        enabled_services.clone(),
+        gossip_advertise_addr,
+        grpc_addr_from_listen_addr_for_test(gossip_advertise_addr),
+        Vec::new(),
+    );
     let failure_detector_config = create_failure_detector_config_for_test();
     let cluster = Cluster::join(
-        ClusterMember::new(
-            node_id,
-            1,
-            enabled_services.clone(),
-            gossip_advertise_addr,
-            grpc_addr_from_listen_addr_for_test(gossip_advertise_addr),
-            Vec::new(),
-        ),
-        gossip_advertise_addr,
         cluster_id,
-        seeds,
+        self_node,
+        gossip_advertise_addr,
+        peer_seed_addrs,
         failure_detector_config,
         transport,
     )
     .await?;
-    cluster.set_self_node_ready(self_node_is_ready).await;
+    cluster.set_self_node_readiness(self_node_readiness).await;
     Ok(cluster)
 }
 
 /// Creates a failure detector config for tests.
+#[cfg(any(test, feature = "testsuite"))]
 fn create_failure_detector_config_for_test() -> FailureDetectorConfig {
     FailureDetectorConfig {
-        phi_threshold: 3.0,
+        phi_threshold: 5.0,
         initial_interval: GOSSIP_INTERVAL,
         ..Default::default()
     }
 }
 
 /// Creates a local cluster listening on a random port.
+#[cfg(any(test, feature = "testsuite"))]
 pub async fn create_cluster_for_test(
     seeds: Vec<String>,
     enabled_services: &[&str],
     transport: &dyn Transport,
-    self_node_is_ready: bool,
+    self_node_readiness: bool,
 ) -> anyhow::Result<Cluster> {
+    use std::str::FromStr;
+    use std::sync::atomic::{AtomicU16, Ordering};
+
+    use quickwit_config::service::QuickwitService;
+
     static NODE_AUTO_INCREMENT: AtomicU16 = AtomicU16::new(1u16);
     let node_id = NODE_AUTO_INCREMENT.fetch_add(1, Ordering::Relaxed);
     let enabled_services = enabled_services
@@ -470,15 +555,10 @@ pub async fn create_cluster_for_test(
         seeds,
         &enabled_services,
         transport,
-        self_node_is_ready,
+        self_node_readiness,
     )
     .await?;
     Ok(cluster)
-}
-
-/// Creates a fake cluster for the CLI indexing commands.
-pub async fn create_fake_cluster_for_cli() -> anyhow::Result<Cluster> {
-    create_cluster_for_test(Vec::new(), &[], &ChannelTransport::default(), false).await
 }
 
 #[cfg(test)]
@@ -490,6 +570,7 @@ mod tests {
     use chitchat::transport::ChannelTransport;
     use itertools::Itertools;
     use quickwit_common::test_utils::wait_until_predicate;
+    use quickwit_config::service::QuickwitService;
     use quickwit_proto::indexing_api::IndexingTask;
     use rand::Rng;
     use ulid::Ulid;
@@ -497,47 +578,175 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_cluster_single_node_readiness() -> anyhow::Result<()> {
+    async fn test_single_node_cluster_readiness() {
         let transport = ChannelTransport::default();
-        let cluster = create_cluster_for_test(Vec::new(), &[], &transport, false).await?;
-        let members: Vec<SocketAddr> = cluster
+        let node = create_cluster_for_test(Vec::new(), &[], &transport, false)
+            .await
+            .unwrap();
+
+        let mut ready_members_watcher = node.ready_members_watcher().await;
+        let ready_members = ready_members_watcher.next().await.unwrap();
+
+        assert!(ready_members.is_empty());
+        assert!(!node.is_self_node_ready().await);
+
+        let cluster_snapshot = node.snapshot().await;
+        assert!(cluster_snapshot.ready_nodes.is_empty());
+
+        let self_node_state = cluster_snapshot
+            .chitchat_state_snapshot
+            .node_state_snapshots
+            .into_iter()
+            .find(|node_state_snapshot| node_state_snapshot.chitchat_id == node.self_chitchat_id)
+            .map(|node_state_snapshot| node_state_snapshot.node_state)
+            .unwrap();
+        assert_eq!(
+            self_node_state.get(READINESS_KEY).unwrap(),
+            READINESS_VALUE_NOT_READY
+        );
+
+        node.set_self_node_readiness(true).await;
+
+        let ready_members = ready_members_watcher.next().await.unwrap();
+        assert_eq!(ready_members.len(), 1);
+        assert!(node.is_self_node_ready().await);
+
+        let cluster_snapshot = node.snapshot().await;
+        assert_eq!(cluster_snapshot.ready_nodes.len(), 1);
+
+        let self_node_state = cluster_snapshot
+            .chitchat_state_snapshot
+            .node_state_snapshots
+            .into_iter()
+            .find(|node_state_snapshot| node_state_snapshot.chitchat_id == node.self_chitchat_id)
+            .map(|node_state_snapshot| node_state_snapshot.node_state)
+            .unwrap();
+        assert_eq!(
+            self_node_state.get(READINESS_KEY).unwrap(),
+            READINESS_VALUE_READY
+        );
+
+        node.set_self_node_readiness(false).await;
+
+        let ready_members = ready_members_watcher.next().await.unwrap();
+        assert!(ready_members.is_empty());
+        assert!(!node.is_self_node_ready().await);
+
+        let cluster_snapshot = node.snapshot().await;
+        assert!(cluster_snapshot.ready_nodes.is_empty());
+
+        let self_node_state = cluster_snapshot
+            .chitchat_state_snapshot
+            .node_state_snapshots
+            .into_iter()
+            .find(|node_state_snapshot| node_state_snapshot.chitchat_id == node.self_chitchat_id)
+            .map(|node_state_snapshot| node_state_snapshot.node_state)
+            .unwrap();
+        assert_eq!(
+            self_node_state.get(READINESS_KEY).unwrap(),
+            READINESS_VALUE_NOT_READY
+        );
+        node.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_cluster_multiple_nodes() -> anyhow::Result<()> {
+        let transport = ChannelTransport::default();
+        let node_1 = create_cluster_for_test(Vec::new(), &[], &transport, true).await?;
+        let node_1_change_stream = node_1.ready_nodes_change_stream().await;
+
+        let peer_seeds = vec![node_1.gossip_listen_addr.to_string()];
+        let node_2 = create_cluster_for_test(peer_seeds, &[], &transport, true).await?;
+
+        let peer_seeds = vec![node_2.gossip_listen_addr.to_string()];
+        let node_3 = create_cluster_for_test(peer_seeds, &[], &transport, true).await?;
+
+        let wait_secs = Duration::from_secs(30);
+
+        for node in [&node_1, &node_2, &node_3] {
+            node.wait_for_ready_members(|members| members.len() == 3, wait_secs)
+                .await
+                .unwrap();
+        }
+        let members: Vec<SocketAddr> = node_1
             .ready_members()
             .await
-            .iter()
+            .into_iter()
             .map(|member| member.gossip_advertise_addr)
+            .sorted()
             .collect();
-        let expected_members = vec![cluster.gossip_listen_addr];
+        let mut expected_members = vec![
+            node_1.gossip_listen_addr,
+            node_2.gossip_listen_addr,
+            node_3.gossip_listen_addr,
+        ];
+        expected_members.sort();
         assert_eq!(members, expected_members);
-        assert!(!cluster.is_self_node_ready().await);
-        assert!(cluster.ready_members_from_chitchat_state().await.is_empty());
-        let cluster_snapshot = cluster.snapshot().await;
-        let self_node_state_not_ready = cluster_snapshot
-            .chitchat_state_snapshot
-            .node_states
-            .get(&cluster.node_id.id)
+
+        node_2.shutdown().await;
+        node_1
+            .wait_for_ready_members(|members| members.len() == 2, wait_secs)
+            .await
             .unwrap();
-        assert_eq!(
-            self_node_state_not_ready.get(HEALTH_KEY).unwrap(),
-            HEALTH_VALUE_NOT_READY
-        );
-        cluster.set_self_node_ready(true).await;
-        assert!(cluster.is_self_node_ready().await);
-        assert_eq!(cluster.ready_members_from_chitchat_state().await.len(), 1);
-        let cluster_state = cluster.snapshot().await;
-        let self_node_state_ready = cluster_state
-            .chitchat_state_snapshot
-            .node_states
-            .get(&cluster.node_id.id)
+
+        node_3.shutdown().await;
+        node_1
+            .wait_for_ready_members(|members| members.len() == 1, wait_secs)
+            .await
             .unwrap();
-        assert_eq!(
-            self_node_state_ready.get(HEALTH_KEY).unwrap(),
-            HEALTH_VALUE_READY
-        );
-        assert!(!cluster.ready_members().await.is_empty(),);
-        cluster.set_self_node_ready(false).await;
-        assert!(!cluster.is_self_node_ready().await);
-        cluster.shutdown().await;
+
+        node_1.shutdown().await;
+
+        let cluster_changes: Vec<ClusterChange> = node_1_change_stream.collect().await;
+        assert_eq!(cluster_changes.len(), 6);
+        assert!(matches!(&cluster_changes[0], ClusterChange::Add(_)));
+        assert!(matches!(&cluster_changes[1], ClusterChange::Add(_)));
+        assert!(matches!(&cluster_changes[2], ClusterChange::Add(_)));
+        assert!(matches!(&cluster_changes[3], ClusterChange::Remove(_)));
+        assert!(matches!(&cluster_changes[4], ClusterChange::Remove(_)));
+        assert!(matches!(&cluster_changes[5], ClusterChange::Remove(_)));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_node_cluster_readiness() {
+        let transport = ChannelTransport::default();
+        let node_1 =
+            create_cluster_for_test(Vec::new(), &["searcher", "indexer"], &transport, true)
+                .await
+                .unwrap();
+
+        let peer_seeds = vec![node_1.gossip_listen_addr.to_string()];
+        let node_2 = create_cluster_for_test(peer_seeds, &["indexer"], &transport, false)
+            .await
+            .unwrap();
+
+        let wait_secs = Duration::from_secs(5);
+
+        // Bother cluster 1 and cluster 2 see only one ready member.
+        node_1
+            .wait_for_ready_members(|members| members.len() == 1, wait_secs)
+            .await
+            .unwrap();
+
+        node_2
+            .wait_for_ready_members(|members| members.len() == 1, wait_secs)
+            .await
+            .unwrap();
+
+        // Now, node 2 becomes ready.
+        node_2.set_self_node_readiness(true).await;
+
+        // Bother cluster 1 and cluster 2 see only two ready members.
+        node_1
+            .wait_for_ready_members(|members| members.len() == 2, wait_secs)
+            .await
+            .unwrap();
+
+        node_2
+            .wait_for_ready_members(|members| members.len() == 2, wait_secs)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -560,24 +769,24 @@ mod tests {
             incarnation_id: Ulid::new().to_string(),
         };
         cluster2
-            .set_key_value(GRPC_ADVERTISE_ADDR_KEY, "127.0.0.1:1001")
+            .set_self_key_value(GRPC_ADVERTISE_ADDR_KEY, "127.0.0.1:1001")
             .await;
         cluster2
             .update_self_node_indexing_tasks(&[indexing_task.clone(), indexing_task.clone()])
             .await
             .unwrap();
         cluster1
-            .wait_for_members(|members| members.len() == 2, Duration::from_secs(30))
+            .wait_for_ready_members(|members| members.len() == 2, Duration::from_secs(30))
             .await
             .unwrap();
-        let members = cluster1.ready_members_from_chitchat_state().await;
+        let members = cluster1.ready_members().await;
         let member_node_1 = members
             .iter()
-            .find(|member| member.chitchat_id() == cluster1.node_id.id)
+            .find(|member| member.chitchat_id() == cluster1.self_chitchat_id)
             .unwrap();
         let member_node_2 = members
             .iter()
-            .find(|member| member.chitchat_id() == cluster2.node_id.id)
+            .find(|member| member.chitchat_id() == cluster2.self_chitchat_id)
             .unwrap();
         assert_eq!(
             member_node_1.enabled_services,
@@ -648,7 +857,7 @@ mod tests {
                 move || {
                     test_indexing_tasks_in_given_node(
                         cluster_clone.clone(),
-                        cluster1.node_id.gossip_public_address,
+                        cluster1.self_chitchat_id.gossip_advertise_addr,
                         indexing_tasks_clone.clone(),
                     )
                 },
@@ -667,7 +876,7 @@ mod tests {
                 move || {
                     test_indexing_tasks_in_given_node(
                         cluster_clone.clone(),
-                        cluster1.node_id.gossip_public_address,
+                        cluster1.self_chitchat_id.gossip_advertise_addr,
                         Vec::new(),
                     )
                 },
@@ -690,7 +899,7 @@ mod tests {
                 move || {
                     test_indexing_tasks_in_given_node(
                         cluster_clone.clone(),
-                        cluster1.node_id.gossip_public_address,
+                        cluster1.self_chitchat_id.gossip_advertise_addr,
                         indexing_tasks_clone.clone(),
                     )
                 },
@@ -704,13 +913,13 @@ mod tests {
 
     async fn test_indexing_tasks_in_given_node(
         cluster: Arc<Cluster>,
-        gossip_public_address: SocketAddr,
+        gossip_advertise_addr: SocketAddr,
         indexing_tasks: Vec<IndexingTask>,
     ) -> bool {
-        let members = cluster.ready_members_from_chitchat_state().await;
+        let members = cluster.ready_members().await;
         let node_opt = members
             .iter()
-            .find(|member| member.gossip_advertise_addr == gossip_public_address);
+            .find(|member| member.gossip_advertise_addr == gossip_advertise_addr);
         let Some(node) = node_opt else {
             return false;
         };
@@ -733,11 +942,11 @@ mod tests {
     #[tokio::test]
     async fn test_chitchat_state_with_malformatted_indexing_task_key() {
         let transport = ChannelTransport::default();
-        let cluster1 = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
+        let node = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await
             .unwrap();
         {
-            let chitchat_handle = cluster1.chitchat_handle.chitchat();
+            let chitchat_handle = node.inner.read().await.chitchat_handle.chitchat();
             let mut chitchat_guard = chitchat_handle.lock().await;
             chitchat_guard.self_node_state().set(
                 format!(
@@ -750,120 +959,11 @@ mod tests {
                 "malformatted value".to_string(),
             );
         }
-        let member = cluster1.ready_members_from_chitchat_state().await;
-        assert_eq!(member[0].indexing_tasks.len(), 2);
-    }
-    #[tokio::test]
-    async fn test_cluster_available_searcher() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster1 = create_cluster_for_test(Vec::new(), &["searcher"], &transport, true).await?;
-        let node_1 = cluster1.gossip_listen_addr.to_string();
-        let cluster2 =
-            create_cluster_for_test(vec![node_1.clone()], &["searcher"], &transport, true).await?;
-        let cluster3 =
-            create_cluster_for_test(vec![node_1], &["indexer"], &transport, true).await?;
-        let mut expected_searchers = vec![
-            grpc_addr_from_listen_addr_for_test(cluster1.gossip_listen_addr),
-            grpc_addr_from_listen_addr_for_test(cluster2.gossip_listen_addr),
-        ];
-        expected_searchers.sort();
-
-        let wait_secs = Duration::from_secs(30);
-        for cluster in [&cluster1, &cluster2, &cluster3] {
-            cluster
-                .wait_for_members(|members| members.len() == 3, wait_secs)
-                .await
-                .unwrap();
-        }
-
-        let mut searchers =
-            cluster1.members_grpc_advertise_addr_for_service(&QuickwitService::Searcher);
-        searchers.sort();
-        assert_eq!(searchers, expected_searchers);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_cluster_available_indexer() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster1 =
-            create_cluster_for_test(Vec::new(), &["searcher", "indexer"], &transport, true).await?;
-        let node_1 = cluster1.gossip_listen_addr.to_string();
-        let cluster2 =
-            create_cluster_for_test(vec![node_1.clone()], &["indexer"], &transport, true).await?;
-        let cluster3 =
-            create_cluster_for_test(vec![node_1], &["indexer", "searcher"], &transport, true)
-                .await?;
-        let mut expected_indexers = vec![
-            grpc_addr_from_listen_addr_for_test(cluster1.gossip_listen_addr),
-            grpc_addr_from_listen_addr_for_test(cluster2.gossip_listen_addr),
-            grpc_addr_from_listen_addr_for_test(cluster3.gossip_listen_addr),
-        ];
-        expected_indexers.sort();
-
-        let wait_secs = Duration::from_secs(30);
-
-        for cluster in [&cluster1, &cluster2, &cluster3] {
-            cluster
-                .wait_for_members(|members| members.len() == 3, wait_secs)
-                .await
-                .unwrap();
-        }
-
-        let mut indexers =
-            cluster1.members_grpc_advertise_addr_for_service(&QuickwitService::Indexer);
-        indexers.sort();
-        assert_eq!(indexers, expected_indexers);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_cluster_multiple_nodes() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster1 = create_cluster_for_test(Vec::new(), &[], &transport, true).await?;
-        let node_1 = cluster1.gossip_listen_addr.to_string();
-        let cluster2 = create_cluster_for_test(vec![node_1.clone()], &[], &transport, true).await?;
-        let cluster3 = create_cluster_for_test(vec![node_1], &[], &transport, true).await?;
-
-        let wait_secs = Duration::from_secs(30);
-
-        for cluster in [&cluster1, &cluster2, &cluster3] {
-            cluster
-                .wait_for_members(|members| members.len() == 3, wait_secs)
-                .await
-                .unwrap();
-        }
-        let members: Vec<SocketAddr> = cluster1
-            .ready_members()
-            .await
-            .iter()
-            .map(|member| member.gossip_advertise_addr)
-            .sorted()
-            .collect();
-        let mut expected_members = vec![
-            cluster1.gossip_listen_addr,
-            cluster2.gossip_listen_addr,
-            cluster3.gossip_listen_addr,
-        ];
-        expected_members.sort();
-        assert_eq!(members, expected_members);
-
-        cluster2.shutdown().await;
-        cluster1
-            .wait_for_members(|members| members.len() == 2, wait_secs)
+        node.wait_for_ready_members(|members| members.len() == 1, Duration::from_secs(5))
             .await
             .unwrap();
-
-        cluster3.shutdown().await;
-        cluster1
-            .wait_for_members(|members| members.len() == 1, wait_secs)
-            .await
-            .unwrap();
-        Ok(())
+        let ready_members = node.ready_members().await;
+        assert_eq!(ready_members[0].indexing_tasks.len(), 2);
     }
 
     #[tokio::test]
@@ -918,7 +1018,7 @@ mod tests {
 
         for cluster in [&cluster1a, &cluster2a, &cluster1b, &cluster2b] {
             cluster
-                .wait_for_members(|members| members.len() == 2, wait_secs)
+                .wait_for_ready_members(|members| members.len() == 2, wait_secs)
                 .await
                 .unwrap();
         }
@@ -946,258 +1046,6 @@ mod tests {
             vec![cluster2a.gossip_listen_addr, cluster2b.gossip_listen_addr];
         expected_members_b.sort();
         assert_eq!(members_b, expected_members_b);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_cluster_rejoin_with_different_id_issue_1018() -> anyhow::Result<()> {
-        let cluster_id = "unified-cluster";
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster1 = create_cluster_for_test_with_id(
-            1u16,
-            cluster_id.to_string(),
-            Vec::new(),
-            &HashSet::default(),
-            &transport,
-            true,
-        )
-        .await?;
-        let node_1 = cluster1.gossip_listen_addr.to_string();
-        let cluster2 = create_cluster_for_test_with_id(
-            2u16,
-            cluster_id.to_string(),
-            vec![node_1.clone()],
-            &HashSet::default(),
-            &transport,
-            true,
-        )
-        .await?;
-
-        let wait_secs = Duration::from_secs(30);
-
-        for cluster in [&cluster1, &cluster2] {
-            cluster
-                .wait_for_members(|members| members.len() == 2, wait_secs)
-                .await
-                .unwrap();
-        }
-        let members: Vec<SocketAddr> = cluster1
-            .ready_members()
-            .await
-            .iter()
-            .map(|member| member.gossip_advertise_addr)
-            .sorted()
-            .collect();
-        let mut expected_members = vec![cluster1.gossip_listen_addr, cluster2.gossip_listen_addr];
-        expected_members.sort();
-        assert_eq!(members, expected_members);
-
-        let cluster2_listen_addr = cluster2.gossip_listen_addr;
-        cluster2.shutdown().await;
-        cluster1
-            .wait_for_members(|members| members.len() == 1, wait_secs)
-            .await
-            .unwrap();
-
-        let grpc_port = quickwit_common::net::find_available_tcp_port()?;
-        let grpc_addr: SocketAddr = ([127, 0, 0, 1], grpc_port).into();
-        let cluster2 = Cluster::join(
-            ClusterMember::new(
-                "new_id".to_string(),
-                1,
-                HashSet::default(),
-                cluster2_listen_addr,
-                grpc_addr,
-                Vec::new(),
-            ),
-            cluster2_listen_addr,
-            cluster_id.to_string(),
-            vec![node_1],
-            create_failure_detector_config_for_test(),
-            &transport,
-        )
-        .await?;
-        cluster2.set_self_node_ready(true).await;
-
-        for cluster in [cluster1, cluster2] {
-            cluster
-                .wait_for_members(
-                    |members| {
-                        assert!(members.len() <= 2);
-                        for member in members {
-                            assert!(["node_1", "new_id"].contains(&member.node_id.as_str()))
-                        }
-                        members.len() == 2
-                    },
-                    wait_secs,
-                )
-                .await
-                .unwrap();
-        }
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_cluster_rejoin_with_different_id_3_nodes_issue_1018() -> anyhow::Result<()> {
-        let cluster_id = "three-nodes-cluster";
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster1 = create_cluster_for_test_with_id(
-            1u16,
-            cluster_id.to_string(),
-            Vec::new(),
-            &HashSet::default(),
-            &transport,
-            true,
-        )
-        .await?;
-        let node_1 = cluster1.gossip_listen_addr.to_string();
-        let cluster2 = create_cluster_for_test_with_id(
-            2u16,
-            cluster_id.to_string(),
-            vec![node_1.clone()],
-            &HashSet::default(),
-            &transport,
-            true,
-        )
-        .await?;
-        let node_2 = cluster2.gossip_listen_addr.to_string();
-        let cluster3 = create_cluster_for_test_with_id(
-            3u16,
-            cluster_id.to_string(),
-            vec![node_2],
-            &HashSet::default(),
-            &transport,
-            true,
-        )
-        .await?;
-
-        let wait_secs = Duration::from_secs(5);
-
-        for cluster in [&cluster1, &cluster2] {
-            cluster
-                .wait_for_members(|members| members.len() == 3, wait_secs)
-                .await
-                .unwrap();
-        }
-        let members: Vec<SocketAddr> = cluster1
-            .ready_members()
-            .await
-            .iter()
-            .map(|member| member.gossip_advertise_addr)
-            .sorted()
-            .collect();
-        let mut expected_members = vec![
-            cluster1.gossip_listen_addr,
-            cluster2.gossip_listen_addr,
-            cluster3.gossip_listen_addr,
-        ];
-        expected_members.sort();
-        assert_eq!(members, expected_members);
-
-        let cluster2_listen_addr = cluster2.gossip_listen_addr;
-        let cluster3_listen_addr = cluster3.gossip_listen_addr;
-        cluster2.shutdown().await;
-        cluster3.shutdown().await;
-        cluster1
-            .wait_for_members(|members| members.len() == 1, wait_secs)
-            .await
-            .unwrap();
-
-        let grpc_port = quickwit_common::net::find_available_tcp_port()?;
-        let grpc_addr: SocketAddr = ([127, 0, 0, 1], grpc_port).into();
-        let cluster2 = Cluster::join(
-            ClusterMember::new(
-                "new_node_2".to_string(),
-                1,
-                HashSet::default(),
-                cluster2_listen_addr,
-                grpc_addr,
-                Vec::new(),
-            ),
-            cluster2_listen_addr,
-            cluster_id.to_string(),
-            vec![node_1],
-            create_failure_detector_config_for_test(),
-            &transport,
-        )
-        .await?;
-        cluster2.set_self_node_ready(true).await;
-        let node_2 = cluster2.gossip_listen_addr.to_string();
-
-        let cluster3 = Cluster::join(
-            ClusterMember::new(
-                "new_node_3".to_string(),
-                1,
-                HashSet::default(),
-                cluster3_listen_addr,
-                grpc_addr,
-                Vec::new(),
-            ),
-            cluster3_listen_addr,
-            cluster_id.to_string(),
-            vec![node_2],
-            create_failure_detector_config_for_test(),
-            &transport,
-        )
-        .await?;
-        cluster3.set_self_node_ready(true).await;
-
-        for cluster in [&cluster1, &cluster2, &cluster3] {
-            cluster
-                .wait_for_members(|members| members.len() == 3, wait_secs)
-                .await
-                .unwrap();
-        }
-
-        let expected_member_ids: HashSet<String> = ["new_node_3", "node_1", "new_node_2"]
-            .iter()
-            .map(ToString::to_string)
-            .collect();
-
-        for cluster in [cluster1, cluster2, cluster3] {
-            let member_ids: HashSet<String> = cluster
-                .ready_members()
-                .await
-                .iter()
-                .map(|member| member.node_id.clone())
-                .collect();
-            assert_eq!(&member_ids, &expected_member_ids);
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_cluster_with_node_becoming_ready() -> anyhow::Result<()> {
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster1 =
-            create_cluster_for_test(Vec::new(), &["searcher", "indexer"], &transport, true).await?;
-        let node_1 = cluster1.gossip_listen_addr.to_string();
-        let cluster2 =
-            create_cluster_for_test(vec![node_1.clone()], &["indexer"], &transport, false).await?;
-        let wait_secs = Duration::from_secs(30);
-
-        // Cluster 2 sees 2 members: himself and node 1.
-        cluster2
-            .wait_for_members(|members| members.len() == 2, wait_secs)
-            .await
-            .unwrap();
-        // However cluster 1 sees only 1 member, himself.
-        cluster1
-            .wait_for_members(|members| members.len() == 1, wait_secs)
-            .await
-            .unwrap();
-        // Cluster2 now becomes ready.
-        cluster2.set_self_node_ready(true).await;
-        // And cluster1 now sees 2 members.
-        cluster1
-            .wait_for_members(|members| members.len() == 2, wait_secs)
-            .await
-            .unwrap();
 
         Ok(())
     }

--- a/quickwit/quickwit-cluster/src/member.rs
+++ b/quickwit/quickwit-cluster/src/member.rs
@@ -20,13 +20,13 @@
 use std::collections::HashSet;
 use std::net::SocketAddr;
 
-use anyhow::anyhow;
-use chitchat::{ClusterStateSnapshot, NodeId, NodeState};
+use anyhow::{anyhow, Context};
+use chitchat::{ChitchatId, NodeState};
 use itertools::Itertools;
 use quickwit_proto::indexing_api::IndexingTask;
-use tracing::{error, warn};
+use tracing::warn;
 
-use crate::QuickwitService;
+use crate::{GenerationId, QuickwitService};
 
 // Keys used to store member's data in chitchat state.
 pub(crate) const GRPC_ADVERTISE_ADDR_KEY: &str = "grpc_advertise_addr";
@@ -36,15 +36,46 @@ pub(crate) const ENABLED_SERVICES_KEY: &str = "enabled_services";
 pub(crate) const INDEXING_TASK_PREFIX: &str = "indexing_task";
 pub(crate) const INDEXING_TASK_SEPARATOR: char = ':';
 
+// Readiness key and values used to store node's readiness in Chitchat state.
+pub(crate) const READINESS_KEY: &str = "readiness";
+pub(crate) const READINESS_VALUE_READY: &str = "READY";
+pub(crate) const READINESS_VALUE_NOT_READY: &str = "NOT_READY";
+
+pub(crate) trait NodeStateExt {
+    fn grpc_advertise_addr(&self) -> anyhow::Result<SocketAddr>;
+
+    fn is_ready(&self) -> bool;
+}
+
+impl NodeStateExt for NodeState {
+    fn grpc_advertise_addr(&self) -> anyhow::Result<SocketAddr> {
+        self.get(GRPC_ADVERTISE_ADDR_KEY)
+            .with_context(|| {
+                format!("Could not find key `{GRPC_ADVERTISE_ADDR_KEY}` in Chitchat node state.")
+            })
+            .map(|grpc_advertise_addr_value| {
+                grpc_advertise_addr_value.parse().with_context(|| {
+                    format!("Failed to parse gRPC advertise address `{grpc_advertise_addr_value}`.")
+                })
+            })?
+    }
+
+    fn is_ready(&self) -> bool {
+        self.get(READINESS_KEY)
+            .map(|health_value| health_value == READINESS_VALUE_READY)
+            .unwrap_or(false)
+    }
+}
+
 /// Cluster member.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ClusterMember {
     /// A unique node ID across the cluster.
     /// The Chitchat node ID is the concatenation of the node ID and the start timestamp:
     /// `{node_id}/{start_timestamp}`.
     pub node_id: String,
     /// The start timestamp (seconds) of the node.
-    pub start_timestamp: u64,
+    pub generation_id: GenerationId,
     /// Enabled services, i.e. services configured to run on the node. Depending on the node and
     /// service health, each service may or may not be available/running.
     pub enabled_services: HashSet<QuickwitService>,
@@ -58,12 +89,14 @@ pub struct ClusterMember {
     /// None if the node is not an indexer or the indexer has not yet started some indexing
     /// pipelines.
     pub indexing_tasks: Vec<IndexingTask>,
+    pub is_ready: bool,
 }
 
 impl ClusterMember {
     pub fn new(
         node_id: String,
-        start_timestamp: u64,
+        generation_id: GenerationId,
+        is_ready: bool,
         enabled_services: HashSet<QuickwitService>,
         gossip_advertise_addr: SocketAddr,
         grpc_advertise_addr: SocketAddr,
@@ -71,7 +104,8 @@ impl ClusterMember {
     ) -> Self {
         Self {
             node_id,
-            start_timestamp,
+            generation_id,
+            is_ready,
             enabled_services,
             gossip_advertise_addr,
             grpc_advertise_addr,
@@ -79,87 +113,51 @@ impl ClusterMember {
         }
     }
 
-    pub fn chitchat_id(&self) -> String {
-        format!("{}/{}", self.node_id, self.start_timestamp)
+    pub fn chitchat_id(&self) -> ChitchatId {
+        ChitchatId::new(
+            self.node_id.clone(),
+            self.generation_id.as_u64(),
+            self.gossip_advertise_addr,
+        )
     }
 }
 
-impl From<ClusterMember> for NodeId {
+impl From<ClusterMember> for ChitchatId {
     fn from(member: ClusterMember) -> Self {
-        Self::new(member.chitchat_id(), member.gossip_advertise_addr)
+        member.chitchat_id()
     }
 }
 
-// Builds cluster members with the given `NodeId`s and `ClusterStateSnapshot`.
-pub(crate) fn build_cluster_members(
-    node_ids: HashSet<NodeId>,
-    cluster_state_snapshot: &ClusterStateSnapshot,
-) -> Vec<ClusterMember> {
-    node_ids
-        .iter()
-        .map(|node_id| {
-            if let Some(node_state) = cluster_state_snapshot.node_states.get(&node_id.id) {
-                build_cluster_member(node_id, node_state)
-            } else {
-                anyhow::bail!("Could not find node id `{}` in ChitChat state.", node_id.id,)
-            }
-        })
-        .filter_map(|member_res| {
-            // Just log an error for members that cannot be built.
-            if let Err(error) = &member_res {
-                error!(
-                    error=?error,
-                    "Failed to build cluster member from cluster state, ignoring member.",
-                );
-            }
-            member_res.ok()
-        })
-        .collect_vec()
-}
-
-// Builds a cluster member from [`NodeId`] and [`NodeState`].
+// Builds a cluster member from a [`NodeState`].
 pub(crate) fn build_cluster_member(
-    chitchat_node: &NodeId,
+    chitchat_id: ChitchatId,
     node_state: &NodeState,
 ) -> anyhow::Result<ClusterMember> {
+    let is_ready = node_state.is_ready();
     let enabled_services = node_state
         .get(ENABLED_SERVICES_KEY)
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "Could not find `{}` key in node `{}` state.",
                 ENABLED_SERVICES_KEY,
-                chitchat_node.id
+                chitchat_id.node_id
             )
         })
         .map(|enabled_services_str| {
-            parse_enabled_services_str(enabled_services_str, &chitchat_node.id)
+            parse_enabled_services_str(enabled_services_str, &chitchat_id.node_id)
         })?;
-    let grpc_advertise_addr = node_state
-        .get(GRPC_ADVERTISE_ADDR_KEY)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Could not find `{}` key in node `{}` state.",
-                GRPC_ADVERTISE_ADDR_KEY,
-                chitchat_node.id
-            )
-        })
-        .map(|addr_str| addr_str.parse::<SocketAddr>())??;
-    let indexing_tasks = parse_indexing_tasks(node_state, &chitchat_node.id);
-    let (node_id, start_timestamp_str) = chitchat_node.id.split_once('/').ok_or_else(|| {
-        anyhow::anyhow!(
-            "Failed to create cluster member instance from NodeId `{}`.",
-            chitchat_node.id
-        )
-    })?;
-    let start_timestamp = start_timestamp_str.parse()?;
-    Ok(ClusterMember::new(
-        node_id.to_string(),
-        start_timestamp,
+    let grpc_advertise_addr = node_state.grpc_advertise_addr()?;
+    let indexing_tasks = parse_indexing_tasks(node_state, &chitchat_id.node_id);
+    let member = ClusterMember::new(
+        chitchat_id.node_id,
+        chitchat_id.generation_id.into(),
+        is_ready,
         enabled_services,
-        chitchat_node.gossip_public_address,
+        chitchat_id.gossip_advertise_addr,
         grpc_advertise_addr,
         indexing_tasks,
-    ))
+    );
+    Ok(member)
 }
 
 // Parses indexing task key into the IndexingTask.
@@ -178,7 +176,7 @@ fn parse_indexing_task_key(key: &str) -> anyhow::Result<IndexingTask> {
 /// ignored, just warnings are emitted.
 pub(crate) fn parse_indexing_tasks(node_state: &NodeState, node_id: &str) -> Vec<IndexingTask> {
     node_state
-        .iter_key_values(|key, _| key.starts_with(INDEXING_TASK_PREFIX))
+        .key_values(|key, _| key.starts_with(INDEXING_TASK_PREFIX))
         .map(|(key, versioned_value)| {
             let indexing_task = parse_indexing_task_key(key)?;
             let num_tasks: usize = versioned_value.value.parse()?;

--- a/quickwit/quickwit-cluster/src/node.rs
+++ b/quickwit/quickwit-cluster/src/node.rs
@@ -1,0 +1,124 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use chitchat::{ChitchatId, NodeState};
+use quickwit_config::service::QuickwitService;
+use quickwit_proto::indexing_api::IndexingTask;
+use tonic::transport::Channel;
+
+use crate::member::build_cluster_member;
+
+#[derive(Clone)]
+pub struct ClusterNode {
+    inner: Arc<InnerNode>,
+}
+
+impl ClusterNode {
+    /// Attempts to create a new `ClusterNode` from a Chitchat `NodeState`.
+    pub(crate) fn try_new(
+        chitchat_id: ChitchatId,
+        node_state: &NodeState,
+        channel: Channel,
+        is_self_node: bool,
+    ) -> anyhow::Result<Self> {
+        let member = build_cluster_member(chitchat_id.clone(), node_state)?;
+        let inner = InnerNode {
+            chitchat_id,
+            channel,
+            enabled_services: member.enabled_services,
+            grpc_advertise_addr: member.grpc_advertise_addr,
+            indexing_tasks: member.indexing_tasks,
+            is_ready: member.is_ready,
+            is_self_node,
+        };
+        let node = ClusterNode {
+            inner: Arc::new(inner),
+        };
+        Ok(node)
+    }
+
+    pub fn chitchat_id(&self) -> &ChitchatId {
+        &self.inner.chitchat_id
+    }
+
+    pub fn node_id(&self) -> &str {
+        &self.inner.chitchat_id.node_id
+    }
+
+    pub fn channel(&self) -> Channel {
+        self.inner.channel.clone()
+    }
+
+    pub fn enabled_services(&self) -> &HashSet<QuickwitService> {
+        &self.inner.enabled_services
+    }
+
+    pub fn grpc_advertise_addr(&self) -> SocketAddr {
+        self.inner.grpc_advertise_addr
+    }
+
+    pub fn indexing_tasks(&self) -> &[IndexingTask] {
+        &self.inner.indexing_tasks
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.inner.is_ready
+    }
+
+    pub fn is_self_node(&self) -> bool {
+        self.inner.is_self_node
+    }
+}
+
+impl Debug for ClusterNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Node")
+            .field("node_id", &self.inner.chitchat_id.node_id)
+            .field("enabled_services", &self.inner.enabled_services)
+            .field("is_ready", &self.inner.is_ready)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+impl PartialEq for ClusterNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.chitchat_id == other.inner.chitchat_id
+            && self.inner.enabled_services == other.inner.enabled_services
+            && self.inner.grpc_advertise_addr == other.inner.grpc_advertise_addr
+            && self.inner.indexing_tasks == other.inner.indexing_tasks
+            && self.inner.is_ready == other.inner.is_ready
+            && self.inner.is_self_node == other.inner.is_self_node
+    }
+}
+
+struct InnerNode {
+    chitchat_id: ChitchatId,
+    channel: Channel,
+    enabled_services: HashSet<QuickwitService>,
+    grpc_advertise_addr: SocketAddr,
+    indexing_tasks: Vec<IndexingTask>,
+    is_ready: bool,
+    is_self_node: bool,
+}

--- a/quickwit/quickwit-codegen/README.md
+++ b/quickwit/quickwit-codegen/README.md
@@ -13,6 +13,8 @@
 async-trait = { workspace = true }
 bytes = { workspace = true }
 dyn-clone = { workspace = true }
+http = { workspace = true }
+hyper = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/quickwit/quickwit-codegen/example/Cargo.toml
+++ b/quickwit/quickwit-codegen/example/Cargo.toml
@@ -12,6 +12,8 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 async-trait = { workspace = true }
 dyn-clone = { workspace = true }
+http = { workspace = true }
+hyper = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/quickwit/quickwit-codegen/src/codegen.rs
+++ b/quickwit/quickwit-codegen/src/codegen.rs
@@ -275,14 +275,25 @@ fn generate_client(context: &CodegenContext) -> TokenStream {
         impl #client_name {
             pub fn new<T>(instance: T) -> Self
             where
-                T: #service_name
+                T: #service_name,
             {
                 Self {
                     inner: Box::new(instance),
                 }
             }
 
-            pub fn from_channel(channel: tower::timeout::Timeout<tonic::transport::Channel>) -> Self {
+            pub fn from_channel<C>(channel: C) -> Self
+            where
+                C: tower::Service<
+                        http::Request<tonic::body::BoxBody>,
+                        Response = http::Response<hyper::Body>,
+                        Error = quickwit_common::tower::BoxError,
+                    > + std::fmt::Debug + Clone + Send + Sync + 'static,
+                <C as tower::Service<http::Request<tonic::body::BoxBody>>>::Future:
+                    std::future::Future<
+                        Output = Result<http::Response<hyper::Body>, quickwit_common::tower::BoxError>,
+                    > + Send + 'static,
+            {
                 #client_name::new(#grpc_client_adapter_name::new(#grpc_client_package_name::#grpc_client_name::new(channel)))
             }
 
@@ -516,8 +527,8 @@ fn generate_tower_block_builder_impl(context: &CodegenContext) -> TokenStream {
         let response_type = syn_method.response_type.to_token_stream();
 
         let layer_method_bound = quote! {
-            L::Service: Service<#request_type, Response = #response_type, Error = #error_type> + Clone + Send + Sync + 'static,
-            <L::Service as Service<#request_type>>::Future: Send + 'static,
+            L::Service: tower::Service<#request_type, Response = #response_type, Error = #error_type> + Clone + Send + Sync + 'static,
+            <L::Service as tower::Service<#request_type>>::Future: Send + 'static,
         };
 
         let layer_method_statement = if i == context.methods.len() - 1 {
@@ -579,7 +590,17 @@ fn generate_tower_block_builder_impl(context: &CodegenContext) -> TokenStream {
                 self.build_from_boxed(Box::new(instance))
             }
 
-            pub fn build_from_channel<T>(self, channel: tower::timeout::Timeout<tonic::transport::Channel>) -> #client_name
+            pub fn build_from_channel<T, C>(self, channel: C) -> #client_name
+            where
+                C: tower::Service<
+                        http::Request<tonic::body::BoxBody>,
+                        Response = http::Response<hyper::Body>,
+                        Error = quickwit_common::tower::BoxError,
+                    > + std::fmt::Debug + Clone + Send + Sync + 'static,
+                <C as tower::Service<http::Request<tonic::body::BoxBody>>>::Future:
+                    std::future::Future<
+                        Output = Result<http::Response<hyper::Body>, quickwit_common::tower::BoxError>,
+                    > + Send + 'static,
             {
                 self.build_from_boxed(Box::new(#client_name::from_channel(channel)))
             }
@@ -751,12 +772,7 @@ fn generate_grpc_client_adapter(context: &CodegenContext) -> TokenStream {
         #[async_trait::async_trait]
         impl<T> #service_name for #grpc_client_adapter_name<#grpc_client_package_name::#grpc_client_name<T>>
         where
-            T: tonic::client::GrpcService<tonic::body::BoxBody>
-                + std::fmt::Debug
-                + Clone
-                + Send
-                + Sync
-                + 'static,
+            T: tonic::client::GrpcService<tonic::body::BoxBody> + std::fmt::Debug + Clone + Send + Sync + 'static,
             T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
             <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
             T::Future: Send

--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = { workspace = true }
 futures = { workspace = true }
 home = { workspace = true }
 hostname = { workspace = true }
+http = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
@@ -32,10 +33,12 @@ regex = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
-warp = { workspace = true }
 utoipa = { workspace = true }
+warp = { workspace = true }
 
 [features]
 testsuite = []

--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -35,6 +35,7 @@ pub mod rand;
 pub mod rendezvous_hasher;
 pub mod runtimes;
 pub mod simple_list;
+pub mod sorted_iter;
 #[cfg(any(test, feature = "testsuite"))]
 pub mod test_utils;
 pub mod tower;

--- a/quickwit/quickwit-common/src/sorted_iter.rs
+++ b/quickwit/quickwit-common/src/sorted_iter.rs
@@ -1,0 +1,296 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::cmp::Ordering;
+use std::collections::{btree_map, btree_set};
+use std::iter::Peekable;
+
+/// Marks sorted iterators, typically iterators over [`btree_set::BTreeSet`] and
+/// [`btree_map::BTreeMap`].
+trait Sorted {}
+
+/// Defines helper methods on sorted iterators.
+pub trait SortedIterator: Iterator + Sized {
+    /// Compares two sorted iterators and returns the diff.
+    fn diff<U>(self, other: U) -> DiffIterator<Self, U>
+    where U: SortedIterator<Item = Self::Item> {
+        DiffIterator {
+            left: self.peekable(),
+            right: other.peekable(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Diff<K> {
+    Added(K),
+    Unchanged(K),
+    Removed(K),
+}
+
+pub struct DiffIterator<T: Iterator, U: Iterator> {
+    left: Peekable<T>,
+    right: Peekable<U>,
+}
+
+impl<T, U, K> Iterator for DiffIterator<T, U>
+where
+    T: Iterator<Item = K>,
+    U: Iterator<Item = K>,
+    K: Ord,
+{
+    type Item = Diff<K>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.left.peek(), self.right.peek()) {
+            (Some(left), Some(right)) => match left.cmp(right) {
+                Ordering::Less => {
+                    let left = self
+                        .left
+                        .next()
+                        .expect("The left iterator should not be empty.");
+                    Some(Diff::Removed(left))
+                }
+                Ordering::Equal => {
+                    let left = self
+                        .left
+                        .next()
+                        .expect("The left iterator should not be empty.");
+                    self.right.next();
+                    Some(Diff::Unchanged(left))
+                }
+                Ordering::Greater => {
+                    let right = self
+                        .right
+                        .next()
+                        .expect("The right iterator should not be empty.");
+                    Some(Diff::Added(right))
+                }
+            },
+            (Some(_), None) => {
+                let left = self
+                    .left
+                    .next()
+                    .expect("The left iterator should not be empty.");
+                Some(Diff::Removed(left))
+            }
+            (None, Some(_)) => {
+                let right = self
+                    .right
+                    .next()
+                    .expect("The right iterator should not be empty.");
+                Some(Diff::Added(right))
+            }
+            (None, None) => None,
+        }
+    }
+}
+
+impl<T> SortedIterator for T where T: Iterator + Sorted {}
+
+impl<K, V> Sorted for btree_map::IntoKeys<K, V> {}
+impl<K, V> Sorted for btree_map::IntoValues<K, V> {}
+impl<'a, K, V> Sorted for btree_map::Keys<'a, K, V> {}
+impl<'a, K, V> Sorted for btree_map::Values<'a, K, V> {}
+impl<K> Sorted for btree_set::IntoIter<K> {}
+impl<'a, K> Sorted for btree_set::Iter<'a, K> {}
+
+/// Same as [`SortedIterator`] but for (key, value) pairs sorted by key.
+pub trait SortedByKeyIterator<K, V>: Iterator + Sized {
+    /// Compares the keys of two sorted key-value iterators and returns the diff.
+    fn diff_by_key<U, W>(self, other: U) -> DiffByKeyIterator<Self, U>
+    where U: SortedByKeyIterator<K, W> {
+        DiffByKeyIterator {
+            left: self.peekable(),
+            right: other.peekable(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum KeyDiff<K, V, W> {
+    Added(K, W),
+    Unchanged(K, V, W),
+    Removed(K, V),
+}
+
+pub struct DiffByKeyIterator<T: Iterator, U: Iterator> {
+    left: Peekable<T>,
+    right: Peekable<U>,
+}
+
+impl<T, U, K, V, W> Iterator for DiffByKeyIterator<T, U>
+where
+    T: Iterator<Item = (K, V)>,
+    U: Iterator<Item = (K, W)>,
+    K: Ord,
+{
+    type Item = KeyDiff<K, V, W>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.left.peek(), self.right.peek()) {
+            (Some((left_key, _)), Some((right_key, _))) => match left_key.cmp(right_key) {
+                Ordering::Less => {
+                    let (left_key, left_value) = self
+                        .left
+                        .next()
+                        .expect("The left iterator should not be empty.");
+                    Some(KeyDiff::Removed(left_key, left_value))
+                }
+                Ordering::Equal => {
+                    let (left_key, left_value) = self
+                        .left
+                        .next()
+                        .expect("The left iterator should not be empty.");
+                    let (_, right_value) = self
+                        .right
+                        .next()
+                        .expect("The right iterator should not be empty.");
+                    Some(KeyDiff::Unchanged(left_key, left_value, right_value))
+                }
+                Ordering::Greater => {
+                    let (right_key, right_value) = self
+                        .right
+                        .next()
+                        .expect("The right iterator should not be empty.");
+                    Some(KeyDiff::Added(right_key, right_value))
+                }
+            },
+            (Some(_), None) => {
+                let (left_key, left_value) = self
+                    .left
+                    .next()
+                    .expect("The left iterator should not be empty.");
+                Some(KeyDiff::Removed(left_key, left_value))
+            }
+            (None, Some(_)) => {
+                let (right_key, right_value) = self
+                    .right
+                    .next()
+                    .expect("The right iterator should not be empty.");
+                Some(KeyDiff::Added(right_key, right_value))
+            }
+            (None, None) => None,
+        }
+    }
+}
+
+impl<T, K, V> SortedByKeyIterator<K, V> for T where T: Iterator<Item = (K, V)> + Sorted {}
+
+impl<K, V> Sorted for btree_map::IntoIter<K, V> {}
+impl<'a, K, V> Sorted for btree_map::Iter<'a, K, V> {}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use super::*;
+
+    #[test]
+    fn test_diff() {
+        {
+            let left: BTreeSet<u64> = vec![].into_iter().collect();
+            let right: BTreeSet<u64> = vec![].into_iter().collect();
+            let diff: Vec<_> = left.iter().diff(right.iter()).collect();
+            assert_eq!(diff, vec![]);
+        }
+        {
+            let left: BTreeSet<_> = vec![1].into_iter().collect();
+            let right: BTreeSet<_> = vec![].into_iter().collect();
+            let diff: Vec<_> = left.iter().diff(right.iter()).collect();
+            assert_eq!(diff, vec![Diff::Removed(&1)]);
+        }
+        {
+            let left: BTreeSet<_> = vec![].into_iter().collect();
+            let right: BTreeSet<_> = vec![1].into_iter().collect();
+            let diff: Vec<_> = left.iter().diff(right.iter()).collect();
+            assert_eq!(diff, vec![Diff::Added(&1)]);
+        }
+        {
+            let left: BTreeSet<_> = vec![1].into_iter().collect();
+            let right: BTreeSet<_> = vec![1].into_iter().collect();
+            let diff: Vec<_> = left.iter().diff(right.iter()).collect();
+            assert_eq!(diff, vec![Diff::Unchanged(&1)]);
+        }
+        {
+            let left: BTreeSet<_> = vec![1, 3, 5, 7].into_iter().collect();
+            let right: BTreeSet<_> = vec![2, 4, 5, 6].into_iter().collect();
+            let diff: Vec<_> = left.iter().diff(right.iter()).collect();
+            assert_eq!(
+                diff,
+                vec![
+                    Diff::Removed(&1),
+                    Diff::Added(&2),
+                    Diff::Removed(&3),
+                    Diff::Added(&4),
+                    Diff::Unchanged(&5),
+                    Diff::Added(&6),
+                    Diff::Removed(&7),
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn test_diff_by_key() {
+        {
+            let left: BTreeMap<u64, u64> = vec![].into_iter().collect();
+            let right: BTreeMap<u64, u64> = vec![].into_iter().collect();
+            let key_diff: Vec<_> = left.iter().diff_by_key(right.iter()).collect();
+            assert_eq!(key_diff, vec![]);
+        }
+        {
+            let left: BTreeMap<_, _> = vec![(1, 1)].into_iter().collect();
+            let right: BTreeMap<_, &'static str> = vec![].into_iter().collect();
+            let key_diff: Vec<_> = left.iter().diff_by_key(right.iter()).collect();
+            assert_eq!(key_diff, vec![KeyDiff::Removed(&1, &1)]);
+        }
+        {
+            let left: BTreeMap<_, usize> = vec![].into_iter().collect();
+            let right: BTreeMap<_, _> = vec![(1, "a")].into_iter().collect();
+            let key_diff: Vec<_> = left.iter().diff_by_key(right.iter()).collect();
+            assert_eq!(key_diff, vec![KeyDiff::Added(&1, &"a")]);
+        }
+        {
+            let left: BTreeMap<_, _> = vec![(1, 11)].into_iter().collect();
+            let right: BTreeMap<_, _> = vec![(1, "a")].into_iter().collect();
+            let key_diff: Vec<_> = left.iter().diff_by_key(right.iter()).collect();
+            assert_eq!(key_diff, vec![KeyDiff::Unchanged(&1, &11, &"a")]);
+        }
+        {
+            let left: BTreeMap<_, _> = vec![(1, 1), (3, 3), (5, 5), (7, 7)].into_iter().collect();
+            let right: BTreeMap<_, _> = vec![(2, "b"), (4, "d"), (5, "e"), (6, "f")]
+                .into_iter()
+                .collect();
+            let key_diff: Vec<_> = left.iter().diff_by_key(right.iter()).collect();
+            assert_eq!(
+                key_diff,
+                vec![
+                    KeyDiff::Removed(&1, &1),
+                    KeyDiff::Added(&2, &"b"),
+                    KeyDiff::Removed(&3, &3),
+                    KeyDiff::Added(&4, &"d"),
+                    KeyDiff::Unchanged(&5, &5, &"e"),
+                    KeyDiff::Added(&6, &"f"),
+                    KeyDiff::Removed(&7, &7),
+                ]
+            );
+        }
+    }
+}

--- a/quickwit/quickwit-common/src/tower/box_service.rs
+++ b/quickwit/quickwit-common/src/tower/box_service.rs
@@ -18,13 +18,11 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
-use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::Future;
 use tower::{Service, ServiceExt};
 
-pub type BoxFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'static>>;
+use super::BoxFuture;
 
 trait CloneService<R, T, E>:
     Service<R, Response = T, Error = E, Future = BoxFuture<T, E>>

--- a/quickwit/quickwit-common/src/tower/buffer.rs
+++ b/quickwit/quickwit-common/src/tower/buffer.rs
@@ -25,9 +25,9 @@ use std::{error, fmt};
 use futures::TryFutureExt;
 use tower::buffer::error::{Closed, ServiceError};
 use tower::buffer::Buffer as TowerBuffer;
-use tower::{BoxError, Layer, Service};
+use tower::{Layer, Service};
 
-use super::box_service::BoxFuture;
+use super::{BoxError, BoxFuture};
 
 #[derive(Debug, thiserror::Error)]
 pub enum BufferError {

--- a/quickwit/quickwit-common/src/tower/change.rs
+++ b/quickwit/quickwit-common/src/tower/change.rs
@@ -17,24 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::net::SocketAddr;
-
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
-
-/// Cluster error kinds.
-#[derive(Error, Debug, Serialize, Deserialize)]
-pub enum ClusterError {
-    /// Port binding error.
-    #[error(
-        "Failed to bind to UDP socket addr `{listen_addr}` for the gossip membership protocol: \
-         `{cause}`"
-    )]
-    UDPPortBindingError {
-        /// Port number.
-        listen_addr: SocketAddr,
-        /// Underlying error message.
-        cause: String,
-    },
+/// A change enum similar to `tower::discover::Change` but cloneable.
+// TODO: Remove when the next version of tower (0.4.14?) is released.
+#[derive(Debug, Clone)]
+pub enum Change<K, V> {
+    Insert(K, V),
+    Remove(K),
 }
-pub type ClusterResult<T> = Result<T, ClusterError>;

--- a/quickwit/quickwit-common/src/tower/mod.rs
+++ b/quickwit/quickwit-common/src/tower/mod.rs
@@ -20,27 +20,36 @@
 mod box_layer;
 mod box_service;
 mod buffer;
+mod change;
 mod estimate_rate;
 mod metrics;
 mod rate;
 mod rate_estimator;
 mod rate_limit;
+mod transport;
 
+use std::error;
 use std::pin::Pin;
 
 pub use box_layer::BoxLayer;
 pub use box_service::BoxService;
 pub use buffer::{Buffer, BufferError, BufferLayer};
+pub use change::Change;
 pub use estimate_rate::{EstimateRate, EstimateRateLayer};
-use futures::Future;
+use futures::{Future, Stream};
 pub use metrics::{PrometheusMetrics, PrometheusMetricsLayer};
 pub use rate::{ConstantRate, Rate};
 pub use rate_estimator::{RateEstimator, SmaRateEstimator};
 pub use rate_limit::{RateLimit, RateLimitLayer};
+pub use transport::{make_channel, warmup_channel, BalanceChannel};
+
+pub type BoxError = Box<dyn error::Error + Send + Sync + 'static>;
 
 pub type BoxFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'static>>;
 
 pub type BoxFutureInfaillible<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
+
+pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send + Unpin + 'static>>;
 
 pub trait Cost {
     fn cost(&self) -> u64;

--- a/quickwit/quickwit-common/src/tower/transport.rs
+++ b/quickwit/quickwit-common/src/tower/transport.rs
@@ -1,0 +1,276 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+use std::convert::Infallible;
+use std::fmt;
+use std::hash::Hash;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::stream::once;
+use futures::{Stream, StreamExt};
+use http::Uri;
+use tokio::sync::{mpsc, watch};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tonic::transport::{Channel, Endpoint};
+use tower::balance::p2c::Balance;
+use tower::buffer::Buffer;
+use tower::discover::Change as TowerChange;
+use tower::load::{CompleteOnResponse, PendingRequestsDiscover};
+use tower::{BoxError, Service, ServiceExt};
+
+use super::{BoxFuture, BoxStream, Change};
+
+// Transforms a boxed stream of `Change<K, Channel>` into a stream of `Result<TowerChange<K,
+// Channel>, Infallible>>` while keeping track of the number of connections.
+struct ChangeStreamAdapter<K> {
+    changes: BoxStream<Change<K, Channel>>,
+    num_connections_tx: watch::Sender<usize>,
+    keys: HashSet<K>,
+}
+
+// A blanket `Discover` implementation exists for any `Stream<Item = Result<Change<K, V>, E>>`
+impl<K> Stream for ChangeStreamAdapter<K>
+where K: Hash + Eq + Clone
+{
+    type Item = Result<TowerChange<K, Channel>, Infallible>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut *self.changes).poll_next(cx) {
+            Poll::Pending | Poll::Ready(None) => Poll::Pending,
+            Poll::Ready(Some(change)) => match change {
+                Change::Insert(key, channel) => {
+                    if self.keys.insert(key.clone()) {
+                        self.num_connections_tx
+                            .send_modify(|num_connections| *num_connections += 1);
+                    }
+                    Poll::Ready(Some(Ok(TowerChange::Insert(key, channel))))
+                }
+                Change::Remove(key) => {
+                    if self.keys.remove(&key) {
+                        self.num_connections_tx
+                            .send_modify(|num_connections| *num_connections -= 1);
+                    }
+                    Poll::Ready(Some(Ok(TowerChange::Remove(key))))
+                }
+            },
+        }
+    }
+}
+
+impl<K> Unpin for ChangeStreamAdapter<K> where K: Hash + Eq + Clone {}
+
+type HttpRequest = http::Request<tonic::body::BoxBody>;
+type HttpResponse = http::Response<hyper::Body>;
+type ChangeStream<K> = UnboundedReceiverStream<Result<TowerChange<K, Channel>, Infallible>>;
+type Discover<K> = PendingRequestsDiscover<ChangeStream<K>, CompleteOnResponse>;
+type ChannelImpl<K> = Buffer<Balance<Discover<K>, HttpRequest>, HttpRequest>;
+
+#[derive(Clone)]
+pub struct BalanceChannel<K: Hash + Eq + Clone> {
+    inner: ChannelImpl<K>,
+    num_connections_rx: watch::Receiver<usize>,
+}
+
+impl<K> BalanceChannel<K>
+where K: Hash + Eq + Send + Clone + 'static
+{
+    pub fn new() -> (Self, mpsc::UnboundedSender<Change<K, Channel>>) {
+        let (change_tx, change_rx) = mpsc::unbounded_channel();
+        let changes = UnboundedReceiverStream::new(change_rx);
+        let channel = Self::from_stream(changes);
+        (channel, change_tx)
+    }
+
+    pub fn from_channel(key: K, channel: Channel) -> Self {
+        Self::from_stream(once(Box::pin(async { Change::Insert(key, channel) })))
+    }
+
+    pub fn from_stream<S>(changes: S) -> Self
+    where S: Stream<Item = Change<K, Channel>> + Send + Unpin + 'static {
+        let (num_connections_tx, num_connections_rx) = watch::channel(0);
+        let change_stream = unlazy_stream(ChangeStreamAdapter::<K> {
+            changes: Box::pin(changes),
+            num_connections_tx,
+            keys: HashSet::new(),
+        });
+        let completion = CompleteOnResponse::default();
+        let pending_requests_discover = PendingRequestsDiscover::new(change_stream, completion);
+        let balance_svc = Balance::new(pending_requests_discover);
+        let buffer_svc = Buffer::new(balance_svc, 512);
+
+        BalanceChannel {
+            inner: buffer_svc,
+            num_connections_rx,
+        }
+    }
+
+    pub fn num_connections(&self) -> usize {
+        *self.num_connections_rx.borrow()
+    }
+
+    pub fn num_connections_watcher(&self) -> watch::Receiver<usize> {
+        self.num_connections_rx.clone()
+    }
+}
+
+/// `tower::buffer::Buffer` and `tower::balance::Balance` lazily polls their inner services. As a
+/// result, the underlying discover stream is only polled when requests are made to the
+/// `BalanceChannel`. When the channel is idle, the pool of connections is not updated and
+/// `num_connections` can be inaccurate. Since this number is used to determine whether a service is
+/// ready or not, we must poll the stream eagerly to always supply an up-to-date value.
+fn unlazy_stream<S, T>(mut inner_stream: S) -> UnboundedReceiverStream<T>
+where
+    T: Send + 'static,
+    S: Stream<Item = T> + Send + Unpin + 'static,
+{
+    let (outer_stream_tx, outer_stream_rx) = mpsc::unbounded_channel();
+    let future = async move {
+        while let Some(item) = inner_stream.next().await {
+            if outer_stream_tx.send(item).is_err() {
+                break;
+            }
+        }
+    };
+    tokio::spawn(future);
+    UnboundedReceiverStream::new(outer_stream_rx)
+}
+
+impl<K> Service<HttpRequest> for BalanceChannel<K>
+where K: Hash + Eq + Clone
+{
+    type Response = HttpResponse;
+    type Error = BoxError;
+    type Future = BoxFuture<HttpResponse, BoxError>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: HttpRequest) -> Self::Future {
+        Box::pin(self.inner.call(request))
+    }
+}
+
+impl<K> fmt::Debug for BalanceChannel<K>
+where K: Hash + Eq + Clone + Send + 'static
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BalanceChannel")
+            .field("num_connections", &self.num_connections())
+            .finish()
+    }
+}
+
+/// Creates a channel from a socket address.
+///
+/// The function is marked as `async` because it requires an executor (`connect_lazy`).
+pub async fn make_channel(socket_addr: SocketAddr) -> Channel {
+    let uri = Uri::builder()
+        .scheme("http")
+        .authority(socket_addr.to_string())
+        .path_and_query("/")
+        .build()
+        .expect("The provided arguments should be valid.");
+    Endpoint::from(uri)
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(30))
+        .connect_lazy()
+}
+
+/// Forces a channel to initiate the underlying HTTP connection. Calling this function only makes
+/// sense for channels connected lazily.
+///
+/// The function is marked as `async` because it requires a tokio runtime.
+pub async fn warmup_channel(channel: Channel) {
+    tokio::spawn(channel.ready_oneshot());
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use tonic::transport::Endpoint;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_channel_discover() {
+        let (change_tx, change_rx) = mpsc::unbounded_channel();
+        let (num_connections_tx, num_connections_rx) = watch::channel(0);
+
+        let mut channel_discover = ChangeStreamAdapter::<&str> {
+            changes: Box::pin(UnboundedReceiverStream::new(change_rx)),
+            num_connections_tx,
+            keys: HashSet::new(),
+        };
+        assert_eq!(*num_connections_rx.borrow(), 0);
+
+        let channel = Endpoint::from_static("http://[::1]:1212").connect_lazy();
+        change_tx.send(Change::Insert("foo", channel)).unwrap();
+
+        let change = channel_discover.next().await.unwrap().unwrap();
+        assert!(matches!(change, TowerChange::Insert("foo", _)));
+        assert_eq!(*num_connections_rx.borrow(), 1);
+
+        let channel = Endpoint::from_static("http://[::1]:1337").connect_lazy();
+        change_tx.send(Change::Insert("foo", channel)).unwrap();
+
+        let change = channel_discover.next().await.unwrap().unwrap();
+        assert!(matches!(change, TowerChange::Insert("foo", _)));
+        assert_eq!(*num_connections_rx.borrow(), 1);
+
+        change_tx.send(Change::Remove("bar")).unwrap();
+        let change = channel_discover.next().await.unwrap().unwrap();
+
+        assert!(matches!(change, TowerChange::Remove("bar")));
+        assert_eq!(*num_connections_rx.borrow(), 1);
+
+        change_tx.send(Change::Remove("foo")).unwrap();
+        let change = channel_discover.next().await.unwrap().unwrap();
+
+        assert!(matches!(change, TowerChange::Remove("foo")));
+        assert_eq!(*num_connections_rx.borrow(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_balance_channel() {
+        let (mut balance_channel, change_tx) = BalanceChannel::<&str>::new();
+        let mut num_connections_watcher = balance_channel.num_connections_watcher();
+        assert_eq!(balance_channel.num_connections(), 0);
+
+        let channel = Endpoint::from_static("http://[::1]:1212").connect_lazy();
+        change_tx.send(Change::Insert("foo", channel)).unwrap();
+        num_connections_watcher.changed().await.unwrap();
+        assert_eq!(balance_channel.num_connections(), 1);
+
+        change_tx.send(Change::Remove("foo")).unwrap();
+        num_connections_watcher.changed().await.unwrap();
+        assert_eq!(balance_channel.num_connections(), 0);
+
+        // `ready()` is lying... See `unlazy_stream()` comment.
+        balance_channel.ready().await.unwrap();
+
+        // The rest of the test lives in the `quickwit-codegen-example` crate.
+        // TODO: Move the test here.
+    }
+}

--- a/quickwit/quickwit-config/src/quickwit_config/serialize.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/serialize.rs
@@ -642,7 +642,7 @@ mod tests {
     async fn test_quickwwit_config_default_values_storage() {
         let config_yaml = r#"
             version: 0.5
-            node_id: "node1"
+            node_id: "node-1"
             metastore_uri: postgres://username:password@host:port/db
         "#;
         let config = load_quickwit_config_with_env(
@@ -653,7 +653,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(config.cluster_id, DEFAULT_CLUSTER_ID);
-        assert_eq!(config.node_id, "node1");
+        assert_eq!(config.node_id, "node-1");
         assert_eq!(
             config.metastore_uri,
             "postgres://username:password@host:port/db"

--- a/quickwit/quickwit-control-plane/Cargo.toml
+++ b/quickwit/quickwit-control-plane/Cargo.toml
@@ -14,6 +14,8 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 chitchat = { workspace = true }
 dyn-clone = { workspace = true }
+http = { workspace = true }
+hyper = { workspace = true }
 itertools = { workspace = true }
 mockall = { workspace = true, optional = true }
 prost = { workspace = true }

--- a/quickwit/quickwit-control-plane/src/indexing_plan.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_plan.rs
@@ -354,7 +354,8 @@ mod tests {
             let addr: SocketAddr = ([127, 0, 0, 1], 10).into();
             members.push(ClusterMember::new(
                 (1 + idx).to_string(),
-                0,
+                0.into(),
+                true,
                 HashSet::from_iter([quickwit_service].into_iter()),
                 addr,
                 addr,

--- a/quickwit/quickwit-control-plane/src/lib.rs
+++ b/quickwit/quickwit-control-plane/src/lib.rs
@@ -82,11 +82,12 @@ impl From<AskError<ControlPlaneError>> for ControlPlaneError {
 /// Starts the Control Plane.
 pub async fn start_control_plane_service(
     universe: &Universe,
-    cluster: Arc<Cluster>,
+    cluster: Cluster,
     metastore: Arc<dyn Metastore>,
 ) -> anyhow::Result<Mailbox<IndexingScheduler>> {
+    let ready_members_watcher = cluster.ready_members_watcher().await;
     let indexing_service_client_pool =
-        ServiceClientPool::create_and_update_members(cluster.ready_member_change_watcher()).await?;
+        ServiceClientPool::create_and_update_members(ready_members_watcher).await?;
     let scheduler = IndexingScheduler::new(cluster, metastore, indexing_service_client_pool);
     let (scheduler_mailbox, _) = universe.spawn_builder().spawn(scheduler);
     Ok(scheduler_mailbox)

--- a/quickwit/quickwit-grpc-clients/Cargo.toml
+++ b/quickwit/quickwit-grpc-clients/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
 itertools = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/quickwit/quickwit-grpc-clients/src/lib.rs
+++ b/quickwit/quickwit-grpc-clients/src/lib.rs
@@ -20,7 +20,7 @@
 pub mod balance_channel;
 pub mod service_client_pool;
 
-pub use balance_channel::create_balance_channel_from_watched_members;
+pub use balance_channel::create_balance_channel_from_cluster_change_stream;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -66,7 +66,7 @@ kinesis = ["rusoto_core", "rusoto_kinesis", "quickwit-aws/kinesis"]
 kinesis-localstack-tests = []
 pulsar = ["dep:pulsar"]
 pulsar-broker-tests = []
-testsuite = ["quickwit-actors/testsuite"]
+testsuite = ["quickwit-actors/testsuite", "quickwit-cluster/testsuite"]
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -67,7 +67,7 @@ pub fn new_split_id() -> String {
 pub async fn start_indexing_service(
     universe: &Universe,
     config: &QuickwitConfig,
-    cluster: Arc<Cluster>,
+    cluster: Cluster,
     metastore: Arc<dyn Metastore>,
     ingest_api_service: Mailbox<IngestApiService>,
     storage_resolver: StorageUriResolver,

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -74,11 +74,9 @@ impl TestSandbox {
     ) -> anyhow::Result<Self> {
         let node_id = append_random_suffix("test-node");
         let transport = ChannelTransport::default();
-        let cluster = Arc::new(
-            create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
-                .await
-                .unwrap(),
-        );
+        let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
+            .await
+            .unwrap();
         let index_uri = index_uri(index_id);
         let mut index_config = IndexConfig::for_test(index_id, index_uri.as_str());
         index_config.doc_mapping = ConfigFormat::Yaml.parse(doc_mapping_yaml.as_bytes())?;

--- a/quickwit/quickwit-ingest/Cargo.toml
+++ b/quickwit/quickwit-ingest/Cargo.toml
@@ -13,6 +13,8 @@ bytes = { workspace = true }
 dyn-clone = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
+http = { workspace = true }
+hyper = { workspace = true }
 mockall = { workspace = true, optional = true }
 mrecordlog = { workspace = true }
 once_cell = { workspace = true }

--- a/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
+++ b/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
@@ -140,9 +140,22 @@ impl IngestServiceClient {
     {
         Self { inner: Box::new(instance) }
     }
-    pub fn from_channel(
-        channel: tower::timeout::Timeout<tonic::transport::Channel>,
-    ) -> Self {
+    pub fn from_channel<C>(channel: C) -> Self
+    where
+        C: tower::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<hyper::Body>,
+                Error = quickwit_common::tower::BoxError,
+            > + std::fmt::Debug + Clone + Send + Sync + 'static,
+        <C as tower::Service<
+            http::Request<tonic::body::BoxBody>,
+        >>::Future: std::future::Future<
+                Output = Result<
+                    http::Response<hyper::Body>,
+                    quickwit_common::tower::BoxError,
+                >,
+            > + Send + 'static,
+    {
         IngestServiceClient::new(
             IngestServiceGrpcClientAdapter::new(
                 ingest_service_grpc_client::IngestServiceGrpcClient::new(channel),
@@ -304,24 +317,24 @@ impl IngestServiceTowerBlockBuilder {
     pub fn shared_layer<L>(mut self, layer: L) -> Self
     where
         L: tower::Layer<Box<dyn IngestService>> + Clone + Send + Sync + 'static,
-        L::Service: Service<
+        L::Service: tower::Service<
                 IngestRequest,
                 Response = IngestResponse,
                 Error = crate::IngestServiceError,
             > + Clone + Send + Sync + 'static,
-        <L::Service as Service<IngestRequest>>::Future: Send + 'static,
-        L::Service: Service<
+        <L::Service as tower::Service<IngestRequest>>::Future: Send + 'static,
+        L::Service: tower::Service<
                 FetchRequest,
                 Response = FetchResponse,
                 Error = crate::IngestServiceError,
             > + Clone + Send + Sync + 'static,
-        <L::Service as Service<FetchRequest>>::Future: Send + 'static,
-        L::Service: Service<
+        <L::Service as tower::Service<FetchRequest>>::Future: Send + 'static,
+        L::Service: tower::Service<
                 TailRequest,
                 Response = FetchResponse,
                 Error = crate::IngestServiceError,
             > + Clone + Send + Sync + 'static,
-        <L::Service as Service<TailRequest>>::Future: Send + 'static,
+        <L::Service as tower::Service<TailRequest>>::Future: Send + 'static,
     {
         self.ingest_layer = Some(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self.fetch_layer = Some(quickwit_common::tower::BoxLayer::new(layer.clone()));
@@ -331,12 +344,12 @@ impl IngestServiceTowerBlockBuilder {
     pub fn ingest_layer<L>(mut self, layer: L) -> Self
     where
         L: tower::Layer<Box<dyn IngestService>> + Send + Sync + 'static,
-        L::Service: Service<
+        L::Service: tower::Service<
                 IngestRequest,
                 Response = IngestResponse,
                 Error = crate::IngestServiceError,
             > + Clone + Send + Sync + 'static,
-        <L::Service as Service<IngestRequest>>::Future: Send + 'static,
+        <L::Service as tower::Service<IngestRequest>>::Future: Send + 'static,
     {
         self.ingest_layer = Some(quickwit_common::tower::BoxLayer::new(layer));
         self
@@ -344,12 +357,12 @@ impl IngestServiceTowerBlockBuilder {
     pub fn fetch_layer<L>(mut self, layer: L) -> Self
     where
         L: tower::Layer<Box<dyn IngestService>> + Send + Sync + 'static,
-        L::Service: Service<
+        L::Service: tower::Service<
                 FetchRequest,
                 Response = FetchResponse,
                 Error = crate::IngestServiceError,
             > + Clone + Send + Sync + 'static,
-        <L::Service as Service<FetchRequest>>::Future: Send + 'static,
+        <L::Service as tower::Service<FetchRequest>>::Future: Send + 'static,
     {
         self.fetch_layer = Some(quickwit_common::tower::BoxLayer::new(layer));
         self
@@ -357,12 +370,12 @@ impl IngestServiceTowerBlockBuilder {
     pub fn tail_layer<L>(mut self, layer: L) -> Self
     where
         L: tower::Layer<Box<dyn IngestService>> + Send + Sync + 'static,
-        L::Service: Service<
+        L::Service: tower::Service<
                 TailRequest,
                 Response = FetchResponse,
                 Error = crate::IngestServiceError,
             > + Clone + Send + Sync + 'static,
-        <L::Service as Service<TailRequest>>::Future: Send + 'static,
+        <L::Service as tower::Service<TailRequest>>::Future: Send + 'static,
     {
         self.tail_layer = Some(quickwit_common::tower::BoxLayer::new(layer));
         self
@@ -373,10 +386,22 @@ impl IngestServiceTowerBlockBuilder {
     {
         self.build_from_boxed(Box::new(instance))
     }
-    pub fn build_from_channel<T>(
-        self,
-        channel: tower::timeout::Timeout<tonic::transport::Channel>,
-    ) -> IngestServiceClient {
+    pub fn build_from_channel<T, C>(self, channel: C) -> IngestServiceClient
+    where
+        C: tower::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<hyper::Body>,
+                Error = quickwit_common::tower::BoxError,
+            > + std::fmt::Debug + Clone + Send + Sync + 'static,
+        <C as tower::Service<
+            http::Request<tonic::body::BoxBody>,
+        >>::Future: std::future::Future<
+                Output = Result<
+                    http::Response<hyper::Body>,
+                    quickwit_common::tower::BoxError,
+                >,
+            > + Send + 'static,
+    {
         self.build_from_boxed(Box::new(IngestServiceClient::from_channel(channel)))
     }
     pub fn build_from_mailbox<A>(

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -210,16 +210,16 @@ impl ClusterSandbox {
 
     pub async fn wait_for_cluster_num_ready_nodes(
         &self,
-        expected_num_alive_nodes: usize,
+        expected_num_ready_nodes: usize,
     ) -> anyhow::Result<()> {
         wait_until_predicate(
             || async move {
                 match self.indexer_rest_client.cluster().snapshot().await {
                     Ok(result) => {
-                        if result.live_nodes.len() != expected_num_alive_nodes {
+                        if result.ready_nodes.len() != expected_num_ready_nodes {
                             debug!(
-                                "wait_for_cluster_num_ready_nodes expected {} alive nodes, got {}",
-                                expected_num_alive_nodes,
+                                "wait_for_cluster_num_ready_nodes expected {} ready nodes, got {}",
+                                expected_num_ready_nodes,
                                 result.live_nodes.len()
                             );
                             false

--- a/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
@@ -153,7 +153,7 @@ async fn test_multi_nodes_cluster() {
     let sandbox = ClusterSandbox::start_cluster_nodes(&nodes_services)
         .await
         .unwrap();
-    sandbox.wait_for_cluster_num_ready_nodes(4).await.unwrap();
+    sandbox.wait_for_cluster_num_ready_nodes(5).await.unwrap();
 
     {
         // Wait for indexer to fully start.

--- a/quickwit/quickwit-serve/src/cluster_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/cluster_api/rest_handler.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::convert::Infallible;
-use std::sync::Arc;
 
 use quickwit_cluster::{Cluster, ClusterSnapshot, NodeIdSchema};
 use warp::{Filter, Rejection};
@@ -34,7 +33,7 @@ pub struct ClusterApi;
 
 /// Cluster handler.
 pub fn cluster_handler(
-    cluster: Arc<Cluster>,
+    cluster: Cluster,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     warp::path!("cluster")
         .and(warp::path::end())
@@ -55,7 +54,7 @@ pub fn cluster_handler(
 )]
 
 /// Get cluster information.
-async fn get_cluster(cluster: Arc<Cluster>) -> Result<ClusterSnapshot, Infallible> {
+async fn get_cluster(cluster: Cluster) -> Result<ClusterSnapshot, Infallible> {
     let snapshot = cluster.snapshot().await;
     Ok(snapshot)
 }

--- a/quickwit/quickwit-serve/src/openapi.rs
+++ b/quickwit/quickwit-serve/src/openapi.rs
@@ -161,11 +161,11 @@ mod openapi_schema_tests {
     #[test]
     fn ensure_schemas_resolve() {
         let docs = build_docs();
-        resolve_openapi_schemas(&docs).expect("All schemas should be resolved");
+        resolve_openapi_schemas(&docs).expect("All schemas should be resolved.");
     }
 
     fn resolve_openapi_schemas(openapi: &utoipa::openapi::OpenApi) -> anyhow::Result<()> {
-        let schemas_lookup = if let Some(ref components) = openapi.components {
+        let schemas_lookup = if let Some(components) = &openapi.components {
             resolve_component_schemas(components)?
         } else {
             BTreeSet::new()

--- a/quickwit/quickwit-serve/src/tests.rs
+++ b/quickwit/quickwit-serve/src/tests.rs
@@ -55,11 +55,9 @@ async fn test_check_cluster_configuration() {
 #[tokio::test]
 async fn test_readiness_updates() {
     let transport = ChannelTransport::default();
-    let cluster = Arc::new(
-        create_cluster_for_test(Vec::new(), &[], &transport, false)
-            .await
-            .unwrap(),
-    );
+    let cluster = create_cluster_for_test(Vec::new(), &[], &transport, false)
+        .await
+        .unwrap();
     let (metastore_readiness_tx, metastore_readiness_rx) = watch::channel(false);
     let mut metastore = MockMetastore::new();
     metastore.expect_check_connectivity().returning(move || {


### PR DESCRIPTION
### Description
I have a few things left to do, but this PR is in good enough shape to receive a review. My goal for this PR was to refactor the cluster logic so we could:
- share HTTP connections between multiple balance channels and client pools
- easily access up-to-date ready nodes
- streamline access to cluster change events
- provide a balance channel with a better balance policy

In addition, a few things have changed:
- Chitchat now always returns the self node in the list of lives nodes
- Readiness is now handled in Quickwit
- We now distinguish the ready nodes from the live nodes in the cluster snapshot

### How was this PR tested?
- Updated unit tests
- Launched multiple nodes locally