### PR TITLE
remove shared AggregationLimits

### DIFF
--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -144,7 +144,7 @@ This section contains the configuration options for a Searcher.
 
 | Property | Description | Default value |
 | --- | --- | --- |
-| `aggregation_memory_limit` | Controls the maximum amount of memory that can be used for aggregations before aborting. This limit is per single leaf query (a leaf query is made of one or several split queries). It is used to prevent excessive memory usage during the aggregation phase, which can lead to performance degradation or crashes. | `500M`|
+| `aggregation_memory_limit` | Controls the maximum amount of memory that can be used for aggregations before aborting. This limit is per request and single leaf query (a leaf query is querying one or multiple splits concurrently). It is used to prevent excessive memory usage during the aggregation phase, which can lead to performance degradation or crashes. Since it is per request, concurrent requests can exceed the limit. | `500M`|
 | `aggregation_bucket_limit` | Determines the maximum number of buckets returned to the client. | `65000` |
 | `fast_field_cache_capacity` | Fast field cache capacity on a Searcher. If your filter by dates, run aggregations, range queries, or if you use the search stream API, or even for tracing, it might worth increasing this parameter. The [metrics](../reference/metrics.md) starting by `quickwit_cache_fastfields_cache` can help you make an informed choice when setting this value. | `1G` |
 | `split_footer_cache_capacity` | Split footer cache (it is essentially the hotcache) capacity on a Searcher.| `500M` |

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -341,11 +341,12 @@ async fn leaf_search_single_split(
     let split_id = split.split_id.to_string();
     let index = open_index_with_caches(searcher_context, storage, &split, true).await?;
     let split_schema = index.schema();
+
     let quickwit_collector = make_collector_for_split(
         split_id.clone(),
         doc_mapper.as_ref(),
         &search_request,
-        searcher_context.aggregation_limits.clone(),
+        searcher_context.get_aggregation_limits(),
     )?;
     let query_ast: QueryAst = serde_json::from_str(search_request.query_ast.as_str())
         .map_err(|err| SearchError::InvalidQuery(err.to_string()))?;
@@ -477,7 +478,8 @@ pub async fn leaf_search(
         });
 
     // Creates a collector which merges responses into one
-    let merge_collector = make_merge_collector(&request, &searcher_context.aggregation_limits)?;
+    let merge_collector =
+        make_merge_collector(&request, &searcher_context.get_aggregation_limits())?;
 
     // Merging is a cpu-bound task.
     // It should be executed by Tokio's blocking threads.

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -291,7 +291,7 @@ pub async fn root_search(
 
     // Creates a collector which merges responses into one
     let merge_collector =
-        make_merge_collector(&search_request, &searcher_context.aggregation_limits)?;
+        make_merge_collector(&search_request, &searcher_context.get_aggregation_limits())?;
     let aggregations = merge_collector.aggregation.clone();
 
     // Merging is a cpu-bound task.
@@ -568,8 +568,8 @@ pub fn finalize_aggregation(
             QuickwitAggregations::TantivyAggregations(aggregations) => {
                 let res: IntermediateAggregationResults =
                     postcard::from_bytes(intermediate_aggregation_result.as_slice())?;
-                let res: AggregationResults =
-                    res.into_final_result(aggregations, &searcher_context.aggregation_limits)?;
+                let res: AggregationResults = res
+                    .into_final_result(aggregations, &searcher_context.get_aggregation_limits())?;
                 Some(serde_json::to_string(&res)?)
             }
         }

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -293,8 +293,6 @@ impl SearchService for SearchServiceImpl {
 pub struct SearcherContext {
     /// Searcher config.
     pub searcher_config: SearcherConfig,
-    /// Aggregation limits.
-    pub aggregation_limits: AggregationLimits,
     /// Fast fields cache.
     pub fast_fields_cache: Arc<dyn Cache>,
     /// Counting semaphore to limit concurrent leaf search split requests.
@@ -334,21 +332,23 @@ impl SearcherContext {
         let fast_field_cache_capacity =
             searcher_config.fast_field_cache_capacity.get_bytes() as usize;
         let storage_long_term_cache = Arc::new(QuickwitCache::new(fast_field_cache_capacity));
-        let aggregation_limits = AggregationLimits::new(
-            Some(searcher_config.aggregation_memory_limit.get_bytes()),
-            Some(searcher_config.aggregation_bucket_limit),
-        );
         let leaf_search_cache = LeafSearchCache::new(
             searcher_config.partial_request_cache_capacity.get_bytes() as usize,
         );
         Self {
             searcher_config,
-            aggregation_limits,
             fast_fields_cache: storage_long_term_cache,
             leaf_search_split_semaphore,
             split_footer_cache: global_split_footer_cache,
             split_stream_semaphore,
             leaf_search_cache,
         }
+    }
+    // Returns a new instance to track the aggregation memory usage.
+    pub fn get_aggregation_limits(&self) -> AggregationLimits {
+        AggregationLimits::new(
+            Some(self.searcher_config.aggregation_memory_limit.get_bytes()),
+            Some(self.searcher_config.aggregation_bucket_limit),
+        )
     }
 }


### PR DESCRIPTION
#3305 added a shared AggregationLimits on SearcherContext, but AggregationLimits tracks the memory itself and should not be shared.
closes #3503


