### PR TITLE
Emit `ClusterChange::Remove` only if node generation IDs match

### DIFF
--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -45,7 +45,7 @@ use crate::member::{
     GRPC_ADVERTISE_ADDR_KEY, INDEXING_TASK_PREFIX, READINESS_KEY, READINESS_VALUE_NOT_READY,
     READINESS_VALUE_READY,
 };
-use crate::ClusterNode;
+use crate::{ClusterNode, NodeId};
 
 const GOSSIP_INTERVAL: Duration = if cfg!(any(test, feature = "testsuite")) {
     Duration::from_millis(25)
@@ -422,7 +422,7 @@ struct InnerCluster {
     cluster_id: String,
     self_chitchat_id: ChitchatId,
     chitchat_handle: ChitchatHandle,
-    live_nodes: BTreeMap<ChitchatId, ClusterNode>,
+    live_nodes: BTreeMap<NodeId, ClusterNode>,
     change_stream_subscribers: Vec<mpsc::UnboundedSender<ClusterChange>>,
     ready_members_rx: watch::Receiver<Vec<ClusterMember>>,
 }

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -41,6 +41,8 @@ pub use crate::cluster::{Cluster, ClusterSnapshot, NodeIdSchema};
 pub use crate::member::ClusterMember;
 pub use crate::node::ClusterNode;
 
+pub type NodeId = String;
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct GenerationId(u64);
 


### PR DESCRIPTION
### Description
Emit `ClusterChange::Remove` only if node generation IDs match, which prevents client pools from evicting nodes that have just rejoined the cluster.

### How was this PR tested?
I reproduced the issue on 0.6.3 and manually verified that this PR fixes the bug. I'll shortly push a PR for `main`, which will contain a unit test.
