### PR TITLE
Disable telemetry in tests and avoid panic when set and tests are run…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - "!quickwit/quickwit-ui/**"
 env:
   CARGO_INCREMENTAL: 0
+  QW_DISABLE_TELEMETRY: 1
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings -Arustdoc::private_intra_doc_links

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ on:
       - quickwit/quickwit-*/**
 
 env:
+  QW_DISABLE_TELEMETRY: 1
   QW_S3_ENDPOINT: "http://localhost:4566" # Services are exposed as localhost because we are not running coverage in a container.
   CARGO_INCREMENTAL: 0
   AWS_REGION: "us-east-1"

--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -83,7 +83,7 @@ impl RunCliCommand {
             tracing::info!(services = %services.iter().join(", "), "Setting services from override.");
             config.enabled_services = services.clone();
         }
-        let telemetry_handle =
+        let telemetry_handle_opt =
             quickwit_telemetry::start_telemetry_loop(quickwit_telemetry_info(&config));
         quickwit_telemetry::send_telemetry_event(TelemetryEvent::RunCommand).await;
         // TODO move in serve quickwit?
@@ -107,7 +107,9 @@ impl RunCliCommand {
             Err(_) => 1,
         };
         quickwit_telemetry::send_telemetry_event(TelemetryEvent::EndCommand { return_code }).await;
-        telemetry_handle.terminate_telemetry().await;
+        if let Some(telemetry_handle) = telemetry_handle_opt {
+            telemetry_handle.terminate_telemetry().await;
+        }
         serve_result?;
         Ok(())
     }

--- a/quickwit/quickwit-telemetry/src/lib.rs
+++ b/quickwit/quickwit-telemetry/src/lib.rs
@@ -39,7 +39,7 @@ static TELEMETRY_SENDER: OnceCell<TelemetrySender> = OnceCell::new();
 pub fn start_telemetry_loop(quickwit_info: QuickwitTelemetryInfo) -> Option<TelemetryLoopHandle> {
     let telemetry_sender =
         TELEMETRY_SENDER.get_or_init(|| TelemetrySender::from_quickwit_info(quickwit_info));
-    // This should not happened... unless telemetry is enabled and you are running tests in parallel
+    // This should not happen... unless telemetry is enabled and you are running tests in parallel
     // in the same process.
     if telemetry_sender.loop_started() {
         info!("Telemetry loop already started. Please disable telemetry during tests.");

--- a/quickwit/quickwit-telemetry/src/lib.rs
+++ b/quickwit/quickwit-telemetry/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) mod sink;
 
 use once_cell::sync::OnceCell;
 use payload::QuickwitTelemetryInfo;
+use tracing::info;
 
 use crate::payload::TelemetryEvent;
 pub use crate::sender::is_telemetry_disabled;
@@ -34,10 +35,17 @@ use crate::sender::{TelemetryLoopHandle, TelemetrySender};
 
 static TELEMETRY_SENDER: OnceCell<TelemetrySender> = OnceCell::new();
 
-pub fn start_telemetry_loop(quickwit_info: QuickwitTelemetryInfo) -> TelemetryLoopHandle {
+/// Returns a `TelemetryLoopHandle` if the telemetry loop is not yet started.
+pub fn start_telemetry_loop(quickwit_info: QuickwitTelemetryInfo) -> Option<TelemetryLoopHandle> {
     let telemetry_sender =
         TELEMETRY_SENDER.get_or_init(|| TelemetrySender::from_quickwit_info(quickwit_info));
-    telemetry_sender.start_loop()
+    // This should not happened... unless telemetry is enabled and you are running tests in parallel
+    // in the same process.
+    if telemetry_sender.loop_started() {
+        info!("Telemetry loop already started. Please disable telemetry during tests.");
+        return None;
+    }
+    Some(telemetry_sender.start_loop())
 }
 
 /// Sends a telemetry event to Quickwit's server via HTTP.

--- a/quickwit/quickwit-telemetry/src/sender.rs
+++ b/quickwit/quickwit-telemetry/src/sender.rs
@@ -258,7 +258,7 @@ impl TelemetrySender {
     }
 
     pub fn loop_started(&self) -> bool {
-        self.inner.is_started.load(Ordering::SeqCst)
+        self.inner.is_started.load(Ordering::Relaxed)
     }
 
     pub fn start_loop(&self) -> TelemetryLoopHandle {

--- a/quickwit/quickwit-telemetry/src/sender.rs
+++ b/quickwit/quickwit-telemetry/src/sender.rs
@@ -257,6 +257,10 @@ impl TelemetrySender {
         }
     }
 
+    pub fn loop_started(&self) -> bool {
+        self.inner.is_started.load(Ordering::SeqCst)
+    }
+
     pub fn start_loop(&self) -> TelemetryLoopHandle {
         let (terminate_command_tx, mut terminate_command_rx) = oneshot::channel();
         if self.inner.is_disabled() {


### PR DESCRIPTION
… in parallel.


Tests:
- check telemetry events are correctly sent
- check that in parallel tests you can see the logs if telemetry is enabled. No logs if telemetry is disabled.
