### PR TITLE
Add readiness signals for gRPC and REST servers

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -699,9 +699,9 @@ checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -710,15 +710,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -2513,9 +2513,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.143"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libm"
@@ -4861,9 +4861,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -8004,9 +8004,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699d0104bcdd7e7af6d093d6c6e2d0c479b8a129ee0d1023b31d2e0c71bfdda2"
+checksum = "4f20f14e2bd1fef6ec891d50dbb37c7290a0568a6bbd9020bf62010d02b6f80e"
 
 [[package]]
 name = "xmlparser"

--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -81,12 +81,12 @@ impl RunCliCommand {
         quickwit_telemetry::send_telemetry_event(telemetry_event).await;
         // TODO move in serve quickwit?
         start_actor_runtimes(&config.enabled_services)?;
-        let _ = serve_quickwit(config, async move {
+        let shutdown_signal = Box::pin(async move {
             signal::ctrl_c()
                 .await
-                .expect("Failure listening for CTRL+C signal")
-        })
-        .await?;
+                .expect("Registering a signal handler for SIGINT should not fail.");
+        });
+        let _ = serve_quickwit(config, shutdown_signal).await?;
         Ok(())
     }
 }

--- a/quickwit/quickwit-common/src/tower/mod.rs
+++ b/quickwit/quickwit-common/src/tower/mod.rs
@@ -26,14 +26,21 @@ mod rate;
 mod rate_estimator;
 mod rate_limit;
 
+use std::pin::Pin;
+
 pub use box_layer::BoxLayer;
 pub use box_service::BoxService;
 pub use buffer::{Buffer, BufferError, BufferLayer};
 pub use estimate_rate::{EstimateRate, EstimateRateLayer};
+use futures::Future;
 pub use metrics::{PrometheusMetrics, PrometheusMetricsLayer};
 pub use rate::{ConstantRate, Rate};
 pub use rate_estimator::{RateEstimator, SmaRateEstimator};
 pub use rate_limit::{RateLimit, RateLimitLayer};
+
+pub type BoxFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'static>>;
+
+pub type BoxFutureInfaillible<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 
 pub trait Cost {
     fn cost(&self) -> u64;

--- a/quickwit/quickwit-serve/src/grpc.rs
+++ b/quickwit/quickwit-serve/src/grpc.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use futures::Future;
+use quickwit_common::tower::BoxFutureInfaillible;
 use quickwit_config::service::QuickwitService;
 use quickwit_control_plane::control_plane_service_grpc_server::ControlPlaneServiceGrpcServer;
 use quickwit_control_plane::ControlPlaneServiceGrpcServerAdapter;
@@ -46,14 +46,12 @@ use crate::search_api::GrpcSearchAdapter;
 use crate::QuickwitServices;
 
 /// Starts gRPC services given a gRPC address.
-pub(crate) async fn start_grpc_server<F>(
+pub(crate) async fn start_grpc_server(
     grpc_listen_addr: SocketAddr,
     services: Arc<QuickwitServices>,
-    shutdown_signal: F,
-) -> anyhow::Result<()>
-where
-    F: Future<Output = ()>,
-{
+    readiness_trigger: BoxFutureInfaillible<()>,
+    shutdown_signal: BoxFutureInfaillible<()>,
+) -> anyhow::Result<()> {
     let mut enabled_grpc_services = BTreeSet::new();
     let mut server = Server::builder();
 
@@ -155,9 +153,13 @@ where
         .add_optional_service(search_grpc_service)
         .add_optional_service(jaeger_grpc_service);
 
-    info!(enabled_grpc_services=?enabled_grpc_services, grpc_listen_addr=?grpc_listen_addr, "Starting gRPC server.");
-    server_router
-        .serve_with_shutdown(grpc_listen_addr, shutdown_signal)
-        .await?;
+    info!(
+        enabled_grpc_services=?enabled_grpc_services,
+        grpc_listen_addr=?grpc_listen_addr,
+        "Starting gRPC server listening on {grpc_listen_addr}."
+    );
+    let serve_fut = server_router.serve_with_shutdown(grpc_listen_addr, shutdown_signal);
+    let (serve_res, _trigger_res) = tokio::join!(serve_fut, readiness_trigger);
+    serve_res?;
     Ok(())
 }

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -20,10 +20,10 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use futures::Future;
 use hyper::http::HeaderValue;
 use hyper::{http, Method};
 use quickwit_common::metrics;
+use quickwit_common::tower::BoxFutureInfaillible;
 use quickwit_proto::ServiceErrorCode;
 use tower::make::Shared;
 use tower::ServiceBuilder;
@@ -51,19 +51,15 @@ use crate::{BodyFormat, QuickwitServices};
 const MINIMUM_RESPONSE_COMPRESSION_SIZE: u16 = 10 << 10;
 
 /// Starts REST services.
-pub(crate) async fn start_rest_server<F>(
+pub(crate) async fn start_rest_server(
     rest_listen_addr: SocketAddr,
     quickwit_services: Arc<QuickwitServices>,
-    shutdown_signal: F,
-) -> anyhow::Result<()>
-where
-    F: Future<Output = ()>,
-{
-    info!(rest_listen_addr = %rest_listen_addr, "Starting REST server.");
+    readiness_trigger: BoxFutureInfaillible<()>,
+    shutdown_signal: BoxFutureInfaillible<()>,
+) -> anyhow::Result<()> {
     let request_counter = warp::log::custom(|_| {
         crate::SERVE_METRICS.http_requests_total.inc();
     });
-
     // Docs routes
     let api_doc = warp::path("openapi.json")
         .and(warp::get())
@@ -142,12 +138,16 @@ where
         .layer(cors)
         .service(warp_service);
 
-    info!("Searcher ready to accept requests at http://{rest_listen_addr}/");
-
-    hyper::Server::bind(&rest_listen_addr)
+    info!(
+        rest_listen_addr=?rest_listen_addr,
+        "Starting REST server listening on {rest_listen_addr}."
+    );
+    let serve_fut = hyper::Server::bind(&rest_listen_addr)
         .serve(Shared::new(service))
-        .with_graceful_shutdown(shutdown_signal)
-        .await?;
+        .with_graceful_shutdown(shutdown_signal);
+
+    let (serve_res, _trigger_res) = tokio::join!(serve_fut, readiness_trigger);
+    serve_res?;
     Ok(())
 }
 

--- a/quickwit/quickwit-serve/src/tests.rs
+++ b/quickwit/quickwit-serve/src/tests.rs
@@ -26,6 +26,7 @@ use quickwit_cluster::create_cluster_for_test;
 use quickwit_common::uri::Uri;
 use quickwit_config::service::QuickwitService;
 use quickwit_metastore::{IndexMetadata, MockMetastore};
+use tokio::sync::{oneshot, watch};
 
 use crate::{check_cluster_configuration, node_readiness_reporting_task};
 
@@ -52,33 +53,41 @@ async fn test_check_cluster_configuration() {
 }
 
 #[tokio::test]
-async fn test_readiness_updates() -> anyhow::Result<()> {
+async fn test_readiness_updates() {
     let transport = ChannelTransport::default();
     let cluster = Arc::new(
         create_cluster_for_test(Vec::new(), &[], &transport, false)
             .await
             .unwrap(),
     );
-    cluster.set_self_node_ready(true).await;
-    let mut counter = 2;
+    let (metastore_readiness_tx, metastore_readiness_rx) = watch::channel(false);
     let mut metastore = MockMetastore::new();
-    metastore
-        .expect_check_connectivity()
-        .times(4)
-        .returning(move || {
-            counter -= 1;
-            if counter == 1 {
-                anyhow::bail!("error")
-            }
+    metastore.expect_check_connectivity().returning(move || {
+        if *metastore_readiness_rx.borrow() {
             Ok(())
-        });
+        } else {
+            Err(anyhow::anyhow!("Metastore not ready"))
+        }
+    });
+    let (grpc_readiness_trigger_tx, grpc_readiness_signal_rx) = oneshot::channel();
+    let (rest_readiness_trigger_tx, rest_readiness_signal_rx) = oneshot::channel();
     tokio::spawn(node_readiness_reporting_task(
         cluster.clone(),
         Arc::new(metastore),
+        grpc_readiness_signal_rx,
+        rest_readiness_signal_rx,
     ));
-    tokio::time::sleep(Duration::from_millis(25)).await;
     assert!(!cluster.is_self_node_ready().await);
+
+    grpc_readiness_trigger_tx.send(()).unwrap();
+    rest_readiness_trigger_tx.send(()).unwrap();
+    assert!(!cluster.is_self_node_ready().await);
+
+    metastore_readiness_tx.send(true).unwrap();
     tokio::time::sleep(Duration::from_millis(25)).await;
     assert!(cluster.is_self_node_ready().await);
-    Ok(())
+
+    metastore_readiness_tx.send(false).unwrap();
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    assert!(!cluster.is_self_node_ready().await);
 }


### PR DESCRIPTION
### Description
- Add readiness signals for gRPC and REST servers
- Clean up shutdown signal handlers code

### How was this PR tested?
- updated unit test
- launched `quickwit run`
