### PR TITLE
add fastfield normalizer

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -115,6 +115,8 @@ type: text
 tokenizer: default
 record: position
 fieldnorms: true
+fast:
+  normalizer: lowercase
 ```
 
 **Parameters for text field**
@@ -126,17 +128,24 @@ fieldnorms: true
 | `tokenizer` | Name of the `Tokenizer`. ([See tokenizers](#description-of-available-tokenizers)) for a list of available tokenizers.  | `default` |
 | `record`    | Describes the amount of information indexed, choices between `basic`, `freq` and `position` | `basic` |
 | `fieldnorms` | Whether to store fieldnorms for the field. Fieldnorms are required to calculate the BM25 Score of the document. | `false` |
-| `fast`     | Whether value is stored in a fast field. The fast field will contain the term ids and the dictionary. The effective cardinality depends on the tokenizer. The default behaviour for `true` is to store the original text unchanged. The tokenizer on the fast field is seperately configured. It can be configured via `{"tokenizer": "lowercase"}`. ([See tokenizers](#description-of-available-tokenizers)) for a list of available tokenizers. | `false` |
+| `fast`     | Whether value is stored in a fast field. The fast field will contain the term ids and the dictionary. The default behaviour for `true` is to store the original text unchanged. The normalizers on the fast field is seperately configured. It can be configured via `normalizer: lowercase`. ([See normalizers](#description-of-available-normalizers)) for a list of available normalizers. | `false` |
 
 #### **Description of available tokenizers**
 
 | Tokenizer     | Description   |
 | ------------- | ------------- |
-| `raw`         | Does not process nor tokenize text  |
-| `default`     | Chops the text on according to whitespace and punctuation, removes tokens that are too long, and converts to lowercase |
-| `en_stem`     |  Like `default`, but also applies stemming on the resulting tokens  |
+| `raw`         | Does not process nor tokenize text. Filters out tokens larger than 255 bytes.  |
+| `default`     | Chops the text on according to whitespace and punctuation, removes tokens that are too long, and converts to lowercase. Filters out tokens larger than 40 bytes. |
+| `en_stem`     |  Like `default`, but also applies stemming on the resulting tokens. Filters out tokens larger than 40 bytes.  |
 | `chinese_compatible` |  Chop between each CJK character in addition to what `default` does. Should be used with `record: position` to be able to properly search |
 | `lowercase` |  Applies a lowercase transformation on the text. It does not tokenize the text. |
+
+#### **Description of available normalizers**
+
+| Normalizer     | Description   |
+| ------------- | ------------- |
+| `raw`         | Does not process nor tokenize text. Filters token larger than 255 bytes.  |
+| `lowercase` |  Applies a lowercase transformation on the text. Filters token larger than 255 bytes. |
 
 **Description of record options**
 
@@ -312,6 +321,8 @@ stored: true
 indexed: true
 tokenizer: "default"
 expand_dots: false
+fast: 
+  normalizer: lowercase
 ```
 
 **Parameters for JSON field**
@@ -321,7 +332,7 @@ expand_dots: false
 | `description` | Optional description for the field. | `None` |
 | `stored`    | Whether value is stored in the document store | `true` |
 | `indexed`   | Whether value is indexed | `true` |
-| `fast`   | Whether value is fast | `false` |
+| `fast`     | Whether value is stored in a fast field. The default behaviour for text in the JSON is to store the text unchanged. An normalizer can be configured via `normalizer: lowercase`. ([See normalizers](#description-of-available-normalizers)) for a list of available normalizers. | `true` |
 | `tokenizer` | **Only affects strings in the json object**. Name of the `Tokenizer`, choices between `raw`, `default`, `en_stem` and `chinese_compatible` | `default` |
 | `record`    | **Only affects strings in the json object**. Describes the amount of information indexed, choices between `basic`, `freq` and `position` | `basic` |
 | `expand_dots`    | If true, json keys containing a `.` should be expanded. For instance, if `expand_dots` is set to true, `{"k8s.node.id": "node-2"}` will be indexed as if it was `{"k8s": {"node": {"id": "node2"}}}`. The benefit is that escaping the `.` will not be required at query time. In other words, `k8s.node.id:node2` will match the document. This does not impact the way the document is stored.  | `true` |

--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -135,8 +135,8 @@ fast:
 | Tokenizer     | Description   |
 | ------------- | ------------- |
 | `raw`         | Does not process nor tokenize text. Filters out tokens larger than 255 bytes.  |
-| `default`     | Chops the text on according to whitespace and punctuation, removes tokens that are too long, and converts to lowercase. Filters out tokens larger than 40 bytes. |
-| `en_stem`     |  Like `default`, but also applies stemming on the resulting tokens. Filters out tokens larger than 40 bytes.  |
+| `default`     | Chops the text on according to whitespace and punctuation, removes tokens that are too long, and converts to lowercase. Filters out tokens larger than 255 bytes. |
+| `en_stem`     |  Like `default`, but also applies stemming on the resulting tokens. Filters out tokens larger than 255 bytes.  |
 | `chinese_compatible` |  Chop between each CJK character in addition to what `default` does. Should be used with `record: position` to be able to properly search |
 | `lowercase` |  Applies a lowercase transformation on the text. It does not tokenize the text. |
 

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3720,7 +3720,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6640,7 +6640,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6695,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "bitpacking",
 ]
@@ -6703,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "fastdivide",
  "fnv",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6741,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.19.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "combine",
  "once_cell",
@@ -6751,7 +6751,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "tantivy-common",
  "tantivy-fst",
@@ -6761,7 +6761,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -6770,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=a3f0013#a3f001360fc1a5c4d97d501b4181bc6b3ad20960"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=7ee78bd#7ee78bda521b82ae61f1df56f67be102a90a15d0"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -223,7 +223,7 @@ quickwit-serve = { version = "0.6.0", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.6.0", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.6.0", path = "./quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "a3f0013", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "7ee78bd", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/date_time_type.rs
@@ -22,7 +22,7 @@ use quickwit_datetime::{DateTimeInputFormat, DateTimeOutputFormat};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use tantivy::schema::Value as TantivyValue;
-use tantivy::DatePrecision as DateTimePrecision;
+use tantivy::DateTimePrecision;
 
 use super::default_as_true;
 

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
@@ -92,7 +92,7 @@ impl Default for DefaultDocMapperBuilder {
 // By default, in dynamic mode, all fields are fast fields.
 fn default_dynamic_mapping() -> QuickwitJsonOptions {
     QuickwitJsonOptions {
-        fast: true,
+        fast: super::FastFieldOptions::IsEnabled(true),
         ..Default::default()
     }
 }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -1282,7 +1282,7 @@ mod tests {
                 "type": "datetime",
                 "input_formats": ["rfc3339", "unix_timestamp"],
                 "output_format": "rfc3339",
-                "precision": "second",
+                "precision": "seconds",
                 "stored": true,
                 "indexed": true,
                 "fast": false,
@@ -1297,7 +1297,7 @@ mod tests {
             {
                 "name": "my_field_name",
                 "type": "array<datetime>",
-                "precision": "millisecond"
+                "precision": "milliseconds"
             }
             "#,
         )
@@ -1310,7 +1310,7 @@ mod tests {
                 "type": "array<datetime>",
                 "input_formats": ["rfc3339", "unix_timestamp"],
                 "output_format": "rfc3339",
-                "precision": "millisecond",
+                "precision": "milliseconds",
                 "stored": true,
                 "indexed": true,
                 "fast": false,

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -221,9 +221,6 @@ pub enum QuickwitTextTokenizer {
     StemEn,
     #[serde(rename = "chinese_compatible")]
     Chinese,
-    #[serde(rename = "lowercase")]
-    /// Does not tokenize, only lowercases the text.
-    Lowercase,
 }
 
 impl QuickwitTextTokenizer {
@@ -233,7 +230,23 @@ impl QuickwitTextTokenizer {
             QuickwitTextTokenizer::Default => "default",
             QuickwitTextTokenizer::StemEn => "en_stem",
             QuickwitTextTokenizer::Chinese => "chinese_compatible",
-            QuickwitTextTokenizer::Lowercase => "lowercase",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+pub enum QuickwitTextNormalizer {
+    #[serde(rename = "raw")]
+    Raw,
+    #[serde(rename = "lowercase")]
+    Lowercase,
+}
+
+impl QuickwitTextNormalizer {
+    pub fn get_name(&self) -> &str {
+        match self {
+            QuickwitTextNormalizer::Raw => "raw",
+            QuickwitTextNormalizer::Lowercase => "lowercase",
         }
     }
 }
@@ -262,11 +275,11 @@ pub struct QuickwitTextOptions {
     pub fast: FastFieldOptions,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(untagged)]
 pub enum FastFieldOptions {
     IsEnabled(bool),
-    EnabledWithTokenizer { tokenizer: String },
+    EnabledWithNormalizer { normalizer: QuickwitTextNormalizer },
 }
 
 impl Default for FastFieldOptions {
@@ -299,8 +312,8 @@ impl From<QuickwitTextOptions> for TextOptions {
             FastFieldOptions::IsEnabled(true) => {
                 text_options = text_options.set_fast(None);
             }
-            FastFieldOptions::EnabledWithTokenizer { tokenizer } => {
-                text_options = text_options.set_fast(Some(tokenizer));
+            FastFieldOptions::EnabledWithNormalizer { normalizer } => {
+                text_options = text_options.set_fast(Some(normalizer.get_name()));
             }
             FastFieldOptions::IsEnabled(false) => {}
         }
@@ -342,7 +355,7 @@ pub enum IndexRecordOptionSchema {
 ///
 /// `QuickwitJsonOptions` is also used to configure
 /// the dynamic mapping.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct QuickwitJsonOptions {
     /// Optional description of JSON object.
@@ -373,7 +386,7 @@ pub struct QuickwitJsonOptions {
     pub expand_dots: bool,
     /// If true, the json object will be stored in columnar format.
     #[serde(default)]
-    pub fast: bool,
+    pub fast: FastFieldOptions,
 }
 
 impl Default for QuickwitJsonOptions {
@@ -385,7 +398,7 @@ impl Default for QuickwitJsonOptions {
             record: None,
             stored: true,
             expand_dots: true,
-            fast: false,
+            fast: FastFieldOptions::default(),
         }
     }
 }
@@ -411,8 +424,14 @@ impl From<QuickwitJsonOptions> for JsonObjectOptions {
         if quickwit_json_options.expand_dots {
             json_options = json_options.set_expand_dots_enabled();
         }
-        if quickwit_json_options.fast {
-            json_options = json_options.set_fast();
+        match &quickwit_json_options.fast {
+            FastFieldOptions::IsEnabled(true) => {
+                json_options = json_options.set_fast(None);
+            }
+            FastFieldOptions::EnabledWithNormalizer { normalizer } => {
+                json_options = json_options.set_fast(Some(normalizer.get_name()));
+            }
+            FastFieldOptions::IsEnabled(false) => {}
         }
         json_options
     }
@@ -575,7 +594,7 @@ mod tests {
     use crate::default_doc_mapper::field_mapping_entry::{
         QuickwitJsonOptions, QuickwitTextOptions, QuickwitTextTokenizer,
     };
-    use crate::default_doc_mapper::FieldMappingType;
+    use crate::default_doc_mapper::{FastFieldOptions, FieldMappingType};
     use crate::Cardinality;
 
     #[test]
@@ -721,7 +740,7 @@ mod tests {
         assert_eq!(
             mapping_entry.unwrap_err().to_string(),
             "Error while parsing field `my_field_name`: unknown variant `notexist`, expected one \
-             of `raw`, `default`, `en_stem`, `chinese_compatible`, `lowercase`"
+             of `raw`, `default`, `en_stem`, `chinese_compatible`"
                 .to_string()
         );
         Ok(())
@@ -1194,13 +1213,13 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_text_fast_field_tokenizer() {
+    fn test_parse_text_fast_field_normalizer() {
         let entry = serde_json::from_str::<FieldMappingEntry>(
             r#"
             {
                 "name": "my_field_name",
                 "type": "text",
-                "fast": {"tokenizer": "lowercase"}
+                "fast": {"normalizer": "lowercase"}
             }
             "#,
         )
@@ -1211,7 +1230,7 @@ mod tests {
             json!({
                 "name": "my_field_name",
                 "type": "text",
-                "fast": {"tokenizer": "lowercase"},
+                "fast": {"normalizer": "lowercase"},
                 "stored": true,
                 "indexed": true,
                 "fieldnorms": false,
@@ -1263,7 +1282,7 @@ mod tests {
                 "type": "datetime",
                 "input_formats": ["rfc3339", "unix_timestamp"],
                 "output_format": "rfc3339",
-                "precision": "seconds",
+                "precision": "second",
                 "stored": true,
                 "indexed": true,
                 "fast": false,
@@ -1278,7 +1297,7 @@ mod tests {
             {
                 "name": "my_field_name",
                 "type": "array<datetime>",
-                "precision": "milliseconds"
+                "precision": "millisecond"
             }
             "#,
         )
@@ -1291,7 +1310,7 @@ mod tests {
                 "type": "array<datetime>",
                 "input_formats": ["rfc3339", "unix_timestamp"],
                 "output_format": "rfc3339",
-                "precision": "milliseconds",
+                "precision": "millisecond",
                 "stored": true,
                 "indexed": true,
                 "fast": false,
@@ -1391,7 +1410,7 @@ mod tests {
             tokenizer: None,
             record: None,
             stored: true,
-            fast: false,
+            fast: FastFieldOptions::IsEnabled(false),
             expand_dots: true,
         };
         assert_eq!(&field_mapping_entry.name, "my_json_field");
@@ -1434,7 +1453,7 @@ mod tests {
             record: None,
             stored: false,
             expand_dots: true,
-            fast: false,
+            fast: FastFieldOptions::IsEnabled(false),
         };
         assert_eq!(&field_mapping_entry.name, "my_json_field_multi");
         assert!(

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -31,8 +31,8 @@ use regex::Regex;
 pub use self::default_mapper::DefaultDocMapper;
 pub use self::default_mapper_builder::{DefaultDocMapperBuilder, ModeType};
 pub use self::field_mapping_entry::{
-    FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions,
-    QuickwitNumericOptions, QuickwitTextOptions,
+    FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions, QuickwitNumericOptions,
+    QuickwitTextNormalizer, QuickwitTextOptions,
 };
 pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -31,8 +31,8 @@ use regex::Regex;
 pub use self::default_mapper::DefaultDocMapper;
 pub use self::default_mapper_builder::{DefaultDocMapperBuilder, ModeType};
 pub use self::field_mapping_entry::{
-    FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions, QuickwitNumericOptions,
-    QuickwitTextNormalizer, QuickwitTextOptions,
+    FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions,
+    QuickwitNumericOptions, QuickwitTextNormalizer, QuickwitTextOptions,
 };
 pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -38,7 +38,8 @@ pub use default_doc_mapper::{
     DefaultDocMapper, DefaultDocMapperBuilder, FieldMappingEntry, ModeType, QuickwitJsonOptions,
 };
 use default_doc_mapper::{
-    FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,
+    FastFieldOptions, FieldMappingEntryForSerialization, IndexRecordOptionSchema,
+    QuickwitTextNormalizer, QuickwitTextTokenizer,
 };
 pub use doc_mapper::{DocMapper, JsonObject, NamedField, TermRange, WarmupInfo};
 pub use error::{DocParsingError, QueryParserError};
@@ -61,6 +62,8 @@ pub(crate) enum Cardinality {
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(
     QuickwitJsonOptions,
+    FastFieldOptions,
+    QuickwitTextNormalizer,
     ModeType,
     QuickwitTextTokenizer,
     IndexRecordOptionSchema,

--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -39,7 +39,7 @@ use quickwit_config::IndexingSettings;
 use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::checkpoint::{IndexCheckpointDelta, SourceCheckpointDelta};
 use quickwit_metastore::Metastore;
-use quickwit_query::get_quickwit_tokenizer_manager;
+use quickwit_query::{get_quickwit_fastfield_normalizer_manager, get_quickwit_tokenizer_manager};
 use serde::Serialize;
 use tantivy::schema::Schema;
 use tantivy::store::{Compressor, ZstdCompressor};
@@ -98,7 +98,8 @@ impl IndexerState {
         let index_builder = IndexBuilder::new()
             .settings(self.index_settings.clone())
             .schema(self.schema.clone())
-            .tokenizers(get_quickwit_tokenizer_manager().clone());
+            .tokenizers(get_quickwit_tokenizer_manager().clone())
+            .fast_field_tokenizers(get_quickwit_fastfield_normalizer_manager().clone());
 
         let io_controls = IoControls::default()
             .set_progress(ctx.progress().clone())

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -35,8 +35,8 @@ use quickwit_directories::UnionDirectory;
 use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::{Metastore, SplitMetadata};
 use quickwit_proto::metastore_api::DeleteTask;
-use quickwit_query::get_quickwit_tokenizer_manager;
 use quickwit_query::query_ast::QueryAst;
+use quickwit_query::{get_quickwit_fastfield_normalizer_manager, get_quickwit_tokenizer_manager};
 use tantivy::directory::{DirectoryClone, MmapDirectory, RamDirectory};
 use tantivy::{Advice, DateTime, Directory, Index, IndexMeta, SegmentId, SegmentReader};
 use tokio::runtime::Handle;
@@ -367,6 +367,7 @@ impl MergeExecutor {
         let mut merged_index = Index::open(controlled_directory.clone())?;
         ctx.record_progress();
         merged_index.set_tokenizers(get_quickwit_tokenizer_manager().clone());
+        merged_index.set_fast_field_tokenizers(get_quickwit_fastfield_normalizer_manager().clone());
 
         ctx.record_progress();
 
@@ -512,6 +513,7 @@ impl MergeExecutor {
 fn open_index<T: Into<Box<dyn Directory>>>(directory: T) -> tantivy::Result<Index> {
     let mut index = Index::open(directory)?;
     index.set_tokenizers(get_quickwit_tokenizer_manager().clone());
+    index.set_fast_field_tokenizers(get_quickwit_fastfield_normalizer_manager().clone());
     Ok(index)
 }
 

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -364,6 +364,9 @@ mod tests {
         let schema = schema_builder.build();
         let mut index = Index::create_in_dir(split_scratch_directory.path(), schema)?;
         index.set_tokenizers(quickwit_query::get_quickwit_tokenizer_manager().clone());
+        index.set_fast_field_tokenizers(
+            quickwit_query::get_quickwit_fastfield_normalizer_manager().clone(),
+        );
         let mut index_writer = index.writer_with_num_threads(1, 10_000_000)?;
         let mut timerange_opt: Option<RangeInclusive<DateTime>> = None;
         let mut num_docs = 0;

--- a/quickwit/quickwit-query/src/lib.rs
+++ b/quickwit/quickwit-query/src/lib.rs
@@ -43,7 +43,7 @@ pub(crate) use not_nan_f32::NotNaNf32;
 pub use query_ast::utils::find_field_or_hit_dynamic;
 use serde::{Deserialize, Serialize};
 pub use tantivy::query::Query as TantivyQuery;
-pub use tokenizers::get_quickwit_tokenizer_manager;
+pub use tokenizers::{get_quickwit_fastfield_normalizer_manager, get_quickwit_tokenizer_manager};
 
 #[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub enum BooleanOperand {

--- a/quickwit/quickwit-query/src/tokenizers.rs
+++ b/quickwit/quickwit-query/src/tokenizers.rs
@@ -36,7 +36,7 @@ fn create_quickwit_tokenizer_manager() -> TokenizerManager {
         .filter(LowerCaser)
         .build();
 
-    let tokenizer_manager = TokenizerManager::default();
+    let tokenizer_manager = TokenizerManager::new();
     tokenizer_manager.register("raw", raw_tokenizer);
     tokenizer_manager.register("chinese_compatible", chinese_tokenizer);
 

--- a/quickwit/quickwit-query/src/tokenizers.rs
+++ b/quickwit/quickwit-query/src/tokenizers.rs
@@ -32,13 +32,32 @@ fn create_quickwit_tokenizer_manager() -> TokenizerManager {
         .build();
 
     let chinese_tokenizer = TextAnalyzer::builder(ChineseTokenizer)
-        .filter(RemoveLongFilter::limit(40))
+        .filter(RemoveLongFilter::limit(255))
         .filter(LowerCaser)
         .build();
 
     let tokenizer_manager = TokenizerManager::default();
     tokenizer_manager.register("raw", raw_tokenizer);
     tokenizer_manager.register("chinese_compatible", chinese_tokenizer);
+
+    tokenizer_manager.register(
+        "default",
+        TextAnalyzer::builder(tantivy::tokenizer::SimpleTokenizer)
+            .filter(RemoveLongFilter::limit(255))
+            .filter(LowerCaser)
+            .build(),
+    );
+    tokenizer_manager.register(
+        "en_stem",
+        TextAnalyzer::builder(tantivy::tokenizer::SimpleTokenizer)
+            .filter(RemoveLongFilter::limit(255))
+            .filter(LowerCaser)
+            .filter(tantivy::tokenizer::Stemmer::new(
+                tantivy::tokenizer::Language::English,
+            ))
+            .build(),
+    );
+
     tokenizer_manager
 }
 

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -119,6 +119,9 @@ pub(crate) async fn open_index_with_caches(
     };
     let mut index = Index::open(hot_directory)?;
     index.set_tokenizers(quickwit_query::get_quickwit_tokenizer_manager().clone());
+    index.set_fast_field_tokenizers(
+        quickwit_query::get_quickwit_fastfield_normalizer_manager().clone(),
+    );
     Ok(index)
 }
 


### PR DESCRIPTION
### Description
split tokenizer into tokenizer and normalizer
use normalizer for fastfield.
handle two tokenizer manager from tantivy
rise length limit for tokens to 255 bytes
update docs for normalizer
enable fast field tokenizer on Json

### How was this PR tested?

tested aggreggations on project airmail with lowercase
