### PR TITLE
Trinity  move es bulk endpoint

### DIFF
--- a/quickwit/quickwit-serve/src/elastic_search_api/bulk.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/bulk.rs
@@ -1,0 +1,331 @@
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use quickwit_ingest::{
+    CommitType, DocBatchBuilder, IngestRequest, IngestResponse, IngestService, IngestServiceClient,
+    IngestServiceError,
+};
+use quickwit_proto::{ServiceError, ServiceErrorCode};
+use thiserror::Error;
+use warp::{Filter, Rejection};
+
+use crate::elastic_search_api::filter::{elastic_bulk_filter, elastic_index_bulk_filter};
+use crate::elastic_search_api::model::{BulkAction, ElasticIngestOptions};
+use crate::format::extract_format_from_qs;
+use crate::ingest_api::lines;
+use crate::json_api_response::make_json_api_response;
+use crate::with_arg;
+
+#[derive(Error, Debug)]
+pub enum IngestRestApiError {
+    #[error("Failed to parse action `{0}`.")]
+    BulkInvalidAction(String),
+    #[error("Failed to parse source `{0}`.")]
+    BulkInvalidSource(String),
+    #[error(transparent)]
+    IngestApi(#[from] IngestServiceError),
+}
+
+impl ServiceError for IngestRestApiError {
+    fn status_code(&self) -> ServiceErrorCode {
+        match self {
+            Self::BulkInvalidAction(_) => ServiceErrorCode::BadRequest,
+            Self::BulkInvalidSource(_) => ServiceErrorCode::BadRequest,
+            Self::IngestApi(ingest_api_error) => ingest_api_error.status_code(),
+        }
+    }
+}
+
+/// POST _elastic/_bulk
+pub fn es_compat_bulk_handler(
+    ingest_service: IngestServiceClient,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
+    elastic_bulk_filter()
+        .and(with_arg(ingest_service))
+        .then(elastic_ingest)
+        .and(extract_format_from_qs())
+        .map(make_json_api_response)
+}
+
+/// POST _elastic/<index>/_bulk
+pub fn es_compat_index_bulk_handler(
+    ingest_service: IngestServiceClient,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
+    elastic_index_bulk_filter()
+        .and(with_arg(ingest_service))
+        .then(elastic_ingest_bulk)
+        .and(extract_format_from_qs())
+        .map(make_json_api_response)
+}
+
+async fn elastic_ingest(
+    body: Bytes,
+    ingest_options: ElasticIngestOptions,
+    mut ingest_service: IngestServiceClient,
+) -> Result<IngestResponse, IngestRestApiError> {
+    let mut doc_batch_builders = HashMap::new();
+    let mut lines = lines(&body);
+
+    while let Some(line) = lines.next() {
+        let action = serde_json::from_slice::<BulkAction>(line)
+            .map_err(|error| IngestRestApiError::BulkInvalidAction(error.to_string()))?;
+        let source = lines.next().ok_or_else(|| {
+            IngestRestApiError::BulkInvalidSource("Expected source for the action.".to_string())
+        })?;
+        let index_id = action.into_index();
+        let doc_batch_builder = doc_batch_builders
+            .entry(index_id.clone())
+            .or_insert(DocBatchBuilder::new(index_id));
+
+        doc_batch_builder.ingest_doc(source);
+    }
+    let doc_batches = doc_batch_builders
+        .into_values()
+        .map(|builder| builder.build())
+        .collect();
+    let commit_type: CommitType = ingest_options.refresh.into();
+    let ingest_request = IngestRequest {
+        doc_batches,
+        commit: commit_type as u32,
+    };
+    let ingest_response = ingest_service.ingest(ingest_request).await?;
+    Ok(ingest_response)
+}
+
+async fn elastic_ingest_bulk(
+    _index: String,
+    _body: Bytes,
+    _ingest_options: ElasticIngestOptions,
+    _ingest_service: IngestServiceClient,
+) -> Result<IngestResponse, IngestRestApiError> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use quickwit_config::IngestApiConfig;
+    use quickwit_ingest::{
+        FetchRequest, IngestResponse, IngestServiceClient, SuggestTruncateRequest,
+    };
+    use quickwit_search::MockSearchService;
+
+    use crate::elastic_search_api::elastic_api_handlers;
+    use crate::ingest_api::setup_ingest_service;
+
+    #[tokio::test]
+    async fn test_bulk_api_returns_404_if_index_id_does_not_exist() {
+        let search_service = Arc::new(MockSearchService::new());
+        let (universe, _temp_dir, ingest_service, _) =
+            setup_ingest_service(&["my-index"], &IngestApiConfig::default()).await;
+        let elastic_api_handlers = elastic_api_handlers(search_service, ingest_service);
+        let payload = r#"
+            { "create" : { "_index" : "my-index", "_id" : "1"} }
+            {"id": 1, "message": "push"}
+            { "create" : { "_index" : "index-2", "_id" : "1" } }
+            {"id": 1, "message": "push"}"#;
+        let resp = warp::test::request()
+            .path("/_elastic/_bulk")
+            .method("POST")
+            .body(payload)
+            .reply(&elastic_api_handlers)
+            .await;
+        assert_eq!(resp.status(), 404);
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_bulk_api_returns_200() {
+        let search_service = Arc::new(MockSearchService::new());
+        let (universe, _temp_dir, ingest_service, _) =
+            setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
+        let elastic_api_handlers = elastic_api_handlers(search_service, ingest_service);
+        let payload = r#"
+            { "create" : { "_index" : "my-index-1", "_id" : "1"} }
+            {"id": 1, "message": "push"}
+            { "create" : { "_index" : "my-index-2", "_id" : "1"} }
+            {"id": 1, "message": "push"}
+            { "create" : { "_index" : "my-index-1" } }
+            {"id": 2, "message": "push"}"#;
+        let resp = warp::test::request()
+            .path("/_elastic/_bulk")
+            .method("POST")
+            .body(payload)
+            .reply(&elastic_api_handlers)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let ingest_response: IngestResponse = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(ingest_response.num_docs_for_processing, 3);
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_bulk_api_blocks_when_refresh_wait_for_is_specified() {
+        let search_service = Arc::new(MockSearchService::new());
+        let (universe, _temp_dir, ingest_service, ingest_service_mailbox) =
+            setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
+        let elastic_api_handlers = elastic_api_handlers(search_service, ingest_service);
+        let payload = r#"
+            { "create" : { "_index" : "my-index-1", "_id" : "1"} }
+            {"id": 1, "message": "push"}
+            { "create" : { "_index" : "my-index-2", "_id" : "1"} }
+            {"id": 1, "message": "push"}
+            { "create" : { "_index" : "my-index-1" } }
+            {"id": 2, "message": "push"}"#;
+        let handle = tokio::spawn(async move {
+            let resp = warp::test::request()
+                .path("/_elastic/_bulk?refresh=wait_for")
+                .method("POST")
+                .body(payload)
+                .reply(&elastic_api_handlers)
+                .await;
+
+            assert_eq!(resp.status(), 200);
+            let ingest_response: IngestResponse = serde_json::from_slice(resp.body()).unwrap();
+            assert_eq!(ingest_response.num_docs_for_processing, 3);
+        });
+        universe.sleep(Duration::from_secs(10)).await;
+        assert!(!handle.is_finished());
+        assert_eq!(
+            ingest_service_mailbox
+                .ask_for_res(FetchRequest {
+                    index_id: "my-index-1".to_string(),
+                    start_after: None,
+                    num_bytes_limit: None,
+                })
+                .await
+                .unwrap()
+                .doc_batch
+                .unwrap()
+                .num_docs(),
+            2
+        );
+        assert!(!handle.is_finished());
+        assert_eq!(
+            ingest_service_mailbox
+                .ask_for_res(FetchRequest {
+                    index_id: "my-index-2".to_string(),
+                    start_after: None,
+                    num_bytes_limit: None,
+                })
+                .await
+                .unwrap()
+                .doc_batch
+                .unwrap()
+                .num_docs(),
+            1
+        );
+        ingest_service_mailbox
+            .ask_for_res(SuggestTruncateRequest {
+                index_id: "my-index-1".to_string(),
+                up_to_position_included: 1,
+            })
+            .await
+            .unwrap();
+        universe.sleep(Duration::from_secs(10)).await;
+        assert!(!handle.is_finished());
+        ingest_service_mailbox
+            .ask_for_res(SuggestTruncateRequest {
+                index_id: "my-index-2".to_string(),
+                up_to_position_included: 0,
+            })
+            .await
+            .unwrap();
+        handle.await.unwrap();
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_bulk_api_blocks_when_refresh_true_is_specified() {
+        let search_service = Arc::new(MockSearchService::new());
+        let (universe, _temp_dir, ingest_service, ingest_service_mailbox) =
+            setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
+        let elastic_api_handlers = elastic_api_handlers(search_service, ingest_service);
+        let payload = r#"
+            { "create" : { "_index" : "my-index-1", "_id" : "1"} }
+            {"id": 1, "message": "push"}
+            { "create" : { "_index" : "my-index-2", "_id" : "1"} }
+            {"id": 1, "message": "push"}
+            { "create" : { "_index" : "my-index-1" } }
+            {"id": 2, "message": "push"}"#;
+        let handle = tokio::spawn(async move {
+            let resp = warp::test::request()
+                .path("/_elastic/_bulk?refresh")
+                .method("POST")
+                .body(payload)
+                .reply(&elastic_api_handlers)
+                .await;
+
+            assert_eq!(resp.status(), 200);
+            let ingest_response: IngestResponse = serde_json::from_slice(resp.body()).unwrap();
+            assert_eq!(ingest_response.num_docs_for_processing, 3);
+        });
+        universe.sleep(Duration::from_secs(10)).await;
+        assert!(!handle.is_finished());
+        assert_eq!(
+            ingest_service_mailbox
+                .ask_for_res(FetchRequest {
+                    index_id: "my-index-1".to_string(),
+                    start_after: None,
+                    num_bytes_limit: None,
+                })
+                .await
+                .unwrap()
+                .doc_batch
+                .unwrap()
+                .num_docs(),
+            3
+        );
+        assert_eq!(
+            ingest_service_mailbox
+                .ask_for_res(FetchRequest {
+                    index_id: "my-index-2".to_string(),
+                    start_after: None,
+                    num_bytes_limit: None,
+                })
+                .await
+                .unwrap()
+                .doc_batch
+                .unwrap()
+                .num_docs(),
+            2
+        );
+        ingest_service_mailbox
+            .ask_for_res(SuggestTruncateRequest {
+                index_id: "my-index-1".to_string(),
+                up_to_position_included: 1,
+            })
+            .await
+            .unwrap();
+        universe.sleep(Duration::from_secs(10)).await;
+        assert!(!handle.is_finished());
+        ingest_service_mailbox
+            .ask_for_res(SuggestTruncateRequest {
+                index_id: "my-index-2".to_string(),
+                up_to_position_included: 0,
+            })
+            .await
+            .unwrap();
+        handle.await.unwrap();
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_bulk_ingest_request_returns_400_if_action_is_malformed() {
+        let search_service = Arc::new(MockSearchService::new());
+        let ingest_service = IngestServiceClient::new(IngestServiceClient::mock());
+        let elastic_api_handlers = elastic_api_handlers(search_service, ingest_service);
+        let payload = r#"
+            {"create": {"_index": "my-index", "_id": "1"},}
+            {"id": 1, "message": "my-doc"}"#;
+        let resp = warp::test::request()
+            .path("/_elastic/_bulk")
+            .method("POST")
+            .body(payload)
+            .reply(&elastic_api_handlers)
+            .await;
+        assert_eq!(resp.status(), 400);
+    }
+}

--- a/quickwit/quickwit-serve/src/elastic_search_api/filter.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/filter.rs
@@ -23,15 +23,39 @@ use serde::de::DeserializeOwned;
 use warp::reject::LengthRequired;
 use warp::{Filter, Rejection};
 
-use crate::elastic_search_api::model::{SearchBody, SearchQueryParams};
+use crate::elastic_search_api::model::{ElasticIngestOptions, SearchBody, SearchQueryParams};
 
 const BODY_LENGTH_LIMIT: Byte = byte_unit::Byte::from_bytes(1_000_000);
+const CONTENT_LENGTH_LIMIT: Byte = byte_unit::Byte::from_bytes(10 * 1024 * 1024); // 10MiB
 
 #[utoipa::path(get, tag = "Search", path = "/_search")]
 pub(crate) fn elastic_search_filter(
 ) -> impl Filter<Extract = (SearchQueryParams,), Error = Rejection> + Clone {
     warp::path!("_elastic" / "_search")
         .and(warp::get().or(warp::post()).unify())
+        .and(serde_qs::warp::query(serde_qs::Config::default()))
+}
+
+#[utoipa::path(
+    post,
+    tag = "Ingest",
+    path = "/_bulk",
+    request_body(content = String, description = "Elasticsearch compatible bulk request body limited to 10MB", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Successfully ingested documents.", body = IngestResponse)
+    ),
+    params(
+        ("refresh" = Option<ElasticRefresh>, Query, description = "Force or wait for commit at the end of the indexing operation."),
+    )
+)]
+pub(crate) fn elastic_bulk_filter(
+) -> impl Filter<Extract = (Bytes, ElasticIngestOptions), Error = Rejection> + Clone {
+    warp::path!("_elastic" / "_bulk")
+        .and(warp::post())
+        .and(warp::body::content_length_limit(
+            CONTENT_LENGTH_LIMIT.get_bytes(),
+        ))
+        .and(warp::body::bytes())
         .and(serde_qs::warp::query(serde_qs::Config::default()))
 }
 
@@ -80,4 +104,29 @@ pub(crate) fn elastic_index_search_filter(
         .and(warp::get().or(warp::post()).unify())
         .and(serde_qs::warp::query(serde_qs::Config::default()))
         .and(json_or_empty())
+}
+
+#[utoipa::path(
+    post,
+    tag = "Ingest",
+    path = "/{index}/_bulk",
+    request_body(content = String, description = "Elasticsearch compatible bulk request body limited to 10MB", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Successfully ingested documents.", body = IngestResponse)
+    ),
+    params(
+        ("refresh" = Option<ElasticRefresh>, Query, description = "Force or wait for commit at the end of the indexing operation."),
+    )
+)]
+pub(crate) fn elastic_index_bulk_filter(
+) -> impl Filter<Extract = (String, Bytes, ElasticIngestOptions), Error = Rejection> + Clone {
+    warp::path!("_elastic" / String / "_bulk")
+        .and(warp::post())
+        .and(warp::body::content_length_limit(
+            CONTENT_LENGTH_LIMIT.get_bytes(),
+        ))
+        .and(warp::body::bytes())
+        .and(serde_qs::warp::query::<ElasticIngestOptions>(
+            serde_qs::Config::default(),
+        ))
 }

--- a/quickwit/quickwit-serve/src/elastic_search_api/model/bulk_body.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/model/bulk_body.rs
@@ -1,0 +1,75 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all(deserialize = "lowercase"))]
+pub enum BulkAction {
+    Index(BulkActionMeta),
+    Create(BulkActionMeta),
+}
+
+impl BulkAction {
+    pub fn into_index(self) -> String {
+        match self {
+            BulkAction::Index(meta) => meta.index_id,
+            BulkAction::Create(meta) => meta.index_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct BulkActionMeta {
+    #[serde(alias = "_index")]
+    pub index_id: String,
+    #[serde(alias = "_id")]
+    #[serde(default)]
+    pub doc_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::elastic_search_api::model::{BulkAction, BulkActionMeta};
+
+    #[test]
+    fn test_bulk_action_serde() {
+        {
+            let bulk_action_json = r#"{
+                "create": {
+                    "_index": "test",
+                    "_id" : "2"
+                }
+            }"#;
+            let bulk_action = serde_json::from_str::<BulkAction>(bulk_action_json).unwrap();
+            assert_eq!(
+                bulk_action,
+                BulkAction::Create(BulkActionMeta {
+                    index_id: "test".to_string(),
+                    doc_id: Some("2".to_string()),
+                })
+            );
+        }
+        {
+            let bulk_action_json = r#"{
+                "create": {
+                    "_index": "test"
+                }
+            }"#;
+            let bulk_action = serde_json::from_str::<BulkAction>(bulk_action_json).unwrap();
+            assert_eq!(
+                bulk_action,
+                BulkAction::Create(BulkActionMeta {
+                    index_id: "test".to_string(),
+                    doc_id: None,
+                })
+            );
+        }
+        {
+            let bulk_action_json = r#"{
+                "delete": {
+                    "_index": "test",
+                    "_id": "2"
+                }
+            }"#;
+            serde_json::from_str::<BulkAction>(bulk_action_json).unwrap_err();
+        }
+    }
+}

--- a/quickwit/quickwit-serve/src/elastic_search_api/model/bulk_body.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/model/bulk_body.rs
@@ -8,7 +8,7 @@ pub enum BulkAction {
 }
 
 impl BulkAction {
-    pub fn into_index(self) -> String {
+    pub fn into_index(self) -> Option<String> {
         match self {
             BulkAction::Index(meta) => meta.index_id,
             BulkAction::Create(meta) => meta.index_id,
@@ -19,7 +19,8 @@ impl BulkAction {
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct BulkActionMeta {
     #[serde(alias = "_index")]
-    pub index_id: String,
+    #[serde(default)]
+    pub index_id: Option<String>,
     #[serde(alias = "_id")]
     #[serde(default)]
     pub doc_id: Option<String>,
@@ -42,7 +43,7 @@ mod tests {
             assert_eq!(
                 bulk_action,
                 BulkAction::Create(BulkActionMeta {
-                    index_id: "test".to_string(),
+                    index_id: Some("test".to_string()),
                     doc_id: Some("2".to_string()),
                 })
             );
@@ -57,8 +58,23 @@ mod tests {
             assert_eq!(
                 bulk_action,
                 BulkAction::Create(BulkActionMeta {
-                    index_id: "test".to_string(),
+                    index_id: Some("test".to_string()),
                     doc_id: None,
+                })
+            );
+        }
+        {
+            let bulk_action_json = r#"{
+                "create": {
+                    "_id": "3"
+                }
+            }"#;
+            let bulk_action = serde_json::from_str::<BulkAction>(bulk_action_json).unwrap();
+            assert_eq!(
+                bulk_action,
+                BulkAction::Create(BulkActionMeta {
+                    index_id: None,
+                    doc_id: Some("3".to_string()),
                 })
             );
         }

--- a/quickwit/quickwit-serve/src/elastic_search_api/model/bulk_query_params.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/model/bulk_query_params.rs
@@ -1,0 +1,87 @@
+use quickwit_ingest::CommitType;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct ElasticIngestOptions {
+    #[serde(default)]
+    pub refresh: ElasticRefresh,
+}
+
+/// ?refresh parameter for elasticsearch bulk request
+///
+/// The syntax for this parameter is a bit confusing for backward compatibility reasons.
+/// - Absence of ?refresh parameter or ?refresh=false means no refresh
+/// - Presence of ?refresh parameter without any values or ?refresh=true means force refresh
+/// - ?refresh=wait_for means wait for refresh
+#[derive(Clone, Debug, Deserialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all(deserialize = "snake_case"))]
+#[derive(Default)]
+pub enum ElasticRefresh {
+    // if the refresh parameter is not present it is false
+    #[default]
+    /// The request doesn't wait for commit
+    False,
+    // but if it is present without a value like this: ?refresh, it should be the same as
+    // ?refresh=true
+    #[serde(alias = "")]
+    /// The request forces an immediate commit after the last document in the batch and waits for
+    /// it to finish.
+    True,
+    /// The request will wait for the next scheduled commit to finish.
+    WaitFor,
+}
+
+impl From<ElasticRefresh> for CommitType {
+    fn from(val: ElasticRefresh) -> Self {
+        match val {
+            ElasticRefresh::False => CommitType::Auto,
+            ElasticRefresh::True => CommitType::Force,
+            ElasticRefresh::WaitFor => CommitType::WaitFor,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::elastic_search_api::model::{ElasticIngestOptions, ElasticRefresh};
+
+    #[test]
+    fn test_elastic_refresh_parsing() {
+        assert_eq!(
+            serde_qs::from_str::<ElasticIngestOptions>("")
+                .unwrap()
+                .refresh,
+            ElasticRefresh::False
+        );
+        assert_eq!(
+            serde_qs::from_str::<ElasticIngestOptions>("refresh=true")
+                .unwrap()
+                .refresh,
+            ElasticRefresh::True
+        );
+        assert_eq!(
+            serde_qs::from_str::<ElasticIngestOptions>("refresh=false")
+                .unwrap()
+                .refresh,
+            ElasticRefresh::False
+        );
+        assert_eq!(
+            serde_qs::from_str::<ElasticIngestOptions>("refresh=wait_for")
+                .unwrap()
+                .refresh,
+            ElasticRefresh::WaitFor
+        );
+        assert_eq!(
+            serde_qs::from_str::<ElasticIngestOptions>("refresh")
+                .unwrap()
+                .refresh,
+            ElasticRefresh::True
+        );
+        assert_eq!(
+            serde_qs::from_str::<ElasticIngestOptions>("refresh=wait")
+                .unwrap_err()
+                .to_string(),
+            "unknown variant `wait`, expected one of `false`, `true`, `wait_for`"
+        );
+    }
+}

--- a/quickwit/quickwit-serve/src/elastic_search_api/model/mod.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/model/mod.rs
@@ -17,10 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+mod bulk_body;
+mod bulk_query_params;
 mod error;
 mod search_body;
 mod search_query_params;
 
+pub use bulk_body::{BulkAction, BulkActionMeta};
+pub use bulk_query_params::{ElasticIngestOptions, ElasticRefresh};
 pub use error::ElasticSearchError;
 pub use search_body::SearchBody;
 pub use search_query_params::SearchQueryParams;

--- a/quickwit/quickwit-serve/src/ingest_api/mod.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/mod.rs
@@ -19,5 +19,7 @@
 
 mod rest_handler;
 
-pub(crate) use rest_handler::ingest_api_handlers;
+#[cfg(test)]
+pub(crate) use rest_handler::tests::setup_ingest_service;
+pub(crate) use rest_handler::{ingest_api_handlers, lines};
 pub use rest_handler::{IngestApi, IngestApiSchemas};

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -17,14 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
-
 use bytes::{Buf, Bytes};
 use quickwit_ingest::{
     CommitType, DocBatchBuilder, FetchResponse, IngestRequest, IngestResponse, IngestService,
     IngestServiceClient, IngestServiceError, TailRequest,
 };
-use quickwit_proto::{ServiceError, ServiceErrorCode};
 use serde::Deserialize;
 use thiserror::Error;
 use warp::{Filter, Rejection};
@@ -34,7 +31,7 @@ use crate::json_api_response::make_json_api_response;
 use crate::{with_arg, BodyFormat};
 
 #[derive(utoipa::OpenApi)]
-#[openapi(paths(ingest, tail_endpoint, elastic_ingest,))]
+#[openapi(paths(ingest, tail_endpoint,))]
 pub struct IngestApi;
 
 #[derive(utoipa::OpenApi)]
@@ -43,7 +40,6 @@ pub struct IngestApi;
     quickwit_ingest::FetchResponse,
     quickwit_ingest::IngestResponse,
     quickwit_ingest::CommitType,
-    ElasticRefresh,
 )))]
 pub struct IngestApiSchemas;
 
@@ -55,51 +51,6 @@ impl warp::reject::Reject for InvalidUtf8 {}
 
 const CONTENT_LENGTH_LIMIT: u64 = 10 * 1024 * 1024; // 10MiB
 
-#[derive(Error, Debug)]
-pub enum IngestRestApiError {
-    #[error("Failed to parse action `{0}`.")]
-    BulkInvalidAction(String),
-    #[error("Failed to parse source `{0}`.")]
-    BulkInvalidSource(String),
-    #[error(transparent)]
-    IngestApi(#[from] IngestServiceError),
-}
-
-impl ServiceError for IngestRestApiError {
-    fn status_code(&self) -> ServiceErrorCode {
-        match self {
-            Self::BulkInvalidAction(_) => ServiceErrorCode::BadRequest,
-            Self::BulkInvalidSource(_) => ServiceErrorCode::BadRequest,
-            Self::IngestApi(ingest_api_error) => ingest_api_error.status_code(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all(deserialize = "lowercase"))]
-enum BulkAction {
-    Index(BulkActionMeta),
-    Create(BulkActionMeta),
-}
-
-impl BulkAction {
-    fn into_index(self) -> String {
-        match self {
-            BulkAction::Index(meta) => meta.index_id,
-            BulkAction::Create(meta) => meta.index_id,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-struct BulkActionMeta {
-    #[serde(alias = "_index")]
-    index_id: String,
-    #[serde(alias = "_id")]
-    #[serde(default)]
-    doc_id: Option<String>,
-}
-
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 struct IngestOptions {
     #[serde(alias = "commit")]
@@ -110,9 +61,7 @@ struct IngestOptions {
 pub(crate) fn ingest_api_handlers(
     ingest_service: IngestServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    ingest_handler(ingest_service.clone())
-        .or(tail_handler(ingest_service.clone()))
-        .or(elastic_bulk_handler(ingest_service))
+    ingest_handler(ingest_service.clone()).or(tail_handler(ingest_service))
 }
 
 fn ingest_filter(
@@ -204,121 +153,13 @@ async fn tail_endpoint(
     Ok(fetch_response)
 }
 
-/// ?refresh parameter for elasticsearch bulk request
-///
-/// The syntax for this parameter is a bit confusing for backward compatibility reasons.
-/// - Absence of ?refresh parameter or ?refresh=false means no refresh
-/// - Presence of ?refresh parameter without any values or ?refresh=true means force refresh
-/// - ?refresh=wait_for means wait for refresh
-#[derive(Clone, Debug, Deserialize, PartialEq, utoipa::ToSchema)]
-#[serde(rename_all(deserialize = "snake_case"))]
-#[derive(Default)]
-pub enum ElasticRefresh {
-    // if the refresh parameter is not present it is false
-    #[default]
-    /// The request doesn't wait for commit
-    False,
-    // but if it is present without a value like this: ?refresh, it should be the same as
-    // ?refresh=true
-    #[serde(alias = "")]
-    /// The request forces an immediate commit after the last document in the batch and waits for
-    /// it to finish.
-    True,
-    /// The request will wait for the next scheduled commit to finish.
-    WaitFor,
-}
-
-impl From<ElasticRefresh> for CommitType {
-    fn from(val: ElasticRefresh) -> Self {
-        match val {
-            ElasticRefresh::False => CommitType::Auto,
-            ElasticRefresh::True => CommitType::Force,
-            ElasticRefresh::WaitFor => CommitType::WaitFor,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-struct ElasticIngestOptions {
-    #[serde(default)]
-    refresh: ElasticRefresh,
-}
-
-fn elastic_bulk_filter(
-) -> impl Filter<Extract = (Bytes, ElasticIngestOptions), Error = Rejection> + Clone {
-    warp::path!("_bulk")
-        .and(warp::post())
-        .and(warp::body::content_length_limit(CONTENT_LENGTH_LIMIT))
-        .and(warp::body::bytes())
-        .and(serde_qs::warp::query::<ElasticIngestOptions>(
-            serde_qs::Config::default(),
-        ))
-}
-
-pub fn elastic_bulk_handler(
-    ingest_service: IngestServiceClient,
-) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    elastic_bulk_filter()
-        .and(with_arg(ingest_service))
-        .then(elastic_ingest)
-        .and(extract_format_from_qs())
-        .map(make_json_api_response)
-}
-
-#[utoipa::path(
-    post,
-    tag = "Ingest",
-    path = "/_bulk",
-    request_body(content = String, description = "Elasticsearch compatible bulk request body limited to 10MB", content_type = "application/json"),
-    responses(
-        (status = 200, description = "Successfully ingested documents.", body = IngestResponse)
-    ),
-    params(
-        ("refresh" = Option<ElasticRefresh>, Query, description = "Force or wait for commit at the end of the indexing operation."),
-    )
-)]
-/// Elasticsearch-compatible Bulk Ingest
-async fn elastic_ingest(
-    body: Bytes,
-    ingest_options: ElasticIngestOptions,
-    mut ingest_service: IngestServiceClient,
-) -> Result<IngestResponse, IngestRestApiError> {
-    let mut doc_batch_builders = HashMap::new();
-    let mut lines = lines(&body);
-
-    while let Some(line) = lines.next() {
-        let action = serde_json::from_slice::<BulkAction>(line)
-            .map_err(|error| IngestRestApiError::BulkInvalidAction(error.to_string()))?;
-        let source = lines.next().ok_or_else(|| {
-            IngestRestApiError::BulkInvalidSource("Expected source for the action.".to_string())
-        })?;
-        let index_id = action.into_index();
-        let doc_batch_builder = doc_batch_builders
-            .entry(index_id.clone())
-            .or_insert(DocBatchBuilder::new(index_id));
-
-        doc_batch_builder.ingest_doc(source);
-    }
-    let doc_batches = doc_batch_builders
-        .into_values()
-        .map(|builder| builder.build())
-        .collect();
-    let commit_type: CommitType = ingest_options.refresh.into();
-    let ingest_request = IngestRequest {
-        doc_batches,
-        commit: commit_type as u32,
-    };
-    let ingest_response = ingest_service.ingest(ingest_request).await?;
-    Ok(ingest_response)
-}
-
-fn lines(body: &Bytes) -> impl Iterator<Item = &[u8]> {
+pub(crate) fn lines(body: &Bytes) -> impl Iterator<Item = &[u8]> {
     body.split(|byte| byte == &b'\n')
         .filter(|line| !line.is_empty())
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::time::Duration;
 
     use byte_unit::Byte;
@@ -330,54 +171,9 @@ mod tests {
         QUEUES_DIR_NAME,
     };
 
-    use super::{ingest_api_handlers, BulkAction, BulkActionMeta};
-    use crate::ingest_api::rest_handler::{ElasticIngestOptions, ElasticRefresh};
+    use super::ingest_api_handlers;
 
-    #[test]
-    fn test_bulk_action_serde() {
-        {
-            let bulk_action_json = r#"{
-                "create": {
-                    "_index": "test",
-                    "_id" : "2"
-                }
-            }"#;
-            let bulk_action = serde_json::from_str::<BulkAction>(bulk_action_json).unwrap();
-            assert_eq!(
-                bulk_action,
-                BulkAction::Create(BulkActionMeta {
-                    index_id: "test".to_string(),
-                    doc_id: Some("2".to_string()),
-                })
-            );
-        }
-        {
-            let bulk_action_json = r#"{
-                "create": {
-                    "_index": "test"
-                }
-            }"#;
-            let bulk_action = serde_json::from_str::<BulkAction>(bulk_action_json).unwrap();
-            assert_eq!(
-                bulk_action,
-                BulkAction::Create(BulkActionMeta {
-                    index_id: "test".to_string(),
-                    doc_id: None,
-                })
-            );
-        }
-        {
-            let bulk_action_json = r#"{
-                "delete": {
-                    "_index": "test",
-                    "_id": "2"
-                }
-            }"#;
-            serde_json::from_str::<BulkAction>(bulk_action_json).unwrap_err();
-        }
-    }
-
-    async fn setup_ingest_service(
+    pub(crate) async fn setup_ingest_service(
         queues: &[&str],
         config: &IngestApiConfig,
     ) -> (
@@ -458,50 +254,6 @@ mod tests {
         let ingest_response: IngestResponse = serde_json::from_slice(resp.body()).unwrap();
         assert_eq!(ingest_response.num_docs_for_processing, 3);
 
-        universe.assert_quit().await;
-    }
-
-    #[tokio::test]
-    async fn test_ingest_api_bulk_request_returns_404_if_index_id_does_not_exist() {
-        let (universe, _temp_dir, ingest_service, _) =
-            setup_ingest_service(&["my-index"], &IngestApiConfig::default()).await;
-        let ingest_api_handlers = ingest_api_handlers(ingest_service);
-        let payload = r#"
-            { "create" : { "_index" : "my-index", "_id" : "1"} }
-            {"id": 1, "message": "push"}
-            { "create" : { "_index" : "index-2", "_id" : "1" } }
-            {"id": 1, "message": "push"}"#;
-        let resp = warp::test::request()
-            .path("/_bulk")
-            .method("POST")
-            .body(payload)
-            .reply(&ingest_api_handlers)
-            .await;
-        assert_eq!(resp.status(), 404);
-        universe.assert_quit().await;
-    }
-
-    #[tokio::test]
-    async fn test_ingest_api_bulk_returns_200() {
-        let (universe, _temp_dir, ingest_service, _) =
-            setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
-        let ingest_api_handlers = ingest_api_handlers(ingest_service);
-        let payload = r#"
-            { "create" : { "_index" : "my-index-1", "_id" : "1"} }
-            {"id": 1, "message": "push"}
-            { "create" : { "_index" : "my-index-2", "_id" : "1"} }
-            {"id": 1, "message": "push"}
-            { "create" : { "_index" : "my-index-1" } }
-            {"id": 2, "message": "push"}"#;
-        let resp = warp::test::request()
-            .path("/_bulk")
-            .method("POST")
-            .body(payload)
-            .reply(&ingest_api_handlers)
-            .await;
-        assert_eq!(resp.status(), 200);
-        let ingest_response: IngestResponse = serde_json::from_slice(resp.body()).unwrap();
-        assert_eq!(ingest_response.num_docs_for_processing, 3);
         universe.assert_quit().await;
     }
 
@@ -611,210 +363,5 @@ mod tests {
             .unwrap();
         handle.await.unwrap();
         universe.assert_quit().await;
-    }
-
-    #[test]
-    fn test_elastic_refresh_parsing() {
-        assert_eq!(
-            serde_qs::from_str::<ElasticIngestOptions>("")
-                .unwrap()
-                .refresh,
-            ElasticRefresh::False
-        );
-        assert_eq!(
-            serde_qs::from_str::<ElasticIngestOptions>("refresh=true")
-                .unwrap()
-                .refresh,
-            ElasticRefresh::True
-        );
-        assert_eq!(
-            serde_qs::from_str::<ElasticIngestOptions>("refresh=false")
-                .unwrap()
-                .refresh,
-            ElasticRefresh::False
-        );
-        assert_eq!(
-            serde_qs::from_str::<ElasticIngestOptions>("refresh=wait_for")
-                .unwrap()
-                .refresh,
-            ElasticRefresh::WaitFor
-        );
-        assert_eq!(
-            serde_qs::from_str::<ElasticIngestOptions>("refresh")
-                .unwrap()
-                .refresh,
-            ElasticRefresh::True
-        );
-        assert_eq!(
-            serde_qs::from_str::<ElasticIngestOptions>("refresh=wait")
-                .unwrap_err()
-                .to_string(),
-            "unknown variant `wait`, expected one of `false`, `true`, `wait_for`"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_bulk_api_blocks_when_refresh_wait_for_is_specified() {
-        let (universe, _temp_dir, ingest_service, ingest_service_mailbox) =
-            setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
-        let ingest_api_handlers = ingest_api_handlers(ingest_service);
-        let payload = r#"
-            { "create" : { "_index" : "my-index-1", "_id" : "1"} }
-            {"id": 1, "message": "push"}
-            { "create" : { "_index" : "my-index-2", "_id" : "1"} }
-            {"id": 1, "message": "push"}
-            { "create" : { "_index" : "my-index-1" } }
-            {"id": 2, "message": "push"}"#;
-        let handle = tokio::spawn(async move {
-            let resp = warp::test::request()
-                .path("/_bulk?refresh=wait_for")
-                .method("POST")
-                .body(payload)
-                .reply(&ingest_api_handlers)
-                .await;
-
-            assert_eq!(resp.status(), 200);
-            let ingest_response: IngestResponse = serde_json::from_slice(resp.body()).unwrap();
-            assert_eq!(ingest_response.num_docs_for_processing, 3);
-        });
-        universe.sleep(Duration::from_secs(10)).await;
-        assert!(!handle.is_finished());
-        assert_eq!(
-            ingest_service_mailbox
-                .ask_for_res(FetchRequest {
-                    index_id: "my-index-1".to_string(),
-                    start_after: None,
-                    num_bytes_limit: None,
-                })
-                .await
-                .unwrap()
-                .doc_batch
-                .unwrap()
-                .num_docs(),
-            2
-        );
-        assert!(!handle.is_finished());
-        assert_eq!(
-            ingest_service_mailbox
-                .ask_for_res(FetchRequest {
-                    index_id: "my-index-2".to_string(),
-                    start_after: None,
-                    num_bytes_limit: None,
-                })
-                .await
-                .unwrap()
-                .doc_batch
-                .unwrap()
-                .num_docs(),
-            1
-        );
-        ingest_service_mailbox
-            .ask_for_res(SuggestTruncateRequest {
-                index_id: "my-index-1".to_string(),
-                up_to_position_included: 1,
-            })
-            .await
-            .unwrap();
-        universe.sleep(Duration::from_secs(10)).await;
-        assert!(!handle.is_finished());
-        ingest_service_mailbox
-            .ask_for_res(SuggestTruncateRequest {
-                index_id: "my-index-2".to_string(),
-                up_to_position_included: 0,
-            })
-            .await
-            .unwrap();
-        handle.await.unwrap();
-        universe.assert_quit().await;
-    }
-
-    #[tokio::test]
-    async fn test_bulk_api_blocks_when_refresh_true_is_specified() {
-        let (universe, _temp_dir, ingest_service, ingest_service_mailbox) =
-            setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
-        let ingest_api_handlers = ingest_api_handlers(ingest_service);
-        let payload = r#"
-            { "create" : { "_index" : "my-index-1", "_id" : "1"} }
-            {"id": 1, "message": "push"}
-            { "create" : { "_index" : "my-index-2", "_id" : "1"} }
-            {"id": 1, "message": "push"}
-            { "create" : { "_index" : "my-index-1" } }
-            {"id": 2, "message": "push"}"#;
-        let handle = tokio::spawn(async move {
-            let resp = warp::test::request()
-                .path("/_bulk?refresh")
-                .method("POST")
-                .body(payload)
-                .reply(&ingest_api_handlers)
-                .await;
-
-            assert_eq!(resp.status(), 200);
-            let ingest_response: IngestResponse = serde_json::from_slice(resp.body()).unwrap();
-            assert_eq!(ingest_response.num_docs_for_processing, 3);
-        });
-        universe.sleep(Duration::from_secs(10)).await;
-        assert!(!handle.is_finished());
-        assert_eq!(
-            ingest_service_mailbox
-                .ask_for_res(FetchRequest {
-                    index_id: "my-index-1".to_string(),
-                    start_after: None,
-                    num_bytes_limit: None,
-                })
-                .await
-                .unwrap()
-                .doc_batch
-                .unwrap()
-                .num_docs(),
-            3
-        );
-        assert_eq!(
-            ingest_service_mailbox
-                .ask_for_res(FetchRequest {
-                    index_id: "my-index-2".to_string(),
-                    start_after: None,
-                    num_bytes_limit: None,
-                })
-                .await
-                .unwrap()
-                .doc_batch
-                .unwrap()
-                .num_docs(),
-            2
-        );
-        ingest_service_mailbox
-            .ask_for_res(SuggestTruncateRequest {
-                index_id: "my-index-1".to_string(),
-                up_to_position_included: 1,
-            })
-            .await
-            .unwrap();
-        universe.sleep(Duration::from_secs(10)).await;
-        assert!(!handle.is_finished());
-        ingest_service_mailbox
-            .ask_for_res(SuggestTruncateRequest {
-                index_id: "my-index-2".to_string(),
-                up_to_position_included: 0,
-            })
-            .await
-            .unwrap();
-        handle.await.unwrap();
-        universe.assert_quit().await;
-    }
-
-    #[tokio::test]
-    async fn test_bulk_ingest_request_returns_400_if_action_is_malformed() {
-        let ingest_service = IngestServiceClient::new(IngestServiceClient::mock());
-        let ingest_api_handlers = ingest_api_handlers(ingest_service);
-        let payload = r#"
-            {"create": {"_index": "my-index", "_id": "1"},}
-            {"id": 1, "message": "my-doc"}"#;
-        let resp = warp::test::request()
-            .path("/_bulk")
-            .method("POST")
-            .body(payload)
-            .reply(&ingest_api_handlers)
-            .await;
-        assert_eq!(resp.status(), 400);
     }
 }

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -116,6 +116,7 @@ pub(crate) async fn start_rest_server(
         ))
         .or(elastic_api_handlers(
             quickwit_services.search_service.clone(),
+            ingest_service.clone(),
         ));
 
     let api_v1_root_route = api_v1_root_url.and(api_v1_routes);


### PR DESCRIPTION
### Description

fix #3138 and implement a `/_elastic/<index>/_bulk` endpoint

review recommendation: use `git diff --color-moved`, most of the changes are blocks being moved around

### How was this PR tested?

some manual testing, plus existing unit tests
