### PR TITLE
config: Added more S3StorageConfig options

### DIFF
--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -73,6 +73,9 @@ version: 0.6
 # default_index_root_uri: s3://your-bucket/indexes
 #
 # -------------------------------- Storage settings --------------------------------
+# Hardcoding credentials into configuration files is not secure and strongly
+# discouraged. Prefer the alternative authentication methods that your storage
+# backend may provide.
 #
 # storage:
 #   azure:
@@ -80,7 +83,10 @@ version: 0.6
 #     access_key: ${QW_AZURE_STORAGE_ACCESS_KEY}
 #
 #   s3:
+#     access_key_id: ${AWS_ACCESS_KEY_ID}
+#     secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 #     endpoint: ${QW_S3_ENDPOINT}
+#     region: ${AWS_REGION}
 #     force_path_style_access: ${QW_S3_FORCE_PATH_STYLE_ACCESS:-true}
 #     disable_multi_object_delete_requests: true
 #

--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -87,8 +87,8 @@ version: 0.6
 #     secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 #     endpoint: ${QW_S3_ENDPOINT}
 #     region: ${AWS_REGION}
-#     force_path_style_access: ${QW_S3_FORCE_PATH_STYLE_ACCESS:-true}
-#     disable_multi_object_delete_requests: true
+#     force_path_style_access: ${QW_S3_FORCE_PATH_STYLE_ACCESS:-false}
+#     disable_multi_object_delete_requests: false
 #
 # -------------------------------- Metastore settings --------------------------------
 #


### PR DESCRIPTION
### Description

Adds the other options of `S3StorageConfig` to the example configuration and sets examples to defaults per https://quickwit.io/docs/configuration/node-config/#s3-storage-configuration