### PR TITLE
Introduce REST client timeouts

### DIFF
--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -141,8 +141,7 @@ pub fn build_index_command() -> Command {
                         .long("commit-timeout")
                         .help("Duration of the commit timeout operation.")
                         .required(false)
-                        .global(true)
-                        .display_order(1),
+                        .global(true),
                 ])
             )
         .subcommand(

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -104,8 +104,6 @@ fn client_args() -> Vec<Arg> {
 #[derive(Debug, Eq, PartialEq)]
 pub struct ClientArgs {
     pub cluster_endpoint: Url,
-    /// The outer option represents the presense of the argument,
-    /// the inner option represents the presence of timeout.
     pub connect_timeout: Option<Timeout>,
     pub timeout: Option<Timeout>,
     pub commit_timeout: Option<Timeout>,

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -20,10 +20,11 @@
 #![deny(clippy::disallowed_methods)]
 
 use std::collections::HashSet;
+use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{bail, Context};
-use clap::{arg, Arg};
+use clap::{arg, Arg, ArgMatches};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
 use once_cell::sync::Lazy;
@@ -34,8 +35,10 @@ use quickwit_config::service::QuickwitService;
 use quickwit_config::{ConfigFormat, QuickwitConfig, SourceConfig, DEFAULT_QW_CONFIG_PATH};
 use quickwit_indexing::check_source_connectivity;
 use quickwit_metastore::quickwit_metastore_uri_resolver;
+use quickwit_rest_client::rest_client::{QuickwitClient, QuickwitClientBuilder, DEFAULT_BASE_URL};
 use quickwit_storage::{load_file, quickwit_storage_uri_resolver};
 use regex::Regex;
+use reqwest::Url;
 use tabled::object::Rows;
 use tabled::{Alignment, Header, Modify, Style, Table, Tabled};
 use tracing::info;
@@ -73,13 +76,127 @@ fn config_cli_arg() -> Arg {
         .display_order(1)
 }
 
-fn cluster_endpoint_arg() -> Arg {
-    arg!(--"endpoint" <QW_CLUSTER_ENDPOINT> "Quickwit cluster endpoint.")
-        .default_value("http://127.0.0.1:7280")
-        .env("QW_CLUSTER_ENDPOINT")
-        .required(false)
-        .display_order(1)
-        .global(true)
+fn client_args() -> Vec<Arg> {
+    vec![
+        arg!(--"endpoint" <QW_CLUSTER_ENDPOINT> "Quickwit cluster endpoint.")
+            .default_value("http://127.0.0.1:7280")
+            .env("QW_CLUSTER_ENDPOINT")
+            .required(false)
+            .display_order(1)
+            .global(true),
+        Arg::new("timeout")
+            .long("timeout")
+            .help("Duration of the timeout.")
+            .required(false)
+            .global(true)
+            .display_order(1),
+        Arg::new("connect-timeout")
+            .long("connect-timeout")
+            .help("Duration of the connect timeout.")
+            .required(false)
+            .global(true)
+            .display_order(1),
+    ]
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ClientArgs {
+    pub cluster_endpoint: Url,
+    /// The outer option represents the presense of the argument,
+    /// the inner option represents the presence of timeout.
+    pub connect_timeout: Option<Option<Duration>>,
+    pub timeout: Option<Option<Duration>>,
+    pub commit_timeout: Option<Option<Duration>>,
+}
+
+impl Default for ClientArgs {
+    fn default() -> Self {
+        Self {
+            cluster_endpoint: Url::parse(DEFAULT_BASE_URL).unwrap(),
+            connect_timeout: None,
+            timeout: None,
+            commit_timeout: None,
+        }
+    }
+}
+
+impl ClientArgs {
+    pub fn client(self) -> QuickwitClient {
+        let mut builder = QuickwitClientBuilder::new(self.cluster_endpoint);
+        if let Some(connect_timeout) = self.connect_timeout {
+            builder = builder.connect_timeout(connect_timeout);
+        }
+        if let Some(timeout) = self.timeout {
+            builder = builder.timeout(timeout);
+        }
+        builder.build()
+    }
+
+    pub fn search_client(self) -> QuickwitClient {
+        let mut builder = QuickwitClientBuilder::new(self.cluster_endpoint);
+        if let Some(connect_timeout) = self.connect_timeout {
+            builder = builder.connect_timeout(connect_timeout);
+        }
+        if let Some(timeout) = self.timeout {
+            builder = builder.search_timeout(timeout);
+        }
+        builder.build()
+    }
+
+    pub fn ingest_client(self) -> QuickwitClient {
+        let mut builder = QuickwitClientBuilder::new(self.cluster_endpoint);
+        if let Some(connect_timeout) = self.connect_timeout {
+            builder = builder.connect_timeout(connect_timeout);
+        }
+        if let Some(timeout) = self.timeout {
+            builder = builder.ingest_timeout(timeout);
+        }
+        if let Some(commit_timeout) = self.commit_timeout {
+            builder = builder.commit_timeout(commit_timeout);
+        }
+        builder.build()
+    }
+
+    pub fn parse_for_ingest(matches: &mut ArgMatches) -> anyhow::Result<Self> {
+        Self::parse_inner(matches, true)
+    }
+
+    pub fn parse(matches: &mut ArgMatches) -> anyhow::Result<Self> {
+        Self::parse_inner(matches, false)
+    }
+
+    fn parse_inner(matches: &mut ArgMatches, process_ingest: bool) -> anyhow::Result<Self> {
+        let cluster_endpoint = matches
+            .remove_one::<String>("endpoint")
+            .map(|endpoint_str| Url::from_str(&endpoint_str))
+            .expect("`endpoint` should be a required arg.")?;
+        let connect_timeout =
+            if let Some(duration) = matches.remove_one::<String>("connect-timeout") {
+                Some(parse_duration_or_none(&duration)?)
+            } else {
+                None
+            };
+        let timeout = if let Some(duration) = matches.remove_one::<String>("timeout") {
+            Some(parse_duration_or_none(&duration)?)
+        } else {
+            None
+        };
+        let commit_timeout = if process_ingest {
+            if let Some(duration) = matches.remove_one::<String>("commit-timeout") {
+                Some(parse_duration_or_none(&duration)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        Ok(Self {
+            cluster_endpoint,
+            connect_timeout,
+            timeout,
+            commit_timeout,
+        })
+    }
 }
 
 /// Parse duration with unit like `1s`, `2m`, `3h`, `5d`.
@@ -98,6 +215,16 @@ pub fn parse_duration_with_unit(duration_with_unit_str: &str) -> anyhow::Result<
         "h" => Ok(Duration::from_secs(value * 60 * 60)),
         "d" => Ok(Duration::from_secs(value * 60 * 60 * 24)),
         _ => bail!("Invalid duration format: `[0-9]+[smhd]`"),
+    }
+}
+
+pub fn parse_duration_or_none(duration_with_unit_str: &str) -> anyhow::Result<Option<Duration>> {
+    if duration_with_unit_str == "none" {
+        Ok(None)
+    } else {
+        parse_duration_with_unit(duration_with_unit_str)
+            .map(Some)
+            .map_err(|_| anyhow::anyhow!("Invalid duration format: `[0-9]+[smhd]|none`"))
     }
 }
 
@@ -281,7 +408,7 @@ pub mod busy_detector {
 mod tests {
     use std::time::Duration;
 
-    use super::parse_duration_with_unit;
+    use super::{parse_duration_or_none, parse_duration_with_unit};
 
     #[test]
     fn test_parse_duration_with_unit() -> anyhow::Result<()> {
@@ -301,6 +428,14 @@ mod tests {
         assert!(parse_duration_with_unit("3 d").is_err());
         assert!(parse_duration_with_unit("3").is_err());
         assert!(parse_duration_with_unit("1h30").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_duration_or_none() -> anyhow::Result<()> {
+        assert_eq!(parse_duration_or_none("8s")?, Some(Duration::from_secs(8)));
+        assert_eq!(parse_duration_or_none("none")?, None);
+        assert!(parse_duration_or_none("something").is_err());
         Ok(())
     }
 }

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -89,13 +89,13 @@ fn client_args() -> Vec<Arg> {
             .help("Duration of the timeout.")
             .required(false)
             .global(true)
-            .display_order(1),
+            .display_order(2),
         Arg::new("connect-timeout")
             .long("connect-timeout")
             .help("Duration of the connect timeout.")
             .required(false)
             .global(true)
-            .display_order(1),
+            .display_order(3),
     ]
 }
 

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -186,6 +186,7 @@ mod tests {
     };
     use quickwit_cli::ClientArgs;
     use quickwit_common::uri::Uri;
+    use quickwit_rest_client::models::Timeout;
     use quickwit_rest_client::rest_client::CommitType;
     use reqwest::Url;
 
@@ -368,8 +369,8 @@ mod tests {
                     commit_type: CommitType::Auto,
                 })) if &index_id == "wikipedia"
                         && client_args.cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
-                        && client_args.timeout == Some(Some(Duration::from_secs(10)))
-                        && client_args.connect_timeout == Some(Some(Duration::from_secs(2)))
+                        && client_args.timeout == Some(Timeout::from_secs(10))
+                        && client_args.connect_timeout == Some(Timeout::from_secs(2))
                         && client_args.commit_timeout.is_none()
         ));
 
@@ -399,9 +400,9 @@ mod tests {
                     commit_type: CommitType::WaitFor,
                 })) if &index_id == "wikipedia"
                         && client_args.cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
-                        && client_args.timeout == Some(None)
-                        && client_args.connect_timeout == Some(Some(Duration::from_secs(15)))
-                        && client_args.commit_timeout == Some(Some(Duration::from_secs(60 * 60 * 4)))
+                        && client_args.timeout == Some(Timeout::none())
+                        && client_args.connect_timeout == Some(Timeout::from_secs(15))
+                        && client_args.commit_timeout == Some(Timeout::from_hours(4))
         ));
 
         let app = build_cli().no_binary_name(true);

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -184,6 +184,7 @@ mod tests {
     use quickwit_cli::tool::{
         ExtractSplitArgs, GarbageCollectIndexArgs, LocalIngestDocsArgs, MergeArgs, ToolCliCommand,
     };
+    use quickwit_cli::ClientArgs;
     use quickwit_common::uri::Uri;
     use quickwit_rest_client::rest_client::CommitType;
     use reqwest::Url;
@@ -196,7 +197,7 @@ mod tests {
             .unwrap();
         let command = CliCommand::parse_cli_args(matches).unwrap();
         let expected_cmd = CliCommand::Index(IndexCliCommand::Clear(ClearIndexArgs {
-            cluster_endpoint: Url::from_str("http://127.0.0.1:7280").unwrap(),
+            client_args: ClientArgs::default(),
             index_id: "wikipedia".to_string(),
             assume_yes: false,
         }));
@@ -208,7 +209,7 @@ mod tests {
             .unwrap();
         let command = CliCommand::parse_cli_args(matches).unwrap();
         let expected_cmd = CliCommand::Index(IndexCliCommand::Clear(ClearIndexArgs {
-            cluster_endpoint: Url::from_str("http://127.0.0.1:7280").unwrap(),
+            client_args: ClientArgs::default(),
             index_id: "wikipedia".to_string(),
             assume_yes: true,
         }));
@@ -232,7 +233,7 @@ mod tests {
         ))
         .unwrap();
         let expected_cmd = CliCommand::Index(IndexCliCommand::Create(CreateIndexArgs {
-            cluster_endpoint: Url::from_str("http://127.0.0.1:7280").unwrap(),
+            client_args: ClientArgs::default(),
             index_config_uri: expected_index_config_uri.clone(),
             overwrite: false,
             assume_yes: false,
@@ -249,7 +250,7 @@ mod tests {
         ])?;
         let command = CliCommand::parse_cli_args(matches)?;
         let expected_cmd = CliCommand::Index(IndexCliCommand::Create(CreateIndexArgs {
-            cluster_endpoint: Url::from_str("http://127.0.0.1:7280").unwrap(),
+            client_args: ClientArgs::default(),
             index_config_uri: expected_index_config_uri,
             overwrite: true,
             assume_yes: false,
@@ -275,13 +276,16 @@ mod tests {
             command,
             CliCommand::Index(IndexCliCommand::Ingest(
                 IngestDocsArgs {
-                    cluster_endpoint,
+                    client_args,
                     index_id,
                     input_path_opt: None,
                     batch_size_limit_opt: None,
                     commit_type: CommitType::Auto,
                 })) if &index_id == "wikipedia"
-                       && cluster_endpoint == Url::from_str("http://127.0.0.1:8000").unwrap()
+                && client_args.timeout.is_none()
+                && client_args.connect_timeout.is_none()
+                && client_args.commit_timeout.is_none()
+                && client_args.cluster_endpoint == Url::from_str("http://127.0.0.1:8000").unwrap()
         ));
 
         let app = build_cli().no_binary_name(true);
@@ -299,14 +303,18 @@ mod tests {
             command,
             CliCommand::Index(IndexCliCommand::Ingest(
                 IngestDocsArgs {
-                    cluster_endpoint,
+                    client_args,
                     index_id,
                     input_path_opt: None,
                     batch_size_limit_opt: Some(batch_size_limit),
                     commit_type: CommitType::Force,
                 })) if &index_id == "wikipedia"
-                        && cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
+                        && client_args.cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
+                        && client_args.timeout.is_none()
+                        && client_args.connect_timeout.is_none()
+                        && client_args.commit_timeout.is_none()
                         && batch_size_limit == Byte::from_str("8MB").unwrap()
+
         ));
 
         let app = build_cli().no_binary_name(true);
@@ -324,14 +332,76 @@ mod tests {
             command,
             CliCommand::Index(IndexCliCommand::Ingest(
                 IngestDocsArgs {
-                    cluster_endpoint,
+                    client_args,
                     index_id,
                     input_path_opt: None,
                     batch_size_limit_opt: Some(batch_size_limit),
                     commit_type: CommitType::WaitFor,
                 })) if &index_id == "wikipedia"
-                        && cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
-                        && batch_size_limit == Byte::from_str("4KB").unwrap()
+                    && client_args.cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
+                    && client_args.timeout.is_none()
+                    && client_args.connect_timeout.is_none()
+                    && client_args.commit_timeout.is_none()
+                    && batch_size_limit == Byte::from_str("4KB").unwrap()
+        ));
+
+        let app = build_cli().no_binary_name(true);
+        let matches = app.try_get_matches_from([
+            "index",
+            "ingest",
+            "--index",
+            "wikipedia",
+            "--timeout",
+            "10s",
+            "--connect-timeout",
+            "2s",
+        ])?;
+        let command = CliCommand::parse_cli_args(matches)?;
+        assert!(matches!(
+            command,
+            CliCommand::Index(IndexCliCommand::Ingest(
+                IngestDocsArgs {
+                    client_args,
+                    index_id,
+                    input_path_opt: None,
+                    batch_size_limit_opt: None,
+                    commit_type: CommitType::Auto,
+                })) if &index_id == "wikipedia"
+                        && client_args.cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
+                        && client_args.timeout == Some(Some(Duration::from_secs(10)))
+                        && client_args.connect_timeout == Some(Some(Duration::from_secs(2)))
+                        && client_args.commit_timeout.is_none()
+        ));
+
+        let app = build_cli().no_binary_name(true);
+        let matches = app.try_get_matches_from([
+            "index",
+            "ingest",
+            "--index",
+            "wikipedia",
+            "--timeout",
+            "none",
+            "--wait",
+            "--connect-timeout",
+            "15s",
+            "--commit-timeout",
+            "4h",
+        ])?;
+        let command = CliCommand::parse_cli_args(matches)?;
+        assert!(matches!(
+            command,
+            CliCommand::Index(IndexCliCommand::Ingest(
+                IngestDocsArgs {
+                    client_args,
+                    index_id,
+                    input_path_opt: None,
+                    batch_size_limit_opt: None,
+                    commit_type: CommitType::WaitFor,
+                })) if &index_id == "wikipedia"
+                        && client_args.cluster_endpoint == Url::from_str("http://127.0.0.1:7280").unwrap()
+                        && client_args.timeout == Some(None)
+                        && client_args.connect_timeout == Some(Some(Duration::from_secs(15)))
+                        && client_args.commit_timeout == Some(Some(Duration::from_secs(60 * 60 * 4)))
         ));
 
         let app = build_cli().no_binary_name(true);
@@ -439,10 +509,10 @@ mod tests {
             "body",
         ])?;
         let command = CliCommand::parse_cli_args(matches)?;
-        let _cluster_endpoint = Uri::from_str("http://127.0.0.1:7280").unwrap();
         assert!(matches!(
             command,
             CliCommand::Index(IndexCliCommand::Search(SearchIndexArgs {
+                client_args: _,
                 index_id,
                 query,
                 aggregation: None,
@@ -452,7 +522,6 @@ mod tests {
                 snippet_fields: Some(snippet_field_names),
                 start_timestamp: Some(0),
                 end_timestamp: Some(1),
-                cluster_endpoint: _cluster_endpoint,
                 sort_by_score: false,
             })) if &index_id == "wikipedia"
                   && query == "Barack Obama"

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -37,6 +37,7 @@ use quickwit_cli::service::RunCliCommand;
 use quickwit_cli::tool::{
     garbage_collect_index_cli, local_ingest_docs_cli, GarbageCollectIndexArgs, LocalIngestDocsArgs,
 };
+use quickwit_cli::ClientArgs;
 use quickwit_common::fs::get_cache_directory_path;
 use quickwit_common::rand::append_random_suffix;
 use quickwit_common::uri::Uri;
@@ -51,7 +52,10 @@ use crate::helpers::{create_test_env, wait_port_ready, PACKAGE_BIN_NAME};
 
 async fn create_logs_index(test_env: &TestEnv) -> anyhow::Result<()> {
     let args = CreateIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_config_uri: test_env.index_config_uri.clone(),
         overwrite: false,
         assume_yes: true,
@@ -110,7 +114,10 @@ async fn test_cmd_create_no_index_uri() {
 
     let index_config_without_uri = Uri::from_str(&test_env.index_config_without_uri()).unwrap();
     let args = CreateIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_config_uri: index_config_without_uri,
         overwrite: false,
         assume_yes: true,
@@ -135,7 +142,10 @@ async fn test_cmd_create_overwrite() {
 
     let index_config_without_uri = Uri::from_str(&test_env.index_config_without_uri()).unwrap();
     let args = CreateIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_config_uri: index_config_without_uri,
         overwrite: true,
         assume_yes: true,
@@ -364,7 +374,10 @@ async fn test_cmd_search_aggregation() {
         snippet_fields: None,
         start_timestamp: None,
         end_timestamp: None,
-        cluster_endpoint: test_env.cluster_endpoint,
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint,
+            ..Default::default()
+        },
         sort_by_score: false,
     };
     let search_response = search_index(args).await.unwrap();
@@ -444,7 +457,10 @@ async fn test_cmd_search_with_snippets() -> Result<()> {
         snippet_fields: Some(vec!["event".to_string()]),
         start_timestamp: None,
         end_timestamp: None,
-        cluster_endpoint: test_env.cluster_endpoint,
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint,
+            ..Default::default()
+        },
         sort_by_score: false,
     };
     let search_response = search_index(args).await.unwrap();
@@ -471,7 +487,10 @@ async fn test_search_index_cli() {
     create_logs_index(&test_env).await.unwrap();
 
     let create_search_args = |query: &str| SearchIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_id: index_id.clone(),
         query: query.to_string(),
         aggregation: None,
@@ -530,7 +549,10 @@ async fn test_delete_index_cli_dry_run() {
     };
 
     let create_delete_args = |dry_run| DeleteIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_id: index_id.clone(),
         dry_run,
         assume_yes: true,
@@ -577,7 +599,10 @@ async fn test_delete_index_cli() {
         .unwrap();
 
     let args = DeleteIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_id: index_id.clone(),
         assume_yes: true,
         dry_run: false,
@@ -681,7 +706,10 @@ async fn test_garbage_collect_cli_no_grace() {
     );
 
     let args = DeleteIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_id,
         dry_run: false,
         assume_yes: true,
@@ -856,7 +884,10 @@ async fn test_all_local_index() {
     service_task.abort();
 
     let args = DeleteIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_id,
         dry_run: false,
         assume_yes: true,
@@ -889,7 +920,10 @@ async fn test_all_with_s3_localstack_cli() {
 
     // Cli search
     let args = SearchIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_id: index_id.clone(),
         query: "level:info".to_string(),
         aggregation: None,
@@ -935,7 +969,10 @@ async fn test_all_with_s3_localstack_cli() {
     service_task.abort();
 
     let args = DeleteIndexArgs {
-        cluster_endpoint: test_env.cluster_endpoint.clone(),
+        client_args: ClientArgs {
+            cluster_endpoint: test_env.cluster_endpoint.clone(),
+            ..Default::default()
+        },
         index_id: index_id.clone(),
         dry_run: false,
         assume_yes: true,

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -34,7 +34,9 @@ use quickwit_config::service::QuickwitService;
 use quickwit_config::QuickwitConfig;
 use quickwit_metastore::SplitState;
 use quickwit_rest_client::models::IngestSource;
-use quickwit_rest_client::rest_client::{CommitType, QuickwitClient, Transport, DEFAULT_BASE_URL};
+use quickwit_rest_client::rest_client::{
+    CommitType, QuickwitClient, QuickwitClientBuilder, DEFAULT_BASE_URL,
+};
 use quickwit_serve::{serve_quickwit, ListSplitsQueryParams};
 use reqwest::Url;
 use tempfile::TempDir;
@@ -152,12 +154,14 @@ impl ClusterSandbox {
         wait_for_server_ready(node_config.quickwit_config.grpc_listen_addr).await?;
         Ok(Self {
             node_configs,
-            indexer_rest_client: QuickwitClient::new(Transport::new(transport_url(
+            indexer_rest_client: QuickwitClientBuilder::new(transport_url(
                 node_config.quickwit_config.rest_listen_addr,
-            ))),
-            searcher_rest_client: QuickwitClient::new(Transport::new(transport_url(
+            ))
+            .build(),
+            searcher_rest_client: QuickwitClientBuilder::new(transport_url(
                 node_config.quickwit_config.rest_listen_addr,
-            ))),
+            ))
+            .build(),
             _temp_dir: temp_dir,
             join_handles,
             shutdown_trigger,
@@ -196,12 +200,14 @@ impl ClusterSandbox {
         tokio::time::sleep(Duration::from_millis(100)).await;
         Ok(Self {
             node_configs,
-            searcher_rest_client: QuickwitClient::new(Transport::new(transport_url(
+            searcher_rest_client: QuickwitClientBuilder::new(transport_url(
                 searcher_config.quickwit_config.rest_listen_addr,
-            ))),
-            indexer_rest_client: QuickwitClient::new(Transport::new(transport_url(
+            ))
+            .build(),
+            indexer_rest_client: QuickwitClientBuilder::new(transport_url(
                 indexer_config.quickwit_config.rest_listen_addr,
-            ))),
+            ))
+            .build(),
             _temp_dir: temp_dir,
             join_handles,
             shutdown_trigger,

--- a/quickwit/quickwit-rest-client/src/models.rs
+++ b/quickwit/quickwit-rest-client/src/models.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use bytes::Bytes;
 use reqwest::StatusCode;
@@ -76,4 +77,60 @@ pub enum IngestSource {
     Bytes(Bytes),
     File(PathBuf),
     Stdin,
+}
+
+/// A structure that represent a timeout. Unlike Duration it can also represent an infinite or no
+/// timeout value.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+pub struct Timeout {
+    duration: Duration,
+}
+
+const SECS_PER_MIN: u64 = 60;
+const MINS_PER_HOUR: u64 = 60;
+const HOURS_PER_DAY: u64 = 24;
+
+impl Timeout {
+    /// Creates a new timeout from duration
+    pub const fn new(duration: Duration) -> Timeout {
+        Timeout { duration }
+    }
+
+    /// Creates a new timeout from seconds
+    pub const fn from_secs(secs: u64) -> Timeout {
+        Timeout {
+            duration: Duration::from_secs(secs),
+        }
+    }
+
+    /// Creates a new timeout from minutes
+    pub const fn from_mins(mins: u64) -> Timeout {
+        Self::from_secs(mins * SECS_PER_MIN)
+    }
+
+    /// Creates a new timeout from hours
+    pub const fn from_hours(hours: u64) -> Timeout {
+        Self::from_secs(hours * SECS_PER_MIN * MINS_PER_HOUR)
+    }
+
+    /// Creates a new timeout from days
+    pub const fn from_days(days: u64) -> Timeout {
+        Self::from_secs(days * SECS_PER_MIN * MINS_PER_HOUR * HOURS_PER_DAY)
+    }
+
+    /// Creates a new infinite timeout
+    pub const fn none() -> Timeout {
+        Timeout {
+            duration: Duration::MAX,
+        }
+    }
+
+    /// Converts timeout into Some(Duration) or None if it is infinite.
+    pub fn as_duration_opt(&self) -> Option<Duration> {
+        if self.duration != Duration::MAX {
+            Some(self.duration)
+        } else {
+            None
+        }
+    }
 }

--- a/quickwit/quickwit-rest-client/src/rest_client.rs
+++ b/quickwit/quickwit-rest-client/src/rest_client.rs
@@ -29,7 +29,7 @@ use quickwit_metastore::{IndexMetadata, Split};
 use quickwit_search::SearchResponseRest;
 use quickwit_serve::{ListSplitsQueryParams, SearchRequestQueryString};
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
-use reqwest::{Client, Method, StatusCode, Url};
+use reqwest::{Client, ClientBuilder, Method, StatusCode, Url};
 use serde::Serialize;
 use serde_json::json;
 
@@ -40,49 +40,44 @@ use crate::BatchLineReader;
 pub const DEFAULT_BASE_URL: &str = "http://127.0.0.1:7280";
 pub const DEFAULT_CONTENT_TYPE: &str = "application/json";
 pub const INGEST_CONTENT_LENGTH_LIMIT: usize = 10 * 1024 * 1024; // 10MiB
+pub const DEFAULT_CLIENT_CONNECT_TIMEOUT: Option<Duration> = Some(Duration::from_secs(5));
+pub const DEFAULT_CLIENT_TIMEOUT: Option<Duration> = Some(Duration::from_secs(10));
+pub const DEFAULT_CLIENT_SEARCH_TIMEOUT: Option<Duration> = Some(Duration::from_secs(60));
+pub const DEFAULT_CLIENT_INGEST_TIMEOUT: Option<Duration> = Some(Duration::from_secs(60));
+pub const DEFAULT_CLIENT_COMMIT_TIMEOUT: Option<Duration> = Some(Duration::from_secs(1800));
 
-pub struct Transport {
+struct Transport {
     base_url: Url,
     api_url: Url,
     client: Client,
 }
 
-impl Default for Transport {
-    fn default() -> Self {
-        let base_url = Url::parse(DEFAULT_BASE_URL).unwrap();
-        Self::new(base_url)
-    }
-}
-
 impl Transport {
-    pub fn new(endpoint: Url) -> Self {
+    fn new(endpoint: Url, connect_timeout: Option<Duration>) -> Self {
         let base_url = endpoint;
         let api_url = base_url
             .join("api/v1/")
             .expect("Endpoint should not be malformed.");
+        let mut client_builder = ClientBuilder::new();
+        if let Some(connect_timeout) = connect_timeout {
+            client_builder = client_builder.connect_timeout(connect_timeout);
+        }
         Self {
             base_url,
             api_url,
-            client: Client::new(),
+            client: client_builder.build().expect("Client should be built."),
         }
     }
 
-    pub fn base_url(&self) -> &Url {
-        &self.base_url
-    }
-
-    pub fn api_url(&self) -> &Url {
-        &self.api_url
-    }
-
     /// Creates an asynchronous request that can be awaited
-    pub async fn send<Q: Serialize + ?Sized>(
+    async fn send<Q: Serialize + ?Sized>(
         &self,
         method: Method,
         path: &str,
         header_map: Option<HeaderMap>,
         query_string: Option<&Q>,
         body: Option<Bytes>,
+        timeout: Option<Duration>,
     ) -> Result<ApiResponse, Error> {
         let url = if path.starts_with('/') {
             self.base_url.join(path)
@@ -91,7 +86,9 @@ impl Transport {
         }
         .map_err(|error| Error::UrlParse(error.to_string()))?;
         let mut request_builder = self.client.request(method, url);
-        request_builder = request_builder.timeout(Duration::from_secs(10));
+        if let Some(timeout) = timeout {
+            request_builder = request_builder.timeout(timeout);
+        }
         let mut request_headers = HeaderMap::new();
         request_headers.insert(CONTENT_TYPE, HeaderValue::from_static(DEFAULT_CONTENT_TYPE));
         if let Some(header_map_val) = header_map {
@@ -110,14 +107,98 @@ impl Transport {
     }
 }
 
+pub struct QuickwitClientBuilder {
+    /// Base url for the client
+    base_url: Url,
+    /// Connection timeout.
+    connect_timeout: Option<Duration>,
+    /// Timeout for most operations except search and ingest.
+    timeout: Option<Duration>,
+    /// Timeout for search operations.
+    search_timeout: Option<Duration>,
+    /// Timeout for the ingest operations with auto commit.
+    ingest_timeout: Option<Duration>,
+    /// Timeout for the ingest operations that require waiting for commit.
+    commit_timeout: Option<Duration>,
+}
+
+impl QuickwitClientBuilder {
+    pub fn new(endpoint: Url) -> Self {
+        QuickwitClientBuilder {
+            base_url: endpoint,
+            connect_timeout: DEFAULT_CLIENT_CONNECT_TIMEOUT,
+            timeout: DEFAULT_CLIENT_TIMEOUT,
+            search_timeout: DEFAULT_CLIENT_SEARCH_TIMEOUT,
+            ingest_timeout: DEFAULT_CLIENT_INGEST_TIMEOUT,
+            commit_timeout: DEFAULT_CLIENT_COMMIT_TIMEOUT,
+        }
+    }
+
+    pub fn connect_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn search_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.search_timeout = timeout;
+        self
+    }
+
+    pub fn ingest_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.ingest_timeout = timeout;
+        self
+    }
+
+    pub fn commit_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.commit_timeout = timeout;
+        self
+    }
+
+    pub fn build(self) -> QuickwitClient {
+        let transport = Transport::new(self.base_url, self.connect_timeout);
+        QuickwitClient::new(
+            transport,
+            self.timeout,
+            self.search_timeout,
+            self.ingest_timeout,
+            self.commit_timeout,
+        )
+    }
+}
+
 /// Root client for top level APIs.
 pub struct QuickwitClient {
     transport: Transport,
+    /// Timeout for all operations except search and ingest.
+    timeout: Option<Duration>,
+    /// Timeout for search operations.
+    search_timeout: Option<Duration>,
+    /// Timeout for the ingest operations.
+    ingest_timeout: Option<Duration>,
+    /// Timeout for the ingest operations that require waiting for commit.
+    commit_timeout: Option<Duration>,
 }
 
 impl QuickwitClient {
-    pub fn new(transport: Transport) -> Self {
-        Self { transport }
+    fn new(
+        transport: Transport,
+        timeout: Option<Duration>,
+        search_timeout: Option<Duration>,
+        ingest_timeout: Option<Duration>,
+        commit_timeout: Option<Duration>,
+    ) -> Self {
+        Self {
+            transport,
+            timeout,
+            search_timeout,
+            ingest_timeout,
+            commit_timeout,
+        }
     }
 
     pub async fn search(
@@ -133,34 +214,41 @@ impl QuickwitClient {
         let body = Bytes::from(bytes);
         let response = self
             .transport
-            .send::<()>(Method::POST, &path, None, None, Some(body))
+            .send::<()>(
+                Method::POST,
+                &path,
+                None,
+                None,
+                Some(body),
+                self.search_timeout,
+            )
             .await?;
         let search_response = response.deserialize().await?;
         Ok(search_response)
     }
 
     pub fn indexes(&self) -> IndexClient {
-        IndexClient::new(&self.transport)
+        IndexClient::new(&self.transport, self.timeout)
     }
 
     pub fn splits<'a, 'b: 'a>(&'a self, index_id: &'b str) -> SplitClient {
-        SplitClient::new(&self.transport, index_id)
+        SplitClient::new(&self.transport, self.timeout, index_id)
     }
 
     pub fn sources<'a, 'b: 'a>(&'a self, index_id: &'b str) -> SourceClient {
-        SourceClient::new(&self.transport, index_id)
+        SourceClient::new(&self.transport, self.timeout, index_id)
     }
 
     pub fn cluster(&self) -> ClusterClient {
-        ClusterClient::new(&self.transport)
+        ClusterClient::new(&self.transport, self.timeout)
     }
 
     pub fn node_stats(&self) -> NodeStatsClient {
-        NodeStatsClient::new(&self.transport)
+        NodeStatsClient::new(&self.transport, self.timeout)
     }
 
     pub fn node_health(&self) -> NodeHealthClient {
-        NodeHealthClient::new(&self.transport)
+        NodeHealthClient::new(&self.transport, self.timeout)
     }
 
     pub async fn ingest(
@@ -182,12 +270,13 @@ impl QuickwitClient {
         };
         while let Some(batch) = batch_reader.next_batch().await? {
             loop {
-                let query_params = if !batch_reader.has_next() {
-                    last_block_commit.to_query_parameter()
-                } else {
-                    None
-                };
-
+                let (query_params, timeout) =
+                    if !batch_reader.has_next() && last_block_commit != CommitType::Auto {
+                        (last_block_commit.to_query_parameter(), self.commit_timeout)
+                    } else {
+                        (None, self.ingest_timeout)
+                    };
+                tracing::warn!("Ingesting {} bytes", batch.len());
                 let response = self
                     .transport
                     .send(
@@ -196,6 +285,7 @@ impl QuickwitClient {
                         None,
                         query_params,
                         Some(batch.clone()),
+                        timeout,
                     )
                     .await?;
 
@@ -226,11 +316,12 @@ pub enum IngestEvent {
 /// Client for indexes APIs.
 pub struct IndexClient<'a> {
     transport: &'a Transport,
+    timeout: Option<Duration>,
 }
 
 impl<'a> IndexClient<'a> {
-    pub fn new(transport: &'a Transport) -> Self {
-        Self { transport }
+    fn new(transport: &'a Transport, timeout: Option<Duration>) -> Self {
+        Self { transport, timeout }
     }
 
     pub async fn create(
@@ -248,6 +339,7 @@ impl<'a> IndexClient<'a> {
                 Some(header_map),
                 Some(&[("overwrite", overwrite)]),
                 Some(body),
+                self.timeout,
             )
             .await?;
         let index_metadata = response.deserialize().await?;
@@ -257,7 +349,7 @@ impl<'a> IndexClient<'a> {
     pub async fn list(&self) -> Result<Vec<IndexMetadata>, Error> {
         let response = self
             .transport
-            .send::<()>(Method::GET, "indexes", None, None, None)
+            .send::<()>(Method::GET, "indexes", None, None, None, self.timeout)
             .await?;
         let indexes_metadatas = response.deserialize().await?;
         Ok(indexes_metadatas)
@@ -267,7 +359,7 @@ impl<'a> IndexClient<'a> {
         let path = format!("indexes/{index_id}");
         let response = self
             .transport
-            .send::<()>(Method::GET, &path, None, None, None)
+            .send::<()>(Method::GET, &path, None, None, None, self.timeout)
             .await?;
         let index_metadata = response.deserialize().await?;
         Ok(index_metadata)
@@ -277,7 +369,7 @@ impl<'a> IndexClient<'a> {
         let path = format!("indexes/{index_id}/clear");
         let response = self
             .transport
-            .send::<()>(Method::PUT, &path, None, None, None)
+            .send::<()>(Method::PUT, &path, None, None, None, self.timeout)
             .await?;
         response.check().await?;
         Ok(())
@@ -293,6 +385,7 @@ impl<'a> IndexClient<'a> {
                 None,
                 Some(&[("dry_run", dry_run)]),
                 None,
+                self.timeout,
             )
             .await?;
         let file_entries = response.deserialize().await?;
@@ -303,13 +396,15 @@ impl<'a> IndexClient<'a> {
 /// Client for splits APIs.
 pub struct SplitClient<'a, 'b> {
     transport: &'a Transport,
+    timeout: Option<Duration>,
     index_id: &'b str,
 }
 
 impl<'a, 'b> SplitClient<'a, 'b> {
-    pub fn new(transport: &'a Transport, index_id: &'b str) -> Self {
+    fn new(transport: &'a Transport, timeout: Option<Duration>, index_id: &'b str) -> Self {
         Self {
             transport,
+            timeout,
             index_id,
         }
     }
@@ -331,6 +426,7 @@ impl<'a, 'b> SplitClient<'a, 'b> {
                 None,
                 Some(&list_splits_query_params),
                 None,
+                self.timeout,
             )
             .await?;
         let splits = response.deserialize().await?;
@@ -342,7 +438,7 @@ impl<'a, 'b> SplitClient<'a, 'b> {
         let body = Bytes::from(serde_json::to_vec(&json!({ "split_ids": split_ids }))?);
         let response = self
             .transport
-            .send::<()>(Method::PUT, &path, None, None, Some(body))
+            .send::<()>(Method::PUT, &path, None, None, Some(body), self.timeout)
             .await?;
         response.check().await?;
         Ok(())
@@ -352,13 +448,15 @@ impl<'a, 'b> SplitClient<'a, 'b> {
 /// Client for source APIs.
 pub struct SourceClient<'a, 'b> {
     transport: &'a Transport,
+    timeout: Option<Duration>,
     index_id: &'b str,
 }
 
 impl<'a, 'b> SourceClient<'a, 'b> {
-    pub fn new(transport: &'a Transport, index_id: &'b str) -> Self {
+    fn new(transport: &'a Transport, timeout: Option<Duration>, index_id: &'b str) -> Self {
         Self {
             transport,
+            timeout,
             index_id,
         }
     }
@@ -381,6 +479,7 @@ impl<'a, 'b> SourceClient<'a, 'b> {
                 Some(header_map),
                 None,
                 Some(body),
+                self.timeout,
             )
             .await?;
         let source_config = response.deserialize().await?;
@@ -391,7 +490,7 @@ impl<'a, 'b> SourceClient<'a, 'b> {
         let path = format!("{}/{source_id}", self.sources_root_url());
         let response = self
             .transport
-            .send::<()>(Method::GET, &path, None, None, None)
+            .send::<()>(Method::GET, &path, None, None, None, self.timeout)
             .await?;
         let source_config = response.deserialize().await?;
         Ok(source_config)
@@ -409,6 +508,7 @@ impl<'a, 'b> SourceClient<'a, 'b> {
                 None,
                 None,
                 Some(Bytes::from(json_bytes)),
+                self.timeout,
             )
             .await?;
         response.check().await?;
@@ -419,7 +519,7 @@ impl<'a, 'b> SourceClient<'a, 'b> {
         let path = format!("{}/{source_id}/reset-checkpoint", self.sources_root_url());
         let response = self
             .transport
-            .send::<()>(Method::PUT, &path, None, None, None)
+            .send::<()>(Method::PUT, &path, None, None, None, self.timeout)
             .await?;
         response.check().await?;
         Ok(())
@@ -428,7 +528,14 @@ impl<'a, 'b> SourceClient<'a, 'b> {
     pub async fn list(&self) -> Result<Vec<SourceConfig>, Error> {
         let response = self
             .transport
-            .send::<()>(Method::GET, &self.sources_root_url(), None, None, None)
+            .send::<()>(
+                Method::GET,
+                &self.sources_root_url(),
+                None,
+                None,
+                None,
+                self.timeout,
+            )
             .await?;
         let source_configs = response.deserialize().await?;
         Ok(source_configs)
@@ -438,7 +545,7 @@ impl<'a, 'b> SourceClient<'a, 'b> {
         let path = format!("{}/{source_id}", self.sources_root_url());
         let response = self
             .transport
-            .send::<()>(Method::DELETE, &path, None, None, None)
+            .send::<()>(Method::DELETE, &path, None, None, None, self.timeout)
             .await?;
         response.check().await?;
         Ok(())
@@ -448,17 +555,18 @@ impl<'a, 'b> SourceClient<'a, 'b> {
 /// Client for Cluster APIs.
 pub struct ClusterClient<'a> {
     transport: &'a Transport,
+    timeout: Option<Duration>,
 }
 
 impl<'a> ClusterClient<'a> {
-    pub fn new(transport: &'a Transport) -> Self {
-        Self { transport }
+    fn new(transport: &'a Transport, timeout: Option<Duration>) -> Self {
+        Self { transport, timeout }
     }
 
     pub async fn snapshot(&self) -> Result<ClusterSnapshot, Error> {
         let response = self
             .transport
-            .send::<()>(Method::GET, "cluster", None, None, None)
+            .send::<()>(Method::GET, "cluster", None, None, None, self.timeout)
             .await?;
         let cluster_snapshot = response.deserialize().await?;
         Ok(cluster_snapshot)
@@ -468,17 +576,18 @@ impl<'a> ClusterClient<'a> {
 /// Client for Node-level Stats APIs.
 pub struct NodeStatsClient<'a> {
     transport: &'a Transport,
+    timeout: Option<Duration>,
 }
 
 impl<'a> NodeStatsClient<'a> {
-    pub fn new(transport: &'a Transport) -> Self {
-        Self { transport }
+    fn new(transport: &'a Transport, timeout: Option<Duration>) -> Self {
+        Self { transport, timeout }
     }
 
     pub async fn indexing(&self) -> Result<IndexingServiceCounters, Error> {
         let response = self
             .transport
-            .send::<()>(Method::GET, "indexing", None, None, None)
+            .send::<()>(Method::GET, "indexing", None, None, None, self.timeout)
             .await?;
         let indexing_stats = response.deserialize().await?;
         Ok(indexing_stats)
@@ -488,18 +597,19 @@ impl<'a> NodeStatsClient<'a> {
 /// Client for Node-level Health APIs.
 pub struct NodeHealthClient<'a> {
     transport: &'a Transport,
+    timeout: Option<Duration>,
 }
 
 impl<'a> NodeHealthClient<'a> {
-    pub fn new(transport: &'a Transport) -> Self {
-        Self { transport }
+    fn new(transport: &'a Transport, timeout: Option<Duration>) -> Self {
+        Self { transport, timeout }
     }
 
     /// Returns true if the node is healthy, returns false or an error otherwise.
     pub async fn is_live(&self) -> Result<bool, Error> {
         let response = self
             .transport
-            .send::<()>(Method::GET, "/health/livez", None, None, None)
+            .send::<()>(Method::GET, "/health/livez", None, None, None, self.timeout)
             .await?;
         let result: bool = response.deserialize().await?;
         Ok(result)
@@ -509,7 +619,14 @@ impl<'a> NodeHealthClient<'a> {
     pub async fn is_ready(&self) -> Result<bool, Error> {
         let response = self
             .transport
-            .send::<()>(Method::GET, "/health/readyz", None, None, None)
+            .send::<()>(
+                Method::GET,
+                "/health/readyz",
+                None,
+                None,
+                None,
+                self.timeout,
+            )
             .await?;
         let result: bool = response.deserialize().await?;
         Ok(result)
@@ -548,28 +665,15 @@ mod test {
     };
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::{QuickwitClient, Transport};
     use crate::error::Error;
     use crate::models::IngestSource;
-
-    #[test]
-    fn test_transport_urls() {
-        let transport = Transport::default();
-        assert_eq!(
-            transport.base_url(),
-            &Url::parse("http://127.0.0.1:7280/").unwrap()
-        );
-        assert_eq!(
-            transport.api_url(),
-            &Url::parse("http://127.0.0.1:7280/api/v1/").unwrap()
-        );
-    }
+    use crate::rest_client::QuickwitClientBuilder;
 
     #[tokio::test]
     async fn test_client_no_server() {
         let port = quickwit_common::net::find_available_tcp_port().unwrap();
         let server_url = Url::parse(&format!("http://127.0.0.1:{port}")).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let error = qw_client.indexes().list().await.unwrap_err();
 
         assert!(matches!(error, Error::Client(_)));
@@ -580,7 +684,7 @@ mod test {
     async fn test_search_endpoint() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         // Search
         let search_query_params = SearchRequestQueryString {
             ..Default::default()
@@ -622,7 +726,7 @@ mod test {
     async fn test_ingest_endpoint() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let ndjson_filepath = get_ndjson_filepath("documents_to_ingest.json");
         let mut buffer = Vec::new();
         File::open(&ndjson_filepath)
@@ -659,7 +763,7 @@ mod test {
     async fn test_ingest_endpoint_with_force_commit() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let ndjson_filepath = get_ndjson_filepath("documents_to_ingest.json");
         let mut buffer = Vec::new();
         File::open(&ndjson_filepath)
@@ -687,7 +791,7 @@ mod test {
     async fn test_ingest_endpoint_with_wait_for_commit() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let ndjson_filepath = get_ndjson_filepath("documents_to_ingest.json");
         let mut buffer = Vec::new();
         File::open(&ndjson_filepath)
@@ -715,7 +819,7 @@ mod test {
     async fn test_ingest_endpoint_should_return_api_error() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let ndjson_filepath = get_ndjson_filepath("documents_to_ingest.json");
         let mut buffer = Vec::new();
         File::open(&ndjson_filepath)
@@ -752,7 +856,7 @@ mod test {
     async fn test_indexes_endpoints() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let index_metadata = IndexMetadata::for_test("test-index", "ram:///indexes/test-index");
         // GET indexes
         Mock::given(method("GET"))
@@ -857,7 +961,7 @@ mod test {
     async fn test_splits_endpoints() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let split = mock_split("split-1");
         // GET splits
         let list_splits_params = ListSplitsQueryParams {
@@ -914,7 +1018,7 @@ mod test {
     async fn test_sources_endpoints() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
         let source_config = SourceConfig::ingest_api_default();
         // POST create source with toml
         Mock::given(method("POST"))
@@ -1038,7 +1142,7 @@ mod test {
     async fn test_health_endpoints() {
         let mock_server = MockServer::start().await;
         let server_url = Url::parse(&mock_server.uri()).unwrap();
-        let qw_client = QuickwitClient::new(Transport::new(server_url));
+        let qw_client = QuickwitClientBuilder::new(server_url).build();
 
         assert!(qw_client.node_health().is_live().await.is_err());
         assert!(qw_client.node_health().is_ready().await.is_err());


### PR DESCRIPTION
### Description

Adds ability to specify operation timeouts for the rust client as well as different CLI commands. Takes a first stab at more conservative timeout defaults. These timeouts are still pretty much guesstimates at this point, but at least we now have a way to adjust default and override them from CLI.

Fixes #3137

### How was this PR tested?

By running automated tests as well as using our large examples from tutorial to see if they fail with new defaults.
