### PR TITLE
Rename `QuickwitConfig` to `NodeConfig`

### DIFF
--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -30,7 +30,7 @@ use quickwit_common::runtimes::RuntimesConfig;
 use quickwit_common::uri::Uri;
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{
-    ConfigFormat, MetastoreConfigs, QuickwitConfig, SourceConfig, StorageConfigs,
+    ConfigFormat, MetastoreConfigs, NodeConfig, SourceConfig, StorageConfigs,
     DEFAULT_QW_CONFIG_PATH,
 };
 use quickwit_indexing::check_source_connectivity;
@@ -223,12 +223,12 @@ pub fn start_actor_runtimes(
 }
 
 /// Loads a node config located at `config_uri` with the default storage configuration.
-async fn load_node_config(config_uri: &Uri) -> anyhow::Result<QuickwitConfig> {
+async fn load_node_config(config_uri: &Uri) -> anyhow::Result<NodeConfig> {
     let config_content = load_file(&StorageResolver::unconfigured(), config_uri)
         .await
         .context("Failed to load node config.")?;
     let config_format = ConfigFormat::sniff_from_uri(config_uri)?;
-    let config = QuickwitConfig::load(config_format, config_content.as_slice())
+    let config = NodeConfig::load(config_format, config_content.as_slice())
         .await
         .with_context(|| format!("Failed to parse node config `{config_uri}`."))?;
     info!(config_uri=%config_uri, config=?config, "Loaded node config.");

--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use quickwit_common::runtimes::RuntimesConfig;
 use quickwit_common::uri::Uri;
 use quickwit_config::service::QuickwitService;
-use quickwit_config::QuickwitConfig;
+use quickwit_config::NodeConfig;
 use quickwit_serve::serve_quickwit;
 use quickwit_telemetry::payload::{QuickwitFeature, QuickwitTelemetryInfo, TelemetryEvent};
 use tokio::signal;
@@ -116,7 +116,7 @@ impl RunCliCommand {
     }
 }
 
-fn quickwit_telemetry_info(config: &QuickwitConfig) -> QuickwitTelemetryInfo {
+fn quickwit_telemetry_info(config: &NodeConfig) -> QuickwitTelemetryInfo {
     let mut features = HashSet::new();
     if config.indexer_config.enable_otlp_endpoint {
         features.insert(QuickwitFeature::Otlp);

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -37,7 +37,7 @@ use quickwit_common::runtimes::RuntimesConfig;
 use quickwit_common::uri::Uri;
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{
-    IndexerConfig, QuickwitConfig, SourceConfig, SourceInputFormat, SourceParams, TransformConfig,
+    IndexerConfig, NodeConfig, SourceConfig, SourceInputFormat, SourceParams, TransformConfig,
     VecSourceParams, CLI_INGEST_SOURCE_ID,
 };
 use quickwit_core::{clear_cache_directory, IndexService};
@@ -775,7 +775,7 @@ impl ThroughputCalculator {
     }
 }
 
-async fn create_empty_cluster(config: &QuickwitConfig) -> anyhow::Result<Cluster> {
+async fn create_empty_cluster(config: &NodeConfig) -> anyhow::Result<Cluster> {
     let self_node = ClusterMember::new(
         config.node_id.clone(),
         quickwit_cluster::GenerationId::now(),

--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -209,11 +209,11 @@ pub async fn create_test_env(
             .replace("#index_id", &index_id)
             .replace("index_uri: #index_uri\n", ""),
     )?;
-    let quickwit_config_path = resources_dir_path.join("config.yaml");
+    let node_config_path = resources_dir_path.join("config.yaml");
     let rest_listen_port = find_available_tcp_port()?;
     let grpc_listen_port = find_available_tcp_port()?;
     fs::write(
-        &quickwit_config_path,
+        &node_config_path,
         // A poor's man templating engine reloaded...
         DEFAULT_QUICKWIT_CONFIG
             .replace("#metastore_uri", metastore_uri.as_str())
@@ -227,7 +227,7 @@ pub async fn create_test_env(
     fs::write(&wikipedia_docs_path, WIKI_JSON_DOCS)?;
 
     let mut resource_files = HashMap::new();
-    resource_files.insert("config", quickwit_config_path);
+    resource_files.insert("config", node_config_path);
     resource_files.insert("index_config", index_config_path);
     resource_files.insert("index_config_without_uri", index_config_without_uri_path);
     resource_files.insert("logs", log_docs_path);

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -31,7 +31,7 @@ pub use chitchat::transport::ChannelTransport;
 use chitchat::transport::UdpTransport;
 use chitchat::FailureDetectorConfig;
 use quickwit_config::service::QuickwitService;
-use quickwit_config::QuickwitConfig as NodeConfig;
+use quickwit_config::NodeConfig;
 use time::OffsetDateTime;
 
 pub use crate::change::ClusterChange;

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -32,7 +32,7 @@ mod config_value;
 mod index_config;
 pub mod merge_policy_config;
 mod metastore_config;
-mod quickwit_config;
+mod node_config;
 mod qw_env_vars;
 pub mod service;
 mod source_config;
@@ -63,8 +63,8 @@ use crate::merge_policy_config::{
 pub use crate::metastore_config::{
     MetastoreBackend, MetastoreConfig, MetastoreConfigs, PostgresMetastoreConfig,
 };
-pub use crate::quickwit_config::{
-    IndexerConfig, IngestApiConfig, JaegerConfig, QuickwitConfig, SearcherConfig,
+pub use crate::node_config::{
+    IndexerConfig, IngestApiConfig, JaegerConfig, NodeConfig, SearcherConfig,
     DEFAULT_QW_CONFIG_PATH,
 };
 use crate::source_config::serialize::{SourceConfigV0_6, VersionedSourceConfig};

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -33,7 +33,7 @@ use quickwit_common::uri::Uri;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use crate::quickwit_config::serialize::load_quickwit_config_with_env;
+use crate::node_config::serialize::load_node_config_with_env;
 use crate::service::QuickwitService;
 use crate::storage_config::StorageConfigs;
 use crate::{ConfigFormat, MetastoreConfigs};
@@ -222,7 +222,7 @@ impl Default for JaegerConfig {
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub struct QuickwitConfig {
+pub struct NodeConfig {
     pub cluster_id: String,
     pub node_id: String,
     pub enabled_services: HashSet<QuickwitService>,
@@ -244,12 +244,11 @@ pub struct QuickwitConfig {
     pub jaeger_config: JaegerConfig,
 }
 
-impl QuickwitConfig {
-    /// Parses and validates a [`QuickwitConfig`] from a given URI and config content.
+impl NodeConfig {
+    /// Parses and validates a [`NodeConfig`] from a given URI and config content.
     pub async fn load(config_format: ConfigFormat, config_content: &[u8]) -> anyhow::Result<Self> {
         let env_vars = env::vars().collect::<HashMap<_, _>>();
-        let config =
-            load_quickwit_config_with_env(config_format, config_content, &env_vars).await?;
+        let config = load_node_config_with_env(config_format, config_content, &env_vars).await?;
         if !config.data_dir_path.try_exists()? {
             bail!(
                 "Data dir `{}` does not exist.",
@@ -294,6 +293,6 @@ impl QuickwitConfig {
 
     #[cfg(any(test, feature = "testsuite"))]
     pub fn for_test() -> Self {
-        serialize::quickwit_config_for_test()
+        serialize::node_config_for_test()
     }
 }

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use quickwit_actors::{Mailbox, Universe};
 use quickwit_cluster::Cluster;
-use quickwit_config::QuickwitConfig;
+use quickwit_config::NodeConfig;
 use quickwit_ingest::IngestApiService;
 use quickwit_metastore::Metastore;
 use quickwit_storage::StorageResolver;
@@ -66,7 +66,7 @@ pub fn new_split_id() -> String {
 
 pub async fn start_indexing_service(
     universe: &Universe,
-    config: &QuickwitConfig,
+    config: &NodeConfig,
     num_blocking_threads: usize,
     cluster: Cluster,
     metastore: Arc<dyn Metastore>,

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -32,7 +32,7 @@ use quickwit_common::test_utils::{wait_for_server_ready, wait_until_predicate};
 use quickwit_common::tower::BoxFutureInfaillible;
 use quickwit_common::uri::Uri as QuickwitUri;
 use quickwit_config::service::QuickwitService;
-use quickwit_config::QuickwitConfig;
+use quickwit_config::NodeConfig;
 use quickwit_metastore::{MetastoreResolver, SplitState};
 use quickwit_rest_client::models::IngestSource;
 use quickwit_rest_client::rest_client::{
@@ -46,11 +46,11 @@ use tokio::sync::watch::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
 use tracing::debug;
 
-/// Configuration of a node made of a [`QuickwitConfig`] and a
+/// Configuration of a node made of a [`NodeConfig`] and a
 /// set of services.
 #[derive(Clone)]
-pub struct NodeConfig {
-    pub quickwit_config: QuickwitConfig,
+pub struct TestNodeConfig {
+    pub node_config: NodeConfig,
     pub services: HashSet<QuickwitService>,
 }
 
@@ -86,7 +86,7 @@ impl ClusterShutdownTrigger {
 /// will share the same `INGEST_API_SERVICE_INSTANCE`. The ingest API will be
 /// dropped by the first running test and the other tests will fail.
 pub struct ClusterSandbox {
-    pub node_configs: Vec<NodeConfig>,
+    pub node_configs: Vec<TestNodeConfig>,
     pub searcher_rest_client: QuickwitClient,
     pub indexer_rest_client: QuickwitClient,
     _temp_dir: TempDir,
@@ -154,7 +154,7 @@ impl ClusterSandbox {
         let shutdown_signal = shutdown_trigger.shutdown_signal();
         let join_handles = vec![tokio::spawn(async move {
             let result = serve_quickwit(
-                node_config_clone.quickwit_config,
+                node_config_clone.node_config,
                 runtimes_config,
                 storage_resolver,
                 metastore_resolver,
@@ -163,15 +163,15 @@ impl ClusterSandbox {
             .await?;
             Result::<_, anyhow::Error>::Ok(result)
         })];
-        wait_for_server_ready(node_config.quickwit_config.grpc_listen_addr).await?;
+        wait_for_server_ready(node_config.node_config.grpc_listen_addr).await?;
         Ok(Self {
             node_configs,
             indexer_rest_client: QuickwitClientBuilder::new(transport_url(
-                node_config.quickwit_config.rest_listen_addr,
+                node_config.node_config.rest_listen_addr,
             ))
             .build(),
             searcher_rest_client: QuickwitClientBuilder::new(transport_url(
-                node_config.quickwit_config.rest_listen_addr,
+                node_config.node_config.rest_listen_addr,
             ))
             .build(),
             _temp_dir: temp_dir,
@@ -193,7 +193,7 @@ impl ClusterSandbox {
         let shutdown_trigger = ClusterShutdownTrigger::new();
         for node_config in node_configs.iter() {
             join_handles.push(tokio::spawn({
-                let node_config = node_config.quickwit_config.clone();
+                let node_config = node_config.node_config.clone();
                 let storage_resolver = storage_resolver.clone();
                 let metastore_resolver = metastore_resolver.clone();
                 let shutdown_signal = shutdown_trigger.shutdown_signal();
@@ -226,11 +226,11 @@ impl ClusterSandbox {
         Ok(Self {
             node_configs,
             searcher_rest_client: QuickwitClientBuilder::new(transport_url(
-                searcher_config.quickwit_config.rest_listen_addr,
+                searcher_config.node_config.rest_listen_addr,
             ))
             .build(),
             indexer_rest_client: QuickwitClientBuilder::new(transport_url(
-                indexer_config.quickwit_config.rest_listen_addr,
+                indexer_config.node_config.rest_listen_addr,
             ))
             .build(),
             _temp_dir: temp_dir,
@@ -366,7 +366,7 @@ impl ClusterSandbox {
 
 /// Builds a list of [`NodeConfig`] given a list of Quickwit services.
 /// Each element of `nodes_services` defines the services of a given node.
-/// For each node, a `QuickwitConfig` is built with the right parameters
+/// For each node, a `NodeConfig` is built with the right parameters
 /// such that we will be able to run `quickwit_serve` on them and form
 /// a quickwit cluster.
 /// For each node, we set:
@@ -377,13 +377,13 @@ impl ClusterSandbox {
 pub fn build_node_configs(
     root_data_dir: PathBuf,
     nodes_services: &[HashSet<QuickwitService>],
-) -> Vec<NodeConfig> {
+) -> Vec<TestNodeConfig> {
     let cluster_id = new_coolid("test-cluster");
     let mut node_configs = Vec::new();
     let mut peers: Vec<String> = Vec::new();
     let unique_dir_name = new_coolid("test-dir");
     for (node_idx, node_services) in nodes_services.iter().enumerate() {
-        let mut config = QuickwitConfig::for_test();
+        let mut config = NodeConfig::for_test();
         config.enabled_services = node_services.clone();
         config.cluster_id = cluster_id.clone();
         config.node_id = format!("test-node-{node_idx}");
@@ -393,22 +393,16 @@ pub fn build_node_configs(
         config.default_index_root_uri =
             QuickwitUri::from_str(&format!("ram:///{unique_dir_name}/indexes")).unwrap();
         peers.push(config.gossip_advertise_addr.to_string());
-        node_configs.push(NodeConfig {
-            quickwit_config: config,
+        node_configs.push(TestNodeConfig {
+            node_config: config,
             services: node_services.clone(),
         });
     }
     for node_config in node_configs.iter_mut() {
-        node_config.quickwit_config.peer_seeds = peers
+        node_config.node_config.peer_seeds = peers
             .clone()
             .into_iter()
-            .filter(|seed| {
-                *seed
-                    != node_config
-                        .quickwit_config
-                        .gossip_advertise_addr
-                        .to_string()
-            })
+            .filter(|seed| *seed != node_config.node_config.gossip_advertise_addr.to_string())
             .collect_vec();
     }
     node_configs

--- a/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
@@ -54,7 +54,7 @@ async fn test_ui_redirect_on_get() {
         .pool_idle_timeout(Duration::from_secs(30))
         .http2_only(true)
         .build_http();
-    let root_uri = format!("http://{}/", node_config.quickwit_config.rest_listen_addr)
+    let root_uri = format!("http://{}/", node_config.node_config.rest_listen_addr)
         .parse::<hyper::Uri>()
         .unwrap();
     let response = client.get(root_uri.clone()).await.unwrap();

--- a/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
@@ -179,7 +179,7 @@ async fn test_restarting_standalone_server() {
         .node_configs
         .first()
         .unwrap()
-        .quickwit_config
+        .node_config
         .data_dir_path
         .clone();
     let delete_service_path = path.join(DELETE_SERVICE_TASK_DIR_NAME);

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use quickwit_actors::{Mailbox, Universe};
 use quickwit_common::FileEntry;
-use quickwit_config::QuickwitConfig;
+use quickwit_config::NodeConfig;
 use quickwit_metastore::Metastore;
 use quickwit_search::SearchJobPlacer;
 use quickwit_storage::StorageResolver;
@@ -50,7 +50,7 @@ pub struct JanitorApiSchemas;
 
 pub async fn start_janitor_service(
     universe: &Universe,
-    config: &QuickwitConfig,
+    config: &NodeConfig,
     metastore: Arc<dyn Metastore>,
     search_job_placer: SearchJobPlacer,
     storage_resolver: StorageResolver,

--- a/quickwit/quickwit-serve/src/elastic_search_api/bulk.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/bulk.rs
@@ -131,7 +131,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use quickwit_config::{IngestApiConfig, QuickwitConfig};
+    use quickwit_config::{IngestApiConfig, NodeConfig};
     use quickwit_ingest::{
         FetchRequest, IngestResponse, IngestServiceClient, SuggestTruncateRequest,
     };
@@ -142,7 +142,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_api_returns_404_if_index_id_does_not_exist() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let search_service = Arc::new(MockSearchService::new());
         let (universe, _temp_dir, ingest_service, _) =
             setup_ingest_service(&["my-index"], &IngestApiConfig::default()).await;
@@ -164,7 +164,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_api_returns_200() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let search_service = Arc::new(MockSearchService::new());
         let (universe, _temp_dir, ingest_service, _) =
             setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
@@ -190,7 +190,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_index_api_returns_200() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let search_service = Arc::new(MockSearchService::new());
         let (universe, _temp_dir, ingest_service, _) =
             setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
@@ -216,7 +216,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_api_blocks_when_refresh_wait_for_is_specified() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let search_service = Arc::new(MockSearchService::new());
         let (universe, _temp_dir, ingest_service, ingest_service_mailbox) =
             setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
@@ -293,7 +293,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_api_blocks_when_refresh_true_is_specified() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let search_service = Arc::new(MockSearchService::new());
         let (universe, _temp_dir, ingest_service, ingest_service_mailbox) =
             setup_ingest_service(&["my-index-1", "my-index-2"], &IngestApiConfig::default()).await;
@@ -369,7 +369,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_ingest_request_returns_400_if_action_is_malformed() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let search_service = Arc::new(MockSearchService::new());
         let ingest_service = IngestServiceClient::new(IngestServiceClient::mock());
         let elastic_api_handlers = elastic_api_handlers(config, search_service, ingest_service);

--- a/quickwit/quickwit-serve/src/elastic_search_api/mod.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/mod.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use bulk::{es_compat_bulk_handler, es_compat_index_bulk_handler};
 pub use filter::ElasticCompatibleApi;
-use quickwit_config::QuickwitConfig;
+use quickwit_config::NodeConfig;
 use quickwit_ingest::IngestServiceClient;
 use quickwit_search::SearchService;
 use rest_handler::{
@@ -43,11 +43,11 @@ use crate::BuildInfo;
 /// This is where all newly supported Elasticsearch handlers
 /// should be registered.
 pub fn elastic_api_handlers(
-    quickwit_config: Arc<QuickwitConfig>,
+    node_config: Arc<NodeConfig>,
     search_service: Arc<dyn SearchService>,
     ingest_service: IngestServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    es_compat_cluster_info_handler(quickwit_config, BuildInfo::get())
+    es_compat_cluster_info_handler(node_config, BuildInfo::get())
         .or(es_compat_search_handler(search_service.clone()))
         .or(es_compat_index_search_handler(search_service.clone()))
         .or(es_compat_index_multi_search_handler(search_service))
@@ -91,7 +91,7 @@ mod tests {
 
     use assert_json_diff::assert_json_include;
     use mockall::predicate;
-    use quickwit_config::QuickwitConfig;
+    use quickwit_config::NodeConfig;
     use quickwit_ingest::{IngestApiService, IngestServiceClient};
     use quickwit_search::MockSearchService;
     use serde_json::Value as JsonValue;
@@ -111,7 +111,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_msearch_api_return_200_responses() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let mut mock_search_service = MockSearchService::new();
         mock_search_service
             .expect_root_search()
@@ -156,7 +156,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_msearch_api_return_one_500_and_one_200_responses() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let mut mock_search_service = MockSearchService::new();
         mock_search_service
             .expect_root_search()
@@ -202,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_msearch_api_return_400_with_malformed_request_header() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let mock_search_service = MockSearchService::new();
         let es_search_api_handler = super::elastic_api_handlers(
             config,
@@ -230,7 +230,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_msearch_api_return_400_with_malformed_request_body() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let mock_search_service = MockSearchService::new();
         let es_search_api_handler = super::elastic_api_handlers(
             config,
@@ -258,7 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_msearch_api_return_400_with_only_a_header_request() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let mock_search_service = MockSearchService::new();
         let es_search_api_handler = super::elastic_api_handlers(
             config,
@@ -285,7 +285,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_msearch_api_return_400_with_no_index() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let mock_search_service = MockSearchService::new();
         let es_search_api_handler = super::elastic_api_handlers(
             config,
@@ -311,7 +311,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_msearch_api_return_400_with_multiple_indexes() {
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let mock_search_service = MockSearchService::new();
         let es_search_api_handler = super::elastic_api_handlers(
             config,
@@ -340,7 +340,7 @@ mod tests {
     #[tokio::test]
     async fn test_es_compat_cluster_info_handler() {
         let build_info = BuildInfo::get();
-        let config = Arc::new(QuickwitConfig::for_test());
+        let config = Arc::new(NodeConfig::for_test());
         let handler =
             es_compat_cluster_info_handler(config.clone(), build_info).recover(recover_fn);
         let resp = warp::test::request()

--- a/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
@@ -29,7 +29,7 @@ use futures_util::StreamExt;
 use hyper::StatusCode;
 use itertools::Itertools;
 use quickwit_common::truncate_str;
-use quickwit_config::QuickwitConfig;
+use quickwit_config::NodeConfig;
 use quickwit_proto::{SearchResponse, ServiceErrorCode};
 use quickwit_query::query_ast::{QueryAst, UserInputQuery};
 use quickwit_query::BooleanOperand;
@@ -51,14 +51,14 @@ use crate::{with_arg, BuildInfo};
 
 /// Elastic compatible cluster info handler.
 pub fn es_compat_cluster_info_handler(
-    quickwit_config: Arc<QuickwitConfig>,
+    node_config: Arc<NodeConfig>,
     build_info: &'static BuildInfo,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     elastic_cluster_info_filter()
-        .and(with_arg(quickwit_config))
+        .and(with_arg(node_config))
         .and(with_arg(build_info))
         .then(
-            |config: Arc<QuickwitConfig>, build_info: &'static BuildInfo| async move {
+            |config: Arc<NodeConfig>, build_info: &'static BuildInfo| async move {
                 warp::reply::json(&json!({
                     "name" : config.node_id,
                     "cluster_name" : config.cluster_id,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -61,7 +61,7 @@ use quickwit_common::tower::{
     Rate, RateLimitLayer, SmaRateEstimator,
 };
 use quickwit_config::service::QuickwitService;
-use quickwit_config::{QuickwitConfig, SearcherConfig};
+use quickwit_config::{NodeConfig, SearcherConfig};
 use quickwit_control_plane::control_plane::ControlPlane;
 use quickwit_control_plane::scheduler::IndexingScheduler;
 use quickwit_control_plane::{
@@ -105,7 +105,7 @@ const READINESS_REPORTING_INTERVAL: Duration = if cfg!(any(test, feature = "test
 };
 
 struct QuickwitServices {
-    pub config: Arc<QuickwitConfig>,
+    pub config: Arc<NodeConfig>,
     pub cluster: Cluster,
     pub metastore: Arc<dyn Metastore>,
     pub control_plane_service: Option<ControlPlaneServiceClient>,
@@ -152,7 +152,7 @@ async fn balance_channel_for_service(
 }
 
 pub async fn serve_quickwit(
-    config: QuickwitConfig,
+    config: NodeConfig,
     runtimes_config: RuntimesConfig,
     storage_resolver: StorageResolver,
     metastore_resolver: MetastoreResolver,

--- a/quickwit/quickwit-serve/src/node_info_handler.rs
+++ b/quickwit/quickwit-serve/src/node_info_handler.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 
-use quickwit_config::QuickwitConfig;
+use quickwit_config::NodeConfig;
 use serde_json::json;
 use warp::{Filter, Rejection};
 
@@ -32,7 +32,7 @@ pub struct NodeInfoApi;
 pub fn node_info_handler(
     build_info: &'static BuildInfo,
     runtime_info: &'static RuntimeInfo,
-    config: Arc<QuickwitConfig>,
+    config: Arc<NodeConfig>,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     node_version_handler(build_info, runtime_info).or(node_config_handler(config))
 }
@@ -61,7 +61,7 @@ async fn get_version(
 
 #[utoipa::path(get, tag = "Node Info", path = "/config")]
 fn node_config_handler(
-    config: Arc<QuickwitConfig>,
+    config: Arc<NodeConfig>,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     warp::path("config")
         .and(warp::path::end())
@@ -69,7 +69,7 @@ fn node_config_handler(
         .then(get_config)
 }
 
-async fn get_config(config: Arc<QuickwitConfig>) -> impl warp::Reply {
+async fn get_config(config: Arc<NodeConfig>) -> impl warp::Reply {
     // We must redact sensitive information such as credentials.
     let mut config = (*config).clone();
     config.redact();
@@ -89,7 +89,7 @@ mod tests {
     async fn test_rest_node_info() {
         let build_info = BuildInfo::get();
         let runtime_info = RuntimeInfo::get();
-        let mut config = QuickwitConfig::for_test();
+        let mut config = NodeConfig::for_test();
         config.metastore_uri = Uri::for_test("postgresql://username:password@db");
         let handler = node_info_handler(build_info, runtime_info, Arc::new(config.clone()))
             .recover(recover_fn);


### PR DESCRIPTION
### Description
Rename the legacy `QuickwitConfig` to `NodeConfig`.

### How was this PR tested?
Ran `make test-all`