### PR TITLE
Add force commit to documentation examples

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -178,7 +178,7 @@ curl -O https://quickwit-datasets-public.s3.amazonaws.com/stackoverflow.posts.tr
 
 ```bash
 # Index our 10k documents.
-./quickwit index ingest --index stackoverflow --input-path stackoverflow.posts.transformed-10000.json
+./quickwit index ingest --index stackoverflow --input-path stackoverflow.posts.transformed-10000.json --force
 ```
 
 </TabItem>
@@ -187,14 +187,14 @@ curl -O https://quickwit-datasets-public.s3.amazonaws.com/stackoverflow.posts.tr
 
 ```bash
 # Index our 10k documents.
-curl -XPOST http://127.0.0.1:7280/api/v1/stackoverflow/ingest --data-binary @stackoverflow.posts.transformed-10000.json
+curl -XPOST "http://127.0.0.1:7280/api/v1/stackoverflow/ingest?commit=force" --data-binary @stackoverflow.posts.transformed-10000.json
 ```
 
 </TabItem>
 
 </Tabs>
 
-Wait around 10 seconds and check if it worked by using `search` command:
+As soon as the ingest command finishes you can start querying data by using the following `search` command:
 
 <Tabs>
 
@@ -295,7 +295,7 @@ Run the following command from within Quickwit's installation directory.
 curl -o stackoverflow-index-config.yaml https://raw.githubusercontent.com/quickwit-oss/quickwit/main/config/tutorials/stackoverflow/index-config.yaml
 ./quickwit index create --index-config ./stackoverflow-index-config.yaml
 curl -O https://quickwit-datasets-public.s3.amazonaws.com/stackoverflow.posts.transformed-10000.json
-./quickwit index ingest --index stackoverflow --input-path ./stackoverflow.posts.transformed-10000.json
+./quickwit index ingest --index stackoverflow --input-path ./stackoverflow.posts.transformed-10000.json --force
 ./quickwit index search --index stackoverflow --query "search AND engine"
 ./quickwit index delete --index stackoverflow
 ```

--- a/docs/guides/schemaless.md
+++ b/docs/guides/schemaless.md
@@ -183,7 +183,7 @@ cat << EOF > my_logs.json
 EOF
 
 # Ingest documents.
-./quickwit index ingest --index my_dynamic_index --input-path my_logs.json 
+./quickwit index ingest --index my_dynamic_index --input-path my_logs.json --force
 
 # Execute search query.
 ./quickwit index search --index my_dynamic_index --query "event_type:order AND cart.product_id:120391
@@ -276,7 +276,7 @@ cat << EOF > otel_logs.json
 EOF
 
 # Ingest documents.
-./quickwit index ingest --index otel_logs --input-path otel_logs.json
+./quickwit index ingest --index otel_logs --input-path otel_logs.json --force
 
 # Execute search query.
 ./quickwit index search --index otel_logs --query "merge AND service:donut_shop"

--- a/docs/ingest-data/ingest-api.md
+++ b/docs/ingest-data/ingest-api.md
@@ -48,10 +48,10 @@ You can ingest data either with the CLI or with cURL. The CLI is more convenient
 
 ```bash
 # Ingest the first 10_000 Stackoverflow posts articles with the CLI...
-./quickwit index ingest --index stackoverflow-schemaless --input-path stackoverflow.posts.transformed-10000.json
+./quickwit index ingest --index stackoverflow-schemaless --input-path stackoverflow.posts.transformed-10000.json --force
 
 # OR with cURL.
-curl -XPOST -H 'Content-Type: application/json' 'http://localhost:7280/api/v1/stackoverflow-schemaless/ingest' --data-binary @stackoverflow.posts.transformed-10000.json
+curl -XPOST -H 'Content-Type: application/json' 'http://localhost:7280/api/v1/stackoverflow-schemaless/ingest?commit=force' --data-binary @stackoverflow.posts.transformed-10000.json
 ```
 
 ## Execute search queries


### PR DESCRIPTION
### Description

This commit adds --force or commit=force to all documentation examples that deal with ingestion of small files. I didn't add it to large dataset examples such as gh-archive and hdfs-logs due to possible failures outlined in #3137.

Fixes #3403

Describe the proposed changes made in this PR.

### How was this PR tested?

I ran this commands against locally running quickwit server.
