### PR TITLE
Fix indexing `TestSandbox`

### DIFF
--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -69,7 +69,11 @@ kinesis = ["aws-config", "aws-smithy-client", "aws-sdk-kinesis", "quickwit-aws/k
 kinesis-localstack-tests = []
 pulsar = ["dep:pulsar"]
 pulsar-broker-tests = []
-testsuite = ["quickwit-actors/testsuite", "quickwit-cluster/testsuite"]
+testsuite = [
+  "quickwit-actors/testsuite",
+  "quickwit-cluster/testsuite",
+  "quickwit-common/testsuite",
+]
 
 [dev-dependencies]
 bytes = { workspace = true }


### PR DESCRIPTION
### Description
The indexing `TestSandbox` now relies on the `testsuite` feature of `quickwit-common` to initialize the actor Tokio runtime.

### How was this PR tested?
`cargo test --manifest-path quickwit/Cargo.toml -p quickwit-search --lib --` (which is currently broken on main)
