### PR TITLE
Gcp pubsub source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN echo "Adding Node.js PPA" \
 
 RUN apt-get -y update \
     && apt-get -y install ca-certificates \
-    clang \
-    cmake \
-    libssl-dev \
-    llvm \
-    nodejs \
-    protobuf-compiler \
+                          clang \
+                          cmake \
+                          libssl-dev \
+                          llvm \
+                          nodejs \
+                          protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 # Required by tonic
@@ -44,8 +44,8 @@ WORKDIR /quickwit
 
 RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CARGO_PROFILE'" \
     && cargo build \
-    --features $CARGO_FEATURES \
-    $(test "$CARGO_PROFILE" = "release" && echo "--release") \
+        --features $CARGO_FEATURES \
+        $(test "$CARGO_PROFILE" = "release" && echo "--release") \
     && echo "Copying binaries to /quickwit/bin" \
     && mkdir -p /quickwit/bin \
     && find target/$CARGO_PROFILE -maxdepth 1 -perm /a+x -type f -exec mv {} /quickwit/bin \;
@@ -62,7 +62,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
 RUN apt-get -y update \
     && apt-get -y install ca-certificates \
-    libssl1.1 \
+                          libssl1.1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /quickwit

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN echo "Adding Node.js PPA" \
 
 RUN apt-get -y update \
     && apt-get -y install ca-certificates \
-                          clang \
-                          cmake \
-                          libssl-dev \
-                          llvm \
-                          nodejs \
-                          protobuf-compiler \
+    clang \
+    cmake \
+    libssl-dev \
+    llvm \
+    nodejs \
+    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 # Required by tonic
@@ -44,8 +44,8 @@ WORKDIR /quickwit
 
 RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CARGO_PROFILE'" \
     && cargo build \
-        --features $CARGO_FEATURES \
-        $(test "$CARGO_PROFILE" = "release" && echo "--release") \
+    --features $CARGO_FEATURES \
+    $(test "$CARGO_PROFILE" = "release" && echo "--release") \
     && echo "Copying binaries to /quickwit/bin" \
     && mkdir -p /quickwit/bin \
     && find target/$CARGO_PROFILE -maxdepth 1 -perm /a+x -type f -exec mv {} /quickwit/bin \;
@@ -62,7 +62,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
 RUN apt-get -y update \
     && apt-get -y install ca-certificates \
-                          libssl1.1 \
+    libssl1.1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /quickwit

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -934,9 +934,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 dependencies = [
  "serde",
 ]
@@ -2256,7 +2256,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
- "rustix 0.38.7",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
 ]
 
@@ -3020,7 +3020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.7",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
 ]
 
@@ -6267,11 +6267,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.7"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.5",
@@ -6959,7 +6959,7 @@ checksum = "8ca69bf415b93b60b80dc8fda3cb4ef52b2336614d8da2de5456cc942a110482"
 dependencies = [
  "atoi",
  "base64 0.21.2",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "byteorder",
  "bytes",
  "crc",
@@ -7002,7 +7002,7 @@ checksum = "a0db2df1b8731c3651e204629dd55e52adbae0462fa1bdcbed56a2302c18181e"
 dependencies = [
  "atoi",
  "base64 0.21.2",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -7339,7 +7339,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.7",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
 ]
 
@@ -7816,7 +7816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
  "async-compression",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8791,9 +8791,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acaaa1190073b2b101e15083c38ee8ec891b5e05cbee516521e94ec008f61e64"
+checksum = "19f495880723d0999eb3500a9064d8dbcf836460b24c17df80ea7b5794053aac"
 dependencies = [
  "memchr",
 ]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5308,7 +5308,6 @@ dependencies = [
  "tracing",
  "ulid",
  "utoipa",
- "uuid",
  "vrl",
  "vrl-stdlib",
 ]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2447,6 +2447,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "google-cloud-auth"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb6624c70caf330298b84a9ad1537ee7a5de788a5b9a06a3bbe206260943011"
+dependencies = [
+ "async-trait",
+ "base64 0.21.2",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.25",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "google-cloud-default"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2248865004b6e699fddb1b562cf7dadcdd006408aa6e50e1c61dd6f3b12dc02b"
+dependencies = [
+ "async-trait",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-pubsub",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08f4e75d0170d154414651d573ae01a928f9da0d62391bb6762007f5410443e"
+dependencies = [
+ "google-cloud-token",
+ "http",
+ "thiserror",
+ "tokio",
+ "tokio-retry",
+ "tonic 0.9.2",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d905d01fe815c6894b309b18a1ba152371e2e2ba7fcc81f4d22e48865b3014c"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "google-cloud-metadata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e4ad0802d3f416f62e7ce01ac1460898ee0efc98f8b45cd4aab7611607012f"
+dependencies = [
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-pubsub"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30dc010fd45992c6af011a506ce83186cc4aad8bdb449713cf003849cd29f464"
+dependencies = [
+ "async-channel",
+ "async-stream",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-token",
+ "prost-types",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-token"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcd62eb34e3de2f085bcc33a09c3e17c4f65650f36d53eb328b00d63bcb536a"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,6 +2855,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,6 +3071,20 @@ name = "json_comments"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ee439ee368ba4a77ac70d04f14015415af8600d6c894dc1f11bd79758c57d5"
+
+[[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.2",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
 
 [[package]]
 name = "keccak"
@@ -5145,6 +5271,9 @@ dependencies = [
  "flume",
  "fnv",
  "futures",
+ "google-cloud-default",
+ "google-cloud-googleapis",
+ "google-cloud-pubsub",
  "itertools 0.11.0",
  "libz-sys",
  "mockall",
@@ -5179,6 +5308,7 @@ dependencies = [
  "tracing",
  "ulid",
  "utoipa",
+ "uuid",
  "vrl",
  "vrl-stdlib",
 ]
@@ -5923,10 +6053,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls 0.24.1",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5936,6 +6068,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
@@ -6166,7 +6299,7 @@ checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.3",
  "sct",
 ]
 
@@ -6189,6 +6322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -6586,6 +6729,18 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.25",
+]
 
 [[package]]
 name = "siphasher"
@@ -7441,6 +7596,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7584,6 +7750,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.2",
@@ -7599,12 +7766,15 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -8398,11 +8568,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki 0.100.1",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
- "rustls-webpki",
+ "rustls-webpki 0.101.3",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -65,6 +65,9 @@ flume = "0.10"
 fnv = "1"
 futures = "0.3"
 futures-util = { version = "0.3.25", default-features = false }
+google-cloud-pubsub = "0.15.0"
+google-cloud-default = { version = "0.3.0", features = ["pubsub"] }
+google-cloud-googleapis = { version = "0.9.0", features = ["pubsub"] }
 heck = "0.4.1"
 hex = "0.4.3"
 home = "0.5.4"

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -51,9 +51,9 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 pub use source_config::{
     load_source_config_from_user_config, FileSourceParams, KafkaSourceParams, KinesisSourceParams,
-    PulsarSourceAuth, PulsarSourceParams, RegionOrEndpoint, SourceConfig, SourceInputFormat,
-    SourceParams, TransformConfig, VecSourceParams, VoidSourceParams, CLI_INGEST_SOURCE_ID,
-    INGEST_API_SOURCE_ID,
+    PubSubSourceParams, PulsarSourceAuth, PulsarSourceParams, RegionOrEndpoint, SourceConfig,
+    SourceInputFormat, SourceParams, TransformConfig, VecSourceParams, VoidSourceParams,
+    CLI_INGEST_SOURCE_ID, INGEST_API_SOURCE_ID,
 };
 use tracing::warn;
 
@@ -88,6 +88,7 @@ pub use crate::storage_config::{
     SourceInputFormat,
     SourceParams,
     FileSourceParams,
+    PubSubSourceParams,
     KafkaSourceParams,
     KinesisSourceParams,
     PulsarSourceParams,
@@ -156,7 +157,9 @@ impl ConfigFormat {
     }
 
     pub fn parse<T>(&self, payload: &[u8]) -> anyhow::Result<T>
-    where T: DeserializeOwned {
+    where
+        T: DeserializeOwned,
+    {
         match self {
             ConfigFormat::Json => {
                 let mut json_value: JsonValue =

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -50,10 +50,10 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 pub use source_config::{
-    load_source_config_from_user_config, FileSourceParams, KafkaSourceParams, KinesisSourceParams,
-    PubSubSourceParams, PulsarSourceAuth, PulsarSourceParams, RegionOrEndpoint, SourceConfig,
-    SourceInputFormat, SourceParams, TransformConfig, VecSourceParams, VoidSourceParams,
-    CLI_INGEST_SOURCE_ID, INGEST_API_SOURCE_ID,
+    load_source_config_from_user_config, FileSourceParams, GcpPubSubSourceParams,
+    KafkaSourceParams, KinesisSourceParams, PulsarSourceAuth, PulsarSourceParams, RegionOrEndpoint,
+    SourceConfig, SourceInputFormat, SourceParams, TransformConfig, VecSourceParams,
+    VoidSourceParams, CLI_INGEST_SOURCE_ID, INGEST_API_SOURCE_ID,
 };
 use tracing::warn;
 
@@ -88,7 +88,7 @@ pub use crate::storage_config::{
     SourceInputFormat,
     SourceParams,
     FileSourceParams,
-    PubSubSourceParams,
+    GcpPubSubSourceParams,
     KafkaSourceParams,
     KinesisSourceParams,
     PulsarSourceParams,
@@ -157,9 +157,7 @@ impl ConfigFormat {
     }
 
     pub fn parse<T>(&self, payload: &[u8]) -> anyhow::Result<T>
-    where
-        T: DeserializeOwned,
-    {
+    where T: DeserializeOwned {
         match self {
             ConfigFormat::Json => {
                 let mut json_value: JsonValue =

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -86,7 +86,7 @@ impl SourceConfig {
         match self.source_params {
             SourceParams::File(_) => "file",
             SourceParams::Kafka(_) => "kafka",
-            SourceParams::PubSub(_) => "pubsub",
+            SourceParams::GcpPubSub(_) => "gcp-pubsub",
             SourceParams::Kinesis(_) => "kinesis",
             SourceParams::Vec(_) => "vec",
             SourceParams::Void(_) => "void",
@@ -101,7 +101,7 @@ impl SourceConfig {
         match &self.source_params {
             SourceParams::File(params) => serde_json::to_value(params),
             SourceParams::Kafka(params) => serde_json::to_value(params),
-            SourceParams::PubSub(params) => serde_json::to_value(params),
+            SourceParams::GcpPubSub(params) => serde_json::to_value(params),
             SourceParams::Kinesis(params) => serde_json::to_value(params),
             SourceParams::Vec(params) => serde_json::to_value(params),
             SourceParams::Void(params) => serde_json::to_value(params),
@@ -206,8 +206,8 @@ pub enum SourceParams {
     File(FileSourceParams),
     #[serde(rename = "kafka")]
     Kafka(KafkaSourceParams),
-    #[serde(rename = "pubsub")]
-    PubSub(PubSubSourceParams),
+    #[serde(rename = "gcp-pubsub")]
+    GcpPubSub(GcpPubSubSourceParams),
     #[serde(rename = "kinesis")]
     Kinesis(KinesisSourceParams),
     #[serde(rename = "pulsar")]
@@ -249,9 +249,7 @@ pub struct FileSourceParams {
 
 // Deserializing a filepath string into an absolute filepath.
 fn absolute_filepath_from_str<'de, D>(deserializer: D) -> Result<Option<PathBuf>, D::Error>
-where
-    D: Deserializer<'de>,
-{
+where D: Deserializer<'de> {
     let filepath_opt: Option<String> = Deserialize::deserialize(deserializer)?;
     if let Some(filepath) = filepath_opt {
         let uri = Uri::from_str(&filepath).map_err(D::Error::custom)?;
@@ -295,7 +293,7 @@ pub struct KafkaSourceParams {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
-pub struct PubSubSourceParams {
+pub struct GcpPubSubSourceParams {
     /// Name of the subscription that the source consumes.
     pub subscription: String,
     /// When backfill mode is enabled, the source exits after reaching the end of the topic.
@@ -409,9 +407,7 @@ pub enum PulsarSourceAuth {
 
 // Deserializing a string into an pulsar uri.
 fn pulsar_uri<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: Deserializer<'de>,
-{
+where D: Deserializer<'de> {
     let uri: String = Deserialize::deserialize(deserializer)?;
 
     if uri.strip_prefix("pulsar://").is_none() {

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -85,14 +85,14 @@ impl SourceConfig {
     pub fn source_type(&self) -> &str {
         match self.source_params {
             SourceParams::File(_) => "file",
-            SourceParams::Kafka(_) => "kafka",
             SourceParams::GcpPubSub(_) => "gcp_pubsub",
-            SourceParams::Kinesis(_) => "kinesis",
-            SourceParams::Vec(_) => "vec",
-            SourceParams::Void(_) => "void",
             SourceParams::IngestApi => "ingest-api",
             SourceParams::IngestCli => "ingest-cli",
+            SourceParams::Kafka(_) => "kafka",
+            SourceParams::Kinesis(_) => "kinesis",
             SourceParams::Pulsar(_) => "pulsar",
+            SourceParams::Vec(_) => "vec",
+            SourceParams::Void(_) => "void",
         }
     }
 
@@ -100,14 +100,14 @@ impl SourceConfig {
     pub fn params(&self) -> JsonValue {
         match &self.source_params {
             SourceParams::File(params) => serde_json::to_value(params),
-            SourceParams::Kafka(params) => serde_json::to_value(params),
             SourceParams::GcpPubSub(params) => serde_json::to_value(params),
-            SourceParams::Kinesis(params) => serde_json::to_value(params),
-            SourceParams::Vec(params) => serde_json::to_value(params),
-            SourceParams::Void(params) => serde_json::to_value(params),
             SourceParams::IngestApi => serde_json::to_value(()),
             SourceParams::IngestCli => serde_json::to_value(()),
+            SourceParams::Kafka(params) => serde_json::to_value(params),
+            SourceParams::Kinesis(params) => serde_json::to_value(params),
             SourceParams::Pulsar(params) => serde_json::to_value(params),
+            SourceParams::Vec(params) => serde_json::to_value(params),
+            SourceParams::Void(params) => serde_json::to_value(params),
         }
         .unwrap()
     }
@@ -203,16 +203,16 @@ impl FromStr for SourceInputFormat {
 #[serde(tag = "source_type", content = "params", rename_all = "snake_case")]
 pub enum SourceParams {
     File(FileSourceParams),
-    Kafka(KafkaSourceParams),
     GcpPubSub(GcpPubSubSourceParams),
-    Kinesis(KinesisSourceParams),
-    Pulsar(PulsarSourceParams),
-    Vec(VecSourceParams),
-    Void(VoidSourceParams),
     #[serde(rename = "ingest-api")]
     IngestApi,
     #[serde(rename = "ingest-cli")]
     IngestCli,
+    Kafka(KafkaSourceParams),
+    Kinesis(KinesisSourceParams),
+    Pulsar(PulsarSourceParams),
+    Vec(VecSourceParams),
+    Void(VoidSourceParams),
 }
 
 impl SourceParams {
@@ -293,12 +293,12 @@ pub struct GcpPubSubSourceParams {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub enable_backfill_mode: bool,
-    /// GCP service account credentials (None will use default via GOOGLE_APPLICATION_CREDENTIALS)
+    /// GCP service account credentials (`None` will use default via
+    /// GOOGLE_APPLICATION_CREDENTIALS)
     pub credentials: Option<String>,
-    /// How many threads spread pubsub pull requests over (default 10)
-    /// Higher values can mean higher throughput but higher overhead
+    /// Number of pull requests issued in parallel by the source (default 1)
     pub pull_parallelism: Option<u64>,
-    /// The max messages to pull per pull request (default 1000)
+    /// Maximum number of messages returned by a pull request (default 1,000)
     pub max_messages_per_pull: Option<i32>,
 }
 

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -86,7 +86,7 @@ impl SourceConfig {
         match self.source_params {
             SourceParams::File(_) => "file",
             SourceParams::Kafka(_) => "kafka",
-            SourceParams::GcpPubSub(_) => "gcp-pubsub",
+            SourceParams::GcpPubSub(_) => "gcp_pubsub",
             SourceParams::Kinesis(_) => "kinesis",
             SourceParams::Vec(_) => "vec",
             SourceParams::Void(_) => "void",
@@ -200,21 +200,14 @@ impl FromStr for SourceInputFormat {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
-#[serde(tag = "source_type", content = "params")]
+#[serde(tag = "source_type", content = "params", rename_all = "snake_case")]
 pub enum SourceParams {
-    #[serde(rename = "file")]
     File(FileSourceParams),
-    #[serde(rename = "kafka")]
     Kafka(KafkaSourceParams),
-    #[serde(rename = "gcp-pubsub")]
     GcpPubSub(GcpPubSubSourceParams),
-    #[serde(rename = "kinesis")]
     Kinesis(KinesisSourceParams),
-    #[serde(rename = "pulsar")]
     Pulsar(PulsarSourceParams),
-    #[serde(rename = "vec")]
     Vec(VecSourceParams),
-    #[serde(rename = "void")]
     Void(VoidSourceParams),
     #[serde(rename = "ingest-api")]
     IngestApi,

--- a/quickwit/quickwit-config/src/source_config/serialize.rs
+++ b/quickwit/quickwit-config/src/source_config/serialize.rs
@@ -98,11 +98,11 @@ impl SourceConfigForSerialization {
             | SourceParams::Void(_)
             | SourceParams::IngestApi
             | SourceParams::IngestCli => {}
-            SourceParams::PubSub(_) => {}
+            SourceParams::GcpPubSub(_) => {}
         }
         match &self.source_params {
             SourceParams::Kafka(_) => {}
-            SourceParams::PubSub(_) => {}
+            SourceParams::GcpPubSub(_) => {}
             _ => {
                 if self.desired_num_pipelines > 1 || self.max_num_pipelines_per_indexer > 1 {
                     bail!("Quickwit currently supports multiple pipelines only for Kafka sources. Open an issue https://github.com/quickwit-oss/quickwit/issues if you need the feature for other source types.");

--- a/quickwit/quickwit-config/src/source_config/serialize.rs
+++ b/quickwit/quickwit-config/src/source_config/serialize.rs
@@ -94,18 +94,17 @@ impl SourceConfigForSerialization {
             SourceParams::Kafka(_) | SourceParams::Kinesis(_) | SourceParams::Pulsar(_) => {
                 // TODO consider any validation opportunity
             }
-            SourceParams::Vec(_)
-            | SourceParams::Void(_)
+            SourceParams::GcpPubSub(_)
             | SourceParams::IngestApi
-            | SourceParams::IngestCli => {}
-            SourceParams::GcpPubSub(_) => {}
+            | SourceParams::IngestCli
+            | SourceParams::Vec(_)
+            | SourceParams::Void(_) => {}
         }
         match &self.source_params {
-            SourceParams::Kafka(_) => {}
-            SourceParams::GcpPubSub(_) => {}
+            SourceParams::GcpPubSub(_) | SourceParams::Kafka(_) => {}
             _ => {
                 if self.desired_num_pipelines > 1 || self.max_num_pipelines_per_indexer > 1 {
-                    bail!("Quickwit currently supports multiple pipelines only for Kafka sources. Open an issue https://github.com/quickwit-oss/quickwit/issues if you need the feature for other source types.");
+                    bail!("Quickwit currently supports multiple pipelines only for GCP PubSub or Kafka sources. Open an issue https://github.com/quickwit-oss/quickwit/issues if you need the feature for other source types.");
                 }
             }
         }

--- a/quickwit/quickwit-config/src/source_config/serialize.rs
+++ b/quickwit/quickwit-config/src/source_config/serialize.rs
@@ -98,9 +98,11 @@ impl SourceConfigForSerialization {
             | SourceParams::Void(_)
             | SourceParams::IngestApi
             | SourceParams::IngestCli => {}
+            SourceParams::PubSub(_) => {}
         }
         match &self.source_params {
             SourceParams::Kafka(_) => {}
+            SourceParams::PubSub(_) => {}
             _ => {
                 if self.desired_num_pipelines > 1 || self.max_num_pipelines_per_indexer > 1 {
                     bail!("Quickwit currently supports multiple pipelines only for Kafka sources. Open an issue https://github.com/quickwit-oss/quickwit/issues if you need the feature for other source types.");

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -46,10 +46,10 @@ ulid = { workspace = true }
 utoipa = { workspace = true }
 vrl = { workspace = true, optional = true }
 vrl-stdlib = { workspace = true, optional = true }
-google-cloud-pubsub = "0.15.0"
-google-cloud-default = { version = "0.3.0", features = ["pubsub"] }
-google-cloud-googleapis = { version = "0.9.0", features = ["pubsub"] }
-uuid = { workspace = true }
+google-cloud-pubsub = { workspace = true, optional = true }
+google-cloud-default = { workspace = true, optional = true }
+google-cloud-googleapis = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 
 quickwit-actors = { workspace = true }
 quickwit-aws = { workspace = true }
@@ -64,6 +64,7 @@ quickwit-proto = { workspace = true }
 quickwit-storage = { workspace = true }
 
 [features]
+gcp-pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis", "dep:uuid"]
 kafka = ["rdkafka", "backoff"]
 kafka-broker-tests = []
 vendored-kafka = ["kafka", "libz-sys/static", "openssl/vendored", "rdkafka/gssapi-vendored"]
@@ -73,7 +74,11 @@ kinesis-localstack-tests = []
 vrl = ["dep:vrl", "vrl-stdlib", "quickwit-config/vrl"]
 pulsar = ["dep:pulsar"]
 pulsar-broker-tests = []
-testsuite = ["quickwit-actors/testsuite", "quickwit-cluster/testsuite", "quickwit-common/testsuite"]
+testsuite = [
+  "quickwit-actors/testsuite",
+  "quickwit-cluster/testsuite",
+  "quickwit-common/testsuite",
+]
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -49,7 +49,6 @@ vrl-stdlib = { workspace = true, optional = true }
 google-cloud-pubsub = { workspace = true, optional = true }
 google-cloud-default = { workspace = true, optional = true }
 google-cloud-googleapis = { workspace = true, optional = true }
-uuid = { workspace = true, optional = true }
 
 quickwit-actors = { workspace = true }
 quickwit-aws = { workspace = true }
@@ -64,7 +63,7 @@ quickwit-proto = { workspace = true }
 quickwit-storage = { workspace = true }
 
 [features]
-gcp-pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis", "dep:uuid"]
+gcp_pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis"]
 kafka = ["rdkafka", "backoff"]
 kafka-broker-tests = []
 vendored-kafka = ["kafka", "libz-sys/static", "openssl/vendored", "rdkafka/gssapi-vendored"]

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -46,6 +46,10 @@ ulid = { workspace = true }
 utoipa = { workspace = true }
 vrl = { workspace = true, optional = true }
 vrl-stdlib = { workspace = true, optional = true }
+google-cloud-pubsub = "0.15.0"
+google-cloud-default = { version = "0.3.0", features = ["pubsub"] }
+google-cloud-googleapis = { version = "0.9.0", features = ["pubsub"] }
+uuid = { workspace = true }
 
 quickwit-actors = { workspace = true }
 quickwit-aws = { workspace = true }
@@ -69,11 +73,7 @@ kinesis-localstack-tests = []
 vrl = ["dep:vrl", "vrl-stdlib", "quickwit-config/vrl"]
 pulsar = ["dep:pulsar"]
 pulsar-broker-tests = []
-testsuite = [
-  "quickwit-actors/testsuite",
-  "quickwit-cluster/testsuite",
-  "quickwit-common/testsuite",
-]
+testsuite = ["quickwit-actors/testsuite", "quickwit-cluster/testsuite", "quickwit-common/testsuite"]
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -25,6 +25,9 @@ fail = { workspace = true }
 flume = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
+google-cloud-default = { workspace = true, optional = true }
+google-cloud-googleapis = { workspace = true, optional = true }
+google-cloud-pubsub = { workspace = true, optional = true }
 itertools = { workspace = true }
 libz-sys = { workspace = true, optional = true }
 once_cell = { workspace = true }
@@ -46,9 +49,6 @@ ulid = { workspace = true }
 utoipa = { workspace = true }
 vrl = { workspace = true, optional = true }
 vrl-stdlib = { workspace = true, optional = true }
-google-cloud-pubsub = { workspace = true, optional = true }
-google-cloud-default = { workspace = true, optional = true }
-google-cloud-googleapis = { workspace = true, optional = true }
 
 quickwit-actors = { workspace = true }
 quickwit-aws = { workspace = true }
@@ -63,7 +63,7 @@ quickwit-proto = { workspace = true }
 quickwit-storage = { workspace = true }
 
 [features]
-gcp_pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis"]
+gcp-pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis"]
 kafka = ["rdkafka", "backoff"]
 kafka-broker-tests = []
 vendored-kafka = ["kafka", "libz-sys/static", "openssl/vendored", "rdkafka/gssapi-vendored"]

--- a/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
+++ b/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
@@ -1,0 +1,338 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use bytes::Bytes;
+use google_cloud_default::WithAuthExt;
+use google_cloud_pubsub::client::{Client, ClientConfig};
+use google_cloud_pubsub::subscriber::ReceivedMessage;
+use google_cloud_pubsub::subscription::Subscription;
+use quickwit_actors::{ActorContext, ActorExitStatus, Mailbox};
+use quickwit_config::PubSubSourceParams;
+use quickwit_metastore::checkpoint::{
+    PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
+};
+use serde_json::Value as JsonValue;
+use tokio::sync::RwLock;
+use tokio::time;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::actors::DocProcessor;
+use crate::models::{NewPublishLock, PublishLock, RawDocBatch};
+use crate::source::{Source, SourceContext, SourceExecutionContext, TypedSourceFactory};
+
+use super::SourceActor;
+
+const BATCH_NUM_BYTES_LIMIT: u64 = 5_000_000;
+const DEFAULT_MAX_MESSAGES_PER_PULL: i32 = 1000;
+const DEFAULT_PULL_PARALLELISM: u64 = 10; // TODO: is 10 too high as a default?
+const BILLION: i64 = 1e9 as i64;
+
+pub struct PubSubSourceFactory;
+
+#[async_trait]
+impl TypedSourceFactory for PubSubSourceFactory {
+    type Source = PubSubSource;
+    type Params = PubSubSourceParams;
+
+    async fn typed_create_source(
+        ctx: Arc<SourceExecutionContext>,
+        params: PubSubSourceParams,
+        _checkpoint: SourceCheckpoint, // TODO: Use checkpoint!
+    ) -> anyhow::Result<Self::Source> {
+        PubSubSource::try_new(ctx, params).await
+    }
+}
+
+#[derive(Default)]
+pub struct PubSubSourceState {
+    ack_ids: RwLock<Vec<String>>,
+    subscription_is_empty: bool,
+    doc_count: RwLock<u64>,
+}
+
+pub struct PubSubSource {
+    ctx: Arc<SourceExecutionContext>,
+    subscription: String,
+    state: PubSubSourceState,
+    subscription_source: Subscription,
+    backfill_mode_enabled: bool,
+    publish_lock: PublishLock,
+    partition_id: String,
+    pull_parallelism: u64,
+    max_messages_per_pull: i32,
+}
+
+impl PubSubSource {
+    pub async fn try_new(
+        ctx: Arc<SourceExecutionContext>,
+        params: PubSubSourceParams,
+    ) -> anyhow::Result<Self> {
+        let subscription = params.subscription.clone();
+        let backfill_mode_enabled = params.enable_backfill_mode;
+        let pull_parallelism = match params.pull_parallelism {
+            Some(parallelism) => parallelism,
+            None => DEFAULT_PULL_PARALLELISM,
+        };
+        let max_messages_per_pull = match params.max_messages_per_pull {
+            Some(max) => max,
+            None => DEFAULT_MAX_MESSAGES_PER_PULL,
+        };
+
+        let config = match params.credentials {
+            Some(credentials) => todo!("Add specific credentials file config"),
+            None => ClientConfig::default().with_auth(),
+        }
+        .await
+        .expect("Failed to use GCP credentials");
+
+        let client = Client::new(config)
+            .await
+            .expect("Failed to create PubSub client");
+        let subscription_source = client.subscription(&subscription);
+        let publish_lock = PublishLock::default();
+
+        info!(
+            index_id=%ctx.index_uid.index_id(),
+            source_id=%ctx.source_config.source_id,
+            subscription=%subscription,
+            parallelism=%pull_parallelism,
+            "Starting PubSub source."
+        );
+
+        Ok(PubSubSource {
+            ctx,
+            subscription,
+            state: PubSubSourceState::default(),
+            subscription_source,
+            backfill_mode_enabled,
+            publish_lock,
+            partition_id: Uuid::new_v4().to_string(),
+            pull_parallelism,
+            max_messages_per_pull,
+        })
+    }
+
+    fn should_exit(&self) -> bool {
+        self.backfill_mode_enabled && self.state.subscription_is_empty
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct BatchBuilder {
+    docs: Vec<Bytes>,
+    num_bytes: u64,
+    checkpoint_delta: SourceCheckpointDelta,
+}
+
+impl BatchBuilder {
+    fn build(self) -> RawDocBatch {
+        RawDocBatch {
+            docs: self.docs,
+            checkpoint_delta: self.checkpoint_delta,
+            force_commit: false,
+        }
+    }
+
+    fn build_force(self) -> RawDocBatch {
+        RawDocBatch {
+            docs: self.docs,
+            checkpoint_delta: self.checkpoint_delta,
+            force_commit: true,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.docs.clear();
+        self.num_bytes = 0;
+        self.checkpoint_delta = SourceCheckpointDelta::default();
+    }
+
+    fn push(&mut self, message: ReceivedMessage) {
+        let doc = message.message.data;
+        self.num_bytes += doc.len() as u64;
+        self.docs.push(doc.into());
+    }
+}
+
+#[async_trait]
+impl Source for PubSubSource {
+    async fn initialize(
+        &mut self,
+        doc_processor_mailbox: &Mailbox<DocProcessor>,
+        ctx: &SourceContext,
+    ) -> Result<(), ActorExitStatus> {
+        info!("PubSub initializing");
+        let publish_lock = self.publish_lock.clone();
+        ctx.send_message(doc_processor_mailbox, NewPublishLock(publish_lock))
+            .await?;
+        info!("PubSub initialized");
+        Ok(())
+    }
+
+    async fn emit_batches(
+        &mut self,
+        doc_processor_mailbox: &Mailbox<DocProcessor>,
+        ctx: &SourceContext,
+    ) -> Result<Duration, ActorExitStatus> {
+        info!("PubSub beginning batch");
+        let now = Instant::now();
+        let batch_lock = Arc::new(RwLock::new(BatchBuilder::default()));
+        let deadline = time::sleep(*quickwit_actors::HEARTBEAT / 2);
+        tokio::pin!(deadline);
+
+        info!("PubSub pulling batch");
+
+        loop {
+            let mut handles = vec![];
+
+            for _ in 1..self.pull_parallelism {
+                handles.push(self.pull_message_batch(Arc::clone(&batch_lock)));
+            }
+
+            tokio::select! {
+                _ = futures::future::join_all(handles) => {
+                    let batch = batch_lock.read().await;
+                    if batch.num_bytes >= BATCH_NUM_BYTES_LIMIT {
+                        break;
+                    }
+                }
+                _ = &mut deadline => {
+                    break;
+                }
+            }
+            ctx.record_progress();
+        }
+
+        let batch = batch_lock.read().await.clone(); // TODO: This clone is wasteful! There must be a better way
+        if self.should_exit() {
+            info!(subscription = %self.subscription, "Reached end of subscription.");
+            ctx.ask(doc_processor_mailbox, batch.build_force())
+                .await
+                .context("Failed to force commit last batch!")?;
+            self.ack_ids().await?;
+            ctx.send_exit_with_success(doc_processor_mailbox).await?;
+            return Err(ActorExitStatus::Success);
+        }
+
+        if batch.checkpoint_delta.is_empty() {
+            self.state.subscription_is_empty = true
+        } else {
+            info!(
+                num_docs=%batch.docs.len(),
+                num_bytes=%batch.num_bytes,
+                num_millis=%now.elapsed().as_millis(),
+                "Sending doc batch to indexer.");
+            let message = batch.build();
+            ctx.send_message(doc_processor_mailbox, message).await?;
+        }
+
+        Ok(Duration::default())
+    }
+
+    async fn suggest_truncate(
+        &mut self,
+        _checkpoint: SourceCheckpoint,
+        _ctx: &ActorContext<SourceActor>,
+    ) -> anyhow::Result<()> {
+        // TODO: How can we know if these are ok to ack? We need to use the checkpoint!
+        self.ack_ids().await
+    }
+
+    async fn finalize(
+        &mut self,
+        _exit_status: &ActorExitStatus,
+        _ctx: &SourceContext,
+    ) -> anyhow::Result<()> {
+        self.ack_ids().await
+    }
+
+    fn name(&self) -> String {
+        format!(
+            "PubSubSource{{source_id={}}}",
+            self.ctx.source_config.source_id
+        )
+    }
+
+    fn observable_state(&self) -> JsonValue {
+        JsonValue::Object(Default::default())
+    }
+}
+
+impl PubSubSource {
+    async fn ack_ids(&mut self) -> anyhow::Result<()> {
+        let mut ack_ids = self.state.ack_ids.write().await;
+        if ack_ids.is_empty() {
+            return Ok(());
+        }
+
+        // TODO: For ordered pubsub topics/subscriptions we need to ensure we
+        // also ack in that same order!
+        // TODO: We may have consumed more messages by the time we get a reply!
+        // We can't just blindly clear... instead we need to keep track of which
+        // ack ids were present in each checkpoint
+        info!("Acking ids...");
+        for chunk in ack_ids.chunks(1000) {
+            self.subscription_source
+                .ack(Vec::from(chunk))
+                .await
+                .map_err(anyhow::Error::from)?;
+        }
+        ack_ids.clear();
+        info!("Acked!");
+        Ok(())
+    }
+
+    async fn pull_message_batch(
+        &self,
+        batch_lock: Arc<RwLock<BatchBuilder>>,
+    ) -> anyhow::Result<()> {
+        let event = self
+            .subscription_source
+            .pull(self.max_messages_per_pull, None)
+            .await;
+
+        let messages = event.map_err(|err| {
+            warn!("{err}");
+            ActorExitStatus::from(anyhow!("PubSub encountered an error."))
+        })?;
+
+        let length = messages.len();
+        info!("PubSub pulled {length} messages");
+        let mut batch = batch_lock.write().await;
+        let mut ack_ids = self.state.ack_ids.write().await;
+        let mut doc_count = self.state.doc_count.write().await;
+        let initial_position = *doc_count;
+
+        for message in messages {
+            ack_ids.push(String::from(message.ack_id()));
+            batch.push(message);
+            *doc_count += 1
+        }
+
+        let first_position = Position::from(initial_position);
+        let last_position = Position::from(*doc_count);
+        let partition_id = PartitionId::from(self.partition_id.clone());
+
+        if first_position != last_position {
+            batch
+                .checkpoint_delta
+                .record_partition_delta(partition_id, first_position, last_position)
+                .context("Failed to record partition delta.")?;
+        }
+
+        Ok(())
+    }
+
+    async fn increase_ack_deadline(self) {
+        todo!("google-cloud-pubsub doesn't implement this...")
+        // BUT it does!... kind of...
+        // It has the ability to do this for a subscriber (streaming pull).
+        // We could potentially make a hacky copy of how it does that...
+        // Or PR in this functionality into the Subscription struct properly.
+        //
+        // For now we can just set the deadline to 600 seconds on gcp and call it day?
+    }
+}

--- a/quickwit/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kafka_source.rs
@@ -306,7 +306,7 @@ impl KafkaSource {
         } = message;
 
         if let Some(doc) = doc_opt {
-            batch.push(doc, payload_len);
+            batch.push(doc);
         } else {
             self.state.num_invalid_messages += 1;
         }
@@ -1144,7 +1144,7 @@ mod kafka_broker_tests {
         let (ack_tx, ack_rx) = oneshot::channel();
 
         let mut batch = BatchBuilder::default();
-        batch.push(Bytes::from_static(b"test-doc"), 8);
+        batch.push(Bytes::from_static(b"test-doc"));
 
         let publish_lock = kafka_source.publish_lock.clone();
         assert!(publish_lock.is_alive());

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -58,7 +58,7 @@
 //! - the kafka source: the partition id is a kafka topic partition id, and the position is a kafka
 //!   offset.
 mod file_source;
-#[cfg(feature = "gcp_pubsub")]
+#[cfg(feature = "gcp-pubsub")]
 mod gcp_pubsub_source;
 mod ingest_api_source;
 #[cfg(feature = "kafka")]
@@ -79,7 +79,7 @@ use anyhow::bail;
 use async_trait::async_trait;
 use bytes::Bytes;
 pub use file_source::{FileSource, FileSourceFactory};
-#[cfg(feature = "gcp_pubsub")]
+#[cfg(feature = "gcp-pubsub")]
 pub use gcp_pubsub_source::{GcpPubSubSource, GcpPubSubSourceFactory};
 #[cfg(feature = "kafka")]
 pub use kafka_source::{KafkaSource, KafkaSourceFactory};
@@ -293,7 +293,7 @@ pub fn quickwit_supported_sources() -> &'static SourceLoader {
     SOURCE_LOADER.get_or_init(|| {
         let mut source_factory = SourceLoader::default();
         source_factory.add_source("file", FileSourceFactory);
-        #[cfg(feature = "gcp_pubsub")]
+        #[cfg(feature = "gcp-pubsub")]
         source_factory.add_source("gcp_pubsub", GcpPubSubSourceFactory);
         #[cfg(feature = "kafka")]
         source_factory.add_source("kafka", KafkaSourceFactory);
@@ -399,9 +399,9 @@ impl BatchBuilder {
         self.checkpoint_delta = SourceCheckpointDelta::default();
     }
 
-    pub fn push(&mut self, doc: Bytes, num_bytes: u64) {
+    pub fn push(&mut self, doc: Bytes) {
+        self.num_bytes += doc.len() as u64;
         self.docs.push(doc);
-        self.num_bytes += num_bytes;
     }
 }
 

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -378,21 +378,21 @@ impl Handler<SuggestTruncate> for SourceActor {
 }
 
 #[derive(Debug, Default)]
-struct BatchBuilder {
+pub struct BatchBuilder {
     docs: Vec<Bytes>,
     num_bytes: u64,
     checkpoint_delta: SourceCheckpointDelta,
 }
 
 impl BatchBuilder {
-    fn build(self) -> RawDocBatch {
+    pub fn build(self) -> RawDocBatch {
         RawDocBatch {
             docs: self.docs,
             checkpoint_delta: self.checkpoint_delta,
             force_commit: false,
         }
     }
-    fn build_force(self) -> RawDocBatch {
+    pub fn build_force(self) -> RawDocBatch {
         RawDocBatch {
             docs: self.docs,
             checkpoint_delta: self.checkpoint_delta,
@@ -400,7 +400,7 @@ impl BatchBuilder {
         }
     }
 
-    fn push(&mut self, doc: Bytes, num_bytes: u64) {
+    pub fn push(&mut self, doc: Bytes, num_bytes: u64) {
         self.docs.push(doc);
         self.num_bytes += num_bytes;
     }

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -392,12 +392,11 @@ impl BatchBuilder {
             force_commit: false,
         }
     }
-    pub fn build_force(self) -> RawDocBatch {
-        RawDocBatch {
-            docs: self.docs,
-            checkpoint_delta: self.checkpoint_delta,
-            force_commit: true,
-        }
+
+    pub fn clear(&mut self) {
+        self.docs.clear();
+        self.num_bytes = 0;
+        self.checkpoint_delta = SourceCheckpointDelta::default();
     }
 
     pub fn push(&mut self, doc: Bytes, num_bytes: u64) {

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -58,6 +58,7 @@
 //! - the kafka source: the partition id is a kafka topic partition id, and the position is a kafka
 //!   offset.
 mod file_source;
+#[cfg(feature = "gcp-pubsub")]
 mod gcp_pubsub_source;
 mod ingest_api_source;
 #[cfg(feature = "kafka")]
@@ -77,7 +78,8 @@ use std::time::Duration;
 use anyhow::bail;
 use async_trait::async_trait;
 pub use file_source::{FileSource, FileSourceFactory};
-pub use gcp_pubsub_source::{PubSubSource, PubSubSourceFactory};
+#[cfg(feature = "gcp-pubsub")]
+pub use gcp_pubsub_source::{GcpPubSubSource, GcpPubSubSourceFactory};
 #[cfg(feature = "kafka")]
 pub use kafka_source::{KafkaSource, KafkaSourceFactory};
 #[cfg(feature = "kinesis")]
@@ -289,7 +291,8 @@ pub fn quickwit_supported_sources() -> &'static SourceLoader {
     SOURCE_LOADER.get_or_init(|| {
         let mut source_factory = SourceLoader::default();
         source_factory.add_source("file", FileSourceFactory);
-        source_factory.add_source("pubsub", PubSubSourceFactory);
+        #[cfg(feature = "gcp-pubsub")]
+        source_factory.add_source("gcp-pubsub", GcpPubSubSourceFactory);
         #[cfg(feature = "kafka")]
         source_factory.add_source("kafka", KafkaSourceFactory);
         #[cfg(feature = "kinesis")]

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -58,6 +58,7 @@
 //! - the kafka source: the partition id is a kafka topic partition id, and the position is a kafka
 //!   offset.
 mod file_source;
+mod gcp_pubsub_source;
 mod ingest_api_source;
 #[cfg(feature = "kafka")]
 mod kafka_source;
@@ -76,6 +77,7 @@ use std::time::Duration;
 use anyhow::bail;
 use async_trait::async_trait;
 pub use file_source::{FileSource, FileSourceFactory};
+pub use gcp_pubsub_source::{PubSubSource, PubSubSourceFactory};
 #[cfg(feature = "kafka")]
 pub use kafka_source::{KafkaSource, KafkaSourceFactory};
 #[cfg(feature = "kinesis")]
@@ -287,6 +289,7 @@ pub fn quickwit_supported_sources() -> &'static SourceLoader {
     SOURCE_LOADER.get_or_init(|| {
         let mut source_factory = SourceLoader::default();
         source_factory.add_source("file", FileSourceFactory);
+        source_factory.add_source("pubsub", PubSubSourceFactory);
         #[cfg(feature = "kafka")]
         source_factory.add_source("kafka", KafkaSourceFactory);
         #[cfg(feature = "kinesis")]

--- a/quickwit/quickwit-indexing/src/source/pulsar_source.rs
+++ b/quickwit/quickwit-indexing/src/source/pulsar_source.rs
@@ -33,18 +33,15 @@ use pulsar::{
 };
 use quickwit_actors::{ActorContext, ActorExitStatus, Mailbox};
 use quickwit_config::{PulsarSourceAuth, PulsarSourceParams};
-use quickwit_metastore::checkpoint::{
-    PartitionId, Position, SourceCheckpoint, SourceCheckpointDelta,
-};
+use quickwit_metastore::checkpoint::{PartitionId, Position, SourceCheckpoint};
 use quickwit_proto::IndexUid;
 use serde_json::{json, Value as JsonValue};
 use tokio::time;
 use tracing::{debug, info, warn};
 
 use crate::actors::DocProcessor;
-use crate::models::RawDocBatch;
 use crate::source::{
-    Source, SourceActor, SourceContext, SourceExecutionContext, TypedSourceFactory,
+    BatchBuilder, Source, SourceActor, SourceContext, SourceExecutionContext, TypedSourceFactory,
 };
 
 /// Number of bytes after which we cut a new batch.
@@ -307,28 +304,6 @@ impl DeserializeMessage for PulsarMessage {
     }
 }
 
-#[derive(Debug, Default)]
-struct BatchBuilder {
-    docs: Vec<Bytes>,
-    num_bytes: u64,
-    checkpoint_delta: SourceCheckpointDelta,
-}
-
-impl BatchBuilder {
-    fn build(self) -> RawDocBatch {
-        RawDocBatch {
-            docs: self.docs,
-            checkpoint_delta: self.checkpoint_delta,
-            force_commit: false,
-        }
-    }
-
-    fn push(&mut self, doc: Bytes, num_bytes: u64) {
-        self.docs.push(doc);
-        self.num_bytes += num_bytes;
-    }
-}
-
 #[tracing::instrument(name = "pulsar-consumer", skip(pulsar))]
 /// Creates a new pulsar consumer
 async fn create_pulsar_consumer(
@@ -476,7 +451,7 @@ mod pulsar_broker_tests {
     use super::*;
     use crate::new_split_id;
     use crate::source::pulsar_source::{msg_id_from_position, msg_id_to_position};
-    use crate::source::{quickwit_supported_sources, SuggestTruncate};
+    use crate::source::{quickwit_supported_sources, RawDocBatch, SuggestTruncate};
 
     static PULSAR_URI: &str = "pulsar://localhost:6650";
     static PULSAR_ADMIN_URI: &str = "http://localhost:8081";

--- a/quickwit/quickwit-indexing/src/source/pulsar_source.rs
+++ b/quickwit/quickwit-indexing/src/source/pulsar_source.rs
@@ -173,7 +173,7 @@ impl PulsarSource {
         }
 
         let partition = PartitionId::from(topic);
-        let num_bytes = doc.len();
+        let num_bytes = doc.len() as u64;
 
         if let Some(current_position) = self.current_positions.get(&partition) {
             // We skip messages older or equal to the current recorded position.
@@ -195,9 +195,9 @@ impl PulsarSource {
             .checkpoint_delta
             .record_partition_delta(partition, current_position, msg_position)
             .context("Failed to record partition delta.")?;
-        batch.push(doc, num_bytes as u64);
+        batch.push(doc);
 
-        self.state.num_bytes_processed += num_bytes as u64;
+        self.state.num_bytes_processed += num_bytes;
         self.state.num_messages_processed += 1;
 
         Ok(())

--- a/quickwit/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit/quickwit-metastore/src/checkpoint.rs
@@ -73,8 +73,9 @@ impl From<i64> for PartitionId {
 ///
 /// The empty string can be used to represent the beginning of the source,
 /// if no position makes sense. It can be built via `Position::default()`.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum Position {
+    #[default]
     Beginning,
     Offset(Arc<String>),
 }

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -1526,8 +1526,10 @@ mod tests {
                 .await;
             assert_eq!(resp.status(), 400);
             let body = from_utf8_lossy(resp.body());
-            assert!(body
-                .contains("Quickwit currently supports multiple pipelines only for Kafka sources"));
+            assert!(body.contains(
+                "Quickwit currently supports multiple pipelines only for GCP PubSub or Kafka \
+                 sources"
+            ));
         }
     }
 


### PR DESCRIPTION
### Description

Continuation of the great work of @magnalite and following advice of @guilload 
This PR, fix the compilation/formatting issues of the previous PR and put the code behind a flag `gcp-pubsub`

Also renamed everywhere `pubsub` by `gcp-pubsub` or `GcpPubSub` to reduce confusion with other pubsub system.

### How was this PR tested?

I didnt test it. It will be added in step 3

### Next Item

  step 2: focus on supporting at-least-once delivery semantics for now and improve the current implementation as you suggested
  step 3: add unit and integration tests for this source
  step 4: test at scale (I can help with that and do so on our GCP account)
  step 5: opportunistically support exactly-once delivery semantics

