### PR TITLE
Issue/3451 default search fields

### DIFF
--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -171,14 +171,19 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
 
         // Resolve default search fields
         let mut default_search_field_names = Vec::new();
-        for field_name in &builder.default_search_fields {
-            if default_search_field_names.contains(field_name) {
-                bail!("Duplicated default search field: `{}`", field_name)
+        for default_search_field_name in &builder.default_search_fields {
+            if default_search_field_names.contains(default_search_field_name) {
+                bail!("Duplicated default search field: `{}`", default_search_field_name)
             }
-            schema
-                .get_field(field_name)
-                .with_context(|| format!("Unknown default search field: `{field_name}`"))?;
-            default_search_field_names.push(field_name.clone());
+            let (default_search_field, _json_path) = schema
+                .find_field(default_search_field_name)
+                .with_context(|| format!("Unknown default search field: `{default_search_field_name}`"))?;
+            if !schema.get_field_entry(default_search_field).is_indexed() {
+                bail!(
+                    "Default search field `{default_search_field_name}` is not indexed.",
+                );
+            }
+            default_search_field_names.push(default_search_field_name.clone());
         }
 
         // Resolve tag fields

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -175,8 +175,9 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
             if default_search_field_names.contains(default_search_field_name) {
                 bail!("Duplicated default search field: `{}`", default_search_field_name)
             }
+            let dynamic_field = schema.get_field(DYNAMIC_FIELD_NAME).ok();
             let (default_search_field, _json_path) = schema
-                .find_field(default_search_field_name)
+                .find_field_with_default(default_search_field_name, dynamic_field)
                 .with_context(|| format!("Unknown default search field: `{default_search_field_name}`"))?;
             if !schema.get_field_entry(default_search_field).is_indexed() {
                 bail!(

--- a/quickwit/rest-api-tests/rest_api_test.py
+++ b/quickwit/rest-api-tests/rest_api_test.py
@@ -245,7 +245,7 @@ def main():
         prog="rest-api-test",
         description="Runs a set of calls against a REST API and checks for conditions over the results."
     )
-    arg_parser.add_argument("--engine", help="Targetted engine (elastic/quickwit).", default="elasticsearch")
+    arg_parser.add_argument("--engine", help="Targetted engine (elastic/quickwit).", default="quickwit")
     arg_parser.add_argument("--test", help="Specific prefix to select the tests to run. If not specified, all tests are run.", nargs="*")
     parsed_args = arg_parser.parse_args()
     scenario_filepaths = glob.glob("scenarii/**/*.yaml", recursive=True)

--- a/quickwit/rest-api-tests/scenarii/default_search_fields/0001_default_fields.yaml
+++ b/quickwit/rest-api-tests/scenarii/default_search_fields/0001_default_fields.yaml
@@ -1,0 +1,26 @@
+endpoint: defaultsearchfields/search
+params:
+  query: hello
+expected:
+  num_hits: 1
+  hits:
+    - id: 1
+      some_dynamic_field: hello
+---
+endpoint: defaultsearchfields/search
+params:
+  query: allo
+expected:
+  num_hits: 1
+  hits:
+    - id: 2
+      inner_json: {'somefieldinjson': 'allo'}
+---
+endpoint: defaultsearchfields/search
+params:
+  query: bonjour
+expected:
+  num_hits: 1
+  hits:
+    - id: 3
+      regular_field: bonjour

--- a/quickwit/rest-api-tests/scenarii/default_search_fields/0002_invalid_default_fields.yaml
+++ b/quickwit/rest-api-tests/scenarii/default_search_fields/0002_invalid_default_fields.yaml
@@ -1,0 +1,56 @@
+# should fail because we are not in dynamic,
+# yet we are targetting a field not in the field mapping.
+method: POST
+endpoint: indexes/
+json:
+  version: "0.6"
+  index_id: failing1
+  doc_mapping:
+    mode: lenient
+    field_mappings: []
+  search_settings:
+    default_search_fields:
+      - regular_field
+status_code: 400
+expected:
+  message:
+    $expect: "\"Unknown default search field: `regular_field`\" in val"
+---
+# should fail because default search field targets the root
+# of a json field.
+method: POST
+endpoint: indexes/
+json:
+  version: "0.6"
+  index_id: failing2
+  doc_mapping:
+    mode: dynamic
+    field_mappings:
+      - name: inner_json
+        type: json
+  search_settings:
+    default_search_fields:
+      - inner_json
+status_code: 400
+expected:
+  message:
+    $expect: "\"Unknown default search field: `inner_json`\" in val"
+---
+# should fail because dynamic field is not indexed.
+method: POST
+endpoint: indexes/
+json:
+  version: "0.6"
+  index_id: failing3
+  doc_mapping:
+    mode: dynamic
+    field_mappings: []
+    dynamic_mapping:
+      indexed: false
+  search_settings:
+    default_search_fields:
+      - some_field
+status_code: 400
+expected:
+  message:
+    $expect: "\"Default search field `some_field` is not indexed\" in val"

--- a/quickwit/rest-api-tests/scenarii/default_search_fields/_ctx.yaml
+++ b/quickwit/rest-api-tests/scenarii/default_search_fields/_ctx.yaml
@@ -1,0 +1,5 @@
+method: GET
+engines: ["quickwit"]
+api_root: "http://localhost:7280/api/v1/"
+headers:
+  Content-Type: application/json

--- a/quickwit/rest-api-tests/scenarii/default_search_fields/_setup.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/default_search_fields/_setup.quickwit.yaml
@@ -1,0 +1,38 @@
+# Delete possibly remaining index
+method: DELETE
+endpoint: indexes/defaultsearchfields
+status_code: null
+---
+# Create index
+method: POST
+endpoint: indexes/
+json:
+  version: "0.6"
+  index_id: defaultsearchfields
+  doc_mapping:
+    mode: dynamic
+    field_mappings:
+      - name: id
+        type: u64
+      - name: inner_json
+        type: json
+      - name: regular_field
+        type: text
+    dynamic_mapping:
+      expand_dots: true
+      fast: true
+  search_settings:
+    default_search_fields:
+      - regular_field
+      - some_dynamic_field
+      - inner_json.somefieldinjson
+
+---
+method: POST
+endpoint: defaultsearchfields/ingest
+params:
+  commit: force
+ndjson:
+  - {"id": 1, "some_dynamic_field": "hello"}
+  - {"id": 2, "inner_json": {"somefieldinjson": "allo"}}
+  - {"id": 3, "regular_field": "bonjour"}

--- a/quickwit/rest-api-tests/scenarii/default_search_fields/_teardown.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/default_search_fields/_teardown.quickwit.yaml
@@ -1,0 +1,3 @@
+# Delete index
+method: DELETE
+endpoint: indexes/defaultsearchfields


### PR DESCRIPTION
Allow default search fields targetting dynamic fields, or fields within json field
    
Also: validates that the targetted field is indexed.
    
Closes #3451
