### PR TITLE
Disabling cancelling concurrent coverage workflow.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,11 +19,6 @@ env:
   AWS_SECRET_ACCESS_KEY: "placeholder"
   TEST_DATABASE_URL: postgres://quickwit-dev:quickwit-dev@localhost:5432/quickwit-metastore-dev
 
-# Ensures that we cancel running jobs for the same PR / same workflow.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: Coverage


### PR DESCRIPTION
We want to correctly identify which PR is breaking CI.

