### PR TITLE
Improve documentation of commit and refresh params

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -152,6 +152,8 @@ POST api/v1/<index id>/ingest -d \
 
 Ingest a batch of documents to make them searchable in a given `<index id>`. Currently, NDJSON is the only accepted payload format. This endpoint is only available on a node that is running an indexer service.
 
+#### Controlling when the indexed documents will be available for search
+
 Newly added documents will not appear in the search results until they are added to a split and that split is committed. This process is automatic and is controlled by `split_num_docs_target` and `commit_timeout_secs` parameters. By default, the ingest command exits as soon as the records are added to the indexing queue, which means that the new documents will not appear in the search results at this moment. This behavior can be changed by adding `commit=wait_for` or `commit=force` parameters to the query. The `wait_for` parameter will cause the command to wait for the documents to be committed according to the standard time or number of documents rules. The `force` parameter will trigger a commit after all documents in the request are processed. It will also wait for this commit to finish before returning. Please note that the `force` option may have a significant performance cost especially if it is used on small batches.
 
 ```
@@ -170,6 +172,12 @@ The payload size is limited to 10MB as this endpoint is intended to receive docu
 | Variable      | Description   |
 | ------------- | ------------- |
 | `index id`  | The index id  |
+
+#### Query parameters
+
+| Variable            | Type       | Description                                        | Default value |
+|---------------------|------------|----------------------------------------------------|---------------|
+| `commit`            | `String`   | The commit behavior: `auto`, `wait_for` or `force` | `auto`        |
 
 #### Response
 
@@ -191,7 +199,10 @@ POST api/v1/_bulk -d \
 {"url":"https://en.wikipedia.org/wiki?id=3","title":"baz","body":"baz"}'
 ```
 
-Ingest a batch of documents to make them searchable using the [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) bulk API. This endpoint provides compatibility with tools or systems that already send data to Elasticsearch for indexing. Currently, only the `create` action of the bulk API is supported, all other actions such as `delete` or `update` are ignored. The [`refresh`](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) parameter is also supported.
+Ingest a batch of documents to make them searchable using the [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) bulk API. This endpoint provides compatibility with tools or systems that already send data to Elasticsearch for indexing. Currently, only the `create` action of the bulk API is supported, all other actions such as `delete` or `update` are ignored.
+
+The [`refresh`](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) parameter is supported.
+
 :::caution
 The quickwit API will not report errors, you need to check the server logs.
 
@@ -202,6 +213,12 @@ Quickwit does not have any notion of document id and does not support this featu
 :::info
 The payload size is limited to 10MB as this endpoint is intended to receive documents in batch.
 :::
+
+#### Query parameter
+
+| Variable      | Type       | Description                                                      | Default value |
+|---------------|------------|------------------------------------------------------------------|---------------|
+| `refresh`     | `String`   | The commit behavior: blank string, `true`, `wait_for` or `false` | `false`       |
 
 #### Response
 

--- a/quickwit/quickwit-ingest/src/lib.rs
+++ b/quickwit/quickwit-ingest/src/lib.rs
@@ -125,7 +125,8 @@ pub enum CommitType {
     Auto = 0,
     /// The request waits for the next scheduled commit to finish.
     WaitFor = 1,
-    /// The request forces an immediate commit after the last document in the batch and waits for it to finish.
+    /// The request forces an immediate commit after the last document in the batch and waits for
+    /// it to finish.
     Force = 2,
 }
 

--- a/quickwit/quickwit-ingest/src/lib.rs
+++ b/quickwit/quickwit-ingest/src/lib.rs
@@ -114,14 +114,18 @@ pub async fn start_ingest_api_service(
     init_ingest_api(universe, &queues_dir_path, config).await
 }
 
+/// Specifies if the ingest request should block waiting for the records to be committed.
 #[repr(u32)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(rename_all(deserialize = "snake_case"))]
 #[derive(Default)]
 pub enum CommitType {
     #[default]
+    /// The request doesn't wait for commit
     Auto = 0,
+    /// The request waits for the next scheduled commit to finish.
     WaitFor = 1,
+    /// The request forces an immediate commit after the last document in the batch and waits for it to finish.
     Force = 2,
 }
 

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -215,11 +215,14 @@ async fn tail_endpoint(
 pub enum ElasticRefresh {
     // if the refresh parameter is not present it is false
     #[default]
+    /// The request doesn't wait for commit
     False,
     // but if it is present without a value like this: ?refresh, it should be the same as
     // ?refresh=true
     #[serde(alias = "")]
+    /// The request forces an immediate commit after the last document in the batch and waits for it to finish.
     True,
+    /// The request will wait for the next scheduled commit to finish.
     WaitFor,
 }
 
@@ -639,6 +642,12 @@ mod tests {
                 .unwrap()
                 .refresh,
             ElasticRefresh::True
+        );
+        assert_eq!(
+            serde_qs::from_str::<ElasticIngestOptions>("refresh=wait")
+                .unwrap_err()
+                .to_string(),
+            "unknown variant `wait`, expected one of `false`, `true`, `wait_for`"
         );
     }
 

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -220,7 +220,8 @@ pub enum ElasticRefresh {
     // but if it is present without a value like this: ?refresh, it should be the same as
     // ?refresh=true
     #[serde(alias = "")]
-    /// The request forces an immediate commit after the last document in the batch and waits for it to finish.
+    /// The request forces an immediate commit after the last document in the batch and waits for
+    /// it to finish.
     True,
     /// The request will wait for the next scheduled commit to finish.
     WaitFor,


### PR DESCRIPTION
### Description

Improves documentation of the ingest's refresh and bulk's commit query parameters. It also adds some comment to corresponding enums.

Fixes #3309

### How was this PR tested?

It is mostly documentation changes. I added a small test to ensure errors in refresh parameter values are handled.
