### PR TITLE
Improve basic-integration-tests

### DIFF
--- a/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
@@ -128,14 +128,7 @@ async fn test_standalone_server() {
                 .num_hits,
             0
         );
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        let counters = sandbox
-            .indexer_rest_client
-            .node_stats()
-            .indexing()
-            .await
-            .unwrap();
-        assert_eq!(counters.num_running_pipelines, 1);
+        sandbox.wait_for_indexing_pipelines(1).await.unwrap();
     }
     sandbox.shutdown().await.unwrap();
 }
@@ -197,14 +190,7 @@ async fn test_multi_nodes_cluster() {
         .unwrap());
 
     // Wait until indexing pipelines are started.
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let indexing_service_counters = sandbox
-        .indexer_rest_client
-        .node_stats()
-        .indexing()
-        .await
-        .unwrap();
-    assert_eq!(indexing_service_counters.num_running_pipelines, 1);
+    sandbox.wait_for_indexing_pipelines(1).await.unwrap();
 
     // Check search is working.
     let search_response_empty = sandbox


### PR DESCRIPTION
### Description

Makes the basic integration tests less flaky by replacing sleep with active waiting.

Fixes #3351

### How was this PR tested?

I ran all tests on CI about 300 times to ensure this test is not as flaky as it used to be. 
