### PR TITLE
Fix quickwit.yaml by adding dummy default Azure access key

### DIFF
--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -77,7 +77,7 @@ version: 0.6
 # storage:
 #   azure:
 #     account: your-azure-account-name
-#     access_key: ${QW_AZURE_ACCESS_KEY}
+#     access_key: ${QW_AZURE_ACCESS_KEY:-your-azure-access-key}
 #
 #   s3:
 #     endpoint: ${QW_S3_ENDPOINT:-http://localhost:4566}


### PR DESCRIPTION
### Description
The template rendering function does render commented lines, which is an issue for mandatory parameters such as Azure `access_key`. 

### How was this PR tested?
```QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER=true \
                                                                          OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:7281 \
                                                                          QW_NODE_ID=node-1 \
                                                                          QW_DATA_DIR=qwdata/node-1 \
                                                                          cargo run --manifest-path quickwit/Cargo.toml -- run```
