### PR TITLE
Prevent `Observe` messages from stacking up

### DIFF
--- a/quickwit/quickwit-actors/src/actor_context.rs
+++ b/quickwit/quickwit-actors/src/actor_context.rs
@@ -68,7 +68,7 @@ pub struct ActorContextInner<A: Actor> {
     actor_state: AtomicState,
     backpressure_micros_counter_opt: Option<IntCounter>,
     observable_state_tx: watch::Sender<A::ObservableState>,
-    // Counter that gets incremented after each observation.
+    // Boolean marking the presence of an observe message in the actor's high priority queue.
     observe_enqueued: AtomicBool,
 }
 

--- a/quickwit/quickwit-actors/src/actor_context.rs
+++ b/quickwit/quickwit-actors/src/actor_context.rs
@@ -21,6 +21,7 @@ use std::convert::Infallible;
 use std::fmt;
 use std::future::Future;
 use std::ops::Deref;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -67,6 +68,8 @@ pub struct ActorContextInner<A: Actor> {
     actor_state: AtomicState,
     backpressure_micros_counter_opt: Option<IntCounter>,
     observable_state_tx: watch::Sender<A::ObservableState>,
+    // Counter that gets incremented after each observation.
+    observe_enqueued: AtomicBool,
 }
 
 impl<A: Actor> ActorContext<A> {
@@ -84,6 +87,7 @@ impl<A: Actor> ActorContext<A> {
                 actor_state: AtomicState::default(),
                 observable_state_tx,
                 backpressure_micros_counter_opt,
+                observe_enqueued: AtomicBool::new(false),
             }
             .into(),
         }
@@ -203,8 +207,16 @@ impl<A: Actor> ActorContext<A> {
         self.actor_state.resume();
     }
 
+    /// Sets the queue as observed and returns the previous value.
+    /// This method is used to make sure we do not have Observe messages
+    /// stacking up in the observe queue.
+    pub(crate) fn set_observe_enqueued_and_return_previous(&self) -> bool {
+        self.observe_enqueued.swap(true, Ordering::Relaxed)
+    }
+
     pub(crate) fn observe(&self, actor: &mut A) -> A::ObservableState {
         let obs_state = actor.observable_state();
+        self.inner.observe_enqueued.store(false, Ordering::Relaxed);
         let _ = self.observable_state_tx.send(obs_state.clone());
         obs_state
     }

--- a/quickwit/quickwit-actors/src/actor_handle.rs
+++ b/quickwit/quickwit-actors/src/actor_handle.rs
@@ -144,8 +144,33 @@ impl<A: Actor> ActorHandle<A> {
     ///
     /// The observation will be scheduled as a high priority message, therefore it will be executed
     /// after the current active message and the current command queue have been processed.
+    ///
+    /// This method does not do anything to avoid Observe messages from stacking up.
+    /// In supervisors, prefer using `refresh_observation`.
     pub async fn observe(&self) -> Observation<A::ObservableState> {
         self.observe_with_priority(Priority::High).await
+    }
+
+    // Triggers an observation.
+    // It is scheduled as a high priority
+    // message, and will hence be executed as soon as possible.
+    //
+    // This method does not enqueue an Observe requests if one is already enqueue.
+    //
+    // The resulting observation can eventually be accessible using the
+    // observation watch channel.
+    //
+    // This function returning does NOT mean that the observation was executed.
+    pub fn refresh_observe(&self) {
+        let observation_already_enqueued = self
+            .actor_context
+            .set_observe_enqueued_and_return_previous();
+        if !observation_already_enqueued {
+            let _ = self
+                .actor_context
+                .mailbox()
+                .send_message_with_high_priority(Observe);
+        }
     }
 
     async fn observe_with_priority(&self, priority: Priority) -> Observation<A::ObservableState> {
@@ -268,6 +293,9 @@ impl<A: Actor> ActorHandle<A> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
     use async_trait::async_trait;
 
     use super::*;
@@ -350,5 +378,55 @@ mod tests {
         assert!(matches!(exit_status, ActorExitStatus::DownstreamClosed));
         assert!(matches!(count, 1)); //< Upon panick we cannot get a post mortem state.
         Ok(())
+    }
+
+    #[derive(Default)]
+    struct ObserveActor {
+        observe: AtomicU32,
+    }
+
+    #[async_trait]
+    impl Actor for ObserveActor {
+        type ObservableState = u32;
+
+        fn observable_state(&self) -> u32 {
+            self.observe.fetch_add(1, Ordering::Relaxed)
+        }
+
+        async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
+            ctx.send_self_message(YieldLoop).await?;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct YieldLoop;
+
+    #[async_trait]
+    impl Handler<YieldLoop> for ObserveActor {
+        type Reply = ();
+        async fn handle(
+            &mut self,
+            _: YieldLoop,
+            ctx: &ActorContext<Self>,
+        ) -> Result<Self::Reply, ActorExitStatus> {
+            ctx.sleep(Duration::from_millis(25)).await; // OBSERVE_TIMEOUT.mul_f32(10.0f32)).await;
+            ctx.send_self_message(YieldLoop).await?;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_observation_debounce() {
+        // TODO investigate why Universe::with_accelerated_time() does not work here.
+        let universe = Universe::new();
+        let (_, actor_handle) = universe.spawn_builder().spawn(ObserveActor::default());
+        for _ in 0..10 {
+            let _ = actor_handle.refresh_observe();
+            universe.sleep(Duration::from_millis(10)).await;
+        }
+        let (_last_obs, num_obs) = actor_handle.quit().await;
+        assert!(num_obs < 8);
+        universe.assert_quit().await;
     }
 }

--- a/quickwit/quickwit-actors/src/actor_handle.rs
+++ b/quickwit/quickwit-actors/src/actor_handle.rs
@@ -151,16 +151,17 @@ impl<A: Actor> ActorHandle<A> {
         self.observe_with_priority(Priority::High).await
     }
 
-    // Triggers an observation.
-    // It is scheduled as a high priority
-    // message, and will hence be executed as soon as possible.
-    //
-    // This method does not enqueue an Observe requests if one is already enqueue.
-    //
-    // The resulting observation can eventually be accessible using the
-    // observation watch channel.
-    //
-    // This function returning does NOT mean that the observation was executed.
+    /// Triggers an observation.
+    /// It is scheduled as a high priority
+    /// message, and will hence be executed as soon as possible.
+    ///
+    /// This method does not enqueue an Observe request if there is already one in
+    /// the queue.
+    ///
+    /// The resulting observation can eventually be accessible using the
+    /// observation watch channel.
+    ///
+    /// This function returning does NOT mean that the observation was executed.
     pub fn refresh_observe(&self) {
         let observation_already_enqueued = self
             .actor_context
@@ -422,7 +423,7 @@ mod tests {
         let universe = Universe::new();
         let (_, actor_handle) = universe.spawn_builder().spawn(ObserveActor::default());
         for _ in 0..10 {
-            let _ = actor_handle.refresh_observe();
+            actor_handle.refresh_observe();
             universe.sleep(Duration::from_millis(10)).await;
         }
         let (_last_obs, num_obs) = actor_handle.quit().await;

--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -253,7 +253,7 @@ impl<A: Actor> Mailbox<A> {
         }
     }
 
-    pub(crate) fn send_message_with_high_priority<M>(
+    pub fn send_message_with_high_priority<M>(
         &self,
         message: M,
     ) -> Result<oneshot::Receiver<A::Reply>, SendError>


### PR DESCRIPTION
# Prevents Observe message emitted by Supervisors from stacking up

This introduce a refresh observation method, that does not wait
for anything but just triggers an eventual refresh of the last
observation.

This method includes debouncing logic to avoid stacking up messages.

We then use it in supervisors, which the other merit of making the
Supervise handler return much faster.

Before we were waiting for the observation to timeout.

Closes https://github.com/quickwit-oss/quickwit/issues/3485