### PR TITLE
Makes it possible to search bytes using base16.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4691,6 +4691,7 @@ name = "quickwit-query"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "base16",
  "base64 0.21.0",
  "once_cell",
  "proptest",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4694,11 +4694,13 @@ dependencies = [
  "base64 0.21.0",
  "once_cell",
  "proptest",
+ "quickwit-datetime",
  "serde",
  "serde_json",
  "serde_with 2.3.3",
  "tantivy",
  "thiserror",
+ "time 0.3.21",
 ]
 
 [[package]]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4295,6 +4295,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickwit-datetime"
+version = "0.6.0"
+dependencies = [
+ "itertools",
+ "ouroboros",
+ "serde",
+ "serde_json",
+ "tantivy",
+ "time 0.3.21",
+ "time-fmt",
+]
+
+[[package]]
 name = "quickwit-directories"
 version = "0.6.0"
 dependencies = [
@@ -4330,8 +4343,8 @@ dependencies = [
  "mockall",
  "nom",
  "once_cell",
- "ouroboros",
  "proptest",
+ "quickwit-datetime",
  "quickwit-proto",
  "quickwit-query",
  "regex",
@@ -4341,7 +4354,6 @@ dependencies = [
  "tantivy",
  "thiserror",
  "time 0.3.21",
- "time-fmt",
  "tracing",
  "typetag",
  "utoipa",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -49,6 +49,7 @@ azure_core = { version = "0.5.0", features = ["enable_reqwest_rustls"] }
 azure_storage = { version = "0.6.0", default-features = false, features = ["enable_reqwest_rustls"] }
 azure_storage_blobs = { version = "0.6.0", default-features = false, features = ["enable_reqwest_rustls"] }
 backoff = { version = "0.4", features = ["tokio"] }
+base16 = "0.2.1"
 base64 = "0.21"
 byte-unit = { version = "4", default-features = false, features = ["serde", "std"] }
 bytes = "1"

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "quickwit-control-plane",
   "quickwit-core",
   "quickwit-directories",
+  "quickwit-datetime",
   "quickwit-doc-mapper",
   "quickwit-grpc-clients",
   "quickwit-indexing",
@@ -205,6 +206,7 @@ quickwit-common = { version = "0.6.0", path = "./quickwit-common" }
 quickwit-config = { version = "0.6.0", path = "./quickwit-config" }
 quickwit-control-plane = { version = "0.6.0", path = "./quickwit-control-plane" }
 quickwit-core = { version = "0.6.0", path = "./quickwit-core" }
+quickwit-datetime = { version = "0.6.0", path = "./quickwit-datetime" }
 quickwit-directories = { version = "0.6.0", path = "./quickwit-directories" }
 quickwit-doc-mapper = { version = "0.6.0", path = "./quickwit-doc-mapper" }
 quickwit-grpc-clients = { version = "0.6.0", path = "./quickwit-grpc-clients" }

--- a/quickwit/quickwit-datetime/Cargo.toml
+++ b/quickwit/quickwit-datetime/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "quickwit-datetime"
+version = "0.6.0"
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
+license = "AGPL-3.0-or-later"                           # For a commercial, license, contact hello@quickwit.io
+description = "Datetime Util crate of quickwit"
+repository = "https://github.com/quickwit-oss/quickwit"
+homepage = "https://quickwit.io/"
+documentation = "https://quickwit.io/docs/"
+
+[dependencies]
+itertools = { workspace = true }
+ouroboros = "0.15.5"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tantivy = { workspace = true }
+time = { workspace = true }
+time-fmt = "0.3.8"

--- a/quickwit/quickwit-datetime/README.md
+++ b/quickwit/quickwit-datetime/README.md
@@ -1,0 +1,4 @@
+Why a datetime crate? Why is it no in quickwit-common or where it is consumed?
+
+- We don't want to add a dependency to tantivy in quickwit-common
+- We need this date logic both in quickwit-query and in quickwit-docmapper

--- a/quickwit/quickwit-datetime/src/date_time_parsing.rs
+++ b/quickwit/quickwit-datetime/src/date_time_parsing.rs
@@ -18,11 +18,11 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use itertools::Itertools;
-use tantivy::DateTime as TantivyDateTime;
 use time::format_description::well_known::{Iso8601, Rfc2822, Rfc3339};
 use time::OffsetDateTime;
 
 use super::date_time_format::DateTimeInputFormat;
+use crate::TantivyDateTime;
 
 // Minimum supported timestamp value in seconds (13 Apr 1972 23:59:55 GMT).
 const MIN_TIMESTAMP_SECONDS: i64 = 72_057_595;
@@ -30,7 +30,7 @@ const MIN_TIMESTAMP_SECONDS: i64 = 72_057_595;
 // Maximum supported timestamp value in seconds (16 Mar 2242 12:56:31 GMT).
 const MAX_TIMESTAMP_SECONDS: i64 = 8_589_934_591;
 
-pub(super) fn parse_date_time_str(
+pub fn parse_date_time_str(
     date_time_str: &str,
     date_time_formats: &[DateTimeInputFormat],
 ) -> Result<TantivyDateTime, String> {
@@ -63,7 +63,7 @@ pub(super) fn parse_date_time_str(
     ))
 }
 
-pub(super) fn parse_date_time_int(
+pub fn parse_date_time_int(
     timestamp: i64,
     date_time_formats: &[DateTimeInputFormat],
 ) -> Result<TantivyDateTime, String> {
@@ -137,7 +137,7 @@ mod tests {
     use time::macros::datetime;
 
     use super::*;
-    use crate::default_doc_mapper::date_time_format::StrptimeParser;
+    use crate::StrptimeParser;
 
     #[test]
     fn test_parse_iso8601() {

--- a/quickwit/quickwit-datetime/src/date_time_parsing.rs
+++ b/quickwit/quickwit-datetime/src/date_time_parsing.rs
@@ -100,7 +100,7 @@ fn parse_rfc3339(value: &str) -> Result<OffsetDateTime, String> {
 /// The tradeoff is that we can only support dates ranging:
 /// - from `13 Apr 1972 23:59:55`: smallest value that can be converted to all precisions.
 /// - to: `16 Mar 2242 12:56:31`: greatest value that can be converted to all precisions.
-fn parse_timestamp(timestamp: i64) -> Result<TantivyDateTime, String> {
+pub fn parse_timestamp(timestamp: i64) -> Result<TantivyDateTime, String> {
     const MIN_TIMESTAMP_MILLIS: i64 = MIN_TIMESTAMP_SECONDS * 1000;
     const MAX_TIMESTAMP_MILLIS: i64 = MAX_TIMESTAMP_SECONDS * 1000;
 

--- a/quickwit/quickwit-datetime/src/lib.rs
+++ b/quickwit/quickwit-datetime/src/lib.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 mod date_time_format;
 mod date_time_parsing;
 

--- a/quickwit/quickwit-datetime/src/lib.rs
+++ b/quickwit/quickwit-datetime/src/lib.rs
@@ -2,5 +2,5 @@ mod date_time_format;
 mod date_time_parsing;
 
 pub use date_time_format::{DateTimeInputFormat, DateTimeOutputFormat, StrptimeParser};
-pub use date_time_parsing::{parse_date_time_int, parse_date_time_str};
+pub use date_time_parsing::{parse_date_time_int, parse_date_time_str, parse_timestamp};
 pub use tantivy::DateTime as TantivyDateTime;

--- a/quickwit/quickwit-datetime/src/lib.rs
+++ b/quickwit/quickwit-datetime/src/lib.rs
@@ -1,0 +1,6 @@
+mod date_time_format;
+mod date_time_parsing;
+
+pub use date_time_format::{DateTimeInputFormat, DateTimeOutputFormat, StrptimeParser};
+pub use date_time_parsing::{parse_date_time_int, parse_date_time_str};
+pub use tantivy::DateTime as TantivyDateTime;

--- a/quickwit/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit/quickwit-doc-mapper/Cargo.toml
@@ -19,6 +19,7 @@ itertools = { workspace = true }
 mockall = { workspace = true, optional = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
+quickwit-datetime = { workspace = true }
 quickwit-query = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
@@ -26,9 +27,6 @@ serde_json = { workspace = true }
 siphasher = { workspace = true }
 tantivy = { workspace = true }
 thiserror = { workspace = true }
-time = { workspace = true }
-time-fmt = "0.3.8"
-ouroboros = "0.15.5"
 tracing = { workspace = true }
 typetag = { workspace = true }
 utoipa = { workspace = true }
@@ -39,6 +37,7 @@ quickwit-proto = { workspace = true }
 proptest = { workspace = true }
 criterion = { workspace = true }
 matches = { workspace = true }
+time = { workspace = true }
 
 [features]
 testsuite = []

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
@@ -206,6 +206,7 @@ fn value_to_json(value: TantivyValue, leaf_type: &LeafType) -> Option<JsonValue>
         }
         (TantivyValue::Date(date_time), LeafType::DateTime(date_time_options)) => {
             let json_value = date_time_options
+                .output_format
                 .format_to_json(*date_time)
                 .expect("Invalid datetime is not allowed.");
             Some(json_value)

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -17,8 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-mod date_time_format;
-mod date_time_parsing;
 mod date_time_type;
 mod default_mapper;
 mod default_mapper_builder;

--- a/quickwit/quickwit-query/Cargo.toml
+++ b/quickwit/quickwit-query/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://quickwit.io/docs/"
 
 [dependencies]
 anyhow = { workspace = true }
+base16 = { workspace = true }
 base64 = { workspace = true }
 once_cell = { workspace = true }
 quickwit-datetime = { workspace = true }

--- a/quickwit/quickwit-query/Cargo.toml
+++ b/quickwit/quickwit-query/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://quickwit.io/docs/"
 anyhow = { workspace = true }
 base64 = { workspace = true }
 once_cell = { workspace = true }
+quickwit-datetime = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
@@ -21,3 +22,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+time = { workspace = true }

--- a/quickwit/quickwit-query/src/json_literal.rs
+++ b/quickwit/quickwit-query/src/json_literal.rs
@@ -20,6 +20,7 @@
 use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
 
+use base64::Engine;
 use once_cell::sync::OnceCell;
 use quickwit_datetime::{parse_date_time_str, parse_timestamp, DateTimeInputFormat};
 use serde::{Deserialize, Serialize};
@@ -159,6 +160,31 @@ impl<'a> InterpretUserInput<'a> for tantivy::DateTime {
     }
 }
 
+/// Lenient base64 engine that allow user to use padding or not.
+const LENIENT_BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::GeneralPurpose::new(
+    &base64::alphabet::STANDARD,
+    base64::engine::GeneralPurposeConfig::new()
+        .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent),
+);
+
+impl<'a> InterpretUserInput<'a> for Vec<u8> {
+    fn interpret_str(mut text: &str) -> Option<Vec<u8>> {
+        let Some(first_byte) = text.as_bytes().first().copied() else { return Some(Vec::new()); };
+        let mut buffer = Vec::with_capacity(text.len() * 3 / 4);
+        if first_byte == b'!' {
+            // We use ! as a marker to force base64 decoding.
+            text = &text[1..];
+        } else {
+            if base16::decode_buf(text, &mut buffer).is_ok() {
+                return Some(buffer);
+            }
+            buffer.clear();
+        }
+        LENIENT_BASE64_ENGINE.decode_vec(text, &mut buffer).ok()?;
+        Some(buffer)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tantivy::DateTime;
@@ -194,5 +220,28 @@ mod tests {
         let dt_opt = DateTime::interpret_json(&JsonLiteral::Number(1685086013.into()));
         let expected_datetime = datetime!(2023-05-26 07:26:53 UTC);
         assert_eq!(dt_opt, Some(DateTime::from_utc(expected_datetime)));
+    }
+
+    #[test]
+    fn test_interpret_bytes_base16() {
+        let bytes_opt = Vec::<u8>::interpret_str("deadbeef");
+        assert_eq!(bytes_opt, Some(vec![0xde, 0xad, 0xbe, 0xef]));
+    }
+
+    #[test]
+    fn test_interpret_bytes_base64() {
+        let decoded = Vec::<u8>::interpret_str("aGVsbG8=").unwrap();
+        assert_eq!(decoded, b"hello");
+    }
+
+    #[test]
+    fn test_interpret_force_ambiguous_base64() {
+        let decoded = Vec::<u8>::interpret_str("!").unwrap();
+        assert_eq!(decoded, b"hello");
+    }
+
+    #[test]
+    fn test_interpret_bytes_invalid() {
+        assert!(Vec::<u8>::interpret_str("deadbeef@").is_none());
     }
 }

--- a/quickwit/quickwit-query/src/json_literal.rs
+++ b/quickwit/quickwit-query/src/json_literal.rs
@@ -21,24 +21,25 @@ use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
 
 use once_cell::sync::OnceCell;
-use quickwit_datetime::{DateTimeInputFormat, parse_timestamp};
-use quickwit_datetime::parse_date_time_str;
+use quickwit_datetime::{parse_date_time_str, parse_timestamp, DateTimeInputFormat};
 use serde::{Deserialize, Serialize};
 use tantivy::schema::IntoIpv6Addr;
 
 fn get_default_date_time_format() -> &'static [DateTimeInputFormat] {
     static DEFAULT_DATE_TIME_FORMATS: OnceCell<Vec<DateTimeInputFormat>> = OnceCell::new();
-    DEFAULT_DATE_TIME_FORMATS.get_or_init(|| {
-        vec![
-            DateTimeInputFormat::Rfc3339,
-            DateTimeInputFormat::Rfc2822,
-            DateTimeInputFormat::Timestamp,
-            DateTimeInputFormat::from_str("%Y-%m-%d %H:%M:%S.%f").unwrap(),
-            DateTimeInputFormat::from_str("%Y-%m-%d %H:%M:%S").unwrap(),
-            DateTimeInputFormat::from_str("%Y-%m-%d").unwrap(),
-            DateTimeInputFormat::from_str("%Y/%m/%d").unwrap(),
-        ]
-    }).as_slice()
+    DEFAULT_DATE_TIME_FORMATS
+        .get_or_init(|| {
+            vec![
+                DateTimeInputFormat::Rfc3339,
+                DateTimeInputFormat::Rfc2822,
+                DateTimeInputFormat::Timestamp,
+                DateTimeInputFormat::from_str("%Y-%m-%d %H:%M:%S.%f").unwrap(),
+                DateTimeInputFormat::from_str("%Y-%m-%d %H:%M:%S").unwrap(),
+                DateTimeInputFormat::from_str("%Y-%m-%d").unwrap(),
+                DateTimeInputFormat::from_str("%Y/%m/%d").unwrap(),
+            ]
+        })
+        .as_slice()
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
@@ -57,24 +58,38 @@ pub enum JsonLiteral {
 }
 
 pub trait InterpretUserInput<'a>: Sized {
-    fn interpret(user_input: &'a JsonLiteral) -> Option<Self>;
+    fn interpret_json(user_input: &'a JsonLiteral) -> Option<Self> {
+        match user_input {
+            JsonLiteral::Number(number) => Self::interpret_number(number),
+            JsonLiteral::String(str_val) => Self::interpret_str(str_val),
+            JsonLiteral::Bool(bool_val) => Self::interpret_bool(*bool_val),
+        }
+    }
+
+    fn interpret_number(_number: &serde_json::Number) -> Option<Self> {
+        None
+    }
+
+    fn interpret_bool(_bool: bool) -> Option<Self> {
+        None
+    }
+    fn interpret_str(_text: &'a str) -> Option<Self> {
+        None
+    }
+
     fn name() -> &'static str {
         std::any::type_name::<Self>()
     }
 }
 
 impl<'a> InterpretUserInput<'a> for &'a str {
-    fn interpret(user_input: &'a JsonLiteral) -> Option<&'a str> {
-        match user_input {
-            JsonLiteral::Number(_) => None,
-            JsonLiteral::String(text) => Some(text.as_str()),
-            JsonLiteral::Bool(_) => None,
-        }
+    fn interpret_str(text: &'a str) -> Option<Self> {
+        Some(text)
     }
 }
 
 impl<'a> InterpretUserInput<'a> for u64 {
-    fn interpret(user_input: &JsonLiteral) -> Option<u64> {
+    fn interpret_json(user_input: &JsonLiteral) -> Option<u64> {
         match user_input {
             JsonLiteral::Number(json_number) => json_number.as_u64(),
             JsonLiteral::String(text) => text.parse().ok(),
@@ -84,7 +99,7 @@ impl<'a> InterpretUserInput<'a> for u64 {
 }
 
 impl<'a> InterpretUserInput<'a> for i64 {
-    fn interpret(user_input: &JsonLiteral) -> Option<i64> {
+    fn interpret_json(user_input: &JsonLiteral) -> Option<i64> {
         match user_input {
             JsonLiteral::Number(json_number) => json_number.as_i64(),
             JsonLiteral::String(text) => text.parse().ok(),
@@ -95,7 +110,7 @@ impl<'a> InterpretUserInput<'a> for i64 {
 
 // We refuse NaN and infinity.
 impl<'a> InterpretUserInput<'a> for f64 {
-    fn interpret(user_input: &JsonLiteral) -> Option<f64> {
+    fn interpret_json(user_input: &JsonLiteral) -> Option<f64> {
         let val: f64 = match user_input {
             JsonLiteral::Number(json_number) => json_number.as_f64()?,
             JsonLiteral::String(text) => text.parse().ok()?,
@@ -111,47 +126,36 @@ impl<'a> InterpretUserInput<'a> for f64 {
 }
 
 impl<'a> InterpretUserInput<'a> for bool {
-    fn interpret(user_input: &JsonLiteral) -> Option<bool> {
-        match user_input {
-            JsonLiteral::Number(_) => None,
-            JsonLiteral::String(text) => text.parse().ok(),
-            JsonLiteral::Bool(bool_value) => Some(*bool_value),
-        }
+    fn interpret_bool(b: bool) -> Option<Self> {
+        Some(b)
+    }
+    fn interpret_str(text: &str) -> Option<Self> {
+        text.parse().ok()
     }
 }
 
 impl<'a> InterpretUserInput<'a> for Ipv6Addr {
-    fn interpret(user_input: &JsonLiteral) -> Option<Ipv6Addr> {
-        match user_input {
-            JsonLiteral::Number(_) => None,
-            JsonLiteral::String(text) => {
-                let ip_addr: IpAddr = text.parse().ok()?;
-                Some(ip_addr.into_ipv6_addr())
-            }
-            JsonLiteral::Bool(_) => None,
-        }
+    fn interpret_str(text: &str) -> Option<Self> {
+        let ip_addr: IpAddr = text.parse().ok()?;
+        Some(ip_addr.into_ipv6_addr())
     }
 }
 
 impl<'a> InterpretUserInput<'a> for tantivy::DateTime {
-    fn interpret(user_input: &JsonLiteral) -> Option<tantivy::DateTime> {
-        match user_input {
-            JsonLiteral::Number(number) => {
-                let possible_timestamp = number.as_i64()?;
-                parse_timestamp(possible_timestamp).ok()
-            },
-            JsonLiteral::String(text) => {
-                let date_time_formats = get_default_date_time_format();
-                if let Ok(datetime) = parse_date_time_str(text, date_time_formats) {
-                    return Some(datetime);
-                }
-                // Parsing the normal string formats failed.
-                // Maybe it is actually a timestamp as a string?
-                let possible_timestamp = text.parse::<i64>().ok()?;
-                parse_timestamp(possible_timestamp).ok()
-            }
-            JsonLiteral::Bool(_) => None,
+    fn interpret_str(text: &str) -> Option<Self> {
+        let date_time_formats = get_default_date_time_format();
+        if let Ok(datetime) = parse_date_time_str(text, date_time_formats) {
+            return Some(datetime);
         }
+        // Parsing the normal string formats failed.
+        // Maybe it is actually a timestamp as a string?
+        let possible_timestamp = text.parse::<i64>().ok()?;
+        parse_timestamp(possible_timestamp).ok()
+    }
+
+    fn interpret_number(number: &serde_json::Number) -> Option<Self> {
+        let possible_timestamp = number.as_i64()?;
+        parse_timestamp(possible_timestamp).ok()
     }
 }
 
@@ -160,33 +164,34 @@ mod tests {
     use tantivy::DateTime;
     use time::macros::datetime;
 
-    use crate::JsonLiteral;
     use crate::json_literal::InterpretUserInput;
+    use crate::JsonLiteral;
 
     #[test]
     fn test_interpret_datetime_simple_date() {
-        let dt_opt = DateTime::interpret(&JsonLiteral::String("2023-05-25".to_string()));
+        let dt_opt = DateTime::interpret_json(&JsonLiteral::String("2023-05-25".to_string()));
         let expected_datetime = datetime!(2023-05-25 00:00 UTC);
         assert_eq!(dt_opt, Some(DateTime::from_utc(expected_datetime)));
     }
 
     #[test]
     fn test_interpret_datetime_fractional_millis() {
-        let dt_opt = DateTime::interpret(&JsonLiteral::String("2023-05-25 10:20:11.322".to_string()));
+        let dt_opt =
+            DateTime::interpret_json(&JsonLiteral::String("2023-05-25 10:20:11.322".to_string()));
         let expected_datetime = datetime!(2023-05-25 10:20:11.322 UTC);
         assert_eq!(dt_opt, Some(DateTime::from_utc(expected_datetime)));
     }
 
     #[test]
     fn test_interpret_datetime_unix_timestamp_as_string() {
-        let dt_opt = DateTime::interpret(&JsonLiteral::String("1685086013".to_string()));
+        let dt_opt = DateTime::interpret_json(&JsonLiteral::String("1685086013".to_string()));
         let expected_datetime = datetime!(2023-05-26 07:26:53 UTC);
         assert_eq!(dt_opt, Some(DateTime::from_utc(expected_datetime)));
     }
 
     #[test]
     fn test_interpret_datetime_unix_timestamp_as_number() {
-        let dt_opt = DateTime::interpret(&JsonLiteral::Number(1685086013.into()));
+        let dt_opt = DateTime::interpret_json(&JsonLiteral::Number(1685086013.into()));
         let expected_datetime = datetime!(2023-05-26 07:26:53 UTC);
         assert_eq!(dt_opt, Some(DateTime::from_utc(expected_datetime)));
     }

--- a/quickwit/quickwit-query/src/query_ast/range_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/range_query.rs
@@ -166,11 +166,11 @@ fn convert_bound<'a, T>(bound: &'a Bound<JsonLiteral>) -> Option<Bound<T>>
 where T: InterpretUserInput<'a> {
     match bound {
         Bound::Included(val) => {
-            let val = T::interpret(val)?;
+            let val = T::interpret_json(val)?;
             Some(Bound::Included(val))
         }
         Bound::Excluded(val) => {
-            let val = T::interpret(val)?;
+            let val = T::interpret_json(val)?;
             Some(Bound::Excluded(val))
         }
         Bound::Unbounded => Some(Bound::Unbounded),

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0007-range_queries.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0007-range_queries.yaml
@@ -124,6 +124,18 @@ expected:
       value: 44
       relation: "eq"
 ---
+# Timestamp field using timestamp
+json:
+  query:
+    range:
+      created_at:
+        lt: 1422748813000
+expected:
+  hits:
+    total:
+      value: 86
+      relation: "eq"
+---
 # Timestamp field
 json:
   query:

--- a/quickwit/rest-api-tests/scenarii/qw_search_api/0001_ts_range.yaml
+++ b/quickwit/rest-api-tests/scenarii/qw_search_api/0001_ts_range.yaml
@@ -25,7 +25,12 @@ expected:
 ---
 endpoint: simple/search
 params:
-  query: "ts:>=2023-05-25T05:36:42" # AND ts:<2023-05-25T05:36:44"
+  query: "ts:>=2023/05/25"
+expected:
+  num_hits: 4
+---
+endpoint: simple/search
+params:
+  query: "ts:>=1684993002 AND ts:<1684993004"
 expected:
   num_hits: 2
-


### PR DESCRIPTION
The logic goes
- base16 first
- base64 then

If someone really wants to search something in base64, that happens to be base16, they can prefix the string with a ! to hint that this is base64.

Closes #3385
