### PR TITLE
Updates version of pulsar-broker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,8 @@ services:
       retries: 100
 
   pulsar-broker:
-    # The oldest supported version. EOL January 10, 2024
-    image: apachepulsar/pulsar:${PULSAR_VERSION:-2.11.1}
+    # The oldest version with arm64 docker images. EOL May 2 2025
+    image: apachepulsar/pulsar:${PULSAR_VERSION:-3.0.0}
     container_name: pulsar-broker
     command: bin/pulsar standalone
     ports:


### PR DESCRIPTION
### Description

Bumps the version of pulsar-broker to 3.0.0. That's the first version that has an official arm64 docker image.

Fixes #2921

### How was this PR tested?

I have been using per-released version of this for about a month on Mac M1 directly as well as in an arm64 Ubuntu VM. It worked pretty well for me. I have occasional pulsar hiccups, but I am not sure they are mac-specific. Now that an official pulsar 3.0.0 image is published I think we should switch to it.
