### PR TITLE
Add nightly binaries link to docs

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -5,6 +5,13 @@ sidebar_position: 2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { useDocsVersion } from '@docusaurus/theme-common/internal';
+
+export const RenderIf = ({children, condition}) => (
+    <>
+        {condition && children}
+    </>
+);
 
 Quickwit compiles to a single binary and we provide different methods to install it:
 
@@ -21,6 +28,21 @@ Support of aarch64 is currently experimental.
 
 ## Download
 
+<RenderIf condition={useDocsVersion().version == 'current'}>
+
+Version: nightly - 
+License: [AGPL V3](https://github.com/quickwit-oss/quickwit/blob/main/LICENSE.md) -
+Downloads `.tar.gz`:
+- [Linux ARM64](https://github.com/quickwit-oss/quickwit/releases/download/nightly/quickwit-nightly-aarch64-unknown-linux-gnu.tar.gz)
+- [Linux x86_64](https://github.com/quickwit-oss/quickwit/releases/download/nightly/quickwit-nightly-x86_64-unknown-linux-gnu.tar.gz)
+- [macOS aarch64](https://github.com/quickwit-oss/quickwit/releases/download/nightly/quickwit-nightly-aarch64-apple-darwin.tar.gz)
+- [macOS x86_64](https://github.com/quickwit-oss/quickwit/releases/download/nightly/quickwit-nightly-x86_64-apple-darwin.tar.gz)
+
+</RenderIf>
+
+<!-- Bellow is the set of links you need to edit when a new version is released -->
+<RenderIf condition={useDocsVersion().version != 'current'}>
+
 version: 0.6.0 - [Release notes](https://github.com/quickwit-oss/quickwit/releases/tag/v0.6.0) - [Changelog](https://github.com/quickwit-oss/quickwit/blob/main/CHANGELOG.md)
 License: [AGPL V3](https://github.com/quickwit-oss/quickwit/blob/main/LICENSE.md)
 Downloads `.tar.gz`:
@@ -29,6 +51,7 @@ Downloads `.tar.gz`:
 - [macOS aarch64](https://github.com/quickwit-oss/quickwit/releases/download/v0.6.0/quickwit-v0.6.0-aarch64-apple-darwin.tar.gz)
 - [macOS x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.6.0/quickwit-v0.6.0-x86_64-apple-darwin.tar.gz)
 
+</RenderIf>
 
 Check out the available builds in greater detail on [GitHub](https://github.com/quickwit-oss/quickwit/releases)
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -40,7 +40,7 @@ Downloads `.tar.gz`:
 
 </RenderIf>
 
-<!-- Bellow is the set of links you need to edit when a new version is released -->
+<!-- Bellow is the set of links to edit when a new version is released -->
 <RenderIf condition={useDocsVersion().version != 'current'}>
 
 version: 0.6.0 - [Release notes](https://github.com/quickwit-oss/quickwit/releases/tag/v0.6.0) - [Changelog](https://github.com/quickwit-oss/quickwit/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Make binaries link on `main-branch` of documentation point to nightly 
Closes https://github.com/quickwit-oss/quickwit/issues/1585