### PR TITLE
Add env variable to set actor's heartbeat. Distinguish heartbeat and …

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4397,6 +4397,7 @@ dependencies = [
  "criterion",
  "flume",
  "futures",
+ "once_cell",
  "quickwit-common",
  "quickwit-proto",
  "rand 0.8.5",

--- a/quickwit/quickwit-actors/Cargo.toml
+++ b/quickwit/quickwit-actors/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
+once_cell = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/quickwit/quickwit-actors/src/lib.rs
+++ b/quickwit/quickwit-actors/src/lib.rs
@@ -28,7 +28,9 @@
 //! - detect when some task is stuck and does not progress anymore
 
 use std::fmt;
+use std::num::NonZeroU64;
 
+use once_cell::sync::Lazy;
 use quickwit_proto::{ServiceError, ServiceErrorCode};
 use tokio::time::Duration;
 mod actor;
@@ -59,6 +61,8 @@ pub use observation::{Observation, ObservationType};
 use quickwit_common::KillSwitch;
 pub use spawn_builder::SpawnContext;
 use thiserror::Error;
+use tracing::info;
+use tracing::log::warn;
 pub use universe::Universe;
 
 pub use self::actor_context::ActorContext;
@@ -73,16 +77,38 @@ pub use self::supervisor::{Supervisor, SupervisorState};
 /// If an actor does not advertise a progress within an interval of duration `HEARTBEAT`,
 /// its supervisor will consider it as blocked and will proceed to kill it, as well
 /// as all of the actors all the actors that share the killswitch.
-pub const HEARTBEAT: Duration = if cfg!(any(test, feature = "testsuite")) {
-    // Right now some unit test end when we detect that a
-    // pipeline has terminated, which can require waiting
-    // for a heartbeat.
-    //
-    // We use a shorter heartbeat to reduce the time running unit tests.
-    Duration::from_millis(500)
-} else {
-    Duration::from_secs(3)
-};
+pub static HEARTBEAT: Lazy<Duration> = Lazy::new(heartbeat_from_env_or_default);
+
+/// Returns the actor's heartbeat duration:
+/// - Derived from `QW_ACTOR_HEARTBEAT_SECS` if set and valid.
+/// - Defaults to 30 seconds or 500ms for tests.
+fn heartbeat_from_env_or_default() -> Duration {
+    if cfg!(any(test, feature = "testsuite")) {
+        // Right now some unit test end when we detect that a
+        // pipeline has terminated, which can require waiting
+        // for a heartbeat.
+        //
+        // We use a shorter heartbeat to reduce the time running unit tests.
+        return Duration::from_millis(500);
+    }
+    if let Ok(actor_hearbeat_secs_str) = std::env::var("QW_ACTOR_HEARTBEAT_SECS") {
+        if let Ok(actor_hearbeat_secs) = actor_hearbeat_secs_str.parse::<NonZeroU64>() {
+            info!("Set the actor heartbeat to {actor_hearbeat_secs} seconds.");
+            return Duration::from_secs(actor_hearbeat_secs.get());
+        } else {
+            warn!(
+                "Failed to parse `QW_ACTOR_HEARTBEAT_SECS={actor_hearbeat_secs_str}` in seconds > \
+                 0, using default heartbeat (30 seconds)."
+            );
+        };
+    } else {
+        warn!(
+            "Failed to parse `QW_ACTOR_HEARTBEAT_SECS` in a valid unicode string, using default \
+             heartbeat (30 seconds)."
+        );
+    }
+    Duration::from_secs(30)
+}
 
 /// Time we accept to wait for a new observation.
 ///

--- a/quickwit/quickwit-actors/src/supervisor.rs
+++ b/quickwit/quickwit-actors/src/supervisor.rs
@@ -61,7 +61,8 @@ impl<A: Actor> Actor for Supervisor<A> {
     }
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
-        ctx.schedule_self_msg(crate::HEARTBEAT, SuperviseLoop).await;
+        ctx.schedule_self_msg(*crate::HEARTBEAT, SuperviseLoop)
+            .await;
         Ok(())
     }
 
@@ -179,7 +180,8 @@ impl<A: Actor> Handler<SuperviseLoop> for Supervisor<A> {
         ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
         self.supervise(ctx).await?;
-        ctx.schedule_self_msg(crate::HEARTBEAT, SuperviseLoop).await;
+        ctx.schedule_self_msg(*crate::HEARTBEAT, SuperviseLoop)
+            .await;
         Ok(())
     }
 }

--- a/quickwit/quickwit-actors/src/tests.rs
+++ b/quickwit/quickwit-actors/src/tests.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
+use std::ops::Mul;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -281,7 +282,7 @@ async fn test_timeouting_actor() {
         ObservationType::Timeout
     );
     assert_eq!(buggy_handle.harvest_health(), Health::Healthy);
-    universe.sleep(crate::HEARTBEAT * 2).await;
+    universe.sleep(crate::HEARTBEAT.mul(2)).await;
     assert_eq!(buggy_handle.harvest_health(), Health::FailureOrUnhealthy);
     buggy_handle.kill().await;
 }

--- a/quickwit/quickwit-control-plane/Cargo.toml
+++ b/quickwit/quickwit-control-plane/Cargo.toml
@@ -45,6 +45,7 @@ proptest = { workspace = true }
 rand = { workspace = true }
 
 quickwit-actors = { workspace = true, features = ["testsuite"] }
+quickwit-cluster = { workspace = true, features = ["testsuite"] }
 quickwit-common = { workspace = true, features = ["testsuite"] }
 quickwit-config = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -471,7 +471,7 @@ impl Handler<Supervise> for IndexingPipeline {
                 Health::Healthy => {}
                 Health::FailureOrUnhealthy => {
                     self.terminate().await;
-                    ctx.schedule_self_msg(quickwit_actors::HEARTBEAT, Spawn { retry_count: 0 })
+                    ctx.schedule_self_msg(*quickwit_actors::HEARTBEAT, Spawn { retry_count: 0 })
                         .await;
                 }
                 Health::Success => {
@@ -479,7 +479,7 @@ impl Handler<Supervise> for IndexingPipeline {
                 }
             }
         }
-        ctx.schedule_self_msg(quickwit_actors::HEARTBEAT, Supervise)
+        ctx.schedule_self_msg(*quickwit_actors::HEARTBEAT, Supervise)
             .await;
         Ok(())
     }
@@ -823,7 +823,7 @@ mod tests {
         let indexer = universe.get::<Indexer>().into_iter().next().unwrap();
         let _ = indexer.ask(Command::Quit).await;
         for _ in 0..10 {
-            universe.sleep(quickwit_actors::HEARTBEAT).await;
+            universe.sleep(*quickwit_actors::HEARTBEAT).await;
             // Check indexing pipeline has restarted.
             let obs = indexing_pipeline_handler
                 .process_pending_and_observe()

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -710,7 +710,7 @@ impl Handler<SuperviseLoop> for IndexingService {
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         self.handle_supervise().await?;
-        ctx.schedule_self_msg(quickwit_actors::HEARTBEAT, SuperviseLoop)
+        ctx.schedule_self_msg(*quickwit_actors::HEARTBEAT, SuperviseLoop)
             .await;
         Ok(())
     }
@@ -1267,12 +1267,12 @@ mod tests {
         pipeline.quit().await;
 
         // Let the service cleanup the merge pipelines.
-        universe.sleep(HEARTBEAT).await;
+        universe.sleep(*HEARTBEAT).await;
 
         let observation = indexing_server_handle.process_pending_and_observe().await;
         assert_eq!(observation.num_running_pipelines, 0);
         assert_eq!(observation.num_running_merge_pipelines, 0);
-        universe.sleep(HEARTBEAT).await;
+        universe.sleep(*HEARTBEAT).await;
         // Check that the merge pipeline is also shut down as they are no more indexing pipeilne on
         // the index.
         assert!(universe.get_one::<MergePipeline>().is_none());
@@ -1290,7 +1290,7 @@ mod tests {
             _: FreezePipeline,
             _ctx: &ActorContext<Self>,
         ) -> Result<Self::Reply, ActorExitStatus> {
-            tokio::time::sleep(HEARTBEAT * 5).await;
+            tokio::time::sleep(*HEARTBEAT * 5).await;
             Ok(())
         }
     }
@@ -1368,7 +1368,7 @@ mod tests {
             .send_message(FreezePipeline)
             .await
             .unwrap();
-        universe.sleep(HEARTBEAT * 5).await;
+        universe.sleep(*HEARTBEAT * 5).await;
         // Check that indexing and merge pipelines are still running.
         let observation = indexing_service_handle.observe().await;
         assert_eq!(observation.num_running_pipelines, 1);

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -376,7 +376,7 @@ impl Handler<Supervise> for MergePipeline {
                 Health::Healthy => {}
                 Health::FailureOrUnhealthy => {
                     self.terminate().await;
-                    ctx.schedule_self_msg(quickwit_actors::HEARTBEAT, Spawn { retry_count: 0 })
+                    ctx.schedule_self_msg(*quickwit_actors::HEARTBEAT, Spawn { retry_count: 0 })
                         .await;
                 }
                 Health::Success => {
@@ -384,7 +384,7 @@ impl Handler<Supervise> for MergePipeline {
                 }
             }
         }
-        ctx.schedule_self_msg(quickwit_actors::HEARTBEAT, Supervise)
+        ctx.schedule_self_msg(*quickwit_actors::HEARTBEAT, Supervise)
             .await;
         Ok(())
     }

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -283,7 +283,7 @@ impl Handler<RefreshMetric> for MergePlanner {
                 self.pipeline_id.source_id.as_str(),
             ])
             .set(self.ongoing_merge_operations_inventory.list().len() as i64);
-        ctx.schedule_self_msg(quickwit_actors::HEARTBEAT, RefreshMetric)
+        ctx.schedule_self_msg(*quickwit_actors::HEARTBEAT, RefreshMetric)
             .await;
         Ok(())
     }

--- a/quickwit/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kafka_source.rs
@@ -494,7 +494,7 @@ impl Source for KafkaSource {
     ) -> Result<Duration, ActorExitStatus> {
         let now = Instant::now();
         let mut batch = BatchBuilder::default();
-        let deadline = time::sleep(quickwit_actors::HEARTBEAT / 2);
+        let deadline = time::sleep(*quickwit_actors::HEARTBEAT / 2);
         tokio::pin!(deadline);
 
         loop {

--- a/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -215,7 +215,7 @@ impl Source for KinesisSource {
         let mut docs = Vec::new();
         let mut checkpoint_delta = SourceCheckpointDelta::default();
 
-        let deadline = time::sleep(quickwit_actors::HEARTBEAT / 2);
+        let deadline = time::sleep(*quickwit_actors::HEARTBEAT / 2);
         tokio::pin!(deadline);
 
         loop {

--- a/quickwit/quickwit-indexing/src/source/pulsar_source.rs
+++ b/quickwit/quickwit-indexing/src/source/pulsar_source.rs
@@ -230,7 +230,7 @@ impl Source for PulsarSource {
     ) -> Result<Duration, ActorExitStatus> {
         let now = Instant::now();
         let mut batch = BatchBuilder::default();
-        let deadline = time::sleep(quickwit_actors::HEARTBEAT / 2);
+        let deadline = time::sleep(*quickwit_actors::HEARTBEAT / 2);
         tokio::pin!(deadline);
 
         loop {
@@ -1211,7 +1211,7 @@ mod pulsar_broker_tests {
             )
             .await
             .unwrap();
-            tokio::time::sleep(HEARTBEAT * 5).await;
+            tokio::time::sleep(*HEARTBEAT * 5).await;
             source_handle2.kill().await;
         }
 

--- a/quickwit/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit/quickwit-indexing/src/source/void_source.rs
@@ -38,7 +38,7 @@ impl Source for VoidSource {
         _: &Mailbox<DocProcessor>,
         _: &SourceContext,
     ) -> Result<Duration, ActorExitStatus> {
-        tokio::time::sleep(HEARTBEAT / 2).await;
+        tokio::time::sleep(*HEARTBEAT / 2).await;
         Ok(Duration::default())
     }
 

--- a/quickwit/quickwit-janitor/Cargo.toml
+++ b/quickwit/quickwit-janitor/Cargo.toml
@@ -41,6 +41,9 @@ quickwit-query = { workspace = true }
 quickwit-search = { workspace = true }
 quickwit-storage = { workspace = true }
 
+[features]
+testsuite = []
+
 [dev-dependencies]
 mockall = "0.11"
 tempfile = "3"

--- a/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
@@ -20,9 +20,10 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
-use quickwit_actors::{Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, HEARTBEAT};
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, ActorHandle, Handler};
 use quickwit_common::temp_dir::{self};
 use quickwit_config::IndexConfig;
 use quickwit_metastore::Metastore;
@@ -35,6 +36,14 @@ use tracing::{error, info, warn};
 use super::delete_task_pipeline::DeleteTaskPipeline;
 
 pub const DELETE_SERVICE_TASK_DIR_NAME: &str = "delete_task_service";
+
+const UPDATE_PIPELINES_INTERVAL: Duration = if cfg!(any(test, feature = "testsuite")) {
+    Duration::from_millis(200)
+} else {
+    // Each update triggers a call to the metastore. Deletes are not frequent operation and
+    // it's fine to wait a bit before updating the pipelines.
+    Duration::from_secs(30)
+};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DeleteTaskServiceState {
@@ -87,7 +96,7 @@ impl Actor for DeleteTaskService {
     }
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
-        self.handle(SuperviseLoop, ctx).await?;
+        self.handle(UpdatePipelines, ctx).await?;
         Ok(())
     }
 }
@@ -171,35 +180,35 @@ impl DeleteTaskService {
 }
 
 #[derive(Debug)]
-struct SuperviseLoop;
+struct UpdatePipelines;
 
 #[async_trait]
-impl Handler<SuperviseLoop> for DeleteTaskService {
+impl Handler<UpdatePipelines> for DeleteTaskService {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _: SuperviseLoop,
+        _: UpdatePipelines,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         let result = self.update_pipeline_handles(ctx).await;
         if let Err(error) = result {
             error!("Delete task pipelines update failed: {}", error);
         }
-        ctx.schedule_self_msg(HEARTBEAT, SuperviseLoop).await;
+        ctx.schedule_self_msg(UPDATE_PIPELINES_INTERVAL, UpdatePipelines)
+            .await;
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use quickwit_actors::HEARTBEAT;
     use quickwit_indexing::TestSandbox;
     use quickwit_proto::metastore_api::DeleteQuery;
     use quickwit_search::{searcher_pool_for_test, MockSearchService, SearchJobPlacer};
     use quickwit_storage::StorageUriResolver;
 
-    use super::DeleteTaskService;
+    use super::{DeleteTaskService, UPDATE_PIPELINES_INTERVAL};
 
     #[tokio::test]
     async fn test_delete_task_service() -> anyhow::Result<()> {
@@ -255,7 +264,10 @@ mod tests {
             1
         );
         metastore.delete_index(index_uid.clone()).await.unwrap();
-        test_sandbox.universe().sleep(HEARTBEAT * 2).await;
+        test_sandbox
+            .universe()
+            .sleep(UPDATE_PIPELINES_INTERVAL * 2)
+            .await;
         let state_after_deletion = delete_task_service_handler
             .process_pending_and_observe()
             .await;
@@ -264,7 +276,10 @@ mod tests {
             .universe()
             .get_one::<DeleteTaskService>()
             .is_some());
-        let actors_observations = test_sandbox.universe().observe(HEARTBEAT).await;
+        let actors_observations = test_sandbox
+            .universe()
+            .observe(UPDATE_PIPELINES_INTERVAL)
+            .await;
         assert!(
             actors_observations
                 .into_iter()

--- a/quickwit/quickwit-serve/Cargo.toml
+++ b/quickwit/quickwit-serve/Cargo.toml
@@ -81,6 +81,7 @@ quickwit-config = { workspace = true, features = ["testsuite"] }
 quickwit-control-plane = { workspace = true, features = ["testsuite"] }
 quickwit-indexing = { workspace = true, features = ["testsuite"] }
 quickwit-ingest = { workspace = true, features = ["testsuite"] }
+quickwit-janitor = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-search = { workspace = true, features = ["testsuite"] }
 quickwit-storage = { workspace = true, features = ["testsuite"] }


### PR DESCRIPTION

- Add env variable to customize the heartbeat. Useful for internal usage.
- Default heartbeat is set to 30 seconds.
- Separates duration intervals that should not be bound to the actor heartbeat.

Drawback: I used a oncecell to store the heartbeat but it's a bit annoying to use it throughout the code. I don't know if it's possible to use something else.
