### PR TITLE
Making the contracts in Uri a tiny bit clearer.

### DIFF
--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 use clap::{arg, ArgAction, ArgMatches, Command};
 use itertools::Itertools;
 use quickwit_common::runtimes::RuntimesConfig;
-use quickwit_common::uri::Uri;
+use quickwit_common::uri::{Protocol, Uri};
 use quickwit_config::service::QuickwitService;
 use quickwit_config::NodeConfig;
 use quickwit_serve::serve_quickwit;
@@ -126,11 +126,12 @@ fn quickwit_telemetry_info(config: &NodeConfig) -> QuickwitTelemetryInfo {
     }
     // The metastore URI is only relevant if the metastore is enabled.
     if config.is_service_enabled(QuickwitService::Metastore) {
-        if config.metastore_uri.protocol().is_postgresql() {
-            features.insert(QuickwitFeature::PostgresqMetastore);
+        let feature = if config.metastore_uri.protocol() == Protocol::PostgreSQL {
+            QuickwitFeature::PostgresqMetastore
         } else {
-            features.insert(QuickwitFeature::FileBackedMetastore);
-        }
+            QuickwitFeature::FileBackedMetastore
+        };
+        features.insert(feature);
     }
     let services = config
         .enabled_services

--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -273,10 +274,8 @@ pub async fn upload_test_file(
 ) -> PathBuf {
     let test_data = tokio::fs::read(local_src_path).await.unwrap();
     let mut src_location: PathBuf = [r"s3://", bucket, prefix].iter().collect();
-    let storage = storage_resolver
-        .resolve(&Uri::from_well_formed(src_location.to_string_lossy()))
-        .await
-        .unwrap();
+    let storage_uri = Uri::from_str(src_location.to_string_lossy().borrow()).unwrap();
+    let storage = storage_resolver.resolve(&storage_uri).await.unwrap();
     storage
         .put(&PathBuf::from(filename), Box::new(test_data))
         .await

--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -20,6 +20,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -186,11 +187,9 @@ pub async fn create_test_env(
     // TODO: refactor when we have a singleton storage resolver.
     let metastore_uri = match storage_type {
         TestStorageType::LocalFileSystem => {
-            Uri::from_well_formed(format!("file://{}", indexes_dir_path.display()))
+            Uri::from_str(&format!("file://{}", indexes_dir_path.display())).unwrap()
         }
-        TestStorageType::S3 => {
-            Uri::from_well_formed("s3://quickwit-integration-tests/indexes".to_string())
-        }
+        TestStorageType::S3 => Uri::for_test("s3://quickwit-integration-tests/indexes"),
     };
     let storage_resolver = StorageResolver::unconfigured();
     let storage = storage_resolver.resolve(&metastore_uri).await?;
@@ -236,11 +235,12 @@ pub async fn create_test_env(
     resource_files.insert("wiki", wikipedia_docs_path);
 
     let config_uri =
-        Uri::from_well_formed(format!("file://{}", resource_files["config"].display()));
-    let index_config_uri = Uri::from_well_formed(format!(
+        Uri::from_str(&format!("file://{}", resource_files["config"].display())).unwrap();
+    let index_config_uri = Uri::from_str(&format!(
         "file://{}",
         resource_files["index_config"].display()
-    ));
+    ))
+    .unwrap();
     let cluster_endpoint = Url::parse(&format!("http://localhost:{rest_listen_port}"))
         .context("failed to parse cluster endpoint")?;
 

--- a/quickwit/quickwit-codegen/example/src/codegen/hello.rs
+++ b/quickwit/quickwit-codegen/example/src/codegen/hello.rs
@@ -41,6 +41,8 @@ pub struct PingResponse {
     pub message: ::prost::alloc::string::String,
 }
 /// BEGIN quickwit-codegen
+#[allow(unused_imports)]
+use std::str::FromStr;
 use tower::{Layer, Service, ServiceExt};
 use quickwit_common::metrics::{PrometheusLabels, OwnedPrometheusLabels};
 impl PrometheusLabels<1> for HelloRequest {
@@ -597,8 +599,8 @@ where
     }
     fn endpoints(&self) -> Vec<quickwit_common::uri::Uri> {
         vec![
-            quickwit_common::uri::Uri::from_well_formed(format!("actor://localhost/{}",
-            self.inner.actor_instance_id()))
+            quickwit_common::uri::Uri::from_str(& format!("actor://localhost/{}", self
+            .inner.actor_instance_id())).expect("URI should be valid")
         ]
     }
 }
@@ -677,8 +679,8 @@ where
         self.connection_addrs_rx
             .borrow()
             .iter()
-            .map(|addr| quickwit_common::uri::Uri::from_well_formed(
-                format!(r"grpc://{}/{}.{}", addr, "hello", "Hello"),
+            .flat_map(|addr| quickwit_common::uri::Uri::from_str(
+                &format!("grpc://{addr}/{}.{}", "hello", "Hello"),
             ))
             .collect()
     }

--- a/quickwit/quickwit-codegen/example/src/lib.rs
+++ b/quickwit/quickwit-codegen/example/src/lib.rs
@@ -149,6 +149,7 @@ impl Hello for HelloImpl {
 #[cfg(test)]
 mod tests {
     use std::net::SocketAddr;
+    use std::str::FromStr;
     use std::sync::atomic::Ordering;
 
     use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Universe};
@@ -313,7 +314,7 @@ mod tests {
         grpc_client.check_connectivity().await.unwrap();
         assert_eq!(
             grpc_client.endpoints(),
-            vec![Uri::from_well_formed("grpc://127.0.0.1:6666/hello.Hello")]
+            vec![Uri::from_str("grpc://127.0.0.1:6666/hello.Hello").unwrap()]
         );
 
         // The connectivity check fails if there is no client behind the channel.
@@ -403,10 +404,11 @@ mod tests {
         actor_client.check_connectivity().await.unwrap();
         assert_eq!(
             actor_client.endpoints(),
-            vec![Uri::from_well_formed(format!(
+            vec![Uri::from_str(&format!(
                 "actor://localhost/{}",
                 actor_mailbox.actor_instance_id()
-            ))]
+            ))
+            .unwrap()]
         );
 
         let (ping_stream_tx, ping_stream) = ServiceStream::new_bounded(1);

--- a/quickwit/quickwit-codegen/src/codegen.rs
+++ b/quickwit/quickwit-codegen/src/codegen.rs
@@ -120,10 +120,7 @@ impl CodegenBuilder {
     pub fn run(self) -> anyhow::Result<()> {
         ensure!(!self.protos.is_empty(), "proto file list is empty");
         ensure!(!self.output_dir.is_empty(), "output directory is undefined");
-        ensure!(
-            !self.result_type_path.is_empty(),
-            "result type is undefined"
-        );
+        ensure!(!self.result_type_path.is_empty(),);
         ensure!(!self.error_type_path.is_empty(), "error type is undefined");
 
         Codegen::run(self)
@@ -305,6 +302,8 @@ fn generate_all(
     quote! {
         // The line below is necessary to opt out of the license header check.
         /// BEGIN quickwit-codegen
+        #[allow(unused_imports)]
+        use std::str::FromStr;
         use tower::{Layer, Service, ServiceExt};
         #prom_labels_impl
 
@@ -970,7 +969,7 @@ fn generate_tower_mailbox(context: &CodegenContext) -> TokenStream {
             }
 
             fn endpoints(&self) -> Vec<quickwit_common::uri::Uri> {
-                vec![quickwit_common::uri::Uri::from_well_formed(format!("actor://localhost/{}", self.inner.actor_instance_id()))]
+                vec![quickwit_common::uri::Uri::from_str(&format!("actor://localhost/{}", self.inner.actor_instance_id())).expect("URI should be valid")]
             }
         }
     } else {
@@ -1114,7 +1113,7 @@ fn generate_grpc_client_adapter(context: &CodegenContext) -> TokenStream {
                 self.connection_addrs_rx
                     .borrow()
                     .iter()
-                    .map(|addr| quickwit_common::uri::Uri::from_well_formed(format!(r"grpc://{}/{}.{}", addr, #grpc_client_package_name_string, #service_name_string)))
+                    .flat_map(|addr| quickwit_common::uri::Uri::from_str(&format!("grpc://{addr}/{}.{}", #grpc_client_package_name_string, #service_name_string)))
                     .collect()
             }
         }

--- a/quickwit/quickwit-common/src/uri.rs
+++ b/quickwit/quickwit-common/src/uri.rs
@@ -108,10 +108,10 @@ const PROTOCOL_SEPARATOR: &str = "://";
 ///
 /// Uri has to be built using `Uri::from_str`.
 /// This function has some normalization behavior.
-/// Some protocol have several acceptable string representation (postgres, pg, postgresql).
+/// Some protocol have several acceptable string representation (`pg`, `postgres`, `postgresql`).
 ///
 /// If the representation in the input string is not canonical, it will get normalized.
-/// In other words, a parsed uri may not have the exact string representation as the original
+/// In other words, a parsed URI may not have the exact string representation as the original
 /// string.
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Uri {
@@ -148,7 +148,7 @@ impl Uri {
             DATABASE_URI_PATTERN
                 .get_or_init(|| {
                     Regex::new("(?P<before>^.*://.*)(?P<password>:.*@)(?P<after>.*)")
-                        .expect("The regular expression should compile.")
+                        .expect("the regular expression should compile")
                 })
                 .replace(&self.uri, "$before:***redacted***@$after")
         } else {
@@ -178,6 +178,7 @@ impl Uri {
         }
         let path = self.path();
         let protocol = self.protocol();
+
         if protocol == Protocol::S3 && path.components().count() < 2 {
             return None;
         }
@@ -185,13 +186,11 @@ impl Uri {
             return None;
         }
         let parent_path = path.parent()?;
-        Some(
-            Uri::from_str(&format!(
-                "{protocol}{PROTOCOL_SEPARATOR}{}",
-                parent_path.display()
-            ))
-            .unwrap(),
-        )
+
+        Some(Self {
+            uri: format!("{protocol}{PROTOCOL_SEPARATOR}{}", parent_path.display()),
+            protocol,
+        })
     }
 
     fn path(&self) -> &Path {
@@ -204,6 +203,7 @@ impl Uri {
             return None;
         }
         let path = self.path();
+
         if self.protocol() == Protocol::S3 && path.components().count() < 2 {
             return None;
         }
@@ -727,7 +727,7 @@ mod tests {
                 ))
                 .unwrap();
                 let expected_uri =
-                    format!("postgresql://username:***redacted***@localhost:5432/metastore");
+                    "postgresql://username:***redacted***@localhost:5432/metastore".to_string();
                 assert_eq!(uri.as_redacted_str(), expected_uri);
                 assert_eq!(format!("{uri}"), expected_uri);
                 assert_eq!(

--- a/quickwit/quickwit-common/src/uri.rs
+++ b/quickwit/quickwit-common/src/uri.rs
@@ -33,14 +33,15 @@ use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[repr(u8)]
 pub enum Protocol {
-    Azure,
-    File,
-    Grpc,
-    Actor,
-    PostgreSQL,
-    Ram,
-    S3,
+    Actor = 1,
+    Azure = 2,
+    File = 3,
+    Grpc = 4,
+    PostgreSQL = 5,
+    Ram = 6,
+    S3 = 7,
 }
 
 impl Protocol {
@@ -56,28 +57,8 @@ impl Protocol {
         }
     }
 
-    pub fn is_azure(&self) -> bool {
-        matches!(&self, Protocol::Azure)
-    }
-
     pub fn is_file(&self) -> bool {
         matches!(&self, Protocol::File)
-    }
-
-    pub fn is_grpc(&self) -> bool {
-        matches!(&self, Protocol::Grpc)
-    }
-
-    pub fn is_postgresql(&self) -> bool {
-        matches!(&self, Protocol::PostgreSQL)
-    }
-
-    pub fn is_ram(&self) -> bool {
-        matches!(&self, Protocol::Ram)
-    }
-
-    pub fn is_s3(&self) -> bool {
-        matches!(&self, Protocol::S3)
     }
 
     pub fn is_file_storage(&self) -> bool {
@@ -119,31 +100,30 @@ impl FromStr for Protocol {
 const PROTOCOL_SEPARATOR: &str = "://";
 
 /// Encapsulates the URI type.
+///
+/// URI's string representation are guaranteed to start
+/// by the protocol `str()` representation.
+///
+/// # Disclaimer
+///
+/// Uri has to be built using `Uri::from_str`.
+/// This function has some normalization behavior.
+/// Some protocol have several acceptable string representation (postgres, pg, postgresql).
+///
+/// If the representation in the input string is not canonical, it will get normalized.
+/// In other words, a parsed uri may not have the exact string representation as the original
+/// string.
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Uri {
     uri: String,
-    protocol_idx: usize,
+    protocol: Protocol,
 }
 
 impl Uri {
-    /// Constructs a [`Uri`] from a properly formatted string `<protocol>://<path>` where `path` is
-    /// normalized. Use this method exclusively for trusted input.
-    pub fn from_well_formed<S: ToString>(uri: S) -> Self {
-        let uri = uri.to_string();
-        let protocol_idx = uri.find(PROTOCOL_SEPARATOR).expect(
-            "URI lacks protocol separator. Use `Uri::from_well_formed` exclusively for trusted \
-             input.",
-        );
-        let protocol_str = &uri[..protocol_idx];
-        protocol_str.parse::<Protocol>().expect(
-            "URI protocol is invalid. Use `Uri::from_well_formed` exclusively for trusted input.`",
-        );
-        Self { uri, protocol_idx }
-    }
-
-    #[cfg(any(test, feature = "testsuite"))]
-    pub fn for_test(uri: &str) -> Self {
-        Uri::from_well_formed(uri)
+    /// This is only used for test. We artificially restrict the lifetime to 'static
+    /// to avoid misuses.
+    pub fn for_test(uri: &'static str) -> Self {
+        Uri::from_str(uri).unwrap()
     }
 
     /// Returns the extension of the URI.
@@ -158,7 +138,7 @@ impl Uri {
 
     /// Returns the protocol of the URI.
     pub fn protocol(&self) -> Protocol {
-        Protocol::from_str(&self.uri[..self.protocol_idx]).expect("Failed to parse URI protocol. This should never happen! Please, report on https://github.com/quickwit-oss/quickwit/issues.")
+        self.protocol
     }
 
     /// Strips sensitive information such as credentials from URI.
@@ -181,12 +161,10 @@ impl Uri {
     }
 
     /// Returns the file path of the URI.
-    /// Applies only to `file://` URIs.
+    /// Applies only to `file://` and `ram://` URIs.
     pub fn filepath(&self) -> Option<&Path> {
         if self.protocol().is_file_storage() {
-            Some(Path::new(
-                &self.uri[self.protocol_idx + PROTOCOL_SEPARATOR.len()..],
-            ))
+            Some(self.path())
         } else {
             None
         }
@@ -198,32 +176,38 @@ impl Uri {
         if self.protocol().is_database() {
             return None;
         }
-        let protocol = &self.uri[..self.protocol_idx];
-        let path = Path::new(&self.uri[self.protocol_idx + PROTOCOL_SEPARATOR.len()..]);
-        if self.protocol().is_s3() && path.components().count() < 2 {
+        let path = self.path();
+        let protocol = self.protocol();
+        if protocol == Protocol::S3 && path.components().count() < 2 {
             return None;
         }
-        if self.protocol().is_azure() && path.components().count() < 3 {
+        if protocol == Protocol::Azure && path.components().count() < 3 {
             return None;
         }
-        path.parent().map(|parent| {
-            Uri::from_well_formed(format!(
+        let parent_path = path.parent()?;
+        Some(
+            Uri::from_str(&format!(
                 "{protocol}{PROTOCOL_SEPARATOR}{}",
-                parent.display()
+                parent_path.display()
             ))
-        })
+            .unwrap(),
+        )
+    }
+
+    fn path(&self) -> &Path {
+        Path::new(&self.uri[self.protocol.as_str().len() + PROTOCOL_SEPARATOR.len()..])
     }
 
     /// Returns the last component of the URI.
     pub fn file_name(&self) -> Option<&Path> {
-        if self.protocol().is_postgresql() {
+        if self.protocol() == Protocol::PostgreSQL {
             return None;
         }
-        let path = Path::new(&self.uri[self.protocol_idx + PROTOCOL_SEPARATOR.len()..]);
-        if self.protocol().is_s3() && path.components().count() < 2 {
+        let path = self.path();
+        if self.protocol() == Protocol::S3 && path.components().count() < 2 {
             return None;
         }
-        if self.protocol().is_azure() && path.components().count() < 3 {
+        if self.protocol() == Protocol::Azure && path.components().count() < 3 {
             return None;
         }
         path.file_name().map(Path::new)
@@ -263,7 +247,7 @@ impl Uri {
         };
         Ok(Self {
             uri: joined,
-            protocol_idx: self.protocol_idx,
+            protocol: self.protocol,
         })
     }
 
@@ -309,7 +293,7 @@ impl Uri {
         }
         Ok(Self {
             uri: format!("{protocol}{PROTOCOL_SEPARATOR}{path}"),
-            protocol_idx: protocol.as_str().len(),
+            protocol,
         })
     }
 }
@@ -730,19 +714,20 @@ mod tests {
         );
         assert_eq!(
             Uri::for_test("postgres://localhost:5432/metastore").as_redacted_str(),
-            "postgres://localhost:5432/metastore"
+            "postgresql://localhost:5432/metastore"
         );
         assert_eq!(
-            Uri::for_test("postgres://username@localhost:5432/metastore").as_redacted_str(),
-            "postgres://username@localhost:5432/metastore"
+            Uri::for_test("pg://username@localhost:5432/metastore").as_redacted_str(),
+            "postgresql://username@localhost:5432/metastore"
         );
         {
             for protocol in ["postgres", "postgresql"] {
-                let uri = Uri::from_well_formed(format!(
+                let uri = Uri::from_str(&format!(
                     "{protocol}://username:password@localhost:5432/metastore"
-                ));
+                ))
+                .unwrap();
                 let expected_uri =
-                    format!("{protocol}://username:***redacted***@localhost:5432/metastore");
+                    format!("postgresql://username:***redacted***@localhost:5432/metastore");
                 assert_eq!(uri.as_redacted_str(), expected_uri);
                 assert_eq!(format!("{uri}"), expected_uri);
                 assert_eq!(

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -480,7 +480,7 @@ impl TestableForRegression for IndexConfig {
         };
         IndexConfig {
             index_id: "my-index".to_string(),
-            index_uri: Uri::from_well_formed("s3://quickwit-indexes/my-index"),
+            index_uri: Uri::for_test("s3://quickwit-indexes/my-index"),
             doc_mapping,
             indexing_settings,
             retention_policy,
@@ -559,7 +559,7 @@ mod tests {
         let index_config = load_index_config_from_user_config(
             config_format,
             file.as_bytes(),
-            &Uri::from_well_formed("s3://defaultbucket/"),
+            &Uri::for_test("s3://defaultbucket/"),
         )
         .unwrap();
         assert_eq!(index_config.doc_mapping.tokenizers.len(), 1);
@@ -638,7 +638,7 @@ mod tests {
 
     #[test]
     fn test_index_config_default_values() {
-        let default_index_root_uri = Uri::from_well_formed("s3://defaultbucket/");
+        let default_index_root_uri = Uri::for_test("s3://defaultbucket/");
         {
             let index_config_filepath = get_index_config_filepath("minimal-hdfs-logs.yaml");
             let file_content = std::fs::read_to_string(index_config_filepath).unwrap();
@@ -721,7 +721,7 @@ mod tests {
         let minimal_config: IndexConfig = load_index_config_from_user_config(
             ConfigFormat::Yaml,
             config_yaml.as_bytes(),
-            &Uri::from_well_formed("s3://my-index"),
+            &Uri::for_test("s3://my-index"),
         )
         .unwrap();
         assert_eq!(
@@ -745,7 +745,7 @@ mod tests {
         let parsing_config_error = load_index_config_from_user_config(
             ConfigFormat::Yaml,
             config_yaml.as_bytes(),
-            &Uri::from_well_formed("s3://my-index"),
+            &Uri::for_test("s3://my-index"),
         )
         .unwrap_err();
         println!("{parsing_config_error:?}");

--- a/quickwit/quickwit-config/src/index_config/serialize.rs
+++ b/quickwit/quickwit-config/src/index_config/serialize.rs
@@ -249,7 +249,7 @@ mod test {
                 ConfigFormat::Yaml,
                 config_yaml.as_bytes(),
                 // same but without the trailing slash.
-                &Uri::from_well_formed("s3://mybucket"),
+                &Uri::for_test("s3://mybucket"),
             )
             .unwrap();
             assert_eq!(index_config.index_uri.as_str(), "s3://mybucket/hdfs-logs");

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::num::NonZeroUsize;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -65,7 +66,7 @@ pub struct TestSandbox {
 const METASTORE_URI: &str = "ram://quickwit-test-indexes";
 
 fn index_uri(index_id: &str) -> Uri {
-    Uri::from_well_formed(format!("{METASTORE_URI}/{index_id}"))
+    Uri::from_str(&format!("{METASTORE_URI}/{index_id}")).unwrap()
 }
 
 impl TestSandbox {
@@ -98,8 +99,8 @@ impl TestSandbox {
         let storage_resolver = StorageResolver::for_test();
         let metastore_resolver =
             MetastoreResolver::configured(storage_resolver.clone(), &MetastoreConfigs::default());
-        let mut metastore = metastore_resolver
-            .resolve(&Uri::from_well_formed(METASTORE_URI))
+        let metastore = metastore_resolver
+            .resolve(&Uri::for_test(METASTORE_URI))
             .await?;
         let create_index_request = CreateIndexRequest::try_from_index_config(index_config.clone())?;
         let index_uid: IndexUid = metastore

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -99,7 +99,7 @@ impl TestSandbox {
         let storage_resolver = StorageResolver::for_test();
         let metastore_resolver =
             MetastoreResolver::configured(storage_resolver.clone(), &MetastoreConfigs::default());
-        let metastore = metastore_resolver
+        let mut metastore = metastore_resolver
             .resolve(&Uri::for_test(METASTORE_URI))
             .await?;
         let create_index_request = CreateIndexRequest::try_from_index_config(index_config.clone())?;

--- a/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
+++ b/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
@@ -151,6 +151,8 @@ impl CommitType {
     }
 }
 /// BEGIN quickwit-codegen
+#[allow(unused_imports)]
+use std::str::FromStr;
 use tower::{Layer, Service, ServiceExt};
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -18,8 +18,11 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
@@ -313,11 +316,12 @@ impl DeleteTaskPlanner {
                 ..Default::default()
             };
             let mut search_indexes_metas = HashMap::new();
+            let index_uri = Uri::from_str(index_uri).context("Invalid index uri")?;
             search_indexes_metas.insert(
                 IndexUid::from(delete_query.index_uid.clone()),
                 IndexMetasForLeafSearch {
                     doc_mapper_str: doc_mapper_str.to_string(),
-                    index_uri: Uri::from_well_formed(index_uri),
+                    index_uri: index_uri,
                 },
             );
             let leaf_search_request = jobs_to_leaf_requests(

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -19,7 +19,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -316,12 +315,12 @@ impl DeleteTaskPlanner {
                 ..Default::default()
             };
             let mut search_indexes_metas = HashMap::new();
-            let index_uri = Uri::from_str(index_uri).context("Invalid index uri")?;
+            let index_uri = Uri::from_str(index_uri).context("invalid index URI")?;
             search_indexes_metas.insert(
                 IndexUid::from(delete_query.index_uid.clone()),
                 IndexMetasForLeafSearch {
                     doc_mapper_str: doc_mapper_str.to_string(),
-                    index_uri: index_uri,
+                    index_uri,
                 },
             );
             let leaf_search_request = jobs_to_leaf_requests(

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -111,7 +112,9 @@ impl MetastoreFactory for FileBackedMetastoreFactory {
         uri: &Uri,
     ) -> Result<MetastoreServiceClient, MetastoreResolverError> {
         let (uri_stripped, polling_interval_opt) = extract_polling_interval_from_uri(uri.as_str());
-        let uri = Uri::from_well_formed(uri_stripped);
+        let uri = Uri::from_str(&uri_stripped).map_err(|_| {
+            MetastoreResolverError::InvalidConfig(format!("Invalid URI `{}`", uri_stripped))
+        })?;
         if let Some(metastore) = self.get_from_cache(&uri).await {
             debug!("using metastore from cache");
             return Ok(metastore);

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
@@ -113,7 +113,7 @@ impl MetastoreFactory for FileBackedMetastoreFactory {
     ) -> Result<MetastoreServiceClient, MetastoreResolverError> {
         let (uri_stripped, polling_interval_opt) = extract_polling_interval_from_uri(uri.as_str());
         let uri = Uri::from_str(&uri_stripped).map_err(|_| {
-            MetastoreResolverError::InvalidConfig(format!("Invalid URI `{}`", uri_stripped))
+            MetastoreResolverError::InvalidConfig(format!("invalid URI: `{uri_stripped}`"))
         })?;
         if let Some(metastore) = self.get_from_cache(&uri).await {
             debug!("using metastore from cache");

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -961,6 +961,7 @@ mod tests {
     use std::sync::Arc;
 
     use futures::executor::block_on;
+    use quickwit_common::uri::Protocol;
     use quickwit_config::IndexConfig;
     use quickwit_proto::metastore::{DeleteQuery, MetastoreError};
     use quickwit_query::query_ast::qast_helper;
@@ -983,7 +984,7 @@ mod tests {
     async fn test_metastore_connectivity_and_endpoints() {
         let mut metastore = FileBackedMetastore::default_for_test().await;
         metastore.check_connectivity().await.unwrap();
-        assert!(metastore.endpoints()[0].protocol().is_ram());
+        assert_eq!(metastore.endpoints()[0].protocol(), Protocol::Ram);
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -1511,6 +1511,7 @@ impl crate::tests::DefaultForTest for PostgresqlMetastore {
 
 #[cfg(test)]
 mod tests {
+    use quickwit_common::uri::Protocol;
     use quickwit_doc_mapper::tag_pruning::{no_tag, tag, TagFilterAst};
     use quickwit_proto::metastore::MetastoreService;
     use quickwit_proto::types::IndexUid;
@@ -1529,7 +1530,7 @@ mod tests {
     async fn test_metastore_connectivity_and_endpoints() {
         let mut metastore = PostgresqlMetastore::default_for_test().await;
         metastore.check_connectivity().await.unwrap();
-        assert!(metastore.endpoints()[0].protocol().is_postgresql());
+        assert_eq!(metastore.endpoints()[0].protocol(), Protocol::PostgreSQL);
     }
 
     fn test_tags_filter_expression_helper(tags_ast: TagFilterAst, expected: Cond) {

--- a/quickwit/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit/quickwit-metastore/src/metastore_resolver.rs
@@ -201,7 +201,7 @@ mod tests {
         });
         let (_uri_protocol, uri_path) = test_database_url.split_once("://").unwrap();
         for protocol in &["postgres", "postgresql"] {
-            let postgres_uri = Uri::for_test(format!("{protocol}://{uri_path}"));
+            let postgres_uri = Uri::from_str(&format!("{protocol}://{uri_path}")).unwrap();
             metastore_resolver.resolve(&postgres_uri).await.unwrap();
         }
     }

--- a/quickwit/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit/quickwit-metastore/src/metastore_resolver.rs
@@ -176,6 +176,8 @@ impl MetastoreResolverBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[tokio::test]
@@ -183,7 +185,7 @@ mod tests {
         let metastore_resolver = MetastoreResolver::unconfigured();
         let tmp_dir = tempfile::tempdir().unwrap();
         let metastore_filepath = format!("file://{}/metastore", tmp_dir.path().display());
-        let metastore_uri = Uri::from_well_formed(metastore_filepath);
+        let metastore_uri = Uri::from_str(&metastore_filepath).unwrap();
         metastore_resolver.resolve(&metastore_uri).await.unwrap();
     }
 
@@ -199,7 +201,7 @@ mod tests {
         });
         let (_uri_protocol, uri_path) = test_database_url.split_once("://").unwrap();
         for protocol in &["postgres", "postgresql"] {
-            let postgres_uri = Uri::from_well_formed(format!("{protocol}://{uri_path}"));
+            let postgres_uri = Uri::for_test(format!("{protocol}://{uri_path}"));
             metastore_resolver.resolve(&postgres_uri).await.unwrap();
         }
     }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
@@ -49,6 +49,8 @@ pub struct GetOpenShardsSubresponse {
     pub open_shards: ::prost::alloc::vec::Vec<super::ingest::Shard>,
 }
 /// BEGIN quickwit-codegen
+#[allow(unused_imports)]
+use std::str::FromStr;
 use tower::{Layer, Service, ServiceExt};
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
@@ -24,6 +24,8 @@ pub struct IndexingTask {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ApplyIndexingPlanResponse {}
 /// BEGIN quickwit-codegen
+#[allow(unused_imports)]
+use std::str::FromStr;
 use tower::{Layer, Service, ServiceExt};
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -310,6 +310,8 @@ impl PersistFailureReason {
     }
 }
 /// BEGIN quickwit-codegen
+#[allow(unused_imports)]
+use std::str::FromStr;
 use tower::{Layer, Service, ServiceExt};
 pub type IngesterServiceStream<T> = quickwit_common::ServiceStream<
     crate::ingest::IngestV2Result<T>,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
@@ -92,6 +92,8 @@ impl IngestFailureReason {
     }
 }
 /// BEGIN quickwit-codegen
+#[allow(unused_imports)]
+use std::str::FromStr;
 use tower::{Layer, Service, ServiceExt};
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -439,6 +439,8 @@ impl SourceType {
     }
 }
 /// BEGIN quickwit-codegen
+#[allow(unused_imports)]
+use std::str::FromStr;
 use tower::{Layer, Service, ServiceExt};
 use quickwit_common::metrics::{PrometheusLabels, OwnedPrometheusLabels};
 impl PrometheusLabels<1> for CreateIndexRequest {
@@ -2975,8 +2977,8 @@ where
     }
     fn endpoints(&self) -> Vec<quickwit_common::uri::Uri> {
         vec![
-            quickwit_common::uri::Uri::from_well_formed(format!("actor://localhost/{}",
-            self.inner.actor_instance_id()))
+            quickwit_common::uri::Uri::from_str(& format!("actor://localhost/{}", self
+            .inner.actor_instance_id())).expect("URI should be valid")
         ]
     }
 }
@@ -3244,10 +3246,8 @@ where
         self.connection_addrs_rx
             .borrow()
             .iter()
-            .map(|addr| quickwit_common::uri::Uri::from_well_formed(
-                format!(
-                    r"grpc://{}/{}.{}", addr, "quickwit.metastore", "MetastoreService"
-                ),
+            .flat_map(|addr| quickwit_common::uri::Uri::from_str(
+                &format!("grpc://{addr}/{}.{}", "quickwit.metastore", "MetastoreService"),
             ))
             .collect()
     }

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -182,12 +182,10 @@ impl SearchService for SearchServiceImpl {
     ) -> crate::Result<LeafSearchResponse> {
         let search_request: Arc<SearchRequest> = leaf_search_request
             .search_request
-            .ok_or_else(|| SearchError::Internal("no search request.".to_string()))?
-            .into();
-        let storage = self
-            .storage_resolver
-            .resolve(&Uri::from_well_formed(leaf_search_request.index_uri))
-            .await?;
+            .ok_or_else(|| SearchError::Internal("no search request".to_string()))?;
+        let index_uri = Uri::from_str(&leaf_search_request.index_uri)?;
+        let storage = self.storage_resolver.resolve(&index_uri).await?;
+        let split_ids = leaf_search_request.split_offsets;
         let doc_mapper = deserialize_doc_mapper(&leaf_search_request.doc_mapper)?;
 
         let leaf_search_response = leaf_search(
@@ -206,10 +204,8 @@ impl SearchService for SearchServiceImpl {
         &self,
         fetch_docs_request: FetchDocsRequest,
     ) -> crate::Result<FetchDocsResponse> {
-        let storage = self
-            .storage_resolver
-            .resolve(&Uri::from_well_formed(fetch_docs_request.index_uri))
-            .await?;
+        let index_uri = Uri::from_str(&fetch_docs_request.index_uri)?;
+        let storage = self.storage_resolver.resolve(&index_uri).await?;
         let snippet_request_opt: Option<&SnippetRequest> =
             fetch_docs_request.snippet_request.as_ref();
         let doc_mapper = deserialize_doc_mapper(&fetch_docs_request.doc_mapper)?;
@@ -246,10 +242,8 @@ impl SearchService for SearchServiceImpl {
         let stream_request = leaf_stream_request
             .request
             .ok_or_else(|| SearchError::Internal("no search request".to_string()))?;
-        let storage = self
-            .storage_resolver
-            .resolve(&Uri::from_well_formed(leaf_stream_request.index_uri))
-            .await?;
+        let index_uri = Uri::from_str(&leaf_stream_request.index_uri)?;
+        let storage = self.storage_resolver.resolve(&index_uri).await?;
         let doc_mapper = deserialize_doc_mapper(&leaf_stream_request.doc_mapper)?;
         let leaf_receiver = leaf_search_stream(
             self.searcher_context.clone(),
@@ -283,10 +277,8 @@ impl SearchService for SearchServiceImpl {
         let search_request = leaf_search_request
             .list_terms_request
             .ok_or_else(|| SearchError::Internal("no search request".to_string()))?;
-        let storage = self
-            .storage_resolver
-            .resolve(&Uri::from_well_formed(leaf_search_request.index_uri))
-            .await?;
+        let index_uri = Uri::from_str(&leaf_search_request.index_uri)?;
+        let storage = self.storage_resolver.resolve(&index_uri).await?;
         let split_ids = leaf_search_request.split_offsets;
 
         let leaf_search_response = leaf_list_terms(

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -182,10 +182,10 @@ impl SearchService for SearchServiceImpl {
     ) -> crate::Result<LeafSearchResponse> {
         let search_request: Arc<SearchRequest> = leaf_search_request
             .search_request
-            .ok_or_else(|| SearchError::Internal("no search request".to_string()))?;
+            .ok_or_else(|| SearchError::Internal("no search request".to_string()))?
+            .into();
         let index_uri = Uri::from_str(&leaf_search_request.index_uri)?;
         let storage = self.storage_resolver.resolve(&index_uri).await?;
-        let split_ids = leaf_search_request.split_offsets;
         let doc_mapper = deserialize_doc_mapper(&leaf_search_request.doc_mapper)?;
 
         let leaf_search_response = leaf_search(

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -1341,8 +1341,7 @@ mod tests {
         let metastore = metastore_for_test();
         let index_service = IndexService::new(metastore.clone(), StorageResolver::unconfigured());
         let mut node_config = NodeConfig::for_test();
-        node_config.default_index_root_uri =
-            Uri::from_well_formed("file:///default-index-root-uri");
+        node_config.default_index_root_uri = Uri::for_test("file:///default-index-root-uri");
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(node_config));
         {
@@ -1382,8 +1381,7 @@ mod tests {
         let mut metastore = metastore_for_test();
         let index_service = IndexService::new(metastore.clone(), StorageResolver::unconfigured());
         let mut node_config = NodeConfig::for_test();
-        node_config.default_index_root_uri =
-            Uri::from_well_formed("file:///default-index-root-uri");
+        node_config.default_index_root_uri = Uri::for_test("file:///default-index-root-uri");
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(node_config));
         let resp = warp::test::request()
@@ -1505,8 +1503,7 @@ mod tests {
         let metastore = metastore_for_test();
         let index_service = IndexService::new(metastore.clone(), StorageResolver::unconfigured());
         let mut node_config = NodeConfig::for_test();
-        node_config.default_index_root_uri =
-            Uri::from_well_formed("file:///default-index-root-uri");
+        node_config.default_index_root_uri = Uri::for_test("file:///default-index-root-uri");
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(node_config))
                 .recover(recover_fn);
@@ -1528,8 +1525,7 @@ mod tests {
         let metastore = metastore_for_test();
         let index_service = IndexService::new(metastore.clone(), StorageResolver::unconfigured());
         let mut node_config = NodeConfig::for_test();
-        node_config.default_index_root_uri =
-            Uri::from_well_formed("file:///default-index-root-uri");
+        node_config.default_index_root_uri = Uri::for_test("file:///default-index-root-uri");
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(node_config))
                 .recover(recover_fn);
@@ -1567,8 +1563,7 @@ mod tests {
         let metastore = metastore_for_test();
         let index_service = IndexService::new(metastore.clone(), StorageResolver::unconfigured());
         let mut node_config = NodeConfig::for_test();
-        node_config.default_index_root_uri =
-            Uri::from_well_formed("file:///default-index-root-uri");
+        node_config.default_index_root_uri = Uri::for_test("file:///default-index-root-uri");
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(node_config))
                 .recover(recover_fn);
@@ -1604,8 +1599,7 @@ mod tests {
         let metastore = metastore_for_test();
         let index_service = IndexService::new(metastore.clone(), StorageResolver::unconfigured());
         let mut node_config = NodeConfig::for_test();
-        node_config.default_index_root_uri =
-            Uri::from_well_formed("file:///default-index-root-uri");
+        node_config.default_index_root_uri = Uri::for_test("file:///default-index-root-uri");
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(node_config))
                 .recover(recover_fn);

--- a/quickwit/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit/quickwit-storage/src/local_file_storage.rs
@@ -402,20 +402,20 @@ mod tests {
     async fn test_local_file_storage_factory() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let index_uri =
-            Uri::from_well_formed(format!("file://{}/foo/bar", temp_dir.path().display()));
-        let local_file_storage_factory = LocalFileStorageFactory;
+            Uri::from_str(&format!("file://{}/foo/bar", temp_dir.path().display())).unwrap();
+        let local_file_storage_factory = LocalFileStorageFactory::default();
         let local_file_storage = local_file_storage_factory.resolve(&index_uri).await?;
         assert_eq!(local_file_storage.uri(), &index_uri);
 
         let err = local_file_storage_factory
-            .resolve(&Uri::from_well_formed("s3://foo/bar"))
+            .resolve(&Uri::for_test("s3://foo/bar"))
             .await
             .err()
             .unwrap();
         assert!(matches!(err, StorageResolverError::InvalidUri { .. }));
 
         let err = local_file_storage_factory
-            .resolve(&Uri::from_well_formed("s3://"))
+            .resolve(&Uri::for_test("s3://"))
             .await
             .err()
             .unwrap();

--- a/quickwit/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit/quickwit-storage/src/local_file_storage.rs
@@ -403,7 +403,7 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let index_uri =
             Uri::from_str(&format!("file://{}/foo/bar", temp_dir.path().display())).unwrap();
-        let local_file_storage_factory = LocalFileStorageFactory::default();
+        let local_file_storage_factory = LocalFileStorageFactory;
         let local_file_storage = local_file_storage_factory.resolve(&index_uri).await?;
         assert_eq!(local_file_storage.uri(), &index_uri);
 

--- a/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
@@ -131,10 +131,12 @@ impl AzureBlobStorage {
     /// Creates an emulated storage for testing.
     #[cfg(feature = "testsuite")]
     pub fn new_emulated(container: &str) -> Self {
+        use std::str::FromStr;
+
         let container_client = ClientBuilder::emulator().container_client(container);
         Self {
             container_client,
-            uri: Uri::from_well_formed(format!("azure://tester/{container}")),
+            uri: Uri::from_str(&format!("azure://tester/{container}")).unwrap(),
             prefix: PathBuf::new(),
             multipart_policy: MultiPartPolicy::default(),
             retry_params: RetryParams {
@@ -619,20 +621,20 @@ mod tests {
 
     #[test]
     fn test_parse_azure_uri() {
-        assert!(parse_azure_uri(&Uri::from_well_formed("azure://")).is_none());
+        assert!(parse_azure_uri(&Uri::for_test("azure://")).is_none());
 
         let (container, prefix) =
-            parse_azure_uri(&Uri::from_well_formed("azure://test-container")).unwrap();
+            parse_azure_uri(&Uri::for_test("azure://test-container")).unwrap();
         assert_eq!(container, "test-container");
         assert!(prefix.to_str().unwrap().is_empty());
 
         let (container, prefix) =
-            parse_azure_uri(&Uri::from_well_formed("azure://test-container/")).unwrap();
+            parse_azure_uri(&Uri::for_test("azure://test-container/")).unwrap();
         assert_eq!(container, "test-container");
         assert!(prefix.to_str().unwrap().is_empty());
 
         let (container, prefix) =
-            parse_azure_uri(&Uri::from_well_formed("azure://test-container/indexes")).unwrap();
+            parse_azure_uri(&Uri::for_test("azure://test-container/indexes")).unwrap();
         assert_eq!(container, "test-container");
         assert_eq!(prefix.to_str().unwrap(), "indexes");
     }

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -873,29 +873,26 @@ mod tests {
     #[test]
     fn test_parse_uri() {
         assert_eq!(
-            parse_s3_uri(&Uri::from_well_formed("s3://bucket/path/to/object")),
+            parse_s3_uri(&Uri::for_test("s3://bucket/path/to/object")),
             Some(("bucket".to_string(), PathBuf::from("path/to/object")))
         );
         assert_eq!(
-            parse_s3_uri(&Uri::from_well_formed("s3://bucket/path")),
+            parse_s3_uri(&Uri::for_test("s3://bucket/path")),
             Some(("bucket".to_string(), PathBuf::from("path")))
         );
         assert_eq!(
-            parse_s3_uri(&Uri::from_well_formed("s3://bucket/path/to/object")),
+            parse_s3_uri(&Uri::for_test("s3://bucket/path/to/object")),
             Some(("bucket".to_string(), PathBuf::from("path/to/object")))
         );
         assert_eq!(
-            parse_s3_uri(&Uri::from_well_formed("s3://bucket/")),
+            parse_s3_uri(&Uri::for_test("s3://bucket/")),
             Some(("bucket".to_string(), PathBuf::from("")))
         );
         assert_eq!(
-            parse_s3_uri(&Uri::from_well_formed("s3://bucket")),
+            parse_s3_uri(&Uri::for_test("s3://bucket")),
             Some(("bucket".to_string(), PathBuf::from("")))
         );
-        assert_eq!(
-            parse_s3_uri(&Uri::from_well_formed("ram://path/to/file")),
-            None
-        );
+        assert_eq!(parse_s3_uri(&Uri::for_test("ram://path/to/file")), None);
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit/quickwit-storage/src/storage_resolver.rs
@@ -178,9 +178,7 @@ mod tests {
             .register(ram_storage_factory)
             .build()
             .unwrap();
-        let storage = storage_resolver
-            .resolve(&Uri::from_well_formed("ram:///".to_string()))
-            .await?;
+        let storage = storage_resolver.resolve(&Uri::for_test("ram:///")).await?;
         let data = storage.get_all(Path::new("hello")).await?;
         assert_eq!(&data[..], b"hello_content_second");
         Ok(())
@@ -213,7 +211,7 @@ mod tests {
             .build()
             .unwrap();
         let storage = storage_resolver
-            .resolve(&Uri::from_well_formed("ram:///home".to_string()))
+            .resolve(&Uri::for_test("ram:///home"))
             .await?;
         let data = storage.get_all(Path::new("hello")).await?;
         assert_eq!(&data[..], b"hello_content_second");
@@ -223,8 +221,7 @@ mod tests {
     #[tokio::test]
     async fn test_storage_resolver_unsupported_protocol() {
         let storage_resolver = StorageResolver::unconfigured();
-        let storage_uri =
-            Uri::from_well_formed("postgresql://localhost:5432/metastore".to_string());
+        let storage_uri = Uri::for_test("postgresql://localhost:5432/metastore");
         let resolver_error = storage_resolver.resolve(&storage_uri).await.unwrap_err();
         assert!(matches!(
             resolver_error,

--- a/quickwit/quickwit-storage/tests/s3_storage.rs
+++ b/quickwit/quickwit-storage/tests/s3_storage.rs
@@ -21,6 +21,7 @@
 // makes it possible to connect to Amazon S3's quickwit-integration-test bucket.
 
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use anyhow::Context;
 use once_cell::sync::OnceCell;
@@ -52,7 +53,7 @@ fn test_runtime_singleton() -> &'static Runtime {
 async fn run_s3_storage_test_suite(s3_storage_config: S3StorageConfig, bucket_uri: &str) {
     setup_logging_for_tests();
 
-    let storage_uri = Uri::from_well_formed(bucket_uri);
+    let storage_uri = Uri::from_str(bucket_uri).unwrap();
     let mut object_storage = S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri)
         .await
         .unwrap();
@@ -124,7 +125,7 @@ fn test_suite_on_s3_storage_bulk_delete_single_object_delete_api() {
     let bucket_uri = append_random_suffix(
         "s3://quickwit-integration-tests/test-bulk-delete-single-object-delete-api",
     );
-    let storage_uri = Uri::from_well_formed(bucket_uri);
+    let storage_uri = Uri::from_str(&bucket_uri).unwrap();
     let test_runtime = test_runtime_singleton();
     test_runtime.block_on(async move {
         let mut object_storage =


### PR DESCRIPTION
Before, the protocol normalization behavior was different depending on whether the Uri was built with `from_well_formed` and `from_str`.

Also, `from_well_formed` was used over string passed via gRPC.