### PR TITLE
Allow sort on dynamic field.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3332,7 +3332,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6355,7 +6355,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6410,7 +6410,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "bitpacking",
 ]
@@ -6418,7 +6418,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "fastdivide",
  "fnv",
@@ -6433,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6456,7 +6456,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "combine",
  "once_cell",
@@ -6466,7 +6466,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "tantivy-common",
  "tantivy-fst",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=62709b8#62709b8094123dff440764d8c2d039b7cc66ddf3"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=d7e9733#d7e97331e59819735b1c07dcff63c35b01e263b2"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -225,7 +225,7 @@ quickwit-serve = { version = "0.6.0", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.6.0", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.6.0", path = "./quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "62709b8", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "d7e9733", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -42,6 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[serde(skip_serializing_if = \"Option::is_none\")]",
         )
         .type_attribute("OutputFormat", "#[serde(rename_all = \"snake_case\")]")
+        .type_attribute("PartialHit.sort_value", "#[derive(Copy)]")
         .type_attribute("SortOrder", "#[serde(rename_all = \"lowercase\")]")
         .out_dir("src/")
         .compile_with_config(prost_config, &protos, &["protos/quickwit"])?;

--- a/quickwit/quickwit-proto/protos/quickwit/search_api.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search_api.proto
@@ -210,12 +210,13 @@ message Hit {
   optional string snippet = 3;
 }
 
+
 // A partial hit, is a hit for which we have not fetch the content yet.
 // Instead, it holds a document_uri which is enough information to
 // go and fetch the actual document data, by performing a `get_doc(...)`
 // request.
 message PartialHit {
-  // Sorting field value. (e.g. timestamp)
+  // Value of the sorting key for the given document.
   //
   // Quickwit only computes top-K of this sorting field.
   // If the user requested for a bottom-K of a given fast field, then quickwit simply
@@ -225,7 +226,17 @@ message PartialHit {
   // - the split_id,
   // - the segment_ord,
   // - the doc id.
-  uint64 sorting_field_value = 1;
+  oneof sort_value {
+    uint64 u64 = 5;
+    int64 i64 = 6;
+    double f64 = 7;
+    bool boolean = 8;
+  }
+  // Deprecated
+  reserved 1;
+  // Room for eventual future sorted key types.
+  reserved 9 to 20;
+
   string split_id = 2;
 
   // (segment_ord, doc) form a tantivy DocAddress, which is sufficient to identify a document

--- a/quickwit/quickwit-proto/src/quickwit.rs
+++ b/quickwit/quickwit-proto/src/quickwit.rs
@@ -168,18 +168,6 @@ pub struct Hit {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartialHit {
-    /// Sorting field value. (e.g. timestamp)
-    ///
-    /// Quickwit only computes top-K of this sorting field.
-    /// If the user requested for a bottom-K of a given fast field, then quickwit simply
-    /// emits an decreasing mapping of this fast field.
-    ///
-    /// In case of a tie, quickwit uses the increasing order of
-    /// - the split_id,
-    /// - the segment_ord,
-    /// - the doc id.
-    #[prost(uint64, tag = "1")]
-    pub sorting_field_value: u64,
     #[prost(string, tag = "2")]
     pub split_id: ::prost::alloc::string::String,
     /// (segment_ord, doc) form a tantivy DocAddress, which is sufficient to identify a document
@@ -189,6 +177,45 @@ pub struct PartialHit {
     /// The DocId identifies a unique document at the scale of a tantivy segment.
     #[prost(uint32, tag = "4")]
     pub doc_id: u32,
+    /// Value of the sorting key for the given document.
+    ///
+    /// Quickwit only computes top-K of this sorting field.
+    /// If the user requested for a bottom-K of a given fast field, then quickwit simply
+    /// emits an decreasing mapping of this fast field.
+    ///
+    /// In case of a tie, quickwit uses the increasing order of
+    /// - the split_id,
+    /// - the segment_ord,
+    /// - the doc id.
+    #[prost(oneof = "partial_hit::SortValue", tags = "5, 6, 7, 8")]
+    pub sort_value: ::core::option::Option<partial_hit::SortValue>,
+}
+/// Nested message and enum types in `PartialHit`.
+pub mod partial_hit {
+    /// Value of the sorting key for the given document.
+    ///
+    /// Quickwit only computes top-K of this sorting field.
+    /// If the user requested for a bottom-K of a given fast field, then quickwit simply
+    /// emits an decreasing mapping of this fast field.
+    ///
+    /// In case of a tie, quickwit uses the increasing order of
+    /// - the split_id,
+    /// - the segment_ord,
+    /// - the doc id.
+    #[derive(Serialize, Deserialize, utoipa::ToSchema)]
+    #[derive(Copy)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum SortValue {
+        #[prost(uint64, tag = "5")]
+        U64(u64),
+        #[prost(int64, tag = "6")]
+        I64(i64),
+        #[prost(double, tag = "7")]
+        F64(f64),
+        #[prost(bool, tag = "8")]
+        Boolean(bool),
+    }
 }
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-search/src/cluster_client.rs
+++ b/quickwit/quickwit-search/src/cluster_client.rs
@@ -234,17 +234,17 @@ mod tests {
     use std::net::SocketAddr;
 
     use quickwit_proto::{
-        qast_helper, PartialHit, SearchRequest, SearchStreamRequest, SplitIdAndFooterOffsets,
-        SplitSearchError,
+        qast_helper, PartialHit, SearchRequest, SearchStreamRequest, SortValue,
+        SplitIdAndFooterOffsets, SplitSearchError,
     };
 
     use super::*;
     use crate::root::SearchJob;
     use crate::{searcher_pool_for_test, MockSearchService};
 
-    fn mock_partial_hit(split_id: &str, sorting_field_value: u64, doc_id: u32) -> PartialHit {
+    fn mock_partial_hit(split_id: &str, sort_value: u64, doc_id: u32) -> PartialHit {
         PartialHit {
-            sorting_field_value,
+            sort_value: Some(SortValue::U64(sort_value)),
             split_id: split_id.to_string(),
             segment_ord: 1,
             doc_id,

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -159,7 +159,7 @@ impl TryFrom<ColumnType> for SortFieldType {
             ColumnType::DateTime => Ok(SortFieldType::DateTime),
             ColumnType::Bool => Ok(SortFieldType::Bool),
             _ => Err(TantivyError::InvalidArgument(format!(
-                "Sort field type {:?}",
+                "Unsupported sort field type `{:?}`.",
                 column_type
             ))),
         }

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -17,24 +17,25 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashSet};
 
 use itertools::Itertools;
+use quickwit_common::binary_heap::top_k;
 use quickwit_doc_mapper::{DocMapper, WarmupInfo};
-use quickwit_proto::{LeafSearchResponse, PartialHit, SearchRequest, SortOrder};
+use quickwit_proto::{LeafSearchResponse, PartialHit, SearchRequest, SortOrder, SortValue};
 use serde::Deserialize;
 use tantivy::aggregation::agg_req::{get_fast_field_names, Aggregations};
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use tantivy::aggregation::{AggregationLimits, AggregationSegmentCollector};
 use tantivy::collector::{Collector, SegmentCollector};
-use tantivy::columnar::ColumnType;
+use tantivy::columnar::{ColumnType, MonotonicallyMappableToU64};
 use tantivy::fastfield::Column;
 use tantivy::{DocId, Score, SegmentOrdinal, SegmentReader, TantivyError};
 
 use crate::filters::{create_timestamp_filter_builder, TimestampFilter, TimestampFilterBuilder};
 use crate::find_trace_ids_collector::{FindTraceIdsCollector, FindTraceIdsSegmentCollector};
-use crate::partial_hit_sorting_key;
+use crate::GlobalDocAddress;
 
 #[derive(Clone, Debug)]
 pub(crate) enum SortBy {
@@ -48,6 +49,25 @@ pub(crate) enum SortBy {
     },
 }
 
+impl SortBy {
+    pub fn sort_order(&self) -> SortOrder {
+        match self {
+            SortBy::DocId => SortOrder::Desc,
+            SortBy::FastField { order, .. } => *order,
+            SortBy::Score { order } => *order,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+enum SortFieldType {
+    U64,
+    I64,
+    F64,
+    DateTime,
+    Bool,
+}
+
 /// The `SortingFieldComputer` can be seen as the specialization of `SortBy` applied to a specific
 /// `SegmentReader`. Its role is to compute the sorting field given a `DocId`.
 enum SortingFieldComputer {
@@ -55,6 +75,7 @@ enum SortingFieldComputer {
     DocId,
     FastField {
         sort_column: Column<u64>,
+        sort_field_type: SortFieldType,
         order: SortOrder,
     },
     Score {
@@ -63,44 +84,86 @@ enum SortingFieldComputer {
 }
 
 impl SortingFieldComputer {
+    fn recover_typed_sort_value(&self, sort_value: u64) -> SortValue {
+        match self {
+            SortingFieldComputer::DocId => SortValue::U64(sort_value),
+            SortingFieldComputer::FastField {
+                sort_field_type,
+                order,
+                ..
+            } => {
+                let sort_value = match order {
+                    SortOrder::Asc => u64::MAX - sort_value,
+                    SortOrder::Desc => sort_value,
+                };
+                match sort_field_type {
+                    SortFieldType::U64 => SortValue::U64(sort_value),
+                    SortFieldType::I64 => SortValue::I64(i64::from_u64(sort_value)),
+                    SortFieldType::F64 => SortValue::F64(f64::from_u64(sort_value)),
+                    SortFieldType::DateTime => SortValue::U64(sort_value),
+                    SortFieldType::Bool => SortValue::Boolean(sort_value == 1u64),
+                }
+            }
+            SortingFieldComputer::Score { .. } => {
+                SortValue::F64(MonotonicallyMappableToU64::from_u64(sort_value))
+            }
+        }
+    }
+
     /// Returns the ranking key for the given element
-    fn compute_sorting_field(&self, doc_id: DocId, score: Score) -> u64 {
+    ///
+    /// The functions return None if the sort key is a fast field, for which we have no value
+    /// for the given doc_id.
+    /// All value are mapped using a monotonic mapping.
+    /// If the sort ord is ascending, we use the mapping `val -> u64::MAX - val` to
+    /// artificially invert the order.
+    ///
+    /// Given the u64 value, it is possible to recover the original value using
+    /// `Self::recover_typed_sort_value`.
+    fn compute_u64_sort_value_opt(&self, doc_id: DocId, score: Score) -> Option<u64> {
         match self {
             SortingFieldComputer::FastField {
                 sort_column: fast_field_reader,
                 order,
+                ..
             } => {
-                if let Some(field_val) = fast_field_reader.first(doc_id) {
-                    match order {
-                        // Descending is our most common case.
-                        SortOrder::Desc => field_val,
-                        // We get Ascending order by using a decreasing mapping over u64 as the
-                        // sorting_field.
-                        SortOrder::Asc => u64::MAX - field_val,
-                    }
-                } else {
-                    0u64
+                let field_val = fast_field_reader.first(doc_id)?;
+                match order {
+                    // Descending is our most common case.
+                    SortOrder::Desc => Some(field_val),
+                    // We get Ascending order by using a decreasing mapping over u64 as the
+                    // sorting_field.
+                    SortOrder::Asc => Some(u64::MAX - field_val),
                 }
             }
-            SortingFieldComputer::DocId => doc_id as u64,
+            SortingFieldComputer::DocId => Some(doc_id as u64),
             SortingFieldComputer::Score { order } => {
-                let u64_score = f32_to_u64(score);
+                let u64_score = (score as f64).to_u64();
                 match order {
-                    SortOrder::Desc => u64_score,
-                    SortOrder::Asc => u64::MAX - u64_score,
+                    SortOrder::Desc => Some(u64_score),
+                    SortOrder::Asc => Some(u64::MAX - u64_score),
                 }
             }
         }
     }
 }
 
-/// Converts a float to an unsigned integer while preserving order.
-/// See `<https://lemire.me/blog/2020/12/14/converting-floating-point-numbers-to-integers-while-preserving-order/>`
-fn f32_to_u64(value: f32) -> u64 {
-    let value_u32 = u32::from_le_bytes(value.to_le_bytes());
-    let mut mask = (value_u32 as i32 >> 31) as u32;
-    mask |= 0x80000000;
-    (value_u32 ^ mask) as u64
+impl TryFrom<ColumnType> for SortFieldType {
+    type Error = tantivy::TantivyError;
+
+    fn try_from(column_type: ColumnType) -> tantivy::Result<Self> {
+        match column_type {
+            ColumnType::U64 => Ok(SortFieldType::U64),
+            ColumnType::I64 => Ok(SortFieldType::I64),
+            ColumnType::F64 => Ok(SortFieldType::F64),
+            ColumnType::DateTime => Ok(SortFieldType::DateTime),
+            ColumnType::Bool => Ok(SortFieldType::Bool),
+            _ => Err(TantivyError::InvalidArgument(format!(
+                "Sort field type {:?}",
+                column_type
+            ))),
+        }
+    }
 }
 
 /// Takes a user-defined sorting criteria and resolves it to a
@@ -114,13 +177,16 @@ fn resolve_sort_by(
         SortBy::FastField { field_name, order } => {
             let sort_column_opt: Option<(Column<u64>, ColumnType)> =
                 segment_reader.fast_fields().u64_lenient(field_name)?;
-            let sort_column = if let Some((sort_column, _column_type)) = sort_column_opt {
-                sort_column
-            } else {
-                Column::build_empty_column(segment_reader.max_doc())
-            };
+            let (sort_column, column_type) = sort_column_opt.unwrap_or_else(|| {
+                (
+                    Column::build_empty_column(segment_reader.max_doc()),
+                    ColumnType::U64,
+                )
+            });
+            let sort_field_type = SortFieldType::try_from(column_type)?;
             Ok(SortingFieldComputer::FastField {
                 sort_column,
+                sort_field_type,
                 order: *order,
             })
         }
@@ -132,7 +198,7 @@ fn resolve_sort_by(
 /// so that we actually have a min-heap.
 #[derive(Clone, Copy)]
 struct PartialHitHeapItem {
-    sorting_field_value: u64,
+    sort_value_opt: Option<u64>,
     doc_id: DocId,
 }
 
@@ -145,10 +211,7 @@ impl PartialOrd for PartialHitHeapItem {
 impl Ord for PartialHitHeapItem {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
-        let by_sorting_field = other
-            .sorting_field_value
-            .partial_cmp(&self.sorting_field_value)
-            .unwrap_or(Ordering::Equal);
+        let by_sorting_field = other.sort_value_opt.cmp(&self.sort_value_opt);
 
         let lazy_order_by_doc_id = || {
             self.doc_id
@@ -194,15 +257,19 @@ impl QuickwitSegmentCollector {
 
     #[inline]
     fn collect_top_k(&mut self, doc_id: DocId, score: Score) {
-        let sorting_field_value: u64 = self.sort_by.compute_sorting_field(doc_id, score);
+        let sorting_field_value_opt: Option<u64> =
+            self.sort_by.compute_u64_sort_value_opt(doc_id, score);
         if self.at_capacity() {
-            if let Some(limit_sorting_field) = self.hits.peek().map(|head| head.sorting_field_value)
-            {
-                // In case of a tie, we keep the document with a lower `DocId`.
-                if limit_sorting_field < sorting_field_value {
-                    if let Some(mut head) = self.hits.peek_mut() {
-                        head.sorting_field_value = sorting_field_value;
-                        head.doc_id = doc_id;
+            if let Some(sorting_field_value) = sorting_field_value_opt {
+                if let Some(limit_sorting_field) =
+                    self.hits.peek().and_then(|head| head.sort_value_opt)
+                {
+                    // In case of a tie, we keep the document with a lower `DocId`.
+                    if limit_sorting_field < sorting_field_value {
+                        if let Some(mut head) = self.hits.peek_mut() {
+                            head.sort_value_opt = Some(sorting_field_value);
+                            head.doc_id = doc_id;
+                        }
                     }
                 }
             }
@@ -210,7 +277,7 @@ impl QuickwitSegmentCollector {
             // we have not reached capacity yet, so we can just push the
             // element.
             self.hits.push(PartialHitHeapItem {
-                sorting_field_value,
+                sort_value_opt: sorting_field_value_opt,
                 doc_id,
             });
         }
@@ -252,12 +319,15 @@ impl SegmentCollector for QuickwitSegmentCollector {
         let segment_ord = self.segment_ord;
         // TODO use into_iter_sorted() once it gets stable.
         let split_id = self.split_id;
+        let sort_by = self.sort_by;
         let partial_hits: Vec<PartialHit> = self
             .hits
             .into_sorted_vec()
             .into_iter()
             .map(|hit| PartialHit {
-                sorting_field_value: hit.sorting_field_value,
+                sort_value: hit
+                    .sort_value_opt
+                    .map(|sort_value| sort_by.recover_typed_sort_value(sort_value)),
                 segment_ord,
                 doc_id: hit.doc_id,
                 split_id: split_id.clone(),
@@ -422,8 +492,9 @@ impl Collector for QuickwitCollector {
         // All leaves will return their top [0..max_hits) documents.
         // We compute the overall [0..start_offset + max_hits) documents ...
         let num_hits = self.start_offset + self.max_hits;
+        let sort_order = self.sort_by.sort_order();
         let mut merged_leaf_response =
-            merge_leaf_responses(&self.aggregation, segment_fruits?, num_hits)?;
+            merge_leaf_responses(&self.aggregation, segment_fruits?, sort_order, num_hits)?;
         // ... and drop the first [..start_offsets) hits.
         merged_leaf_response
             .partial_hits
@@ -445,6 +516,7 @@ fn map_error(err: postcard::Error) -> TantivyError {
 fn merge_leaf_responses(
     aggregations_opt: &Option<QuickwitAggregations>,
     mut leaf_responses: Vec<LeafSearchResponse>,
+    sort_order: SortOrder,
     max_hits: usize,
 ) -> tantivy::Result<LeafSearchResponse> {
     // Optimization: No merging needed if there is only one result.
@@ -515,8 +587,8 @@ fn merge_leaf_responses(
         .into_iter()
         .flat_map(|leaf_response| leaf_response.partial_hits)
         .collect();
-    // TODO optimize
-    let top_k_partial_hits = top_k_partial_hits(all_partial_hits, max_hits);
+    let top_k_partial_hits: Vec<PartialHit> =
+        top_k_partial_hits(all_partial_hits.into_iter(), sort_order, max_hits);
     Ok(LeafSearchResponse {
         intermediate_aggregation_result: merged_intermediate_aggregation_result,
         num_hits,
@@ -530,14 +602,49 @@ fn merge_leaf_responses(
 /// and so that these elements are sorted.
 ///
 /// TODO we could possibly optimize the sort away (but I doubt it matters).
-fn top_k_partial_hits(mut partial_hits: Vec<PartialHit>, num_hits: usize) -> Vec<PartialHit> {
-    partial_hits.sort_unstable_by(|left, right| {
-        let left_key = partial_hit_sorting_key(left);
-        let right_key = partial_hit_sorting_key(right);
-        left_key.cmp(&right_key)
-    });
-    partial_hits.truncate(num_hits);
-    partial_hits
+fn top_k_partial_hits(
+    partial_hits: impl Iterator<Item = PartialHit>,
+    sort_order: SortOrder,
+    num_hits: usize,
+) -> Vec<PartialHit> {
+    match sort_order {
+        SortOrder::Asc => top_k(partial_hits.into_iter(), num_hits, |partial_hit| {
+            // This reverse dance is a little bit complicated.
+            // Note that `Option<Reverse<T>>` is very different from `Reverse<Option<T>>`.
+            //
+            // We do want the earlier: documents without any values should always get ranked after
+            // documents with a value, regardless of whether we use ascending or
+            // descending order.
+            let score = partial_hit.sort_value.map(Reverse);
+            let addr = GlobalDocAddress::from_partial_hit(partial_hit);
+            (score, Reverse(addr))
+        }),
+        SortOrder::Desc => top_k(partial_hits.into_iter(), num_hits, |partial_hit| {
+            let addr = GlobalDocAddress::from_partial_hit(partial_hit);
+            (partial_hit.sort_value, addr)
+        }),
+    }
+}
+
+pub(crate) fn sort_by_from_request(search_request: &SearchRequest) -> SortBy {
+    let sort_order = search_request
+        .sort_order
+        .and_then(SortOrder::from_i32)
+        .unwrap_or(SortOrder::Desc);
+    search_request
+        .sort_by_field
+        .as_ref()
+        .map(|field_name| {
+            if field_name == "_score" {
+                SortBy::Score { order: sort_order }
+            } else {
+                SortBy::FastField {
+                    field_name: field_name.clone(),
+                    order: sort_order,
+                }
+            }
+        })
+        .unwrap_or(SortBy::DocId)
 }
 
 /// Builds the QuickwitCollector, in function of the information that was requested by the user.
@@ -556,25 +663,7 @@ pub(crate) fn make_collector_for_split(
         search_request.start_timestamp,
         search_request.end_timestamp,
     );
-    let sort_order = search_request
-        .sort_order
-        .and_then(SortOrder::from_i32)
-        .unwrap_or(SortOrder::Desc);
-    let sort_by = search_request
-        .sort_by_field
-        .as_ref()
-        .map(|field_name| {
-            if field_name == "_score" {
-                SortBy::Score { order: sort_order }
-            } else {
-                SortBy::FastField {
-                    field_name: field_name.clone(),
-                    order: sort_order,
-                }
-            }
-        })
-        .unwrap_or(SortBy::DocId);
-
+    let sort_by = sort_by_from_request(search_request);
     Ok(QuickwitCollector {
         split_id,
         start_offset: search_request.start_offset as usize,
@@ -587,9 +676,6 @@ pub(crate) fn make_collector_for_split(
 }
 
 /// Builds a QuickwitCollector that's only useful for merging fruits.
-///
-/// This collector only needs `start_offset` & `max_hit` so the other attributes
-/// can be set to default.
 pub(crate) fn make_merge_collector(
     search_request: &SearchRequest,
     aggregation_limits: &AggregationLimits,
@@ -598,11 +684,12 @@ pub(crate) fn make_merge_collector(
         Some(aggregation) => Some(serde_json::from_str(aggregation)?),
         None => None,
     };
+    let sort_by = sort_by_from_request(search_request);
     Ok(QuickwitCollector {
         split_id: String::default(),
         start_offset: search_request.start_offset as usize,
         max_hits: search_request.max_hits as usize,
-        sort_by: SortBy::DocId,
+        sort_by,
         timestamp_filter_builder_opt: None,
         aggregation,
         aggregation_limits: aggregation_limits.clone(),
@@ -613,20 +700,19 @@ pub(crate) fn make_merge_collector(
 mod tests {
     use std::cmp::Ordering;
 
-    use proptest::prelude::*;
-    use quickwit_proto::PartialHit;
+    use quickwit_proto::{PartialHit, SortOrder, SortValue};
 
     use super::PartialHitHeapItem;
-    use crate::collector::{f32_to_u64, top_k_partial_hits};
+    use crate::collector::top_k_partial_hits;
 
     #[test]
     fn test_partial_hit_ordered_by_sorting_field() {
         let lesser_score = PartialHitHeapItem {
-            sorting_field_value: 1u64,
             doc_id: 1u32,
+            sort_value_opt: Some(1u64),
         };
         let higher_score = PartialHitHeapItem {
-            sorting_field_value: 2u64,
+            sort_value_opt: Some(2u64),
             doc_id: 1u32,
         };
         assert_eq!(lesser_score.cmp(&higher_score), Ordering::Greater);
@@ -634,53 +720,55 @@ mod tests {
 
     #[test]
     fn test_merge_partial_hits_no_tie() {
-        let make_doc = |sorting_field_value: u64| PartialHit {
-            sorting_field_value,
+        let make_doc = |sort_value: u64| PartialHit {
+            sort_value: Some(SortValue::U64(sort_value)),
             split_id: "split1".to_string(),
             segment_ord: 0u32,
             doc_id: 0u32,
         };
         assert_eq!(
-            top_k_partial_hits(vec![make_doc(1u64), make_doc(3u64), make_doc(2u64),], 2),
-            vec![make_doc(3), make_doc(2)]
+            top_k_partial_hits(
+                vec![make_doc(1u64), make_doc(3u64), make_doc(2u64),].into_iter(),
+                SortOrder::Asc,
+                2
+            ),
+            vec![make_doc(1), make_doc(2)]
         );
     }
 
     #[test]
     fn test_merge_partial_hits_with_tie() {
         let make_hit_given_split_id = |split_id: u64| PartialHit {
-            sorting_field_value: 0u64,
+            sort_value: Some(SortValue::U64(0u64)),
             split_id: format!("split_{split_id}"),
             segment_ord: 0u32,
             doc_id: 0u32,
         };
         assert_eq!(
-            top_k_partial_hits(
+            &top_k_partial_hits(
                 vec![
                     make_hit_given_split_id(1u64),
                     make_hit_given_split_id(3u64),
                     make_hit_given_split_id(2u64),
-                ],
+                ]
+                .into_iter(),
+                SortOrder::Desc,
                 2
             ),
-            vec![make_hit_given_split_id(1), make_hit_given_split_id(2)]
+            &[make_hit_given_split_id(3), make_hit_given_split_id(2)]
         );
-    }
-
-    prop_compose! {
-        // Turns out, zero's and negative zero's u64 representation is not same.
-        // It is not relevant for our use case. For simplicity we filter the negative
-        // zero.
-        fn any_f32_without_negative_zero()(val in any::<f32>().prop_filter("Value can't be negative zero", |val| *val != -0.0)) -> f32 {
-            val
-        }
-    }
-
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(10000))]
-        #[test]
-        fn test_proptest_f32_to_u64_compare_arbitrary(a in any_f32_without_negative_zero(), b in any_f32_without_negative_zero()) {
-            prop_assert_eq!(a < b, f32_to_u64(a) < f32_to_u64(b))
-        }
+        assert_eq!(
+            &top_k_partial_hits(
+                vec![
+                    make_hit_given_split_id(1u64),
+                    make_hit_given_split_id(3u64),
+                    make_hit_given_split_id(2u64),
+                ]
+                .into_iter(),
+                SortOrder::Asc,
+                2
+            ),
+            &[make_hit_given_split_id(1), make_hit_given_split_id(2)]
+        );
     }
 }

--- a/quickwit/quickwit-search/src/leaf_cache.rs
+++ b/quickwit/quickwit-search/src/leaf_cache.rs
@@ -170,7 +170,9 @@ impl std::ops::RangeBounds<i64> for Range {
 
 #[cfg(test)]
 mod tests {
-    use quickwit_proto::{LeafSearchResponse, PartialHit, SearchRequest, SplitIdAndFooterOffsets};
+    use quickwit_proto::{
+        LeafSearchResponse, PartialHit, SearchRequest, SortValue, SplitIdAndFooterOffsets,
+    };
 
     use super::LeafSearchCache;
 
@@ -222,7 +224,7 @@ mod tests {
             partial_hits: vec![PartialHit {
                 doc_id: 1,
                 segment_ord: 0,
-                sorting_field_value: 0,
+                sort_value: Some(SortValue::U64(0u64)),
                 split_id: "split_1".to_string(),
             }],
         };
@@ -307,7 +309,7 @@ mod tests {
             partial_hits: vec![PartialHit {
                 doc_id: 1,
                 segment_ord: 0,
-                sorting_field_value: 0,
+                sort_value: Some(SortValue::U64(0)),
                 split_id: "split_1".to_string(),
             }],
         };

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -56,7 +56,6 @@ use tantivy::schema::NamedFieldDocument;
 /// Refer to this as `crate::Result<T>`.
 pub type Result<T> = std::result::Result<T, SearchError>;
 
-use std::cmp::Reverse;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -106,13 +105,6 @@ impl GlobalDocAddress {
             },
         }
     }
-}
-
-fn partial_hit_sorting_key(partial_hit: &PartialHit) -> (Reverse<u64>, GlobalDocAddress) {
-    (
-        Reverse(partial_hit.sorting_field_value),
-        GlobalDocAddress::from_partial_hit(partial_hit),
-    )
 }
 
 fn extract_split_and_footer_offsets(split_metadata: &SplitMetadata) -> SplitIdAndFooterOffsets {

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -631,7 +631,7 @@ async fn test_sort_by_static_and_dynamic_field() {
     // In this test, we will try sorting docs by several fields.
     // - static_i64
     // - static_u64
-    // - dynamic_u64
+    // - dynamic_i64
     // - dynamic_u64
     let doc_mapping_yaml = r#"
             mode: dynamic

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -26,6 +26,7 @@ use quickwit_indexing::TestSandbox;
 use quickwit_opentelemetry::otlp::TraceId;
 use quickwit_proto::{
     qast_helper, query_ast_from_user_text, LeafListTermsResponse, SearchRequest, SortOrder,
+    SortValue,
 };
 use serde_json::{json, Value as JsonValue};
 use tantivy::schema::Value as TantivyValue;
@@ -319,7 +320,13 @@ async fn test_single_node_several_splits() -> anyhow::Result<()> {
     assert!(&single_node_result.hits[0].json.contains("Snoopy"));
     assert!(&single_node_result.hits[1].json.contains("breed"));
     assert!(is_sorted(single_node_result.hits.iter().flat_map(|hit| {
-        hit.partial_hit.as_ref().map(partial_hit_sorting_key)
+        hit.partial_hit.as_ref().map(|partial_hit| {
+            (
+                partial_hit.sort_value,
+                partial_hit.split_id.as_str(),
+                partial_hit.doc_id,
+            )
+        })
     })));
     assert!(single_node_result.elapsed_time_micros > 10);
     assert!(single_node_result.elapsed_time_micros < 1_000_000);
@@ -513,8 +520,8 @@ async fn single_node_search_sort_by_field(
                 .partial_hit
                 .as_ref()
                 .unwrap()
-                .sorting_field_value
-                >= hits[1].partial_hit.as_ref().unwrap().sorting_field_value));
+                .sort_value
+                >= hits[1].partial_hit.as_ref().unwrap().sort_value));
             test_sandbox.assert_quit().await;
             Ok(())
         }
@@ -530,16 +537,6 @@ async fn test_single_node_sorting_with_query() -> anyhow::Result<()> {
     single_node_search_sort_by_field("temperature", false).await?;
     single_node_search_sort_by_field("_score", true).await?;
     Ok(())
-}
-
-fn u64_to_f32(value: u64) -> f32 {
-    const HIGHEST_BIT: u32 = 1 << 31;
-    let value_u32 = value as u32;
-    f32::from_bits(if value_u32 & HIGHEST_BIT != 0 {
-        value_u32 ^ HIGHEST_BIT
-    } else {
-        !value_u32
-    })
 }
 
 #[tokio::test]
@@ -598,10 +595,8 @@ async fn test_sort_bm25() {
                 .into_iter()
                 .map(|hit| {
                     let partial_hit = hit.partial_hit.unwrap();
-                    (
-                        u64_to_f32(partial_hit.sorting_field_value),
-                        partial_hit.doc_id,
-                    )
+                    let Some(SortValue::F64(score)) = partial_hit.sort_value else { panic!()};
+                    (score as f32, partial_hit.doc_id)
                 })
                 .collect()
         }
@@ -626,6 +621,103 @@ async fn test_sort_bm25() {
             &hits[..],
             &[(0.31931427, 1), (0.2972603, 2), (0.24686484, 0)]
         );
+    }
+    test_sandbox.assert_quit().await;
+}
+
+#[tokio::test]
+async fn test_sort_by_static_and_dynamic_field() {
+    let index_id = "sort_by_dynamic_field".to_string();
+    // In this test, we will try sorting docs by several fields.
+    // - static_i64
+    // - static_u64
+    // - dynamic_u64
+    // - dynamic_u64
+    let doc_mapping_yaml = r#"
+            mode: dynamic
+            field_mappings:
+              - name: static_u64
+                type: u64
+                fast: true
+              - name: static_i64
+                type: i64
+                fast: true
+            dynamic_mapping:
+                fast: true
+                stored: true
+            "#;
+    let test_sandbox = TestSandbox::create(&index_id, doc_mapping_yaml, "{}", &[])
+        .await
+        .unwrap();
+    let docs = vec![
+        // 0
+        json!({"static_u64": 3u64, "dynamic_u64": 3u64, "static_i64": 0i64, "dynamic_i64": 0i64}),
+        // 1
+        json!({"static_u64": 2u64, "dynamic_u64": 2u64, "static_i64": -1i64, "dynamic_i64": -1i64}),
+        // 2
+        json!({}),
+        // 3
+        json!({"static_u64": 4u64, "dynamic_u64": (i64::MAX as u64) + 1, "static_i64": 1i64, "dynamic_i64": 1i64}),
+    ];
+    test_sandbox.add_documents(docs).await.unwrap();
+    let search_hits = |sort_field: &str, order: SortOrder| {
+        let query_ast_json = serde_json::to_string(&QueryAst::MatchAll).unwrap();
+        let search_request = SearchRequest {
+            index_id: index_id.to_string(),
+            query_ast: query_ast_json,
+            max_hits: 1_000,
+            sort_by_field: Some(sort_field.to_string()),
+            sort_order: Some(order as i32),
+            ..Default::default()
+        };
+        let metastore = test_sandbox.metastore();
+        let storage_uri_resolver = test_sandbox.storage_uri_resolver();
+        async move {
+            let search_resp = single_node_search(search_request, &*metastore, storage_uri_resolver)
+                .await
+                .unwrap();
+            assert_eq!(search_resp.num_hits, 4);
+            search_resp
+                .hits
+                .into_iter()
+                .map(|hit| {
+                    let partial_hit = hit.partial_hit.unwrap();
+                    partial_hit.doc_id
+                })
+                .collect::<Vec<u32>>()
+        }
+    };
+    {
+        let ordered_docs: Vec<u32> = search_hits("static_u64", SortOrder::Desc).await;
+        assert_eq!(&ordered_docs[..], &[3, 0, 1, 2]);
+    }
+    {
+        let ordered_docs: Vec<u32> = search_hits("static_u64", SortOrder::Asc).await;
+        assert_eq!(&ordered_docs[..], &[1, 0, 3, 2]);
+    }
+    {
+        let ordered_docs: Vec<u32> = search_hits("static_i64", SortOrder::Desc).await;
+        assert_eq!(&ordered_docs[..], &[3, 0, 1, 2]);
+    }
+    {
+        let ordered_docs: Vec<u32> = search_hits("static_i64", SortOrder::Asc).await;
+        assert_eq!(&ordered_docs[..], &[1, 0, 3, 2]);
+    }
+    {
+        let ordered_docs: Vec<u32> = search_hits("dynamic_u64", SortOrder::Desc).await;
+        assert_eq!(&ordered_docs[..], &[3, 0, 1, 2]);
+    }
+    {
+        let ordered_docs: Vec<u32> = search_hits("dynamic_u64", SortOrder::Asc).await;
+        assert_eq!(&ordered_docs[..], &[1, 0, 3, 2]);
+    }
+    {
+        let ordered_docs: Vec<u32> = search_hits("dynamic_i64", SortOrder::Desc).await;
+        assert_eq!(&ordered_docs[..], &[3, 0, 1, 2]);
+    }
+    {
+        let ordered_docs: Vec<u32> = search_hits("dynamic_i64", SortOrder::Asc).await;
+        assert_eq!(&ordered_docs[..], &[1, 0, 3, 2]);
     }
     test_sandbox.assert_quit().await;
 }
@@ -739,7 +831,6 @@ async fn test_single_node_split_pruning_by_tags() -> anyhow::Result<()> {
     )
     .await?;
     assert_eq!(selected_splits.len(), 2);
-
     let split_tags: BTreeSet<String> = selected_splits
         .iter()
         .flat_map(|split| split.tags.clone())
@@ -752,7 +843,6 @@ async fn test_single_node_split_pruning_by_tags() -> anyhow::Result<()> {
         vec!["owner!", "owner:adrien", "owner:paul"]
     );
     test_sandbox.assert_quit().await;
-
     Ok(())
 }
 

--- a/quickwit/rest-api-tests/rest_api_test.py
+++ b/quickwit/rest-api-tests/rest_api_test.py
@@ -43,9 +43,12 @@ def run_request_step(method, step, root):
         print(r.text)
         raise Exception("Wrong status code. Got %s, expected %s" % (r.status_code, expected_status_code))
     expected_resp = step.get("expected", {})
-    if not check_result(r.json(), expected_resp):
-        return False
-    return True
+    try:
+        check_result(r.json(), expected_resp)
+    except Exception as e:
+        print(r.text)
+        raise e
+
 
 def check_result(result, expected, context_path = ""):
     if type(expected) == dict and "$expect" in expected:

--- a/quickwit/rest-api-tests/scenarii/sort_orders/0001-sort.yaml
+++ b/quickwit/rest-api-tests/scenarii/sort_orders/0001-sort.yaml
@@ -1,0 +1,43 @@
+method: [GET]
+engines:
+  - quickwit
+endpoint:
+  /sortorder/_search
+json:
+  query:
+    match_all: {}
+  sort:
+    - count: {"order" : "desc"}
+expected:
+  hits:
+    total:
+      value: 5
+      relation: "eq"
+    hits:
+      - fields: { "count": 15, "id": 2 }
+      - fields: { "count": 10, "id": 1 }
+      - fields: {"count": -2.5, "id": 4}
+      - fields: { "id": 5 }
+      - fields: { "id": 3 }
+---
+method: [GET]
+engines:
+  - quickwit
+endpoint:
+  /sortorder/_search
+json:
+  query:
+    match_all: {}
+  sort:
+    - count: {"order" : "asc"}
+expected:
+  hits:
+    total:
+      value: 5
+      relation: "eq"
+    hits:
+      - fields: {"count": -2.5, "id": 4}
+      - fields: {"count": 10, "id": 1 }
+      - fields: {"count": 15, "id": 2 }
+      - fields: {"id": 3}
+      - fields: {"id": 5}

--- a/quickwit/rest-api-tests/scenarii/sort_orders/quickwit-sortorder.json
+++ b/quickwit/rest-api-tests/scenarii/sort_orders/quickwit-sortorder.json
@@ -1,0 +1,10 @@
+{
+    "version": "0.6",
+    "index_id": "sortorder",
+    "doc_mapping": {
+        "mode": "dynamic",
+        "dynamic_mapping": {
+            "fast": true
+        }
+    }
+}

--- a/quickwit/rest-api-tests/scenarii/sort_orders/setup.quickwit.sh
+++ b/quickwit/rest-api-tests/scenarii/sort_orders/setup.quickwit.sh
@@ -1,0 +1,4 @@
+curl -s -X DELETE "localhost:7280/api/v1/indexes/sortorder" > /dev/null
+curl -s -X POST "localhost:7280/api/v1/indexes/" -H 'Content-Type: application/json' -d @quickwit-sortorder.json > /dev/null
+cat split1.json | curl -s -X POST "localhost:7280/api/v1/_elastic/_bulk?refresh=true" -H 'Content-Type: application/json' --data-binary @- > /dev/null
+cat split2.json | curl -s -X POST "localhost:7280/api/v1/_elastic/_bulk?refresh=true" -H 'Content-Type: application/json' --data-binary @- > /dev/null

--- a/quickwit/rest-api-tests/scenarii/sort_orders/split1.json
+++ b/quickwit/rest-api-tests/scenarii/sort_orders/split1.json
@@ -1,0 +1,6 @@
+{"index":{"_index":"sortorder"}}
+{"count": 10, "id": 1}
+{"index":{"_index":"sortorder"}}
+{"count": 15, "id": 2}
+{"index":{"_index":"sortorder"}}
+{"id": 3}

--- a/quickwit/rest-api-tests/scenarii/sort_orders/split2.json
+++ b/quickwit/rest-api-tests/scenarii/sort_orders/split2.json
@@ -1,0 +1,5 @@
+{"index":{"_index":"sortorder"}}
+{"count": -2.5, "id": 4}
+{"index":{"_index":"sortorder"}}
+{"id": 5}
+

--- a/quickwit/rest-api-tests/scenarii/sort_orders/teardown.quickwit.sh
+++ b/quickwit/rest-api-tests/scenarii/sort_orders/teardown.quickwit.sh
@@ -1,0 +1,1 @@
+curl -s -X DELETE "localhost:7280/api/v1/indexes/sortorder" > /dev/null


### PR DESCRIPTION
This PR also makes sure we return "true sort values" in the REST payload. None is supported. Documents with None will get at the end of the SERP regardless of Ascending or Descending order.

