### PR TITLE
Runs gRPC and REST server in different tasks.

### DIFF
--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -23,7 +23,6 @@ use std::ops::{Range, RangeInclusive};
 use std::str::FromStr;
 
 use quickwit_common::FileEntry;
-use quickwit_config::TestableForRegression;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -174,7 +173,7 @@ impl From<&SplitMetadata> for FileEntry {
 }
 
 #[cfg(any(test, feature = "testsuite"))]
-impl TestableForRegression for SplitMetadata {
+impl quickwit_config::TestableForRegression for SplitMetadata {
     fn sample_for_regression() -> Self {
         SplitMetadata {
             split_id: "split".to_string(),

--- a/quickwit/quickwit-serve/src/grpc.rs
+++ b/quickwit/quickwit-serve/src/grpc.rs
@@ -19,6 +19,7 @@
 
 use std::collections::BTreeSet;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use futures::Future;
 use quickwit_config::service::QuickwitService;
@@ -47,7 +48,7 @@ use crate::QuickwitServices;
 /// Starts gRPC services given a gRPC address.
 pub(crate) async fn start_grpc_server<F>(
     grpc_listen_addr: SocketAddr,
-    services: &QuickwitServices,
+    services: Arc<QuickwitServices>,
     shutdown_signal: F,
 ) -> anyhow::Result<()>
 where

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use futures::Future;
 use hyper::http::HeaderValue;
@@ -52,7 +53,7 @@ const MINIMUM_RESPONSE_COMPRESSION_SIZE: u16 = 10 << 10;
 /// Starts REST services.
 pub(crate) async fn start_rest_server<F>(
     rest_listen_addr: SocketAddr,
-    quickwit_services: &QuickwitServices,
+    quickwit_services: Arc<QuickwitServices>,
     shutdown_signal: F,
 ) -> anyhow::Result<()>
 where


### PR DESCRIPTION
Runs gRPC and REST server handler in separate tasks.
This has NOT been observed to lower the latency of small requests,
but it makes more sense.
