### PR TITLE
[fix] Quickwit panics while attempting to parse index_uri

### DIFF
--- a/quickwit/quickwit-common/src/uri.rs
+++ b/quickwit/quickwit-common/src/uri.rs
@@ -486,6 +486,12 @@ mod tests {
             Uri::from_str("azure://account/container/homer/docs/../dognuts").unwrap(),
             "azure://account/container/homer/docs/../dognuts"
         );
+
+        assert_eq!(
+            Uri::from_str("http://localhost:9000/quickwit").unwrap_err().to_string(),
+            "Unknown URI protocol `http`."
+        );
+
     }
 
     #[test]

--- a/quickwit/quickwit-common/src/uri.rs
+++ b/quickwit/quickwit-common/src/uri.rs
@@ -275,10 +275,10 @@ impl Uri {
             bail!("Failed to parse empty URI.");
         }
         let (protocol, mut path) = match uri_str.split_once(PROTOCOL_SEPARATOR) {
-            None => (Protocol::File.as_str(), uri_str.to_string()),
-            Some((protocol, path)) => (protocol, path.to_string()),
+            None => (Protocol::File, uri_str.to_string()),
+            Some((protocol, path)) => (Protocol::from_str(protocol)?, path.to_string()),
         };
-        if protocol == Protocol::File.as_str() {
+        if protocol == Protocol::File {
             if path.starts_with('~') {
                 // We only accept `~` (alias to the home directory) and `~/path/to/something`.
                 // If there is something following the `~` that is not `/`, we bail.
@@ -306,7 +306,7 @@ impl Uri {
         }
         Ok(Self {
             uri: format!("{protocol}{PROTOCOL_SEPARATOR}{path}"),
-            protocol_idx: protocol.len(),
+            protocol_idx: protocol.as_str().len(),
         })
     }
 }

--- a/quickwit/quickwit-common/src/uri.rs
+++ b/quickwit/quickwit-common/src/uri.rs
@@ -488,10 +488,11 @@ mod tests {
         );
 
         assert_eq!(
-            Uri::from_str("http://localhost:9000/quickwit").unwrap_err().to_string(),
+            Uri::from_str("http://localhost:9000/quickwit")
+                .unwrap_err()
+                .to_string(),
             "Unknown URI protocol `http`."
         );
-
     }
 
     #[test]

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(config.data_dir_path, Path::new("/opt/quickwit/data"));
         assert_eq!(
             config.metastore_uri,
-            "postgres://username:password@host:port/db"
+            "postgresql://username:password@host:port/db"
         );
         assert_eq!(config.default_index_root_uri, "s3://quickwit-indexes");
 
@@ -618,7 +618,7 @@ mod tests {
         env_vars.insert("QW_DATA_DIR".to_string(), "test-data-dir".to_string());
         env_vars.insert(
             "QW_METASTORE_URI".to_string(),
-            "postgres://test-user:test-password@test-host:4321/test-db".to_string(),
+            "postgresql://test-user:test-password@test-host:4321/test-db".to_string(),
         );
         env_vars.insert(
             "QW_DEFAULT_INDEX_ROOT_URI".to_string(),
@@ -672,7 +672,7 @@ mod tests {
         );
         assert_eq!(
             config.metastore_uri,
-            "postgres://test-user:test-password@test-host:4321/test-db"
+            "postgresql://test-user:test-password@test-host:4321/test-db"
         );
         assert_eq!(config.default_index_root_uri, "s3://quickwit-indexes/prod");
     }
@@ -695,7 +695,7 @@ mod tests {
         assert_eq!(config.node_id, "node-1");
         assert_eq!(
             config.metastore_uri,
-            "postgres://username:password@host:port/db"
+            "postgresql://username:password@host:port/db"
         );
     }
 
@@ -715,7 +715,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             config.metastore_uri,
-            "postgres://username:password@host:port/db"
+            "postgresql://username:password@host:port/db"
         );
         assert_eq!(config.indexer_config, IndexerConfig::default());
         assert_eq!(config.searcher_config, SearcherConfig::default());


### PR DESCRIPTION
### Description

Fix https://github.com/quickwit-oss/quickwit/issues/2991
The goal is to ensure that protocol are well validated, instead of having some panic in later stage.

- [x] ensure that protocol are validated during de-serialization
- [x] add test

Before
```
url -XPOST http://localhost:7280/api/v1/indexes -H "content-type: application/yaml" --data-binary @example.yaml
curl: (52) Empty reply from server
```

After
```
curl -XPOST http://localhost:7280/api/v1/indexes -H "content-type: application/yaml" --data-binary @example.yaml
{
  "message": "Invalid config: Failed to read YAML file.: Unknown URI protocol `http`.."
}
```

### How was this PR tested?

* manually by creating an index with an invalid `index_uri`
* added test in Uri 
