### PR TITLE
Add a parameter to limit the size of a query string

### DIFF
--- a/quickwit/quickwit-config/src/quickwit_config/mod.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/mod.rs
@@ -120,6 +120,7 @@ pub struct SearcherConfig {
     pub partial_request_cache_capacity: Byte,
     pub max_num_concurrent_split_searches: usize,
     pub max_num_concurrent_split_streams: usize,
+    pub max_query_string_length: Byte,
 }
 
 impl Default for SearcherConfig {
@@ -132,6 +133,7 @@ impl Default for SearcherConfig {
             max_num_concurrent_split_searches: 100,
             aggregation_memory_limit: Byte::from_bytes(500_000_000), // 500M
             aggregation_bucket_limit: 65000,
+            max_query_string_length: Byte::from_bytes(512), // 512 bytes
         }
     }
 }

--- a/quickwit/quickwit-config/src/quickwit_config/serialize.rs
+++ b/quickwit/quickwit-config/src/quickwit_config/serialize.rs
@@ -494,6 +494,7 @@ mod tests {
                 partial_request_cache_capacity: Byte::from_str("64M").unwrap(),
                 max_num_concurrent_split_searches: 150,
                 max_num_concurrent_split_streams: 120,
+                max_query_string_length: Byte::from_str("512").unwrap(),
             }
         );
         assert_eq!(

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -199,14 +199,13 @@ pub async fn single_node_search(
     let metas = list_relevant_splits(index_uid, &search_request, metastore).await?;
     let split_metadata: Vec<SplitIdAndFooterOffsets> =
         metas.iter().map(extract_split_and_footer_offsets).collect();
-    validate_request(&*doc_mapper, &search_request)?;
+    let searcher_context = Arc::new(SearcherContext::new(SearcherConfig::default()));
+    validate_request(&*doc_mapper, &search_request, &searcher_context)?;
 
     // Verifying that the query is valid.
     doc_mapper
         .query(doc_mapper.schema(), &query_ast_resolved, true)
         .map_err(|err| SearchError::InvalidQuery(err.to_string()))?;
-
-    let searcher_context = Arc::new(SearcherContext::new(SearcherConfig::default()));
 
     let leaf_search_response = leaf_search(
         searcher_context.clone(),

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -303,6 +303,8 @@ pub struct SearcherContext {
     pub split_stream_semaphore: Semaphore,
     /// Recent sub-query cache.
     pub leaf_search_cache: LeafSearchCache,
+    /// Query string max length.
+    pub query_string_max_length: usize,
 }
 
 impl std::fmt::Debug for SearcherContext {
@@ -335,6 +337,7 @@ impl SearcherContext {
         let leaf_search_cache = LeafSearchCache::new(
             searcher_config.partial_request_cache_capacity.get_bytes() as usize,
         );
+        let query_string_max_length = searcher_config.max_query_string_length.get_bytes() as usize;
         Self {
             searcher_config,
             fast_fields_cache: storage_long_term_cache,
@@ -342,6 +345,7 @@ impl SearcherContext {
             split_footer_cache: global_split_footer_cache,
             split_stream_semaphore,
             leaf_search_cache,
+            query_string_max_length,
         }
     }
     // Returns a new instance to track the aggregation memory usage.


### PR DESCRIPTION
### Description

fix #3546 
Added a parameter to set the maximum number of characters in a query.
Default is set to 512 for the following reasons.
Because the query for this test was 395 bytes, and I thought the default of 256 byte might be too short even for a normal use case. (I'd like to hear from maintainers here)
https://github.com/quickwit-oss/quickwit/blob/main/quickwit/quickwit-jaeger/src/integration_tests.rs#L197

### How was this PR tested?

add a few unit tests.
Please let us know if you feel your test case is missing :)
