### PR TITLE
avoid downloading fast fields when avoidable

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -88,7 +88,7 @@ The response is a JSON object, and the content type is `application/json; charse
 ### Search stream in an index
 
 ```
-GET api/v1/<index id>/search/stream?query=searchterm
+GET api/v1/<index id>/search/stream?query=searchterm&fast_field=my_id
 ```
 
 Streams field values from ALL documents matching a search query in the given index `<index id>`, in a specified output format among the following:
@@ -124,7 +124,6 @@ The endpoint will return 10 million values if 10 million documents match the que
 | `start_timestamp` | `i64`      | If set, restrict search to documents with a `timestamp >= start_timestamp`. The value must be in seconds.        |                                                    |
 | `end_timestamp`   | `i64`      | If set, restrict search to documents with a `timestamp < end_timestamp`. The value must be in seconds.           |                                                    |
 | `partition_by_field`   | `String`      | If set, the endpoint returns chunks of data for each partition field value. This field must be a fast field of type `i64` or `u64`.           |                                                    |
-
 | `output_format`   | `String`   | Response output format. `csv` or `clickHouseRowBinary`                                                           | `csv`                                              |
 
 :::info

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -347,7 +347,6 @@ impl QuickwitCollector {
 
     pub fn warmup_info(&self) -> WarmupInfo {
         WarmupInfo {
-            term_dict_field_names: Default::default(),
             fast_field_names: self.fast_field_names(),
             field_norms: self.requires_scoring(),
             ..WarmupInfo::default()


### PR DESCRIPTION
### Description

fix #1748

### How was this PR tested?

querying a dataset and looking for the log line containing `WarmupInfo`, to verify what doesn't need to be loaded is effectively not preloaded.