### PR TITLE
Add `StorageConfig` and `MetastoreConfig` objects in index config

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3494,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.53"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4897,6 +4897,7 @@ dependencies = [
  "quickwit-rest-client",
  "quickwit-search",
  "quickwit-serve",
+ "quickwit-storage",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -5269,6 +5270,7 @@ dependencies = [
  "proptest",
  "quickwit-aws",
  "quickwit-common",
+ "quickwit-config",
  "rand 0.8.5",
  "regex",
  "serde",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -140,7 +140,6 @@ serde_json = "1.0"
 serde_qs = { version = "0.10", features = ["warp"] }
 serde_with = "2.3.0"
 serde_yaml = "0.9"
-serial_test = "0.9.0"
 siphasher = "0.3"
 sqlx = { version = "0.6", features = [
   "runtime-tokio-rustls",

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -45,7 +45,7 @@ use quickwit_rest_client::models::IngestSource;
 use quickwit_rest_client::rest_client::{CommitType, IngestEvent};
 use quickwit_search::SearchResponseRest;
 use quickwit_serve::{ListSplitsQueryParams, SearchRequestQueryString, SortByField};
-use quickwit_storage::load_file;
+use quickwit_storage::{load_file, StorageResolver};
 use tabled::object::{Columns, Segment};
 use tabled::{Alignment, Concat, Format, Modify, Panel, Rotate, Style, Table, Tabled};
 use thousands::Separable;
@@ -452,7 +452,8 @@ pub async fn clear_index_cli(args: ClearIndexArgs) -> anyhow::Result<()> {
 pub async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
     debug!(args=?args, "create-index");
     println!("❯ Creating index...");
-    let file_content = load_file(&args.index_config_uri).await?;
+    let storage_resolver = StorageResolver::unconfigured();
+    let file_content = load_file(&storage_resolver, &args.index_config_uri).await?;
     let config_format = ConfigFormat::sniff_from_uri(&args.index_config_uri)?;
     let qw_client = args.client_args.client();
     // TODO: nice to have: check first if the index exists by send a GET request, if we get a 404,

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -440,7 +440,6 @@ mod tests {
             ])
             .unwrap();
         let command = CliCommand::parse_cli_args(matches).unwrap();
-        println!("{command:?}");
         assert!(matches!(
             command,
             CliCommand::Tool(ToolCliCommand::LocalIngest(

--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -28,7 +28,7 @@ use quickwit_common::uri::Uri;
 use quickwit_common::GREEN_COLOR;
 use quickwit_config::{validate_identifier, ConfigFormat, SourceConfig};
 use quickwit_metastore::checkpoint::SourceCheckpoint;
-use quickwit_storage::load_file;
+use quickwit_storage::{load_file, StorageResolver};
 use serde_json::Value as JsonValue;
 use tabled::{Table, Tabled};
 use tracing::debug;
@@ -328,7 +328,8 @@ impl SourceCliCommand {
 async fn create_source_cli(args: CreateSourceArgs) -> anyhow::Result<()> {
     debug!(args=?args, "create-source");
     println!("❯ Creating source...");
-    let source_config_content = load_file(&args.source_config_uri).await?;
+    let storage_resolver = StorageResolver::unconfigured();
+    let source_config_content = load_file(&storage_resolver, &args.source_config_uri).await?;
     let config_format = ConfigFormat::sniff_from_uri(&args.source_config_uri)?;
     let qw_client = args.client_args.client();
     qw_client

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -19,7 +19,22 @@
     "data_dir": "/opt/quickwit/data",
     "metastore_uri": "postgres://username:password@host:port/db",
     "default_index_root_uri": "s3://quickwit-indexes",
+    "storage": {
+        "azure": {
+            "account_name": "quickwit-dev"
+        },
+        "s3": {
+            "endpoint": "http://localhost:4566",
+            "force_path_style_access": true
+        }
+    },
+    "metastore": {
+        "postgres": {
+            "max_num_connections": 12
+        }
+    },
     "indexer": {
+        "enable_otlp_endpoint": true,
         "split_store_max_num_bytes": "1T",
         "split_store_max_num_splits": 10000,
         "max_concurrent_split_uploads": 8
@@ -33,7 +48,7 @@
         "max_num_concurrent_split_searches": 150
     },
     "jaeger": {
-        "enable_endpoint": false,
+        "enable_endpoint": true,
         "lookback_period_hours": 24,
         "max_trace_duration_secs": 600,
         "max_fetch_spans": 1000

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -1,4 +1,5 @@
 version = "0.6"
+
 cluster_id = "quickwit-cluster"
 node_id = "my-unique-node-id"
 enabled_services = [ "janitor", "metastore" ]
@@ -12,7 +13,18 @@ data_dir = "/opt/quickwit/data"
 metastore_uri = "postgres://username:password@host:port/db"
 default_index_root_uri = "s3://quickwit-indexes"
 
+[storage.azure]
+account_name = "quickwit-dev"
+
+[storage.s3]
+endpoint = "http://localhost:4566"
+force_path_style_access = true
+
+[metastore.postgres]
+max_num_connections = 12
+
 [indexer]
+enable_otlp_endpoint = true
 split_store_max_num_bytes = "1T"
 split_store_max_num_splits = 10_000
 max_concurrent_split_uploads = 8
@@ -26,7 +38,7 @@ max_num_concurrent_split_streams = 120
 max_num_concurrent_split_searches = 150
 
 [jaeger]
-enable_endpoint = false
+enable_endpoint = true
 lookback_period_hours = 24
 max_trace_duration_secs = 600
 max_fetch_spans = 1_000

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -1,4 +1,5 @@
 version: 0.6
+
 cluster_id: quickwit-cluster
 node_id: my-unique-node-id
 enabled_services:
@@ -16,7 +17,19 @@ data_dir: /opt/quickwit/data
 metastore_uri: postgres://username:password@host:port/db
 default_index_root_uri: s3://quickwit-indexes
 
+storage:
+  azure:
+    account_name: quickwit-dev
+  s3:
+    endpoint: http://localhost:4566
+    force_path_style_access: true
+
+metastore:
+  postgres:
+    max_num_connections: 12
+
 indexer:
+  enable_otlp_endpoint: true
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000
   max_concurrent_split_uploads: 8
@@ -30,7 +43,7 @@ searcher:
   max_num_concurrent_split_searches: 150
 
 jaeger:
-  enable_endpoint: false
+  enable_endpoint: true
   lookback_period_hours: 24
   max_trace_duration_secs: 600
   max_fetch_spans: 1000

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -31,10 +31,12 @@ use regex::Regex;
 mod config_value;
 mod index_config;
 pub mod merge_policy_config;
+mod metastore_config;
 mod quickwit_config;
 mod qw_env_vars;
 pub mod service;
 mod source_config;
+mod storage_config;
 mod templating;
 
 // We export that one for backward compatibility.
@@ -58,11 +60,18 @@ use tracing::warn;
 use crate::merge_policy_config::{
     ConstWriteAmplificationMergePolicyConfig, MergePolicyConfig, StableLogMergePolicyConfig,
 };
+pub use crate::metastore_config::{
+    MetastoreBackend, MetastoreConfig, MetastoreConfigs, PostgresMetastoreConfig,
+};
 pub use crate::quickwit_config::{
     IndexerConfig, IngestApiConfig, JaegerConfig, QuickwitConfig, SearcherConfig,
     DEFAULT_QW_CONFIG_PATH,
 };
 use crate::source_config::serialize::{SourceConfigV0_6, VersionedSourceConfig};
+pub use crate::storage_config::{
+    AzureStorageConfig, FileStorageConfig, RamStorageConfig, S3StorageConfig, StorageBackend,
+    StorageConfig, StorageConfigs,
+};
 
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(

--- a/quickwit/quickwit-config/src/metastore_config.rs
+++ b/quickwit/quickwit-config/src/metastore_config.rs
@@ -1,0 +1,231 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::num::NonZeroUsize;
+use std::ops::Deref;
+
+use anyhow::ensure;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, EnumMap};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetastoreBackend {
+    File,
+    #[serde(alias = "pg", alias = "postgres")]
+    PostgreSQL,
+}
+
+/// Holds the metastore configurations defined in the `metastore` section of node config files.
+///
+/// ```yaml
+/// metastore:
+///   file:
+///     polling_interval: 30s
+///
+///   postgres:
+///     max_num_connections: 12
+/// ```
+#[serde_as]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MetastoreConfigs(#[serde_as(as = "EnumMap")] Vec<MetastoreConfig>);
+
+impl MetastoreConfigs {
+    pub fn redact(&mut self) {
+        for metastore_config in self.0.iter_mut() {
+            metastore_config.redact();
+        }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let backends: Vec<MetastoreBackend> = self
+            .0
+            .iter()
+            .map(|metastore_config| metastore_config.backend())
+            .sorted()
+            .collect();
+
+        for (left, right) in backends.iter().zip(backends.iter().skip(1)) {
+            ensure!(
+                left != right,
+                "{left:?} metastore config is defined multiple times."
+            );
+        }
+        Ok(())
+    }
+
+    pub fn find_file(&self) -> Option<&FileMetastoreConfig> {
+        self.0
+            .iter()
+            .find_map(|metastore_config| match metastore_config {
+                MetastoreConfig::File(file_metastore_config) => Some(file_metastore_config),
+                _ => None,
+            })
+    }
+
+    pub fn find_postgres(&self) -> Option<&PostgresMetastoreConfig> {
+        self.0
+            .iter()
+            .find_map(|metastore_config| match metastore_config {
+                MetastoreConfig::PostgreSQL(postgres_metastore_config) => {
+                    Some(postgres_metastore_config)
+                }
+                _ => None,
+            })
+    }
+}
+
+impl Deref for MetastoreConfigs {
+    type Target = Vec<MetastoreConfig>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetastoreConfig {
+    File(FileMetastoreConfig),
+    #[serde(alias = "pg", alias = "postgres")]
+    PostgreSQL(PostgresMetastoreConfig),
+}
+
+impl MetastoreConfig {
+    pub fn backend(&self) -> MetastoreBackend {
+        match self {
+            Self::File(_) => MetastoreBackend::File,
+            Self::PostgreSQL(_) => MetastoreBackend::PostgreSQL,
+        }
+    }
+
+    pub fn as_file(&self) -> Option<&FileMetastoreConfig> {
+        match self {
+            Self::File(file_metastore_config) => Some(file_metastore_config),
+            _ => None,
+        }
+    }
+
+    pub fn as_postgres(&self) -> Option<&PostgresMetastoreConfig> {
+        match self {
+            Self::PostgreSQL(postgres_metastore_config) => Some(postgres_metastore_config),
+            _ => None,
+        }
+    }
+
+    pub fn redact(&mut self) {
+        // TODO: Implement this method when we end up storing secrets in the
+        // metastore config.
+    }
+}
+
+impl From<FileMetastoreConfig> for MetastoreConfig {
+    fn from(file_metastore_config: FileMetastoreConfig) -> Self {
+        Self::File(file_metastore_config)
+    }
+}
+
+impl From<PostgresMetastoreConfig> for MetastoreConfig {
+    fn from(postgres_metastore_config: PostgresMetastoreConfig) -> Self {
+        Self::PostgreSQL(postgres_metastore_config)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresMetastoreConfig {
+    #[serde(default = "PostgresMetastoreConfig::default_max_num_connections")]
+    pub max_num_connections: NonZeroUsize,
+}
+
+impl Default for PostgresMetastoreConfig {
+    fn default() -> Self {
+        Self {
+            max_num_connections: Self::default_max_num_connections(),
+        }
+    }
+}
+
+impl PostgresMetastoreConfig {
+    pub fn default_max_num_connections() -> NonZeroUsize {
+        NonZeroUsize::new(10).expect("10 is always non-zero.")
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileMetastoreConfig;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metastore_configs_serde() {
+        let metastore_configs_yaml = "";
+        let metastore_configs: MetastoreConfigs =
+            serde_yaml::from_str(metastore_configs_yaml).unwrap();
+        assert!(metastore_configs.is_empty());
+
+        let metastore_configs_yaml = r#"
+                postgres:
+                    max_num_connections: 12
+            "#;
+        let metastore_configs: MetastoreConfigs =
+            serde_yaml::from_str(metastore_configs_yaml).unwrap();
+
+        let expected_metastore_configs = MetastoreConfigs(vec![PostgresMetastoreConfig {
+            max_num_connections: NonZeroUsize::new(12).expect("12 is always non-zero."),
+        }
+        .into()]);
+        assert_eq!(metastore_configs, expected_metastore_configs);
+    }
+
+    #[test]
+    fn test_metastore_configs_validate() {
+        let metastore_configs = MetastoreConfigs(vec![
+            PostgresMetastoreConfig {
+                max_num_connections: NonZeroUsize::new(12).expect("12 is always non-zero."),
+            }
+            .into(),
+            PostgresMetastoreConfig {
+                max_num_connections: NonZeroUsize::new(12).expect("12 is always non-zero."),
+            }
+            .into(),
+        ]);
+        metastore_configs.validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_pg_metastore_config_serde() {
+        {
+            let pg_metastore_config_yaml = r#"
+                max_num_connections: 12
+            "#;
+            let pg_metastore_config: PostgresMetastoreConfig =
+                serde_yaml::from_str(pg_metastore_config_yaml).unwrap();
+
+            let expected_pg_metastore_config = PostgresMetastoreConfig {
+                max_num_connections: NonZeroUsize::new(12).expect("12 is always non-zero."),
+            };
+            assert_eq!(pg_metastore_config, expected_pg_metastore_config);
+        }
+    }
+}

--- a/quickwit/quickwit-config/src/storage_config.rs
+++ b/quickwit/quickwit-config/src/storage_config.rs
@@ -1,0 +1,440 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt;
+use std::ops::Deref;
+
+use anyhow::ensure;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, EnumMap};
+
+/// Lists the storage backends supported by Quickwit.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageBackend {
+    /// Azure Blob Storage
+    Azure,
+    /// Local file system
+    File,
+    /// In-memory storage, for testing purposes
+    Ram,
+    /// Amazon S3 or S3-compatible storage
+    S3,
+}
+
+/// Holds the storage configurations defined in the `storage` section of node config files.
+///
+/// ```yaml
+/// storage:
+///   azure:
+///     account: test-account
+///
+///   s3:
+///     endpoint: http://localhost:4566
+/// ```
+#[serde_as]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StorageConfigs(#[serde_as(as = "EnumMap")] Vec<StorageConfig>);
+
+impl StorageConfigs {
+    pub fn redact(&mut self) {
+        for storage_config in self.0.iter_mut() {
+            storage_config.redact();
+        }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let backends: Vec<StorageBackend> = self
+            .0
+            .iter()
+            .map(|storage_config| storage_config.backend())
+            .sorted()
+            .collect();
+
+        for (left, right) in backends.iter().zip(backends.iter().skip(1)) {
+            ensure!(
+                left != right,
+                "{left:?} storage config is defined multiple times.",
+            );
+        }
+        Ok(())
+    }
+
+    pub fn find_azure(&self) -> Option<&AzureStorageConfig> {
+        self.0
+            .iter()
+            .find_map(|storage_config| match storage_config {
+                StorageConfig::Azure(azure_storage_config) => Some(azure_storage_config),
+                _ => None,
+            })
+    }
+
+    pub fn find_file(&self) -> Option<&FileStorageConfig> {
+        self.0
+            .iter()
+            .find_map(|storage_config| match storage_config {
+                StorageConfig::File(file_storage_config) => Some(file_storage_config),
+                _ => None,
+            })
+    }
+
+    pub fn find_ram(&self) -> Option<&RamStorageConfig> {
+        self.0
+            .iter()
+            .find_map(|storage_config| match storage_config {
+                StorageConfig::Ram(ram_storage_config) => Some(ram_storage_config),
+                _ => None,
+            })
+    }
+
+    pub fn find_s3(&self) -> Option<&S3StorageConfig> {
+        self.0
+            .iter()
+            .find_map(|storage_config| match storage_config {
+                StorageConfig::S3(s3_storage_config) => Some(s3_storage_config),
+                _ => None,
+            })
+    }
+}
+
+impl Deref for StorageConfigs {
+    type Target = Vec<StorageConfig>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageConfig {
+    Azure(AzureStorageConfig),
+    File(FileStorageConfig),
+    Ram(RamStorageConfig),
+    S3(S3StorageConfig),
+}
+
+impl StorageConfig {
+    pub fn redact(&mut self) {
+        match self {
+            Self::Azure(azure_storage_config) => azure_storage_config.redact(),
+            Self::File(_) | Self::Ram(_) => {}
+            Self::S3(s3_storage_config) => s3_storage_config.redact(),
+        }
+    }
+
+    pub fn as_azure(&self) -> Option<&AzureStorageConfig> {
+        match self {
+            Self::Azure(azure_storage_config) => Some(azure_storage_config),
+            _ => None,
+        }
+    }
+
+    pub fn as_file(&self) -> Option<&FileStorageConfig> {
+        match self {
+            Self::File(file_storage_config) => Some(file_storage_config),
+            _ => None,
+        }
+    }
+
+    pub fn as_ram(&self) -> Option<&RamStorageConfig> {
+        match self {
+            Self::Ram(ram_storage_config) => Some(ram_storage_config),
+            _ => None,
+        }
+    }
+
+    pub fn as_s3(&self) -> Option<&S3StorageConfig> {
+        match self {
+            Self::S3(s3_storage_config) => Some(s3_storage_config),
+            _ => None,
+        }
+    }
+}
+
+impl From<AzureStorageConfig> for StorageConfig {
+    fn from(azure_storage_config: AzureStorageConfig) -> Self {
+        Self::Azure(azure_storage_config)
+    }
+}
+
+impl From<FileStorageConfig> for StorageConfig {
+    fn from(file_storage_config: FileStorageConfig) -> Self {
+        Self::File(file_storage_config)
+    }
+}
+
+impl From<RamStorageConfig> for StorageConfig {
+    fn from(ram_storage_config: RamStorageConfig) -> Self {
+        Self::Ram(ram_storage_config)
+    }
+}
+
+impl From<S3StorageConfig> for StorageConfig {
+    fn from(s3_storage_config: S3StorageConfig) -> Self {
+        Self::S3(s3_storage_config)
+    }
+}
+
+impl StorageConfig {
+    pub fn backend(&self) -> StorageBackend {
+        match self {
+            Self::Azure(_) => StorageBackend::Azure,
+            Self::File(_) => StorageBackend::File,
+            Self::Ram(_) => StorageBackend::Ram,
+            Self::S3(_) => StorageBackend::S3,
+        }
+    }
+}
+
+#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AzureStorageConfig {
+    #[serde(default)]
+    pub account_name: Option<String>,
+    #[serde(default)]
+    pub access_key: Option<String>,
+}
+
+impl AzureStorageConfig {
+    pub fn redact(&mut self) {
+        if let Some(access_key) = self.access_key.as_mut() {
+            *access_key = "***redacted***".to_string();
+        }
+    }
+}
+
+impl fmt::Debug for AzureStorageConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AzureStorageConfig")
+            .field("account_name", &self.account_name)
+            .field(
+                "access_key",
+                &self.access_key.as_ref().map(|_| "***redacted***"),
+            )
+            .finish()
+    }
+}
+
+#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct S3StorageConfig {
+    #[serde(default)]
+    access_key_id: Option<String>,
+    #[serde(default)]
+    secret_access_key: Option<String>,
+    #[serde(default)]
+    pub region: Option<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub force_path_style_access: bool,
+    #[serde(default)]
+    pub disable_multi_object_delete_requests: bool,
+}
+
+impl S3StorageConfig {
+    pub fn redact(&mut self) {
+        if let Some(secret_access_key) = self.secret_access_key.as_mut() {
+            *secret_access_key = "***redacted***".to_string();
+        }
+    }
+}
+
+impl fmt::Debug for S3StorageConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("S3StorageConfig")
+            .field("access_key_id", &self.access_key_id)
+            .field(
+                "secret_access_key",
+                &self.secret_access_key.as_ref().map(|_| "***redacted***"),
+            )
+            .field("region", &self.region)
+            .field("endpoint", &self.endpoint)
+            .field("force_path_style_access", &self.force_path_style_access)
+            .field(
+                "disable_multi_object_delete_requests",
+                &self.disable_multi_object_delete_requests,
+            )
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileStorageConfig;
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RamStorageConfig;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_configs_serde() {
+        let storage_configs_yaml = "";
+        let storage_configs: StorageConfigs = serde_yaml::from_str(storage_configs_yaml).unwrap();
+        assert!(storage_configs.is_empty());
+
+        let storage_configs_yaml = r#"
+                azure:
+                    account_name: test-account
+                s3:
+                    endpoint: http://localhost:4566
+            "#;
+        let storage_configs: StorageConfigs = serde_yaml::from_str(storage_configs_yaml).unwrap();
+
+        let expected_storage_configs = StorageConfigs(vec![
+            AzureStorageConfig {
+                account_name: Some("test-account".to_string()),
+                ..Default::default()
+            }
+            .into(),
+            S3StorageConfig {
+                endpoint: Some("http://localhost:4566".to_string()),
+                ..Default::default()
+            }
+            .into(),
+        ]);
+        assert_eq!(storage_configs, expected_storage_configs);
+    }
+
+    #[test]
+    fn test_storage_configs_validate() {
+        let storage_configs = StorageConfigs(vec![
+            AzureStorageConfig {
+                account_name: Some("test-account".to_string()),
+                ..Default::default()
+            }
+            .into(),
+            AzureStorageConfig {
+                account_name: Some("prod-account".to_string()),
+                ..Default::default()
+            }
+            .into(),
+        ]);
+        storage_configs.validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_storage_configs_redact() {
+        let mut storage_configs = StorageConfigs(vec![
+            AzureStorageConfig {
+                access_key: Some("test-azure-access-key".to_string()),
+                ..Default::default()
+            }
+            .into(),
+            S3StorageConfig {
+                secret_access_key: Some("test-s3-secret-access-key".to_string()),
+                ..Default::default()
+            }
+            .into(),
+        ]);
+        storage_configs.redact();
+
+        assert_eq!(
+            storage_configs
+                .find_azure()
+                .unwrap()
+                .access_key
+                .as_ref()
+                .unwrap(),
+            "***redacted***"
+        );
+        assert_eq!(
+            storage_configs
+                .find_s3()
+                .unwrap()
+                .secret_access_key
+                .as_ref()
+                .unwrap(),
+            "***redacted***"
+        );
+    }
+
+    #[test]
+    fn test_storage_azure_config_serde() {
+        {
+            let azure_storage_config_yaml = r#"
+                account_name: test-account
+            "#;
+            let azure_storage_config: AzureStorageConfig =
+                serde_yaml::from_str(azure_storage_config_yaml).unwrap();
+
+            let expected_azure_config = AzureStorageConfig {
+                account_name: Some("test-account".to_string()),
+                ..Default::default()
+            };
+            assert_eq!(azure_storage_config, expected_azure_config);
+        }
+        {
+            let azure_storage_config_yaml = r#"
+                account_name: test-account
+                access_key: test-access-key
+            "#;
+            let azure_storage_config: AzureStorageConfig =
+                serde_yaml::from_str(azure_storage_config_yaml).unwrap();
+
+            let expected_azure_config = AzureStorageConfig {
+                account_name: Some("test-account".to_string()),
+                access_key: Some("test-access-key".to_string()),
+            };
+            assert_eq!(azure_storage_config, expected_azure_config);
+        }
+    }
+
+    #[test]
+    fn test_storage_s3_config_serde() {
+        {
+            let s3_storage_config_yaml = r#"
+                endpoint: http://localhost:4566
+            "#;
+            let s3_storage_config: S3StorageConfig =
+                serde_yaml::from_str(s3_storage_config_yaml).unwrap();
+
+            let expected_s3_config = S3StorageConfig {
+                endpoint: Some("http://localhost:4566".to_string()),
+                ..Default::default()
+            };
+            assert_eq!(s3_storage_config, expected_s3_config);
+        }
+        {
+            let s3_storage_config_yaml = r#"
+                region: us-east-1
+                endpoint: http://localhost:4566
+                force_path_style_access: true
+                disable_multi_object_delete_requests: true
+            "#;
+            let s3_storage_config: S3StorageConfig =
+                serde_yaml::from_str(s3_storage_config_yaml).unwrap();
+
+            let expected_s3_config = S3StorageConfig {
+                region: Some("us-east-1".to_string()),
+                endpoint: Some("http://localhost:4566".to_string()),
+                force_path_style_access: true,
+                disable_multi_object_delete_requests: true,
+                ..Default::default()
+            };
+            assert_eq!(s3_storage_config, expected_s3_config);
+        }
+    }
+}

--- a/quickwit/quickwit-core/src/lib.rs
+++ b/quickwit/quickwit-core/src/lib.rs
@@ -29,7 +29,7 @@ mod tests {
 
     use quickwit_common::FileEntry;
     use quickwit_indexing::TestSandbox;
-    use quickwit_storage::StorageUriResolver;
+    use quickwit_storage::StorageResolver;
 
     use crate::IndexService;
 
@@ -68,7 +68,7 @@ mod tests {
         }
         // Now delete the index.
         let index_service =
-            IndexService::new(test_sandbox.metastore(), StorageUriResolver::for_test());
+            IndexService::new(test_sandbox.metastore(), StorageResolver::unconfigured());
         let deleted_file_entries = index_service.delete_index(index_id, false).await?;
         assert_eq!(deleted_file_entries.len(), 1);
         test_sandbox.assert_quit().await;

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -39,7 +39,7 @@ use quickwit_ingest::{DropQueueRequest, IngestApiService, ListQueuesRequest, QUE
 use quickwit_metastore::{IndexMetadata, Metastore, MetastoreError};
 use quickwit_proto::indexing_api::{ApplyIndexingPlanRequest, IndexingTask};
 use quickwit_proto::{IndexUid, ServiceError, ServiceErrorCode};
-use quickwit_storage::{StorageError, StorageResolverError, StorageUriResolver};
+use quickwit_storage::{StorageError, StorageResolver, StorageResolverError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Semaphore;
@@ -133,7 +133,7 @@ pub struct IndexingService {
     cluster: Cluster,
     metastore: Arc<dyn Metastore>,
     ingest_api_service_opt: Option<Mailbox<IngestApiService>>,
-    storage_resolver: StorageUriResolver,
+    storage_resolver: StorageResolver,
     indexing_pipeline_handles: HashMap<IndexingPipelineId, ActorHandle<IndexingPipeline>>,
     counters: IndexingServiceCounters,
     local_split_store: Arc<LocalSplitStore>,
@@ -152,7 +152,7 @@ impl IndexingService {
         cluster: Cluster,
         metastore: Arc<dyn Metastore>,
         ingest_api_service_opt: Option<Mailbox<IngestApiService>>,
-        storage_resolver: StorageUriResolver,
+        storage_resolver: StorageResolver,
     ) -> anyhow::Result<IndexingService> {
         let split_store_space_quota = SplitStoreQuota::new(
             indexer_config.split_store_max_num_splits,
@@ -798,12 +798,11 @@ mod tests {
     use quickwit_actors::{Health, ObservationType, Supervisable, Universe, HEARTBEAT};
     use quickwit_cluster::create_cluster_for_test;
     use quickwit_common::rand::append_random_suffix;
-    use quickwit_common::uri::Uri;
     use quickwit_config::{
         IngestApiConfig, SourceConfig, SourceInputFormat, SourceParams, VecSourceParams,
     };
     use quickwit_ingest::{init_ingest_api, CreateQueueIfNotExistsRequest};
-    use quickwit_metastore::{quickwit_metastore_uri_resolver, MockMetastore};
+    use quickwit_metastore::{metastore_for_test, MockMetastore};
     use quickwit_proto::indexing_api::IndexingTask;
 
     use super::*;
@@ -816,7 +815,7 @@ mod tests {
     ) -> (Mailbox<IndexingService>, ActorHandle<IndexingService>) {
         let indexer_config = IndexerConfig::for_test().unwrap();
         let num_blocking_threads = 1;
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let queues_dir_path = data_dir_path.join(QUEUES_DIR_NAME);
         let ingest_api_service =
             init_ingest_api(universe, &queues_dir_path, &IngestApiConfig::default())
@@ -844,11 +843,7 @@ mod tests {
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await
             .unwrap();
-        let metastore_uri = Uri::from_well_formed("ram:///metastore");
-        let metastore = quickwit_metastore_uri_resolver()
-            .resolve(&metastore_uri)
-            .await
-            .unwrap();
+        let metastore = metastore_for_test();
 
         let index_id = append_random_suffix("test-indexing-service");
         let index_uri = format!("ram:///indexes/{index_id}");
@@ -941,11 +936,7 @@ mod tests {
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await
             .unwrap();
-        let metastore_uri = Uri::from_well_formed("ram:///metastore");
-        let metastore = quickwit_metastore_uri_resolver()
-            .resolve(&metastore_uri)
-            .await
-            .unwrap();
+        let metastore = metastore_for_test();
 
         let index_id = append_random_suffix("test-indexing-service");
         let index_uri = format!("ram:///indexes/{index_id}");
@@ -999,11 +990,7 @@ mod tests {
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await
             .unwrap();
-        let metastore_uri = Uri::from_well_formed("ram:///metastore");
-        let metastore = quickwit_metastore_uri_resolver()
-            .resolve(&metastore_uri)
-            .await
-            .unwrap();
+        let metastore = metastore_for_test();
 
         let index_id = append_random_suffix("test-indexing-service");
         let index_uri = format!("ram:///indexes/{index_id}");
@@ -1194,11 +1181,7 @@ mod tests {
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await
             .unwrap();
-        let metastore_uri = Uri::from_well_formed("ram:///metastore");
-        let metastore = quickwit_metastore_uri_resolver()
-            .resolve(&metastore_uri)
-            .await
-            .unwrap();
+        let metastore = metastore_for_test();
 
         let index_id = append_random_suffix("test-indexing-service");
         let index_uri = format!("ram:///indexes/{index_id}");
@@ -1224,7 +1207,7 @@ mod tests {
         let data_dir_path = temp_dir.path().to_path_buf();
         let indexer_config = IndexerConfig::for_test().unwrap();
         let num_blocking_threads = 1;
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let universe = Universe::with_accelerated_time();
         let queues_dir_path = data_dir_path.join(QUEUES_DIR_NAME);
         let ingest_api_service =
@@ -1387,11 +1370,7 @@ mod tests {
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await
             .unwrap();
-        let metastore_uri = Uri::from_well_formed("ram:///metastore");
-        let metastore = quickwit_metastore_uri_resolver()
-            .resolve(&metastore_uri)
-            .await
-            .unwrap();
+        let metastore = metastore_for_test();
         let index_uid = metastore.create_index(index_config).await.unwrap();
 
         // Setup ingest api objects
@@ -1414,7 +1393,7 @@ mod tests {
         let data_dir_path = temp_dir.path().to_path_buf();
         let indexer_config = IndexerConfig::for_test().unwrap();
         let num_blocking_threads = 1;
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let mut indexing_server = IndexingService::new(
             "test-ingest-api-gc-node".to_string(),
             data_dir_path,

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -26,7 +26,7 @@ use quickwit_cluster::Cluster;
 use quickwit_config::QuickwitConfig;
 use quickwit_ingest::IngestApiService;
 use quickwit_metastore::Metastore;
-use quickwit_storage::StorageUriResolver;
+use quickwit_storage::StorageResolver;
 use tracing::info;
 
 pub use crate::actors::{
@@ -71,7 +71,7 @@ pub async fn start_indexing_service(
     cluster: Cluster,
     metastore: Arc<dyn Metastore>,
     ingest_api_service: Mailbox<IngestApiService>,
-    storage_resolver: StorageUriResolver,
+    storage_resolver: StorageResolver,
 ) -> anyhow::Result<Mailbox<IndexingService>> {
     info!("Starting indexer service.");
 

--- a/quickwit/quickwit-indexing/src/models/split_attrs.rs
+++ b/quickwit/quickwit-indexing/src/models/split_attrs.rs
@@ -31,7 +31,7 @@ pub struct SplitAttrs {
     /// Split ID. Joined with the index URI (<index URI>/<split ID>), this ID
     /// should be enough to uniquely identify a split.
     /// In reality, some information may be implicitly configured
-    /// in the storage URI resolver: for instance, the Amazon S3 region.
+    /// in the storage resolver: for instance, the Amazon S3 region.
     pub split_id: String,
 
     /// Partition to which the split belongs to.

--- a/quickwit/quickwit-integration-tests/Cargo.toml
+++ b/quickwit/quickwit-integration-tests/Cargo.toml
@@ -35,6 +35,7 @@ quickwit-indexing = { workspace = true, features = ["testsuite"] }
 quickwit-janitor = { workspace = true }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-search = { workspace = true, features = ["testsuite"] }
+quickwit-storage = { workspace = true, features = ["testsuite"] }
 quickwit-rest-client = { workspace = true }
 quickwit-serve = { workspace = true }
 quickwit-proto = { workspace = true }

--- a/quickwit/quickwit-janitor/Cargo.toml
+++ b/quickwit/quickwit-janitor/Cargo.toml
@@ -45,8 +45,8 @@ quickwit-storage = { workspace = true }
 testsuite = []
 
 [dev-dependencies]
-mockall = "0.11"
-tempfile = "3"
+mockall = { workspace = true }
+tempfile = { workspace = true }
 
 quickwit-actors = { workspace = true, features = ["testsuite"] }
 quickwit-common = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
@@ -29,7 +29,7 @@ use quickwit_config::IndexConfig;
 use quickwit_metastore::Metastore;
 use quickwit_proto::IndexUid;
 use quickwit_search::SearchJobPlacer;
-use quickwit_storage::StorageUriResolver;
+use quickwit_storage::StorageResolver;
 use serde::Serialize;
 use tracing::{error, info, warn};
 
@@ -53,7 +53,7 @@ pub struct DeleteTaskServiceState {
 pub struct DeleteTaskService {
     metastore: Arc<dyn Metastore>,
     search_job_placer: SearchJobPlacer,
-    storage_resolver: StorageUriResolver,
+    storage_resolver: StorageResolver,
     delete_service_task_dir: PathBuf,
     pipeline_handles_by_index_uid: HashMap<IndexUid, ActorHandle<DeleteTaskPipeline>>,
     max_concurrent_split_uploads: usize,
@@ -63,7 +63,7 @@ impl DeleteTaskService {
     pub async fn new(
         metastore: Arc<dyn Metastore>,
         search_job_placer: SearchJobPlacer,
-        storage_resolver: StorageUriResolver,
+        storage_resolver: StorageResolver,
         data_dir_path: PathBuf,
         max_concurrent_split_uploads: usize,
     ) -> anyhow::Result<Self> {
@@ -206,7 +206,7 @@ mod tests {
     use quickwit_indexing::TestSandbox;
     use quickwit_proto::metastore_api::DeleteQuery;
     use quickwit_search::{searcher_pool_for_test, MockSearchService, SearchJobPlacer};
-    use quickwit_storage::StorageUriResolver;
+    use quickwit_storage::StorageResolver;
 
     use super::{DeleteTaskService, UPDATE_PIPELINES_INTERVAL};
 
@@ -233,7 +233,7 @@ mod tests {
         let delete_task_service = DeleteTaskService::new(
             metastore.clone(),
             search_job_placer,
-            StorageUriResolver::for_test(),
+            StorageResolver::unconfigured(),
             data_dir_path,
             4,
         )

--- a/quickwit/quickwit-janitor/src/actors/garbage_collector.rs
+++ b/quickwit/quickwit-janitor/src/actors/garbage_collector.rs
@@ -26,7 +26,7 @@ use futures::{stream, StreamExt};
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, Handler};
 use quickwit_metastore::Metastore;
-use quickwit_storage::StorageUriResolver;
+use quickwit_storage::StorageResolver;
 use serde::Serialize;
 use tracing::{error, info};
 
@@ -73,12 +73,12 @@ struct Loop;
 /// An actor for collecting garbage periodically from an index.
 pub struct GarbageCollector {
     metastore: Arc<dyn Metastore>,
-    storage_resolver: StorageUriResolver,
+    storage_resolver: StorageResolver,
     counters: GarbageCollectorCounters,
 }
 
 impl GarbageCollector {
-    pub fn new(metastore: Arc<dyn Metastore>, storage_resolver: StorageUriResolver) -> Self {
+    pub fn new(metastore: Arc<dyn Metastore>, storage_resolver: StorageResolver) -> Self {
         Self {
             metastore,
             storage_resolver,
@@ -327,7 +327,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_garbage_collect_calls_dependencies_appropriately() {
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
             .expect_list_indexes_metadatas()
@@ -388,7 +388,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_garbage_collect_get_calls_repeatedly() {
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
             .expect_list_indexes_metadatas()
@@ -474,7 +474,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_garbage_collect_get_called_repeatedly_on_failure() {
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
             .expect_list_indexes_metadatas()
@@ -505,7 +505,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_garbage_collect_fails_to_resolve_storage() {
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
             .expect_list_indexes_metadatas()
@@ -535,7 +535,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_garbage_collect_fails_to_run_gc_on_one_index() {
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
             .expect_list_indexes_metadatas()
@@ -604,7 +604,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_garbage_collect_fails_to_run_delete_on_one_index() {
-        let storage_resolver = StorageUriResolver::for_test();
+        let storage_resolver = StorageResolver::unconfigured();
         let mut mock_metastore = MockMetastore::default();
         mock_metastore
             .expect_list_indexes_metadatas()

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -26,7 +26,7 @@ use quickwit_common::FileEntry;
 use quickwit_config::QuickwitConfig;
 use quickwit_metastore::Metastore;
 use quickwit_search::SearchJobPlacer;
-use quickwit_storage::StorageUriResolver;
+use quickwit_storage::StorageResolver;
 use tracing::info;
 
 pub mod actors;
@@ -53,10 +53,10 @@ pub async fn start_janitor_service(
     config: &QuickwitConfig,
     metastore: Arc<dyn Metastore>,
     search_job_placer: SearchJobPlacer,
-    storage_uri_resolver: StorageUriResolver,
+    storage_resolver: StorageResolver,
 ) -> anyhow::Result<Mailbox<JanitorService>> {
     info!("Starting janitor service.");
-    let garbage_collector = GarbageCollector::new(metastore.clone(), storage_uri_resolver.clone());
+    let garbage_collector = GarbageCollector::new(metastore.clone(), storage_resolver.clone());
     let (_, garbage_collector_handle) = universe.spawn_builder().spawn(garbage_collector);
 
     let retention_policy_executor = RetentionPolicyExecutor::new(metastore.clone());
@@ -66,7 +66,7 @@ pub async fn start_janitor_service(
     let delete_task_service = DeleteTaskService::new(
         metastore,
         search_job_placer,
-        storage_uri_resolver,
+        storage_resolver,
         config.data_dir_path.clone(),
         config.indexer_config.max_concurrent_split_uploads,
     )

--- a/quickwit/quickwit-metastore/src/error.rs
+++ b/quickwit/quickwit-metastore/src/error.rs
@@ -19,13 +19,13 @@
 
 use quickwit_proto::{ServiceError, ServiceErrorCode};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use thiserror::Error as ThisError;
 
 use crate::checkpoint::IncompatibleCheckpointDelta;
 
 /// Metastore error kinds.
 #[allow(missing_docs)]
-#[derive(Clone, Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, ThisError, Serialize, Deserialize, PartialEq, Eq)]
 pub enum MetastoreError {
     #[error("Connection error: `{message}`.")]
     ConnectionError { message: String },
@@ -133,21 +133,23 @@ impl ServiceError for MetastoreError {
 pub type MetastoreResult<T> = Result<T, MetastoreError>;
 
 /// Generic Storage Resolver Error.
-#[derive(Error, Debug)]
+#[derive(Debug, ThisError)]
 pub enum MetastoreResolverError {
-    /// The input is not a valid URI.
-    /// A protocol is required for the URI.
-    #[error("Invalid URI format: required: `{0}`")]
+    /// The metastore config is invalid.
+    #[error("Invalid metastore config: `{0}`")]
+    InvalidConfig(String),
+
+    /// The URI does not contain sufficient information to connect to the metastore.
+    #[error("Invalid metastore URI: `{0}`")]
     InvalidUri(String),
 
-    /// The protocol is not supported by this resolver.
-    #[error("Unsupported protocol: `{0}`")]
-    ProtocolUnsupported(String),
+    /// The requested backend is unsupported or unavailable.
+    #[error("Unsupported metastore backend: `{0}`")]
+    UnsupportedBackend(String),
 
-    /// The URI is valid, and is meant to be handled by this resolver,
-    /// but the resolver failed to actually connect to the storage.
-    /// e.g. Connection error, credential error, incompatible version,
-    /// internal error in third party, etc.
+    /// The config and URI are valid, and are meant to be handled by this resolver, but the
+    /// resolver failed to actually connect to the backend. e.g. connection error, credentials
+    /// error, incompatible version, internal error in a third party, etc.
     #[error("Failed to connect to metastore: `{0}`")]
     FailedToOpenMetastore(MetastoreError),
 }

--- a/quickwit/quickwit-metastore/src/lib.rs
+++ b/quickwit/quickwit-metastore/src/lib.rs
@@ -33,6 +33,7 @@ mod tests;
 pub mod checkpoint;
 mod error;
 mod metastore;
+mod metastore_factory;
 mod metastore_resolver;
 mod metrics;
 mod split_metadata;
@@ -51,9 +52,8 @@ pub use metastore::retrying_metastore::RetryingMetastore;
 #[cfg(any(test, feature = "testsuite"))]
 pub use metastore::MockMetastore;
 pub use metastore::{file_backed_metastore, IndexMetadata, ListSplitsQuery, Metastore};
-pub use metastore_resolver::{
-    quickwit_metastore_uri_resolver, MetastoreFactory, MetastoreUriResolver,
-};
+pub use metastore_factory::{MetastoreFactory, UnsupportedMetastore};
+pub use metastore_resolver::MetastoreResolver;
 use quickwit_common::is_disjoint;
 use quickwit_doc_mapper::tag_pruning::TagFilterAst;
 pub use split_metadata::{Split, SplitMetadata, SplitState};

--- a/quickwit/quickwit-metastore/src/metastore_factory.rs
+++ b/quickwit/quickwit-metastore/src/metastore_factory.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use quickwit_common::uri::Uri;
+use quickwit_config::{MetastoreBackend, MetastoreConfig};
+
+use crate::{Metastore, MetastoreResolverError};
+
+/// A metastore factory builds a [`Metastore`] object for a target [`MetastoreBackend`] from a
+/// [`MetastoreConfig`] and a [`Uri`].
+#[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
+#[async_trait]
+pub trait MetastoreFactory: Send + Sync + 'static {
+    /// Returns the metastore backend targeted by the factory.
+    fn backend(&self) -> MetastoreBackend;
+
+    /// Returns the appropriate [`Metastore`] object for the `uri`.
+    async fn resolve(
+        &self,
+        metastore_config: &MetastoreConfig,
+        uri: &Uri,
+    ) -> Result<Arc<dyn Metastore>, MetastoreResolverError>;
+}
+
+/// A metastore factory for handling unsupported or unavailable metastore backends.
+#[derive(Clone)]
+pub struct UnsupportedMetastore {
+    backend: MetastoreBackend,
+    message: &'static str,
+}
+
+impl UnsupportedMetastore {
+    /// Creates a new [`UnsupportedMetastore`].
+    pub fn new(backend: MetastoreBackend, message: &'static str) -> Self {
+        Self { backend, message }
+    }
+}
+
+#[async_trait]
+impl MetastoreFactory for UnsupportedMetastore {
+    fn backend(&self) -> MetastoreBackend {
+        self.backend
+    }
+
+    async fn resolve(
+        &self,
+        _metastore_config: &MetastoreConfig,
+        _uri: &Uri,
+    ) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {
+        Err(MetastoreResolverError::UnsupportedBackend(
+            self.message.to_string(),
+        ))
+    }
+}

--- a/quickwit/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit/quickwit-metastore/src/metastore_resolver.rs
@@ -18,148 +18,168 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use once_cell::sync::OnceCell;
+use anyhow::ensure;
+use once_cell::sync::Lazy;
 use quickwit_common::uri::{Protocol, Uri};
+use quickwit_config::{MetastoreBackend, MetastoreConfig, MetastoreConfigs};
+use quickwit_storage::StorageResolver;
 
 use crate::metastore::file_backed_metastore::FileBackedMetastoreFactory;
 #[cfg(feature = "postgres")]
 use crate::metastore::postgresql_metastore::PostgresqlMetastoreFactory;
-use crate::{Metastore, MetastoreResolverError};
+use crate::{Metastore, MetastoreFactory, MetastoreResolverError};
 
-/// A metastore factory builds a [`Metastore`] object from an URI.
-#[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
-#[async_trait]
-pub trait MetastoreFactory: Send + Sync + 'static {
-    /// Returns the appropriate [`Metastore`] object for the URI.
-    async fn resolve(&self, uri: &Uri) -> Result<Arc<dyn Metastore>, MetastoreResolverError>;
+type FactoryAndConfig = (Box<dyn MetastoreFactory>, MetastoreConfig);
+
+/// Returns the [`Metastore`] instance associated with the protocol of a URI. The actual creation of
+/// metastore objects is delegated to pre-registered [`MetastoreFactory`]. The resolver is only
+/// responsible for dispatching to the appropriate factory.
+#[derive(Clone)]
+pub struct MetastoreResolver {
+    per_backend_factories: Arc<HashMap<MetastoreBackend, FactoryAndConfig>>,
+}
+
+impl fmt::Debug for MetastoreResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetastoreResolver").finish()
+    }
+}
+
+impl MetastoreResolver {
+    /// Creates an empty [`MetastoreResolverBuilder`].
+    pub fn builder() -> MetastoreResolverBuilder {
+        MetastoreResolverBuilder::default()
+    }
+
+    /// Resolves the given `uri`.
+    pub async fn resolve(&self, uri: &Uri) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {
+        let backend = match uri.protocol() {
+            Protocol::Azure => MetastoreBackend::File,
+            Protocol::File => MetastoreBackend::File,
+            Protocol::Ram => MetastoreBackend::File,
+            Protocol::S3 => MetastoreBackend::File,
+            Protocol::PostgreSQL => MetastoreBackend::PostgreSQL,
+            _ => {
+                return Err(MetastoreResolverError::UnsupportedBackend(
+                    "no implementation exists for this backend.".to_string(),
+                ))
+            }
+        };
+        let (metastore_factory, metastore_config) = self
+            .per_backend_factories
+            .get(&backend)
+            .ok_or(MetastoreResolverError::UnsupportedBackend(
+                "no metastore factory is registered for this backend.".to_string(),
+            ))?;
+        let metastore = metastore_factory.resolve(metastore_config, uri).await?;
+        Ok(metastore)
+    }
+
+    /// Creates and returns a [`MetastoreResolver`] holding the default configuration for each
+    /// backend. Note that if the environment (env vars, instance metadata, ...) fails
+    /// to provide the necessary credentials, the default Azure or S3 file-backed metastores
+    /// returned by this resolver will not work.
+    pub fn unconfigured() -> Self {
+        static METASTORE_RESOLVER: Lazy<MetastoreResolver> = Lazy::new(|| {
+            MetastoreResolver::configured(
+                StorageResolver::unconfigured(),
+                &MetastoreConfigs::default(),
+            )
+        });
+        METASTORE_RESOLVER.clone()
+    }
+
+    /// Creates and returns a [`MetastoreResolver`].
+    pub fn configured(
+        storage_resolver: StorageResolver,
+        metastore_configs: &MetastoreConfigs,
+    ) -> Self {
+        let mut builder = MetastoreResolver::builder().register(
+            FileBackedMetastoreFactory::new(storage_resolver),
+            metastore_configs
+                .find_file()
+                .cloned()
+                .unwrap_or_default()
+                .into(),
+        );
+        #[cfg(feature = "postgres")]
+        {
+            builder = builder.register(
+                PostgresqlMetastoreFactory::default(),
+                metastore_configs
+                    .find_postgres()
+                    .cloned()
+                    .unwrap_or_default()
+                    .into(),
+            );
+        }
+        #[cfg(not(feature = "postgres"))]
+        {
+            use quickwit_config::PostgresMetastoreConfig;
+
+            use crate::UnsupportedMetastore;
+
+            builder = builder.register(
+                UnsupportedMetastore::new(
+                    MetastoreBackend::PostgreSQL,
+                    "Quickwit was compiled without the `postgres` feature.",
+                ),
+                PostgresMetastoreConfig::default().into(),
+            );
+        }
+        builder
+            .build()
+            .expect("Metastore factory and config backends should match.")
+    }
 }
 
 #[derive(Default)]
-pub struct MetastoreUriResolverBuilder {
-    per_protocol_resolver: HashMap<Protocol, Arc<dyn MetastoreFactory>>,
+pub struct MetastoreResolverBuilder {
+    per_protocol_factories: HashMap<MetastoreBackend, (Box<dyn MetastoreFactory>, MetastoreConfig)>,
 }
 
-impl MetastoreUriResolverBuilder {
-    pub fn register<S: MetastoreFactory>(mut self, protocol: Protocol, resolver: S) -> Self {
-        self.per_protocol_resolver
-            .insert(protocol, Arc::new(resolver));
+impl MetastoreResolverBuilder {
+    pub fn register<S: MetastoreFactory>(
+        mut self,
+        metastore_factory: S,
+        metastore_config: MetastoreConfig,
+    ) -> Self {
+        self.per_protocol_factories.insert(
+            metastore_factory.backend(),
+            (Box::new(metastore_factory), metastore_config),
+        );
         self
     }
 
-    pub fn build(self) -> MetastoreUriResolver {
-        MetastoreUriResolver {
-            per_protocol_resolver: Arc::new(self.per_protocol_resolver),
+    pub fn build(self) -> anyhow::Result<MetastoreResolver> {
+        for (metastore_factory, metastore_config) in self.per_protocol_factories.values() {
+            ensure!(
+                metastore_factory.backend() == metastore_config.backend(),
+                "Metastore factory and config backends do not match: {:?} vs. {:?}.",
+                metastore_factory.backend(),
+                metastore_config.backend(),
+            );
         }
-    }
-}
-
-/// Resolves an URI by dispatching it to the right [`MetastoreFactory`]
-/// based on its protocol.
-pub struct MetastoreUriResolver {
-    per_protocol_resolver: Arc<HashMap<Protocol, Arc<dyn MetastoreFactory>>>,
-}
-
-/// Quickwit supported storage resolvers.
-///
-/// The returned metastore uri resolver is a Singleton.
-pub fn quickwit_metastore_uri_resolver() -> &'static MetastoreUriResolver {
-    static METASTORE_URI_RESOLVER: OnceCell<MetastoreUriResolver> = OnceCell::new();
-    METASTORE_URI_RESOLVER.get_or_init(|| {
-        #[allow(unused_mut)]
-        let mut builder = MetastoreUriResolver::builder()
-            .register(Protocol::Ram, FileBackedMetastoreFactory::default())
-            .register(Protocol::File, FileBackedMetastoreFactory::default())
-            .register(Protocol::S3, FileBackedMetastoreFactory::default());
-
-        #[cfg(feature = "postgres")]
-        {
-            builder = builder.register(Protocol::PostgreSQL, PostgresqlMetastoreFactory::default());
-        }
-
-        #[cfg(not(feature = "postgres"))]
-        {
-            builder = builder.register(
-                Protocol::PostgreSQL,
-                UnsupportedMetastore {
-                    message: "postgres unsupported, quickwit was compiled without the 'postgres' \
-                              feature flag"
-                        .to_string(),
-                },
-            )
-        }
-
-        #[cfg(feature = "azure")]
-        {
-            builder = builder.register(Protocol::Azure, FileBackedMetastoreFactory::default());
-        }
-
-        #[cfg(not(feature = "azure"))]
-        {
-            builder = builder.register(
-                Protocol::Azure,
-                UnsupportedMetastore {
-                    message: "azure unsupported, quickwit was compiled without the `azure` \
-                              feature flag"
-                        .to_string(),
-                },
-            )
-        }
-
-        builder.build()
-    })
-}
-
-/// A metastore factory for handling unsupported metastore.
-#[derive(Clone, Default)]
-pub struct UnsupportedMetastore {
-    message: String,
-}
-
-#[async_trait]
-impl MetastoreFactory for UnsupportedMetastore {
-    async fn resolve(&self, _uri: &Uri) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {
-        Err(MetastoreResolverError::ProtocolUnsupported(
-            self.message.to_string(),
-        ))
-    }
-}
-
-impl MetastoreUriResolver {
-    /// Creates an empty `MetastoreUriResolver`.
-    pub fn builder() -> MetastoreUriResolverBuilder {
-        MetastoreUriResolverBuilder::default()
-    }
-
-    /// Resolves the given URI.
-    pub async fn resolve(&self, uri: &Uri) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {
-        let resolver = self
-            .per_protocol_resolver
-            .get(&uri.protocol())
-            .ok_or_else(|| {
-                MetastoreResolverError::ProtocolUnsupported(uri.protocol().to_string())
-            })?;
-        let metastore = resolver.resolve(uri).await?;
-        Ok(metastore)
+        let metastore_resolver = MetastoreResolver {
+            per_backend_factories: Arc::new(self.per_protocol_factories),
+        };
+        Ok(metastore_resolver)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use quickwit_common::uri::Uri;
-
-    use crate::quickwit_metastore_uri_resolver;
+    use super::*;
 
     #[tokio::test]
     async fn test_metastore_resolver_should_not_raise_errors_on_file() {
-        let metastore_resolver = quickwit_metastore_uri_resolver();
+        let metastore_resolver = MetastoreResolver::unconfigured();
         let tmp_dir = tempfile::tempdir().unwrap();
         let metastore_filepath = format!("file://{}/metastore", tmp_dir.path().display());
-        let metastore_uri = Uri::from_str(&metastore_filepath).unwrap();
+        let metastore_uri = Uri::from_well_formed(&metastore_filepath);
         metastore_resolver.resolve(&metastore_uri).await.unwrap();
     }
 
@@ -167,7 +187,7 @@ mod tests {
     #[tokio::test]
     async fn test_postgres_and_postgresql_protocol_accepted() {
         use std::env;
-        let metastore_resolver = quickwit_metastore_uri_resolver();
+        let metastore_resolver = MetastoreResolver::unconfigured();
         // If the database defined in the env var or the default one is not up, the
         // test block after making 10 attempts with a timeout of 10s each = 100s.
         let test_database_url = env::var("TEST_DATABASE_URL").unwrap_or_else(|_| {

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -64,7 +64,7 @@ pub struct SplitMetadata {
     /// Split ID. Joined with the index URI (<index URI>/<split ID>), this ID
     /// should be enough to uniquely identify a split.
     /// In reality, some information may be implicitly configured
-    /// in the storage URI resolver: for instance, the Amazon S3 region.
+    /// in the storage resolver: for instance, the Amazon S3 region.
     pub split_id: String,
 
     /// Id of the index this split belongs to.

--- a/quickwit/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata_version.rs
@@ -31,7 +31,7 @@ pub(crate) struct SplitMetadataV0_6 {
     /// Split ID. Joined with the index URI (<index URI>/<split ID>), this ID
     /// should be enough to uniquely identify a split.
     /// In reality, some information may be implicitly configured
-    /// in the storage URI resolver: for instance, the Amazon S3 region.
+    /// in the storage resolver: for instance, the Amazon S3 region.
     pub split_id: String,
 
     /// Uid of the index this split belongs to.

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -68,7 +68,7 @@ use quickwit_metastore::{ListSplitsQuery, Metastore, SplitMetadata, SplitState};
 use quickwit_proto::{
     Hit, IndexUid, PartialHit, SearchRequest, SearchResponse, SplitIdAndFooterOffsets,
 };
-use quickwit_storage::StorageUriResolver;
+use quickwit_storage::StorageResolver;
 use tantivy::DocAddress;
 
 pub use crate::client::{
@@ -178,7 +178,7 @@ fn convert_document_to_json_string(
 pub async fn single_node_search(
     mut search_request: SearchRequest,
     metastore: &dyn Metastore,
-    storage_resolver: StorageUriResolver,
+    storage_resolver: StorageResolver,
 ) -> crate::Result<SearchResponse> {
     let start_instant = tokio::time::Instant::now();
     let index_metadata = metastore.index_metadata(&search_request.index_id).await?;
@@ -273,13 +273,13 @@ pub async fn single_node_search(
 pub async fn start_searcher_service(
     searcher_config: SearcherConfig,
     metastore: Arc<dyn Metastore>,
-    storage_uri_resolver: StorageUriResolver,
+    storage_resolver: StorageResolver,
     search_job_placer: SearchJobPlacer,
 ) -> anyhow::Result<Arc<dyn SearchService>> {
     let cluster_client = ClusterClient::new(search_job_placer.clone());
     let search_service = Arc::new(SearchServiceImpl::new(
         metastore,
-        storage_uri_resolver,
+        storage_resolver,
         cluster_client,
         search_job_placer,
         searcher_config,

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -66,7 +66,7 @@ async fn test_single_node_simple() -> anyhow::Result<()> {
     let single_node_result = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     assert_eq!(single_node_result.num_hits, 1);
@@ -112,7 +112,7 @@ async fn test_single_node_termset() -> anyhow::Result<()> {
     let single_node_result = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     assert_eq!(single_node_result.num_hits, 1);
@@ -153,7 +153,7 @@ async fn test_single_search_with_snippet() -> anyhow::Result<()> {
     let single_node_result = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     assert_eq!(single_node_result.num_hits, 2);
@@ -192,7 +192,7 @@ async fn slop_search_and_check(
     let single_node_result = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     assert_eq!(
@@ -312,7 +312,7 @@ async fn test_single_node_several_splits() -> anyhow::Result<()> {
     let single_node_result = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     assert_eq!(single_node_result.num_hits, 20);
@@ -385,7 +385,7 @@ async fn test_single_node_filtering() -> anyhow::Result<()> {
     let single_node_response = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     assert_eq!(single_node_response.num_hits, 10);
@@ -406,7 +406,7 @@ async fn test_single_node_filtering() -> anyhow::Result<()> {
     let single_node_response = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     assert_eq!(single_node_response.num_hits, 19);
@@ -426,7 +426,7 @@ async fn test_single_node_filtering() -> anyhow::Result<()> {
     let single_node_response = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await;
     assert!(single_node_response.is_err());
@@ -510,7 +510,7 @@ async fn single_node_search_sort_by_field(
     match single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await
     {
@@ -590,9 +590,9 @@ async fn test_sort_bm25() {
             ..Default::default()
         };
         let metastore = test_sandbox.metastore();
-        let storage_uri_resolver = test_sandbox.storage_uri_resolver();
+        let storage_resolver = test_sandbox.storage_resolver();
         async move {
-            single_node_search(search_request, &*metastore, storage_uri_resolver)
+            single_node_search(search_request, &*metastore, storage_resolver)
                 .await
                 .unwrap()
                 .hits
@@ -675,9 +675,9 @@ async fn test_sort_by_static_and_dynamic_field() {
             ..Default::default()
         };
         let metastore = test_sandbox.metastore();
-        let storage_uri_resolver = test_sandbox.storage_uri_resolver();
+        let storage_resolver = test_sandbox.storage_resolver();
         async move {
-            let search_resp = single_node_search(search_request, &*metastore, storage_uri_resolver)
+            let search_resp = single_node_search(search_request, &*metastore, storage_resolver)
                 .await
                 .unwrap();
             assert_eq!(search_resp.num_hits, 4);
@@ -759,7 +759,7 @@ async fn test_single_node_invalid_sorting_with_query() {
     let single_node_response = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await;
     assert!(single_node_response.is_err());
@@ -1192,7 +1192,7 @@ async fn test_single_node_aggregation() -> anyhow::Result<()> {
     let single_node_result = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await?;
     let agg_res_json: JsonValue = serde_json::from_str(&single_node_result.aggregation.unwrap())?;
@@ -1265,7 +1265,7 @@ async fn test_single_node_aggregation_missing_fast_field() {
     let single_node_result = single_node_search(
         search_request,
         &*test_sandbox.metastore(),
-        test_sandbox.storage_uri_resolver(),
+        test_sandbox.storage_resolver(),
     )
     .await
     .unwrap();
@@ -1307,7 +1307,7 @@ async fn test_single_node_with_ip_field() -> anyhow::Result<()> {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await?;
         assert_eq!(single_node_result.num_hits, 6);
@@ -1323,7 +1323,7 @@ async fn test_single_node_with_ip_field() -> anyhow::Result<()> {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await?;
         assert_eq!(single_node_result.num_hits, 1);
@@ -1382,7 +1382,7 @@ async fn test_single_node_range_queries() -> anyhow::Result<()> {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await?;
         assert_eq!(single_node_result.num_hits, 2);
@@ -1398,7 +1398,7 @@ async fn test_single_node_range_queries() -> anyhow::Result<()> {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await?;
         assert_eq!(single_node_result.num_hits, 3);
@@ -1414,7 +1414,7 @@ async fn test_single_node_range_queries() -> anyhow::Result<()> {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await?;
         assert_eq!(single_node_result.num_hits, 3);
@@ -1430,7 +1430,7 @@ async fn test_single_node_range_queries() -> anyhow::Result<()> {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await?;
         assert_eq!(single_node_result.num_hits, 3);
@@ -1446,7 +1446,7 @@ async fn test_single_node_range_queries() -> anyhow::Result<()> {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await?;
         assert_eq!(single_node_result.num_hits, 4);
@@ -1636,7 +1636,7 @@ async fn test_single_node_find_trace_ids_collector() {
         let single_node_result = single_node_search(
             search_request,
             &*test_sandbox.metastore(),
-            test_sandbox.storage_uri_resolver(),
+            test_sandbox.storage_resolver(),
         )
         .await
         .unwrap();

--- a/quickwit/quickwit-serve/src/node_info_handler.rs
+++ b/quickwit/quickwit-serve/src/node_info_handler.rs
@@ -19,7 +19,6 @@
 
 use std::sync::Arc;
 
-use quickwit_common::uri::Uri;
 use quickwit_config::QuickwitConfig;
 use serde_json::json;
 use warp::{Filter, Rejection};
@@ -65,16 +64,16 @@ fn node_config_handler(
 }
 
 async fn get_config(config: Arc<QuickwitConfig>) -> impl warp::Reply {
-    // We need to hide sensitive information from metastore URI.
-    let mut config_to_serialize = (*config).clone();
-    let redacted_uri = Uri::from_well_formed(config_to_serialize.metastore_uri.as_redacted_str());
-    config_to_serialize.metastore_uri = redacted_uri;
-    warp::reply::json(&config_to_serialize)
+    // We must redact sensitive information such as credentials.
+    let mut config = (*config).clone();
+    config.redact();
+    warp::reply::json(&config)
 }
 
 #[cfg(test)]
 mod tests {
     use assert_json_diff::assert_json_include;
+    use quickwit_common::uri::Uri;
     use serde_json::Value as JsonValue;
 
     use super::*;

--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -44,6 +44,7 @@ azure_storage_blobs = { workspace = true, optional = true }
 
 quickwit-aws = { workspace = true }
 quickwit-common = { workspace = true }
+quickwit-config = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/quickwit/quickwit-storage/src/cache/storage_with_cache.rs
+++ b/quickwit/quickwit-storage/src/cache/storage_with_cache.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt;
 use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
@@ -32,6 +33,12 @@ use crate::{OwnedBytes, Storage, StorageResult};
 pub struct StorageWithCache {
     pub storage: Arc<dyn Storage>,
     pub cache: Arc<dyn Cache>,
+}
+
+impl fmt::Debug for StorageWithCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageWithCache").finish()
+    }
 }
 
 #[async_trait]

--- a/quickwit/quickwit-storage/src/debouncer.rs
+++ b/quickwit/quickwit-storage/src/debouncer.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt;
 use std::hash::Hash;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -117,6 +118,12 @@ pub(crate) struct DebouncedStorage<T> {
     // associated
     underlying: Arc<T>,
     slice_debouncer: Arc<AsyncDebouncer<DebouncerKey, StorageResult<OwnedBytes>>>,
+}
+
+impl<T> fmt::Debug for DebouncedStorage<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DebouncedStorage").finish()
+    }
 }
 
 impl<T: Storage> DebouncedStorage<T> {

--- a/quickwit/quickwit-storage/src/error.rs
+++ b/quickwit/quickwit-storage/src/error.rs
@@ -43,15 +43,20 @@ pub enum StorageErrorKind {
 
 /// Generic Storage Resolver Error.
 #[allow(missing_docs)]
-#[derive(Error, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Clone, thiserror::Error, Serialize, Deserialize)]
 pub enum StorageResolverError {
-    /// The input is not a valid URI.
-    /// A protocol is required for the URI.
-    #[error("Invalid format for URI: required: `{message}`")]
-    InvalidUri { message: String },
-    /// The protocol is not supported by this resolver.
-    #[error("Unsupported protocol: `{protocol}`")]
-    ProtocolUnsupported { protocol: String },
+    /// The storage config is invalid.
+    #[error("Invalid storage config: `{0}`")]
+    InvalidConfig(String),
+
+    /// The URI does not contain sufficient information to connect to the storage.
+    #[error("Invalid storage URI: `{0}`")]
+    InvalidUri(String),
+
+    /// The requested backend is unsupported or unavailable.
+    #[error("Unsupported storage backend: `{0}`")]
+    UnsupportedBackend(String),
+
     /// The URI is valid, and is meant to be handled by this resolver,
     /// but the resolver failed to actually connect to the storage.
     /// e.g. Connection error, credential error, incompatible version,

--- a/quickwit/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit/quickwit-storage/src/local_file_storage.rs
@@ -28,15 +28,17 @@ use async_trait::async_trait;
 use futures::future::{BoxFuture, FutureExt};
 use futures::StreamExt;
 use quickwit_common::ignore_error_kind;
-use quickwit_common::uri::{Protocol, Uri};
+use quickwit_common::uri::Uri;
+use quickwit_config::{StorageBackend, StorageConfig};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use tracing::warn;
 
 use crate::storage::{BulkDeleteError, DeleteFailure, SendableAsync};
+use crate::storage_factory::StorageFactory;
 use crate::{
-    DebouncedStorage, OwnedBytes, Storage, StorageError, StorageErrorKind, StorageFactory,
-    StorageResolverError, StorageResult,
+    DebouncedStorage, OwnedBytes, Storage, StorageError, StorageErrorKind, StorageResolverError,
+    StorageResult,
 };
 
 /// File system compatible storage implementation.
@@ -68,8 +70,9 @@ impl LocalFileStorage {
                 uri: uri.clone(),
                 root: root.to_path_buf(),
             })
-            .ok_or_else(|| StorageResolverError::InvalidUri {
-                message: format!("URI `{uri}` is not a valid file URI."),
+            .ok_or_else(|| {
+                let message = format!("URI `{uri}` is not a valid file URI.");
+                StorageResolverError::InvalidUri(message)
             })
     }
 
@@ -335,15 +338,19 @@ impl Storage for LocalFileStorage {
 
 /// A File storage resolver
 #[derive(Clone, Debug, Default)]
-pub struct LocalFileStorageFactory {}
+pub struct LocalFileStorageFactory;
 
 #[async_trait]
 impl StorageFactory for LocalFileStorageFactory {
-    fn protocol(&self) -> Protocol {
-        Protocol::File
+    fn backend(&self) -> StorageBackend {
+        StorageBackend::File
     }
 
-    async fn resolve(&self, uri: &Uri) -> Result<Arc<dyn Storage>, StorageResolverError> {
+    async fn resolve(
+        &self,
+        _storage_config: &StorageConfig,
+        uri: &Uri,
+    ) -> Result<Arc<dyn Storage>, StorageResolverError> {
         let storage = LocalFileStorage::from_uri(uri)?;
         Ok(Arc::new(DebouncedStorage::new(storage)))
     }
@@ -353,6 +360,8 @@ impl StorageFactory for LocalFileStorageFactory {
 mod tests {
 
     use std::str::FromStr;
+
+    use quickwit_config::FileStorageConfig;
 
     use super::*;
     use crate::test_suite::storage_test_suite;
@@ -387,22 +396,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_local_file_storage_factory() -> anyhow::Result<()> {
+        let storage_config = FileStorageConfig::default().into();
         let temp_dir = tempfile::tempdir()?;
         let index_uri =
             Uri::from_well_formed(format!("file://{}/foo/bar", temp_dir.path().display()));
         let local_file_storage_factory = LocalFileStorageFactory::default();
-        let local_file_storage = local_file_storage_factory.resolve(&index_uri).await?;
+        let local_file_storage = local_file_storage_factory
+            .resolve(&storage_config, &index_uri)
+            .await?;
         assert_eq!(local_file_storage.uri(), &index_uri);
 
         let err = local_file_storage_factory
-            .resolve(&Uri::from_well_formed("s3://foo/bar"))
+            .resolve(&storage_config, &Uri::from_well_formed("s3://foo/bar"))
             .await
             .err()
             .unwrap();
         assert!(matches!(err, StorageResolverError::InvalidUri { .. }));
 
         let err = local_file_storage_factory
-            .resolve(&Uri::from_well_formed("s3://"))
+            .resolve(&storage_config, &Uri::from_well_formed("s3://"))
             .await
             .err()
             .unwrap();

--- a/quickwit/quickwit-storage/src/object_storage/mod.rs
+++ b/quickwit/quickwit-storage/src/object_storage/mod.rs
@@ -21,12 +21,12 @@ mod error;
 
 mod s3_compatible_storage;
 pub use self::s3_compatible_storage::S3CompatibleObjectStorage;
-pub use self::s3_compatible_storage_uri_resolver::S3CompatibleObjectStorageFactory;
+pub use self::s3_compatible_storage_resolver::S3CompatibleObjectStorageFactory;
 
 mod policy;
 pub use crate::object_storage::policy::MultiPartPolicy;
 
-mod s3_compatible_storage_uri_resolver;
+mod s3_compatible_storage_resolver;
 
 #[cfg(feature = "azure")]
 mod azure_blob_storage;

--- a/quickwit/quickwit-storage/src/object_storage/policy.rs
+++ b/quickwit/quickwit-storage/src/object_storage/policy.rs
@@ -32,8 +32,8 @@ pub struct MultiPartPolicy {
     pub multipart_threshold_num_bytes: u64,
     /// Maximum size allowed for an object.
     pub max_object_num_bytes: u64,
-    /// Maximum number of part to be upload concurrently.
-    pub max_concurrent_upload: usize,
+    /// Maximum number of parts to be upload concurrently.
+    pub max_concurrent_uploads: usize,
 }
 
 impl MultiPartPolicy {
@@ -63,8 +63,8 @@ impl MultiPartPolicy {
     }
 
     /// Limits the number of parts that can be concurrently uploaded.
-    pub fn max_concurrent_upload(&self) -> usize {
-        self.max_concurrent_upload
+    pub fn max_concurrent_uploads(&self) -> usize {
+        self.max_concurrent_uploads
     }
 }
 
@@ -79,7 +79,7 @@ impl Default for MultiPartPolicy {
             multipart_threshold_num_bytes: 128 * 1_024 * 1_024, // 128 MiB
             max_num_parts: 10_000,
             max_object_num_bytes: 5_000_000_000_000u64, // S3 allows up to 5TB objects
-            max_concurrent_upload: 100,
+            max_concurrent_uploads: 100,
         }
     }
 }

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage_resolver.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage_resolver.rs
@@ -20,24 +20,35 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use quickwit_common::uri::{Protocol, Uri};
+use quickwit_common::uri::Uri;
+use quickwit_config::{StorageBackend, StorageConfig};
 
-use crate::{
-    DebouncedStorage, S3CompatibleObjectStorage, Storage, StorageFactory, StorageResolverError,
-};
+use crate::storage_factory::StorageFactory;
+use crate::{DebouncedStorage, S3CompatibleObjectStorage, Storage, StorageResolverError};
 
-/// S3 compatible object storage URI resolver.
+/// S3 compatible object storage resolver.
 #[derive(Default)]
 pub struct S3CompatibleObjectStorageFactory;
 
 #[async_trait]
 impl StorageFactory for S3CompatibleObjectStorageFactory {
-    fn protocol(&self) -> Protocol {
-        Protocol::S3
+    fn backend(&self) -> StorageBackend {
+        StorageBackend::S3
     }
 
-    async fn resolve(&self, uri: &Uri) -> Result<Arc<dyn Storage>, StorageResolverError> {
-        let storage = S3CompatibleObjectStorage::from_uri(uri).await?;
+    async fn resolve(
+        &self,
+        storage_config: &StorageConfig,
+        uri: &Uri,
+    ) -> Result<Arc<dyn Storage>, StorageResolverError> {
+        let s3_storage_config = storage_config.as_s3().ok_or_else(|| {
+            let message = format!(
+                "Expected S3 storage config, got `{:?}`.",
+                storage_config.backend()
+            );
+            StorageResolverError::InvalidConfig(message)
+        })?;
+        let storage = S3CompatibleObjectStorage::from_uri(s3_storage_config, uri).await?;
         Ok(Arc::new(DebouncedStorage::new(storage)))
     }
 }

--- a/quickwit/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit/quickwit-storage/src/prefix_storage.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -33,6 +34,15 @@ struct PrefixStorage {
     pub storage: Arc<dyn Storage>,
     pub prefix: PathBuf,
     uri: Uri,
+}
+
+impl fmt::Debug for PrefixStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrefixStorage")
+            .field("uri", &self.uri)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
 }
 
 #[async_trait]

--- a/quickwit/quickwit-storage/src/storage.rs
+++ b/quickwit/quickwit-storage/src/storage.rs
@@ -45,7 +45,7 @@ impl<W: AsyncWrite + Send + Unpin> SendableAsync for W {}
 /// these intermediate directories.
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait]
-pub trait Storage: Send + Sync + 'static {
+pub trait Storage: fmt::Debug + Send + Sync + 'static {
     /// Check storage connection if applicable
     async fn check_connectivity(&self) -> anyhow::Result<()>;
 

--- a/quickwit/quickwit-storage/src/storage_factory.rs
+++ b/quickwit/quickwit-storage/src/storage_factory.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use quickwit_common::uri::Uri;
+use quickwit_config::{StorageBackend, StorageConfig};
+
+use crate::{Storage, StorageResolverError};
+
+/// A storage factory builds a [`Storage`] object for a target [`StorageBackend`] from a
+/// [`StorageConfig`] and a [`Uri`].
+#[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
+#[async_trait]
+pub trait StorageFactory: Send + Sync + 'static {
+    /// Returns the storage backend targeted by the factory.
+    fn backend(&self) -> StorageBackend;
+
+    /// Returns the appropriate [`Storage`] object for the URI.
+    async fn resolve(
+        &self,
+        storage_config: &StorageConfig,
+        uri: &Uri,
+    ) -> Result<Arc<dyn Storage>, StorageResolverError>;
+}
+
+/// A storage factory for handling unsupported or unavailable storage backends.
+#[derive(Debug, Clone)]
+pub struct UnsupportedStorage {
+    backend: StorageBackend,
+    message: &'static str,
+}
+
+impl UnsupportedStorage {
+    /// Creates a new [`UnsupportedStorage`].
+    pub fn new(backend: StorageBackend, message: &'static str) -> Self {
+        Self { backend, message }
+    }
+}
+
+#[async_trait]
+impl StorageFactory for UnsupportedStorage {
+    fn backend(&self) -> StorageBackend {
+        self.backend
+    }
+
+    async fn resolve(
+        &self,
+        _storage_config: &StorageConfig,
+        _uri: &Uri,
+    ) -> Result<Arc<dyn Storage>, StorageResolverError> {
+        Err(StorageResolverError::UnsupportedBackend(
+            self.message.to_string(),
+        ))
+    }
+}

--- a/quickwit/quickwit-storage/tests/azure_storage.rs
+++ b/quickwit/quickwit-storage/tests/azure_storage.rs
@@ -53,7 +53,7 @@ async fn test_suite_on_azure_storage() -> anyhow::Result<()> {
         max_num_parts: 10_000,
         multipart_threshold_num_bytes: 10_000_000,
         max_object_num_bytes: 5_000_000_000_000,
-        max_concurrent_upload: 100,
+        max_concurrent_uploads: 100,
     });
     quickwit_storage::storage_test_multi_part_upload(&mut object_storage)
         .await

--- a/quickwit/quickwit-storage/tests/s3_storage.rs
+++ b/quickwit/quickwit-storage/tests/s3_storage.rs
@@ -29,14 +29,17 @@ async fn test_suite_on_s3_storage() -> anyhow::Result<()> {
 
     use anyhow::Context;
     use quickwit_common::uri::Uri;
+    use quickwit_config::S3StorageConfig;
     use quickwit_storage::{MultiPartPolicy, S3CompatibleObjectStorage};
 
     let _ = tracing_subscriber::fmt::try_init();
+    let s3_storage_config = S3StorageConfig::default();
     let storage_uri = Uri::from_well_formed("s3://quickwit-integration-tests");
-    let mut object_storage = S3CompatibleObjectStorage::from_uri(&storage_uri).await?;
+    let mut object_storage =
+        S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri).await?;
     quickwit_storage::storage_test_suite(&mut object_storage).await?;
 
-    let mut object_storage = S3CompatibleObjectStorage::from_uri(&storage_uri)
+    let mut object_storage = S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri)
         .await?
         .with_prefix(Path::new("test-s3-compatible-storage"));
     quickwit_storage::storage_test_single_part_upload(&mut object_storage)
@@ -48,7 +51,7 @@ async fn test_suite_on_s3_storage() -> anyhow::Result<()> {
         max_num_parts: 10_000,
         multipart_threshold_num_bytes: 10_000_000,
         max_object_num_bytes: 5_000_000_000_000,
-        max_concurrent_upload: 100,
+        max_concurrent_uploads: 100,
     });
     quickwit_storage::storage_test_multi_part_upload(&mut object_storage)
         .await

--- a/quickwit/quickwit-telemetry/src/payload.rs
+++ b/quickwit/quickwit-telemetry/src/payload.rs
@@ -121,16 +121,16 @@ impl Default for QuickwitTelemetryInfo {
 #[serde(rename_all = "snake_case")]
 pub enum QuickwitFeature {
     FileBackedMetastore,
-    PostgresqMetastore,
-    Otlp,
     Jaeger,
+    Otlp,
+    PostgresqMetastore,
 }
 
 fn hashed_host_username() -> String {
     let hostname = hostname::get()
         .map(|hostname| hostname.to_string_lossy().to_string())
-        .unwrap_or_else(|_| "".to_string());
-    let username = username::get_user_name().unwrap_or_else(|_| "".to_string());
+        .unwrap_or_default();
+    let username = username::get_user_name().unwrap_or_default();
     let hashed_value = format!("{hostname}:{username}");
     let digest = md5::compute(hashed_value.as_bytes());
     format!("{digest:x}")


### PR DESCRIPTION
### Description
Introduce `StorageConfig` and `MetastoreConfig` objects. The storage config will allow us to configure virtual vs. path-style URLs and disable the multi-objects delete API for GCS.

The `MetastoreConfig` is only useful for setting the max num of connections for Postgres for now, but it can host more settings in the future.

### How was this PR tested?
In progress
