### PR TITLE
Fix otel log mapping.

### DIFF
--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -73,6 +73,7 @@ doc_mapping:
       fast: true
     - name: body
       type: json
+      tokenizer: default
     - name: attributes
       type: json
       tokenizer: raw


### PR DESCRIPTION
Motivation: the log message in put in `body.message` and we should tokenize it with the default tokenizer.

