### PR TITLE
Issue/3731 lenient

### DIFF
--- a/quickwit/quickwit-query/src/elastic_query_dsl/exists_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/exists_query.rs
@@ -17,12 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::elastic_query_dsl::ConvertableToQueryAst;
 use crate::query_ast::{self, QueryAst};
 
-#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[derive(Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct ExistsQuery {
     field: String,
 }

--- a/quickwit/quickwit-query/src/elastic_query_dsl/match_phrase_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/match_phrase_query.rs
@@ -20,7 +20,7 @@
 use std::fmt;
 
 use serde::de::{self, MapAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer};
 
 use crate::elastic_query_dsl::ConvertableToQueryAst;
 use crate::query_ast::{FullTextMode, FullTextParams, FullTextQuery, QueryAst};
@@ -28,7 +28,7 @@ use crate::{MatchAllOrNone, OneFieldMap};
 
 /// `MatchQuery` as defined in
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html>
-#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[derive(Deserialize, Clone, Eq, PartialEq, Debug)]
 #[serde(
     from = "OneFieldMap<MatchPhraseQueryParamsForDeserialization>",
     into = "OneFieldMap<MatchPhraseQueryParams>"
@@ -38,7 +38,7 @@ pub(crate) struct MatchPhraseQuery {
     pub(crate) params: MatchPhraseQueryParams,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Eq, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct MatchPhraseQueryParams {
     query: String,
@@ -69,7 +69,7 @@ impl ConvertableToQueryAst for MatchPhraseQuery {
 
 // --------------
 //
-// Below is the Serialization/Deserialization code
+// Below is the Deserialization code
 // The difficulty here is to support the two following formats:
 //
 // `{"field": {"query": "my query", "default_operator": "OR"}}`
@@ -79,7 +79,7 @@ impl ConvertableToQueryAst for MatchPhraseQuery {
 //
 // The code below is adapted from solution described here: https://serde.rs/string-or-struct.html
 
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 #[serde(transparent)]
 struct MatchPhraseQueryParamsForDeserialization {
     #[serde(deserialize_with = "string_or_struct")]

--- a/quickwit/quickwit-query/src/elastic_query_dsl/multi_match.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/multi_match.rs
@@ -47,6 +47,11 @@ struct MultiMatchQueryForDeserialization {
     #[serde_as(deserialize_as = "OneOrMany<_, PreferMany>")]
     #[serde(default)]
     fields: Vec<String>,
+    // Regardless of this option Quickwit behaves in elasticsearch definition of
+    // lenient. We include this property here just to accept user queries containing
+    // this option.
+    #[serde(default, rename = "lenient")]
+    _lenient: bool,
 }
 
 fn deserialize_match_query_for_one_field(
@@ -180,6 +185,7 @@ mod tests {
                         query: "quick brown fox".to_string(),
                         operator: crate::BooleanOperand::Or,
                         zero_terms_query: Default::default(),
+                        _lenient: false,
                     },
                 }
                 .into(),
@@ -189,6 +195,7 @@ mod tests {
                         query: "quick brown fox".to_string(),
                         operator: crate::BooleanOperand::Or,
                         zero_terms_query: Default::default(),
+                        _lenient: false,
                     },
                 }
                 .into(),

--- a/quickwit/quickwit-query/src/elastic_query_dsl/phrase_prefix_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/phrase_prefix_query.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::elastic_query_dsl::one_field_map::OneFieldMap;
 use crate::elastic_query_dsl::{ConvertableToQueryAst, ElasticQueryDslInner};
@@ -30,7 +30,7 @@ fn default_max_expansions() -> u32 {
     50
 }
 
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct MatchPhrasePrefixQueryParams {
     pub query: String,

--- a/quickwit/quickwit-query/src/elastic_query_dsl/query_string_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/query_string_query.rs
@@ -17,18 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::elastic_query_dsl::ConvertableToQueryAst;
 use crate::not_nan_f32::NotNaNf32;
 use crate::query_ast::UserInputQuery;
 use crate::BooleanOperand;
 
-fn is_default<T: Default + Eq>(val: &T) -> bool {
-    *val == Default::default()
-}
-
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct QueryStringQuery {
     query: String,
@@ -36,12 +32,17 @@ pub(crate) struct QueryStringQuery {
     /// We do not support JSON field either.
     ///
     /// Note that following elastic, we do not support "string" and require an array here.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     fields: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default)]
     default_operator: BooleanOperand,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     boost: Option<NotNaNf32>,
+    // Regardless of this option Quickwit behaves in elasticsearch definition of
+    // lenient. We include this property here just to accept user queries containing
+    // this option.
+    #[serde(default, rename = "lenient")]
+    _lenient: bool,
 }
 
 impl ConvertableToQueryAst for QueryStringQuery {
@@ -68,6 +69,7 @@ mod tests {
             fields: Some(vec!["hello".to_string()]),
             default_operator: crate::BooleanOperand::Or,
             boost: None,
+            _lenient: false,
         };
         let QueryAst::UserInput(user_input_query) =
             query_string_query.convert_to_query_ast().unwrap()
@@ -88,6 +90,7 @@ mod tests {
             fields: Some(Vec::new()),
             default_operator: crate::BooleanOperand::And,
             boost: None,
+            _lenient: false,
         };
         let QueryAst::UserInput(user_input_query) =
             query_string_query.convert_to_query_ast().unwrap()
@@ -104,6 +107,7 @@ mod tests {
             fields: Some(Vec::new()),
             default_operator: crate::BooleanOperand::Or,
             boost: None,
+            _lenient: false,
         };
         let QueryAst::UserInput(user_input_query) =
             query_string_query.convert_to_query_ast().unwrap()
@@ -121,6 +125,7 @@ mod tests {
             fields: None,
             default_operator: crate::BooleanOperand::Or,
             boost: None,
+            _lenient: false,
         };
         let QueryAst::UserInput(user_input_query) =
             query_string_query.convert_to_query_ast().unwrap()

--- a/quickwit/quickwit-query/src/elastic_query_dsl/range_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/range_query.rs
@@ -19,7 +19,7 @@
 
 use std::ops::Bound;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::elastic_query_dsl::one_field_map::OneFieldMap;
 use crate::elastic_query_dsl::ConvertableToQueryAst;
@@ -27,7 +27,7 @@ use crate::not_nan_f32::NotNaNf32;
 use crate::query_ast::QueryAst;
 use crate::JsonLiteral;
 
-#[derive(Serialize, Deserialize, Debug, Default, Eq, PartialEq, Clone)]
+#[derive(Deserialize, Debug, Default, Eq, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct RangeQueryParams {
     #[serde(default)]

--- a/quickwit/quickwit-query/src/elastic_query_dsl/term_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/term_query.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::elastic_query_dsl::one_field_map::OneFieldMap;
 use crate::elastic_query_dsl::{ConvertableToQueryAst, ElasticQueryDslInner};
@@ -26,7 +26,7 @@ use crate::query_ast::{self, QueryAst};
 
 pub type TermQuery = OneFieldMap<TermQueryValue>;
 
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TermQueryValue {
     pub value: String,

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -624,7 +624,11 @@ pub async fn root_search(
 
     let query_ast: QueryAst = serde_json::from_str(&search_request.query_ast)
         .map_err(|err| SearchError::InvalidQuery(err.to_string()))?;
-    let query_ast_resolved = query_ast.parse_user_query(doc_mapper.default_search_fields())?;
+
+    let query_ast_resolved = query_ast
+        .parse_user_query(doc_mapper.default_search_fields())
+        // We convert the error to return a 400 to the user (and not a 500).
+        .map_err(|err| SearchError::InvalidQuery(err.to_string()))?;
 
     if let Some(timestamp_field) = doc_mapper.timestamp_field_name() {
         refine_start_end_timestamp_from_ast(

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0005-query_string.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0005-query_string.yaml
@@ -31,3 +31,101 @@ json:
       query: "PushEvent"
       fields: "type"
 status_code: 400
+---
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:PushEvent OR"
+      fields: []
+status_code: 400
+---
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:PushEvent OR"
+      fields: ["body"]
+      lenient: true
+# Lenient is not about the syntax.
+status_code: 400
+---
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:PushEvent"
+      fields: []
+      lenient: true
+expected:
+  hits:
+    total:
+      value: 60
+---
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:PushEvent"
+      fields: []
+      lenient: true
+expected:
+  hits:
+    total:
+      value: 60
+---
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "actor.id:1315639"
+      fields: []
+expected:
+  hits:
+    total:
+      value: 1
+---
+# This test does not work on quickwit.
+# Quickwit always act like elasticsearch's lenient mode.
+engines: [elasticsearch]
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:PushEvent OR actor.id:shouldhavebeenanumber"
+      fields: []
+      lenient: false
+status_code: 400
+---
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:PushEvent OR actor.id:shouldhavebeenanumber"
+      fields: []
+      lenient: true
+expected:
+  hits:
+    total:
+      value: 60
+---
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:PushEvent AND actor.id:shouldhavebeenanumber"
+      fields: []
+      lenient: true
+expected:
+  hits:
+    total:
+      value: 0
+

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0014-multi-match-query.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0014-multi-match-query.yaml
@@ -122,3 +122,20 @@ expected:
   hits:
     total:
       value: 1
+---
+json:
+  query:
+    multi_match:
+      type: phrase_prefix
+      query: zone of expl
+      # Yeah it makes no sense at all, but elastic accepts it.
+      lenient: true
+      fields: ["payload.commits.message"]
+---
+json:
+  query:
+    multi_match:
+      type: most_fields
+      query: the
+      lenient: false
+      fields: ["payload.commits.message", "hello"]

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/_setup.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/_setup.quickwit.yaml
@@ -16,6 +16,10 @@ json:
     timestamp_field: created_at
     mode: dynamic
     field_mappings:
+        - name: actor.id
+          type: u64
+          fast: true
+          indexed: true
         - name: created_at
           type: datetime
           fast: true


### PR DESCRIPTION
Support but ignoring lenient property in MultiMatchQuery in the ES API.

Elasticsearch has a lenient property that just avoids
returning an error when facing a type mismatch between the query and the
schema.

For instance, searching a text in a integer field.

This PR does not add this feature. This definition of lenient is
actually already Quickwit's default behavior.
This PR however makes it possible to accept the "lenient" in request
bodies.

The property value is always ignored and we always behave as lenient.