### PR TITLE
Add local search CLI.

### DIFF
--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -46,6 +46,11 @@ use quickwit_indexing::models::{
     DetachIndexingPipeline, DetachMergePipeline, IndexingStatistics, SpawnPipeline,
 };
 use quickwit_indexing::IndexingPipeline;
+use quickwit_proto::SearchResponse;
+use quickwit_search::{single_node_search, SearchResponseRest};
+use quickwit_serve::{
+    search_request_from_api_request, BodyFormat, SearchRequestQueryString, SortByField,
+};
 use quickwit_storage::{BundleStorage, Storage};
 use thousands::Separable;
 use tracing::{debug, info};
@@ -79,6 +84,40 @@ pub fn build_tool_command() -> Command {
                     arg!(--"transform-script" <SCRIPT> "VRL program to transform docs before ingesting.")
                         .required(false),
                     arg!(--"keep-cache" "Does not clear local cache directory upon completion.")
+                        .required(false),
+                ])
+            )
+        .subcommand(
+            Command::new("local-search")
+                .display_order(10)
+                .about("Searches an index locally.")
+                .long_about("Searchers an index directly on the configured storage without using a server.")
+                .args(&[
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1)
+                        .required(true),
+                    arg!(--query <QUERY> "Query expressed in natural query language ((barack AND obama) OR \"president of united states\"). Learn more on https://quickwit.io/docs/reference/search-language.")
+                        .display_order(2)
+                        .required(true),
+                    arg!(--aggregation <AGG> "JSON serialized aggregation request in tantivy/elasticsearch format.")
+                        .required(false),
+                    arg!(--"max-hits" <MAX_HITS> "Maximum number of hits returned.")
+                        .default_value("20")
+                        .required(false),
+                    arg!(--"start-offset" <OFFSET> "Offset in the global result set of the first hit returned.")
+                        .default_value("0")
+                        .required(false),
+                    arg!(--"search-fields" <FIELD_NAME> "List of fields that Quickwit will search into if the user query does not explicitly target a field in the query. It overrides the default search fields defined in the index config. Space-separated list, e.g. \"field1 field2\". ")
+                        .num_args(1..)
+                        .required(false),
+                    arg!(--"snippet-fields" <FIELD_NAME> "List of fields that Quickwit will return snippet highlight on. Space-separated list, e.g. \"field1 field2\". ")
+                        .num_args(1..)
+                        .required(false),
+                    arg!(--"start-timestamp" <TIMESTAMP> "Filters out documents before that timestamp (time-series indexes only).")
+                        .required(false),
+                    arg!(--"end-timestamp" <TIMESTAMP> "Filters out documents after that timestamp (time-series indexes only).")
+                        .required(false),
+                    arg!(--"sort-by-field" <SORT_BY_FIELD> "Sort by field.")
                         .required(false),
                 ])
             )
@@ -138,6 +177,21 @@ pub struct LocalIngestDocsArgs {
 }
 
 #[derive(Debug, Eq, PartialEq)]
+pub struct LocalSearchArgs {
+    pub config_uri: Uri,
+    pub index_id: String,
+    pub query: String,
+    pub aggregation: Option<String>,
+    pub max_hits: usize,
+    pub start_offset: usize,
+    pub search_fields: Option<Vec<String>>,
+    pub snippet_fields: Option<Vec<String>>,
+    pub start_timestamp: Option<i64>,
+    pub end_timestamp: Option<i64>,
+    pub sort_by_field: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
 pub struct GarbageCollectIndexArgs {
     pub config_uri: Uri,
     pub index_id: String,
@@ -164,6 +218,7 @@ pub struct ExtractSplitArgs {
 pub enum ToolCliCommand {
     GarbageCollect(GarbageCollectIndexArgs),
     LocalIngest(LocalIngestDocsArgs),
+    LocalSearch(LocalSearchArgs),
     Merge(MergeArgs),
     ExtractSplit(ExtractSplitArgs),
 }
@@ -176,6 +231,7 @@ impl ToolCliCommand {
         match subcommand.as_str() {
             "gc" => Self::parse_garbage_collect_args(submatches),
             "local-ingest" => Self::parse_local_ingest_args(submatches),
+            "local-search" => Self::parse_local_search_args(submatches),
             "merge" => Self::parse_merge_args(submatches),
             "extract-split" => Self::parse_extract_split_args(submatches),
             _ => bail!("Unknown tool subcommand `{subcommand}`."),
@@ -215,6 +271,56 @@ impl ToolCliCommand {
             overwrite,
             vrl_script,
             clear_cache,
+        }))
+    }
+
+    fn parse_local_search_args(mut matches: ArgMatches) -> anyhow::Result<Self> {
+        let config_uri = matches
+            .remove_one::<String>("config")
+            .map(|uri_str| Uri::from_str(&uri_str))
+            .expect("`config` should be a required arg.")?;
+        let index_id = matches
+            .remove_one::<String>("index")
+            .expect("`index` should be a required arg.");
+        let query = matches
+            .remove_one::<String>("query")
+            .context("`query` should be a required arg.")?;
+        let aggregation = matches.remove_one::<String>("aggregation");
+        let max_hits = matches
+            .remove_one::<String>("max-hits")
+            .expect("`max-hits` should have a default value.")
+            .parse()?;
+        let start_offset = matches
+            .remove_one::<String>("start-offset")
+            .expect("`start-offset` should have a default value.")
+            .parse()?;
+        let search_fields = matches
+            .remove_many::<String>("search-fields")
+            .map(|values| values.collect());
+        let snippet_fields = matches
+            .remove_many::<String>("snippet-fields")
+            .map(|values| values.collect());
+        let sort_by_field = matches.remove_one::<String>("sort-by-field");
+        let start_timestamp = matches
+            .remove_one::<String>("start-timestamp")
+            .map(|ts| ts.parse())
+            .transpose()?;
+        let end_timestamp = matches
+            .remove_one::<String>("end-timestamp")
+            .map(|ts| ts.parse())
+            .transpose()?;
+        Ok(Self::LocalSearch(LocalSearchArgs {
+            config_uri,
+            index_id,
+            query,
+            aggregation,
+            max_hits,
+            start_offset,
+            search_fields,
+            snippet_fields,
+            start_timestamp,
+            end_timestamp,
+            sort_by_field,
         }))
     }
 
@@ -284,6 +390,7 @@ impl ToolCliCommand {
         match self {
             Self::GarbageCollect(args) => garbage_collect_index_cli(args).await,
             Self::LocalIngest(args) => local_ingest_docs_cli(args).await,
+            Self::LocalSearch(args) => local_search_cli(args).await,
             Self::Merge(args) => merge_cli(args).await,
             Self::ExtractSplit(args) => extract_split_cli(args).await,
         }
@@ -411,6 +518,40 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
         }
         _ => bail!("Failed to ingest all the documents."),
     }
+}
+
+pub async fn local_search_cli(args: LocalSearchArgs) -> anyhow::Result<()> {
+    debug!(args=?args, "local-search");
+    println!("❯ Searching directly on the index storage (without calling REST API)...");
+    let config = load_node_config(&args.config_uri).await?;
+    let (storage_resolver, metastore_resolver) = get_resolvers(&config).await;
+    let metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
+    let aggs = args
+        .aggregation
+        .map(|agg_string| serde_json::from_str(&agg_string))
+        .transpose()?;
+    let sort_by_field = args.sort_by_field.map(SortByField::from);
+    let search_request_query_string = SearchRequestQueryString {
+        query: args.query,
+        start_offset: args.start_offset as u64,
+        max_hits: args.max_hits as u64,
+        search_fields: args.search_fields,
+        snippet_fields: args.snippet_fields,
+        start_timestamp: args.start_timestamp,
+        end_timestamp: args.end_timestamp,
+        aggs,
+        format: BodyFormat::Json,
+        sort_by_field,
+    };
+    let search_request =
+        search_request_from_api_request(args.index_id, search_request_query_string)?;
+    debug!(search_request=?search_request, "search-request");
+    let search_response: SearchResponse =
+        single_node_search(search_request, &*metastore, storage_resolver).await?;
+    let search_response_rest = SearchResponseRest::try_from(search_response)?;
+    let search_response_json = serde_json::to_string_pretty(&search_response_rest)?;
+    println!("{}", search_response_json);
+    Ok(())
 }
 
 pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::Ipv4Addr;
 
 use assert_json_diff::{assert_json_eq, assert_json_include};
 use quickwit_config::SearcherConfig;
@@ -26,8 +25,7 @@ use quickwit_doc_mapper::DefaultDocMapper;
 use quickwit_indexing::TestSandbox;
 use quickwit_opentelemetry::otlp::TraceId;
 use quickwit_proto::{
-    LeafListTermsResponse, SearchRequest, SearchResponse, SortByValue, SortField, SortOrder,
-    SortValue,
+    LeafListTermsResponse, SearchRequest, SortByValue, SortField, SortOrder, SortValue,
 };
 use quickwit_query::query_ast::{qast_helper, query_ast_from_user_text};
 use serde_json::{json, Value as JsonValue};
@@ -38,6 +36,7 @@ use tantivy::Term;
 use super::*;
 use crate::find_trace_ids_collector::Span;
 use crate::service::SearcherContext;
+use crate::single_node_search;
 
 #[tokio::test]
 async fn test_single_node_simple() -> anyhow::Result<()> {
@@ -276,39 +275,6 @@ where E: Ord {
         previous_el = next_el;
     }
     true
-}
-
-/// Performs a search on the current node.
-/// See also `[distributed_search]`.
-async fn single_node_search(
-    search_request: SearchRequest,
-    metastore: Arc<dyn Metastore>,
-    storage_resolver: StorageResolver,
-) -> crate::Result<SearchResponse> {
-    let socket_addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 7280u16);
-    let searcher_pool = SearcherPool::default();
-    let search_job_placer = SearchJobPlacer::new(searcher_pool.clone());
-    let cluster_client = ClusterClient::new(search_job_placer);
-    let search_service = Arc::new(SearchServiceImpl::new(
-        metastore.clone(),
-        storage_resolver,
-        cluster_client.clone(),
-        SearcherConfig::default(),
-    ));
-    let search_service_client =
-        SearchServiceClient::from_service(search_service.clone(), socket_addr);
-    searcher_pool
-        .insert(socket_addr, search_service_client)
-        .await;
-    let searcher_config = SearcherConfig::default();
-    let searcher_context = SearcherContext::new(searcher_config);
-    root_search(
-        &searcher_context,
-        search_request,
-        &*metastore,
-        &cluster_client,
-    )
-    .await
 }
 
 #[tokio::test]

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::index_api::ListSplitsQueryParams;
 pub use crate::metrics::SERVE_METRICS;
 #[cfg(test)]
 use crate::rest::recover_fn;
+pub use crate::search_api::{search_request_from_api_request, SearchRequestQueryString, SortBy};
 
 const READINESS_REPORTING_INTERVAL: Duration = if cfg!(any(test, feature = "testsuite")) {
     Duration::from_millis(25)

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -49,7 +49,7 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use byte_unit::n_mib_bytes;
-use format::BodyFormat;
+pub use format::BodyFormat;
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use quickwit_actors::{ActorExitStatus, Mailbox, Universe};
@@ -97,7 +97,6 @@ pub use crate::index_api::ListSplitsQueryParams;
 pub use crate::metrics::SERVE_METRICS;
 #[cfg(test)]
 use crate::rest::recover_fn;
-pub use crate::search_api::{SearchRequestQueryString, SortBy};
 
 const READINESS_REPORTING_INTERVAL: Duration = if cfg!(any(test, feature = "testsuite")) {
     Duration::from_millis(25)

--- a/quickwit/quickwit-serve/src/search_api/mod.rs
+++ b/quickwit/quickwit-serve/src/search_api/mod.rs
@@ -22,9 +22,8 @@ mod rest_handler;
 
 pub use self::grpc_adapter::GrpcSearchAdapter;
 pub use self::rest_handler::{
-    search_get_handler, search_post_handler, search_stream_handler, SearchApi,
-    SearchRequestQueryString, SortBy,
-    SearchRequestQueryString
+    search_get_handler, search_post_handler, search_request_from_api_request,
+    search_stream_handler, SearchApi, SearchRequestQueryString, SortBy,
 };
 
 #[cfg(test)]

--- a/quickwit/quickwit-serve/src/search_api/mod.rs
+++ b/quickwit/quickwit-serve/src/search_api/mod.rs
@@ -24,6 +24,7 @@ pub use self::grpc_adapter::GrpcSearchAdapter;
 pub use self::rest_handler::{
     search_get_handler, search_post_handler, search_stream_handler, SearchApi,
     SearchRequestQueryString, SortBy,
+    SearchRequestQueryString
 };
 
 #[cfg(test)]

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -199,11 +199,11 @@ pub struct SearchRequestQueryString {
     pub sort_by: SortBy,
 }
 
-async fn search_endpoint(
+pub fn search_request_from_api_request(
     index_id: String,
     search_request: SearchRequestQueryString,
-    search_service: &dyn SearchService,
-) -> Result<SearchResponseRest, SearchError> {
+) -> Result<quickwit_proto::SearchRequest, SearchError> {
+    let (sort_order, sort_by_field) = get_proto_search_by(&search_request);
     // The query ast below may still contain user input query. The actual
     // parsing of the user query will happen in the root service, and might require
     // the user of the docmapper default fields (which we do not have at this point).
@@ -223,6 +223,15 @@ async fn search_endpoint(
         sort_fields: search_request.sort_by.sort_fields,
         scroll_ttl_secs: None,
     };
+    Ok(search_request)
+}
+
+async fn search_endpoint(
+    index_id: String,
+    search_request: SearchRequestQueryString,
+    search_service: &dyn SearchService,
+) -> Result<SearchResponseRest, SearchError> {
+    let search_request = search_request_from_api_request(index_id, search_request)?;
     let search_response = search_service.root_search(search_request).await?;
     let search_response_rest = SearchResponseRest::try_from(search_response)?;
     Ok(search_response_rest)

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -203,7 +203,6 @@ pub fn search_request_from_api_request(
     index_id: String,
     search_request: SearchRequestQueryString,
 ) -> Result<quickwit_proto::SearchRequest, SearchError> {
-    let (sort_order, sort_by_field) = get_proto_search_by(&search_request);
     // The query ast below may still contain user input query. The actual
     // parsing of the user query will happen in the root service, and might require
     // the user of the docmapper default fields (which we do not have at this point).


### PR DESCRIPTION
Fixes #3554

Add `tool local-search` command  to reenable searching without starting a server.

One test added to check the parsing;

Tested locally on the [quickstart](https://quickwit.io/docs/get-started/quickstart/) StackOverflow dataset:

```console
tool local-search --index stackoverflow --query "search AND engine" --sort-by-field="-creationDate" --config ../config/quickwit.yaml
```

