### PR TITLE
Switch to recommended Node.js install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,25 @@ ENV QW_COMMIT_HASH=$QW_COMMIT_HASH
 ENV QW_COMMIT_TAGS=$QW_COMMIT_TAGS
 
 
-RUN echo "Adding Node.js PPA" \
-    && curl -s https://deb.nodesource.com/setup_16.x | bash
-
 RUN apt-get -y update \
     && apt-get -y install ca-certificates \
                           clang \
                           cmake \
+                          curl \
+                          gnupg \
                           libssl-dev \
                           llvm \
-                          nodejs \
                           protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" \
+        | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get -y install nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Required by tonic


### PR DESCRIPTION
### Description

Move away from deprecated nodesource installer script (https://github.com/nodesource/distributions#new-update-%EF%B8%8F).

Benefits of the change:
- avoid 60s deprecation wait in docker build
- the installer script might just be removed by nodesource some time in the future

### How was this PR tested?

Ran docker build locally.


