### PR TITLE
Honor credentials and region from S3 storage config if provided

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5191,6 +5191,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
  "aws-smithy-client",
  "aws-smithy-http",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -180,6 +180,7 @@ warp = "0.3"
 wiremock = "0.5"
 
 aws-config = "0.55.0"
+aws-credential-types = { version = "0.55.0", features = ["hardcoded-credentials"] }
 aws-sdk-kinesis = "0.27.0"
 aws-sdk-s3 = "0.27.0"
 aws-smithy-async = "0.55.0"

--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -34,6 +34,7 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 aws-config = { workspace = true }
+aws-credential-types = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 aws-smithy-http = { workspace = true }
 aws-smithy-types = { workspace = true }


### PR DESCRIPTION
### Description
Previously, credentials and region provided in the storage config were ignored.

### How was this PR tested?
- Ran `make test-all`
- [x] I'm going to perform additional manual testing
