### PR TITLE
Clone mocks while keeping expectations around

### DIFF
--- a/quickwit/quickwit-codegen/example/src/lib.rs
+++ b/quickwit/quickwit-codegen/example/src/lib.rs
@@ -484,4 +484,38 @@ mod tests {
         );
         assert_eq!(balance_channel.num_connections(), 1);
     }
+
+    #[tokio::test]
+    async fn test_hello_codegen_mock() {
+        let mut hello_mock = HelloClient::mock();
+        hello_mock.expect_hello().returning(|_| {
+            Ok(HelloResponse {
+                message: "Hello, mock!".to_string(),
+            })
+        });
+        let mut hello: HelloClient = hello_mock.into();
+        assert_eq!(
+            hello
+                .hello(HelloRequest {
+                    name: "World".to_string()
+                })
+                .await
+                .unwrap(),
+            HelloResponse {
+                message: "Hello, mock!".to_string()
+            }
+        );
+        assert_eq!(
+            hello
+                .clone()
+                .hello(HelloRequest {
+                    name: "World".to_string()
+                })
+                .await
+                .unwrap(),
+            HelloResponse {
+                message: "Hello, mock!".to_string()
+            }
+        );
+    }
 }


### PR DESCRIPTION
### Description
When you clone a mock, the expectations don't stick around, which causes some trouble when writing unit tests with a `quickwit_common::Pool` of mocks:

```rust
struct Pool<K, V> {
  map: Arc<RwLock<HashMap<K, V>>>
}

impl Pool<K, V> where ... {
  async fn get<Q>(&self, key: &Q) -> Option<V> where ... {
    self.map.read().await.get(key).cloned() # <-- cloning the mock
  }
}
```

This PR introduces a mock wrapper that allows mocks to be cloned using an `Arc`. The `Mutex` is mandatory because methods of service client traits are `&mut self`.

### How was this PR tested?
- Added unit test
