### PR TITLE
Support for head request on elasticsearch root endpoint.

### DIFF
--- a/quickwit/quickwit-serve/src/elastic_search_api/filter.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/filter.rs
@@ -42,7 +42,7 @@ pub struct ElasticCompatibleApi;
 pub(crate) fn elastic_cluster_info_filter() -> impl Filter<Extract = (), Error = Rejection> + Clone
 {
     warp::path!("_elastic")
-        .and(warp::get())
+        .and(warp::get().or(warp::head()).unify())
         .and(warp::path::end())
 }
 

--- a/quickwit/quickwit-serve/src/elastic_search_api/mod.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/mod.rs
@@ -373,4 +373,18 @@ mod tests {
         });
         assert_json_include!(actual: resp_json, expected: expected_response_json);
     }
+
+    #[tokio::test]
+    async fn test_head_request_on_root_endpoint() {
+        let build_info = BuildInfo::get();
+        let config = Arc::new(NodeConfig::for_test());
+        let handler =
+            es_compat_cluster_info_handler(config.clone(), build_info).recover(recover_fn);
+        let resp = warp::test::request()
+            .path("/_elastic")
+            .method("HEAD")
+            .reply(&handler)
+            .await;
+        assert_eq!(resp.status(), 200);
+    }
 }


### PR DESCRIPTION
Some clients like the [opensearch-js](https://github.com/opensearch-project/opensearch-js/blob/9228ff101da32ad0d738addd5b9ca1150d8d70fb/api/api/ping.js#L50) send a HEAD request on the elasticsearch root endpoint to check if it's alive.

This PR adds the support of HEAD request on the `_elastic` endpoint, now returning a 200.