### PR TITLE
Implement ingest source v2

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
 
 [[package]]
 name = "anstyle-parse"
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d495b6dc0184693324491a5ac05f559acc97bf937ab31d7a1c33dd0016be6d2b"
+checksum = "bb42b2197bf15ccb092b62c74515dbd8b86d0effd934795f6687c93b6e679a2c"
 dependencies = [
  "flate2",
  "futures-core",
@@ -290,7 +290,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.26",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -537,7 +537,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2",
- "time 0.3.26",
+ "time",
  "tracing",
 ]
 
@@ -695,7 +695,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.26",
+ "time",
 ]
 
 [[package]]
@@ -775,7 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b0f0eea648347e40f5f7f7e6bfea4553bcefad0fbf52044ea339e5ce3aba61"
 dependencies = [
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "dyn-clone",
  "futures",
@@ -790,7 +790,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "time 0.3.26",
+ "time",
  "url",
  "uuid",
 ]
@@ -813,7 +813,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2",
- "time 0.3.26",
+ "time",
  "url",
  "uuid",
 ]
@@ -833,7 +833,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.26",
+ "time",
  "url",
  "uuid",
 ]
@@ -881,9 +881,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64-simd"
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-unit"
@@ -1188,16 +1188,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.27"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -1253,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "cidr-utils"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdfa36f04861d39453affe1cf084ce2d6554021a84eb6f31ebdeafb6fb92a01c"
+checksum = "2315f7119b7146d6a883de6acd63ddf96071b5f79d9d98d2adaa84d749f6abf1"
 dependencies = [
  "debug-helper",
  "num-bigint",
@@ -1276,18 +1275,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.1"
+version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8d502cbaec4595d2e7d5f61e318f05417bd2b66fdc3809498f0d3fdf0bea27"
+checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5891c7bc0edb3e1c2204fc5e94009affabeb1821c9e5fdc3959536c5c0bb984d"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1670,7 +1669,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -1692,7 +1691,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -1917,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "elasticsearch-dsl"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e17a6bd2ee53e64da09f261bed7215235b7adfe3accbd20f20d66b91f2e7fb"
+checksum = "2769dbd50c1e0d74c0685a8b41f2dcc9cb0451fd27b095cab3d2c3301ced4ba8"
 dependencies = [
  "chrono",
  "num-traits",
@@ -2041,7 +2040,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -2167,6 +2166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2251,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
- "rustix 0.38.10",
+ "rustix 0.38.13",
  "windows-sys 0.48.0",
 ]
 
@@ -2338,7 +2343,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -2443,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb6624c70caf330298b84a9ad1537ee7a5de788a5b9a06a3bbe206260943011"
 dependencies = [
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "google-cloud-metadata",
  "google-cloud-token",
  "home",
@@ -2452,7 +2457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tracing",
  "urlencoding",
@@ -2465,7 +2470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "931bedb2264cb00f914b0a6a5c304e34865c34306632d3932e0951a073e4a67d"
 dependencies = [
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "google-cloud-metadata",
  "google-cloud-token",
  "home",
@@ -2474,7 +2479,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tracing",
  "urlencoding",
@@ -2680,12 +2685,11 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.4",
  "bytes",
  "headers-core",
  "http",
@@ -3072,7 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.10",
+ "rustix 0.38.13",
  "windows-sys 0.48.0",
 ]
 
@@ -3130,7 +3134,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "pem",
  "ring",
  "serde",
@@ -3201,9 +3205,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libm"
@@ -3475,9 +3479,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -3511,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
  "hashbrown 0.14.0",
 ]
@@ -3598,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memmap2"
@@ -3917,9 +3921,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oauth2"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a6e2a2b13a56ebeabba9142f911745be6456163fd6c3d361274ebcd891a80c"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -3937,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -3961,9 +3965,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oneshot"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc22d22931513428ea6cc089e942d38600e3d00976eef8c86de6b8a3aadec6eb"
+checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
 dependencies = [
  "loom",
 ]
@@ -4024,7 +4028,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -4035,18 +4039,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.27.0+1.1.1v"
+version = "300.1.3+3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
+checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.92"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
@@ -4184,7 +4188,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -4396,7 +4400,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -4565,9 +4569,9 @@ checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "postcard"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ee729232311d3cd113749948b689627618133b1c5012b77342c1950b25eaeb"
+checksum = "d534c6e61df1c7166e636ca612d9820d486fe96ddad37f7abc671517b297488e"
 dependencies = [
  "cobs",
  "serde",
@@ -4652,12 +4656,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -4705,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -4984,10 +4988,10 @@ dependencies = [
  "thousands",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-util",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tonic 0.9.2",
  "tracing",
  "tracing-opentelemetry",
@@ -5011,7 +5015,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
@@ -5026,13 +5030,13 @@ version = "0.6.3"
 dependencies = [
  "anyhow",
  "heck",
- "prettyplease 0.2.12",
+ "prettyplease 0.2.15",
  "proc-macro2",
  "prost",
  "prost-build",
  "quote",
  "serde",
- "syn 2.0.29",
+ "syn 2.0.34",
  "tonic-build",
 ]
 
@@ -5120,7 +5124,7 @@ dependencies = [
  "serde_with 3.3.0",
  "serde_yaml 0.9.25",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tracing",
  "utoipa",
  "vrl",
@@ -5156,7 +5160,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
@@ -5173,7 +5177,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tantivy",
- "time 0.3.26",
+ "time",
  "time-fmt",
 ]
 
@@ -5193,7 +5197,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tracing",
 ]
@@ -5203,7 +5207,7 @@ name = "quickwit-doc-mapper"
 version = "0.6.3"
 dependencies = [
  "anyhow",
- "base64 0.21.3",
+ "base64 0.21.4",
  "criterion",
  "dyn-clone",
  "fnv",
@@ -5227,7 +5231,7 @@ dependencies = [
  "siphasher",
  "tantivy",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tracing",
  "typetag",
  "utoipa",
@@ -5259,7 +5263,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5318,7 +5322,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5402,7 +5406,7 @@ version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "itertools 0.11.0",
  "once_cell",
  "prost",
@@ -5423,7 +5427,7 @@ dependencies = [
  "serde_json",
  "tantivy",
  "tempfile",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
@@ -5459,7 +5463,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5474,7 +5478,7 @@ dependencies = [
  "proc-macro2",
  "quickwit-macros-impl",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -5484,7 +5488,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -5515,7 +5519,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tower",
@@ -5531,7 +5535,7 @@ version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "once_cell",
  "prost",
  "quickwit-actors",
@@ -5586,7 +5590,7 @@ name = "quickwit-query"
 version = "0.6.3"
 dependencies = [
  "anyhow",
- "base64 0.21.3",
+ "base64 0.21.4",
  "criterion",
  "fnv",
  "hex",
@@ -5602,7 +5606,7 @@ dependencies = [
  "serde_with 3.3.0",
  "tantivy",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tracing",
  "whichlang",
 ]
@@ -5638,7 +5642,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff 2.0.2",
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "chitchat",
  "fnv",
@@ -5733,7 +5737,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tower",
@@ -5759,7 +5763,7 @@ dependencies = [
  "azure_core",
  "azure_storage",
  "azure_storage_blobs",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "fnv",
  "futures",
@@ -6002,13 +6006,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.7",
+ "regex-automata 0.3.8",
  "regex-syntax 0.7.5",
 ]
 
@@ -6023,9 +6027,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6059,7 +6063,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -6206,7 +6210,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.29",
+ "syn 2.0.34",
  "walkdir",
 ]
 
@@ -6283,14 +6287,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.10"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.5",
+ "linux-raw-sys 0.4.7",
  "windows-sys 0.48.0",
 ]
 
@@ -6314,7 +6318,7 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.5",
  "sct",
 ]
 
@@ -6336,14 +6340,14 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.2"
+version = "0.100.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
+checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
 dependencies = [
  "ring",
  "untrusted",
@@ -6351,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",
@@ -6497,14 +6501,14 @@ checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -6592,7 +6596,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -6600,7 +6604,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros 3.3.0",
- "time 0.3.26",
+ "time",
 ]
 
 [[package]]
@@ -6624,7 +6628,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -6754,7 +6758,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.26",
+ "time",
 ]
 
 [[package]]
@@ -6827,9 +6831,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -6862,11 +6866,11 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
+checksum = "6b7b278788e7be4d0d29c0f39497a0eef3fba6bbc8e70d8bf7fde46edeaa9e85"
 dependencies = [
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "nom",
  "unicode_categories",
 ]
@@ -6920,7 +6924,7 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6974,7 +6978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca69bf415b93b60b80dc8fda3cb4ef52b2336614d8da2de5456cc942a110482"
 dependencies = [
  "atoi",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "bytes",
@@ -7005,7 +7009,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -7017,7 +7021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0db2df1b8731c3651e204629dd55e52adbae0462fa1bdcbed56a2302c18181e"
 dependencies = [
  "atoi",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "byteorder",
  "crc",
@@ -7045,7 +7049,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
- "time 0.3.26",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -7068,7 +7072,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "time 0.3.26",
+ "time",
  "tracing",
  "url",
 ]
@@ -7100,10 +7104,11 @@ dependencies = [
 
 [[package]]
 name = "stringprep"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3737bde7edce97102e0e2b15365bf7a20bfdb5f60f4f9e8d7004258a51a8da"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
 dependencies = [
+ "finl_unicode",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -7142,9 +7147,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "88ec6cdb6a4c16306eccf52ccd8d492e4ab64705a15a5016acb205251001bf72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7200,7 +7205,7 @@ dependencies = [
  "aho-corasick",
  "arc-swap",
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bitpacking",
  "byteorder",
  "census",
@@ -7240,7 +7245,7 @@ dependencies = [
  "tantivy-tokenizer-api",
  "tempfile",
  "thiserror",
- "time 0.3.26",
+ "time",
  "uuid",
  "winapi 0.3.9",
  "zstd 0.12.4",
@@ -7278,7 +7283,7 @@ dependencies = [
  "byteorder",
  "ownedbytes",
  "serde",
- "time 0.3.26",
+ "time",
 ]
 
 [[package]]
@@ -7353,7 +7358,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.10",
+ "rustix 0.38.13",
  "windows-sys 0.48.0",
 ]
 
@@ -7385,22 +7390,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -7452,17 +7457,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
@@ -7489,7 +7483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bfd61bca99323ce96911bd2c443259115460615e44f1d449cee8cb3831a1dd"
 dependencies = [
  "thiserror",
- "time 0.3.26",
+ "time",
 ]
 
 [[package]]
@@ -7549,7 +7543,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -7573,7 +7567,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -7671,9 +7665,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -7692,9 +7686,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -7744,7 +7738,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "flate2",
  "futures-core",
@@ -7803,9 +7797,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
  "bitflags 2.4.0",
@@ -7855,7 +7849,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -7916,7 +7910,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.26",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -7958,9 +7952,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typetag"
@@ -7983,7 +7977,7 @@ checksum = "bfc13d450dc4a695200da3074dacf43d449b968baee95e341920e47f61a3b40f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -8033,9 +8027,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -8155,7 +8149,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
 ]
 
 [[package]]
@@ -8289,7 +8283,7 @@ source = "git+https://github.com/vectordotdev/vrl?rev=v0.3.0#113005bcee6cd7b5ea0
 dependencies = [
  "aes",
  "base16",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "cbc",
  "cfb-mode",
@@ -8383,9 +8377,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -8439,12 +8433,6 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -8470,7 +8458,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
  "wasm-bindgen-shared",
 ]
 
@@ -8504,7 +8492,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.34",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8554,7 +8542,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki 0.100.2",
+ "rustls-webpki 0.100.3",
 ]
 
 [[package]]
@@ -8563,7 +8551,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.5",
 ]
 
 [[package]]
@@ -8574,13 +8562,14 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix 0.38.13",
 ]
 
 [[package]]
@@ -8805,7 +8794,7 @@ checksum = "c6f71803d3a1c80377a06221e0530be02035d5b3e854af56c6ece7ac20ac441d"
 dependencies = [
  "assert-json-diff 2.0.2",
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "deadpool",
  "futures",
  "futures-timer",
@@ -8896,7 +8885,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.26",
+ "time",
  "zstd 0.11.2+zstd.1.5.2",
 ]
 

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4972,6 +4972,7 @@ dependencies = [
  "quickwit-doc-mapper",
  "quickwit-index-management",
  "quickwit-indexing",
+ "quickwit-ingest",
  "quickwit-metastore",
  "quickwit-proto",
  "quickwit-rest-client",

--- a/quickwit/quickwit-actors/src/actor_handle.rs
+++ b/quickwit/quickwit-actors/src/actor_handle.rs
@@ -188,7 +188,7 @@ impl<A: Actor> ActorHandle<A> {
                 return self.wait_for_observable_state_callback(oneshot_rx).await;
             } else {
                 error!(
-                    actor_id = self.actor_context.actor_instance_id(),
+                    actor_id=%self.actor_context.actor_instance_id(),
                     "Failed to send observe message"
                 );
             }

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -58,10 +58,11 @@ quickwit-actors = { workspace = true }
 quickwit-cluster = { workspace = true }
 quickwit-common = { workspace = true }
 quickwit-config = { workspace = true }
-quickwit-index-management = { workspace = true }
 quickwit-directories = { workspace = true }
 quickwit-doc-mapper = { workspace = true }
+quickwit-index-management = { workspace = true }
 quickwit-indexing = { workspace = true }
+quickwit-ingest = { workspace = true }
 quickwit-metastore = { workspace = true }
 quickwit-proto = { workspace = true }
 quickwit-rest-client = { workspace = true }

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -47,6 +47,7 @@ use quickwit_indexing::models::{
     DetachIndexingPipeline, DetachMergePipeline, IndexingStatistics, SpawnPipeline,
 };
 use quickwit_indexing::IndexingPipeline;
+use quickwit_ingest::IngesterPool;
 use quickwit_metastore::Metastore;
 use quickwit_proto::search::SearchResponse;
 use quickwit_search::{single_node_search, SearchResponseRest};
@@ -457,6 +458,7 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
         cluster,
         metastore,
         None,
+        IngesterPool::default(),
         storage_resolver,
     )
     .await?;
@@ -586,6 +588,7 @@ pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
         cluster,
         metastore,
         None,
+        IngesterPool::default(),
         storage_resolver,
     )
     .await?;

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -45,6 +45,9 @@ pub const INGEST_API_SOURCE_ID: &str = "_ingest-api-source";
 /// Reserved source ID used for native Quickwit ingest.
 pub const INGEST_SOURCE_ID: &str = "_ingest-source";
 
+pub const RESERVED_SOURCE_IDS: &[&str] =
+    &[CLI_INGEST_SOURCE_ID, INGEST_API_SOURCE_ID, INGEST_SOURCE_ID];
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(into = "VersionedSourceConfig")]
 #[serde(try_from = "VersionedSourceConfig")]
@@ -122,8 +125,8 @@ impl SourceConfig {
     pub fn ingest_default() -> Self {
         Self {
             source_id: INGEST_SOURCE_ID.to_string(),
-            max_num_pipelines_per_indexer: NonZeroUsize::new(1).unwrap(),
-            desired_num_pipelines: NonZeroUsize::new(1).unwrap(),
+            max_num_pipelines_per_indexer: NonZeroUsize::new(1).expect("1 should be non-zero"),
+            desired_num_pipelines: NonZeroUsize::new(1).expect("1 should be non-zero"),
             enabled: false,
             source_params: SourceParams::Ingest,
             transform_config: None,
@@ -135,8 +138,8 @@ impl SourceConfig {
     pub fn ingest_api_default() -> Self {
         Self {
             source_id: INGEST_API_SOURCE_ID.to_string(),
-            max_num_pipelines_per_indexer: NonZeroUsize::new(1).unwrap(),
-            desired_num_pipelines: NonZeroUsize::new(1).unwrap(),
+            max_num_pipelines_per_indexer: NonZeroUsize::new(1).expect("1 should be non-zero"),
+            desired_num_pipelines: NonZeroUsize::new(1).expect("1 should be non-zero"),
             enabled: true,
             source_params: SourceParams::IngestApi,
             transform_config: None,
@@ -148,8 +151,8 @@ impl SourceConfig {
     pub fn cli_ingest_source() -> Self {
         Self {
             source_id: CLI_INGEST_SOURCE_ID.to_string(),
-            max_num_pipelines_per_indexer: NonZeroUsize::new(1).unwrap(),
-            desired_num_pipelines: NonZeroUsize::new(1).unwrap(),
+            max_num_pipelines_per_indexer: NonZeroUsize::new(1).expect("1 should be non-zero"),
+            desired_num_pipelines: NonZeroUsize::new(1).expect("1 should be non-zero"),
             enabled: true,
             source_params: SourceParams::IngestCli,
             transform_config: None,
@@ -161,8 +164,8 @@ impl SourceConfig {
     pub fn for_test(source_id: &str, source_params: SourceParams) -> Self {
         Self {
             source_id: source_id.to_string(),
-            max_num_pipelines_per_indexer: NonZeroUsize::new(1).unwrap(),
-            desired_num_pipelines: NonZeroUsize::new(1).unwrap(),
+            max_num_pipelines_per_indexer: NonZeroUsize::new(1).expect("1 should be non-zero"),
+            desired_num_pipelines: NonZeroUsize::new(1).expect("1 should be non-zero"),
             enabled: true,
             source_params,
             transform_config: None,
@@ -658,8 +661,8 @@ mod tests {
             load_source_config_from_user_config(config_format, file_content.as_bytes()).unwrap();
         let expected_source_config = SourceConfig {
             source_id: "hdfs-logs-kinesis-source".to_string(),
-            max_num_pipelines_per_indexer: NonZeroUsize::new(1).unwrap(),
-            desired_num_pipelines: NonZeroUsize::new(1).unwrap(),
+            max_num_pipelines_per_indexer: NonZeroUsize::new(1).expect("1 should be non-zero"),
+            desired_num_pipelines: NonZeroUsize::new(1).expect("1 should be non-zero"),
             enabled: true,
             source_params: SourceParams::Kinesis(KinesisSourceParams {
                 stream_name: "emr-cluster-logs".to_string(),
@@ -1066,8 +1069,8 @@ mod tests {
         let source_config: SourceConfig = ConfigFormat::Json.parse(&file_content).unwrap();
         let expected_source_config = SourceConfig {
             source_id: INGEST_API_SOURCE_ID.to_string(),
-            max_num_pipelines_per_indexer: NonZeroUsize::new(1).unwrap(),
-            desired_num_pipelines: NonZeroUsize::new(1).unwrap(),
+            max_num_pipelines_per_indexer: NonZeroUsize::new(1).expect("1 should be non-zero"),
+            desired_num_pipelines: NonZeroUsize::new(1).expect("1 should be non-zero"),
             enabled: true,
             source_params: SourceParams::IngestApi,
             transform_config: Some(TransformConfig {

--- a/quickwit/quickwit-config/src/source_config/serialize.rs
+++ b/quickwit/quickwit-config/src/source_config/serialize.rs
@@ -22,11 +22,8 @@ use std::num::NonZeroUsize;
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
-use super::TransformConfig;
-use crate::{
-    validate_identifier, ConfigFormat, SourceConfig, SourceInputFormat, SourceParams,
-    CLI_INGEST_SOURCE_ID, INGEST_API_SOURCE_ID,
-};
+use super::{TransformConfig, RESERVED_SOURCE_IDS};
+use crate::{validate_identifier, ConfigFormat, SourceConfig, SourceInputFormat, SourceParams};
 
 type SourceConfigForSerialization = SourceConfigV0_6;
 
@@ -72,7 +69,7 @@ impl SourceConfigForSerialization {
     ///
     /// TODO refactor #1065
     fn validate_and_build(self) -> anyhow::Result<SourceConfig> {
-        if self.source_id != CLI_INGEST_SOURCE_ID && self.source_id != INGEST_API_SOURCE_ID {
+        if !RESERVED_SOURCE_IDS.contains(&self.source_id.as_str()) {
             validate_identifier("Source ID", &self.source_id)?;
         }
         let desired_num_pipelines = NonZeroUsize::new(self.desired_num_pipelines)

--- a/quickwit/quickwit-index-management/src/index.rs
+++ b/quickwit/quickwit-index-management/src/index.rs
@@ -122,6 +122,9 @@ impl IndexService {
             .add_source(index_uid.clone(), SourceConfig::ingest_api_default())
             .await?;
         self.metastore
+            .add_source(index_uid.clone(), SourceConfig::ingest_default())
+            .await?;
+        self.metastore
             .add_source(index_uid, SourceConfig::cli_ingest_source())
             .await?;
         let index_metadata = self.metastore.index_metadata(&index_id).await?;

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -93,10 +93,12 @@ reqwest = { workspace = true }
 
 quickwit-actors = { workspace = true, features = ["testsuite"] }
 quickwit-cluster = { workspace = true, features = ["testsuite"] }
-quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }
 quickwit-common = { workspace = true, features = ["testsuite"] }
 quickwit-config = { workspace = true, features = ["testsuite"] }
+quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }
+quickwit-ingest = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
+quickwit-proto = { workspace = true, features = ["testsuite"] }
 quickwit-storage = { workspace = true, features = ["testsuite"] }
 
 [[test]]

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -17,38 +17,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-mod indexing_pipeline;
-mod merge_pipeline;
-
 mod doc_processor;
 mod index_serializer;
 mod indexer;
+mod indexing_pipeline;
 mod indexing_service;
+mod merge_executor;
+mod merge_pipeline;
+mod merge_planner;
+mod merge_split_downloader;
 mod packager;
 mod publisher;
 mod sequencer;
 mod uploader;
+#[cfg(feature = "vrl")]
+mod vrl_processing;
 
+pub use doc_processor::{DocProcessor, DocProcessorCounters};
+pub use index_serializer::IndexSerializer;
+pub use indexer::{Indexer, IndexerCounters};
 pub use indexing_pipeline::{IndexingPipeline, IndexingPipelineParams};
 pub use indexing_service::{
     IndexingService, IndexingServiceCounters, MergePipelineId, INDEXING_DIR_NAME,
 };
+pub use merge_executor::{combine_partition_ids, merge_split_attrs, MergeExecutor};
+pub use merge_pipeline::MergePipeline;
+pub use merge_planner::MergePlanner;
+pub use merge_split_downloader::MergeSplitDownloader;
+pub use packager::Packager;
+pub use publisher::{Publisher, PublisherCounters, PublisherType};
 pub use quickwit_proto::indexing::IndexingError;
 pub use sequencer::Sequencer;
-mod merge_executor;
-mod merge_planner;
-mod merge_split_downloader;
-
-#[cfg(feature = "vrl")]
-mod vrl_processing;
-
-pub use self::doc_processor::{DocProcessor, DocProcessorCounters};
-pub use self::index_serializer::IndexSerializer;
-pub use self::indexer::{Indexer, IndexerCounters};
-pub use self::merge_executor::{combine_partition_ids, merge_split_attrs, MergeExecutor};
-pub use self::merge_pipeline::MergePipeline;
-pub use self::merge_planner::MergePlanner;
-pub use self::merge_split_downloader::MergeSplitDownloader;
-pub use self::packager::Packager;
-pub use self::publisher::{Publisher, PublisherCounters, PublisherType};
-pub use self::uploader::{SplitsUpdateMailbox, Uploader, UploaderCounters, UploaderType};
+pub use uploader::{SplitsUpdateMailbox, Uploader, UploaderCounters, UploaderType};

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use quickwit_actors::{Mailbox, Universe};
 use quickwit_cluster::Cluster;
 use quickwit_config::NodeConfig;
-use quickwit_ingest::IngestApiService;
+use quickwit_ingest::{IngestApiService, IngesterPool};
 use quickwit_metastore::Metastore;
 use quickwit_storage::StorageResolver;
 use tracing::info;
@@ -62,6 +62,7 @@ pub fn new_split_id() -> String {
     ulid::Ulid::new().to_string()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_indexing_service(
     universe: &Universe,
     config: &NodeConfig,
@@ -69,6 +70,7 @@ pub async fn start_indexing_service(
     cluster: Cluster,
     metastore: Arc<dyn Metastore>,
     ingest_api_service: Mailbox<IngestApiService>,
+    ingester_pool: IngesterPool,
     storage_resolver: StorageResolver,
 ) -> anyhow::Result<Mailbox<IndexingService>> {
     info!("Starting indexer service.");
@@ -82,6 +84,7 @@ pub async fn start_indexing_service(
         cluster,
         metastore.clone(),
         Some(ingest_api_service),
+        ingester_pool,
         storage_resolver,
     )
     .await?;

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -47,5 +47,9 @@ pub use packaged_split::{PackagedSplit, PackagedSplitBatch};
 pub use processed_doc::{ProcessedDoc, ProcessedDocBatch};
 pub use publish_lock::{NewPublishLock, PublishLock};
 pub use publisher_message::SplitsUpdate;
+use quickwit_proto::PublishToken;
 pub use raw_doc_batch::RawDocBatch;
 pub use split_attrs::{create_split_metadata, SplitAttrs};
+
+#[derive(Debug)]
+pub struct NewPublishToken(pub PublishToken);

--- a/quickwit/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit/quickwit-indexing/src/models/packaged_split.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use itertools::Itertools;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
-use quickwit_proto::{IndexUid, PublishToken};
+use quickwit_proto::{IndexUid, PublishToken, SplitId};
 use tantivy::TrackedObject;
 use tracing::Span;
 
@@ -105,13 +105,10 @@ impl PackagedSplitBatch {
     }
 
     pub fn index_uid(&self) -> IndexUid {
-        self.splits
-            .get(0)
-            .map(|split| split.split_attrs.pipeline_id.index_uid.clone())
-            .unwrap()
+        self.splits[0].split_attrs.pipeline_id.index_uid.clone()
     }
 
-    pub fn split_ids(&self) -> Vec<String> {
+    pub fn split_ids(&self) -> Vec<SplitId> {
         self.splits
             .iter()
             .map(|split| split.split_attrs.split_id.clone())

--- a/quickwit/quickwit-indexing/src/source/ingest/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest/mod.rs
@@ -1,0 +1,762 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use itertools::Itertools;
+use quickwit_actors::{ActorExitStatus, Mailbox};
+use quickwit_ingest::{IngesterPool, MultiFetchStream};
+use quickwit_metastore::checkpoint::{PartitionId, Position, SourceCheckpoint};
+use quickwit_metastore::Metastore;
+use quickwit_proto::ingest::ingester::{
+    FetchResponseV2, IngesterService, TruncateRequest, TruncateSubrequest,
+};
+use quickwit_proto::metastore::{AcquireShardsRequest, AcquireShardsSubrequest};
+use quickwit_proto::types::NodeId;
+use quickwit_proto::{IndexUid, PublishToken, ShardId, SourceId};
+use serde_json::json;
+use tokio::time;
+use tracing::{debug, error, info, warn};
+use ulid::Ulid;
+
+use super::{
+    Assignment, BatchBuilder, Source, SourceContext, SourceRuntimeArgs, TypedSourceFactory,
+};
+use crate::actors::DocProcessor;
+use crate::models::{NewPublishLock, NewPublishToken, PublishLock};
+
+const EMIT_BATCHES_TIMEOUT: Duration = Duration::from_millis(if cfg!(test) { 100 } else { 1_000 });
+
+pub struct IngestSourceFactory;
+
+#[async_trait]
+impl TypedSourceFactory for IngestSourceFactory {
+    type Source = IngestSource;
+    type Params = ();
+
+    async fn typed_create_source(
+        runtime_args: Arc<SourceRuntimeArgs>,
+        _: Self::Params,
+        checkpoint: SourceCheckpoint,
+    ) -> anyhow::Result<Self::Source> {
+        IngestSource::try_new(runtime_args, checkpoint).await
+    }
+}
+
+/// The [`ClientId`] is a unique identifier for a client of the ingest service and allows to
+/// distinguish which indexers are streaming documents from a shard. It is also used to form a
+/// publish token.
+#[derive(Debug, Clone)]
+struct ClientId {
+    node_id: NodeId,
+    index_uid: IndexUid,
+    source_id: SourceId,
+    pipeline_ord: usize,
+}
+
+impl ClientId {
+    fn new(node_id: NodeId, index_uid: IndexUid, source_id: SourceId, pipeline_ord: usize) -> Self {
+        Self {
+            node_id,
+            index_uid,
+            source_id,
+            pipeline_ord,
+        }
+    }
+
+    fn client_id(&self) -> String {
+        format!(
+            "indexer/{}/{}/{}/{}",
+            self.node_id, self.index_uid, self.source_id, self.pipeline_ord
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct AssignedShard {
+    leader_id: NodeId,
+    partition_id: PartitionId,
+    current_position_inclusive: Position,
+}
+
+/// Streams documents from a set of shards.
+pub struct IngestSource {
+    client_id: ClientId,
+    metastore: Arc<dyn Metastore>,
+    ingester_pool: IngesterPool,
+    assigned_shards: HashMap<ShardId, AssignedShard>,
+    fetch_stream: MultiFetchStream,
+    publish_lock: PublishLock,
+    publish_token: PublishToken,
+}
+
+impl fmt::Debug for IngestSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.debug_struct("IngestSource").finish()
+    }
+}
+
+impl IngestSource {
+    pub async fn try_new(
+        runtime_args: Arc<SourceRuntimeArgs>,
+        _checkpoint: SourceCheckpoint,
+    ) -> anyhow::Result<Self> {
+        let node_id: NodeId = runtime_args.node_id().into();
+        let client_id = ClientId::new(
+            node_id.clone(),
+            runtime_args.index_uid().clone(),
+            runtime_args.source_id().to_string(),
+            runtime_args.pipeline_ord(),
+        );
+        let metastore = runtime_args.metastore.clone();
+        let ingester_pool = runtime_args.ingester_pool.clone();
+        let assigned_shards = HashMap::new();
+        let fetch_stream =
+            MultiFetchStream::new(node_id, client_id.client_id(), ingester_pool.clone());
+        let publish_lock = PublishLock::default();
+        let publish_token = format!("{}:{}", client_id.client_id(), Ulid::new());
+
+        Ok(Self {
+            client_id,
+            metastore,
+            ingester_pool,
+            assigned_shards,
+            fetch_stream,
+            publish_lock,
+            publish_token,
+        })
+    }
+
+    fn process_fetch_response(
+        &mut self,
+        batch_builder: &mut BatchBuilder,
+        fetch_response: FetchResponseV2,
+    ) -> anyhow::Result<()> {
+        let assigned_shard = self
+            .assigned_shards
+            .get_mut(&fetch_response.shard_id)
+            .expect("shard should be assigned");
+        let partition_id = assigned_shard.partition_id.clone();
+
+        for doc in fetch_response.docs() {
+            batch_builder.add_doc(doc);
+        }
+        let from_position_exclusive = assigned_shard.current_position_inclusive.clone();
+        let to_position_inclusive = fetch_response
+            .to_position_inclusive()
+            .map(Position::from)
+            .unwrap_or(Position::Beginning);
+        batch_builder
+            .checkpoint_delta
+            .record_partition_delta(
+                partition_id,
+                from_position_exclusive,
+                to_position_inclusive.clone(),
+            )
+            .context("failed to record partition delta")?;
+        assigned_shard.current_position_inclusive = to_position_inclusive;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Source for IngestSource {
+    async fn emit_batches(
+        &mut self,
+        doc_processor_mailbox: &Mailbox<DocProcessor>,
+        ctx: &SourceContext,
+    ) -> Result<Duration, ActorExitStatus> {
+        let mut batch_builder = BatchBuilder::default();
+
+        let now = time::Instant::now();
+        let deadline = now + EMIT_BATCHES_TIMEOUT;
+
+        loop {
+            match time::timeout_at(deadline, self.fetch_stream.next()).await {
+                Ok(Ok(fetch_payload)) => {
+                    self.process_fetch_response(&mut batch_builder, fetch_payload)?;
+
+                    if batch_builder.num_bytes >= 5 * 1024 * 1024 {
+                        break;
+                    }
+                }
+                Ok(Err(error)) => {
+                    error!(error=?error, "failed to fetch payload");
+                }
+                Err(_) => {
+                    break;
+                }
+            }
+            ctx.record_progress();
+        }
+        if !batch_builder.checkpoint_delta.is_empty() {
+            debug!(
+                num_docs=%batch_builder.docs.len(),
+                num_bytes=%batch_builder.num_bytes,
+                num_millis=%now.elapsed().as_millis(),
+                "Sending doc batch to indexer."
+            );
+            let message = batch_builder.build();
+            ctx.send_message(doc_processor_mailbox, message).await?;
+        }
+        Ok(Duration::default())
+    }
+
+    async fn assign_shards(
+        &mut self,
+        assignment: Assignment,
+        doc_processor_mailbox: &Mailbox<DocProcessor>,
+        ctx: &SourceContext,
+    ) -> anyhow::Result<()> {
+        // TODO: Remove this check once the control plane stops sending identical assignments.
+        let current_assigned_shard_ids = self
+            .assigned_shards
+            .keys()
+            .copied()
+            .sorted()
+            .collect::<Vec<ShardId>>();
+
+        let mut new_assigned_shard_ids: Vec<ShardId> = assignment.shard_ids;
+        new_assigned_shard_ids.sort();
+
+        if current_assigned_shard_ids == new_assigned_shard_ids {
+            return Ok(());
+        }
+        info!("new shard assignment: `{:?}`", new_assigned_shard_ids);
+
+        self.publish_lock.kill().await;
+
+        self.publish_lock = PublishLock::default();
+        ctx.send_message(
+            doc_processor_mailbox,
+            NewPublishLock(self.publish_lock.clone()),
+        )
+        .await?;
+
+        self.publish_token = format!("{}:{}", self.client_id.client_id(), Ulid::new());
+        ctx.send_message(
+            doc_processor_mailbox,
+            NewPublishToken(self.publish_token.clone()),
+        )
+        .await?;
+
+        let acquire_shards_subrequest = AcquireShardsSubrequest {
+            index_uid: self.client_id.index_uid.to_string(),
+            source_id: self.client_id.source_id.clone(),
+            shard_ids: new_assigned_shard_ids,
+            publish_token: self.publish_token.clone(),
+        };
+        let acquire_shards_request = AcquireShardsRequest {
+            subrequests: vec![acquire_shards_subrequest],
+        };
+        let acquire_shards_response = ctx
+            .protect_future(self.metastore.acquire_shards(acquire_shards_request))
+            .await
+            .context("failed to acquire shards")?;
+
+        let Some(acquire_shards_subresponse) = acquire_shards_response
+            .subresponses
+            .into_iter()
+            .find(|subresponse| {
+                self.client_id.index_uid.as_str() == subresponse.index_uid
+                    && subresponse.source_id == self.client_id.source_id
+            })
+        else {
+            return Ok(());
+        };
+        self.assigned_shards.clear();
+        self.fetch_stream.reset();
+
+        for acquired_shard in acquire_shards_subresponse.acquired_shards {
+            let leader_id: NodeId = acquired_shard.leader_id.into();
+            let follower_id: Option<NodeId> = acquired_shard
+                .follower_id
+                .map(|follower_id| follower_id.into());
+            let index_uid: IndexUid = acquired_shard.index_uid.into();
+            let source_id: SourceId = acquired_shard.source_id;
+            let shard_id = acquired_shard.shard_id;
+            let partition_id = PartitionId::from(shard_id);
+            let current_position_inclusive =
+                Position::from(acquired_shard.publish_position_inclusive);
+            let from_position_exclusive = current_position_inclusive.as_u64();
+            let to_position_inclusive = None;
+
+            if let Err(error) = ctx
+                .protect_future(self.fetch_stream.subscribe(
+                    leader_id.clone(),
+                    follower_id.clone(),
+                    index_uid,
+                    source_id,
+                    shard_id,
+                    from_position_exclusive,
+                    to_position_inclusive,
+                ))
+                .await
+            {
+                error!(error=%error, "failed to subscribe to shard");
+                continue;
+            }
+            let assigned_shard = AssignedShard {
+                leader_id,
+                partition_id,
+                current_position_inclusive,
+            };
+            self.assigned_shards.insert(shard_id, assigned_shard);
+        }
+        Ok(())
+    }
+
+    async fn suggest_truncate(
+        &mut self,
+        checkpoint: SourceCheckpoint,
+        _ctx: &SourceContext,
+    ) -> anyhow::Result<()> {
+        let mut per_leader_truncate_subrequests: HashMap<&NodeId, Vec<TruncateSubrequest>> =
+            HashMap::new();
+
+        for (partition_id, position) in checkpoint.iter() {
+            let shard_id = partition_id.as_u64().expect("shard ID should be a u64");
+            let leader_id = &self
+                .assigned_shards
+                .get(&shard_id)
+                .expect("shard should be assigned") // TODO: This is not true if `assign_shards` is called before `suggest_truncate`.
+                .leader_id;
+            let to_position_inclusive = position.as_u64().expect("position should be a u64");
+
+            let truncate_subrequest = TruncateSubrequest {
+                index_uid: self.client_id.index_uid.clone().into(),
+                source_id: self.client_id.source_id.clone(),
+                shard_id,
+                to_position_inclusive,
+            };
+            per_leader_truncate_subrequests
+                .entry(leader_id)
+                .or_default()
+                .push(truncate_subrequest);
+        }
+        for (leader_id, truncate_subrequests) in per_leader_truncate_subrequests {
+            let Some(mut ingester) = self.ingester_pool.get(leader_id).await else {
+                warn!(
+                    "failed to truncate shard: ingester `{}` is unavailable",
+                    leader_id
+                );
+                continue;
+            };
+            let truncate_request = TruncateRequest {
+                leader_id: leader_id.clone().into(),
+                subrequests: truncate_subrequests,
+            };
+            let truncate_future = async move {
+                if let Err(error) = ingester.truncate(truncate_request).await {
+                    warn!("failed to truncate shard(s): {error}");
+                }
+            };
+            // Truncation is best-effort, so fire and forget.
+            tokio::spawn(truncate_future);
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        "IngestSource".to_string()
+    }
+
+    fn observable_state(&self) -> serde_json::Value {
+        json!({
+            "client_id": self.client_id.client_id(),
+            "assigned_shards": self.assigned_shards.keys().copied().collect::<Vec<ShardId>>(),
+            "publish_token": self.publish_token,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use bytes::Bytes;
+    use quickwit_actors::{ActorContext, Universe};
+    use quickwit_common::ServiceStream;
+    use quickwit_config::{SourceConfig, SourceParams};
+    use quickwit_metastore::MockMetastore;
+    use quickwit_proto::indexing::IndexingPipelineId;
+    use quickwit_proto::ingest::ingester::{IngesterServiceClient, TruncateResponse};
+    use quickwit_proto::ingest::{DocBatchV2, Shard};
+    use quickwit_proto::metastore::{AcquireShardsResponse, AcquireShardsSubresponse};
+    use tokio::sync::watch;
+
+    use super::*;
+    use crate::models::RawDocBatch;
+    use crate::source::SourceActor;
+
+    #[tokio::test]
+    async fn test_ingest_source_assign_shards() {
+        let pipeline_id = IndexingPipelineId {
+            node_id: "test-node".to_string(),
+            index_uid: "test-index:0".into(),
+            source_id: "test-source".to_string(),
+            pipeline_ord: 0,
+        };
+        let source_config = SourceConfig::for_test("test-source", SourceParams::Ingest);
+        let mut mock_metastore = MockMetastore::default();
+        mock_metastore
+            .expect_acquire_shards()
+            .once()
+            .returning(|request| {
+                assert_eq!(request.subrequests.len(), 1);
+
+                let subrequest = &request.subrequests[0];
+                assert_eq!(subrequest.index_uid, "test-index:0");
+                assert_eq!(subrequest.source_id, "test-source");
+                assert_eq!(subrequest.shard_ids, vec![1, 2, 3]);
+
+                let response = AcquireShardsResponse {
+                    subresponses: vec![AcquireShardsSubresponse {
+                        index_uid: "test-index:0".to_string(),
+                        source_id: "test-source".to_string(),
+                        acquired_shards: vec![Shard {
+                            leader_id: "test-ingester-0".to_string(),
+                            follower_id: None,
+                            index_uid: "test-index:0".to_string(),
+                            source_id: "test-source".to_string(),
+                            shard_id: 1,
+                            publish_position_inclusive: "00000000000000000011".to_string(),
+                            ..Default::default()
+                        }],
+                    }],
+                };
+                Ok(response)
+            });
+        let metastore = Arc::new(mock_metastore);
+
+        let ingester_pool = IngesterPool::default();
+
+        let mut ingester_mock_0 = IngesterServiceClient::mock();
+        ingester_mock_0
+            .expect_open_fetch_stream()
+            .once()
+            .returning(|request| {
+                assert_eq!(
+                    request.client_id,
+                    "indexer/test-node/test-index:0/test-source/0"
+                );
+                assert_eq!(request.index_uid, "test-index:0");
+                assert_eq!(request.source_id, "test-source");
+                assert_eq!(request.shard_id, 1);
+                assert_eq!(request.from_position_exclusive, Some(11));
+
+                let (_service_stream_tx, service_stream) = ServiceStream::new_bounded(1);
+                Ok(service_stream)
+            });
+        let ingester_0: IngesterServiceClient = ingester_mock_0.into();
+        ingester_pool
+            .insert("test-ingester-0".into(), ingester_0.clone())
+            .await;
+
+        let runtime_args = Arc::new(SourceRuntimeArgs {
+            pipeline_id,
+            source_config,
+            metastore,
+            ingester_pool: ingester_pool.clone(),
+            queues_dir_path: PathBuf::from("./queues"),
+        });
+        let checkpoint = SourceCheckpoint::default();
+        let mut source = IngestSource::try_new(runtime_args, checkpoint)
+            .await
+            .unwrap();
+
+        let universe = Universe::with_accelerated_time();
+        let (source_mailbox, _source_inbox) = universe.create_test_mailbox::<SourceActor>();
+        let (doc_processor_mailbox, doc_processor_inbox) =
+            universe.create_test_mailbox::<DocProcessor>();
+        let (observable_state_tx, _observable_state_rx) = watch::channel(serde_json::Value::Null);
+        let ctx: SourceContext =
+            ActorContext::for_test(&universe, source_mailbox, observable_state_tx);
+
+        // In this scenario, the indexer will only be able to acquire shard 1 and 2 and will fail to
+        // subscribe to shard 2.
+        let assignment = Assignment {
+            shard_ids: vec![1, 2, 3],
+        };
+        let publish_lock = source.publish_lock.clone();
+        let publish_token = source.publish_token.clone();
+
+        source
+            .assign_shards(assignment, &doc_processor_mailbox, &ctx)
+            .await
+            .unwrap();
+
+        assert!(publish_lock.is_dead());
+        assert!(source.publish_lock.is_alive());
+
+        let NewPublishLock(publish_lock) = doc_processor_inbox
+            .recv_typed_message::<NewPublishLock>()
+            .await
+            .unwrap();
+        assert_eq!(&source.publish_lock, &publish_lock);
+
+        assert!(publish_token != source.publish_token);
+
+        let NewPublishToken(publish_token) = doc_processor_inbox
+            .recv_typed_message::<NewPublishToken>()
+            .await
+            .unwrap();
+        assert_eq!(source.publish_token, publish_token);
+
+        assert_eq!(source.assigned_shards.len(), 1);
+        let assigned_shard = source.assigned_shards.get(&1).unwrap();
+        let expected_assigned_shard = AssignedShard {
+            leader_id: "test-ingester-0".into(),
+            partition_id: 1u64.into(),
+            current_position_inclusive: Position::from(11u64),
+        };
+        assert_eq!(assigned_shard, &expected_assigned_shard);
+    }
+
+    #[tokio::test]
+    async fn test_ingest_source_emit_batches() {
+        let pipeline_id = IndexingPipelineId {
+            node_id: "test-node".to_string(),
+            index_uid: "test-index:0".into(),
+            source_id: "test-source".to_string(),
+            pipeline_ord: 0,
+        };
+        let source_config = SourceConfig::for_test("test-source", SourceParams::Ingest);
+        let mock_metastore = MockMetastore::default();
+        let metastore = Arc::new(mock_metastore);
+        let ingester_pool = IngesterPool::default();
+
+        let runtime_args = Arc::new(SourceRuntimeArgs {
+            pipeline_id,
+            source_config,
+            metastore,
+            ingester_pool: ingester_pool.clone(),
+            queues_dir_path: PathBuf::from("./queues"),
+        });
+        let checkpoint = SourceCheckpoint::default();
+        let mut source = IngestSource::try_new(runtime_args, checkpoint)
+            .await
+            .unwrap();
+
+        let universe = Universe::with_accelerated_time();
+        let (source_mailbox, _source_inbox) = universe.create_test_mailbox::<SourceActor>();
+        let (doc_processor_mailbox, doc_processor_inbox) =
+            universe.create_test_mailbox::<DocProcessor>();
+        let (observable_state_tx, _observable_state_rx) = watch::channel(serde_json::Value::Null);
+        let ctx: SourceContext =
+            ActorContext::for_test(&universe, source_mailbox, observable_state_tx);
+
+        // In this scenario, the ingester receives fetch responses from shard 1 and 2.
+        source.assigned_shards.insert(
+            1,
+            AssignedShard {
+                leader_id: "test-ingester-0".into(),
+                partition_id: 1u64.into(),
+                current_position_inclusive: Position::from(11u64),
+            },
+        );
+        source.assigned_shards.insert(
+            2,
+            AssignedShard {
+                leader_id: "test-ingester-1".into(),
+                partition_id: 2u64.into(),
+                current_position_inclusive: Position::from(22u64),
+            },
+        );
+        let fetch_response_tx = source.fetch_stream.fetch_response_tx();
+
+        fetch_response_tx
+            .send(Ok(FetchResponseV2 {
+                index_uid: "test-index:0".into(),
+                source_id: "test-source".into(),
+                shard_id: 1,
+                from_position_inclusive: 12,
+                doc_batch: Some(DocBatchV2 {
+                    doc_buffer: Bytes::from_static(b"test-doc-112test-doc-113"),
+                    doc_lengths: vec![12, 12],
+                }),
+            }))
+            .await
+            .unwrap();
+
+        fetch_response_tx
+            .send(Ok(FetchResponseV2 {
+                index_uid: "test-index:0".into(),
+                source_id: "test-source".into(),
+                shard_id: 2,
+                from_position_inclusive: 23,
+                doc_batch: Some(DocBatchV2 {
+                    doc_buffer: Bytes::from_static(b"test-doc-223"),
+                    doc_lengths: vec![12],
+                }),
+            }))
+            .await
+            .unwrap();
+
+        source
+            .emit_batches(&doc_processor_mailbox, &ctx)
+            .await
+            .unwrap();
+        let doc_batch = doc_processor_inbox
+            .recv_typed_message::<RawDocBatch>()
+            .await
+            .unwrap();
+        assert_eq!(doc_batch.docs.len(), 3);
+        assert_eq!(doc_batch.docs[0], "test-doc-112");
+        assert_eq!(doc_batch.docs[1], "test-doc-113");
+        assert_eq!(doc_batch.docs[2], "test-doc-223");
+
+        let partition_deltas = doc_batch
+            .checkpoint_delta
+            .iter()
+            .sorted_by(|left, right| left.0.cmp(&right.0))
+            .collect::<Vec<_>>();
+
+        assert_eq!(partition_deltas.len(), 2);
+        assert_eq!(partition_deltas[0].0, 1u64.into());
+        assert_eq!(partition_deltas[0].1.from, 11u64.into());
+        assert_eq!(partition_deltas[0].1.to, 13u64.into());
+
+        assert_eq!(partition_deltas[1].0, 2u64.into());
+        assert_eq!(partition_deltas[1].1.from, 22u64.into());
+        assert_eq!(partition_deltas[1].1.to, 23u64.into());
+    }
+
+    #[tokio::test]
+    async fn test_ingest_source_suggest_truncate() {
+        let pipeline_id = IndexingPipelineId {
+            node_id: "test-node".to_string(),
+            index_uid: "test-index:0".into(),
+            source_id: "test-source".to_string(),
+            pipeline_ord: 0,
+        };
+        let source_config = SourceConfig::for_test("test-source", SourceParams::Ingest);
+        let mock_metastore = MockMetastore::default();
+        let metastore = Arc::new(mock_metastore);
+
+        let ingester_pool = IngesterPool::default();
+
+        let mut ingester_mock_0 = IngesterServiceClient::mock();
+        ingester_mock_0
+            .expect_truncate()
+            .once()
+            .returning(|request| {
+                assert_eq!(request.leader_id, "test-ingester-0");
+                assert_eq!(request.subrequests.len(), 2);
+
+                let subrequest_0 = &request.subrequests[0];
+                assert_eq!(subrequest_0.shard_id, 1);
+                assert_eq!(subrequest_0.to_position_inclusive, 11);
+
+                let subrequest_1 = &request.subrequests[1];
+                assert_eq!(subrequest_1.shard_id, 2);
+                assert_eq!(subrequest_1.to_position_inclusive, 22);
+
+                Ok(TruncateResponse {})
+            });
+        let ingester_0: IngesterServiceClient = ingester_mock_0.into();
+        ingester_pool
+            .insert("test-ingester-0".into(), ingester_0.clone())
+            .await;
+
+        let mut ingester_mock_1 = IngesterServiceClient::mock();
+        ingester_mock_1
+            .expect_truncate()
+            .once()
+            .returning(|request| {
+                assert_eq!(request.leader_id, "test-ingester-1");
+                assert_eq!(request.subrequests.len(), 1);
+
+                let subrequest_0 = &request.subrequests[0];
+                assert_eq!(subrequest_0.shard_id, 3);
+                assert_eq!(subrequest_0.to_position_inclusive, 33);
+
+                Ok(TruncateResponse {})
+            });
+        let ingester_1: IngesterServiceClient = ingester_mock_1.into();
+        ingester_pool
+            .insert("test-ingester-1".into(), ingester_1.clone())
+            .await;
+
+        let runtime_args = Arc::new(SourceRuntimeArgs {
+            pipeline_id,
+            source_config,
+            metastore,
+            ingester_pool: ingester_pool.clone(),
+            queues_dir_path: PathBuf::from("./queues"),
+        });
+        let checkpoint = SourceCheckpoint::default();
+        let mut source = IngestSource::try_new(runtime_args, checkpoint)
+            .await
+            .unwrap();
+
+        let universe = Universe::with_accelerated_time();
+        let (source_mailbox, _source_inbox) = universe.create_test_mailbox::<SourceActor>();
+        let (observable_state_tx, _observable_state_rx) = watch::channel(serde_json::Value::Null);
+        let ctx: SourceContext =
+            ActorContext::for_test(&universe, source_mailbox, observable_state_tx);
+
+        // In this scenario, the ingester 2 is not available and the shard 5 is no longer assigned.
+        source.assigned_shards.insert(
+            1,
+            AssignedShard {
+                leader_id: "test-ingester-0".into(),
+                partition_id: 1u64.into(),
+                current_position_inclusive: Position::from(11u64),
+            },
+        );
+        source.assigned_shards.insert(
+            2,
+            AssignedShard {
+                leader_id: "test-ingester-0".into(),
+                partition_id: 2u64.into(),
+                current_position_inclusive: Position::from(22u64),
+            },
+        );
+        source.assigned_shards.insert(
+            3,
+            AssignedShard {
+                leader_id: "test-ingester-1".into(),
+                partition_id: 3u64.into(),
+                current_position_inclusive: Position::from(33u64),
+            },
+        );
+        source.assigned_shards.insert(
+            4,
+            AssignedShard {
+                leader_id: "test-ingester-2".into(),
+                partition_id: 4u64.into(),
+                current_position_inclusive: Position::from(44u64),
+            },
+        );
+        let checkpoint = SourceCheckpoint::from_iter(vec![
+            (1u64.into(), 11u64.into()),
+            (2u64.into(), 22u64.into()),
+            (3u64.into(), 33u64.into()),
+            (4u64.into(), 44u64.into()),
+            // (5u64.into(), 55u64.into()),
+        ]);
+        source.suggest_truncate(checkpoint, &ctx).await.unwrap();
+    }
+}

--- a/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -44,7 +44,7 @@ use super::shard_consumer::{ShardConsumer, ShardConsumerHandle, ShardConsumerMes
 use crate::actors::DocProcessor;
 use crate::models::RawDocBatch;
 use crate::source::kinesis::helpers::get_kinesis_client;
-use crate::source::{Source, SourceContext, SourceExecutionContext, TypedSourceFactory};
+use crate::source::{Source, SourceContext, SourceRuntimeArgs, TypedSourceFactory};
 
 const TARGET_BATCH_NUM_BYTES: u64 = 5_000_000;
 
@@ -59,11 +59,11 @@ impl TypedSourceFactory for KinesisSourceFactory {
     type Params = KinesisSourceParams;
 
     async fn typed_create_source(
-        ctx: Arc<SourceExecutionContext>,
+        ctx: Arc<SourceRuntimeArgs>,
         params: KinesisSourceParams,
         checkpoint: SourceCheckpoint,
     ) -> anyhow::Result<Self::Source> {
-        KinesisSource::try_new(ctx.source_config.source_id.clone(), params, checkpoint).await
+        KinesisSource::try_new(ctx.source_id().to_string(), params, checkpoint).await
     }
 }
 

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -32,7 +32,7 @@ use quickwit_config::{
     SourceConfig, SourceInputFormat, SourceParams, VecSourceParams,
 };
 use quickwit_doc_mapper::DocMapper;
-use quickwit_ingest::{init_ingest_api, QUEUES_DIR_NAME};
+use quickwit_ingest::{init_ingest_api, IngesterPool, QUEUES_DIR_NAME};
 use quickwit_metastore::{Metastore, MetastoreResolver, Split, SplitMetadata, SplitState};
 use quickwit_proto::IndexUid;
 use quickwit_storage::{Storage, StorageResolver};
@@ -111,6 +111,7 @@ impl TestSandbox {
             cluster,
             metastore.clone(),
             Some(ingest_api_service),
+            IngesterPool::default(),
             storage_resolver.clone(),
         )
         .await?;

--- a/quickwit/quickwit-ingest/src/ingest_v2/test_utils.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/test_utils.rs
@@ -68,6 +68,8 @@ pub(super) trait PrimaryShardTestExt {
         expected_replica_position: Option<impl Into<Position>>,
     );
 
+    fn assert_publish_position(&self, expected_publish_position: impl Into<Position>);
+
     fn assert_is_open(&self, expected_position: impl Into<Position>);
 }
 
@@ -91,6 +93,24 @@ impl PrimaryShardTestExt for PrimaryShard {
             self.replica_position_inclusive_opt, expected_replica_position,
             "expected replica position at `{:?}`, got `{:?}`",
             expected_replica_position, self.replica_position_inclusive_opt
+        );
+    }
+
+    #[track_caller]
+    fn assert_publish_position(&self, expected_publish_position: impl Into<Position>) {
+        let expected_publish_position = expected_publish_position.into();
+
+        assert_eq!(
+            self.publish_position_inclusive, expected_publish_position,
+            "expected publish position at `{:?}`, got `{:?}`",
+            expected_publish_position, self.publish_position_inclusive
+        );
+        assert_eq!(
+            self.shard_status_tx.borrow().publish_position_inclusive,
+            expected_publish_position,
+            "expected publish position at `{:?}`, got `{:?}`",
+            expected_publish_position,
+            self.publish_position_inclusive
         );
     }
 

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -151,15 +151,15 @@ impl ClusterSandbox {
         for node_config in node_configs.iter() {
             join_handles.push(tokio::spawn({
                 let node_config = node_config.node_config.clone();
-                let storage_resolver = storage_resolver.clone();
                 let metastore_resolver = metastore_resolver.clone();
+                let storage_resolver = storage_resolver.clone();
                 let shutdown_signal = shutdown_trigger.shutdown_signal();
                 async move {
                     let result = serve_quickwit(
                         node_config,
                         runtimes_config,
-                        storage_resolver,
                         metastore_resolver,
+                        storage_resolver,
                         shutdown_signal,
                     )
                     .await?;

--- a/quickwit/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit/quickwit-metastore/src/checkpoint.rs
@@ -102,6 +102,10 @@ impl Position {
             Position::Offset(offset) => offset,
         }
     }
+
+    pub fn as_u64(&self) -> Option<u64> {
+        self.as_str().parse().ok()
+    }
 }
 
 impl From<i64> for Position {

--- a/quickwit/quickwit-metastore/src/metastore/control_plane_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/control_plane_metastore.rs
@@ -25,10 +25,11 @@ use quickwit_common::uri::Uri;
 use quickwit_config::{IndexConfig, SourceConfig};
 use quickwit_proto::control_plane::{ControlPlaneService, ControlPlaneServiceClient};
 use quickwit_proto::metastore::{
-    serde_utils as metastore_serde_utils, AddSourceRequest, CloseShardsRequest,
-    CloseShardsResponse, CreateIndexRequest, DeleteIndexRequest, DeleteQuery, DeleteShardsRequest,
-    DeleteShardsResponse, DeleteSourceRequest, DeleteTask, ListShardsRequest, ListShardsResponse,
-    MetastoreResult, OpenShardsRequest, OpenShardsResponse, ToggleSourceRequest,
+    serde_utils as metastore_serde_utils, AcquireShardsRequest, AcquireShardsResponse,
+    AddSourceRequest, CloseShardsRequest, CloseShardsResponse, CreateIndexRequest,
+    DeleteIndexRequest, DeleteQuery, DeleteShardsRequest, DeleteShardsResponse,
+    DeleteSourceRequest, DeleteTask, ListShardsRequest, ListShardsResponse, MetastoreResult,
+    OpenShardsRequest, OpenShardsResponse, ToggleSourceRequest,
 };
 use quickwit_proto::{IndexUid, PublishToken};
 
@@ -37,7 +38,6 @@ use crate::{IndexMetadata, ListIndexesQuery, ListSplitsQuery, Metastore, Split, 
 
 /// A [`Metastore`] implementation that proxies some requests to the control plane so it can
 /// track the state of the metastore accurately and react to events in real-time.
-#[derive(Clone)]
 pub struct ControlPlaneMetastore {
     control_plane: ControlPlaneServiceClient,
     metastore: Arc<dyn Metastore>,
@@ -229,6 +229,13 @@ impl Metastore for ControlPlaneMetastore {
 
     async fn open_shards(&self, request: OpenShardsRequest) -> MetastoreResult<OpenShardsResponse> {
         self.metastore.open_shards(request).await
+    }
+
+    async fn acquire_shards(
+        &self,
+        request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse> {
+        self.metastore.acquire_shards(request).await
     }
 
     async fn close_shards(

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -32,9 +32,10 @@ use itertools::Either;
 use quickwit_common::PrettySample;
 use quickwit_config::{SourceConfig, INGEST_SOURCE_ID};
 use quickwit_proto::metastore::{
-    CloseShardsFailure, CloseShardsSubrequest, CloseShardsSuccess, DeleteQuery,
-    DeleteShardsSubrequest, DeleteTask, EntityKind, ListShardsSubrequest, ListShardsSubresponse,
-    MetastoreError, MetastoreResult, OpenShardsSubrequest, OpenShardsSubresponse,
+    AcquireShardsSubrequest, AcquireShardsSubresponse, CloseShardsFailure, CloseShardsSubrequest,
+    CloseShardsSuccess, DeleteQuery, DeleteShardsSubrequest, DeleteTask, EntityKind,
+    ListShardsSubrequest, ListShardsSubresponse, MetastoreError, MetastoreResult,
+    OpenShardsSubrequest, OpenShardsSubresponse,
 };
 use quickwit_proto::{IndexUid, PublishToken, SourceId, SplitId};
 use serde::{Deserialize, Serialize};
@@ -546,6 +547,14 @@ impl FileBackedIndex {
     ) -> MetastoreResult<MutationOccurred<OpenShardsSubresponse>> {
         self.get_shards_for_source_mut(&subrequest.source_id)?
             .open_shards(subrequest)
+    }
+
+    pub(crate) fn acquire_shards(
+        &mut self,
+        subrequest: AcquireShardsSubrequest,
+    ) -> MetastoreResult<MutationOccurred<AcquireShardsSubresponse>> {
+        self.get_shards_for_source_mut(&subrequest.source_id)?
+            .acquire_shards(subrequest)
     }
 
     pub(crate) fn close_shards(

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
@@ -57,7 +57,7 @@ pub(crate) struct FileBackedIndexV0_6 {
     #[serde(rename = "index")]
     metadata: IndexMetadata,
     splits: Vec<Split>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     shards: HashMap<SourceId, SerdeShards>,
     #[serde(default)]
     delete_tasks: Vec<DeleteTask>,

--- a/quickwit/quickwit-metastore/src/metastore/grpc_metastore/grpc_adapter.rs
+++ b/quickwit/quickwit-metastore/src/metastore/grpc_metastore/grpc_adapter.rs
@@ -23,17 +23,18 @@ use async_trait::async_trait;
 use itertools::Itertools;
 use quickwit_config::IndexConfig;
 use quickwit_proto::metastore::{
-    serde_utils as metastore_serde_utils, AddSourceRequest, CloseShardsRequest,
-    CloseShardsResponse, CreateIndexRequest, CreateIndexResponse, DeleteIndexRequest, DeleteQuery,
-    DeleteShardsRequest, DeleteShardsResponse, DeleteSourceRequest, DeleteSplitsRequest,
-    DeleteTask, EmptyResponse, IndexMetadataRequest, IndexMetadataResponse,
-    LastDeleteOpstampRequest, LastDeleteOpstampResponse, ListAllSplitsRequest,
-    ListDeleteTasksRequest, ListDeleteTasksResponse, ListIndexesMetadatasRequest,
-    ListIndexesMetadatasResponse, ListShardsRequest, ListShardsResponse, ListSplitsRequest,
-    ListSplitsResponse, ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreError,
-    MetastoreService, OpenShardsRequest, OpenShardsResponse, PublishSplitsRequest,
-    ResetSourceCheckpointRequest, StageSplitsRequest, ToggleSourceRequest,
-    UpdateSplitsDeleteOpstampRequest, UpdateSplitsDeleteOpstampResponse,
+    serde_utils as metastore_serde_utils, AcquireShardsRequest, AcquireShardsResponse,
+    AddSourceRequest, CloseShardsRequest, CloseShardsResponse, CreateIndexRequest,
+    CreateIndexResponse, DeleteIndexRequest, DeleteQuery, DeleteShardsRequest,
+    DeleteShardsResponse, DeleteSourceRequest, DeleteSplitsRequest, DeleteTask, EmptyResponse,
+    IndexMetadataRequest, IndexMetadataResponse, LastDeleteOpstampRequest,
+    LastDeleteOpstampResponse, ListAllSplitsRequest, ListDeleteTasksRequest,
+    ListDeleteTasksResponse, ListIndexesMetadatasRequest, ListIndexesMetadatasResponse,
+    ListShardsRequest, ListShardsResponse, ListSplitsRequest, ListSplitsResponse,
+    ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreError, MetastoreService,
+    OpenShardsRequest, OpenShardsResponse, PublishSplitsRequest, ResetSourceCheckpointRequest,
+    StageSplitsRequest, ToggleSourceRequest, UpdateSplitsDeleteOpstampRequest,
+    UpdateSplitsDeleteOpstampResponse,
 };
 use quickwit_proto::tonic::{Request, Response, Status};
 use quickwit_proto::{set_parent_span_from_request_metadata, tonic};
@@ -454,6 +455,7 @@ impl MetastoreService for GrpcMetastoreAdapter {
 
     // Shard API:
     // - `open_shards`
+    // - `acquire_shards`
     // - `close_shards`
     // - `list_shards`
     // - `delete_shards`
@@ -466,6 +468,17 @@ impl MetastoreService for GrpcMetastoreAdapter {
         set_parent_span_from_request_metadata(request.metadata());
         let request = request.into_inner();
         let response = self.0.open_shards(request).await?;
+        Ok(tonic::Response::new(response))
+    }
+
+    #[instrument(skip(self, request))]
+    async fn acquire_shards(
+        &self,
+        request: tonic::Request<AcquireShardsRequest>,
+    ) -> Result<tonic::Response<AcquireShardsResponse>, tonic::Status> {
+        set_parent_span_from_request_metadata(request.metadata());
+        let request = request.into_inner();
+        let response = self.0.acquire_shards(request).await?;
         Ok(tonic::Response::new(response))
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/grpc_metastore/mod.rs
@@ -31,12 +31,15 @@ use quickwit_common::tower::BalanceChannel;
 use quickwit_common::uri::Uri as QuickwitUri;
 use quickwit_config::{IndexConfig, SourceConfig};
 use quickwit_proto::metastore::{
-    serde_utils as metastore_serde_utils, AddSourceRequest, CreateIndexRequest, DeleteIndexRequest,
-    DeleteQuery, DeleteSourceRequest, DeleteSplitsRequest, DeleteTask, IndexMetadataRequest,
+    serde_utils as metastore_serde_utils, AcquireShardsRequest, AcquireShardsResponse,
+    AddSourceRequest, CloseShardsRequest, CloseShardsResponse, CreateIndexRequest,
+    DeleteIndexRequest, DeleteQuery, DeleteShardsRequest, DeleteShardsResponse,
+    DeleteSourceRequest, DeleteSplitsRequest, DeleteTask, IndexMetadataRequest,
     LastDeleteOpstampRequest, ListAllSplitsRequest, ListDeleteTasksRequest,
-    ListIndexesMetadatasRequest, ListSplitsRequest, ListStaleSplitsRequest,
-    MarkSplitsForDeletionRequest, MetastoreError, MetastoreResult, MetastoreServiceClient,
-    PublishSplitsRequest, ResetSourceCheckpointRequest, StageSplitsRequest, ToggleSourceRequest,
+    ListIndexesMetadatasRequest, ListShardsRequest, ListShardsResponse, ListSplitsRequest,
+    ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreError, MetastoreResult,
+    MetastoreServiceClient, OpenShardsRequest, OpenShardsResponse, PublishSplitsRequest,
+    ResetSourceCheckpointRequest, StageSplitsRequest, ToggleSourceRequest,
     UpdateSplitsDeleteOpstampRequest,
 };
 use quickwit_proto::tonic::codegen::InterceptedService;
@@ -549,6 +552,65 @@ impl Metastore for MetastoreGrpcClient {
                 }
             })?;
         Ok(splits)
+    }
+
+    async fn open_shards(&self, request: OpenShardsRequest) -> MetastoreResult<OpenShardsResponse> {
+        let response = self
+            .underlying
+            .clone()
+            .open_shards(request)
+            .await
+            .map_err(|tonic_error| parse_grpc_error(&tonic_error))?;
+        Ok(response.into_inner())
+    }
+
+    async fn acquire_shards(
+        &self,
+        request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse> {
+        let response = self
+            .underlying
+            .clone()
+            .acquire_shards(request)
+            .await
+            .map_err(|tonic_error| parse_grpc_error(&tonic_error))?;
+        Ok(response.into_inner())
+    }
+
+    async fn close_shards(
+        &self,
+        request: CloseShardsRequest,
+    ) -> MetastoreResult<CloseShardsResponse> {
+        let response = self
+            .underlying
+            .clone()
+            .close_shards(request)
+            .await
+            .map_err(|tonic_error| parse_grpc_error(&tonic_error))?;
+        Ok(response.into_inner())
+    }
+
+    async fn list_shards(&self, request: ListShardsRequest) -> MetastoreResult<ListShardsResponse> {
+        let response = self
+            .underlying
+            .clone()
+            .list_shards(request)
+            .await
+            .map_err(|tonic_error| parse_grpc_error(&tonic_error))?;
+        Ok(response.into_inner())
+    }
+
+    async fn delete_shards(
+        &self,
+        request: DeleteShardsRequest,
+    ) -> MetastoreResult<DeleteShardsResponse> {
+        let response = self
+            .underlying
+            .clone()
+            .delete_shards(request)
+            .await
+            .map_err(|tonic_error| parse_grpc_error(&tonic_error))?;
+        Ok(response.into_inner())
     }
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/instrumented_metastore.rs
@@ -23,7 +23,11 @@ use async_trait::async_trait;
 use itertools::Itertools;
 use quickwit_common::uri::Uri;
 use quickwit_config::{IndexConfig, SourceConfig};
-use quickwit_proto::metastore::{DeleteQuery, DeleteTask, MetastoreResult};
+use quickwit_proto::metastore::{
+    AcquireShardsRequest, AcquireShardsResponse, CloseShardsRequest, CloseShardsResponse,
+    DeleteQuery, DeleteShardsRequest, DeleteShardsResponse, DeleteTask, ListShardsRequest,
+    ListShardsResponse, MetastoreResult, OpenShardsRequest, OpenShardsResponse,
+};
 use quickwit_proto::{IndexUid, PublishToken};
 
 use crate::checkpoint::IndexCheckpointDelta;
@@ -313,6 +317,50 @@ impl Metastore for InstrumentedMetastore {
                 .list_stale_splits(index_uid.clone(), delete_opstamp, num_splits)
                 .await,
             [list_stale_splits, index_uid.index_id()]
+        );
+    }
+
+    async fn open_shards(&self, request: OpenShardsRequest) -> MetastoreResult<OpenShardsResponse> {
+        instrument!(
+            self.underlying.open_shards(request).await,
+            [open_shards, ""]
+        );
+    }
+
+    async fn acquire_shards(
+        &self,
+        request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse> {
+        instrument!(
+            self.underlying.acquire_shards(request).await,
+            [acquire_shards, ""]
+        );
+    }
+
+    async fn close_shards(
+        &self,
+        request: CloseShardsRequest,
+    ) -> MetastoreResult<CloseShardsResponse> {
+        instrument!(
+            self.underlying.close_shards(request).await,
+            [close_shards, ""]
+        );
+    }
+
+    async fn list_shards(&self, request: ListShardsRequest) -> MetastoreResult<ListShardsResponse> {
+        instrument!(
+            self.underlying.list_shards(request).await,
+            [list_shards, ""]
+        );
+    }
+
+    async fn delete_shards(
+        &self,
+        request: DeleteShardsRequest,
+    ) -> MetastoreResult<DeleteShardsResponse> {
+        instrument!(
+            self.underlying.delete_shards(request).await,
+            [delete_shards, ""]
         );
     }
 }

--- a/quickwit/quickwit-metastore/src/metastore/metastore_event_publisher.rs
+++ b/quickwit/quickwit-metastore/src/metastore/metastore_event_publisher.rs
@@ -27,7 +27,11 @@ use quickwit_config::{IndexConfig, SourceConfig};
 use quickwit_proto::metastore::events::{
     AddSourceEvent, DeleteIndexEvent, DeleteSourceEvent, ToggleSourceEvent,
 };
-use quickwit_proto::metastore::{DeleteQuery, DeleteTask, MetastoreResult};
+use quickwit_proto::metastore::{
+    AcquireShardsRequest, AcquireShardsResponse, CloseShardsRequest, CloseShardsResponse,
+    DeleteQuery, DeleteShardsRequest, DeleteShardsResponse, DeleteTask, ListShardsRequest,
+    ListShardsResponse, MetastoreResult, OpenShardsRequest, OpenShardsResponse,
+};
 use quickwit_proto::{IndexUid, PublishToken};
 use tracing::info;
 
@@ -245,6 +249,35 @@ impl Metastore for MetastoreEventPublisher {
         self.underlying
             .list_stale_splits(index_uid, delete_opstamp, num_splits)
             .await
+    }
+
+    async fn open_shards(&self, request: OpenShardsRequest) -> MetastoreResult<OpenShardsResponse> {
+        self.underlying.open_shards(request).await
+    }
+
+    async fn acquire_shards(
+        &self,
+        request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse> {
+        self.underlying.acquire_shards(request).await
+    }
+
+    async fn close_shards(
+        &self,
+        request: CloseShardsRequest,
+    ) -> MetastoreResult<CloseShardsResponse> {
+        self.underlying.close_shards(request).await
+    }
+
+    async fn list_shards(&self, request: ListShardsRequest) -> MetastoreResult<ListShardsResponse> {
+        self.underlying.list_shards(request).await
+    }
+
+    async fn delete_shards(
+        &self,
+        request: DeleteShardsRequest,
+    ) -> MetastoreResult<DeleteShardsResponse> {
+        self.underlying.delete_shards(request).await
     }
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -38,9 +38,10 @@ use quickwit_common::uri::Uri;
 use quickwit_config::{IndexConfig, SourceConfig};
 use quickwit_doc_mapper::tag_pruning::TagFilterAst;
 use quickwit_proto::metastore::{
-    CloseShardsRequest, CloseShardsResponse, DeleteQuery, DeleteShardsRequest,
-    DeleteShardsResponse, DeleteTask, EntityKind, ListShardsRequest, ListShardsResponse,
-    MetastoreError, MetastoreResult, OpenShardsRequest, OpenShardsResponse,
+    AcquireShardsRequest, AcquireShardsResponse, CloseShardsRequest, CloseShardsResponse,
+    DeleteQuery, DeleteShardsRequest, DeleteShardsResponse, DeleteTask, EntityKind,
+    ListShardsRequest, ListShardsResponse, MetastoreError, MetastoreResult, OpenShardsRequest,
+    OpenShardsResponse,
 };
 use quickwit_proto::{IndexUid, PublishToken};
 use time::OffsetDateTime;
@@ -322,40 +323,28 @@ pub trait Metastore: fmt::Debug + Send + Sync + 'static {
     // - `delete_shards`
 
     /// Creates new open shards for one or multiple indexes.
-    async fn open_shards(
+    async fn open_shards(&self, request: OpenShardsRequest) -> MetastoreResult<OpenShardsResponse>;
+
+    ///
+    async fn acquire_shards(
         &self,
-        _request: OpenShardsRequest,
-    ) -> MetastoreResult<OpenShardsResponse> {
-        // TODO: Remove default implementation once all metastores implement this method.
-        unimplemented!()
-    }
+        request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse>;
 
     /// Closes some shards, i.e. changes their state from `Open` to `Closing` or `Closed`.
     async fn close_shards(
         &self,
-        _request: CloseShardsRequest,
-    ) -> MetastoreResult<CloseShardsResponse> {
-        // TODO: Remove default implementation once all metastores implement this method.
-        unimplemented!()
-    }
+        request: CloseShardsRequest,
+    ) -> MetastoreResult<CloseShardsResponse>;
 
     /// Lists the shards of one or multiple indexes.
-    async fn list_shards(
-        &self,
-        _request: ListShardsRequest,
-    ) -> MetastoreResult<ListShardsResponse> {
-        // TODO: Remove default implementation once all metastores implement this method.
-        unimplemented!()
-    }
+    async fn list_shards(&self, request: ListShardsRequest) -> MetastoreResult<ListShardsResponse>;
 
     /// Deletes some shards.
     async fn delete_shards(
         &self,
-        _request: DeleteShardsRequest,
-    ) -> MetastoreResult<DeleteShardsResponse> {
-        // TODO: Remove default implementation once all metastores implement this method.
-        unimplemented!()
-    }
+        request: DeleteShardsRequest,
+    ) -> MetastoreResult<DeleteShardsResponse>;
 }
 
 /// A query object for listing indexes stored in the metastore.

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -34,7 +34,10 @@ use quickwit_config::{
 };
 use quickwit_doc_mapper::tag_pruning::TagFilterAst;
 use quickwit_proto::metastore::{
-    DeleteQuery, DeleteTask, EntityKind, MetastoreError, MetastoreResult,
+    AcquireShardsRequest, AcquireShardsResponse, CloseShardsRequest, CloseShardsResponse,
+    DeleteQuery, DeleteShardsRequest, DeleteShardsResponse, DeleteTask, EntityKind,
+    ListShardsRequest, ListShardsResponse, MetastoreError, MetastoreResult, OpenShardsRequest,
+    OpenShardsResponse,
 };
 use quickwit_proto::{IndexUid, PublishToken};
 use sqlx::migrate::Migrator;
@@ -1224,6 +1227,41 @@ impl Metastore for PostgresqlMetastore {
             .into_iter()
             .map(|pg_split| pg_split.try_into())
             .collect()
+    }
+
+    async fn open_shards(
+        &self,
+        _request: OpenShardsRequest,
+    ) -> MetastoreResult<OpenShardsResponse> {
+        unimplemented!("`open_shards` is not implemented for PostgreSQL metastore")
+    }
+
+    async fn acquire_shards(
+        &self,
+        _request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse> {
+        unimplemented!("`close_shards` is not implemented for PostgreSQL metastore")
+    }
+
+    async fn close_shards(
+        &self,
+        _request: CloseShardsRequest,
+    ) -> MetastoreResult<CloseShardsResponse> {
+        unimplemented!("`close_shards` is not implemented for PostgreSQL metastore")
+    }
+
+    async fn list_shards(
+        &self,
+        _request: ListShardsRequest,
+    ) -> MetastoreResult<ListShardsResponse> {
+        unimplemented!("`list_shards` is not implemented for PostgreSQL metastore")
+    }
+
+    async fn delete_shards(
+        &self,
+        _request: DeleteShardsRequest,
+    ) -> MetastoreResult<DeleteShardsResponse> {
+        unimplemented!("`delete_shards` is not implemented for PostgreSQL metastore")
     }
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/retrying_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/retrying_metastore/mod.rs
@@ -27,7 +27,11 @@ use async_trait::async_trait;
 use quickwit_common::retry::RetryParams;
 use quickwit_common::uri::Uri;
 use quickwit_config::{IndexConfig, SourceConfig};
-use quickwit_proto::metastore::{DeleteQuery, DeleteTask, MetastoreResult};
+use quickwit_proto::metastore::{
+    AcquireShardsRequest, AcquireShardsResponse, CloseShardsRequest, CloseShardsResponse,
+    DeleteQuery, DeleteShardsRequest, DeleteShardsResponse, DeleteTask, ListShardsRequest,
+    ListShardsResponse, MetastoreResult, OpenShardsRequest, OpenShardsResponse,
+};
 use quickwit_proto::{IndexUid, PublishToken};
 
 use self::retry::retry;
@@ -277,6 +281,50 @@ impl Metastore for RetryingMetastore {
             self.inner
                 .list_delete_tasks(index_uid.clone(), opstamp_start)
                 .await
+        })
+        .await
+    }
+
+    async fn open_shards(&self, request: OpenShardsRequest) -> MetastoreResult<OpenShardsResponse> {
+        retry(&self.retry_params, || async {
+            self.inner.open_shards(request.clone()).await
+        })
+        .await
+    }
+
+    async fn acquire_shards(
+        &self,
+        request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse> {
+        retry(&self.retry_params, || async {
+            self.inner.acquire_shards(request.clone()).await
+        })
+        .await
+    }
+
+    async fn close_shards(
+        &self,
+        request: CloseShardsRequest,
+    ) -> MetastoreResult<CloseShardsResponse> {
+        retry(&self.retry_params, || async {
+            self.inner.close_shards(request.clone()).await
+        })
+        .await
+    }
+
+    async fn list_shards(&self, request: ListShardsRequest) -> MetastoreResult<ListShardsResponse> {
+        retry(&self.retry_params, || async {
+            self.inner.list_shards(request.clone()).await
+        })
+        .await
+    }
+
+    async fn delete_shards(
+        &self,
+        request: DeleteShardsRequest,
+    ) -> MetastoreResult<DeleteShardsResponse> {
+        retry(&self.retry_params, || async {
+            self.inner.delete_shards(request.clone()).await
         })
         .await
     }

--- a/quickwit/quickwit-metastore/src/metastore/retrying_metastore/test.rs
+++ b/quickwit/quickwit-metastore/src/metastore/retrying_metastore/test.rs
@@ -25,7 +25,10 @@ use quickwit_common::retry::RetryParams;
 use quickwit_common::uri::Uri;
 use quickwit_config::{IndexConfig, SourceConfig};
 use quickwit_proto::metastore::{
-    DeleteQuery, DeleteTask, EntityKind, MetastoreError, MetastoreResult,
+    AcquireShardsRequest, AcquireShardsResponse, CloseShardsRequest, CloseShardsResponse,
+    DeleteQuery, DeleteShardsRequest, DeleteShardsResponse, DeleteTask, EntityKind,
+    ListShardsRequest, ListShardsResponse, MetastoreError, MetastoreResult, OpenShardsRequest,
+    OpenShardsResponse,
 };
 use quickwit_proto::{IndexUid, PublishToken};
 
@@ -228,6 +231,41 @@ impl Metastore for RetryTestMetastore {
             Ok(_) => Ok(Vec::new()),
             Err(err) => Err(err),
         }
+    }
+
+    async fn open_shards(
+        &self,
+        _request: OpenShardsRequest,
+    ) -> MetastoreResult<OpenShardsResponse> {
+        self.try_success().map(|_| Default::default())
+    }
+
+    async fn acquire_shards(
+        &self,
+        _request: AcquireShardsRequest,
+    ) -> MetastoreResult<AcquireShardsResponse> {
+        self.try_success().map(|_| Default::default())
+    }
+
+    async fn close_shards(
+        &self,
+        _request: CloseShardsRequest,
+    ) -> MetastoreResult<CloseShardsResponse> {
+        self.try_success().map(|_| Default::default())
+    }
+
+    async fn list_shards(
+        &self,
+        _request: ListShardsRequest,
+    ) -> MetastoreResult<ListShardsResponse> {
+        self.try_success().map(|_| Default::default())
+    }
+
+    async fn delete_shards(
+        &self,
+        _request: DeleteShardsRequest,
+    ) -> MetastoreResult<DeleteShardsResponse> {
+        self.try_success().map(|_| Default::default())
     }
 }
 

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
@@ -131,7 +131,6 @@
     ],
     "version": "0.6"
   },
-  "shards": {},
   "splits": [
     {
       "create_timestamp": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
@@ -135,7 +135,6 @@
     ],
     "version": "0.6"
   },
-  "shards": {},
   "splits": [
     {
       "create_timestamp": 3,

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -36,16 +36,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .unwrap();
 
     // Indexing Service
-    let mut prost_config = prost_build::Config::default();
-    prost_config.type_attribute("IndexingTask", "#[derive(Eq, Hash)]");
-
-    Codegen::run_with_config(
+    Codegen::run(
         &["protos/quickwit/indexing.proto"],
         "src/codegen/quickwit",
         "crate::indexing::IndexingResult",
         "crate::indexing::IndexingError",
         &[],
-        prost_config,
     )
     .unwrap();
 

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -25,21 +25,21 @@ import "quickwit/ingest.proto";
 
 
 service IngesterService {
-    /// Persists batches of documents to primary shards owned by a leader.
+    // Persists batches of documents to primary shards owned by a leader.
     rpc Persist(PersistRequest) returns (PersistResponse);
 
-    /// Opens a replication stream from a leader to a follower.
+    // Opens a replication stream from a leader to a follower.
     rpc OpenReplicationStream(stream SynReplicationMessage) returns (stream AckReplicationMessage);
 
-    /// Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
+    // Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
     rpc OpenFetchStream(OpenFetchStreamRequest) returns (stream FetchResponseV2);
 
     // rpc OpenWatchStream(OpenWatchStreamRequest) returns (stream WatchMessage);
 
-    /// Pings an ingester to check if it is ready to host shards and serve requests.
+    // Pings an ingester to check if it is ready to host shards and serve requests.
     rpc Ping(PingRequest) returns (PingResponse);
 
-    /// Truncates the shards at the given positions. Callers should this RPC on leaders and they will forward to followers.
+    // Truncates the shards at the given positions. Indexers should call this RPC on leaders, which will replicate the request to followers.
     rpc Truncate(TruncateRequest) returns (TruncateResponse);
 }
 

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 syntax = "proto3";
 
 package quickwit.metastore;
@@ -106,6 +105,11 @@ service MetastoreService {
   /// `failures`.
 
   rpc OpenShards(OpenShardsRequest) returns (OpenShardsResponse);
+
+  // Acquires a set of shards for indexing. This RPC locks the shards for publishing thanks to a publish token and only
+  // the last indexer that has acquired the shards is allowed to publish. The response returns for each subrequest the
+  // list of acquired shards along with the positions to index from.
+  rpc AcquireShards(AcquireShardsRequest) returns (AcquireShardsResponse);
 
   rpc CloseShards(CloseShardsRequest) returns (CloseShardsResponse);
 
@@ -282,6 +286,27 @@ message OpenShardsSubresponse {
     string source_id = 2;
     repeated quickwit.ingest.Shard open_shards = 3;
     uint64 next_shard_id = 4;
+}
+
+message AcquireShardsRequest {
+  repeated AcquireShardsSubrequest subrequests = 1;
+}
+
+message AcquireShardsSubrequest {
+    string index_uid = 1;
+    string source_id = 2;
+    repeated uint64 shard_ids = 3;
+    string publish_token = 4;
+}
+
+message AcquireShardsResponse {
+  repeated AcquireShardsSubresponse subresponses = 1;
+}
+
+message AcquireShardsSubresponse {
+    string index_uid = 1;
+    string source_id = 2;
+    repeated quickwit.ingest.Shard acquired_shards = 3;
 }
 
 message CloseShardsRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
@@ -5,7 +5,6 @@ pub struct ApplyIndexingPlanRequest {
     #[prost(message, repeated, tag = "1")]
     pub indexing_tasks: ::prost::alloc::vec::Vec<IndexingTask>,
 }
-#[derive(Eq, Hash)]
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -1225,7 +1225,7 @@ pub mod ingester_service_grpc_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
-        /// / Persists batches of documents to primary shards owned by a leader.
+        /// Persists batches of documents to primary shards owned by a leader.
         pub async fn persist(
             &mut self,
             request: impl tonic::IntoRequest<super::PersistRequest>,
@@ -1256,7 +1256,7 @@ pub mod ingester_service_grpc_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// / Opens a replication stream from a leader to a follower.
+        /// Opens a replication stream from a leader to a follower.
         pub async fn open_replication_stream(
             &mut self,
             request: impl tonic::IntoStreamingRequest<
@@ -1289,7 +1289,7 @@ pub mod ingester_service_grpc_client {
                 );
             self.inner.streaming(req, path, codec).await
         }
-        /// / Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
+        /// Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
         pub async fn open_fetch_stream(
             &mut self,
             request: impl tonic::IntoRequest<super::OpenFetchStreamRequest>,
@@ -1320,7 +1320,7 @@ pub mod ingester_service_grpc_client {
                 );
             self.inner.server_streaming(req, path, codec).await
         }
-        /// / Pings an ingester to check if it is ready to host shards and serve requests.
+        /// Pings an ingester to check if it is ready to host shards and serve requests.
         pub async fn ping(
             &mut self,
             request: impl tonic::IntoRequest<super::PingRequest>,
@@ -1345,7 +1345,7 @@ pub mod ingester_service_grpc_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// / Truncates the shards at the given positions. Callers should this RPC on leaders and they will forward to followers.
+        /// Truncates the shards at the given positions. Indexers should call this RPC on leaders, which will replicate the request to followers.
         pub async fn truncate(
             &mut self,
             request: impl tonic::IntoRequest<super::TruncateRequest>,
@@ -1385,7 +1385,7 @@ pub mod ingester_service_grpc_server {
     /// Generated trait containing gRPC methods that should be implemented for use with IngesterServiceGrpcServer.
     #[async_trait]
     pub trait IngesterServiceGrpc: Send + Sync + 'static {
-        /// / Persists batches of documents to primary shards owned by a leader.
+        /// Persists batches of documents to primary shards owned by a leader.
         async fn persist(
             &self,
             request: tonic::Request<super::PersistRequest>,
@@ -1396,7 +1396,7 @@ pub mod ingester_service_grpc_server {
             >
             + Send
             + 'static;
-        /// / Opens a replication stream from a leader to a follower.
+        /// Opens a replication stream from a leader to a follower.
         async fn open_replication_stream(
             &self,
             request: tonic::Request<tonic::Streaming<super::SynReplicationMessage>>,
@@ -1410,7 +1410,7 @@ pub mod ingester_service_grpc_server {
             >
             + Send
             + 'static;
-        /// / Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
+        /// Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
         async fn open_fetch_stream(
             &self,
             request: tonic::Request<super::OpenFetchStreamRequest>,
@@ -1418,12 +1418,12 @@ pub mod ingester_service_grpc_server {
             tonic::Response<Self::OpenFetchStreamStream>,
             tonic::Status,
         >;
-        /// / Pings an ingester to check if it is ready to host shards and serve requests.
+        /// Pings an ingester to check if it is ready to host shards and serve requests.
         async fn ping(
             &self,
             request: tonic::Request<super::PingRequest>,
         ) -> std::result::Result<tonic::Response<super::PingResponse>, tonic::Status>;
-        /// / Truncates the shards at the given positions. Callers should this RPC on leaders and they will forward to followers.
+        /// Truncates the shards at the given positions. Indexers should call this RPC on leaders, which will replicate the request to followers.
         async fn truncate(
             &self,
             request: tonic::Request<super::TruncateRequest>,

--- a/quickwit/quickwit-serve/src/grpc.rs
+++ b/quickwit/quickwit-serve/src/grpc.rs
@@ -50,10 +50,9 @@ pub(crate) async fn start_grpc_server(
     let mut server = Server::builder();
 
     // Mount gRPC metastore service if `QuickwitService::Metastore` is enabled on node.
-    let metastore_grpc_service = if services.services.contains(&QuickwitService::Metastore) {
+    let metastore_grpc_service = if let Some(metastore_server) = &services.metastore_server_opt {
         enabled_grpc_services.insert("metastore");
-        let metastore = services.metastore.clone();
-        let grpc_metastore_adapter = GrpcMetastoreAdapter::from(metastore);
+        let grpc_metastore_adapter = GrpcMetastoreAdapter::from(metastore_server.clone());
         Some(MetastoreServiceServer::new(grpc_metastore_adapter))
     } else {
         None
@@ -101,7 +100,7 @@ pub(crate) async fn start_grpc_server(
     };
     // Mount gRPC OpenTelemetry OTLP trace service if `QuickwitService::Indexer` is enabled on node.
     let enable_opentelemetry_otlp_grpc_service =
-        services.config.indexer_config.enable_otlp_endpoint;
+        services.node_config.indexer_config.enable_otlp_endpoint;
     let otlp_trace_grpc_service = if enable_opentelemetry_otlp_grpc_service
         && services.services.contains(&QuickwitService::Indexer)
     {
@@ -135,13 +134,13 @@ pub(crate) async fn start_grpc_server(
     } else {
         None
     };
-    let enable_jaeger_endpoint = services.config.jaeger_config.enable_endpoint;
+    let enable_jaeger_endpoint = services.node_config.jaeger_config.enable_endpoint;
     let jaeger_grpc_service =
         if enable_jaeger_endpoint && services.services.contains(&QuickwitService::Searcher) {
             enabled_grpc_services.insert("jaeger");
             let search_service = services.search_service.clone();
             Some(SpanReaderPluginServer::new(JaegerService::new(
-                services.config.jaeger_config.clone(),
+                services.node_config.jaeger_config.clone(),
                 search_service,
             )))
         } else {


### PR DESCRIPTION
### Description
Implement the new ingest source that receives shard assignments from the control plane and streams documents from shards.

Shard assignments from the control plane are a hack at the moment and will be properly implemented in a follow-up PR.

### How was this PR tested?
- Updated ingester unit tests
- Added ingest source v2 unit tests
