### PR TITLE
Uploading nightly builds to a release

### DIFF
--- a/.github/actions/cargo-build-macos-binary/action.yml
+++ b/.github/actions/cargo-build-macos-binary/action.yml
@@ -67,4 +67,5 @@ runs:
       with:
         file: ${{ env.ASSET_FULL_NAME }}.tar.gz
         overwrite: true
+        draft: false
         tag_name: ${{ inputs.version }}

--- a/.github/actions/cargo-build-macos-binary/action.yml
+++ b/.github/actions/cargo-build-macos-binary/action.yml
@@ -61,7 +61,6 @@ runs:
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz
         retention-days: 3
     - name: Deploy archive to GitHub release
-      if: "${{ inputs.version != 'nightly' }}"
       uses: quickwit-inc/upload-to-github-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/cargo-build-macos-binary/action.yml
+++ b/.github/actions/cargo-build-macos-binary/action.yml
@@ -60,7 +60,8 @@ runs:
         name: ${{ env.ASSET_FULL_NAME }}.tar.gz
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz
         retention-days: 3
-    - name: Deploy archive to GitHub release
+    - name: Deploy archive to GitHub nightly release
+      if: "${{ inputs.version == 'nightly' }}"
       uses: quickwit-inc/upload-to-github-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
@@ -68,4 +69,14 @@ runs:
         file: ${{ env.ASSET_FULL_NAME }}.tar.gz
         overwrite: true
         draft: false
+        tag_name: ${{ inputs.version }}
+    - name: Deploy archive to GitHub release
+      if: "${{ inputs.version != 'nightly' }}"
+      uses: quickwit-inc/upload-to-github-release@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      with:
+        file: ${{ env.ASSET_FULL_NAME }}.tar.gz
+        overwrite: true
+        draft: true
         tag_name: ${{ inputs.version }}

--- a/.github/actions/cargo-build-macos-binary/action.yml
+++ b/.github/actions/cargo-build-macos-binary/action.yml
@@ -60,23 +60,12 @@ runs:
         name: ${{ env.ASSET_FULL_NAME }}.tar.gz
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz
         retention-days: 3
-    - name: Deploy archive to GitHub nightly release
-      if: "${{ inputs.version == 'nightly' }}"
-      uses: quickwit-inc/upload-to-github-release@v1
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      with:
-        file: ${{ env.ASSET_FULL_NAME }}.tar.gz
-        overwrite: true
-        draft: false
-        tag_name: ${{ inputs.version }}
     - name: Deploy archive to GitHub release
-      if: "${{ inputs.version != 'nightly' }}"
       uses: quickwit-inc/upload-to-github-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
         file: ${{ env.ASSET_FULL_NAME }}.tar.gz
         overwrite: true
-        draft: true
+        draft: ${{ inputs.version != 'nightly' }}
         tag_name: ${{ inputs.version }}

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -57,7 +57,6 @@ runs:
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz
         retention-days: 3
     - name: Upload archive
-      if: "${{ inputs.version != 'nightly' }}"
       uses: quickwit-inc/upload-to-github-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -56,7 +56,8 @@ runs:
         name: ${{ env.ASSET_FULL_NAME }}.tar.gz
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz
         retention-days: 3
-    - name: Upload archive
+    - name: Deploy archive to GitHub nightly release
+      if: "${{ inputs.version == 'nightly' }}"
       uses: quickwit-inc/upload-to-github-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
@@ -64,4 +65,14 @@ runs:
         file: ${{ env.ASSET_FULL_NAME }}.tar.gz
         overwrite: true
         draft: false
+        tag_name: ${{ inputs.version }}
+    - name: Deploy archive to GitHub release
+      if: "${{ inputs.version != 'nightly' }}"
+      uses: quickwit-inc/upload-to-github-release@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      with:
+        file: ${{ env.ASSET_FULL_NAME }}.tar.gz
+        overwrite: true
+        draft: true
         tag_name: ${{ inputs.version }}

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -56,23 +56,12 @@ runs:
         name: ${{ env.ASSET_FULL_NAME }}.tar.gz
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz
         retention-days: 3
-    - name: Deploy archive to GitHub nightly release
-      if: "${{ inputs.version == 'nightly' }}"
+    - name: Upload archive
       uses: quickwit-inc/upload-to-github-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
         file: ${{ env.ASSET_FULL_NAME }}.tar.gz
         overwrite: true
-        draft: false
-        tag_name: ${{ inputs.version }}
-    - name: Deploy archive to GitHub release
-      if: "${{ inputs.version != 'nightly' }}"
-      uses: quickwit-inc/upload-to-github-release@v1
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      with:
-        file: ${{ env.ASSET_FULL_NAME }}.tar.gz
-        overwrite: true
-        draft: true
+        draft: ${{ inputs.version != 'nightly' }}
         tag_name: ${{ inputs.version }}

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -63,4 +63,5 @@ runs:
       with:
         file: ${{ env.ASSET_FULL_NAME }}.tar.gz
         overwrite: true
+        draft: false
         tag_name: ${{ inputs.version }}


### PR DESCRIPTION
Uploading nightly builds to a specific nightly release so that we can refer to the nightly build binaries using as stable URL.
Related to https://github.com/quickwit-oss/quickwit/issues/1585