### PR TITLE
Upgrade rustix 0.36.13->0.36.14 and fix debug info

### DIFF
--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -26,8 +26,7 @@ jobs:
               CI=false yarn --cwd quickwit-ui build
               cargo build --features=postgres
               mkdir qwdata
-              # Workaround for possible rust regression - https://github.com/quickwit-oss/quickwit/issues/3346
-              target/debug/quickwit run --service searcher --service metastore --config ../config/quickwit.yaml &
+              cargo run --features=postgres -- run --service searcher --service metastore --config ../config/quickwit.yaml &
               yarn --cwd quickwit-ui cypress run
           - name: Lint
             command: yarn --cwd quickwit-ui lint

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3721,7 +3721,7 @@ dependencies = [
  "byteorder",
  "hex",
  "lazy_static",
- "rustix 0.36.13",
+ "rustix 0.36.14",
 ]
 
 [[package]]
@@ -5327,9 +5327,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.13"
+version = "0.36.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a38f9520be93aba504e8ca974197f46158de5dcaa9fa04b57c57cd6a679d658"
+checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
 dependencies = [
  "bitflags",
  "errno",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-rust-version = "1.68"
+rust-version = "1.69"
 members = [
   "quickwit-actors",
   "quickwit-aws",
@@ -35,7 +35,7 @@ members = [
 ]
 
 [profile.dev]
-debug = 0
+debug = false
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
### Description

This version of rustix no longer causes recompilation during tests runs while using VSCode. This commit also works around a bug introduced in rust 1.69.0 that was causing rebuilding between cargo build and cargo run.

Fixes #3346

### How was this PR tested?

That part was quite an adventure 😄 
