### PR TITLE
Refactoring of the quickwit services initialization.

### DIFF
--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -125,10 +125,7 @@ fn quickwit_telemetry_info(config: &NodeConfig) -> QuickwitTelemetryInfo {
         features.insert(QuickwitFeature::Jaeger);
     }
     // The metastore URI is only relevant if the metastore is enabled.
-    if config
-        .enabled_services
-        .contains(&QuickwitService::Metastore)
-    {
+    if config.is_service_enabled(QuickwitService::Metastore) {
         if config.metastore_uri.protocol().is_postgresql() {
             features.insert(QuickwitFeature::PostgresqMetastore);
         } else {

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -24,8 +24,6 @@ mod cluster;
 mod member;
 mod node;
 
-use std::collections::HashSet;
-
 #[cfg(any(test, feature = "testsuite"))]
 pub use chitchat::transport::ChannelTransport;
 use chitchat::transport::UdpTransport;
@@ -60,10 +58,7 @@ impl From<u64> for GenerationId {
     }
 }
 
-pub async fn start_cluster_service(
-    node_config: &NodeConfig,
-    enabled_services: &HashSet<QuickwitService>,
-) -> anyhow::Result<Cluster> {
+pub async fn start_cluster_service(node_config: &NodeConfig) -> anyhow::Result<Cluster> {
     let cluster_id = node_config.cluster_id.clone();
     let gossip_listen_addr = node_config.gossip_listen_addr;
     let peer_seed_addrs = node_config.peer_seed_addrs().await?;
@@ -76,7 +71,7 @@ pub async fn start_cluster_service(
         node_id,
         generation_id,
         is_ready,
-        enabled_services.clone(),
+        node_config.enabled_services.clone(),
         node_config.gossip_advertise_addr,
         node_config.grpc_advertise_addr,
         indexing_tasks,

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -275,6 +275,10 @@ pub struct NodeConfig {
 }
 
 impl NodeConfig {
+    pub fn is_service_enabled(&self, service: QuickwitService) -> bool {
+        self.enabled_services.contains(&service)
+    }
+
     /// Parses and validates a [`NodeConfig`] from a given URI and config content.
     pub async fn load(config_format: ConfigFormat, config_content: &[u8]) -> anyhow::Result<Self> {
         let env_vars = env::vars().collect::<HashMap<_, _>>();

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -421,10 +421,8 @@ mod tests {
         assert_eq!(config.cluster_id, "quickwit-cluster");
         assert_eq!(config.enabled_services.len(), 2);
 
-        assert!(config.enabled_services.contains(&QuickwitService::Janitor));
-        assert!(config
-            .enabled_services
-            .contains(&QuickwitService::Metastore));
+        assert!(config.is_service_enabled(QuickwitService::Janitor));
+        assert!(config.is_service_enabled(QuickwitService::Metastore));
 
         assert_eq!(
             config.rest_listen_addr,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -32,6 +32,7 @@ mod metrics;
 mod metrics_api;
 mod node_info_handler;
 mod openapi;
+mod rate_modulator;
 mod rest;
 mod search_api;
 pub(crate) mod simple_list;
@@ -45,7 +46,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
+use anyhow::Context;
 use byte_unit::n_mib_bytes;
 pub use format::BodyFormat;
 use futures::{Stream, StreamExt};
@@ -56,7 +57,7 @@ use quickwit_common::pubsub::{EventBroker, EventSubscriptionHandle};
 use quickwit_common::runtimes::RuntimesConfig;
 use quickwit_common::tower::{
     BalanceChannel, BoxFutureInfaillible, BufferLayer, Change, ConstantRate, EstimateRateLayer,
-    Rate, RateLimitLayer, SmaRateEstimator,
+    RateLimitLayer, SmaRateEstimator,
 };
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{NodeConfig, SearcherConfig};
@@ -66,8 +67,8 @@ use quickwit_index_management::{IndexService as IndexManager, IndexServiceError}
 use quickwit_indexing::actors::IndexingService;
 use quickwit_indexing::start_indexing_service;
 use quickwit_ingest::{
-    start_ingest_api_service, GetMemoryCapacity, IngestRequest, IngestRouter, IngestServiceClient,
-    Ingester, IngesterPool, MemoryCapacity,
+    start_ingest_api_service, GetMemoryCapacity, IngestApiService, IngestRequest, IngestRouter,
+    IngestServiceClient, Ingester, IngesterPool,
 };
 use quickwit_janitor::{start_janitor_service, JanitorService};
 use quickwit_metastore::{
@@ -98,6 +99,7 @@ use warp::{Filter, Rejection};
 pub use crate::build_info::{BuildInfo, RuntimeInfo};
 pub use crate::index_api::ListSplitsQueryParams;
 pub use crate::metrics::SERVE_METRICS;
+use crate::rate_modulator::RateModulator;
 #[cfg(test)]
 use crate::rest::recover_fn;
 pub use crate::search_api::{search_request_from_api_request, SearchRequestQueryString, SortBy};
@@ -110,7 +112,6 @@ const READINESS_REPORTING_INTERVAL: Duration = if cfg!(any(test, feature = "test
 
 struct QuickwitServices {
     pub node_config: Arc<NodeConfig>,
-    pub services: HashSet<QuickwitService>,
     pub cluster: Cluster,
     pub metastore_server_opt: Option<Arc<dyn Metastore>>,
     pub metastore_client: Arc<dyn Metastore>,
@@ -161,129 +162,16 @@ async fn balance_channel_for_service(
     BalanceChannel::from_stream(service_change_stream)
 }
 
-pub async fn serve_quickwit(
-    node_config: NodeConfig,
-    runtimes_config: RuntimesConfig,
-    metastore_resolver: MetastoreResolver,
-    storage_resolver: StorageResolver,
-    shutdown_signal: BoxFutureInfaillible<()>,
-) -> anyhow::Result<HashMap<String, ActorExitStatus>> {
-    let cluster = start_cluster_service(&node_config, &node_config.enabled_services).await?;
-
-    let event_broker = EventBroker::default();
-    let indexer_pool = IndexerPool::default();
-    let ingester_pool = IngesterPool::default();
-    let universe = Universe::new();
-
-    // Instantiate a metastore "server" if the `metastore` role is enabled on the node.
-    let metastore_server_opt: Option<Arc<dyn Metastore>> = if node_config
-        .enabled_services
-        .contains(&QuickwitService::Metastore)
-    {
-        let metastore = metastore_resolver
-            .resolve(&node_config.metastore_uri)
-            .await?;
-        let metastore = MetastoreEventPublisher::new(metastore.clone(), event_broker.clone());
-        Some(Arc::new(metastore))
-    } else {
-        None
-    };
-    // Instantiate a metastore client, either local if available or remote otherwise.
-    let metastore_client: Arc<dyn Metastore> = if let Some(metastore_server) = &metastore_server_opt
-    {
-        metastore_server.clone()
-    } else {
-        // Wait for a metastore service to be available for at most 10 seconds.
-        cluster
-            .wait_for_ready_members(has_node_with_metastore_service, Duration::from_secs(10))
-            .await
-            .map_err(|_| {
-                error!("No metastore service found among cluster members, stopping server.");
-                anyhow!(
-                    "failed to start server: no metastore service was found among cluster \
-                     members. try running Quickwit with additional metastore service `quickwit \
-                     run --service metastore`"
-                )
-            })?;
-        let balance_channel =
-            balance_channel_for_service(&cluster, QuickwitService::Metastore).await;
-        let grpc_metastore_client =
-            MetastoreGrpcClient::from_balance_channel(balance_channel).await?;
-        let metastore_client = RetryingMetastore::new(Box::new(grpc_metastore_client));
-        Arc::new(metastore_client)
-    };
-
-    // Instantiate a control plane server if the `control-plane` role is enabled on the node.
-    // Otherwise, instantiate a control plane client.
-    let control_plane_service: ControlPlaneServiceClient = if node_config
-        .enabled_services
-        .contains(&QuickwitService::ControlPlane)
-    {
-        check_cluster_configuration(
-            &node_config.enabled_services,
-            &node_config.peer_seeds,
-            metastore_client.clone(),
-        )
-        .await?;
-
-        let cluster_id = cluster.cluster_id().to_string();
-        let self_node_id = cluster.self_node_id().to_string();
-
-        let replication_factor = node_config
-            .ingest_api_config
-            .replication_factor()
-            .expect("replication factor should have been validated")
-            .get();
-        let control_plane_mailbox = setup_control_plane(
-            &universe,
-            cluster_id,
-            self_node_id,
-            indexer_pool.clone(),
-            ingester_pool.clone(),
-            metastore_client.clone(),
-            replication_factor,
-        )
-        .await?;
-        ControlPlaneServiceClient::from_mailbox(control_plane_mailbox)
-    } else {
-        let balance_channel =
-            balance_channel_for_service(&cluster, QuickwitService::ControlPlane).await;
-        ControlPlaneServiceClient::from_channel(balance_channel)
-    };
-    // Setup control plane event subscriptions.
-    let control_plane_event_subscription_handles_opt = setup_control_plane_event_subscriptions(
-        &node_config,
-        &event_broker,
-        &control_plane_service,
-    );
-
-    // Set up the "control plane proxy" for the metastore.
-    let metastore_client: Arc<dyn Metastore> = Arc::new(ControlPlaneMetastore::new(
-        control_plane_service.clone(),
-        metastore_client.clone(),
-    ));
-
-    // Setup ingest service v1.
-    let (ingest_service, indexing_service_opt) = if node_config
-        .enabled_services
-        .contains(&QuickwitService::Indexer)
-    {
+async fn start_ingest_client_if_needed(
+    node_config: &NodeConfig,
+    universe: &Universe,
+    cluster: &Cluster,
+) -> anyhow::Result<IngestServiceClient> {
+    if node_config.is_service_enabled(QuickwitService::Indexer) {
         let ingest_api_service = start_ingest_api_service(
-            &universe,
+            universe,
             &node_config.data_dir_path,
             &node_config.ingest_api_config,
-        )
-        .await?;
-
-        let indexing_service = start_indexing_service(
-            &universe,
-            &node_config,
-            runtimes_config.num_threads_blocking,
-            cluster.clone(),
-            metastore_client.clone(),
-            ingest_api_service.clone(),
-            ingester_pool.clone(),
-            storage_resolver.clone(),
         )
         .await?;
         let num_buckets = NonZeroUsize::new(60).expect("60 should be non-zero");
@@ -306,12 +194,148 @@ pub async fn serve_quickwit(
                     .into_inner(),
             )
             .build_from_mailbox(ingest_api_service);
-        (ingest_service, Some(indexing_service))
+        Ok(ingest_service)
     } else {
-        let balance_channel = balance_channel_for_service(&cluster, QuickwitService::Indexer).await;
+        let balance_channel = balance_channel_for_service(cluster, QuickwitService::Indexer).await;
         let ingest_service = IngestServiceClient::from_channel(balance_channel);
-        (ingest_service, None)
+        Ok(ingest_service)
+    }
+}
+
+async fn start_control_plane_if_needed(
+    node_config: &NodeConfig,
+    cluster: &Cluster,
+    metastore_client: &Arc<dyn Metastore>,
+    universe: &Universe,
+    indexer_pool: &IndexerPool,
+    ingester_pool: &IngesterPool,
+) -> anyhow::Result<ControlPlaneServiceClient> {
+    if node_config.is_service_enabled(QuickwitService::ControlPlane) {
+        check_cluster_configuration(
+            &node_config.enabled_services,
+            &node_config.peer_seeds,
+            metastore_client.clone(),
+        )
+        .await?;
+
+        let cluster_id = cluster.cluster_id().to_string();
+        let self_node_id = cluster.self_node_id().to_string();
+
+        let replication_factor = node_config
+            .ingest_api_config
+            .replication_factor()
+            .expect("replication factor should have been validated")
+            .get();
+        let control_plane_mailbox = setup_control_plane(
+            universe,
+            cluster_id,
+            self_node_id,
+            indexer_pool.clone(),
+            ingester_pool.clone(),
+            metastore_client.clone(),
+            replication_factor,
+        )
+        .await?;
+        Ok(ControlPlaneServiceClient::from_mailbox(
+            control_plane_mailbox,
+        ))
+    } else {
+        let balance_channel =
+            balance_channel_for_service(cluster, QuickwitService::ControlPlane).await;
+        Ok(ControlPlaneServiceClient::from_channel(balance_channel))
+    }
+}
+
+pub async fn serve_quickwit(
+    node_config: NodeConfig,
+    runtimes_config: RuntimesConfig,
+    metastore_resolver: MetastoreResolver,
+    storage_resolver: StorageResolver,
+    shutdown_signal: BoxFutureInfaillible<()>,
+) -> anyhow::Result<HashMap<String, ActorExitStatus>> {
+    let cluster = start_cluster_service(&node_config).await?;
+
+    let event_broker = EventBroker::default();
+    let indexer_pool = IndexerPool::default();
+    let ingester_pool = IngesterPool::default();
+    let universe = Universe::new();
+
+    // Instantiate a metastore "server" if the `metastore` role is enabled on the node.
+    let metastore_server_opt: Option<Arc<dyn Metastore>> =
+        if node_config.is_service_enabled(QuickwitService::Metastore) {
+            let metastore = metastore_resolver
+                .resolve(&node_config.metastore_uri)
+                .await?;
+            let metastore = MetastoreEventPublisher::new(metastore.clone(), event_broker.clone());
+            Some(Arc::new(metastore))
+        } else {
+            None
+        };
+    // Instantiate a metastore client, either local if available or remote otherwise.
+    let metastore_client: Arc<dyn Metastore> = if let Some(metastore_server) = &metastore_server_opt
+    {
+        metastore_server.clone()
+    } else {
+        // Wait for a metastore service to be available for at most 10 seconds.
+        if cluster
+            .wait_for_ready_members(has_node_with_metastore_service, Duration::from_secs(10))
+            .await
+            .is_err()
+        {
+            error!("No metastore service found among cluster members, stopping server.");
+            anyhow::bail!(
+                "failed to start server: no metastore service was found among cluster members. \
+                 try running Quickwit with additional metastore service `quickwit run --service \
+                 metastore`"
+            );
+        }
+        let balance_channel =
+            balance_channel_for_service(&cluster, QuickwitService::Metastore).await;
+        let grpc_metastore_client =
+            MetastoreGrpcClient::from_balance_channel(balance_channel).await?;
+        let metastore_client = RetryingMetastore::new(Box::new(grpc_metastore_client));
+        Arc::new(metastore_client)
     };
+
+    // Instantiate a control plane server if the `control-plane` role is enabled on the node.
+    // Otherwise, instantiate a control plane client.
+    let control_plane_service: ControlPlaneServiceClient = start_control_plane_if_needed(
+        &node_config,
+        &cluster,
+        &metastore_client,
+        &universe,
+        &indexer_pool,
+        &ingester_pool,
+    )
+    .await?;
+
+    // Set up the "control plane proxy" for the metastore.
+    let metastore_client_through_control_plane: Arc<dyn Metastore> = Arc::new(
+        ControlPlaneMetastore::new(control_plane_service.clone(), metastore_client),
+    );
+
+    // Setup ingest service v1.
+    let ingest_service = start_ingest_client_if_needed(&node_config, &universe, &cluster).await?;
+    let indexing_service_opt = if node_config.is_service_enabled(QuickwitService::Indexer) {
+        let ingest_api_service: Mailbox<IngestApiService> = universe
+            .get_one()
+            .context("Ingest API Service should have been started.")?;
+        let indexing_service = start_indexing_service(
+            &universe,
+            &node_config,
+            runtimes_config.num_threads_blocking,
+            cluster.clone(),
+            metastore_client_through_control_plane.clone(),
+            ingest_api_service,
+            ingester_pool.clone(),
+            storage_resolver.clone(),
+        )
+        .await?;
+        Some(indexing_service)
+    } else {
+        None
+    };
+
     // Setup indexer pool.
     let cluster_change_stream = cluster.ready_nodes_change_stream().await;
     setup_indexer_pool(
@@ -331,28 +355,27 @@ pub async fn serve_quickwit(
 
     // Any node can serve index management requests (create/update/delete index, add/remove source,
     // etc.), so we always instantiate an index manager.
-    let index_manager = IndexManager::new(metastore_client.clone(), storage_resolver.clone());
+    let index_manager = IndexManager::new(
+        metastore_client_through_control_plane.clone(),
+        storage_resolver.clone(),
+    );
 
-    if node_config
-        .enabled_services
-        .contains(&QuickwitService::Indexer)
+    if node_config.is_service_enabled(QuickwitService::Indexer)
         && node_config.indexer_config.enable_otlp_endpoint
     {
-        {
-            let otel_logs_index_config =
-                OtlpGrpcLogsService::index_config(&node_config.default_index_root_uri)?;
-            let otel_traces_index_config =
-                OtlpGrpcTracesService::index_config(&node_config.default_index_root_uri)?;
+        let otel_logs_index_config =
+            OtlpGrpcLogsService::index_config(&node_config.default_index_root_uri)?;
+        let otel_traces_index_config =
+            OtlpGrpcTracesService::index_config(&node_config.default_index_root_uri)?;
 
-            for index_config in [otel_logs_index_config, otel_traces_index_config] {
-                match index_manager.create_index(index_config, false).await {
-                    Ok(_)
-                    | Err(IndexServiceError::Metastore(MetastoreError::AlreadyExists(
-                        EntityKind::Index { .. },
-                    ))) => Ok(()),
-                    Err(error) => Err(error),
-                }?;
-            }
+        for index_config in [otel_logs_index_config, otel_traces_index_config] {
+            match index_manager.create_index(index_config, false).await {
+                Ok(_)
+                | Err(IndexServiceError::Metastore(MetastoreError::AlreadyExists(
+                    EntityKind::Index { .. },
+                ))) => Ok(()),
+                Err(error) => Err(error),
+            }?;
         }
     }
 
@@ -362,19 +385,16 @@ pub async fn serve_quickwit(
     let (search_job_placer, search_service) = setup_searcher(
         searcher_config,
         cluster_change_stream,
-        metastore_client.clone(),
+        metastore_client_through_control_plane.clone(),
         storage_resolver.clone(),
     )
     .await?;
 
-    let janitor_service_opt = if node_config
-        .enabled_services
-        .contains(&QuickwitService::Janitor)
-    {
+    let janitor_service_opt = if node_config.is_service_enabled(QuickwitService::Janitor) {
         let janitor_service = start_janitor_service(
             &universe,
             &node_config,
-            metastore_client.clone(),
+            metastore_client_through_control_plane.clone(),
             search_job_placer,
             storage_resolver.clone(),
         )
@@ -384,15 +404,19 @@ pub async fn serve_quickwit(
         None
     };
 
+    let control_plane_event_subscription_handles_opt = setup_control_plane_event_subscriptions(
+        &node_config,
+        &event_broker,
+        &control_plane_service,
+    );
+
     let grpc_listen_addr = node_config.grpc_listen_addr;
     let rest_listen_addr = node_config.rest_listen_addr;
-    let services = node_config.enabled_services.clone();
     let quickwit_services: Arc<QuickwitServices> = Arc::new(QuickwitServices {
         node_config: Arc::new(node_config),
-        services,
         cluster: cluster.clone(),
         metastore_server_opt,
-        metastore_client: metastore_client.clone(),
+        metastore_client: metastore_client_through_control_plane.clone(),
         control_plane_service,
         control_plane_event_subscription_handles_opt,
         index_manager,
@@ -446,7 +470,7 @@ pub async fn serve_quickwit(
     // Thus readiness task is started once gRPC and REST servers are started.
     tokio::spawn(node_readiness_reporting_task(
         cluster,
-        metastore_client,
+        metastore_client_through_control_plane,
         grpc_readiness_signal_rx,
         rest_readiness_signal_rx,
     ));
@@ -475,67 +499,6 @@ pub async fn serve_quickwit(
     }
     let actor_exit_statuses = shutdown_handle.await?;
     Ok(actor_exit_statuses)
-}
-
-#[derive(Clone)]
-struct RateModulator<R> {
-    rate_estimator: R,
-    memory_capacity: MemoryCapacity,
-    min_rate: ConstantRate,
-}
-
-impl<R> RateModulator<R>
-where R: Rate
-{
-    /// Creates a new [`RateModulator`] instance.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `rate_estimator` and `min_rate` have different periods.
-    pub fn new(rate_estimator: R, memory_capacity: MemoryCapacity, min_rate: ConstantRate) -> Self {
-        assert_eq!(
-            rate_estimator.period(),
-            min_rate.period(),
-            "Rate estimator and min rate periods must be equal."
-        );
-
-        Self {
-            rate_estimator,
-            memory_capacity,
-            min_rate,
-        }
-    }
-}
-
-impl<R> Rate for RateModulator<R>
-where R: Rate
-{
-    fn work(&self) -> u64 {
-        let memory_usage_ratio = self.memory_capacity.usage_ratio();
-        let work = self.rate_estimator.work().max(self.min_rate.work());
-
-        if memory_usage_ratio < 0.25 {
-            work * 2
-        } else if memory_usage_ratio > 0.99 {
-            work / 32
-        } else if memory_usage_ratio > 0.98 {
-            work / 16
-        } else if memory_usage_ratio > 0.95 {
-            work / 8
-        } else if memory_usage_ratio > 0.90 {
-            work / 4
-        } else if memory_usage_ratio > 0.80 {
-            work / 2
-        } else if memory_usage_ratio > 0.70 {
-            work * 2 / 3
-        } else {
-            work
-        }
-    }
-
-    fn period(&self) -> Duration {
-        self.rate_estimator.period()
-    }
 }
 
 #[allow(dead_code)]
@@ -600,7 +563,7 @@ async fn setup_ingest_v2(
     let ingest_router_service = IngestRouterServiceClient::new(ingest_router);
 
     // Instantiate ingester.
-    let ingester_service_opt = if config.enabled_services.contains(&QuickwitService::Indexer) {
+    let ingester_service_opt = if config.is_service_enabled(QuickwitService::Indexer) {
         let wal_dir_path = config.data_dir_path.join("wal");
         fs::create_dir_all(&wal_dir_path)?;
 

--- a/quickwit/quickwit-serve/src/rate_modulator.rs
+++ b/quickwit/quickwit-serve/src/rate_modulator.rs
@@ -1,0 +1,84 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::Duration;
+
+use quickwit_common::tower::{ConstantRate, Rate};
+use quickwit_ingest::MemoryCapacity;
+
+#[derive(Clone)]
+pub(crate) struct RateModulator<R> {
+    rate_estimator: R,
+    memory_capacity: MemoryCapacity,
+    min_rate: ConstantRate,
+}
+
+impl<R> RateModulator<R>
+where R: Rate
+{
+    /// Creates a new [`RateModulator`] instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rate_estimator` and `min_rate` have different periods.
+    pub fn new(rate_estimator: R, memory_capacity: MemoryCapacity, min_rate: ConstantRate) -> Self {
+        assert_eq!(
+            rate_estimator.period(),
+            min_rate.period(),
+            "Rate estimator and min rate periods must be equal."
+        );
+
+        Self {
+            rate_estimator,
+            memory_capacity,
+            min_rate,
+        }
+    }
+}
+
+impl<R> Rate for RateModulator<R>
+where R: Rate
+{
+    fn work(&self) -> u64 {
+        let memory_usage_ratio = self.memory_capacity.usage_ratio();
+        let work = self.rate_estimator.work().max(self.min_rate.work());
+
+        if memory_usage_ratio < 0.25 {
+            work * 2
+        } else if memory_usage_ratio > 0.99 {
+            work / 32
+        } else if memory_usage_ratio > 0.98 {
+            work / 16
+        } else if memory_usage_ratio > 0.95 {
+            work / 8
+        } else if memory_usage_ratio > 0.90 {
+            work / 4
+        } else if memory_usage_ratio > 0.80 {
+            work / 2
+        } else if memory_usage_ratio > 0.70 {
+            work * 2 / 3
+        } else {
+            work
+        }
+    }
+
+    fn period(&self) -> Duration {
+        self.rate_estimator.period()
+    }
+}


### PR DESCRIPTION
Refactoring of the quickwit services initialization.

The big NON trivial change, is that this removes the forward of events to the control plane through the EventBroker as it seemed redundant with the control plane proxy.

The second non trivial change, is the uncoupling of the ingest service and the indexing service. This is made possible using the universe actor registry.