### PR TITLE
Add initial test for gcp pubsub indexer

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,7 @@ env:
   QW_S3_ENDPOINT: "http://localhost:4566" # Services are exposed as localhost because we are not running coverage in a container.
   QW_S3_FORCE_PATH_STYLE_ACCESS: 1
   TEST_DATABASE_URL: postgres://quickwit-dev:quickwit-dev@localhost:5432/quickwit-metastore-dev
+  PUBSUB_EMULATOR_HOST: "localhost:8681"
 
 jobs:
   test:
@@ -103,6 +104,13 @@ jobs:
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      gcp-pubsub-emulator:
+        image: thekevjames/gcloud-pubsub-emulator:7555256f2c
+        ports:
+          - "8681:8681"
+        environment:
+          - PUBSUB_PROJECT1=quickwit-emulator,emulator_topic:emulator_subscription
 
     steps:
       - uses: actions/checkout@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,17 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  gcp-pubsub-emulator:
+    # It is not an official docker image
+    # if we prefer we can build a docker from the official docker image (gcloud cli)
+    # and install the pubsub emulator https://cloud.google.com/pubsub/docs/emulator
+    image: thekevjames/gcloud-pubsub-emulator:${GCLOUD_EMULATOR:-7555256f2c}
+    ports:
+      - "${MAP_HOST_GCLOUD_EMULATOR:-127.0.0.1}:8681:8681"
+    environment:
+      # create a fake gcp project and a topic / subscription
+      - PUBSUB_PROJECT1=quickwit-emulator,emulator_topic:emulator_subscription
+
 volumes:
   localstack_data:
   postgres_data:

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2469,15 +2469,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931bedb2264cb00f914b0a6a5c304e34865c34306632d3932e0951a073e4a67d"
+dependencies = [
+ "async-trait",
+ "base64 0.21.2",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.25",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
 name = "google-cloud-default"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2248865004b6e699fddb1b562cf7dadcdd006408aa6e50e1c61dd6f3b12dc02b"
 dependencies = [
  "async-trait",
- "google-cloud-auth",
- "google-cloud-gax",
- "google-cloud-pubsub",
+ "google-cloud-auth 0.10.0",
+ "google-cloud-gax 0.14.2",
+ "google-cloud-pubsub 0.15.0",
 ]
 
 [[package]]
@@ -2497,10 +2519,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-gax"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bdaaa4bc036e8318274d1b25f0f2265b3e95418b765fd1ea1c7ef938fd69bd"
+dependencies = [
+ "google-cloud-token",
+ "http",
+ "thiserror",
+ "tokio",
+ "tokio-retry",
+ "tonic 0.9.2",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "google-cloud-googleapis"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d905d01fe815c6894b309b18a1ba152371e2e2ba7fcc81f4d22e48865b3014c"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3b24a3f57be08afc02344e693afb55e48172c9c2ab86ff3fdb8efff550e4b9"
 dependencies = [
  "prost",
  "prost-types",
@@ -2526,8 +2575,27 @@ checksum = "30dc010fd45992c6af011a506ce83186cc4aad8bdb449713cf003849cd29f464"
 dependencies = [
  "async-channel",
  "async-stream",
- "google-cloud-gax",
- "google-cloud-googleapis",
+ "google-cloud-gax 0.14.2",
+ "google-cloud-googleapis 0.9.0",
+ "google-cloud-token",
+ "prost-types",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-pubsub"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "095b104502b6e1abbad9b9768af944b9202e032dbc7f0947d3c30d4191761071"
+dependencies = [
+ "async-channel",
+ "async-stream",
+ "google-cloud-auth 0.12.0",
+ "google-cloud-gax 0.15.0",
+ "google-cloud-googleapis 0.10.0",
  "google-cloud-token",
  "prost-types",
  "thiserror",
@@ -5271,9 +5339,11 @@ dependencies = [
  "flume",
  "fnv",
  "futures",
+ "google-cloud-auth 0.12.0",
  "google-cloud-default",
- "google-cloud-googleapis",
- "google-cloud-pubsub",
+ "google-cloud-gax 0.15.0",
+ "google-cloud-googleapis 0.10.0",
+ "google-cloud-pubsub 0.18.0",
  "itertools 0.11.0",
  "libz-sys",
  "mockall",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -65,9 +65,11 @@ flume = "0.10"
 fnv = "1"
 futures = "0.3"
 futures-util = { version = "0.3.25", default-features = false }
-google-cloud-pubsub = "0.15.0"
+google-cloud-pubsub = "0.18.0"
+google-cloud-auth = "0.12.0"
+google-cloud-gax = "0.15.0"
 google-cloud-default = { version = "0.3.0", features = ["pubsub"] }
-google-cloud-googleapis = { version = "0.9.0", features = ["pubsub"] }
+google-cloud-googleapis = { version = "0.10.0", features = ["pubsub"] }
 heck = "0.4.1"
 hex = "0.4.3"
 home = "0.5.4"

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -65,11 +65,11 @@ flume = "0.10"
 fnv = "1"
 futures = "0.3"
 futures-util = { version = "0.3.25", default-features = false }
-google-cloud-pubsub = "0.18.0"
 google-cloud-auth = "0.12.0"
-google-cloud-gax = "0.15.0"
 google-cloud-default = { version = "0.3.0", features = ["pubsub"] }
+google-cloud-gax = "0.15.0"
 google-cloud-googleapis = { version = "0.10.0", features = ["pubsub"] }
+google-cloud-pubsub = "0.18.0"
 heck = "0.4.1"
 hex = "0.4.3"
 home = "0.5.4"

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -295,7 +295,7 @@ pub struct GcpPubSubSourceParams {
     pub enable_backfill_mode: bool,
     /// GCP service account credentials (`None` will use default via
     /// GOOGLE_APPLICATION_CREDENTIALS)
-    /// Path to a [`google_cloud_auth::credentials::CredentialsFile`] serialized in JSON. See also
+    /// Path to a google_cloud_auth::credentials::CredentialsFile serialized in JSON. See also
     /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>`.
     pub credentials_file: Option<String>,
     /// GCP project ID (Defaults to credentials file project ID).

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -296,7 +296,9 @@ pub struct GcpPubSubSourceParams {
     /// GCP service account credentials (`None` will use default via
     /// GOOGLE_APPLICATION_CREDENTIALS)
     /// Path to a google_cloud_auth::credentials::CredentialsFile serialized in JSON. See also
-    /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>`.
+    /// `<https://cloud.google.com/docs/authentication/application-default-credentials>` and
+    /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>` and
+    /// `<https://docs.rs/google-cloud-auth/0.12.0/google_cloud_auth/credentials/struct.CredentialsFile.html>`.
     pub credentials_file: Option<String>,
     /// GCP project ID (Defaults to credentials file project ID).
     pub project_id: Option<String>,

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -296,8 +296,8 @@ pub struct GcpPubSubSourceParams {
     /// GCP service account credentials (`None` will use default via
     /// GOOGLE_APPLICATION_CREDENTIALS)
     /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>`
-    pub credentials_file_path: Option<String>,
-    /// GCP project id. (`None` will use default like credentials_file_path)
+    pub credentials_file: Option<String>,
+    /// GCP project ID (Defaults to credentials file project ID).
     pub project_id: Option<String>,
     /// Maximum number of messages returned by a pull request (default 1,000)
     pub max_messages_per_pull: Option<i32>,

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -295,9 +295,10 @@ pub struct GcpPubSubSourceParams {
     pub enable_backfill_mode: bool,
     /// GCP service account credentials (`None` will use default via
     /// GOOGLE_APPLICATION_CREDENTIALS)
-    pub credentials: Option<String>,
-    /// Number of pull requests issued in parallel by the source (default 1)
-    pub pull_parallelism: Option<u64>,
+    /// https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically
+    pub credentials_file_path: Option<String>,
+    /// GCP project id. (`None` will use default like credentials_file_path)
+    pub project_id: Option<String>,
     /// Maximum number of messages returned by a pull request (default 1,000)
     pub max_messages_per_pull: Option<i32>,
 }

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -295,6 +295,7 @@ pub struct GcpPubSubSourceParams {
     pub enable_backfill_mode: bool,
     /// GCP service account credentials (`None` will use default via
     /// GOOGLE_APPLICATION_CREDENTIALS)
+    /// Path to a [`google_cloud_auth::credentials::CredentialsFile`] serialized in JSON. See also 
     /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>`
     pub credentials_file: Option<String>,
     /// GCP project ID (Defaults to credentials file project ID).

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -295,7 +295,7 @@ pub struct GcpPubSubSourceParams {
     pub enable_backfill_mode: bool,
     /// GCP service account credentials (`None` will use default via
     /// GOOGLE_APPLICATION_CREDENTIALS)
-    /// https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically
+    /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>`
     pub credentials_file_path: Option<String>,
     /// GCP project id. (`None` will use default like credentials_file_path)
     pub project_id: Option<String>,

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -295,8 +295,8 @@ pub struct GcpPubSubSourceParams {
     pub enable_backfill_mode: bool,
     /// GCP service account credentials (`None` will use default via
     /// GOOGLE_APPLICATION_CREDENTIALS)
-    /// Path to a [`google_cloud_auth::credentials::CredentialsFile`] serialized in JSON. See also 
-    /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>`
+    /// Path to a [`google_cloud_auth::credentials::CredentialsFile`] serialized in JSON. See also
+    /// `<https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub#automatically>`.
     pub credentials_file: Option<String>,
     /// GCP project ID (Defaults to credentials file project ID).
     pub project_id: Option<String>,

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -66,7 +66,7 @@ quickwit-storage = { workspace = true }
 
 [features]
 gcp-pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis", "dep:google-cloud-auth", "dep:google-cloud-gax"]
-gcp-pubsub-broker-tests = []
+gcp-pubsub-emulator-tests = []
 kafka = ["rdkafka", "backoff"]
 kafka-broker-tests = []
 vendored-kafka = ["kafka", "libz-sys/static", "openssl/vendored", "rdkafka/gssapi-vendored"]

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -25,11 +25,11 @@ fail = { workspace = true }
 flume = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
+google-cloud-auth = { workspace = true, optional = true }
 google-cloud-default = { workspace = true, optional = true }
+google-cloud-gax = { workspace = true, optional = true }
 google-cloud-googleapis = { workspace = true, optional = true }
 google-cloud-pubsub = { workspace = true, optional = true }
-google-cloud-auth = { workspace = true, optional = true }
-google-cloud-gax = { workspace = true, optional = true }
 itertools = { workspace = true }
 libz-sys = { workspace = true, optional = true }
 once_cell = { workspace = true }

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -28,6 +28,8 @@ futures = { workspace = true }
 google-cloud-default = { workspace = true, optional = true }
 google-cloud-googleapis = { workspace = true, optional = true }
 google-cloud-pubsub = { workspace = true, optional = true }
+google-cloud-auth = { workspace = true, optional = true }
+google-cloud-gax = { workspace = true, optional = true }
 itertools = { workspace = true }
 libz-sys = { workspace = true, optional = true }
 once_cell = { workspace = true }
@@ -63,7 +65,8 @@ quickwit-proto = { workspace = true }
 quickwit-storage = { workspace = true }
 
 [features]
-gcp-pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis"]
+gcp-pubsub = ["dep:google-cloud-pubsub", "dep:google-cloud-default", "dep:google-cloud-googleapis", "dep:google-cloud-auth", "dep:google-cloud-gax"]
+gcp-pubsub-broker-tests = []
 kafka = ["rdkafka", "backoff"]
 kafka-broker-tests = []
 vendored-kafka = ["kafka", "libz-sys/static", "openssl/vendored", "rdkafka/gssapi-vendored"]

--- a/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
+++ b/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
@@ -17,9 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{mem, fmt};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::{fmt, mem};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -338,11 +338,16 @@ mod gcp_pubsub_emulator_tests {
             project_id: Some(GCP_TEST_PROJECT.to_string()),
             ..Default::default()
         };
-        let client = Client::new(client_config.with_auth().await.unwrap()).await.unwrap();
+        let client = Client::new(client_config.with_auth().await.unwrap())
+            .await
+            .unwrap();
         let subscription_config = SubscriptionConfig::default();
 
         let created_topic = client.create_topic(topic, None, None).await.unwrap();
-        client.create_subscription(subscription, topic, subscription_config, None).await.unwrap();
+        client
+            .create_subscription(subscription, topic, subscription_config, None)
+            .await
+            .unwrap();
         created_topic.new_publisher(None)
     }
 
@@ -411,7 +416,8 @@ mod gcp_pubsub_emulator_tests {
                 ),
                 SourceCheckpoint::default(),
             )
-            .await.unwrap();
+            .await
+            .unwrap();
 
         let (doc_processor_mailbox, doc_processor_inbox) = universe.create_test_mailbox();
         let source_actor = SourceActor {

--- a/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
+++ b/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
@@ -24,16 +24,17 @@ use std::time::{Duration, Instant};
 use anyhow::Context;
 use async_trait::async_trait;
 use bytes::Bytes;
-use google_cloud_default::WithAuthExt;
+use google_cloud_auth::credentials::CredentialsFile;
+use google_cloud_gax::retry::RetrySetting;
 use google_cloud_pubsub::client::{Client, ClientConfig};
 use google_cloud_pubsub::subscription::Subscription;
 use quickwit_actors::{ActorContext, ActorExitStatus, Mailbox};
 use quickwit_common::rand::append_random_suffix;
 use quickwit_config::GcpPubSubSourceParams;
 use quickwit_metastore::checkpoint::{PartitionId, Position, SourceCheckpoint};
-use serde_json::Value as JsonValue;
+use serde_json::{json, Value as JsonValue};
 use tokio::time;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use super::SourceActor;
 use crate::actors::DocProcessor;
@@ -43,7 +44,6 @@ use crate::source::{
 
 const BATCH_NUM_BYTES_LIMIT: u64 = 5_000_000;
 const DEFAULT_MAX_MESSAGES_PER_PULL: i32 = 1_000;
-// const DEFAULT_PULL_PARALLELISM: u64 = 1;
 
 pub struct GcpPubSubSourceFactory;
 
@@ -69,8 +69,10 @@ pub struct GcpPubSubSourceState {
     num_messages_processed: u64,
     /// Current position of the source, i.e. the position of the last message processed.
     current_position: Position,
-    /// Whether the subscription is empty.
-    subscription_is_empty: bool,
+    // Number of invalid messages, i.e., that were empty or could not be parsed.
+    num_invalid_messages: u64,
+    /// Number of time we looped without getting a single message
+    num_consecutive_empty_batch: u64,
 }
 
 pub struct GcpPubSubSource {
@@ -80,8 +82,6 @@ pub struct GcpPubSubSource {
     state: GcpPubSubSourceState,
     backfill_mode_enabled: bool,
     partition_id: PartitionId,
-    // Parallelism will be enabled in next PR
-    // pull_parallelism: u64,
     max_messages_per_pull: i32,
 }
 
@@ -92,14 +92,24 @@ impl GcpPubSubSource {
     ) -> anyhow::Result<Self> {
         let subscription_name = params.subscription;
         let backfill_mode_enabled = params.enable_backfill_mode;
-        // let pull_parallelism = params.pull_parallelism.unwrap_or(DEFAULT_PULL_PARALLELISM);
         let max_messages_per_pull = params
             .max_messages_per_pull
             .unwrap_or(DEFAULT_MAX_MESSAGES_PER_PULL);
-        let client_config = ClientConfig::default()
-            .with_auth()
-            .await
-            .context("Failed to authenticate GCP PubSub source.")?;
+
+        let mut client_config: ClientConfig = match params.credentials_file_path {
+            Some(file_path) => {
+                let cred: CredentialsFile =
+                    CredentialsFile::new_from_file(file_path).await.unwrap();
+                ClientConfig::default().with_credentials(cred).await
+            }
+            None => ClientConfig::default().with_auth().await,
+        }
+        .context("Failed to create GCP PubSub client.")?;
+
+        if params.project_id.is_some() {
+            client_config.project_id = params.project_id
+        }
+
         let client = Client::new(client_config)
             .await
             .context("Failed to create GCP PubSub client.")?;
@@ -113,9 +123,12 @@ impl GcpPubSubSource {
             source_id=%ctx.source_config.source_id,
             subscription=%subscription_name,
             max_messages_per_pull=%max_messages_per_pull,
-            // parallelism=%pull_parallelism,
             "Starting GCP PubSub source."
         );
+
+        if !subscription.exists(Some(RetrySetting::default())).await? {
+            anyhow::bail!("gcp pubsub subscription {subscription_name} does not exist");
+        }
 
         Ok(Self {
             ctx,
@@ -124,13 +137,12 @@ impl GcpPubSubSource {
             state: GcpPubSubSourceState::default(),
             backfill_mode_enabled,
             partition_id,
-            // pull_parallelism,
             max_messages_per_pull,
         })
     }
 
     fn should_exit(&self) -> bool {
-        self.backfill_mode_enabled && self.state.subscription_is_empty
+        self.backfill_mode_enabled && self.state.num_consecutive_empty_batch > 3
     }
 }
 
@@ -145,13 +157,15 @@ impl Source for GcpPubSubSource {
         let mut batch: BatchBuilder = BatchBuilder::default();
         let deadline = time::sleep(*quickwit_actors::HEARTBEAT / 2);
         tokio::pin!(deadline);
-
-        // TODO: lets add parallelism support in next PR
         // TODO: ensure we ACK the message after being commit: at least once
         // TODO: ensure we increase_ack_deadline for the items
         loop {
             tokio::select! {
-                _ = self.pull_message_batch(&mut batch) => {
+                resp = self.pull_message_batch(&mut batch) => {
+                    if let Err(err) = resp {
+                        warn!("failed to pull message {:?}", err);
+                    }
+
                     if batch.num_bytes >= BATCH_NUM_BYTES_LIMIT {
                         break;
                     }
@@ -162,6 +176,13 @@ impl Source for GcpPubSubSource {
             }
             ctx.record_progress();
         }
+
+        if batch.num_bytes > 0 {
+            self.state.num_consecutive_empty_batch = 0
+        } else {
+            self.state.num_consecutive_empty_batch += 1
+        }
+
         // TODO: need to wait for all the id to be ack for at_least_once
         if self.should_exit() {
             info!(subscription=%self.subscription_name, "Reached end of subscription.");
@@ -197,7 +218,15 @@ impl Source for GcpPubSubSource {
     }
 
     fn observable_state(&self) -> JsonValue {
-        JsonValue::Object(Default::default())
+        json!({
+            "index_id": self.ctx.index_uid.index_id(),
+            "source_id": self.ctx.source_config.source_id,
+            "subscription_name": self.subscription_name,
+            "num_bytes_processed": self.state.num_bytes_processed,
+            "num_messages_processed": self.state.num_messages_processed,
+            "num_invalid_messages": self.state.num_invalid_messages,
+            "num_consecutive_empty_batch": self.state.num_consecutive_empty_batch,
+        })
     }
 }
 
@@ -210,7 +239,6 @@ impl GcpPubSubSource {
             .context("Failed to pull messages from subscription.")?;
 
         let Some(last_message) = messages.last() else {
-            self.state.subscription_is_empty = true;
             return Ok(());
         };
         let message_id = last_message.message.message_id.clone();
@@ -225,8 +253,12 @@ impl GcpPubSubSource {
             message.ack().await?; // TODO: remove ACK here when doing at least once
             self.state.num_messages_processed += 1;
             self.state.num_bytes_processed += message.message.data.len() as u64;
-            let doc = Bytes::from(message.message.data);
-            batch.push(doc);
+            let doc: Bytes = Bytes::from(message.message.data);
+            if doc.is_empty() {
+                self.state.num_invalid_messages += 1;
+            } else {
+                batch.push(doc);
+            }
         }
         let to_position = Position::from(format!(
             "{}:{message_id}:{publish_timestamp_millis}",
@@ -239,5 +271,172 @@ impl GcpPubSubSource {
             .record_partition_delta(self.partition_id.clone(), from_position, to_position)
             .context("Failed to record partition delta.")?;
         Ok(())
+    }
+}
+
+// TODO: first implementation of the test
+// After we need to ensure at_least_once and concurrent pipeline
+#[cfg(all(test, feature = "gcp-pubsub-broker-tests"))]
+mod gcp_pubsub_broker_tests {
+    use std::env::var;
+    use std::num::NonZeroUsize;
+    use std::path::PathBuf;
+
+    use google_cloud_googleapis::pubsub::v1::PubsubMessage;
+    use google_cloud_pubsub::publisher::Publisher;
+    use google_cloud_pubsub::subscription::SubscriptionConfig;
+    use quickwit_actors::Universe;
+    use quickwit_config::{SourceConfig, SourceInputFormat, SourceParams};
+    use quickwit_metastore::metastore_for_test;
+    use quickwit_proto::IndexUid;
+    use serde_json::json;
+
+    use super::*;
+    use crate::models::RawDocBatch;
+    use crate::source::quickwit_supported_sources;
+
+    static GCP_TEST_PROJECT: &str = "quickwit-emulator";
+
+    fn get_source_config(subscription: &str) -> SourceConfig {
+        var("PUBSUB_EMULATOR_HOST").expect("test should be run with PUBSUB_EMULATOR_HOST env");
+        let source_id = append_random_suffix("test-gcp-pubsub-source--source");
+        SourceConfig {
+            source_id,
+            desired_num_pipelines: NonZeroUsize::new(1).unwrap(),
+            max_num_pipelines_per_indexer: NonZeroUsize::new(1).unwrap(),
+            enabled: true,
+            source_params: SourceParams::GcpPubSub(GcpPubSubSourceParams {
+                project_id: Some(GCP_TEST_PROJECT.to_string()),
+                enable_backfill_mode: true,
+                subscription: subscription.to_string(),
+                credentials_file_path: None,
+                max_messages_per_pull: None,
+            }),
+            transform_config: None,
+            input_format: SourceInputFormat::Json,
+        }
+    }
+
+    async fn create_topic_and_subscription(
+        topic: &str,
+        subscription: &str,
+    ) -> anyhow::Result<Publisher> {
+        let conf = google_cloud_pubsub::client::ClientConfig {
+            project_id: Some(GCP_TEST_PROJECT.to_string()),
+            ..Default::default()
+        };
+        let c = Client::new(conf.with_auth().await?).await?;
+        let subscription_config = SubscriptionConfig::default();
+
+        let created_topic = c.create_topic(topic, None, None).await?;
+        c.create_subscription(subscription, topic, subscription_config, None)
+            .await?;
+
+        anyhow::Ok(created_topic.new_publisher(None))
+    }
+
+    #[tokio::test]
+    async fn test_gcp_source_invalid_subscription() -> anyhow::Result<()> {
+        quickwit_common::setup_logging_for_tests();
+        let sub = append_random_suffix("test-gcp-pubsub-source--sub");
+        let source_config = get_source_config(&sub);
+
+        let index_id = append_random_suffix("test-gcp-pubsub-source--process-message--index");
+        let index_uid = IndexUid::new(&index_id);
+        let metastore = metastore_for_test();
+        let params = if let SourceParams::GcpPubSub(params) = source_config.clone().source_params {
+            params
+        } else {
+            unreachable!()
+        };
+        let ctx = SourceExecutionContext::for_test(
+            metastore,
+            index_uid,
+            PathBuf::from("./queues"),
+            source_config,
+        );
+        match GcpPubSubSource::try_new(ctx, params).await {
+            Err(_) => anyhow::Ok(()),
+            _ => Err(anyhow::anyhow!(
+                "gcp pubsub should fail to create when subscription does not exist"
+            )),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gcp_source() -> anyhow::Result<()> {
+        quickwit_common::setup_logging_for_tests();
+        let universe = Universe::with_accelerated_time();
+
+        let topic = append_random_suffix("test-gcp-pubsub-source--topic");
+        let subscription = append_random_suffix("test-gcp-pubsub-source--sub");
+        let publisher = create_topic_and_subscription(&topic, &subscription).await?;
+
+        let source_config = get_source_config(&subscription);
+        let source_id = source_config.source_id.clone();
+
+        let source_loader = quickwit_supported_sources();
+        let metastore = metastore_for_test();
+        let index_id: String = append_random_suffix("test-gcp-pubsub-source--index");
+        let index_uid = IndexUid::new(&index_id);
+
+        let mut msgs = Vec::new();
+        for i in 0..6 {
+            let msg = PubsubMessage {
+                data: format!("Message {}", i).into(),
+                ..Default::default()
+            };
+            msgs.push(msg);
+        }
+
+        let publish_resp = publisher.publish_bulk(msgs).await;
+        for val in publish_resp {
+            val.get().await?;
+        }
+
+        let source = source_loader
+            .load_source(
+                SourceExecutionContext::for_test(
+                    metastore,
+                    index_uid,
+                    PathBuf::from("./queues"),
+                    source_config,
+                ),
+                SourceCheckpoint::default(),
+            )
+            .await?;
+
+        let (doc_processor_mailbox, doc_processor_inbox) = universe.create_test_mailbox();
+        let source_actor = SourceActor {
+            source,
+            doc_processor_mailbox: doc_processor_mailbox.clone(),
+        };
+        let (_source_mailbox, source_handle) = universe.spawn_builder().spawn(source_actor);
+        let (exit_status, exit_state) = source_handle.join().await;
+        assert!(exit_status.is_success());
+
+        let messages: Vec<RawDocBatch> = doc_processor_inbox.drain_for_test_typed();
+        assert_eq!(messages.len(), 1);
+        let expected_docs = vec![
+            "Message 0",
+            "Message 1",
+            "Message 2",
+            "Message 3",
+            "Message 4",
+            "Message 5",
+        ];
+        assert_eq!(messages[0].docs, expected_docs);
+        let expected_state: JsonValue = json!({
+            "index_id": index_id,
+            "source_id": source_id,
+            "subscription_name": subscription,
+            "num_bytes_processed": 54,
+            "num_messages_processed": 6,
+            "num_invalid_messages": 0,
+            "num_consecutive_empty_batch": 4,
+        });
+        assert_eq!(exit_state, expected_state);
+
+        anyhow::Ok(())
     }
 }


### PR DESCRIPTION
### Description

**PR is still in draft, few things I need to do before review**

Before adding new functionality to gcp pubsub indexer (`at_least_once` support), we want to be sure that basics functionality are working.
As suggested in https://github.com/quickwit-oss/quickwit/pull/3720#issuecomment-1675038458 this PR is adding basic integration test. 

- [x] test: client return error if subscription does not exist
- [x] test: ensure we process message and exit when backfill_mode

We are also doing small improvement: upgrade the dependency, better support for GCP auth.

### How was this PR tested?

This pr is adding integration test :) 
