### PR TITLE
Remove unnecessary `Sync` bounds in actor framework

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4341,6 +4341,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "sync_wrapper",
  "thiserror",
  "tokio",
  "tracing",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -148,6 +148,7 @@ sqlx = { version = "0.6", features = [
   "time",
 ] }
 syn = "2.0.11"
+sync_wrapper = "0.1.2"
 tabled = { version = "0.8", features = ["color"] }
 tempfile = "3"
 termcolor = "1"

--- a/quickwit/quickwit-actors/Cargo.toml
+++ b/quickwit/quickwit-actors/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sync_wrapper = { workspace = true }
 
 quickwit-common = { workspace = true }
 quickwit-proto = { workspace = true }

--- a/quickwit/quickwit-actors/src/actor.rs
+++ b/quickwit/quickwit-actors/src/actor.rs
@@ -105,9 +105,9 @@ impl From<SendError> for ActorExitStatus {
 /// - update its state;
 /// - emits one or more messages to other actors.
 #[async_trait]
-pub trait Actor: Send + Sync + Sized + 'static {
+pub trait Actor: Send + Sized + 'static {
     /// Piece of state that can be copied for assert in unit test, admin, etc.
-    type ObservableState: Send + Sync + Clone + serde::Serialize + fmt::Debug;
+    type ObservableState: fmt::Debug + serde::Serialize + Send + Sync + Clone;
     /// A name identifying the type of actor.
     ///
     /// Ideally respect the `CamelCase` convention.
@@ -205,7 +205,7 @@ pub trait DeferableReplyHandler<M>: Actor {
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus>
     where
-        M: Send + Sync + 'static;
+        M: Send + 'static;
 }
 
 /// Message handler that requires actor to provide immediate response
@@ -238,7 +238,7 @@ where H: Handler<M>
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus>
     where
-        M: Send + 'static + Send + Sync,
+        M: Send + 'static,
     {
         self.handle(message, ctx).await.map(reply)
     }

--- a/quickwit/quickwit-actors/src/actor_context.rs
+++ b/quickwit/quickwit-actors/src/actor_context.rs
@@ -243,7 +243,7 @@ impl<A: Actor> ActorContext<A> {
     ) -> Result<oneshot::Receiver<DestActor::Reply>, SendError>
     where
         DestActor: DeferableReplyHandler<M>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let _guard = self.protect_zone();
         debug!(from=%self.self_mailbox.actor_instance_id(), send=%mailbox.actor_instance_id(), msg=?msg);
@@ -262,7 +262,7 @@ impl<A: Actor> ActorContext<A> {
     ) -> Result<T, AskError<Infallible>>
     where
         DestActor: DeferableReplyHandler<M, Reply = T>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let _guard = self.protect_zone();
         debug!(from=%self.self_mailbox.actor_instance_id(), send=%mailbox.actor_instance_id(), msg=?msg, "ask");

--- a/quickwit/quickwit-actors/src/envelope.rs
+++ b/quickwit/quickwit-actors/src/envelope.rs
@@ -75,7 +75,7 @@ impl<A: Actor> fmt::Debug for Envelope<A> {
 }
 
 #[async_trait]
-trait EnvelopeT<A: Actor>: Send + Sync {
+trait EnvelopeT<A: Actor>: Send {
     fn debug_msg(&self) -> String;
 
     /// Returns the message as a boxed any.
@@ -95,7 +95,7 @@ trait EnvelopeT<A: Actor>: Send + Sync {
 impl<A, M> EnvelopeT<A> for Option<(oneshot::Sender<A::Reply>, M)>
 where
     A: DeferableReplyHandler<M>,
-    M: 'static + Send + Sync + fmt::Debug,
+    M: fmt::Debug + Send + 'static,
 {
     fn debug_msg(&self) -> String {
         #[allow(clippy::needless_option_take)]
@@ -143,7 +143,7 @@ pub(crate) fn wrap_in_envelope<A, M>(
 ) -> (Envelope<A>, oneshot::Receiver<A::Reply>)
 where
     A: DeferableReplyHandler<M>,
-    M: 'static + Send + Sync + fmt::Debug,
+    M: fmt::Debug + Send + 'static,
 {
     let (response_tx, response_rx) = oneshot::channel();
     let handler_envelope = Some((response_tx, msg));

--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -174,7 +174,7 @@ impl<A: Actor> Mailbox<A> {
     ) -> Result<oneshot::Receiver<A::Reply>, SendError>
     where
         A: DeferableReplyHandler<M>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         self.send_message_with_backpressure_counter(message, None)
             .await
@@ -189,7 +189,7 @@ impl<A: Actor> Mailbox<A> {
     ) -> Result<oneshot::Receiver<A::Reply>, TrySendError<M>>
     where
         A: DeferableReplyHandler<M>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let (envelope, response_rx) = self.wrap_in_envelope(message);
         self.inner
@@ -211,7 +211,7 @@ impl<A: Actor> Mailbox<A> {
     fn wrap_in_envelope<M>(&self, message: M) -> (Envelope<A>, oneshot::Receiver<A::Reply>)
     where
         A: DeferableReplyHandler<M>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let guard = self
             .inner
@@ -233,7 +233,7 @@ impl<A: Actor> Mailbox<A> {
     ) -> Result<oneshot::Receiver<A::Reply>, SendError>
     where
         A: DeferableReplyHandler<M>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let (envelope, response_rx) = self.wrap_in_envelope(message);
         match self.inner.tx.try_send_low_priority(envelope) {
@@ -259,7 +259,7 @@ impl<A: Actor> Mailbox<A> {
     ) -> Result<oneshot::Receiver<A::Reply>, SendError>
     where
         A: DeferableReplyHandler<M>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let (envelope, response_rx) = self.wrap_in_envelope(message);
         self.inner.tx.send_high_priority(envelope)?;
@@ -273,7 +273,7 @@ impl<A: Actor> Mailbox<A> {
     ) -> Result<oneshot::Receiver<A::Reply>, SendError>
     where
         A: DeferableReplyHandler<M>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let (envelope, response_rx) = self.wrap_in_envelope(message);
         match priority {
@@ -292,7 +292,7 @@ impl<A: Actor> Mailbox<A> {
     pub async fn ask<M, T>(&self, message: M) -> Result<T, AskError<Infallible>>
     where
         A: DeferableReplyHandler<M, Reply = T>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         self.ask_with_backpressure_counter(message, None).await
     }
@@ -315,7 +315,7 @@ impl<A: Actor> Mailbox<A> {
     ) -> Result<T, AskError<Infallible>>
     where
         A: DeferableReplyHandler<M, Reply = T>,
-        M: 'static + Send + Sync + fmt::Debug,
+        M: fmt::Debug + Send + 'static,
     {
         let resp = self
             .send_message_with_backpressure_counter(message, backpressure_micros_counter_opt)
@@ -332,7 +332,7 @@ impl<A: Actor> Mailbox<A> {
     pub async fn ask_for_res<M, T, E>(&self, message: M) -> Result<T, AskError<E>>
     where
         A: DeferableReplyHandler<M, Reply = Result<T, E>>,
-        M: fmt::Debug + Send + Sync + 'static,
+        M: fmt::Debug + Send + 'static,
         E: fmt::Debug,
     {
         self.send_message(message)

--- a/quickwit/quickwit-actors/src/supervisor.rs
+++ b/quickwit/quickwit-actors/src/supervisor.rs
@@ -35,7 +35,7 @@ pub struct SupervisorState {
 
 pub struct Supervisor<A: Actor> {
     actor_name: String,
-    actor_factory: Box<dyn Fn() -> A + Sync + Send>,
+    actor_factory: Box<dyn Fn() -> A + Send>,
     inbox: Inbox<A>,
     handle_opt: Option<ActorHandle<A>>,
     state: SupervisorState,
@@ -95,7 +95,7 @@ impl<A: Actor> Actor for Supervisor<A> {
 impl<A: Actor> Supervisor<A> {
     pub(crate) fn new(
         actor_name: String,
-        actor_factory: Box<dyn Fn() -> A + Sync + Send>,
+        actor_factory: Box<dyn Fn() -> A + Send>,
         inbox: Inbox<A>,
         handle: ActorHandle<A>,
     ) -> Self {

--- a/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
@@ -171,7 +171,7 @@ impl Source for IngestApiSource {
     }
 
     async fn suggest_truncate(
-        &self,
+        &mut self,
         checkpoint: SourceCheckpoint,
         ctx: &ActorContext<SourceActor>,
     ) -> anyhow::Result<()> {

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -151,7 +151,7 @@ pub type SourceContext = ActorContext<SourceActor>;
 /// # }
 /// ```
 #[async_trait]
-pub trait Source: Send + Sync + 'static {
+pub trait Source: Send + 'static {
     /// This method will be called before any calls to `emit_batches`.
     async fn initialize(
         &mut self,
@@ -189,7 +189,7 @@ pub trait Source: Send + Sync + 'static {
     /// indexing pipeline, as truncation is just "a suggestion".
     /// The error will however be logged.
     async fn suggest_truncate(
-        &self,
+        &mut self,
         _checkpoint: SourceCheckpoint,
         _ctx: &ActorContext<SourceActor>,
     ) -> anyhow::Result<()> {


### PR DESCRIPTION
### Description
- Actors don't need to be `Sync` because they're behind channels and process messages sequentially
- Messages sent to actors don't need to be `Sync` either.

I used `SyncWrapper` in this PR to make the actor loop future `Sync`.

### How was this PR tested?
- added unit tests
- `make test-all`
