### PR TITLE
Add maturity date in split metadata and use it to filter mature splits for merges

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4954,6 +4954,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with 2.3.3",
  "sqlx",
  "tempfile",
  "thiserror",

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -1124,13 +1124,13 @@ mod test {
             split_metadata: split_metadata_1,
             split_state: quickwit_metastore::SplitState::Published,
             update_timestamp: 0,
-            publish_timestamp: Some(0),
+            publish_timestamp: Some(10),
         };
         let split_data_2 = Split {
             split_metadata: split_metadata_2,
             split_state: quickwit_metastore::SplitState::MarkedForDeletion,
             update_timestamp: 0,
-            publish_timestamp: Some(0),
+            publish_timestamp: Some(10),
         };
 
         let index_stats =
@@ -1162,8 +1162,8 @@ mod test {
         let split_id = "stat-test-split".to_string();
         let template_split = Split {
             split_state: quickwit_metastore::SplitState::Published,
-            update_timestamp: 0,
-            publish_timestamp: Some(0),
+            update_timestamp: 10,
+            publish_timestamp: Some(10),
             split_metadata: SplitMetadata::default(),
         };
 

--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -458,7 +458,6 @@ impl Handler<NewPublishLock> for Indexer {
 }
 
 impl Indexer {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pipeline_id: IndexingPipelineId,
         doc_mapper: Arc<dyn DocMapper>,
@@ -560,7 +559,6 @@ impl Indexer {
         // Dropping the indexing permit explicitly here for enhanced readability.
         drop(indexing_permit);
 
-        // Update the time to maturity of the splits as they won't receive documents anymore.
         let mut splits: Vec<IndexedSplitBuilder> = indexed_splits.into_values().collect();
 
         if let Some(other_split) = other_indexed_split_opt {

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -43,6 +43,7 @@ use crate::actors::publisher::PublisherType;
 use crate::actors::sequencer::Sequencer;
 use crate::actors::uploader::UploaderType;
 use crate::actors::{Indexer, Packager, Publisher, Uploader};
+use crate::merge_policy::MergePolicy;
 use crate::models::{IndexingPipelineId, IndexingStatistics, Observe};
 use crate::source::{quickwit_supported_sources, SourceActor, SourceExecutionContext};
 use crate::split_store::IndexingSplitStore;
@@ -298,6 +299,7 @@ impl IndexingPipeline {
         let uploader = Uploader::new(
             UploaderType::IndexUploader,
             self.params.metastore.clone(),
+            self.params.merge_policy.clone(),
             self.params.split_store.clone(),
             SplitsUpdateMailbox::Sequencer(sequencer_mailbox),
             self.params.max_concurrent_split_uploads_index,
@@ -529,6 +531,7 @@ pub struct IndexingPipelineParams {
     pub metastore: Arc<dyn Metastore>,
     pub storage: Arc<dyn Storage>,
     pub split_store: IndexingSplitStore,
+    pub merge_policy: Arc<dyn MergePolicy>,
     pub max_concurrent_split_uploads_index: usize,
     pub max_concurrent_split_uploads_merge: usize,
     pub cooperative_indexing_permits: Option<Arc<Semaphore>>,
@@ -639,6 +642,7 @@ mod tests {
             metastore: metastore.clone(),
             storage,
             split_store,
+            merge_policy: default_merge_policy(),
             queues_dir_path: PathBuf::from("./queues"),
             max_concurrent_split_uploads_index: 4,
             max_concurrent_split_uploads_merge: 5,
@@ -734,6 +738,7 @@ mod tests {
             queues_dir_path: PathBuf::from("./queues"),
             storage,
             split_store,
+            merge_policy: default_merge_policy(),
             max_concurrent_split_uploads_index: 4,
             max_concurrent_split_uploads_merge: 5,
             cooperative_indexing_permits: None,
@@ -808,6 +813,7 @@ mod tests {
             queues_dir_path: PathBuf::from("./queues"),
             storage,
             split_store,
+            merge_policy: default_merge_policy(),
             max_concurrent_split_uploads_index: 4,
             max_concurrent_split_uploads_merge: 5,
             cooperative_indexing_permits: None,
@@ -924,6 +930,7 @@ mod tests {
             queues_dir_path: PathBuf::from("./queues"),
             storage,
             split_store,
+            merge_policy: default_merge_policy(),
             max_concurrent_split_uploads_index: 4,
             max_concurrent_split_uploads_merge: 5,
             cooperative_indexing_permits: None,

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -281,11 +281,7 @@ impl IndexingService {
             .await?;
         let merge_policy =
             crate::merge_policy::merge_policy_from_settings(&index_config.indexing_settings);
-        let split_store = IndexingSplitStore::new(
-            storage.clone(),
-            merge_policy.clone(),
-            self.local_split_store.clone(),
-        );
+        let split_store = IndexingSplitStore::new(storage.clone(), self.local_split_store.clone());
 
         let doc_mapper = build_doc_mapper(&index_config.doc_mapping, &index_config.search_settings)
             .map_err(IndexingServiceError::InvalidParams)?;
@@ -296,7 +292,7 @@ impl IndexingService {
             indexing_directory: indexing_directory.clone(),
             metastore: self.metastore.clone(),
             split_store: split_store.clone(),
-            merge_policy,
+            merge_policy: merge_policy.clone(),
             merge_max_io_num_bytes_per_sec: index_config
                 .indexing_settings
                 .resources
@@ -322,6 +318,7 @@ impl IndexingService {
             metastore: self.metastore.clone(),
             storage,
             split_store,
+            merge_policy,
             max_concurrent_split_uploads_index,
             max_concurrent_split_uploads_merge,
             queues_dir_path: self.queue_dir_path.clone(),

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -245,6 +245,7 @@ pub fn merge_split_attrs(
         .map(|split| split.delete_opstamp)
         .min()
         .unwrap_or(0);
+    let num_merge_ops = max_merge_ops(splits) + 1;
     SplitAttrs {
         split_id: merge_split_id,
         partition_id,
@@ -254,7 +255,7 @@ pub fn merge_split_attrs(
         num_docs,
         uncompressed_docs_size_in_bytes,
         delete_opstamp,
-        num_merge_ops: max_merge_ops(splits) + 1,
+        num_merge_ops,
     }
 }
 

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -245,7 +245,6 @@ pub fn merge_split_attrs(
         .map(|split| split.delete_opstamp)
         .min()
         .unwrap_or(0);
-    let num_merge_ops = max_merge_ops(splits) + 1;
     SplitAttrs {
         split_id: merge_split_id,
         partition_id,
@@ -255,7 +254,7 @@ pub fn merge_split_attrs(
         num_docs,
         uncompressed_docs_size_in_bytes,
         delete_opstamp,
-        num_merge_ops,
+        num_merge_ops: max_merge_ops(splits) + 1,
     }
 }
 

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -31,6 +31,7 @@ use quickwit_common::temp_dir::TempDirectory;
 use quickwit_common::KillSwitch;
 use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::{ListSplitsQuery, Metastore, MetastoreError, SplitState};
+use time::OffsetDateTime;
 use tokio::join;
 use tracing::{debug, error, info, instrument};
 
@@ -199,7 +200,8 @@ impl MergePipeline {
             "Spawning merge pipeline.",
         );
         let query = ListSplitsQuery::for_index(self.params.pipeline_id.index_uid.clone())
-            .with_split_state(SplitState::Published);
+            .with_split_state(SplitState::Published)
+            .with_maturity_timestamp_lte(OffsetDateTime::now_utc().unix_timestamp());
         let published_splits = ctx
             .protect_future(self.params.metastore.list_splits(query))
             .await?
@@ -223,6 +225,7 @@ impl MergePipeline {
         let merge_uploader = Uploader::new(
             UploaderType::MergeUploader,
             self.params.metastore.clone(),
+            self.params.merge_policy.clone(),
             self.params.split_store.clone(),
             merge_publisher_mailbox.into(),
             self.params.max_concurrent_split_uploads,
@@ -438,6 +441,7 @@ pub struct MergePipelineParams {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Bound;
     use std::sync::Arc;
 
     use quickwit_actors::{ActorExitStatus, Universe};
@@ -446,6 +450,7 @@ mod tests {
     use quickwit_metastore::MockMetastore;
     use quickwit_proto::IndexUid;
     use quickwit_storage::RamStorage;
+    use time::OffsetDateTime;
 
     use crate::actors::merge_pipeline::{MergePipeline, MergePipelineParams};
     use crate::merge_policy::default_merge_policy;
@@ -455,17 +460,38 @@ mod tests {
     #[tokio::test]
     async fn test_merge_pipeline_simple() -> anyhow::Result<()> {
         let mut metastore = MockMetastore::default();
-        metastore
-            .expect_list_splits()
-            .times(1)
-            .returning(|_| Ok(Vec::new()));
-        let universe = Universe::with_accelerated_time();
+        let index_uid = IndexUid::new("test-index");
         let pipeline_id = IndexingPipelineId {
-            index_uid: IndexUid::new("test-index"),
+            index_uid: index_uid.clone(),
             source_id: "test-source".to_string(),
             node_id: "test-node".to_string(),
             pipeline_ord: 0,
         };
+        metastore
+            .expect_list_splits()
+            .times(1)
+            .returning(move |list_split_query| {
+                assert_eq!(list_split_query.index_uid, index_uid);
+                assert_eq!(
+                    list_split_query.split_states,
+                    vec![quickwit_metastore::SplitState::Published]
+                );
+                match list_split_query.maturity_timestamp.end {
+                    Bound::Included(maturity_timestamp_end) => {
+                        assert!(
+                            maturity_timestamp_end
+                                < OffsetDateTime::now_utc().unix_timestamp() + 3600
+                        );
+                        assert!(
+                            maturity_timestamp_end
+                                > OffsetDateTime::now_utc().unix_timestamp() - 3600
+                        )
+                    }
+                    _ => panic!("Expected unbounded maturity timestamp."),
+                }
+                Ok(Vec::new())
+            });
+        let universe = Universe::with_accelerated_time();
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store(storage.clone());
         let pipeline_params = MergePipelineParams {

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -201,7 +201,7 @@ impl MergePipeline {
         );
         let query = ListSplitsQuery::for_index(self.params.pipeline_id.index_uid.clone())
             .with_split_state(SplitState::Published)
-            .with_maturity_timestamp_lte(OffsetDateTime::now_utc().unix_timestamp());
+            .is_mature(false, OffsetDateTime::now_utc());
         let published_splits = ctx
             .protect_future(self.params.metastore.list_splits(query))
             .await?
@@ -441,7 +441,6 @@ pub struct MergePipelineParams {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Bound;
     use std::sync::Arc;
 
     use quickwit_actors::{ActorExitStatus, Universe};
@@ -450,7 +449,6 @@ mod tests {
     use quickwit_metastore::MockMetastore;
     use quickwit_proto::IndexUid;
     use quickwit_storage::RamStorage;
-    use time::OffsetDateTime;
 
     use crate::actors::merge_pipeline::{MergePipeline, MergePipelineParams};
     use crate::merge_policy::default_merge_policy;
@@ -476,18 +474,10 @@ mod tests {
                     list_split_query.split_states,
                     vec![quickwit_metastore::SplitState::Published]
                 );
-                match list_split_query.maturity_timestamp.end {
-                    Bound::Included(maturity_timestamp_end) => {
-                        assert!(
-                            maturity_timestamp_end
-                                < OffsetDateTime::now_utc().unix_timestamp() + 3600
-                        );
-                        assert!(
-                            maturity_timestamp_end
-                                > OffsetDateTime::now_utc().unix_timestamp() - 3600
-                        )
-                    }
-                    _ => panic!("Expected unbounded maturity timestamp."),
+                if let Some(maturity_filter) = list_split_query.maturity {
+                    assert!(!maturity_filter.mature);
+                } else {
+                    panic!("Expected maturity filter.");
                 }
                 Ok(Vec::new())
             });

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -331,8 +331,8 @@ mod tests {
             partition_id,
             num_merge_ops,
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            maturity: SplitMaturity::MatureAfterPeriod {
-                period: Duration::from_secs(3600),
+            maturity: SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(3600),
             },
             ..Default::default()
         }

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -148,7 +148,7 @@ impl MergePlanner {
     }
 
     fn record_split(&mut self, new_split: SplitMetadata) {
-        if self.merge_policy.is_mature(&new_split) {
+        if new_split.is_mature() {
             return;
         }
         let splits_for_partition: &mut Vec<SplitMetadata> = self
@@ -331,6 +331,7 @@ mod tests {
             partition_id,
             num_merge_ops,
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
+            maturity_timestamp: OffsetDateTime::now_utc().unix_timestamp() + 3600,
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -305,7 +305,7 @@ mod tests {
         ConstWriteAmplificationMergePolicyConfig, MergePolicyConfig, StableLogMergePolicyConfig,
     };
     use quickwit_config::IndexingSettings;
-    use quickwit_metastore::SplitMetadata;
+    use quickwit_metastore::{SplitMaturity, SplitMetadata};
     use quickwit_proto::IndexUid;
     use tantivy::TrackedObject;
     use time::OffsetDateTime;
@@ -331,7 +331,7 @@ mod tests {
             partition_id,
             num_merge_ops,
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            time_to_maturity: Some(Duration::from_secs(3600)),
+            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(3600)),
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -28,6 +28,7 @@ use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, Qu
 use quickwit_metastore::SplitMetadata;
 use serde::Serialize;
 use tantivy::Inventory;
+use time::OffsetDateTime;
 use tracing::info;
 
 use crate::actors::MergeSplitDownloader;
@@ -148,7 +149,7 @@ impl MergePlanner {
     }
 
     fn record_split(&mut self, new_split: SplitMetadata) {
-        if new_split.is_mature() {
+        if new_split.is_mature(OffsetDateTime::now_utc()) {
             return;
         }
         let splits_for_partition: &mut Vec<SplitMetadata> = self

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -331,7 +331,7 @@ mod tests {
             partition_id,
             num_merge_ops,
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            maturity_timestamp: OffsetDateTime::now_utc().unix_timestamp() + 3600,
+            time_to_maturity: Some(Duration::from_secs(3600)),
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -331,7 +331,9 @@ mod tests {
             partition_id,
             num_merge_ops,
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(3600)),
+            maturity: SplitMaturity::MatureAfterPeriod {
+                period: Duration::from_secs(3600),
+            },
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-indexing/src/merge_policy/const_write_amplification.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/const_write_amplification.rs
@@ -160,7 +160,9 @@ impl MergePolicy for ConstWriteAmplificationMergePolicy {
         if split_num_docs >= self.split_num_docs_target {
             return SplitMaturity::Mature;
         }
-        SplitMaturity::TimeToMaturity(self.config.maturation_period)
+        SplitMaturity::MatureAfterPeriod {
+            period: self.config.maturation_period,
+        }
     }
 
     #[cfg(test)]
@@ -213,7 +215,9 @@ mod tests {
         // maturation_period is not mature.
         assert_eq!(
             merge_policy.split_maturity(split.num_docs, split.num_merge_ops),
-            SplitMaturity::TimeToMaturity(Duration::from_secs(3600))
+            SplitMaturity::MatureAfterPeriod {
+                period: Duration::from_secs(3600)
+            }
         );
         // Split with docs > max_merge_docs is mature.
         assert_eq!(

--- a/quickwit/quickwit-indexing/src/merge_policy/const_write_amplification.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/const_write_amplification.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use quickwit_config::merge_policy_config::ConstWriteAmplificationMergePolicyConfig;
 use quickwit_config::IndexingSettings;
 use quickwit_metastore::{SplitMaturity, SplitMetadata};
+use time::OffsetDateTime;
 
 use super::MergeOperation;
 use crate::merge_policy::MergePolicy;
@@ -134,7 +135,7 @@ impl MergePolicy for ConstWriteAmplificationMergePolicy {
         let mut group_by_num_merge_ops: HashMap<usize, Vec<SplitMetadata>> = HashMap::default();
         let mut mature_splits = Vec::new();
         for split in splits.drain(..) {
-            if split.is_mature() {
+            if split.is_mature(OffsetDateTime::now_utc()) {
                 mature_splits.push(split);
             } else {
                 group_by_num_merge_ops

--- a/quickwit/quickwit-indexing/src/merge_policy/const_write_amplification.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/const_write_amplification.rs
@@ -160,8 +160,8 @@ impl MergePolicy for ConstWriteAmplificationMergePolicy {
         if split_num_docs >= self.split_num_docs_target {
             return SplitMaturity::Mature;
         }
-        SplitMaturity::MatureAfterPeriod {
-            period: self.config.maturation_period,
+        SplitMaturity::Immature {
+            maturation_period: self.config.maturation_period,
         }
     }
 
@@ -215,8 +215,8 @@ mod tests {
         // maturation_period is not mature.
         assert_eq!(
             merge_policy.split_maturity(split.num_docs, split.num_merge_ops),
-            SplitMaturity::MatureAfterPeriod {
-                period: Duration::from_secs(3600)
+            SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(3600)
             }
         );
         // Split with docs > max_merge_docs is mature.

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -108,8 +108,10 @@ impl fmt::Debug for MergeOperation {
 pub trait MergePolicy: Send + Sync + fmt::Debug {
     /// Returns the list of merge operations that should be performed.
     fn operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation>;
-    /// Returns split maturity after which a split becomes mature.
-    /// A split is mature if it does not undergo new merge operations.
+    /// Returns split maturity.
+    /// A split is either:
+    /// - `Mature` if it does not undergo new merge operations.
+    /// - will become mature after a `TimeToMaturity` period of time.
     fn split_maturity(&self, split_num_docs: usize, split_num_merge_ops: usize) -> SplitMaturity;
 
     /// Checks a bunch of properties specific to the given merge policy.

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -108,10 +108,11 @@ impl fmt::Debug for MergeOperation {
 pub trait MergePolicy: Send + Sync + fmt::Debug {
     /// Returns the list of merge operations that should be performed.
     fn operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation>;
+
     /// Returns split maturity.
     /// A split is either:
     /// - `Mature` if it does not undergo new merge operations.
-    /// - or will become mature after a `TimeToMaturity` period of time.
+    /// - or `Immature` with a `maturation_period` after which it becomes mature.
     fn split_maturity(&self, split_num_docs: usize, split_num_merge_ops: usize) -> SplitMaturity;
 
     /// Checks a bunch of properties specific to the given merge policy.

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -108,8 +108,8 @@ impl fmt::Debug for MergeOperation {
 pub trait MergePolicy: Send + Sync + fmt::Debug {
     /// Returns the list of merge operations that should be performed.
     fn operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation>;
-    /// Returns the duration after which a split becomes mature.
-    /// If the split is already mature given its num docs and merge ops, returns `None`.
+    /// Returns split maturity after which a split becomes mature.
+    /// A split is mature if it does not undergo new merge operations.
     fn split_maturity(&self, split_num_docs: usize, split_num_merge_ops: usize) -> SplitMaturity;
 
     /// Checks a bunch of properties specific to the given merge policy.

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -111,7 +111,7 @@ pub trait MergePolicy: Send + Sync + fmt::Debug {
     /// Returns split maturity.
     /// A split is either:
     /// - `Mature` if it does not undergo new merge operations.
-    /// - will become mature after a `TimeToMaturity` period of time.
+    /// - or will become mature after a `TimeToMaturity` period of time.
     fn split_maturity(&self, split_num_docs: usize, split_num_merge_ops: usize) -> SplitMaturity;
 
     /// Checks a bunch of properties specific to the given merge policy.

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -303,7 +303,7 @@ pub mod tests {
             //     merge_policy.operations(&mut splits).is_empty(),
             //     "Merge policy are expected to return all available merge operations."
             // );
-
+            let now_utc = OffsetDateTime::now_utc();
             for merge_op in &mut operations {
                 assert_eq!(merge_op.operation_type, MergeOperationType::Merge,
                     "A merge policy should only emit Merge operations."
@@ -311,7 +311,7 @@ pub mod tests {
                 assert!(merge_op.splits_as_slice().len() >= 2,
             "Merge policies should not suggest merging a single split.");
                 for split in merge_op.splits_as_slice() {
-                    assert!(!split.is_mature(), "Merges should not contain mature splits.");
+                    assert!(!split.is_mature(now_utc), "Merges should not contain mature splits.");
                 }
                 merge_policy.check_is_valid(merge_op, &splits[..]);
             }

--- a/quickwit/quickwit-indexing/src/merge_policy/nop_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/nop_merge_policy.rs
@@ -18,7 +18,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
-use std::time::Duration;
+
+use quickwit_metastore::SplitMaturity;
 
 use crate::merge_policy::MergePolicy;
 
@@ -41,26 +42,24 @@ impl MergePolicy for NopMergePolicy {
         Vec::new()
     }
 
-    fn split_time_to_maturity(
-        &self,
-        _split_num_docs: usize,
-        _split_num_merge_ops: usize,
-    ) -> Option<Duration> {
+    fn split_maturity(&self, _split_num_docs: usize, _split_num_merge_ops: usize) -> SplitMaturity {
         // With the no merge policy, all splits are mature immediately as they will never undergo
         // any merge.
-        None
+        SplitMaturity::Mature
     }
 }
 
 #[cfg(test)]
 mod tests {
 
+    use quickwit_metastore::SplitMaturity;
+
     use crate::merge_policy::{MergePolicy, NopMergePolicy};
 
     #[test]
     pub fn test_no_merge_policy_maturity_timestamp() {
         // All splits are always mature for `NopMergePolicy`.
-        assert!(NopMergePolicy.split_time_to_maturity(10, 0).is_none());
+        assert_eq!(NopMergePolicy.split_maturity(10, 0), SplitMaturity::Mature);
     }
 
     #[test]

--- a/quickwit/quickwit-indexing/src/merge_policy/nop_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/nop_merge_policy.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
+use std::time::Duration;
 
 use crate::merge_policy::MergePolicy;
 
@@ -40,29 +41,31 @@ impl MergePolicy for NopMergePolicy {
         Vec::new()
     }
 
-    fn is_mature(&self, _split: &quickwit_metastore::SplitMetadata) -> bool {
-        // With the no merge policy, all splits are mature as they will never undergo any merge.
-        true
+    fn split_time_to_maturity(
+        &self,
+        _split_num_docs: usize,
+        _split_num_merge_ops: usize,
+    ) -> Option<Duration> {
+        // With the no merge policy, all splits are mature immediately as they will never undergo
+        // any merge.
+        None
     }
 }
 
 #[cfg(test)]
 mod tests {
+
     use crate::merge_policy::{MergePolicy, NopMergePolicy};
 
     #[test]
-    pub fn test_no_merge_policy_is_mature() {
-        let split = super::super::tests::create_splits(vec![1])
-            .into_iter()
-            .next()
-            .unwrap();
+    pub fn test_no_merge_policy_maturity_timestamp() {
         // All splits are always mature for `NopMergePolicy`.
-        assert!(NopMergePolicy.is_mature(&split));
+        assert!(NopMergePolicy.split_time_to_maturity(10, 0).is_none());
     }
 
     #[test]
     pub fn test_no_merge_policy_operations() {
-        let mut splits = super::super::tests::create_splits(vec![1; 100]);
+        let mut splits = super::super::tests::create_splits(&NopMergePolicy, vec![1; 100]);
         assert!(NopMergePolicy.operations(&mut splits).is_empty());
         assert_eq!(splits.len(), 100);
     }

--- a/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
@@ -121,8 +121,8 @@ impl MergePolicy for StableLogMergePolicy {
         if split_num_docs >= self.split_num_docs_target {
             return SplitMaturity::Mature;
         }
-        SplitMaturity::MatureAfterPeriod {
-            period: self.config.maturation_period,
+        SplitMaturity::Immature {
+            maturation_period: self.config.maturation_period,
         }
     }
 
@@ -375,8 +375,8 @@ mod tests {
         // Split under max_merge_docs and created before now() - maturation_period is not mature.
         assert_eq!(
             merge_policy.split_maturity(9_000_000, 0),
-            SplitMaturity::MatureAfterPeriod {
-                period: Duration::from_secs(3600 * 48)
+            SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(3600 * 48)
             }
         );
         assert_eq!(
@@ -387,8 +387,8 @@ mod tests {
         // mature.
         assert_eq!(
             merge_policy.split_maturity(9_000_000, 0),
-            SplitMaturity::MatureAfterPeriod {
-                period: merge_policy.config.maturation_period
+            SplitMaturity::Immature {
+                maturation_period: merge_policy.config.maturation_period
             }
         );
     }

--- a/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
@@ -23,6 +23,7 @@ use std::ops::Range;
 use quickwit_config::merge_policy_config::StableLogMergePolicyConfig;
 use quickwit_config::IndexingSettings;
 use quickwit_metastore::{SplitMaturity, SplitMetadata};
+use time::OffsetDateTime;
 use tracing::debug;
 
 use crate::merge_policy::{splits_short_debug, MergeOperation, MergePolicy};
@@ -187,7 +188,8 @@ impl StableLogMergePolicy {
             return Vec::new();
         }
         // First we isolate splits that are mature.
-        let splits_not_for_merge = remove_matching_items(splits, |split| split.is_mature());
+        let splits_not_for_merge =
+            remove_matching_items(splits, |split| split.is_mature(OffsetDateTime::now_utc()));
 
         let mut merge_operations: Vec<MergeOperation> = Vec::new();
         splits.sort_unstable_by(cmp_splits_by_reverse_time_end);

--- a/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
@@ -121,7 +121,9 @@ impl MergePolicy for StableLogMergePolicy {
         if split_num_docs >= self.split_num_docs_target {
             return SplitMaturity::Mature;
         }
-        SplitMaturity::TimeToMaturity(self.config.maturation_period)
+        SplitMaturity::MatureAfterPeriod {
+            period: self.config.maturation_period,
+        }
     }
 
     #[cfg(test)]
@@ -373,7 +375,9 @@ mod tests {
         // Split under max_merge_docs and created before now() - maturation_period is not mature.
         assert_eq!(
             merge_policy.split_maturity(9_000_000, 0),
-            SplitMaturity::TimeToMaturity(Duration::from_secs(3600 * 48))
+            SplitMaturity::MatureAfterPeriod {
+                period: Duration::from_secs(3600 * 48)
+            }
         );
         assert_eq!(
             merge_policy.split_maturity(&merge_policy.split_num_docs_target + 1, 0),
@@ -383,7 +387,9 @@ mod tests {
         // mature.
         assert_eq!(
             merge_policy.split_maturity(9_000_000, 0),
-            SplitMaturity::TimeToMaturity(merge_policy.config.maturation_period)
+            SplitMaturity::MatureAfterPeriod {
+                period: merge_policy.config.maturation_period
+            }
         );
     }
 

--- a/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
@@ -568,10 +568,7 @@ mod tests {
         for split in splits.iter_mut() {
             let time_to_maturity =
                 merge_policy.split_time_to_maturity(split.num_docs, split.num_merge_ops);
-            let maturity_timestamp = time_to_maturity
-                .map(|duration| split.create_timestamp + duration.as_secs() as i64)
-                .unwrap_or(0);
-            split.maturity_timestamp = maturity_timestamp;
+            split.time_to_maturity = time_to_maturity;
         }
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 2);

--- a/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
@@ -19,11 +19,11 @@
 
 use std::cmp::Ordering;
 use std::ops::Range;
+use std::time::Duration;
 
 use quickwit_config::merge_policy_config::StableLogMergePolicyConfig;
 use quickwit_config::IndexingSettings;
 use quickwit_metastore::SplitMetadata;
-use time::OffsetDateTime;
 use tracing::debug;
 
 use crate::merge_policy::{splits_short_debug, MergeOperation, MergePolicy};
@@ -118,16 +118,15 @@ impl MergePolicy for StableLogMergePolicy {
     }
 
     /// A mature split for merge is a split that won't undergo any merge operation in the future.
-    fn is_mature(&self, split: &SplitMetadata) -> bool {
-        if split.num_docs >= self.split_num_docs_target {
-            return true;
+    fn split_time_to_maturity(
+        &self,
+        split_num_docs: usize,
+        _split_num_merge_ops: usize,
+    ) -> Option<Duration> {
+        if split_num_docs >= self.split_num_docs_target {
+            return None;
         }
-        if OffsetDateTime::now_utc().unix_timestamp()
-            >= split.create_timestamp + self.config.maturation_period.as_secs() as i64
-        {
-            return true;
-        }
-        false
+        Some(self.config.maturation_period)
     }
 
     #[cfg(test)]
@@ -191,7 +190,7 @@ impl StableLogMergePolicy {
             return Vec::new();
         }
         // First we isolate splits that are mature.
-        let splits_not_for_merge = remove_matching_items(splits, |split| self.is_mature(split));
+        let splits_not_for_merge = remove_matching_items(splits, |split| split.is_mature());
 
         let mut merge_operations: Vec<MergeOperation> = Vec::new();
         splits.sort_unstable_by(cmp_splits_by_reverse_time_end);
@@ -377,21 +376,19 @@ mod tests {
     fn test_split_is_mature() {
         let merge_policy = StableLogMergePolicy::default();
         // Split under max_merge_docs and created before now() - maturation_period is not mature.
-        let split = create_splits(vec![9_000_000]).into_iter().next().unwrap();
-        assert!(!merge_policy.is_mature(&split));
-        {
-            // Split with docs > max_merge_docs is mature.
-            let mut mature_split = split.clone();
-            mature_split.num_docs = merge_policy.split_num_docs_target + 1;
-            assert!(merge_policy.is_mature(&mature_split));
-        }
-        {
-            // Split under max_merge_docs but with create_timestamp >= now + maturity duration is
-            // mature.
-            let mut mature_split = split;
-            mature_split.create_timestamp -= merge_policy.config.maturation_period.as_secs() as i64;
-            assert!(merge_policy.is_mature(&mature_split));
-        }
+        assert_eq!(
+            merge_policy.split_time_to_maturity(9_000_000, 0),
+            Some(Duration::from_secs(3600 * 48))
+        );
+        assert!(merge_policy
+            .split_time_to_maturity(&merge_policy.split_num_docs_target + 1, 0)
+            .is_none());
+        // Split under max_merge_docs but with create_timestamp >= now + maturity duration is
+        // mature.
+        assert_eq!(
+            merge_policy.split_time_to_maturity(9_000_000, 0),
+            Some(merge_policy.config.maturation_period)
+        );
     }
 
     #[test]
@@ -404,8 +401,11 @@ mod tests {
 
     #[test]
     fn test_stable_log_merge_policy_build_split_simple() {
-        let merge_policy = StableLogMergePolicy::default();
-        let splits = create_splits(vec![100_000, 100_000, 100_000, 800_000, 900_000]);
+        let merge_policy: StableLogMergePolicy = StableLogMergePolicy::default();
+        let splits = create_splits(
+            &merge_policy,
+            vec![100_000, 100_000, 100_000, 800_000, 900_000],
+        );
         let split_groups = merge_policy.build_split_levels(&splits);
         assert_eq!(&split_groups, &[0..3, 3..5]);
     }
@@ -413,10 +413,13 @@ mod tests {
     #[test]
     fn test_stable_log_merge_policy_build_split_perfect_world() {
         let merge_policy = StableLogMergePolicy::default();
-        let splits = create_splits(vec![
-            100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
-            1_600_000,
-        ]);
+        let splits = create_splits(
+            &merge_policy,
+            vec![
+                100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
+                1_600_000,
+            ],
+        );
         let split_groups = merge_policy.build_split_levels(&splits);
         assert_eq!(&split_groups, &[0..8, 8..10]);
     }
@@ -424,10 +427,13 @@ mod tests {
     #[test]
     fn test_stable_log_merge_policy_build_split_decreasing() {
         let merge_policy = StableLogMergePolicy::default();
-        let splits = create_splits(vec![
-            100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
-            100_000, 1_600_000,
-        ]);
+        let splits = create_splits(
+            &merge_policy,
+            vec![
+                100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 100_000, 800_000,
+                100_000, 1_600_000,
+            ],
+        );
         let split_groups = merge_policy.build_split_levels(&splits);
         assert_eq!(&split_groups, &[0..8, 8..11]);
     }
@@ -436,14 +442,14 @@ mod tests {
     #[should_panic(expected = "All splits are expected to be smaller than `max_merge_docs`.")]
     fn test_stable_log_merge_policy_build_split_panics_if_exceeding_max_merge_docs() {
         let merge_policy = StableLogMergePolicy::default();
-        let splits = create_splits(vec![11_000_000]);
+        let splits = create_splits(&merge_policy, vec![11_000_000]);
         merge_policy.build_split_levels(&splits);
     }
 
     #[test]
     fn test_stable_log_merge_policy_not_enough_splits() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![100; 7]);
+        let mut splits = create_splits(&merge_policy, vec![100; 7]);
         assert_eq!(splits.len(), 7);
         assert!(merge_policy.operations(&mut splits).is_empty());
     }
@@ -451,7 +457,7 @@ mod tests {
     #[test]
     fn test_stable_log_merge_policy_just_enough_splits_for_a_merge() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![100; 10]);
+        let mut splits = create_splits(&merge_policy, vec![100; 10]);
         let mut merge_ops = merge_policy.operations(&mut splits);
         assert!(splits.is_empty());
         assert_eq!(merge_ops.len(), 1);
@@ -474,7 +480,7 @@ mod tests {
     #[test]
     fn test_stable_log_merge_policy_many_splits_on_same_level() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![100; 13]);
+        let mut splits = create_splits(&merge_policy, vec![100; 13]);
         let mut merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 1);
         assert_eq!(splits[0].split_id(), "split_00");
@@ -498,9 +504,12 @@ mod tests {
     #[test]
     fn test_stable_log_merge_policy_splits_below_min_level() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![
-            100, 1000, 10_000, 10_000, 10_000, 10_000, 10_000, 40_000, 40_000, 40_000,
-        ]);
+        let mut splits = create_splits(
+            &merge_policy,
+            vec![
+                100, 1000, 10_000, 10_000, 10_000, 10_000, 10_000, 40_000, 40_000, 40_000,
+            ],
+        );
         let mut merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 0);
         assert_eq!(merge_ops.len(), 1);
@@ -523,9 +532,13 @@ mod tests {
     #[test]
     fn test_stable_log_merge_policy_splits_above_min_level() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![
-            100_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000,
-        ]);
+        let mut splits = create_splits(
+            &merge_policy,
+            vec![
+                100_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000,
+                1_000_000,
+            ],
+        );
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 8);
         assert_eq!(merge_ops.len(), 0);
@@ -534,11 +547,14 @@ mod tests {
     #[test]
     fn test_stable_log_merge_policy_above_max_merge_docs_is_ignored() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![
-            100_000, 100_000, 100_000, 100_000, 100_000,
-            10_000_000, // this split should not interfere with the merging of other splits
-            100_000, 100_000, 100_000, 100_000, 100_000,
-        ]);
+        let mut splits = create_splits(
+            &merge_policy,
+            vec![
+                100_000, 100_000, 100_000, 100_000, 100_000,
+                10_000_000, // this split should not interfere with the merging of other splits
+                100_000, 100_000, 100_000, 100_000, 100_000,
+            ],
+        );
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 1);
         assert_eq!(splits[0].num_docs, 10_000_000);
@@ -548,7 +564,15 @@ mod tests {
     #[test]
     fn test_merge_policy_splits_too_large_are_ignored() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![9_999_999, 10_000_000]);
+        let mut splits = create_splits(&merge_policy, vec![9_999_999, 10_000_000]);
+        for split in splits.iter_mut() {
+            let time_to_maturity =
+                merge_policy.split_time_to_maturity(split.num_docs, split.num_merge_ops);
+            let maturity_timestamp = time_to_maturity
+                .map(|duration| split.create_timestamp + duration.as_secs() as i64)
+                .unwrap_or(0);
+            split.maturity_timestamp = maturity_timestamp;
+        }
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 2);
         assert_eq!(splits[0].num_docs, 9_999_999);
@@ -559,7 +583,7 @@ mod tests {
     #[test]
     fn test_merge_policy_splits_entire_level_reach_merge_max_doc() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![5_000_000, 5_000_000]);
+        let mut splits = create_splits(&merge_policy, vec![5_000_000, 5_000_000]);
         let merge_ops = merge_policy.operations(&mut splits);
         assert!(splits.is_empty());
         assert_eq!(merge_ops.len(), 1);
@@ -569,7 +593,7 @@ mod tests {
     #[test]
     fn test_merge_policy_last_merge_can_have_a_lower_merge_factor() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![9_999_997, 9_999_998, 9_999_999]);
+        let mut splits = create_splits(&merge_policy, vec![9_999_997, 9_999_998, 9_999_999]);
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 1);
         assert_eq!(splits[0].num_docs, 9_999_997);
@@ -580,7 +604,7 @@ mod tests {
     #[test]
     fn test_merge_policy_no_merge_with_only_one_split() {
         let merge_policy = StableLogMergePolicy::default();
-        let mut splits = create_splits(vec![9_999_999]);
+        let mut splits = create_splits(&merge_policy, vec![9_999_999]);
         let merge_ops = merge_policy.operations(&mut splits);
         assert_eq!(splits.len(), 1);
         assert_eq!(splits[0].num_docs, 9_999_999);

--- a/quickwit/quickwit-indexing/src/models/split_attrs.rs
+++ b/quickwit/quickwit-indexing/src/models/split_attrs.rs
@@ -20,11 +20,13 @@
 use std::collections::BTreeSet;
 use std::fmt;
 use std::ops::{Range, RangeInclusive};
+use std::sync::Arc;
 
 use quickwit_metastore::SplitMetadata;
 use tantivy::DateTime;
 use time::OffsetDateTime;
 
+use crate::merge_policy::MergePolicy;
 use crate::models::IndexingPipelineId;
 
 pub struct SplitAttrs {
@@ -81,10 +83,17 @@ impl fmt::Debug for SplitAttrs {
 }
 
 pub fn create_split_metadata(
+    merge_policy: &Arc<dyn MergePolicy>,
     split_attrs: &SplitAttrs,
     tags: BTreeSet<String>,
     footer_offsets: Range<u64>,
 ) -> SplitMetadata {
+    let create_timestamp = OffsetDateTime::now_utc().unix_timestamp();
+    let maturity_timestamp = merge_policy.split_maturity_timestamp(
+        create_timestamp,
+        split_attrs.num_docs as usize,
+        split_attrs.num_merge_ops,
+    );
     SplitMetadata {
         split_id: split_attrs.split_id.clone(),
         index_uid: split_attrs.pipeline_id.index_uid.clone(),
@@ -97,7 +106,8 @@ pub fn create_split_metadata(
             .as_ref()
             .map(|range| range.start().into_timestamp_secs()..=range.end().into_timestamp_secs()),
         uncompressed_docs_size_in_bytes: split_attrs.uncompressed_docs_size_in_bytes,
-        create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
+        create_timestamp,
+        maturity_timestamp,
         tags,
         footer_offsets,
         delete_opstamp: split_attrs.delete_opstamp,

--- a/quickwit/quickwit-indexing/src/models/split_attrs.rs
+++ b/quickwit/quickwit-indexing/src/models/split_attrs.rs
@@ -89,11 +89,8 @@ pub fn create_split_metadata(
     footer_offsets: Range<u64>,
 ) -> SplitMetadata {
     let create_timestamp = OffsetDateTime::now_utc().unix_timestamp();
-    let maturity_timestamp = merge_policy.split_maturity_timestamp(
-        create_timestamp,
-        split_attrs.num_docs as usize,
-        split_attrs.num_merge_ops,
-    );
+    let time_to_maturity = merge_policy
+        .split_time_to_maturity(split_attrs.num_docs as usize, split_attrs.num_merge_ops);
     SplitMetadata {
         split_id: split_attrs.split_id.clone(),
         index_uid: split_attrs.pipeline_id.index_uid.clone(),
@@ -107,7 +104,7 @@ pub fn create_split_metadata(
             .map(|range| range.start().into_timestamp_secs()..=range.end().into_timestamp_secs()),
         uncompressed_docs_size_in_bytes: split_attrs.uncompressed_docs_size_in_bytes,
         create_timestamp,
-        maturity_timestamp,
+        time_to_maturity,
         tags,
         footer_offsets,
         delete_opstamp: split_attrs.delete_opstamp,

--- a/quickwit/quickwit-indexing/src/models/split_attrs.rs
+++ b/quickwit/quickwit-indexing/src/models/split_attrs.rs
@@ -89,7 +89,7 @@ pub fn create_split_metadata(
     footer_offsets: Range<u64>,
 ) -> SplitMetadata {
     let create_timestamp = OffsetDateTime::now_utc().unix_timestamp();
-    let time_to_maturity =
+    let maturity =
         merge_policy.split_maturity(split_attrs.num_docs as usize, split_attrs.num_merge_ops);
     SplitMetadata {
         split_id: split_attrs.split_id.clone(),
@@ -104,7 +104,7 @@ pub fn create_split_metadata(
             .map(|range| range.start().into_timestamp_secs()..=range.end().into_timestamp_secs()),
         uncompressed_docs_size_in_bytes: split_attrs.uncompressed_docs_size_in_bytes,
         create_timestamp,
-        maturity: time_to_maturity,
+        maturity,
         tags,
         footer_offsets,
         delete_opstamp: split_attrs.delete_opstamp,

--- a/quickwit/quickwit-indexing/src/models/split_attrs.rs
+++ b/quickwit/quickwit-indexing/src/models/split_attrs.rs
@@ -89,8 +89,8 @@ pub fn create_split_metadata(
     footer_offsets: Range<u64>,
 ) -> SplitMetadata {
     let create_timestamp = OffsetDateTime::now_utc().unix_timestamp();
-    let time_to_maturity = merge_policy
-        .split_time_to_maturity(split_attrs.num_docs as usize, split_attrs.num_merge_ops);
+    let time_to_maturity =
+        merge_policy.split_maturity(split_attrs.num_docs as usize, split_attrs.num_merge_ops);
     SplitMetadata {
         split_id: split_attrs.split_id.clone(),
         index_uid: split_attrs.pipeline_id.index_uid.clone(),
@@ -104,7 +104,7 @@ pub fn create_split_metadata(
             .map(|range| range.start().into_timestamp_secs()..=range.end().into_timestamp_secs()),
         uncompressed_docs_size_in_bytes: split_attrs.uncompressed_docs_size_in_bytes,
         create_timestamp,
-        time_to_maturity,
+        maturity: time_to_maturity,
         tags,
         footer_offsets,
         delete_opstamp: split_attrs.delete_opstamp,

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -34,8 +34,7 @@ use tantivy::{Advice, Directory};
 use tracing::{info, info_span, instrument, Instrument};
 
 use super::LocalSplitStore;
-use crate::merge_policy::NopMergePolicy;
-use crate::{get_tantivy_directory_from_split_bundle, MergePolicy};
+use crate::get_tantivy_directory_from_split_bundle;
 
 /// IndexingSplitStore is a wrapper around a regular `Storage` to upload and
 /// download splits while allowing for efficient caching.
@@ -66,11 +65,6 @@ struct InnerIndexingSplitStore {
     remote_storage: Arc<dyn Storage>,
 
     local_split_store: Arc<LocalSplitStore>,
-
-    /// The merge policy is useful to identify whether a split
-    /// should be stored in the local storage or not.
-    /// (mature splits do not need to be stored).
-    merge_policy: Arc<dyn MergePolicy>,
 }
 
 pub struct WeakIndexingSplitStore {
@@ -89,15 +83,10 @@ impl IndexingSplitStore {
     /// Creates an instance of [`IndexingSplitStore`]
     ///
     /// It needs the remote storage to work with.
-    pub fn new(
-        remote_storage: Arc<dyn Storage>,
-        merge_policy: Arc<dyn MergePolicy>,
-        local_split_store: Arc<LocalSplitStore>,
-    ) -> Self {
+    pub fn new(remote_storage: Arc<dyn Storage>, local_split_store: Arc<LocalSplitStore>) -> Self {
         let inner = InnerIndexingSplitStore {
             remote_storage,
             local_split_store,
-            merge_policy,
         };
         Self {
             inner: Arc::new(inner),
@@ -110,7 +99,6 @@ impl IndexingSplitStore {
         let inner = InnerIndexingSplitStore {
             remote_storage,
             local_split_store: Arc::new(LocalSplitStore::no_caching()),
-            merge_policy: Arc::new(NopMergePolicy),
         };
         IndexingSplitStore {
             inner: Arc::new(inner),
@@ -137,7 +125,7 @@ impl IndexingSplitStore {
         let split_num_bytes = put_payload.len();
 
         let key = PathBuf::from(quickwit_common::split_file(split.split_id()));
-        let is_mature = self.inner.merge_policy.is_mature(split);
+        let is_mature = split.is_mature();
         self.inner
             .remote_storage
             .put(&key, put_payload)
@@ -257,13 +245,13 @@ mod tests {
     use ulid::Ulid;
 
     use super::IndexingSplitStore;
-    use crate::merge_policy::default_merge_policy;
     use crate::split_store::{LocalSplitStore, SplitStoreQuota};
 
     fn create_test_split_metadata(split_id: &str) -> SplitMetadata {
         SplitMetadata {
             split_id: split_id.to_string(),
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
+            maturity_timestamp: OffsetDateTime::now_utc().unix_timestamp() + 3600,
             ..Default::default()
         }
     }
@@ -279,11 +267,7 @@ mod tests {
         )
         .await?;
         let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::new(
-            remote_storage,
-            default_merge_policy(),
-            Arc::new(local_split_store),
-        );
+        let split_store = IndexingSplitStore::new(remote_storage, Arc::new(local_split_store));
 
         let split_id1 = Ulid::new().to_string();
         let split_id2 = Ulid::new().to_string();
@@ -349,11 +333,7 @@ mod tests {
         .await?;
 
         let remote_storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::new(
-            remote_storage,
-            default_merge_policy(),
-            Arc::new(local_split_store),
-        );
+        let split_store = IndexingSplitStore::new(remote_storage, Arc::new(local_split_store));
 
         let split_id1 = Ulid::new().to_string();
         let split_id2 = Ulid::new().to_string();

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -234,6 +234,7 @@ impl IndexingSplitStore {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use byte_unit::Byte;
     use quickwit_common::io::IoControls;
@@ -251,7 +252,7 @@ mod tests {
         SplitMetadata {
             split_id: split_id.to_string(),
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            maturity_timestamp: OffsetDateTime::now_utc().unix_timestamp() + 3600,
+            time_to_maturity: Some(Duration::from_secs(3600)),
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -31,6 +31,7 @@ use quickwit_metastore::SplitMetadata;
 use quickwit_storage::{PutPayload, Storage, StorageResult};
 use tantivy::directory::MmapDirectory;
 use tantivy::{Advice, Directory};
+use time::OffsetDateTime;
 use tracing::{info, info_span, instrument, Instrument};
 
 use super::LocalSplitStore;
@@ -125,7 +126,7 @@ impl IndexingSplitStore {
         let split_num_bytes = put_payload.len();
 
         let key = PathBuf::from(quickwit_common::split_file(split.split_id()));
-        let is_mature = split.is_mature();
+        let is_mature = split.is_mature(OffsetDateTime::now_utc());
         self.inner
             .remote_storage
             .put(&key, put_payload)

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -252,8 +252,8 @@ mod tests {
         SplitMetadata {
             split_id: split_id.to_string(),
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            maturity: SplitMaturity::MatureAfterPeriod {
-                period: Duration::from_secs(3600),
+            maturity: SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(3600),
             },
             ..Default::default()
         }

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -238,7 +238,7 @@ mod tests {
 
     use byte_unit::Byte;
     use quickwit_common::io::IoControls;
-    use quickwit_metastore::SplitMetadata;
+    use quickwit_metastore::{SplitMaturity, SplitMetadata};
     use quickwit_storage::{RamStorage, SplitPayloadBuilder};
     use tempfile::tempdir;
     use time::OffsetDateTime;
@@ -252,7 +252,7 @@ mod tests {
         SplitMetadata {
             split_id: split_id.to_string(),
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            time_to_maturity: Some(Duration::from_secs(3600)),
+            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(3600)),
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -252,7 +252,9 @@ mod tests {
         SplitMetadata {
             split_id: split_id.to_string(),
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
-            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(3600)),
+            maturity: SplitMaturity::MatureAfterPeriod {
+                period: Duration::from_secs(3600),
+            },
             ..Default::default()
         }
     }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -335,12 +335,9 @@ impl DeleteTaskPlanner {
             last_delete_opstamp = last_delete_opstamp,
             num_stale_splits_from_metastore = stale_splits.len()
         );
-        // Keep only mature splits and splits that are not already part of ongoing delete
-        // operations.
         let ongoing_delete_operations = self.ongoing_delete_operations_inventory.list();
         let filtered_splits = stale_splits
             .into_iter()
-            .filter(|stale_split| stale_split.split_metadata.is_mature())
             .filter(|stale_split| {
                 !ongoing_delete_operations.iter().any(|operation| {
                     operation

--- a/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
@@ -167,7 +167,6 @@ impl DeleteTaskService {
             index_metadata.index_uid.clone(),
             self.metastore.clone(),
             self.search_job_placer.clone(),
-            index_config.indexing_settings,
             index_storage,
             self.delete_service_task_dir.clone(),
             self.max_concurrent_split_uploads,

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -62,7 +62,6 @@ pub async fn start_janitor_service(
     let retention_policy_executor = RetentionPolicyExecutor::new(metastore.clone());
     let (_, retention_policy_executor_handle) =
         universe.spawn_builder().spawn(retention_policy_executor);
-
     let delete_task_service = DeleteTaskService::new(
         metastore,
         search_job_placer,

--- a/quickwit/quickwit-metastore/Cargo.toml
+++ b/quickwit/quickwit-metastore/Cargo.toml
@@ -23,6 +23,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true }
 time = { workspace = true }

--- a/quickwit/quickwit-metastore/migrations/postgresql/11_add-split-maturity-timestamp-field.down.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/11_add-split-maturity-timestamp-field.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE splits
+  DROP COLUMN maturity_timestamp;

--- a/quickwit/quickwit-metastore/migrations/postgresql/11_add-split-maturity-timestamp-field.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/11_add-split-maturity-timestamp-field.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE splits
+    ADD COLUMN maturity_timestamp TIMESTAMP DEFAULT TO_TIMESTAMP(0);

--- a/quickwit/quickwit-metastore/src/lib.rs
+++ b/quickwit/quickwit-metastore/src/lib.rs
@@ -56,7 +56,7 @@ pub use metastore_factory::{MetastoreFactory, UnsupportedMetastore};
 pub use metastore_resolver::MetastoreResolver;
 use quickwit_common::is_disjoint;
 use quickwit_doc_mapper::tag_pruning::TagFilterAst;
-pub use split_metadata::{Split, SplitMetadata, SplitState};
+pub use split_metadata::{Split, SplitMaturity, SplitMetadata, SplitState};
 pub(crate) use split_metadata_version::{SplitMetadataV0_6, VersionedSplitMetadata};
 
 #[derive(utoipa::OpenApi)]

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -500,11 +500,11 @@ fn split_query_predicate(split: &&Split, query: &ListSplitsQuery) -> bool {
         return false;
     }
 
-    if !query
-        .maturity_timestamp
-        .contains(&split.split_metadata.maturity_timestamp())
-    {
-        return false;
+    if let Some(maturity_filter) = &query.maturity {
+        let is_mature = split
+            .split_metadata
+            .is_mature(maturity_filter.evaluation_datetime);
+        return is_mature == maturity_filter.mature;
     }
 
     if let Some(range) = split.split_metadata.time_range.as_ref() {

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -502,7 +502,7 @@ fn split_query_predicate(split: &&Split, query: &ListSplitsQuery) -> bool {
 
     if !query
         .maturity_timestamp
-        .contains(&split.split_metadata.maturity_timestamp)
+        .contains(&split.split_metadata.maturity_timestamp())
     {
         return false;
     }

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -500,6 +500,13 @@ fn split_query_predicate(split: &&Split, query: &ListSplitsQuery) -> bool {
         return false;
     }
 
+    if !query
+        .maturity_timestamp
+        .contains(&split.split_metadata.maturity_timestamp)
+    {
+        return false;
+    }
+
     if let Some(range) = split.split_metadata.time_range.as_ref() {
         if !query.time_range.overlaps_with(range.clone()) {
             return false;
@@ -558,7 +565,7 @@ mod tests {
                 },
                 split_state: SplitState::Published,
                 update_timestamp: 0i64,
-                publish_timestamp: None,
+                publish_timestamp: Some(10i64),
             },
         ]
     }

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -336,6 +336,9 @@ pub struct ListSplitsQuery {
 
     /// The create timestamp range to filter by.
     pub create_timestamp: FilterRange<i64>,
+
+    /// The maturity timestamp range to filter by.
+    pub maturity_timestamp: FilterRange<i64>,
 }
 
 #[allow(unused_attributes)]
@@ -352,6 +355,7 @@ impl ListSplitsQuery {
             delete_opstamp: Default::default(),
             update_timestamp: Default::default(),
             create_timestamp: Default::default(),
+            maturity_timestamp: Default::default(),
         }
     }
 
@@ -494,6 +498,34 @@ impl ListSplitsQuery {
     /// *greater than* the provided value.
     pub fn with_create_timestamp_gt(mut self, v: i64) -> Self {
         self.create_timestamp.start = Bound::Excluded(v);
+        self
+    }
+
+    /// Set the field's lower bound to match values that are
+    /// *less than or equal to* the provided value.
+    pub fn with_maturity_timestamp_lte(mut self, v: i64) -> Self {
+        self.maturity_timestamp.end = Bound::Included(v);
+        self
+    }
+
+    /// Set the field's lower bound to match values that are
+    /// *less than* the provided value.
+    pub fn with_maturity_timestamp_lt(mut self, v: i64) -> Self {
+        self.maturity_timestamp.end = Bound::Excluded(v);
+        self
+    }
+
+    /// Set the field's upper bound to match values that are
+    /// *greater than or equal to* the provided value.
+    pub fn with_maturity_timestamp_gte(mut self, v: i64) -> Self {
+        self.maturity_timestamp.start = Bound::Included(v);
+        self
+    }
+
+    /// Set the field's upper bound to match values that are
+    /// *greater than* the provided value.
+    pub fn with_maturity_timestamp_gt(mut self, v: i64) -> Self {
+        self.maturity_timestamp.start = Bound::Excluded(v);
         self
     }
 }

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -339,7 +339,7 @@ pub struct ListSplitsQuery {
     /// The create timestamp range to filter by.
     pub create_timestamp: FilterRange<i64>,
 
-    /// Is the split mature or immature.
+    /// Is the split mature or immature at a given datetime.
     pub maturity: Option<SplitMaturityFilter>,
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -315,8 +315,7 @@ fn build_query_filter(mut sql: String, query: &ListSplitsQuery) -> String {
 
 /// Returns the unix timestamp at which the split becomes mature.
 /// If the split is mature (`SplitMaturity::Mature`), we return 0
-/// as we don't want to depend on the current time when we know for sure
-/// that a split is mature.
+/// as we don't want the maturity to depend on datetime.
 fn split_maturity_timestamp(split_metadata: &SplitMetadata) -> i64 {
     match split_metadata.maturity {
         SplitMaturity::Mature => 0,

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -493,16 +493,15 @@ impl Metastore for PostgresqlMetastore {
                 .as_ref()
                 .map(|range| *range.start());
             time_range_start_list.push(time_range_start);
+            maturity_timestamps.push(split_metadata.maturity_timestamp());
 
             let time_range_end = split_metadata.time_range.map(|range| *range.end());
             time_range_end_list.push(time_range_end);
 
             let tags: Vec<String> = split_metadata.tags.into_iter().collect();
             tags_list.push(sqlx::types::Json(tags));
-
             split_ids.push(split_metadata.split_id);
             delete_opstamps.push(split_metadata.delete_opstamp as i64);
-            maturity_timestamps.push(split_metadata.maturity_timestamp);
         }
         tracing::Span::current().record("split_ids", format!("{split_ids:?}"));
 

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
@@ -136,10 +136,8 @@ impl TryInto<QuickwitSplit> for Split {
         let publish_timestamp = self
             .publish_timestamp
             .map(|publish_timestamp| publish_timestamp.assume_utc().unix_timestamp());
-        let maturity_timestamp = self.maturity_timestamp.assume_utc().unix_timestamp();
         split_metadata.index_uid = self.index_uid;
         split_metadata.delete_opstamp = self.delete_opstamp as u64;
-        split_metadata.maturity_timestamp = maturity_timestamp;
         Ok(QuickwitSplit {
             split_metadata,
             split_state,

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
@@ -83,6 +83,9 @@ pub struct Split {
     pub update_timestamp: sqlx::types::time::PrimitiveDateTime,
     /// Timestamp for tracking when the split was published.
     pub publish_timestamp: Option<sqlx::types::time::PrimitiveDateTime>,
+    /// Timestamp for tracking when the split becomes mature.
+    /// If a split is already mature, this timestamp is set to 0.
+    pub maturity_timestamp: sqlx::types::time::PrimitiveDateTime,
     /// A list of tags for categorizing and searching group of splits.
     pub tags: Vec<String>,
     // The split's metadata serialized as a JSON string.
@@ -133,8 +136,10 @@ impl TryInto<QuickwitSplit> for Split {
         let publish_timestamp = self
             .publish_timestamp
             .map(|publish_timestamp| publish_timestamp.assume_utc().unix_timestamp());
+        let maturity_timestamp = self.maturity_timestamp.assume_utc().unix_timestamp();
         split_metadata.index_uid = self.index_uid;
         split_metadata.delete_opstamp = self.delete_opstamp as u64;
+        split_metadata.maturity_timestamp = maturity_timestamp;
         Ok(QuickwitSplit {
             split_metadata,
             split_state,

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -101,6 +101,10 @@ pub struct SplitMetadata {
     /// Timestamp for tracking when the split was created.
     pub create_timestamp: i64,
 
+    /// Timestamp for tracking when the split becomes mature.
+    /// If a split is already mature, this timestamp is set to 0.
+    pub maturity_timestamp: i64,
+
     /// Set of unique tags values of form `{field_name}:{field_value}`.
     /// The set is filled at indexing with values from each field registered
     /// in the [`DocMapping`](quickwit_config::DocMapping) `tag_fields` attribute and only when
@@ -153,6 +157,11 @@ impl SplitMetadata {
         &self.split_id
     }
 
+    /// Returns true if the split is mature at `utc_now_timetamp()`.
+    pub fn is_mature(&self) -> bool {
+        self.maturity_timestamp <= utc_now_timestamp()
+    }
+
     #[cfg(any(test, feature = "testsuite"))]
     /// Returns an instance of `SplitMetadata` for testing.
     pub fn for_test(split_id: String) -> Self {
@@ -186,6 +195,7 @@ impl quickwit_config::TestableForRegression for SplitMetadata {
             uncompressed_docs_size_in_bytes: 234234,
             time_range: Some(121000..=130198),
             create_timestamp: 3,
+            maturity_timestamp: 4,
             tags: ["234".to_string(), "aaa".to_string()].into_iter().collect(),
             footer_offsets: 1000..2000,
             num_merge_ops: 3,

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -168,10 +168,10 @@ impl SplitMetadata {
     }
 
     /// Returns the unix timestamp at which the split becomes mature.
-    /// Not that if the split is mature `SplitMaturity::Mature`, we return 0.
-    /// This is handy only for metastore implementations where we want to filter
-    /// out splits that are not mature yet and/or for persisting the maturity
-    /// timestamp in a database.
+    /// If the split is mature (`SplitMaturity::Mature`), we return 0.
+    /// This is handy only for metastore implementations that need to filter
+    /// on split maturity and/or for persisting the maturity timestamp
+    /// in a database.
     pub(crate) fn maturity_timestamp(&self) -> i64 {
         match self.maturity {
             SplitMaturity::Mature => 0,
@@ -272,10 +272,10 @@ impl FromStr for SplitState {
     }
 }
 
-/// Split maturity is determined by the `MergePolicy`. Once a split is mature,
-/// it does not undergo new merge operations.
+/// A split is mature if it does not undergo new merge operations.
 /// A split is either `Mature` or becomes mature after a given period, aka
 /// `TimeToMaturity`.
+/// The maturity is determined by the `MergePolicy`.
 #[derive(Clone, Copy, Debug, Default, Eq, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum SplitMaturity {

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -276,7 +276,7 @@ impl FromStr for SplitState {
 /// it does not undergo new merge operations.
 /// A split is either `Mature` or becomes mature after a given period, aka
 /// `TimeToMaturity`.
-#[derive(Clone, Copy, Debug, Default, Eq, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[derive(Clone, Copy, Debug, Default, Eq, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum SplitMaturity {
     /// Split is mature.

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -102,7 +102,7 @@ pub struct SplitMetadata {
     /// Timestamp for tracking when the split was created.
     pub create_timestamp: i64,
 
-    /// Split maturity.
+    /// Split maturity either `Mature` or `Immature` with a given maturation period.
     pub maturity: SplitMaturity,
 
     /// Set of unique tags values of form `{field_name}:{field_value}`.
@@ -263,7 +263,7 @@ impl FromStr for SplitState {
     }
 }
 
-/// `SplitMaturity` defines the maturity of a split, is is either `Mature`
+/// `SplitMaturity` defines the maturity of a split, it is either `Mature`
 /// or `Immature` with a given maturation period.
 /// The maturity is determined by the `MergePolicy`.
 #[derive(Clone, Copy, Debug, Default, Eq, Serialize, Deserialize, PartialEq)]

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -167,7 +167,11 @@ impl SplitMetadata {
         }
     }
 
-    /// TODO
+    /// Returns the unix timestamp at which the split becomes mature.
+    /// Not that if the split is mature `SplitMaturity::Mature`, we return 0.
+    /// This is handy only for metastore implementations where we want to filter
+    /// out splits that are not mature yet and/or for persisting the maturity
+    /// timestamp in a database.
     pub(crate) fn maturity_timestamp(&self) -> i64 {
         match self.maturity {
             SplitMaturity::Mature => 0,
@@ -268,7 +272,10 @@ impl FromStr for SplitState {
     }
 }
 
-/// A split maturity.
+/// Split maturity is determined by the `MergePolicy`. Once a split is mature,
+/// it does not undergo new merge operations.
+/// A split is either `Mature` or becomes mature after a given period, aka
+/// `TimeToMaturity`.
 #[derive(Clone, Copy, Debug, Default, Eq, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
 #[serde(untagged)]
 pub enum SplitMaturity {

--- a/quickwit/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata_version.rs
@@ -19,12 +19,11 @@
 
 use std::collections::BTreeSet;
 use std::ops::{Range, RangeInclusive};
-use std::time::Duration;
 
 use quickwit_proto::IndexUid;
 use serde::{Deserialize, Serialize};
 
-use crate::split_metadata::utc_now_timestamp;
+use crate::split_metadata::{utc_now_timestamp, SplitMaturity};
 use crate::SplitMetadata;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
@@ -68,9 +67,9 @@ pub(crate) struct SplitMetadataV0_6 {
     #[serde(default = "utc_now_timestamp")]
     pub create_timestamp: i64,
 
-    /// Timestamp for tracking when the split becomes mature.
+    /// Split maturity.
     #[serde(default)]
-    pub time_to_maturity: Option<Duration>,
+    pub maturity: SplitMaturity,
 
     #[serde(default)]
     #[schema(value_type = Vec<String>)]
@@ -122,7 +121,7 @@ impl From<SplitMetadataV0_6> for SplitMetadata {
             uncompressed_docs_size_in_bytes: v6.uncompressed_docs_size_in_bytes,
             time_range: v6.time_range,
             create_timestamp: v6.create_timestamp,
-            time_to_maturity: v6.time_to_maturity,
+            maturity: v6.maturity,
             tags: v6.tags,
             footer_offsets: v6.footer_offsets,
             num_merge_ops: v6.num_merge_ops,
@@ -143,7 +142,7 @@ impl From<SplitMetadata> for SplitMetadataV0_6 {
             uncompressed_docs_size_in_bytes: split.uncompressed_docs_size_in_bytes,
             time_range: split.time_range,
             create_timestamp: split.create_timestamp,
-            time_to_maturity: split.time_to_maturity,
+            maturity: split.maturity,
             tags: split.tags,
             footer_offsets: split.footer_offsets,
             num_merge_ops: split.num_merge_ops,

--- a/quickwit/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata_version.rs
@@ -67,7 +67,7 @@ pub(crate) struct SplitMetadataV0_6 {
     #[serde(default = "utc_now_timestamp")]
     pub create_timestamp: i64,
 
-    /// Split maturity.
+    /// Split maturity either `Mature` or `Immature` with a given maturation period.
     #[serde(default)]
     #[schema(value_type = Value)]
     pub maturity: SplitMaturity,

--- a/quickwit/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata_version.rs
@@ -69,6 +69,7 @@ pub(crate) struct SplitMetadataV0_6 {
 
     /// Split maturity.
     #[serde(default)]
+    #[schema(value_type = Value)]
     pub maturity: SplitMaturity,
 
     #[serde(default)]

--- a/quickwit/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata_version.rs
@@ -19,6 +19,7 @@
 
 use std::collections::BTreeSet;
 use std::ops::{Range, RangeInclusive};
+use std::time::Duration;
 
 use quickwit_proto::IndexUid;
 use serde::{Deserialize, Serialize};
@@ -69,7 +70,7 @@ pub(crate) struct SplitMetadataV0_6 {
 
     /// Timestamp for tracking when the split becomes mature.
     #[serde(default)]
-    pub maturity_timestamp: i64,
+    pub time_to_maturity: Option<Duration>,
 
     #[serde(default)]
     #[schema(value_type = Vec<String>)]
@@ -121,7 +122,7 @@ impl From<SplitMetadataV0_6> for SplitMetadata {
             uncompressed_docs_size_in_bytes: v6.uncompressed_docs_size_in_bytes,
             time_range: v6.time_range,
             create_timestamp: v6.create_timestamp,
-            maturity_timestamp: v6.maturity_timestamp,
+            time_to_maturity: v6.time_to_maturity,
             tags: v6.tags,
             footer_offsets: v6.footer_offsets,
             num_merge_ops: v6.num_merge_ops,
@@ -142,7 +143,7 @@ impl From<SplitMetadata> for SplitMetadataV0_6 {
             uncompressed_docs_size_in_bytes: split.uncompressed_docs_size_in_bytes,
             time_range: split.time_range,
             create_timestamp: split.create_timestamp,
-            maturity_timestamp: split.maturity_timestamp,
+            time_to_maturity: split.time_to_maturity,
             tags: split.tags,
             footer_offsets: split.footer_offsets,
             num_merge_ops: split.num_merge_ops,

--- a/quickwit/quickwit-metastore/src/split_metadata_version.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata_version.rs
@@ -67,6 +67,10 @@ pub(crate) struct SplitMetadataV0_6 {
     #[serde(default = "utc_now_timestamp")]
     pub create_timestamp: i64,
 
+    /// Timestamp for tracking when the split becomes mature.
+    #[serde(default)]
+    pub maturity_timestamp: i64,
+
     #[serde(default)]
     #[schema(value_type = Vec<String>)]
     /// A set of tags for categorizing and searching group of splits.
@@ -89,10 +93,10 @@ pub(crate) struct SplitMetadataV0_6 {
 }
 
 impl From<SplitMetadataV0_6> for SplitMetadata {
-    fn from(v3: SplitMetadataV0_6) -> Self {
-        let source_id = v3.source_id.unwrap_or_else(|| "unknown".to_string());
+    fn from(v6: SplitMetadataV0_6) -> Self {
+        let source_id = v6.source_id.unwrap_or_else(|| "unknown".to_string());
 
-        let node_id = if let Some(node_id) = v3.node_id {
+        let node_id = if let Some(node_id) = v6.node_id {
             // The previous version encoded `v1.node_id` as `{node_id}/{pipeline_ord}`.
             // Since pipeline_ord is no longer needed, we only extract the `node_id` portion
             // to keep backward compatibility.  This has the advantage of avoiding a
@@ -107,19 +111,20 @@ impl From<SplitMetadataV0_6> for SplitMetadata {
         };
 
         SplitMetadata {
-            split_id: v3.split_id,
-            index_uid: v3.index_uid,
-            partition_id: v3.partition_id,
+            split_id: v6.split_id,
+            index_uid: v6.index_uid,
+            partition_id: v6.partition_id,
             source_id,
             node_id,
-            delete_opstamp: v3.delete_opstamp,
-            num_docs: v3.num_docs,
-            uncompressed_docs_size_in_bytes: v3.uncompressed_docs_size_in_bytes,
-            time_range: v3.time_range,
-            create_timestamp: v3.create_timestamp,
-            tags: v3.tags,
-            footer_offsets: v3.footer_offsets,
-            num_merge_ops: v3.num_merge_ops,
+            delete_opstamp: v6.delete_opstamp,
+            num_docs: v6.num_docs,
+            uncompressed_docs_size_in_bytes: v6.uncompressed_docs_size_in_bytes,
+            time_range: v6.time_range,
+            create_timestamp: v6.create_timestamp,
+            maturity_timestamp: v6.maturity_timestamp,
+            tags: v6.tags,
+            footer_offsets: v6.footer_offsets,
+            num_merge_ops: v6.num_merge_ops,
         }
     }
 }
@@ -137,6 +142,7 @@ impl From<SplitMetadata> for SplitMetadataV0_6 {
             uncompressed_docs_size_in_bytes: split.uncompressed_docs_size_in_bytes,
             time_range: split.time_range,
             create_timestamp: split.create_timestamp,
+            maturity_timestamp: split.maturity_timestamp,
             tags: split.tags,
             footer_offsets: split.footer_offsets,
             num_merge_ops: split.num_merge_ops,

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -1662,8 +1662,8 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(0..=99),
             create_timestamp: current_timestamp,
-            maturity: SplitMaturity::MatureAfterPeriod {
-                period: Duration::from_secs(0),
+            maturity: SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(0),
             },
             tags: to_btree_set(&["tag!", "tag:foo", "tag:bar"]),
             delete_opstamp: 3,
@@ -1676,8 +1676,8 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(100..=199),
             create_timestamp: current_timestamp,
-            maturity: SplitMaturity::MatureAfterPeriod {
-                period: Duration::from_secs(10),
+            maturity: SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(10),
             },
             tags: to_btree_set(&["tag!", "tag:bar"]),
             delete_opstamp: 1,
@@ -1690,8 +1690,8 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(200..=299),
             create_timestamp: current_timestamp,
-            maturity: SplitMaturity::MatureAfterPeriod {
-                period: Duration::from_secs(20),
+            maturity: SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(20),
             },
             tags: to_btree_set(&["tag!", "tag:foo", "tag:baz"]),
             delete_opstamp: 5,

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -1662,7 +1662,9 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(0..=99),
             create_timestamp: current_timestamp,
-            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(0)),
+            maturity: SplitMaturity::MatureAfterPeriod {
+                period: Duration::from_secs(0),
+            },
             tags: to_btree_set(&["tag!", "tag:foo", "tag:bar"]),
             delete_opstamp: 3,
             ..Default::default()
@@ -1674,7 +1676,9 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(100..=199),
             create_timestamp: current_timestamp,
-            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(10)),
+            maturity: SplitMaturity::MatureAfterPeriod {
+                period: Duration::from_secs(10),
+            },
             tags: to_btree_set(&["tag!", "tag:bar"]),
             delete_opstamp: 1,
             ..Default::default()
@@ -1686,7 +1690,9 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(200..=299),
             create_timestamp: current_timestamp,
-            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(20)),
+            maturity: SplitMaturity::MatureAfterPeriod {
+                period: Duration::from_secs(20),
+            },
             tags: to_btree_set(&["tag!", "tag:foo", "tag:baz"]),
             delete_opstamp: 5,
             ..Default::default()

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -1661,6 +1661,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(0..=99),
             create_timestamp: current_timestamp,
+            maturity_timestamp: current_timestamp,
             tags: to_btree_set(&["tag!", "tag:foo", "tag:bar"]),
             delete_opstamp: 3,
             ..Default::default()
@@ -1672,6 +1673,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(100..=199),
             create_timestamp: current_timestamp,
+            maturity_timestamp: current_timestamp + 10,
             tags: to_btree_set(&["tag!", "tag:bar"]),
             delete_opstamp: 1,
             ..Default::default()
@@ -1683,6 +1685,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(200..=299),
             create_timestamp: current_timestamp,
+            maturity_timestamp: current_timestamp + 20,
             tags: to_btree_set(&["tag!", "tag:foo", "tag:baz"]),
             delete_opstamp: 5,
             ..Default::default()
@@ -2068,6 +2071,22 @@ pub mod test_suite {
                 split_ids,
                 &[&split_id_1, &split_id_2, &split_id_3, &split_id_6,]
             );
+
+            // Test maturity_timestamp filter
+            let query = ListSplitsQuery::for_index(index_uid.clone())
+                .with_maturity_timestamp_lte(current_timestamp);
+            let splits = metastore.list_splits(query.clone()).await.unwrap();
+            let split_ids = collect_split_ids(&splits);
+            assert_eq!(
+                split_ids,
+                &[&split_id_1, &split_id_4, &split_id_5, &split_id_6,]
+            );
+
+            let query = ListSplitsQuery::for_index(index_uid.clone())
+                .with_maturity_timestamp_gte(current_timestamp);
+            let splits = metastore.list_splits(query.clone()).await.unwrap();
+            let split_ids = collect_split_ids(&splits);
+            assert_eq!(split_ids, &[&split_id_1, &split_id_2, &split_id_3]);
 
             cleanup_index(&metastore, index_uid).await;
         }

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -39,8 +39,9 @@ pub mod test_suite {
     use crate::checkpoint::{
         IndexCheckpointDelta, PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
     };
-    use crate::split_metadata::SplitMaturity;
-    use crate::{ListSplitsQuery, Metastore, MetastoreError, Split, SplitMetadata, SplitState};
+    use crate::{
+        ListSplitsQuery, Metastore, MetastoreError, Split, SplitMaturity, SplitMetadata, SplitState,
+    };
 
     #[async_trait]
     pub trait DefaultForTest {
@@ -2079,9 +2080,11 @@ pub mod test_suite {
                 &[&split_id_1, &split_id_2, &split_id_3, &split_id_6,]
             );
 
-            // Test maturity_timestamp filter
+            // Test maturity filter
+            let maturity_evaluation_timestamp =
+                OffsetDateTime::from_unix_timestamp(current_timestamp).unwrap();
             let query = ListSplitsQuery::for_index(index_uid.clone())
-                .with_maturity_timestamp_lte(current_timestamp);
+                .is_mature(true, maturity_evaluation_timestamp);
             let splits = metastore.list_splits(query.clone()).await.unwrap();
             let split_ids = collect_split_ids(&splits);
             assert_eq!(
@@ -2090,10 +2093,10 @@ pub mod test_suite {
             );
 
             let query = ListSplitsQuery::for_index(index_uid.clone())
-                .with_maturity_timestamp_gte(current_timestamp);
+                .is_mature(false, maturity_evaluation_timestamp);
             let splits = metastore.list_splits(query.clone()).await.unwrap();
             let split_ids = collect_split_ids(&splits);
-            assert_eq!(split_ids, &[&split_id_1, &split_id_2, &split_id_3]);
+            assert_eq!(split_ids, &[&split_id_2, &split_id_3]);
 
             cleanup_index(&metastore, index_uid).await;
         }
@@ -2418,6 +2421,18 @@ pub mod test_suite {
             delete_opstamp: 20,
             ..Default::default()
         };
+        // immature split
+        let split_id_5 = format!("{index_id}--split-5");
+        let split_metadata_5 = SplitMetadata {
+            split_id: split_id_5.clone(),
+            index_uid: index_uid.clone(),
+            create_timestamp: current_timestamp,
+            maturity: SplitMaturity::Immature {
+                maturation_period: Duration::from_secs(100),
+            },
+            delete_opstamp: 0,
+            ..Default::default()
+        };
 
         let error = metastore
             .list_stale_splits(IndexUid::new("index-not-found"), 0, 10)
@@ -2436,6 +2451,7 @@ pub mod test_suite {
                         split_metadata_1.clone(),
                         split_metadata_2.clone(),
                         split_metadata_3.clone(),
+                        split_metadata_5.clone(),
                     ],
                 )
                 .await
@@ -2455,7 +2471,12 @@ pub mod test_suite {
             // Sleep for 1 second to have different publish timestamps.
             tokio::time::sleep(Duration::from_secs(1)).await;
             metastore
-                .publish_splits(index_uid.clone(), &[&split_id_1, &split_id_2], &[], None)
+                .publish_splits(
+                    index_uid.clone(),
+                    &[&split_id_1, &split_id_2, &split_id_5],
+                    &[],
+                    None,
+                )
                 .await
                 .unwrap();
             let splits = metastore

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -39,6 +39,7 @@ pub mod test_suite {
     use crate::checkpoint::{
         IndexCheckpointDelta, PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
     };
+    use crate::split_metadata::SplitMaturity;
     use crate::{ListSplitsQuery, Metastore, MetastoreError, Split, SplitMetadata, SplitState};
 
     #[async_trait]
@@ -1661,7 +1662,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(0..=99),
             create_timestamp: current_timestamp,
-            time_to_maturity: Some(Duration::from_secs(0)),
+            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(0)),
             tags: to_btree_set(&["tag!", "tag:foo", "tag:bar"]),
             delete_opstamp: 3,
             ..Default::default()
@@ -1673,7 +1674,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(100..=199),
             create_timestamp: current_timestamp,
-            time_to_maturity: Some(Duration::from_secs(10)),
+            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(10)),
             tags: to_btree_set(&["tag!", "tag:bar"]),
             delete_opstamp: 1,
             ..Default::default()
@@ -1685,7 +1686,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(200..=299),
             create_timestamp: current_timestamp,
-            time_to_maturity: Some(Duration::from_secs(20)),
+            maturity: SplitMaturity::TimeToMaturity(Duration::from_secs(20)),
             tags: to_btree_set(&["tag!", "tag:foo", "tag:baz"]),
             delete_opstamp: 5,
             ..Default::default()

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -1661,7 +1661,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(0..=99),
             create_timestamp: current_timestamp,
-            maturity_timestamp: current_timestamp,
+            time_to_maturity: Some(Duration::from_secs(0)),
             tags: to_btree_set(&["tag!", "tag:foo", "tag:bar"]),
             delete_opstamp: 3,
             ..Default::default()
@@ -1673,7 +1673,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(100..=199),
             create_timestamp: current_timestamp,
-            maturity_timestamp: current_timestamp + 10,
+            time_to_maturity: Some(Duration::from_secs(10)),
             tags: to_btree_set(&["tag!", "tag:bar"]),
             delete_opstamp: 1,
             ..Default::default()
@@ -1685,7 +1685,7 @@ pub mod test_suite {
             index_uid: index_uid.clone(),
             time_range: Some(200..=299),
             create_timestamp: current_timestamp,
-            maturity_timestamp: current_timestamp + 20,
+            time_to_maturity: Some(Duration::from_secs(20)),
             tags: to_btree_set(&["tag!", "tag:foo", "tag:baz"]),
             delete_opstamp: 5,
             ..Default::default()

--- a/quickwit/quickwit-metastore/src/tests.rs
+++ b/quickwit/quickwit-metastore/src/tests.rs
@@ -2084,7 +2084,7 @@ pub mod test_suite {
             let maturity_evaluation_timestamp =
                 OffsetDateTime::from_unix_timestamp(current_timestamp).unwrap();
             let query = ListSplitsQuery::for_index(index_uid.clone())
-                .is_mature(true, maturity_evaluation_timestamp);
+                .retain_mature(maturity_evaluation_timestamp);
             let splits = metastore.list_splits(query.clone()).await.unwrap();
             let split_ids = collect_split_ids(&splits);
             assert_eq!(
@@ -2093,7 +2093,7 @@ pub mod test_suite {
             );
 
             let query = ListSplitsQuery::for_index(index_uid.clone())
-                .is_mature(false, maturity_evaluation_timestamp);
+                .retain_immature(maturity_evaluation_timestamp);
             let splits = metastore.list_splits(query.clone()).await.unwrap();
             let split_ids = collect_split_ids(&splits);
             assert_eq!(split_ids, &[&split_id_2, &split_id_3]);

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
@@ -126,6 +126,7 @@
         "start": 1000
       },
       "index_uid": "my-index",
+      "maturity_timestamp": 0,
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
@@ -126,7 +126,9 @@
         "start": 1000
       },
       "index_uid": "my-index",
-      "maturity": "mature",
+      "maturity": {
+        "type": "mature"
+      },
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
@@ -126,7 +126,7 @@
         "start": 1000
       },
       "index_uid": "my-index",
-      "maturity_timestamp": 0,
+      "maturity": "mature",
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
@@ -129,6 +129,7 @@
         "start": 1000
       },
       "index_uid": "my-index",
+      "maturity_timestamp": 0,
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
@@ -129,7 +129,7 @@
         "start": 1000
       },
       "index_uid": "my-index",
-      "maturity_timestamp": 0,
+      "maturity": "mature",
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
@@ -129,7 +129,9 @@
         "start": 1000
       },
       "index_uid": "my-index",
-      "maturity": "mature",
+      "maturity": {
+        "type": "mature"
+      },
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -136,7 +136,10 @@
         "start": 1000
       },
       "index_uid": "my-index:11111111111111111111111111",
-      "maturity": 4,
+      "maturity": {
+        "type": "mature_after_period",
+        "period": 4
+      },
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -137,7 +137,7 @@
       },
       "index_uid": "my-index:11111111111111111111111111",
       "maturity": {
-        "maturation_period_millisecs": 4000,
+        "maturation_period_millis": 4000,
         "type": "immature"
       },
       "node_id": "node",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -136,7 +136,7 @@
         "start": 1000
       },
       "index_uid": "my-index:11111111111111111111111111",
-      "maturity_timestamp": 4,
+      "maturity": 4,
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -136,6 +136,7 @@
         "start": 1000
       },
       "index_uid": "my-index:11111111111111111111111111",
+      "maturity_timestamp": 4,
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -137,8 +137,8 @@
       },
       "index_uid": "my-index:11111111111111111111111111",
       "maturity": {
-        "type": "mature_after_period",
-        "period": 4
+        "maturation_period_millisecs": 4000,
+        "type": "immature"
       },
       "node_id": "node",
       "num_docs": 12303,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -136,7 +136,10 @@
         "start": 1000
       },
       "index_uid": "my-index:11111111111111111111111111",
-      "maturity": 4,
+      "maturity": {
+        "type": "mature_after_period",
+        "period": 4
+      },
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -137,7 +137,7 @@
       },
       "index_uid": "my-index:11111111111111111111111111",
       "maturity": {
-        "maturation_period_millisecs": 4000,
+        "maturation_period_millis": 4000,
         "type": "immature"
       },
       "node_id": "node",

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -136,7 +136,7 @@
         "start": 1000
       },
       "index_uid": "my-index:11111111111111111111111111",
-      "maturity_timestamp": 4,
+      "maturity": 4,
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -136,6 +136,7 @@
         "start": 1000
       },
       "index_uid": "my-index:11111111111111111111111111",
+      "maturity_timestamp": 4,
       "node_id": "node",
       "num_docs": 12303,
       "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -137,8 +137,8 @@
       },
       "index_uid": "my-index:11111111111111111111111111",
       "maturity": {
-        "type": "mature_after_period",
-        "period": 4
+        "maturation_period_millisecs": 4000,
+        "type": "immature"
       },
       "node_id": "node",
       "num_docs": 12303,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.4.expected.json
@@ -6,7 +6,9 @@
     "start": 1000
   },
   "index_uid": "my-index",
-  "maturity": "mature",
+  "maturity": {
+    "type": "mature"
+  },
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.4.expected.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index",
-  "maturity_timestamp": 0,
+  "maturity": "mature",
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.4.expected.json
@@ -6,6 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index",
+  "maturity_timestamp": 0,
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.5.expected.json
@@ -6,7 +6,9 @@
     "start": 1000
   },
   "index_uid": "my-index",
-  "maturity": "mature",
+  "maturity": {
+    "type": "mature"
+  },
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.5.expected.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index",
-  "maturity_timestamp": 0,
+  "maturity": "mature",
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.5.expected.json
@@ -6,6 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index",
+  "maturity_timestamp": 0,
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
@@ -7,7 +7,7 @@
   },
   "index_uid": "my-index:11111111111111111111111111",
   "maturity": {
-    "maturation_period_millisecs": 4000,
+    "maturation_period_millis": 4000,
     "type": "immature"
   },
   "node_id": "node",

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index:11111111111111111111111111",
-  "maturity_timestamp": 4,
+  "maturity": 4,
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
@@ -6,7 +6,10 @@
     "start": 1000
   },
   "index_uid": "my-index:11111111111111111111111111",
-  "maturity": 4,
+  "maturity": {
+    "type": "mature_after_period",
+    "period": 4
+  },
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
@@ -7,8 +7,8 @@
   },
   "index_uid": "my-index:11111111111111111111111111",
   "maturity": {
-    "type": "mature_after_period",
-    "period": 4
+    "maturation_period_millisecs": 4000,
+    "type": "immature"
   },
   "node_id": "node",
   "num_docs": 12303,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.expected.json
@@ -6,6 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index:11111111111111111111111111",
+  "maturity_timestamp": 4,
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
@@ -7,7 +7,7 @@
   },
   "index_uid": "my-index:11111111111111111111111111",
   "maturity": {
-    "maturation_period_millisecs": 4000,
+    "maturation_period_millis": 4000,
     "type": "immature"
   },
   "node_id": "node",

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
@@ -6,7 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index:11111111111111111111111111",
-  "maturity_timestamp": 4,
+  "maturity": 4,
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
@@ -6,7 +6,10 @@
     "start": 1000
   },
   "index_uid": "my-index:11111111111111111111111111",
-  "maturity": 4,
+  "maturity": {
+    "type": "mature_after_period",
+    "period": 4
+  },
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
@@ -7,8 +7,8 @@
   },
   "index_uid": "my-index:11111111111111111111111111",
   "maturity": {
-    "type": "mature_after_period",
-    "period": 4
+    "maturation_period_millisecs": 4000,
+    "type": "immature"
   },
   "node_id": "node",
   "num_docs": 12303,

--- a/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/split-metadata/v0.6.json
@@ -6,6 +6,7 @@
     "start": 1000
   },
   "index_uid": "my-index:11111111111111111111111111",
+  "maturity_timestamp": 4,
   "node_id": "node",
   "num_docs": 12303,
   "num_merge_ops": 3,


### PR DESCRIPTION
Fix #3576 

## MergePolicy update

This PR modifies the `MergePolicy` by replacing `is_mature` method  by `split_maturity`

```rust

trait MergePolicy {
    fn split_maturity(
        &self,
        split_num_docs: usize,
        split_num_merge_ops: usize,
    ) -> SplitMaturity;
}

/// `SplitMaturity` defines the maturity of a split, is is either `Mature`
/// or becomes mature after a given period.
#[derive(Clone, Copy, Debug, Default, Eq, Serialize, Deserialize, PartialEq)]
#[serde(tag = "type")]
#[serde(rename_all = "snake_case")]
pub enum SplitMaturity {
    #[default]
    Mature,
    Immature {
        #[serde(with = "serde_duration_millisecs")]
        maturation_period: Duration,
    },
}


```


## Migration

Splits from the old quickwit version will be considered mature.




