### PR TITLE
Enhancement of docker section

### DIFF
--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -39,11 +39,8 @@ There are also other parameters that can be only defined by env variables:
 
 | Env variable | Description |
 | --- | --- |
-| `QW_S3_ENDPOINT` | Custom S3 endpoint. |
-| `QW_S3_MAX_CONCURRENCY` | Limit the number of concurent requests to S3 |
+| `QW_S3_MAX_CONCURRENCY` | Limit the number of concurrent requests to S3 |
 | `QW_ENABLE_JAEGER_EXPORTER` | Enable trace export to Jaeger. |
-| `QW_AZURE_STORAGE_ACCOUNT` | Azure Blob Storage account name. |
-| `QW_AZURE_STORAGE_ACCESS_KEY` | Azure Blob Storage account access key. |
 
 More details about [storage configuration](../reference/storage-uri.md).
 
@@ -57,10 +54,10 @@ If a storage configuration is not explicitly set, Quickwit will rely on the defa
 
 ### Azure storage configuration
 
-| Property | Description | Default value |
-| --- | --- | --- |
-| `account` | The Azure storage account name. | |
-| `access_key` | The Azure storage account access key. | |
+| Property | Description | Env variable | Default value |
+| --- | --- | --- | --- |
+| `account` | The Azure storage account name. | `QW_AZURE_STORAGE_ACCOUNT` | |
+| `access_key` | The Azure storage account access key. | `QW_AZURE_STORAGE_ACCESS_KEY` | |
 
 Example of a storage configuration for Azure in YAML format:
 
@@ -73,11 +70,11 @@ storage:
 
 ### S3 storage configuration
 
-| Property | Description | Default value |
-| --- | --- | --- |
-| `endpoint` | Custom endpoint for use with S3-compatible providers. | SDK default |
-| `force_path_style_access` | Disables [virtual-hosted–style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) requests. Required by some S3-compatible providers (Ceph, MinIO). | `false` |
-| `disable_multi_object_delete_requests` | Disables [Multi-Object Delete](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) requests. Required by some S3-compatible providers (GCS). | `false` |
+| Property | Description | Env variable | Default value |
+| --- | --- | --- | --- |
+| `endpoint` | Custom endpoint for use with S3-compatible providers. | `QW_S3_ENDPOINT` | SDK default |
+| `force_path_style_access` | Disables [virtual-hosted–style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) requests. Required by some S3-compatible providers (Ceph, MinIO). | `QW_S3_FORCE_PATH_STYLE_ACCESS` | `false` |
+| `disable_multi_object_delete_requests` | Disables [Multi-Object Delete](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) requests. Required by some S3-compatible providers (GCS). | | `false` |
 
 Example of a storage configuration for S3 in YAML format:
 
@@ -126,12 +123,12 @@ metastore:
 
 This section contains the configuration options for an indexer. The split store is documented in the  [indexing document](../overview/concepts/indexing.md#split-store).
 
-| Property | Description | Default value |
-| --- | --- | --- |
-| `split_store_max_num_bytes` | Maximum size in bytes allowed in the split store for each index-source pair. | `100G` |
-| `split_store_max_num_splits` | Maximum number of files allowed in the split store for each index-source pair. | `1000` |
-| `max_concurrent_split_uploads` | Maximum number of concurrent split uploads allowed on the node. | `12` |
-| `enable_otlp_endpoint` | If true, enables the OpenTelemetry exporter endpoint to ingest logs and traces via the OpenTelemetry Protocol (OTLP). | `false` |
+| Property | Description | Env variable | Default value |
+| --- | --- | --- | --- |
+| `split_store_max_num_bytes` | Maximum size in bytes allowed in the split store for each index-source pair. | | `100G` |
+| `split_store_max_num_splits` | Maximum number of files allowed in the split store for each index-source pair. | | `1000` |
+| `max_concurrent_split_uploads` | Maximum number of concurrent split uploads allowed on the node. | | `12` |
+| `enable_otlp_endpoint` | If true, enables the OpenTelemetry exporter endpoint to ingest logs and traces via the OpenTelemetry Protocol (OTLP). | `QW_ENABLE_OTLP_ENDPOINT` | `false` |
 
 ## Ingest API configuration
 
@@ -157,9 +154,9 @@ This section contains the configuration options for a Searcher.
 
 ## Jaeger configuration
 
-| Property | Description | Default value |
-| --- | --- | --- |
-| `enable_endpoint` | If true, enables the gRPC endpoint that allows the Jaeger Query Service to connect and retrieve traces. | `false` |
+| Property | Description | Env Variable | Default value |
+| --- | --- | --- | --- |
+| `enable_endpoint` | If true, enables the gRPC endpoint that allows the Jaeger Query Service to connect and retrieve traces | `QW_ENABLE_JAEGER_ENDPOINT` | `false` |
 
 
 ## Using environment variables in the configuration

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -150,6 +150,46 @@ docker run --rm quickwit/quickwit --version
 # You can also safely ignore jemalloc warnings.
 docker run --rm --platform linux/amd64 quickwit/quickwit --version
 ```
+Here is the directory layout of quickwit inside the container in case you need to mount a volume:
+
+```bash
+quickwit
+    ├── config
+    │   └── quickwit.yaml
+    ├── quickwit
+    └── qwdata
+```
+
+- `config/quickwit.yaml`: the default configuration file.
+- `quickwit`: the quickwit executable binary.
+- `qwdata/`: the default data directory.
+
+Here is a list of the available environment variables and ports options that can be used to configure Quickwit:
+
+[Node configuration](../configuration/node-config.md):
+- `QW_CLUSTER_ID`
+- `QW_NODE_ID`
+- `QW_ENABLED_SERVICES`
+- `QW_LISTEN_ADDRESS`
+- `QW_ADVERTISE_ADDRESS`
+- `QW_PEER_SEEDS`
+- `QW_DATA_DIR`
+- `QW_METASTORE_URI`
+- `QW_DEFAULT_INDEX_ROOT_URI`
+- `QW_ENABLE_JAEGER_EXPORTER`
+- `QW_ENABLE_JAEGER_ENDPOINT`
+- `QW_S3_ENDPOINT`
+- `QW_S3_MAX_CONCURRENCY`
+- `QW_AZURE_STORAGE_ACCOUNT`
+- `QW_AZURE_STORAGE_ACCESS_KEY`
+
+[Ports configuration](../configuration/ports-config.md):
+- `QW_REST_LISTEN_PORT`
+- `QW_GOSSIP_LISTEN_PORT`
+- `QW_GRPC_LISTEN_PORT`
+
+[Telemetry](../telemetry.md):
+- `QW_DISABLE_TELEMETRY`
 
 To get the full gist of this, follow the [Quickstart guide](./quickstart.md).
 


### PR DESCRIPTION
- Added a list of available environment variables in the docker installation section
- Updated `node-config.md` to add the environment variables to the respective config option

@guilload  The idea is to link this section from Quickwit Dockerhub page 
https://quickwit.io/docs/get-started/installation#use-the-docker-image