### PR TITLE
Fix test_directory_randomness

### DIFF
--- a/quickwit/quickwit-common/src/temp_dir.rs
+++ b/quickwit/quickwit-common/src/temp_dir.rs
@@ -423,8 +423,9 @@ mod tests {
         let mut directories = Vec::new();
         let mut paths = Vec::new();
         let temp_dir = Builder::default().tempdir().unwrap();
-        // Try creating the maximum number of directories for a single random byte a-z,A-Z,0-9
-        for _ in 0..62 {
+        // Try creating the maximum number of directories for a single random byte
+        // On case-insensitive filesystems we can only have 36 different directories a-z,0-9
+        for _ in 0..36 {
             let dir = Builder::default()
                 .join("test")
                 .rand_bytes(1)


### PR DESCRIPTION
### Description

Fix test_directory_randomness on  case-insensitive filesystems.

Fixes #3419

### How was this PR tested?

It wasn't tested. I am running builds in VM on my mac and I don't have a bare metal setup at the moment. @guilload could you run it in your setup to see if this change indeed fixes the issue?
