### PR TITLE
Fixes graceful shutdown of cluster sandbox

### DIFF
--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -319,7 +319,7 @@ impl ClusterSandbox {
 
     pub async fn shutdown(self) -> Result<Vec<HashMap<String, ActorExitStatus>>, anyhow::Error> {
         // We need to drop rest clients first because reqwest can hold connections open
-        // preventing rest server's graceful shutdown. 
+        // preventing rest server's graceful shutdown.
         drop(self.searcher_rest_client);
         drop(self.indexer_rest_client);
         self.shutdown_trigger.shutdown();

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -318,6 +318,10 @@ impl ClusterSandbox {
     }
 
     pub async fn shutdown(self) -> Result<Vec<HashMap<String, ActorExitStatus>>, anyhow::Error> {
+        // We need to drop rest clients first because reqwest can hold connections open
+        // preventing rest server's graceful shutdown. 
+        drop(self.searcher_rest_client);
+        drop(self.indexer_rest_client);
         self.shutdown_trigger.shutdown();
         let result = future::join_all(self.join_handles).await;
         let mut statuses = Vec::new();

--- a/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
@@ -219,5 +219,8 @@ async fn test_shutdown() {
         .unwrap();
 
     // Clean up
-    tokio::time::timeout(std::time::Duration::from_secs(10), sandbox.shutdown()).await.unwrap().unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(10), sandbox.shutdown())
+        .await
+        .unwrap()
+        .unwrap();
 }

--- a/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
@@ -357,7 +357,10 @@ async fn test_shutdown() {
         .await
         .unwrap();
 
-    // Clean up
+    // The error we are trying to catch here is that the sandbox is getting stuck in
+    // shutdown for 180 seconds if not all services exit cleanly, which in turn manifests
+    // itself with a very slow test that passes. This timeout ensures that the test fails
+    // if the sandbox gets stuck in shutdown.
     tokio::time::timeout(std::time::Duration::from_secs(10), sandbox.shutdown())
         .await
         .unwrap()


### PR DESCRIPTION
### Description

Certain rest client commands such as ingest may leave connection to the rest server open, which in turn prevents a quick graceful rest server shutdown. This change shuts down the rest clients before attempting to shutdown the server to ensure quick shutdown.

Fixes #3270

### How was this PR tested?

It is fixing tests.
