### PR TITLE
Fix JSON Field docs

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -325,7 +325,7 @@ name: parameters
 type: json
 stored: true
 indexed: true
-tokenizer: "default"
+tokenizer: raw
 expand_dots: false
 fast:
   normalizer: lowercase
@@ -339,7 +339,7 @@ fast:
 | `stored`    | Whether value is stored in the document store | `true` |
 | `indexed`   | Whether value is indexed | `true` |
 | `fast`     | Whether value is stored in a fast field. The default behaviour for text in the JSON is to store the text unchanged. An normalizer can be configured via `normalizer: lowercase`. ([See normalizers](#description-of-available-normalizers)) for a list of available normalizers. | `true` |
-| `tokenizer` | **Only affects strings in the json object**. Name of the `Tokenizer`, choices between `raw`, `default`, `en_stem` and `chinese_compatible` | `default` |
+| `tokenizer` | **Only affects strings in the json object**. Name of the `Tokenizer`, choices between `raw`, `default`, `en_stem` and `chinese_compatible` | `raw` |
 | `record`    | **Only affects strings in the json object**. Describes the amount of information indexed, choices between `basic`, `freq` and `position` | `basic` |
 | `expand_dots`    | If true, json keys containing a `.` should be expanded. For instance, if `expand_dots` is set to true, `{"k8s.node.id": "node-2"}` will be indexed as if it was `{"k8s": {"node": {"id": "node2"}}}`. The benefit is that escaping the `.` will not be required at query time. In other words, `k8s.node.id:node2` will match the document. This does not impact the way the document is stored.  | `true` |
 


### PR DESCRIPTION
### Description

In #3473 we changed the default tokenizer for the JSON field from default to raw. This commit reflects this change in the documentation.

Fixes #3557

### How was this PR tested?

It's a doc change. 
