### PR TITLE
Add support for client-side streaming for code-generated gRPC clients

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4477,6 +4477,7 @@ version = "0.6.1"
 dependencies = [
  "async-trait",
  "dyn-clone",
+ "futures",
  "http",
  "hyper",
  "mockall",

--- a/quickwit/quickwit-codegen/example/Cargo.toml
+++ b/quickwit/quickwit-codegen/example/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 async-trait = { workspace = true }
 dyn-clone = { workspace = true }
+futures = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }
 prost = { workspace = true }

--- a/quickwit/quickwit-codegen/example/src/hello.proto
+++ b/quickwit/quickwit-codegen/example/src/hello.proto
@@ -48,5 +48,5 @@ message PingResponse {
 service Hello {
     rpc Hello(HelloRequest) returns (HelloResponse);
     rpc Goodbye(GoodbyeRequest) returns (GoodbyeResponse);
-    rpc Ping(PingRequest) returns (stream PingResponse);
+    rpc Ping(stream PingRequest) returns (stream PingResponse);
 }

--- a/quickwit/quickwit-control-plane/src/codegen/control_plane_service.rs
+++ b/quickwit/quickwit-control-plane/src/codegen/control_plane_service.rs
@@ -7,6 +7,7 @@ pub struct NotifyIndexChangeRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NotifyIndexChangeResponse {}
 /// BEGIN quickwit-codegen
+use tower::{Layer, Service, ServiceExt};
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]
 pub trait ControlPlaneService: std::fmt::Debug + dyn_clone::DynClone + Send + Sync + 'static {
@@ -281,13 +282,12 @@ impl<A: quickwit_actors::Actor> Clone for ControlPlaneServiceMailbox<A> {
         Self { inner }
     }
 }
-use tower::{Layer, Service, ServiceExt};
 impl<A, M, T, E> tower::Service<M> for ControlPlaneServiceMailbox<A>
 where
     A: quickwit_actors::Actor
         + quickwit_actors::DeferableReplyHandler<M, Reply = Result<T, E>> + Send
         + 'static,
-    M: std::fmt::Debug + Send + Sync + 'static,
+    M: std::fmt::Debug + Send + 'static,
     T: Send + 'static,
     E: std::fmt::Debug + Send + 'static,
     crate::ControlPlaneError: From<quickwit_actors::AskError<E>>,
@@ -315,7 +315,7 @@ where
 #[async_trait::async_trait]
 impl<A> ControlPlaneService for ControlPlaneServiceMailbox<A>
 where
-    A: quickwit_actors::Actor + std::fmt::Debug + Send + Sync + 'static,
+    A: quickwit_actors::Actor + std::fmt::Debug,
     ControlPlaneServiceMailbox<
         A,
     >: tower::Service<

--- a/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
+++ b/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
@@ -115,6 +115,7 @@ pub struct ListQueuesResponse {
     pub queues: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// BEGIN quickwit-codegen
+use tower::{Layer, Service, ServiceExt};
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]
 pub trait IngestService: std::fmt::Debug + dyn_clone::DynClone + Send + Sync + 'static {
@@ -508,13 +509,12 @@ impl<A: quickwit_actors::Actor> Clone for IngestServiceMailbox<A> {
         Self { inner }
     }
 }
-use tower::{Layer, Service, ServiceExt};
 impl<A, M, T, E> tower::Service<M> for IngestServiceMailbox<A>
 where
     A: quickwit_actors::Actor
         + quickwit_actors::DeferableReplyHandler<M, Reply = Result<T, E>> + Send
         + 'static,
-    M: std::fmt::Debug + Send + Sync + 'static,
+    M: std::fmt::Debug + Send + 'static,
     T: Send + 'static,
     E: std::fmt::Debug + Send + 'static,
     crate::IngestServiceError: From<quickwit_actors::AskError<E>>,
@@ -542,7 +542,7 @@ where
 #[async_trait::async_trait]
 impl<A> IngestService for IngestServiceMailbox<A>
 where
-    A: quickwit_actors::Actor + std::fmt::Debug + Send + Sync + 'static,
+    A: quickwit_actors::Actor + std::fmt::Debug,
     IngestServiceMailbox<
         A,
     >: tower::Service<


### PR DESCRIPTION
### Description
I want to support replications from primary shards to replica shards with streams rather than multiple requests/responses because the ordering of messages guaranteed by gRPC streams makes error handling much easier.

### How was this PR tested?
- Add unit tests