### PR TITLE
Add support for custom tokenizers ngram and regex.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3683,7 +3683,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6473,8 +6473,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.20.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+version = "0.20.2"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6486,7 +6486,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "downcast-rs",
- "fail",
+ "dyn-clone",
  "fastdivide",
  "fs4",
  "futures-util",
@@ -6529,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.4.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "bitpacking",
 ]
@@ -6537,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "fastdivide",
  "fnv",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6575,7 +6575,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.20.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "combine",
  "once_cell",
@@ -6585,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "tantivy-common",
  "tantivy-fst",
@@ -6595,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=924fc70#924fc70cb58f56dcd1a0547f2528c9ea86452763"
+source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2997,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
 
 [[package]]
 name = "match_cfg"
@@ -3061,9 +3061,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
 ]
@@ -3683,7 +3683,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6474,7 +6474,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.20.2"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6486,7 +6486,6 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "downcast-rs",
- "dyn-clone",
  "fastdivide",
  "fs4",
  "futures-util",
@@ -6529,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.4.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "bitpacking",
 ]
@@ -6537,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "fastdivide",
  "fnv",
@@ -6552,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6575,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.20.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "combine",
  "once_cell",
@@ -6585,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "tantivy-common",
  "tantivy-fst",
@@ -6595,7 +6594,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -6604,7 +6603,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?branch=fmassot/add-box-token-filter-and-refactor#f6a6b4a2ff569891e3892a7e4126257810468c19"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3c30066#3c300666ad448386136d2595b613b3236b123ff9"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -224,7 +224,7 @@ quickwit-serve = { version = "0.6.1", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.6.1", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.6.1", path = "./quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", branch = "fmassot/add-box-token-filter-and-refactor", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "3c30066", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -224,7 +224,7 @@ quickwit-serve = { version = "0.6.1", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.6.1", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.6.1", path = "./quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "924fc70", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", branch = "fmassot/add-box-token-filter-and-refactor", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.json
+++ b/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.json
@@ -4,6 +4,13 @@
     "index_id": "hdfs-logs",
     "index_uri": "s3://quickwit-indexes/hdfs-logs",
     "doc_mapping": {
+        "tokenizers": [
+            {
+                "name": "service_regex",
+                "type": "regex",
+                "pattern": "\\w*"
+            }
+        ],
         "field_mappings": [
             {
                 "name": "tenant_id",
@@ -33,7 +40,7 @@
                     {
                         "name": "service",
                         "type": "text",
-                        "tokenizer": "raw"
+                        "tokenizer": "service_regex"
                     }
                 ]
             }

--- a/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.toml
+++ b/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.toml
@@ -3,12 +3,15 @@ index_id = "hdfs-logs"
 index_uri = "s3://quickwit-indexes/hdfs-logs"
 
 [doc_mapping]
+tokenizers = [
+  { name = "service_regex", type = "regex", pattern = "\\w*" },
+]
 field_mappings = [
   { name = "tenant_id", type = "u64", fast = true },
   { name = "timestamp", type = "datetime", fast = true },
   { name = "severity_text", type = "text", tokenizer = "raw" },
   { name = "body", type = "text", tokenizer = "default", record = "position" },
-  { name = "resource", type = "object", field_mappings = [ { name = "service", type = "text", tokenizer = "raw" } ] },
+  { name = "resource", type = "object", field_mappings = [ { name = "service", type = "text", tokenizer = "service_regex" } ] },
 ]
 tag_fields = [ "tenant_id" ]
 store_source = true

--- a/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
+++ b/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
@@ -3,6 +3,10 @@ index_id: hdfs-logs
 index_uri: s3://quickwit-indexes/hdfs-logs
 
 doc_mapping:
+  tokenizers:
+    - name: service_regex
+      type: regex
+      pattern: "\\w*"
   field_mappings:
     - name: tenant_id
       type: u64
@@ -22,7 +26,7 @@ doc_mapping:
       field_mappings:
         - name: service
           type: text
-          tokenizer: raw
+          tokenizer: service_regex
   tag_fields: [tenant_id]
   timestamp_field: timestamp
   store_source: true

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -416,6 +416,14 @@ impl TestableForRegression for IndexConfig {
         }"#,
         )
         .unwrap();
+        let tokenizer = serde_json::from_str(
+            r#"{
+                "name": "custom_tokenizer",
+                "type": "regex",
+                "pattern": "[^\\p{L}\\p{N}]+"
+            }"#,
+        )
+        .unwrap();
         let doc_mapping = DocMapping {
             field_mappings: vec![
                 tenant_id_mapping,
@@ -433,7 +441,7 @@ impl TestableForRegression for IndexConfig {
             partition_key: Some("tenant_id".to_string()),
             max_num_partitions: NonZeroU32::new(100).unwrap(),
             timestamp_field: Some("timestamp".to_string()),
-            tokenizers: vec![],
+            tokenizers: vec![tokenizer],
         };
         let retention_policy = Some(RetentionPolicy::new(
             "90 days".to_string(),

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -33,7 +33,7 @@ use humantime::parse_duration;
 use quickwit_common::uri::Uri;
 use quickwit_doc_mapper::{
     DefaultDocMapper, DefaultDocMapperBuilder, DocMapper, FieldMappingEntry, ModeType,
-    QuickwitJsonOptions,
+    QuickwitJsonOptions, TokenizerEntry,
 };
 use serde::{Deserialize, Serialize};
 pub use serialize::load_index_config_from_user_config;
@@ -76,6 +76,8 @@ pub struct DocMapping {
     #[schema(value_type = u32)]
     #[serde(default = "DefaultDocMapper::default_max_num_partitions")]
     pub max_num_partitions: NonZeroU32,
+    #[serde(default)]
+    pub tokenizers: Vec<TokenizerEntry>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
@@ -431,6 +433,7 @@ impl TestableForRegression for IndexConfig {
             partition_key: Some("tenant_id".to_string()),
             max_num_partitions: NonZeroU32::new(100).unwrap(),
             timestamp_field: Some("timestamp".to_string()),
+            tokenizers: vec![],
         };
         let retention_policy = Some(RetentionPolicy::new(
             "90 days".to_string(),
@@ -507,6 +510,7 @@ pub fn build_doc_mapper(
         dynamic_mapping: doc_mapping.dynamic_mapping.clone(),
         partition_key: doc_mapping.partition_key.clone(),
         max_num_partitions: doc_mapping.max_num_partitions,
+        tokenizers: doc_mapping.tokenizers.clone(),
     };
     Ok(Arc::new(builder.try_build()?))
 }

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -551,6 +551,8 @@ mod tests {
             &Uri::from_well_formed("s3://defaultbucket/"),
         )
         .unwrap();
+        assert_eq!(index_config.doc_mapping.tokenizers.len(), 1);
+        assert_eq!(index_config.doc_mapping.tokenizers[0].name, "service_regex");
         assert_eq!(index_config.doc_mapping.field_mappings.len(), 5);
         assert_eq!(index_config.doc_mapping.field_mappings[0].name, "tenant_id");
         assert_eq!(index_config.doc_mapping.field_mappings[1].name, "timestamp");

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -17,18 +17,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::num::NonZeroU32;
 
 use anyhow::{bail, Context};
+use quickwit_query::create_default_quickwit_tokenizer_manager;
 use quickwit_query::query_ast::QueryAst;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Value as JsonValue};
 use tantivy::query::Query;
 use tantivy::schema::{Field, FieldType, Schema, Value as TantivyValue, STORED};
+use tantivy::tokenizer::TokenizerManager;
 use tantivy::Document;
 
-use super::field_mapping_entry::QuickwitTextTokenizer;
+use super::field_mapping_entry::RAW_TOKENIZER_NAME;
 use super::DefaultDocMapperBuilder;
 use crate::default_doc_mapper::mapping_tree::{build_mapping_tree, MappingNode};
 use crate::default_doc_mapper::FieldMappingType;
@@ -37,8 +39,8 @@ use crate::doc_mapper::{JsonObject, Partition};
 use crate::query_builder::build_query;
 use crate::routing_expression::RoutingExpr;
 use crate::{
-    Cardinality, DocMapper, DocParsingError, ModeType, QueryParserError, WarmupInfo,
-    DYNAMIC_FIELD_NAME, SOURCE_FIELD_NAME,
+    Cardinality, DocMapper, DocParsingError, ModeType, QueryParserError, TokenizerEntry,
+    WarmupInfo, DYNAMIC_FIELD_NAME, SOURCE_FIELD_NAME,
 };
 
 /// Defines how an unmapped field should be handled.
@@ -96,6 +98,10 @@ pub struct DefaultDocMapper {
     required_fields: Vec<Field>,
     /// Defines how unmapped fields should be handle.
     mode: Mode,
+    /// User-defined tokenizers.
+    tokenizer_entries: Vec<TokenizerEntry>,
+    /// Tokenizer manager.
+    tokenizer_manager: TokenizerManager,
 }
 
 impl DefaultDocMapper {
@@ -164,6 +170,40 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
 
         let schema = schema_builder.build();
 
+        let tokenizer_manager = create_default_quickwit_tokenizer_manager();
+        let mut custom_tokenizer_names = HashSet::new();
+        for tokenizer_config_entry in builder.tokenizers.iter() {
+            if custom_tokenizer_names.contains(&tokenizer_config_entry.name) {
+                bail!(
+                    "Duplicated custom tokenizer: `{}`",
+                    tokenizer_config_entry.name
+                );
+            }
+            if tokenizer_manager
+                .get(&tokenizer_config_entry.name)
+                .is_some()
+            {
+                bail!(
+                    "Custom tokenizer name `{}` should be different from built-in tokenizer's \
+                     names.",
+                    tokenizer_config_entry.name
+                );
+            }
+            let tokenizer = tokenizer_config_entry
+                .config
+                .text_analyzer()
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "Failed to build tokenizer `{}`: {:?}",
+                        tokenizer_config_entry.name,
+                        error
+                    )
+                })?;
+            tokenizer_manager.register(&tokenizer_config_entry.name, tokenizer);
+            custom_tokenizer_names.insert(&tokenizer_config_entry.name);
+        }
+        validate_fields_tokenizers(&schema, &tokenizer_manager)?;
+
         // Resolve default search fields
         let mut default_search_field_names = Vec::new();
         for default_search_field_name in &builder.default_search_fields {
@@ -216,6 +256,8 @@ impl TryFrom<DefaultDocMapperBuilder> for DefaultDocMapper {
             partition_key,
             max_num_partitions: builder.max_num_partitions,
             mode,
+            tokenizer_entries: builder.tokenizers,
+            tokenizer_manager,
         })
     }
 }
@@ -235,8 +277,8 @@ fn validate_tag(tag_field_name: &str, schema: &Schema) -> Result<(), anyhow::Err
         FieldType::Str(options) => {
             let tokenizer_opt = options
                 .get_indexing_options()
-                .map(|text_options| text_options.tokenizer());
-            if tokenizer_opt != Some(QuickwitTextTokenizer::Raw.get_name()) {
+                .map(|text_options: &tantivy::schema::TextFieldIndexing| text_options.tokenizer());
+            if tokenizer_opt != Some(RAW_TOKENIZER_NAME) {
                 bail!("Tags collection is only allowed on text fields with the `raw` tokenizer.");
             }
         }
@@ -266,6 +308,34 @@ fn validate_tag(tag_field_name: &str, schema: &Schema) -> Result<(), anyhow::Err
     Ok(())
 }
 
+/// Checks that a given text/json field name has a registered tokenizer.
+fn validate_fields_tokenizers(
+    schema: &Schema,
+    tokenizer_manager: &TokenizerManager,
+) -> Result<(), anyhow::Error> {
+    for (_, field_entry) in schema.fields() {
+        let tokenizer_name_opt = match field_entry.field_type() {
+            FieldType::Str(options) => options
+                .get_indexing_options()
+                .map(|text_options: &tantivy::schema::TextFieldIndexing| text_options.tokenizer()),
+            FieldType::JsonObject(options) => options
+                .get_text_indexing_options()
+                .map(|text_options: &tantivy::schema::TextFieldIndexing| text_options.tokenizer()),
+            _ => None,
+        };
+        if let Some(tokenizer_name) = tokenizer_name_opt {
+            if tokenizer_manager.get(tokenizer_name).is_none() {
+                bail!(
+                    "Unknown tokenizer `{}` for field `{}`.",
+                    tokenizer_name,
+                    field_entry.name()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 impl From<DefaultDocMapper> for DefaultDocMapperBuilder {
     fn from(default_doc_mapper: DefaultDocMapper) -> Self {
         let mode = default_doc_mapper.mode.mode_type();
@@ -291,6 +361,7 @@ impl From<DefaultDocMapper> for DefaultDocMapperBuilder {
             dynamic_mapping,
             partition_key: partition_key_opt,
             max_num_partitions: default_doc_mapper.max_num_partitions,
+            tokenizers: default_doc_mapper.tokenizer_entries,
         }
     }
 }
@@ -397,6 +468,7 @@ impl DocMapper for DefaultDocMapper {
         build_query(
             query_ast,
             split_schema,
+            self.tokenizer_manager(),
             &self.default_search_field_names[..],
             with_validation,
         )
@@ -421,6 +493,10 @@ impl DocMapper for DefaultDocMapper {
     fn max_num_partitions(&self) -> NonZeroU32 {
         self.max_num_partitions
     }
+
+    fn tokenizer_manager(&self) -> &TokenizerManager {
+        &self.tokenizer_manager
+    }
 }
 
 #[cfg(test)]
@@ -432,6 +508,7 @@ mod tests {
     use tantivy::schema::{FieldType, IndexRecordOption, Type, Value as TantivyValue};
 
     use super::DefaultDocMapper;
+    use crate::default_doc_mapper::field_mapping_entry::DEFAULT_TOKENIZER_NAME;
     use crate::{
         DefaultDocMapperBuilder, DocMapper, DocParsingError, DYNAMIC_FIELD_NAME, SOURCE_FIELD_NAME,
     };
@@ -1358,10 +1435,7 @@ mod tests {
                 panic!()
             };
             let text_indexing_options = json_options.get_text_indexing_options().unwrap();
-            assert_eq!(
-                text_indexing_options.tokenizer(),
-                super::QuickwitTextTokenizer::Raw.get_name()
-            );
+            assert_eq!(text_indexing_options.tokenizer(), super::RAW_TOKENIZER_NAME);
             assert_eq!(
                 text_indexing_options.index_option(),
                 IndexRecordOption::Basic
@@ -1376,7 +1450,7 @@ mod tests {
             };
             assert_eq!(
                 text_options.get_indexing_options().unwrap().tokenizer(),
-                super::QuickwitTextTokenizer::Default.get_name()
+                DEFAULT_TOKENIZER_NAME
             );
         }
     }
@@ -1440,5 +1514,123 @@ mod tests {
             .field_mappings
             .find_field_mapping_type("my\\.timestamp")
             .unwrap();
+    }
+
+    #[test]
+    fn test_build_doc_mapper_with_custom_ngram_tokenizer() {
+        let mapper = serde_json::from_str::<DefaultDocMapper>(
+            r#"{
+            "tokenizers": [
+                {
+                    "name": "my_tokenizer",
+                    "filters": ["lower_caser", "ascii_folding", "remove_long"],
+                    "type": "ngram",
+                    "min_gram": 3,
+                    "max_gram": 5
+                }
+            ],
+            "field_mappings": [
+                {
+                    "name": "my_text",
+                    "type": "text",
+                    "tokenizer": "my_tokenizer"
+                    
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+        let field_mapping_type = mapper
+            .field_mappings
+            .find_field_mapping_type("my_text")
+            .unwrap();
+        match &field_mapping_type {
+            super::FieldMappingType::Text(options, _) => {
+                assert!(options.tokenizer.is_some());
+                let tokenizer = options.tokenizer.as_ref().unwrap();
+                assert_eq!(tokenizer.name(), "my_tokenizer");
+            }
+            _ => panic!("Expected a text field"),
+        }
+        assert!(mapper.tokenizer_manager().get("my_tokenizer").is_some());
+    }
+
+    #[test]
+    fn test_build_doc_mapper_should_fail_with_unknown_tokenizer() {
+        let mapper_builder = serde_json::from_str::<DefaultDocMapperBuilder>(
+            r#"{
+            "field_mappings": [
+                {
+                    "name": "my_text",
+                    "type": "text",
+                    "tokenizer": "my_tokenizer"
+                    
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+        let mapper = mapper_builder.try_build();
+        let error_msg = mapper.unwrap_err().to_string();
+        assert!(error_msg.contains("Unknown tokenizer"));
+    }
+
+    #[test]
+    fn test_build_doc_mapper_tokenizer_manager_with_custom_tokenizer() {
+        let mapper = serde_json::from_str::<DefaultDocMapper>(
+            r#"{
+            "tokenizers": [
+                {
+                    "name": "my_tokenizer",
+                    "filters": ["lower_caser"],
+                    "type": "ngram",
+                    "min_gram": 3,
+                    "max_gram": 5
+                }
+            ],
+            "field_mappings": [
+                {
+                    "name": "my_text",
+                    "type": "text",
+                    "tokenizer": "my_tokenizer"
+                    
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+        let mut tokenizer = mapper.tokenizer_manager().get("my_tokenizer").unwrap();
+        let mut token_stream = tokenizer.token_stream("HELLO WORLD");
+        assert_eq!(token_stream.next().unwrap().text, "hel");
+        assert_eq!(token_stream.next().unwrap().text, "hell");
+        assert_eq!(token_stream.next().unwrap().text, "hello");
+    }
+
+    #[test]
+    fn test_build_doc_mapper_with_custom_invalid_regex_tokenizer() {
+        let mapper_builder = serde_json::from_str::<DefaultDocMapperBuilder>(
+            r#"{
+            "tokenizers": [
+                {
+                    "name": "my_tokenizer",
+                    "type": "regex",
+                    "pattern": "(my_pattern"
+                }
+            ],
+            "field_mappings": [
+                {
+                    "name": "my_text",
+                    "type": "text",
+                    "tokenizer": "my_tokenizer"
+                    
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+        let mapper = mapper_builder.try_build();
+        assert!(mapper.is_err());
+        let error_mesg = mapper.unwrap_err().to_string();
+        assert!(error_mesg.contains("Invalid regex tokenizer"));
     }
 }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -1534,7 +1534,6 @@ mod tests {
                     "name": "my_text",
                     "type": "text",
                     "tokenizer": "my_tokenizer"
-                    
                 }
             ]
         }"#,
@@ -1564,7 +1563,6 @@ mod tests {
                     "name": "my_text",
                     "type": "text",
                     "tokenizer": "my_tokenizer"
-                    
                 }
             ]
         }"#,
@@ -1593,7 +1591,6 @@ mod tests {
                     "name": "my_text",
                     "type": "text",
                     "tokenizer": "my_tokenizer"
-                    
                 }
             ]
         }"#,
@@ -1622,7 +1619,6 @@ mod tests {
                     "name": "my_text",
                     "type": "text",
                     "tokenizer": "my_tokenizer"
-                    
                 }
             ]
         }"#,
@@ -1632,5 +1628,41 @@ mod tests {
         assert!(mapper.is_err());
         let error_mesg = mapper.unwrap_err().to_string();
         assert!(error_mesg.contains("Invalid regex tokenizer"));
+    }
+
+    #[test]
+    fn test_doc_mapper_with_custom_tokenizer_equivalent_to_default() {
+        let mapper = serde_json::from_str::<DefaultDocMapper>(
+            r#"{
+            "tokenizers": [
+                {
+                    "name": "my_tokenizer",
+                    "filters": ["remove_long", "lower_caser"],
+                    "type": "simple",
+                    "min_gram": 3,
+                    "max_gram": 5
+                }
+            ],
+            "field_mappings": [
+                {
+                    "name": "my_text",
+                    "type": "text",
+                    "tokenizer": "my_tokenizer"
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+        let mut default_tokenizer = mapper.tokenizer_manager().get("default").unwrap();
+        let mut tokenizer = mapper.tokenizer_manager().get("my_tokenizer").unwrap();
+        let text = "I've seen things... seen things you little people wouldn't believe.";
+        let mut default_token_stream = default_tokenizer.token_stream(text);
+        let mut token_stream = tokenizer.token_stream(text);
+        for _ in 0..10 {
+            assert_eq!(
+                default_token_stream.next().unwrap().text,
+                token_stream.next().unwrap().text
+            );
+        }
     }
 }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
@@ -22,6 +22,7 @@ use std::num::NonZeroU32;
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
+use super::tokenizer_entry::TokenizerEntry;
 use super::FieldMappingEntry;
 use crate::default_doc_mapper::default_mapper::Mode;
 use crate::default_doc_mapper::QuickwitJsonOptions;
@@ -66,6 +67,9 @@ pub struct DefaultDocMapperBuilder {
     /// how the unmapped fields should be handled.
     #[serde(default)]
     pub dynamic_mapping: Option<QuickwitJsonOptions>,
+    /// Custom tokenizers.
+    #[serde(default)]
+    pub tokenizers: Vec<TokenizerEntry>,
 }
 
 /// `Mode` describing how the unmapped field should be handled.

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper_builder.rs
@@ -67,7 +67,7 @@ pub struct DefaultDocMapperBuilder {
     /// how the unmapped fields should be handled.
     #[serde(default)]
     pub dynamic_mapping: Option<QuickwitJsonOptions>,
-    /// Custom tokenizers.
+    /// User-defined tokenizers.
     #[serde(default)]
     pub tokenizers: Vec<TokenizerEntry>,
 }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -23,6 +23,7 @@ mod default_mapper_builder;
 mod field_mapping_entry;
 mod field_mapping_type;
 mod mapping_tree;
+mod tokenizer_entry;
 
 use anyhow::bail;
 use once_cell::sync::Lazy;
@@ -38,6 +39,10 @@ pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,
 };
 pub(crate) use self::field_mapping_type::FieldMappingType;
+pub use self::tokenizer_entry::{
+    NgramTokenizerOption, RegexTokenizerOption, TokenFilterType, TokenizerConfig, TokenizerEntry,
+    TokenizerType,
+};
 use crate::QW_RESERVED_FIELD_NAMES;
 
 /// Regular expression validating a field mapping name.

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -40,8 +40,8 @@ pub(crate) use self::field_mapping_entry::{
 };
 pub(crate) use self::field_mapping_type::FieldMappingType;
 pub use self::tokenizer_entry::{
-    NgramTokenizerOption, RegexTokenizerOption, TokenFilterType, TokenizerConfig, TokenizerEntry,
-    TokenizerType,
+    analyze_text, NgramTokenizerOption, RegexTokenizerOption, TokenFilterType, TokenizerConfig,
+    TokenizerEntry, TokenizerType,
 };
 use crate::QW_RESERVED_FIELD_NAMES;
 

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -39,9 +39,9 @@ pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,
 };
 pub(crate) use self::field_mapping_type::FieldMappingType;
-pub use self::tokenizer_entry::{
-    analyze_text, NgramTokenizerOption, RegexTokenizerOption, TokenFilterType, TokenizerConfig,
-    TokenizerEntry, TokenizerType,
+pub use self::tokenizer_entry::{analyze_text, TokenizerConfig, TokenizerEntry};
+pub(crate) use self::tokenizer_entry::{
+    NgramTokenizerOption, RegexTokenizerOption, TokenFilterType, TokenizerType,
 };
 use crate::QW_RESERVED_FIELD_NAMES;
 

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/tokenizer_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/tokenizer_entry.rs
@@ -1,0 +1,196 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::Context;
+use itertools::Itertools;
+use quickwit_query::DEFAULT_REMOVE_TOKEN_LENGTH;
+use serde::{Deserialize, Serialize};
+use tantivy::tokenizer::{
+    AsciiFoldingFilter, BoxTokenFilter, LowerCaser, NgramTokenizer, RegexTokenizer,
+    RemoveLongFilter, TextAnalyzer,
+};
+
+/// A `TokenizerEntry` defines a custom tokenizer with its name and configuration.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+pub struct TokenizerEntry {
+    /// Tokenizer name.
+    pub name: String,
+    /// Tokenizer configuration.
+    #[serde(flatten)]
+    pub(crate) config: TokenizerConfig,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+pub struct TokenizerConfig {
+    #[serde(flatten)]
+    tokenizer_type: TokenizerType,
+    #[serde(default)]
+    filters: Vec<TokenFilterType>,
+}
+
+impl TokenizerConfig {
+    pub fn text_analyzer(&self) -> anyhow::Result<TextAnalyzer> {
+        let boxed_token_filters = self.token_filters();
+        let text_analyzer = match &self.tokenizer_type {
+            TokenizerType::Ngram(options) => {
+                let tokenizer =
+                    NgramTokenizer::new(options.min_gram, options.max_gram, options.prefix_only);
+                TextAnalyzer::new(tokenizer, boxed_token_filters)
+            }
+            TokenizerType::Regex(options) => {
+                let tokenizer = RegexTokenizer::new(&options.pattern)
+                    .with_context(|| "Invalid regex tokenizer".to_string())?;
+                TextAnalyzer::new(tokenizer, boxed_token_filters)
+            }
+        };
+        Ok(text_analyzer)
+    }
+
+    fn token_filters(&self) -> Vec<BoxTokenFilter> {
+        self.filters
+            .iter()
+            .map(|token_filter| token_filter.box_token_filter())
+            .collect_vec()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenFilterType {
+    RemoveLong,
+    LowerCaser,
+    AsciiFolding,
+}
+
+impl TokenFilterType {
+    fn box_token_filter(&self) -> BoxTokenFilter {
+        match &self {
+            Self::RemoveLong => {
+                BoxTokenFilter::from(RemoveLongFilter::limit(DEFAULT_REMOVE_TOKEN_LENGTH))
+            }
+            Self::LowerCaser => BoxTokenFilter::from(LowerCaser),
+            Self::AsciiFolding => BoxTokenFilter::from(AsciiFoldingFilter),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TokenizerType {
+    Ngram(NgramTokenizerOption),
+    Regex(RegexTokenizerOption),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct NgramTokenizerOption {
+    pub min_gram: usize,
+    pub max_gram: usize,
+    #[serde(default)]
+    pub prefix_only: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RegexTokenizerOption {
+    pub pattern: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NgramTokenizerOption, TokenizerType};
+    use crate::TokenizerEntry;
+
+    #[test]
+    fn test_deserialize_tokenizer_entry() {
+        let result: Result<TokenizerEntry, serde_json::Error> =
+            serde_json::from_str::<TokenizerEntry>(
+                r#"
+            {
+                "name": "my_tokenizer",
+                "type": "ngram",
+                "filters": [
+                    "remove_long",
+                    "lower_caser",
+                    "ascii_folding"
+                ],
+                "min_gram": 1,
+                "max_gram": 3
+            }
+            "#,
+            );
+        assert!(result.is_ok());
+        let tokenizer_config_entry = result.unwrap();
+        assert_eq!(tokenizer_config_entry.config.filters.len(), 3);
+        match tokenizer_config_entry.config.tokenizer_type {
+            TokenizerType::Ngram(options) => {
+                assert_eq!(
+                    options,
+                    NgramTokenizerOption {
+                        min_gram: 1,
+                        max_gram: 3,
+                        prefix_only: false,
+                    }
+                )
+            }
+            _ => panic!("Unexpected tokenizer type"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_tokenizer_entry_failed_with_wrong_key() {
+        let result: Result<TokenizerEntry, serde_json::Error> =
+            serde_json::from_str::<TokenizerEntry>(
+                r#"
+            {
+                "name": "my_tokenizer",
+                "type": "ngram",
+                "filters": [
+                    "remove_long",
+                    "lower_caser",
+                    "ascii_folding"
+                ],
+                "min_gram": 1,
+                "max_gram": 3,
+                "abc": 123
+            }
+            "#,
+            );
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("unknown field `abc`"));
+    }
+
+    #[test]
+    fn test_deserialize_tokenizer_entry_regex() {
+        let result: Result<TokenizerEntry, serde_json::Error> =
+            serde_json::from_str::<TokenizerEntry>(
+                r#"
+            {
+                "name": "my_tokenizer",
+                "type": "regex",
+                "pattern": "(my_pattern)"
+            }
+            "#,
+            );
+        assert!(result.is_ok());
+    }
+}

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper.rs
@@ -28,6 +28,7 @@ use quickwit_query::query_ast::QueryAst;
 use serde_json::Value as JsonValue;
 use tantivy::query::Query;
 use tantivy::schema::{Field, FieldType, Schema, Value};
+use tantivy::tokenizer::TokenizerManager;
 use tantivy::{Document, Term};
 
 pub type Partition = u64;
@@ -143,6 +144,9 @@ pub trait DocMapper: Send + Sync + Debug + DynClone + 'static {
 
     /// Returns the maximum number of partitions.
     fn max_num_partitions(&self) -> NonZeroU32;
+
+    /// Returns the tokenizer manager.
+    fn tokenizer_manager(&self) -> &TokenizerManager;
 }
 
 /// A struct to wrap a tantivy field with its name.

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -35,13 +35,13 @@ mod routing_expression;
 pub mod tag_pruning;
 
 pub use default_doc_mapper::{
-    DefaultDocMapper, DefaultDocMapperBuilder, FieldMappingEntry, ModeType, QuickwitJsonOptions,
-    TokenizerEntry,
+    analyze_text, DefaultDocMapper, DefaultDocMapperBuilder, FieldMappingEntry, ModeType,
+    QuickwitJsonOptions, TokenizerConfig, TokenizerEntry,
 };
 use default_doc_mapper::{
     FastFieldOptions, FieldMappingEntryForSerialization, IndexRecordOptionSchema,
     NgramTokenizerOption, QuickwitTextNormalizer, QuickwitTextTokenizer, RegexTokenizerOption,
-    TokenFilterType, TokenizerConfig, TokenizerType,
+    TokenFilterType, TokenizerType,
 };
 pub use doc_mapper::{DocMapper, JsonObject, NamedField, TermRange, WarmupInfo};
 pub use error::{DocParsingError, QueryParserError};

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -36,10 +36,12 @@ pub mod tag_pruning;
 
 pub use default_doc_mapper::{
     DefaultDocMapper, DefaultDocMapperBuilder, FieldMappingEntry, ModeType, QuickwitJsonOptions,
+    TokenizerEntry,
 };
 use default_doc_mapper::{
     FastFieldOptions, FieldMappingEntryForSerialization, IndexRecordOptionSchema,
-    QuickwitTextNormalizer, QuickwitTextTokenizer,
+    NgramTokenizerOption, QuickwitTextNormalizer, QuickwitTextTokenizer, RegexTokenizerOption,
+    TokenFilterType, TokenizerConfig, TokenizerType,
 };
 pub use doc_mapper::{DocMapper, JsonObject, NamedField, TermRange, WarmupInfo};
 pub use error::{DocParsingError, QueryParserError};
@@ -61,13 +63,19 @@ pub(crate) enum Cardinality {
 
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(
-    QuickwitJsonOptions,
     FastFieldOptions,
-    QuickwitTextNormalizer,
-    ModeType,
-    QuickwitTextTokenizer,
-    IndexRecordOptionSchema,
     FieldMappingEntryForSerialization,
+    IndexRecordOptionSchema,
+    ModeType,
+    NgramTokenizerOption,
+    QuickwitJsonOptions,
+    QuickwitTextNormalizer,
+    QuickwitTextTokenizer,
+    RegexTokenizerOption,
+    TokenFilterType,
+    TokenizerConfig,
+    TokenizerEntry,
+    TokenizerType,
 )))]
 /// Schema used for the OpenAPI generation which are apart of this crate.
 pub struct DocMapperApiSchemas;

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -363,7 +363,7 @@ mod tests {
             schema_builder.add_bool_field("tag_bool", NumericOptions::default().set_indexed());
         let schema = schema_builder.build();
         let mut index = Index::create_in_dir(split_scratch_directory.path(), schema)?;
-        index.set_tokenizers(quickwit_query::get_quickwit_tokenizer_manager().clone());
+        index.set_tokenizers(quickwit_query::create_default_quickwit_tokenizer_manager());
         index.set_fast_field_tokenizers(
             quickwit_query::get_quickwit_fastfield_normalizer_manager().clone(),
         );

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
@@ -67,7 +67,8 @@
           "log_level",
           "tenant_id"
         ],
-        "timestamp_field": "timestamp"
+        "timestamp_field": "timestamp",
+        "tokenizers": []
       },
       "index_id": "my-index",
       "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
@@ -67,7 +67,8 @@
           "log_level",
           "tenant_id"
         ],
-        "timestamp_field": "timestamp"
+        "timestamp_field": "timestamp",
+        "tokenizers": []
       },
       "index_id": "my-index",
       "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -67,7 +67,15 @@
           "log_level",
           "tenant_id"
         ],
-        "timestamp_field": "timestamp"
+        "timestamp_field": "timestamp",
+        "tokenizers": [
+          {
+            "filters": [],
+            "name": "custom_tokenizer",
+            "pattern": "[^\\p{L}\\p{N}]+",
+            "type": "regex"
+          }
+        ]
       },
       "index_id": "my-index",
       "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -67,7 +67,15 @@
           "log_level",
           "tenant_id"
         ],
-        "timestamp_field": "timestamp"
+        "timestamp_field": "timestamp",
+        "tokenizers": [
+          {
+            "filters": [],
+            "name": "custom_tokenizer",
+            "pattern": "[^\\p{L}\\p{N}]+",
+            "type": "regex"
+          }
+        ]
       },
       "index_id": "my-index",
       "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4.expected.json
@@ -56,7 +56,8 @@
         "log_level",
         "tenant_id"
       ],
-      "timestamp_field": "timestamp"
+      "timestamp_field": "timestamp",
+      "tokenizers": []
     },
     "index_id": "my-index",
     "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.5.expected.json
@@ -56,7 +56,8 @@
         "log_level",
         "tenant_id"
       ],
-      "timestamp_field": "timestamp"
+      "timestamp_field": "timestamp",
+      "tokenizers": []
     },
     "index_id": "my-index",
     "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.expected.json
@@ -56,7 +56,15 @@
         "log_level",
         "tenant_id"
       ],
-      "timestamp_field": "timestamp"
+      "timestamp_field": "timestamp",
+      "tokenizers": [
+        {
+          "filters": [],
+          "name": "custom_tokenizer",
+          "pattern": "[^\\p{L}\\p{N}]+",
+          "type": "regex"
+        }
+      ]
     },
     "index_id": "my-index",
     "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.json
@@ -56,7 +56,15 @@
         "log_level",
         "tenant_id"
       ],
-      "timestamp_field": "timestamp"
+      "timestamp_field": "timestamp",
+      "tokenizers": [
+        {
+          "filters": [],
+          "name": "custom_tokenizer",
+          "pattern": "[^\\p{L}\\p{N}]+",
+          "type": "regex"
+        }
+      ]
     },
     "index_id": "my-index",
     "index_uri": "s3://quickwit-indexes/my-index",

--- a/quickwit/quickwit-query/src/lib.rs
+++ b/quickwit/quickwit-query/src/lib.rs
@@ -43,7 +43,10 @@ pub(crate) use not_nan_f32::NotNaNf32;
 pub use query_ast::utils::find_field_or_hit_dynamic;
 use serde::{Deserialize, Serialize};
 pub use tantivy::query::Query as TantivyQuery;
-pub use tokenizers::{get_quickwit_fastfield_normalizer_manager, get_quickwit_tokenizer_manager};
+pub use tokenizers::{
+    create_default_quickwit_tokenizer_manager, get_quickwit_fastfield_normalizer_manager,
+    DEFAULT_REMOVE_TOKEN_LENGTH,
+};
 
 #[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub enum BooleanOperand {

--- a/quickwit/quickwit-query/src/query_ast/bool_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/bool_query.rs
@@ -19,6 +19,7 @@
 
 use serde::{Deserialize, Serialize};
 use tantivy::schema::Schema as TantivySchema;
+use tantivy::tokenizer::TokenizerManager;
 
 use super::{BuildTantivyAst, TantivyQueryAst};
 use crate::query_ast::QueryAst;
@@ -59,27 +60,45 @@ impl BuildTantivyAst for BoolQuery {
     fn build_tantivy_ast_impl(
         &self,
         schema: &TantivySchema,
+        tokenizer_manager: &TokenizerManager,
         search_fields: &[String],
         with_validation: bool,
     ) -> Result<TantivyQueryAst, InvalidQuery> {
         let mut boolean_query = super::tantivy_query_ast::TantivyBoolQuery::default();
         for must in &self.must {
-            let must_leaf = must.build_tantivy_ast_call(schema, search_fields, with_validation)?;
+            let must_leaf = must.build_tantivy_ast_call(
+                schema,
+                tokenizer_manager,
+                search_fields,
+                with_validation,
+            )?;
             boolean_query.must.push(must_leaf);
         }
         for must_not in &self.must_not {
-            let must_not_leaf =
-                must_not.build_tantivy_ast_call(schema, search_fields, with_validation)?;
+            let must_not_leaf = must_not.build_tantivy_ast_call(
+                schema,
+                tokenizer_manager,
+                search_fields,
+                with_validation,
+            )?;
             boolean_query.must_not.push(must_not_leaf);
         }
         for should in &self.should {
-            let should_leaf =
-                should.build_tantivy_ast_call(schema, search_fields, with_validation)?;
+            let should_leaf = should.build_tantivy_ast_call(
+                schema,
+                tokenizer_manager,
+                search_fields,
+                with_validation,
+            )?;
             boolean_query.should.push(should_leaf);
         }
         for filter in &self.filter {
-            let filter_leaf =
-                filter.build_tantivy_ast_call(schema, search_fields, with_validation)?;
+            let filter_leaf = filter.build_tantivy_ast_call(
+                schema,
+                tokenizer_manager,
+                search_fields,
+                with_validation,
+            )?;
             boolean_query.filter.push(filter_leaf);
         }
         Ok(TantivyQueryAst::Bool(boolean_query))

--- a/quickwit/quickwit-query/src/query_ast/term_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/term_query.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use tantivy::schema::Schema as TantivySchema;
+use tantivy::tokenizer::TokenizerManager;
 
 use super::{BuildTantivyAst, QueryAst};
 use crate::query_ast::{FullTextParams, TantivyQueryAst};
@@ -54,6 +55,7 @@ impl BuildTantivyAst for TermQuery {
     fn build_tantivy_ast_impl(
         &self,
         schema: &TantivySchema,
+        tokenizer_manager: &TokenizerManager,
         _search_fields: &[String],
         _with_validation: bool,
     ) -> Result<TantivyQueryAst, InvalidQuery> {
@@ -68,6 +70,7 @@ impl BuildTantivyAst for TermQuery {
             &self.value,
             &full_text_params,
             schema,
+            tokenizer_manager,
         )
     }
 }
@@ -124,6 +127,7 @@ impl From<TermQuery> for HashMap<String, TermQueryValue> {
 mod tests {
     use tantivy::schema::{Schema, INDEXED};
 
+    use crate::create_default_quickwit_tokenizer_manager;
     use crate::query_ast::{BuildTantivyAst, TermQuery};
 
     #[test]
@@ -136,7 +140,12 @@ mod tests {
         schema_builder.add_ip_addr_field("ip", INDEXED);
         let schema = schema_builder.build();
         let tantivy_query_ast = term_query
-            .build_tantivy_ast_call(&schema, &[], true)
+            .build_tantivy_ast_call(
+                &schema,
+                &create_default_quickwit_tokenizer_manager(),
+                &[],
+                true,
+            )
             .unwrap();
         let leaf = tantivy_query_ast.as_leaf().unwrap();
         assert_eq!(
@@ -155,7 +164,12 @@ mod tests {
         schema_builder.add_ip_addr_field("ip", INDEXED);
         let schema = schema_builder.build();
         let tantivy_query_ast = term_query
-            .build_tantivy_ast_call(&schema, &[], true)
+            .build_tantivy_ast_call(
+                &schema,
+                &create_default_quickwit_tokenizer_manager(),
+                &[],
+                true,
+            )
             .unwrap();
         let leaf = tantivy_query_ast.as_leaf().unwrap();
         assert_eq!(
@@ -174,7 +188,12 @@ mod tests {
         schema_builder.add_bytes_field("bytes", INDEXED);
         let schema = schema_builder.build();
         let tantivy_query_ast = term_query
-            .build_tantivy_ast_call(&schema, &[], true)
+            .build_tantivy_ast_call(
+                &schema,
+                &create_default_quickwit_tokenizer_manager(),
+                &[],
+                true,
+            )
             .unwrap();
         let leaf = tantivy_query_ast.as_leaf().unwrap();
         assert_eq!(
@@ -193,7 +212,12 @@ mod tests {
         schema_builder.add_bytes_field("bytes", INDEXED);
         let schema = schema_builder.build();
         let tantivy_query_ast = term_query
-            .build_tantivy_ast_call(&schema, &[], true)
+            .build_tantivy_ast_call(
+                &schema,
+                &create_default_quickwit_tokenizer_manager(),
+                &[],
+                true,
+            )
             .unwrap();
         let leaf = tantivy_query_ast.as_leaf().unwrap();
         assert_eq!(

--- a/quickwit/quickwit-query/src/query_ast/user_input_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/user_input_query.rs
@@ -26,6 +26,7 @@ use tantivy::query_grammar::{
     Delimiter, Occur, UserInputAst, UserInputBound, UserInputLeaf, UserInputLiteral,
 };
 use tantivy::schema::Schema as TantivySchema;
+use tantivy::tokenizer::TokenizerManager;
 
 use crate::not_nan_f32::NotNaNf32;
 use crate::query_ast::tantivy_query_ast::TantivyQueryAst;
@@ -84,6 +85,7 @@ impl BuildTantivyAst for UserInputQuery {
     fn build_tantivy_ast_impl(
         &self,
         _schema: &TantivySchema,
+        _tokenizer_manager: &TokenizerManager,
         _default_search_fields: &[String],
         _with_validation: bool,
     ) -> Result<TantivyQueryAst, crate::InvalidQuery> {
@@ -249,7 +251,7 @@ mod tests {
     use crate::query_ast::{
         BoolQuery, BuildTantivyAst, FullTextMode, FullTextQuery, QueryAst, UserInputQuery,
     };
-    use crate::{BooleanOperand, InvalidQuery};
+    use crate::{create_default_quickwit_tokenizer_manager, BooleanOperand, InvalidQuery};
 
     #[test]
     fn test_user_input_query_not_parsed_error() {
@@ -261,13 +263,23 @@ mod tests {
         let schema = tantivy::schema::Schema::builder().build();
         {
             let invalid_query = user_input_query
-                .build_tantivy_ast_call(&schema, &[], true)
+                .build_tantivy_ast_call(
+                    &schema,
+                    &create_default_quickwit_tokenizer_manager(),
+                    &[],
+                    true,
+                )
                 .unwrap_err();
             assert!(matches!(invalid_query, InvalidQuery::UserQueryNotParsed));
         }
         {
             let invalid_query = user_input_query
-                .build_tantivy_ast_call(&schema, &[], false)
+                .build_tantivy_ast_call(
+                    &schema,
+                    &create_default_quickwit_tokenizer_manager(),
+                    &[],
+                    false,
+                )
                 .unwrap_err();
             assert!(matches!(invalid_query, InvalidQuery::UserQueryNotParsed));
         }

--- a/quickwit/quickwit-search/Cargo.toml
+++ b/quickwit/quickwit-search/Cargo.toml
@@ -59,6 +59,7 @@ tempfile = { workspace = true }
 
 quickwit-indexing = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
+quickwit-storage = { workspace = true, features = ["testsuite"] }
 
 [features]
 testsuite = []

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -171,9 +171,15 @@ async fn fetch_docs_in_split(
     global_doc_addrs.sort_by_key(|doc| doc.doc_addr);
     // Opens the index without the ephemeral unbounded cache, this cache is indeed not useful
     // when fetching docs as we will fetch them only once.
-    let index = open_index_with_caches(&searcher_context, index_storage, split, false)
-        .await
-        .with_context(|| "open-index-for-split")?;
+    let index = open_index_with_caches(
+        &searcher_context,
+        index_storage,
+        split,
+        Some(doc_mapper.tokenizer_manager()),
+        false,
+    )
+    .await
+    .with_context(|| "open-index-for-split")?;
     let index_reader = index
         .reader_builder()
         // the docs are presorted so a cache size of NUM_CONCURRENT_REQUESTS is fine

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -179,7 +179,7 @@ async fn fetch_docs_in_split(
         false,
     )
     .await
-    .with_context(|| "open-index-for-split")?;
+    .context("open-index-for-split")?;
     let index_reader = index
         .reader_builder()
         // the docs are presorted so a cache size of NUM_CONCURRENT_REQUESTS is fine

--- a/quickwit/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit/quickwit-search/src/search_stream/leaf.rs
@@ -124,7 +124,14 @@ async fn leaf_search_stream_single_split(
         &split,
     );
 
-    let index = open_index_with_caches(&searcher_context, storage, &split, true).await?;
+    let index = open_index_with_caches(
+        &searcher_context,
+        storage,
+        &split,
+        Some(doc_mapper.tokenizer_manager()),
+        true,
+    )
+    .await?;
     let split_schema = index.schema();
 
     let request_fields = Arc::new(SearchStreamRequestFields::from_request(

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -28,6 +28,7 @@ use quickwit_config::{
     CLI_INGEST_SOURCE_ID, INGEST_API_SOURCE_ID,
 };
 use quickwit_core::{IndexService, IndexServiceError};
+use quickwit_doc_mapper::{analyze_text, TokenizerConfig};
 use quickwit_metastore::{
     IndexMetadata, ListSplitsQuery, Metastore, MetastoreError, Split, SplitState,
 };
@@ -82,6 +83,8 @@ pub fn index_management_handlers(
         .or(create_source_handler(index_service.clone()))
         .or(get_source_handler(index_service.metastore()))
         .or(delete_source_handler(index_service.metastore()))
+        // Tokenizer handlers.
+        .or(analyze_request_handler())
 }
 
 fn json_body<T: DeserializeOwned + Send>(
@@ -716,6 +719,47 @@ async fn delete_source(
     }
     metastore.delete_source(index_uid, &source_id).await?;
     Ok(())
+}
+
+#[derive(Debug, Deserialize, utoipa::IntoParams, utoipa::ToSchema)]
+struct AnalyzeRequest {
+    /// The tokenizer to use.
+    #[serde(flatten)]
+    pub tokenizer_config: TokenizerConfig,
+    /// The text to analyze.
+    pub text: String,
+}
+
+fn analyze_request_filter() -> impl Filter<Extract = (AnalyzeRequest,), Error = Rejection> + Clone {
+    warp::path!("analyze")
+        .and(warp::post())
+        .and(warp::body::json())
+}
+
+fn analyze_request_handler() -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone
+{
+    analyze_request_filter()
+        .then(analyze_request)
+        .and(extract_format_from_qs())
+        .map(make_json_api_response)
+}
+
+/// Analyzes text with given tokenizer config and returns the list of tokens.
+#[utoipa::path(
+    post,
+    tag = "analyze",
+    path = "/analyze",
+    request_body = AnalyzeRequest,
+    responses(
+        (status = 200, description = "Successfully analyze text.")
+    ),
+)]
+async fn analyze_request(request: AnalyzeRequest) -> Result<serde_json::Value, IndexServiceError> {
+    let tokens = analyze_text(&request.text, &request.tokenizer_config)
+        .map_err(|err| IndexServiceError::Internal(err.to_string()))?;
+    let json_value =
+        serde_json::to_value(tokens).map_err(|err| IndexServiceError::Internal(err.to_string()))?;
+    Ok(json_value)
 }
 
 #[cfg(test)]
@@ -1641,5 +1685,46 @@ mod tests {
             .await;
         assert_eq!(resp.status(), 405);
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_analyze_request() {
+        let mut metastore = MockMetastore::new();
+        metastore
+            .expect_index_metadata()
+            .return_once(|_index_id: &str| {
+                Ok(IndexMetadata::for_test(
+                    "test-index",
+                    "ram:///indexes/test-index",
+                ))
+            });
+        let index_service = IndexService::new(Arc::new(metastore), StorageResolver::unconfigured());
+        let index_management_handler = super::index_management_handlers(
+            Arc::new(index_service),
+            Arc::new(QuickwitConfig::for_test()),
+        )
+        .recover(recover_fn);
+        let resp = warp::test::request()
+            .path("/analyze")
+            .method("POST")
+            .json(&true)
+            .body(r#"{"type": "ngram", "min_gram": 3, "max_gram": 3, "text": "Hel", "filters": ["lower_caser"]}"#)
+            .reply(&index_management_handler)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let actual_response_json: JsonValue = serde_json::from_slice(resp.body()).unwrap();
+        let expected_response_json = serde_json::json!([
+            {
+                "offset_from": 0,
+                "offset_to": 3,
+                "position": 0,
+                "position_length": 1,
+                "text": "hel"
+            }
+        ]);
+        assert_json_include!(
+            actual: actual_response_json,
+            expected: expected_response_json
+        );
     }
 }

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -756,9 +756,9 @@ fn analyze_request_handler() -> impl Filter<Extract = (impl warp::Reply,), Error
 )]
 async fn analyze_request(request: AnalyzeRequest) -> Result<serde_json::Value, IndexServiceError> {
     let tokens = analyze_text(&request.text, &request.tokenizer_config)
-        .map_err(|err| IndexServiceError::Internal(err.to_string()))?;
-    let json_value =
-        serde_json::to_value(tokens).map_err(|err| IndexServiceError::Internal(err.to_string()))?;
+        .map_err(|err| IndexServiceError::Internal(format!("{err:?}")))?;
+    let json_value = serde_json::to_value(tokens)
+        .map_err(|err| IndexServiceError::Internal(format!("Cannot serialize tokens: {err}")))?;
     Ok(json_value)
 }
 


### PR DESCRIPTION
Fix #3056 and #3392

This PR adds support for custom analyzers, aka tokenizer + filters.


## Doc mapping config with custom tokenizers

```yaml
doc_mapping:
  tokenizers:
    - name: service_regex
      type: regex
      pattern: "\\w*"
  field_mappings:
    - name: service
      type: text
      tokenizer: service_regex
```

## Endpoint to test a custom tokenizer

`POST /analyze`

with payload

```json
{
  "type": "ngram",
  "min_gram": 3,
  "max_gram": 5,
  "text": "hello"
}
```

```console
curl -XPOST http://localhost:7280/api/v1/analyze -H "content-type: application/json" --data '{"type": "regex", "pattern": "\\w+", "text":"hello world"}'
[
  {
    "offset_from": 0,
    "offset_to": 5,
    "position": 0,
    "position_length": 1,
    "text": "hello"
  },
  {
    "offset_from": 6,
    "offset_to": 11,
    "position": 1,
    "position_length": 1,
    "text": "world"
  }
]
```



## Follow-up in PRs to come

- [ ] Add documentation.
- [ ] Add multilang tokenizer
- [ ] What else?

