### PR TITLE
Default docmapper with dynamic mode.

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -376,9 +376,9 @@ field_mappings:
 The `mode` describes how Quickwit should behave when it receives a field that is not defined in the field mapping.
 
 Quickwit offers you three different modes:
-- `lenient` (default value): unmapped fields are dismissed by Quickwit.
+- `dynamic` (default value): unmapped fields are gathered by Quickwit and handled as defined in the `dynamic_mapping` parameter.
+- `lenient`: unmapped fields are dismissed by Quickwit.
 - `strict`: if a document contains a field that is not mapped, quickwit will dismiss it, and count it as an error.
-- `dynamic`: unmapped fields are gathered by Quickwit and handled as defined in the `dynamic_mapping` parameter.
 
 #### Dynamic Mapping
 
@@ -409,12 +409,13 @@ For instance, in a entirely schemaless settings, a minimal index configuration c
 ```yaml
 version: 0.6
 index_id: my-dynamic-index
-# note we did not map anything.
 doc_mapping:
-  mode: dynamic
+    # If you have a timestamp field, it is important to tell quickwit about it.
+    timestamp_field: unix_timestamp
+    # mode: dynamic #< Commented out, as dynamic is the default mode.
 ```
 
-We could then index a complex document like the following:
+With such a simple configuration, we can index a complex document like the following:
 
 ```json
 {
@@ -568,7 +569,8 @@ This section describes search settings for a given index.
 
 | Variable      | Description   | Default value |
 | ------------- | ------------- | ------------- |
-| `default_search_fields`      | Default list of fields that will be used for search.   | `None` |
+| `default_search_fields`      | Default list of fields that will be used for search. The field names in this list may be declared
+explicitly in the schema, or may refer to a field captured by the dynamic mode.   | `None` |
 
 ## Retention policy
 

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -297,6 +297,7 @@ impl IndexConfig {
     pub fn for_test(index_id: &str, index_uri: &str) -> Self {
         let index_uri = Uri::from_str(index_uri).unwrap();
         let doc_mapping_json = r#"{
+            "mode": "lenient",
             "field_mappings": [
                 {
                     "name": "timestamp",
@@ -685,7 +686,7 @@ mod tests {
     }
 
     #[test]
-    fn test_minimal_index_config_default_lenient() {
+    fn test_minimal_index_config_default_dynamic() {
         let config_yaml = r#"
             version: 0.6
             index_id: hdfs-logs
@@ -698,7 +699,7 @@ mod tests {
             &Uri::from_well_formed("s3://my-index"),
         )
         .unwrap();
-        assert_eq!(minimal_config.doc_mapping.mode, ModeType::Lenient);
+        assert_eq!(minimal_config.doc_mapping.mode, ModeType::Dynamic);
     }
 
     #[test]

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -499,7 +499,7 @@ mod tests {
         let schema = doc_mapper.schema();
         // 8 property entry + 1 field "_source" + two fields values for "tags" field
         // + 2 values inf "server.status" field + 2 values in "server.payload" field
-        assert_eq!(document.len(), 15);
+        assert_eq!(document.len(), 16);
         let expected_json_paths_and_values: HashMap<String, JsonValue> =
             serde_json::from_str(EXPECTED_JSON_PATHS_AND_VALUES).unwrap();
         document.field_values().iter().for_each(|field_value| {

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
@@ -69,17 +69,16 @@ pub struct DefaultDocMapperBuilder {
 }
 
 /// `Mode` describing how the unmapped field should be handled.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "lowercase")]
-#[derive(Default)]
 pub enum ModeType {
     /// Lenient mode: unmapped fields are just ignored.
-    #[default]
     Lenient,
     /// Strict mode: when parsing a document with an unmapped field, an error is yielded.
     Strict,
     /// Dynamic mode: unmapped fields are captured and handled according to the
     /// `dynamic_mapping` configuration.
+    #[default]
     Dynamic,
 }
 
@@ -135,7 +134,7 @@ mod tests {
         assert!(default_mapper_builder.default_search_fields.is_empty());
         assert!(default_mapper_builder.field_mappings.is_empty());
         assert!(default_mapper_builder.tag_fields.is_empty());
-        assert_eq!(default_mapper_builder.mode, ModeType::Lenient);
+        assert_eq!(default_mapper_builder.mode, ModeType::Dynamic);
         assert!(default_mapper_builder.dynamic_mapping.is_none());
         assert_eq!(default_mapper_builder.store_source, false);
         assert!(default_mapper_builder.timestamp_field.is_none());

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -353,6 +353,7 @@ async fn test_single_node_filtering() -> anyhow::Result<()> {
                 type: text
                 tokenizer: raw
             timestamp_field: ts
+            mode: lenient
         "#;
     let indexing_settings_json = r#"{}"#;
     let test_sandbox = TestSandbox::create(
@@ -533,10 +534,13 @@ async fn single_node_search_sort_by_field(
 }
 
 #[tokio::test]
-async fn test_single_node_sorting_with_query() -> anyhow::Result<()> {
-    single_node_search_sort_by_field("temperature", false).await?;
-    single_node_search_sort_by_field("_score", true).await?;
-    Ok(())
+async fn test_single_node_sorting_with_query_fieldnorms_enabled() -> anyhow::Result<()> {
+    single_node_search_sort_by_field("_score", true).await
+}
+
+#[tokio::test]
+async fn test_single_node_sorting_with_query_fieldnorms_disabled() -> anyhow::Result<()> {
+    single_node_search_sort_by_field("temperature", false).await
 }
 
 #[tokio::test]

--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -183,6 +183,7 @@ mod tests {
               - name: ts
                 type: i64
                 fast: true
+            mode: lenient
         "#;
         let test_sandbox = TestSandbox::create(index_id, doc_mapping_yaml, "{}", &["body"])
             .await


### PR DESCRIPTION
Makes the dynamic mode the default, and allow unspecified doc mapping

Accepting sort by score even if one of the default field does not have fieldnorm.
Minor code cleanup

Closes #2910
