### PR TITLE
Fix error on log on SIGINT signal

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -388,8 +388,9 @@ impl Actor for Indexer {
             | ActorExitStatus::Failure(_)
             | ActorExitStatus::Panicked => return Ok(()),
             ActorExitStatus::Quit | ActorExitStatus::Success => {
-                self.send_to_serializer(CommitTrigger::NoMoreDocs, ctx)
-                    .await?;
+                let _ = self
+                    .send_to_serializer(CommitTrigger::NoMoreDocs, ctx)
+                    .await;
             }
         }
         Ok(())


### PR DESCRIPTION
### Description
The indexer fails to finalize because the serializer has already quit when handling the SIGINT signal. I don't think this change prevents us from discovering bugs in the future because actors already do a good job at surfacing their own errors.

### How was this PR tested?
Before:
<img width="895" alt="Screenshot 2023-05-31 at 9 02 31 AM" src="https://github.com/quickwit-oss/quickwit/assets/3011588/9cfcc7be-77e8-4bc6-9848-8a5bf65d12a6">

After:
<img width="917" alt="Screenshot 2023-05-31 at 9 06 43 AM" src="https://github.com/quickwit-oss/quickwit/assets/3011588/1409918a-9542-4a99-bb4d-dde3d0cd66e5">

