### PR TITLE
Add default search field for otel logs index.

### DIFF
--- a/docs/distributed-tracing/send-traces/using-otel-collector.md
+++ b/docs/distributed-tracing/send-traces/using-otel-collector.md
@@ -127,6 +127,7 @@ curl -XPOST "http://localhost:4318/v1/traces" -H "Content-Type: application/json
          "spans": [
            {
              "time_unix_nano": "1678974011000000000",
+             "observed_time_unix_nano": "1678974011000000000",
              "start_time_unix_nano": "1678974011000000000",
              "end_time_unix_nano": "1678974021000000000",
              "trace_id": "3c191d03fa8be0653c191d03fa8be065",

--- a/docs/log-management/send-logs/using-otel-collector.md
+++ b/docs/log-management/send-logs/using-otel-collector.md
@@ -128,6 +128,7 @@ curl -XPOST "http://localhost:4318/v1/logs" -H "Content-Type: application/json" 
          "log_records": [
            {
              "time_unix_nano": "1678974011000000000",
+             "observed_time_unix_nano": "1678974011000000000",
              "name": "test",
              "severity_text": "INFO"
            }

--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -117,7 +117,7 @@ indexing_settings:
   commit_timeout_secs: 5
 
 search_settings:
-  default_search_fields: []
+  default_search_fields: [body.message]
 "#;
 
 pub type Base64 = String;


### PR DESCRIPTION
I did not find a good default search field for the otel traces index.

I can change that if @guilload you have a good idea.

Tested locally.