### PR TITLE
Expose the number of CPUs available on the node

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4682,6 +4682,7 @@ dependencies = [
  "itertools",
  "mime_guess",
  "mockall",
+ "num_cpus",
  "once_cell",
  "opentelemetry",
  "quickwit-actors",

--- a/quickwit/quickwit-cli/src/generate_markdown.rs
+++ b/quickwit/quickwit-cli/src/generate_markdown.rs
@@ -19,29 +19,27 @@
 
 use clap::Command;
 use quickwit_cli::cli::build_cli;
-use quickwit_serve::quickwit_build_info;
+use quickwit_serve::BuildInfo;
 use toml::Value;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let build_info = quickwit_build_info();
+    let build_info = BuildInfo::get();
     let version_text = format!(
         "{} ({} {})",
         build_info.cargo_pkg_version, build_info.cargo_pkg_version, build_info.commit_date,
     );
-
     let app = build_cli()
         .version(version_text.as_str())
         .disable_help_subcommand(true);
 
     generate_markdown_from_clap(&app);
-
     Ok(())
 }
 
 fn markdown_for_command(command: &Command, doc_extensions: &toml::Value) {
     let command_name = command.get_name();
-    let command_ext: Option<&Value> = doc_extensions.get(command_name.to_owned());
+    let command_ext: Option<&Value> = doc_extensions.get(command_name.to_string());
     markdown_for_command_helper(command, command_ext, command_name.to_string(), Vec::new());
 }
 
@@ -56,11 +54,11 @@ fn markdown_for_subcommand(
     println!("### {command_name}\n");
 
     let subcommand_ext: Option<&Value> = {
-        let mut val_opt: Option<&Value> = doc_extensions.get(command_group[0].to_owned());
+        let mut val_opt: Option<&Value> = doc_extensions.get(command_group[0].to_string());
         for command in command_group
             .iter()
             .skip(1)
-            .chain(&[subcommand_name.to_owned()])
+            .chain(&[subcommand_name.to_string()])
         {
             if let Some(val) = val_opt {
                 val_opt = val.get(command);

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -32,7 +32,7 @@ use quickwit_cli::{
     busy_detector, QW_ENABLE_JAEGER_EXPORTER_ENV_KEY, QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER_ENV_KEY,
 };
 use quickwit_common::RED_COLOR;
-use quickwit_serve::{quickwit_build_info, QuickwitBuildInfo};
+use quickwit_serve::BuildInfo;
 use quickwit_telemetry::payload::TelemetryEvent;
 use tracing::Level;
 use tracing_subscriber::fmt::time::UtcTime;
@@ -42,7 +42,7 @@ use tracing_subscriber::EnvFilter;
 fn setup_logging_and_tracing(
     level: Level,
     ansi: bool,
-    build_info: &QuickwitBuildInfo,
+    build_info: &BuildInfo,
 ) -> anyhow::Result<()> {
     #[cfg(feature = "tokio-console")]
     {
@@ -123,7 +123,7 @@ async fn main_impl() -> anyhow::Result<()> {
 
     let telemetry_handle = quickwit_telemetry::start_telemetry_loop();
     let about_text = about_text();
-    let build_info = quickwit_build_info();
+    let build_info = BuildInfo::get();
     let version_text = format!(
         "{} ({} {})",
         build_info.version, build_info.commit_short_hash, build_info.build_date

--- a/quickwit/quickwit-serve/Cargo.toml
+++ b/quickwit/quickwit-serve/Cargo.toml
@@ -21,6 +21,7 @@ http-serde = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
 mime_guess = { workspace = true }
+num_cpus = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 rust-embed = { workspace = true }

--- a/quickwit/quickwit-serve/src/build_info.rs
+++ b/quickwit/quickwit-serve/src/build_info.rs
@@ -1,0 +1,100 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use once_cell::sync::OnceCell;
+use serde::Serialize;
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct BuildInfo {
+    pub build_date: &'static str,
+    pub build_profile: &'static str,
+    pub build_target: &'static str,
+    pub cargo_pkg_version: &'static str,
+    pub commit_date: &'static str,
+    pub commit_hash: &'static str,
+    pub commit_short_hash: &'static str,
+    pub commit_tags: Vec<String>,
+    pub version: String,
+}
+
+impl BuildInfo {
+    /// Returns the properties of the binary.
+    pub fn get() -> &'static Self {
+        const UNKNOWN: &str = "unknown";
+
+        static INSTANCE: OnceCell<BuildInfo> = OnceCell::new();
+
+        INSTANCE.get_or_init(|| {
+            let commit_date = option_env!("QW_COMMIT_DATE")
+                .filter(|commit_date| !commit_date.is_empty())
+                .unwrap_or(UNKNOWN);
+            let commit_hash = option_env!("QW_COMMIT_HASH")
+                .filter(|commit_hash| !commit_hash.is_empty())
+                .unwrap_or(UNKNOWN);
+            let commit_short_hash = option_env!("QW_COMMIT_HASH")
+                .filter(|commit_hash| commit_hash.len() >= 7)
+                .map(|commit_hash| &commit_hash[..7])
+                .unwrap_or(UNKNOWN);
+            let mut commit_tags: Vec<String> = option_env!("QW_COMMIT_TAGS")
+                .map(|tags| {
+                    tags.split(',')
+                        .map(|tag| tag.trim().to_string())
+                        .filter(|tag| !tag.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+            commit_tags.sort();
+
+            let version = commit_tags
+                .iter()
+                .find(|tag| tag.starts_with('v'))
+                .cloned()
+                .unwrap_or_else(|| concat!(env!("CARGO_PKG_VERSION"), "-nightly").to_string());
+
+            Self {
+                build_date: env!("BUILD_DATE"),
+                build_profile: env!("BUILD_PROFILE"),
+                build_target: env!("BUILD_TARGET"),
+                cargo_pkg_version: env!("CARGO_PKG_VERSION"),
+                commit_date,
+                commit_hash,
+                commit_short_hash,
+                commit_tags,
+                version,
+            }
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct RuntimeInfo {
+    pub num_cpus_logical: usize,
+    pub num_cpus_physical: usize,
+}
+
+impl RuntimeInfo {
+    /// Returns the properties of the node.
+    pub fn get() -> &'static Self {
+        static INSTANCE: OnceCell<RuntimeInfo> = OnceCell::new();
+        INSTANCE.get_or_init(|| Self {
+            num_cpus_logical: num_cpus::get(),
+            num_cpus_physical: num_cpus::get_physical(),
+        })
+    }
+}

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -44,7 +44,7 @@ use crate::json_api_response::{ApiError, JsonApiResponse};
 use crate::node_info_handler::node_info_handler;
 use crate::search_api::{search_get_handler, search_post_handler, search_stream_handler};
 use crate::ui_handler::ui_handler;
-use crate::{BodyFormat, QuickwitServices};
+use crate::{BodyFormat, BuildInfo, QuickwitServices, RuntimeInfo};
 
 /// The minimum size a response body must be in order to
 /// be automatically compressed with gzip.
@@ -93,7 +93,8 @@ pub(crate) async fn start_rest_server(
     let api_v1_root_url = warp::path!("api" / "v1" / ..);
     let api_v1_routes = cluster_handler(quickwit_services.cluster.clone())
         .or(node_info_handler(
-            quickwit_services.build_info,
+            BuildInfo::get(),
+            RuntimeInfo::get(),
             quickwit_services.config.clone(),
         ))
         .or(indexing_get_handler(


### PR DESCRIPTION
### Description
In the long run, I'd like to expose more info (ram, os, uptime, ...) so it's easy for our users to copy and paste this stuff when opening issues.

### How was this PR tested?
- Updated units test
- Hit endpoint