### PR TITLE
Fix broken doc link in quickwit-storage

### DIFF
--- a/quickwit/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit/quickwit-storage/src/storage_resolver.rs
@@ -130,7 +130,7 @@ pub struct StorageResolverBuilder {
 }
 
 impl StorageResolverBuilder {
-    /// Registers a [`StorageFactory`] and a [`StorageConfig`].
+    /// Registers a [`StorageFactory`].
     pub fn register<S: StorageFactory>(mut self, storage_factory: S) -> Self {
         self.per_backend_factories
             .insert(storage_factory.backend(), Box::new(storage_factory));


### PR DESCRIPTION
### Description

In #3709 there was a refactor that removed `StorageConfig` from the scope of the changed file in this commit. This was fine as the function `register` in StorageResolveBuilder did not need it anymore. However, the docs alluded to registering both a factory and a config. When running `make build-docs` for a different change I ran into this causing the command to fail. This change updates the docs so that they can build properly again.

### How was this PR tested?

I ran `make build-docs` to make sure they built and checked the output.