### PR TITLE
Incorrect field name within index config in document

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -568,7 +568,7 @@ This section describes search settings for a given index.
 
 | Variable      | Description   | Default value |
 | ------------- | ------------- | ------------- |
-| `search_default_fields`      | Default list of fields that will be used for search.   | `None` |
+| `default_search_fields`      | Default list of fields that will be used for search.   | `None` |
 
 ## Retention policy
 


### PR DESCRIPTION
Field `search_default_fields` for index search settings should be `default_search_fields`

### Description

Did some API tests according to the document. REST API returned error message when I specified `search_default_fields` when creating new index:

```json
{
  "message": "Invalid config: Failed to read JSON file.: unknown field `search_default_fields`, expected `default_search_fields`."
}
```

### How was this PR tested?

Index created ok after changing the field name to `default_search_fields`