### PR TITLE
Pass aggregation limits when finalizing aggregation on the root node.

### DIFF
--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -244,6 +244,7 @@ pub async fn single_node_search(
     let aggregation = finalize_aggregation(
         leaf_search_response.intermediate_aggregation_result,
         aggregations,
+        &searcher_context,
     )?;
     Ok(SearchResponse {
         aggregation,

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -379,7 +379,7 @@ pub async fn root_search(
     let aggregation: Option<String> = finalize_aggregation(
         leaf_search_response.intermediate_aggregation_result,
         aggregations,
-        &searcher_context,
+        searcher_context,
     )?;
 
     Ok(SearchResponse {

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -32,6 +32,7 @@ use quickwit_proto::{
     ListTermsRequest, ListTermsResponse, SearchRequest, SearchResponse, SearchStreamRequest,
 };
 use quickwit_storage::{Cache, MemorySizedCache, QuickwitCache, StorageUriResolver};
+use tantivy::aggregation::AggregationLimits;
 use tokio::sync::Semaphore;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::info;
@@ -144,7 +145,7 @@ fn deserialize_doc_mapper(doc_mapper_str: &str) -> crate::Result<Arc<dyn DocMapp
 impl SearchService for SearchServiceImpl {
     async fn root_search(&self, search_request: SearchRequest) -> crate::Result<SearchResponse> {
         let search_result = root_search(
-            self.searcher_context.clone(),
+            &self.searcher_context,
             search_request,
             self.metastore.as_ref(),
             &self.cluster_client,
@@ -287,14 +288,16 @@ impl SearchService for SearchServiceImpl {
 pub struct SearcherContext {
     /// Searcher config.
     pub searcher_config: SearcherConfig,
-    /// Counting semaphore to limit concurrent leaf search split requests.
-    pub leaf_search_split_semaphore: Semaphore,
-    /// Counting semaphore to limit concurrent split stream requests.
-    pub split_stream_semaphore: Semaphore,
-    /// Split footer cache.
-    pub split_footer_cache: MemorySizedCache<String>,
+    // Aggregation limits.
+    pub aggregation_limits: AggregationLimits,
     /// Fast fields cache.
     pub fast_fields_cache: Arc<dyn Cache>,
+    /// Counting semaphore to limit concurrent leaf search split requests.
+    pub leaf_search_split_semaphore: Semaphore,
+    /// Split footer cache.
+    pub split_footer_cache: MemorySizedCache<String>,
+    /// Counting semaphore to limit concurrent split stream requests.
+    pub split_stream_semaphore: Semaphore,
 }
 
 impl std::fmt::Debug for SearcherContext {
@@ -324,12 +327,17 @@ impl SearcherContext {
         let fast_field_cache_capacity =
             searcher_config.fast_field_cache_capacity.get_bytes() as usize;
         let storage_long_term_cache = Arc::new(QuickwitCache::new(fast_field_cache_capacity));
+        let aggregation_limits = AggregationLimits::new(
+            Some(searcher_config.aggregation_memory_limit.get_bytes()),
+            Some(searcher_config.aggregation_bucket_limit),
+        );
         Self {
             searcher_config,
-            split_footer_cache: global_split_footer_cache,
-            leaf_search_split_semaphore,
-            split_stream_semaphore,
+            aggregation_limits,
             fast_fields_cache: storage_long_term_cache,
+            leaf_search_split_semaphore,
+            split_footer_cache: global_split_footer_cache,
+            split_stream_semaphore,
         }
     }
 }


### PR DESCRIPTION
Tested on an aggregation that was failing because the default aggregation limits were still used in the finalization step.