### PR TITLE
Add Digital Ocean storage flavor

### DIFF
--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -75,7 +75,7 @@ storage:
 
 | Property | Description | Default value |
 | --- | --- | --- |
-| `flavor` |  The optional storage flavor to use. Available flavors are `garage`, `gcs`, and `minio`. | |
+| `flavor` |  The optional storage flavor to use. Available flavors are `digital_ocean`, `garage`, `gcs`, and `minio`. | |
 | `access_key_id` | The AWS access key ID. | |
 | `secret_access_key` | The AWS secret access key. | |
 | `region` | The AWS region to send requests to. | `us-east-1` (SDK default) |
@@ -91,9 +91,14 @@ Hardcoding credentials into configuration files is not secure and strongly disco
 **Storage flavors**
 
 Storage flavors ensure that Quickwit works correctly with storage providers that deviate from the S3 API by automatically configuring the appropriate settings. The available flavors are:
+- `digital_ocean`
 - `garage`
 - `gcs`
 - `minio`
+
+*Digital Ocean*
+
+The Digital Ocean flavor (`digital_ocean`) forces path-style access and turns off multi-object delete requests.
 
 *Garage flavor*
 

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -70,7 +70,7 @@ pub use crate::quickwit_config::{
 use crate::source_config::serialize::{SourceConfigV0_6, VersionedSourceConfig};
 pub use crate::storage_config::{
     AzureStorageConfig, FileStorageConfig, RamStorageConfig, S3StorageConfig, StorageBackend,
-    StorageConfig, StorageConfigs,
+    StorageBackendFlavor, StorageConfig, StorageConfigs,
 };
 
 #[derive(utoipa::OpenApi)]


### PR DESCRIPTION
### Description
- Add Digital Ocean storage flavor
- Fix MinIO flavor

### How was this PR tested?
- Added unit tests
- Run the following integrating test on Digital Ocean:

```rust
fn test_suite_on_s3_storage_path_style_access() {
    let s3_storage_config = S3StorageConfig {
        force_path_style_access: true,
        disable_multi_object_delete: true,
        ..Default::default()
    };
    let bucket_uri = append_random_suffix("s3://quickwit-integration-tests/test-path-style-access");
    let test_runtime = test_runtime_singleton();
    test_runtime.block_on(run_s3_storage_test_suite(s3_storage_config, &bucket_uri));
}
```

```bash
AWS_PROFILE=do \
AWS_REGION=nyc3 \
QW_S3_ENDPOINT=https://quickwit-integration-tests.nyc3.digitaloceanspaces.com \
cargo test --manifest-path quickwit/Cargo.toml -p quickwit-storage --all-features -- test_suite_on_s3_storage_path_style_access
```
