### PR TITLE
allow to customize kafka-source's group.id

### DIFF
--- a/docs/configuration/source-config.md
+++ b/docs/configuration/source-config.md
@@ -68,7 +68,7 @@ Comma-separated list of host and port pairs that are the addresses of a subset o
 The Kafka source manages commit offsets manually using the [checkpoint API](../overview/concepts/indexing.md#checkpoint) and disables auto-commit.
 
 - `group.id`
-Kafka-based distributed indexing relies on consumer groups. The group ID assigned to each consumer managed by the source is `quickwit-{index_id}-{source_id}`.
+Kafka-based distributed indexing relies on consumer groups. Unless overridden in the client parameters, the default group ID assigned to each consumer managed by the source is `quickwit-{index_uid}-{source_id}`
 
 - `max.poll.interval.ms`
 Short max poll interval durations may cause a source to crash when back pressure from the indexer occurs. Therefore, Quickwit recommends using the default value of `300000` (5 minutes).

--- a/quickwit/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kafka_source.rs
@@ -667,11 +667,14 @@ fn create_consumer(
     params: KafkaSourceParams,
     events_tx: mpsc::Sender<KafkaEvent>,
 ) -> anyhow::Result<(ClientConfig, RdKafkaConsumer)> {
-    let mut client_config = parse_client_params(params.client_params)?;
-
     // Group ID is limited to 255 characters.
-    let mut group_id = format!("quickwit-{index_uid}-{source_id}");
+    let mut group_id = match &params.client_params["group.id"] {
+        JsonValue::String(group_id) => group_id.clone(),
+        _ => format!("quickwit-{index_uid}-{source_id}"),
+    };
     group_id.truncate(255);
+
+    let mut client_config = parse_client_params(params.client_params)?;
 
     let log_level = parse_client_log_level(params.client_log_level)?;
     let consumer: RdKafkaConsumer = client_config


### PR DESCRIPTION
### Description

quickwit auto generated group-id can't be used with Aliyun's kafka server.

this patch allows to customize kafka-source's `group.id` via `client_params` in source config.

### How was this PR tested?

deployed to my testing cluster, working well with Aliyun's kafka server
