### PR TITLE
Display uncompressed document size in UI

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -226,22 +226,24 @@ quickwit run --service metastore --config=./config/quickwit.yaml
 quickwit index describe --endpoint=http://127.0.0.1:7280 --index wikipedia
 
 1. General infos
-===============================================================================
-Index id:                           wikipedia
-Index uri:                          file:///home/quickwit-indices/qwdata/indexes/wikipedia
-Number of published splits:         1
-Number of published documents:      300000
-Size of published splits:           448 MB
+---------------------------------------------+---------------------------------------------------------
+Index ID:                                    | wikipedia
+Index URI:                                   | file:///home/quickwit-indices/qwdata/indexes/wikipedia
+Number of published documents:               | 300000
+Size of published documents (uncompressed):  | 33.73 MB 
+Number of published splits:                  | 1
+Size of published splits:                    | 24.07 MB
+Timestamp field:                             | Field does not exist for the index.                                     
+Timestamp range:                             | Range does not exist for the index. 
 
-2. Statistics on splits
-===============================================================================
-Document count stats:
-Mean ± σ in [min … max]:            300000 ± 0 in [300000 … 300000]
-Quantiles [1%, 25%, 50%, 75%, 99%]: [300000, 300000, 300000, 300000, 300000]
-
-Size in MB stats:
-Mean ± σ in [min … max]:            448 ± 0 in [448 … 448]
-Quantiles [1%, 25%, 50%, 75%, 99%]: [448, 448, 448, 448, 448]
+Document count stats (published)                                                                                        
+Mean ± σ in [min … max]:                     | 15000 ± 5000 in [10000 … 20000]                                         
+Quantiles [1%, 25%, 50%, 75%, 99%]:          | [10100, 15000, 15000, 17500, 17500]                                     
+                                                                                                                        
+                                                                                                                        
+Size in MB stats (published)                                                                                            
+Mean ± σ in [min … max]:                     | 12.037121 ± 3.802938 in [8 … 15]                                        
+Quantiles [1%, 25%, 50%, 75%, 99%]:          | [8.310242, 12.037121, 12.037121, 13.93859, 13.93859] 
 
 ```
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -354,16 +354,17 @@ Describes an index of ID `index id`.
 
 The response is the stats about the requested index, and the content type is `application/json; charset=UTF-8.`
 
-| Field                  | Description                               |         Type          |
-|------------------------|-------------------------------------------|:---------------------:|
-| `index_id`             | Index ID of index.                        |       `String`        |
-| `index_uri`            | Uri of index                              |       `String`        |
-| `num_published_splits` | Number of published splits.               |       `number`        |
-| `num_published_docs`   | Number of published documents.            |       `number`        |
-| `size_published_docs`  | Size of the published documents in bytes. |       `number`        |
-| `timestamp_field_name` | Type of timestamp.                        |       `String`        |
-| `min_timestamp`        | Starting time of timestamp.               |       `number`        |
-| `max_timestamp`        | Ending time of timestamp.                 |       `number`        |
+| Field                               | Description                                              |         Type          |
+|-------------------------------------|----------------------------------------------------------|:---------------------:|
+| `index_id`                          | Index ID of index.                                       |       `String`        |
+| `index_uri`                         | Uri of index                                             |       `String`        |
+| `num_published_splits`              | Number of published splits.                              |       `number`        |
+| `size_published_splits`             | Size of published splits.                                |       `number`        |
+| `num_published_docs`                | Number of published documents.                           |       `number`        |
+| `size_published_docs_uncompressed`  | Size of the published documents in bytes (uncompressed). |       `number`        |
+| `timestamp_field_name`              | Name of timestamp field.                                       |       `String`        |
+| `min_timestamp`                     | Starting time of timestamp.                              |       `number`        |
+| `max_timestamp`                     | Ending time of timestamp.                                |       `number`        |
 
 ### Clears an index
 

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -550,9 +550,12 @@ impl Tabled for IndexStats {
         vec![
             self.index_id.clone(),
             self.index_uri.to_string(),
-            self.num_published_splits.to_string(),
             self.num_published_docs.to_string(),
             self.size_published_docs_uncompressed
+                .get_appropriate_unit(false)
+                .to_string(),
+            self.num_published_splits.to_string(),
+            self.size_published_splits
                 .get_appropriate_unit(false)
                 .to_string(),
             display_option_in_table(&self.timestamp_field_name),
@@ -564,8 +567,9 @@ impl Tabled for IndexStats {
         vec![
             "Index ID: ".to_string(),
             "Index URI: ".to_string(),
-            "Number of published splits: ".to_string(),
             "Number of published documents: ".to_string(),
+            "Size of published documents (uncompressed): ".to_string(),
+            "Number of published splits: ".to_string(),
             "Size of published splits: ".to_string(),
             "Timestamp field: ".to_string(),
             "Timestamp range: ".to_string(),

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -534,8 +534,9 @@ pub struct IndexStats {
     pub index_id: String,
     pub index_uri: Uri,
     pub num_published_splits: usize,
+    pub size_published_splits: Byte,
     pub num_published_docs: u64,
-    pub size_published_docs: Byte,
+    pub size_published_docs_uncompressed: Byte,
     pub timestamp_field_name: Option<String>,
     pub timestamp_range: Option<(i64, i64)>,
     pub num_docs_descriptive: Option<DescriptiveStats>,
@@ -551,7 +552,7 @@ impl Tabled for IndexStats {
             self.index_uri.to_string(),
             self.num_published_splits.to_string(),
             self.num_published_docs.to_string(),
-            self.size_published_docs
+            self.size_published_docs_uncompressed
                 .get_appropriate_unit(false)
                 .to_string(),
             display_option_in_table(&self.timestamp_field_name),
@@ -607,11 +608,14 @@ impl IndexStats {
 
         let splits_bytes = published_splits
             .iter()
-            .filter(|split| split.split_state == SplitState::Published)
             .map(|split| split.split_metadata.footer_offsets.end)
             .sorted()
             .collect_vec();
-        let total_bytes = splits_bytes.iter().sum::<u64>();
+        let total_num_bytes = splits_bytes.iter().sum::<u64>();
+        let total_uncompressed_num_bytes = published_splits
+            .iter()
+            .map(|split| split.split_metadata.uncompressed_docs_size_in_bytes)
+            .sum::<u64>();
 
         let timestamp_range = if index_metadata
             .index_config()
@@ -652,8 +656,9 @@ impl IndexStats {
             index_id: index_config.index_id.clone(),
             index_uri: index_config.index_uri.clone(),
             num_published_splits: published_splits.len(),
+            size_published_splits: Byte::from(total_num_bytes),
             num_published_docs: total_num_docs,
-            size_published_docs: Byte::from(total_bytes),
+            size_published_docs_uncompressed: Byte::from(total_uncompressed_num_bytes),
             timestamp_field_name: index_config.doc_mapping.timestamp_field,
             timestamp_range,
             num_docs_descriptive,
@@ -1114,10 +1119,12 @@ mod test {
         let index_uri = "s3://some-test-bucket";
 
         let index_metadata = IndexMetadata::for_test(&index_id, index_uri);
-        let split_metadata_1 =
+        let mut split_metadata_1 =
             split_metadata_for_test(&split_id_1, 100_000, 1111..=2222, 15_000_000);
-        let split_metadata_2 =
+        split_metadata_1.uncompressed_docs_size_in_bytes = 19_000_000;
+        let mut split_metadata_2 =
             split_metadata_for_test(&split_id_2, 100_000, 1000..=3000, 30_000_000);
+        split_metadata_2.uncompressed_docs_size_in_bytes = 36_000_000;
 
         let split_data_1 = Split {
             split_metadata: split_metadata_1,
@@ -1138,8 +1145,15 @@ mod test {
         assert_eq!(index_stats.index_id, index_id);
         assert_eq!(index_stats.index_uri.as_str(), index_uri);
         assert_eq!(index_stats.num_published_splits, 1);
+        assert_eq!(
+            index_stats.size_published_splits,
+            Byte::from(15_000_000usize)
+        );
         assert_eq!(index_stats.num_published_docs, 100_000);
-        assert_eq!(index_stats.size_published_docs, Byte::from(15_000_000usize));
+        assert_eq!(
+            index_stats.size_published_docs_uncompressed,
+            Byte::from(19_000_000usize)
+        );
         assert_eq!(
             index_stats.timestamp_field_name,
             Some("timestamp".to_string())

--- a/quickwit/quickwit-ui/src/components/IndexSummary.tsx
+++ b/quickwit/quickwit-ui/src/components/IndexSummary.tsx
@@ -85,7 +85,7 @@ export function IndexSummary({ index }: { index: Index }) {
             thousandSeparator={true}
           />
         </IndexRow>
-        <IndexRow title="Size of published documents:">
+        <IndexRow title="Size of published documents (uncompressed):">
           <NumberFormat
             value={total_uncompressed_num_bytes / 1000000}
             displayType={"text"}

--- a/quickwit/quickwit-ui/src/components/IndexSummary.tsx
+++ b/quickwit/quickwit-ui/src/components/IndexSummary.tsx
@@ -38,7 +38,7 @@ flex-direction: row;
 &:nth-of-type(odd){ background: rgba(0,0,0,0.05) }
 `
 const RowKey = styled.div`
-width: 300px;
+width: 350px;
 `
 const IndexRow: FC<{ title: string; children: ReactNode }> = ({
   title,

--- a/quickwit/quickwit-ui/src/components/IndexSummary.tsx
+++ b/quickwit/quickwit-ui/src/components/IndexSummary.tsx
@@ -63,6 +63,11 @@ export function IndexSummary({ index }: { index: Index }) {
       return split.footer_offsets.end
     })
     .reduce((sum, current) => sum + current, 0);
+  const total_uncompressed_num_bytes = published_splits
+    .map(split => {
+      return split.uncompressed_docs_size_in_bytes
+    })
+    .reduce((sum, current) => sum + current, 0);
   return (
     <Paper variant="outlined" >
       <ItemContainer>
@@ -73,6 +78,23 @@ export function IndexSummary({ index }: { index: Index }) {
             .format("YYYY/MM/DD HH:MM")}
         </IndexRow>
         <IndexRow title="URI:">{index.metadata.index_config.index_uri}</IndexRow>
+        <IndexRow title="Number of published documents:">
+          <NumberFormat
+            value={total_num_docs}
+            displayType={"text"}
+            thousandSeparator={true}
+          />
+        </IndexRow>
+        <IndexRow title="Size of published documents:">
+          <NumberFormat
+            value={total_uncompressed_num_bytes / 1000000}
+            displayType={"text"}
+            thousandSeparator={true}
+            suffix=" MB"
+            decimalScale={2}
+          />
+        </IndexRow>
+        <IndexRow title="Number of published splits:">{published_splits.length}</IndexRow>
         <IndexRow title="Size of published splits:">
           <NumberFormat
             value={total_num_bytes / 1000000}
@@ -82,14 +104,6 @@ export function IndexSummary({ index }: { index: Index }) {
             decimalScale={2}
           />
         </IndexRow>
-        <IndexRow title="Number of published documents:">
-          <NumberFormat
-            value={total_num_docs}
-            displayType={"text"}
-            thousandSeparator={true}
-          />
-        </IndexRow>
-        <IndexRow title="Number of published splits:">{published_splits.length}</IndexRow>
         <IndexRow title="Number of staged splits:">{num_of_staged_splits}</IndexRow>
         <IndexRow title="Number of splits marked for deletion:">{num_of_marked_for_delete_splits}</IndexRow>
       </ItemContainer>

--- a/quickwit/quickwit-ui/src/utils/models.ts
+++ b/quickwit/quickwit-ui/src/utils/models.ts
@@ -150,6 +150,7 @@ export type SplitMetadata = {
   split_id: string;
   split_state: string;
   num_docs: number;
+  uncompressed_docs_size_in_bytes: number;
   time_range: null | Range;
   update_timestamp: number;
   version: number;


### PR DESCRIPTION
Closes https://github.com/quickwit-oss/quickwit/issues/3320

Reordered display and added  `Size of published documents`
![Screenshot from 2023-05-16 16-44-09](https://github.com/quickwit-oss/quickwit/assets/468277/966a2c5a-ecc6-43dc-8c58-342b8f9ca09b)

updated label
![Screenshot from 2023-05-21 07-28-06](https://github.com/quickwit-oss/quickwit/assets/468277/b7ac72fa-0430-4ece-9722-4e19469c48c9)

