### PR TITLE
Support other term query format and support number term value. 

### DIFF
--- a/quickwit/quickwit-query/src/elastic_query_dsl/term_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/term_query.rs
@@ -17,18 +17,27 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 use crate::elastic_query_dsl::one_field_map::OneFieldMap;
 use crate::elastic_query_dsl::{ConvertableToQueryAst, ElasticQueryDslInner};
 use crate::not_nan_f32::NotNaNf32;
 use crate::query_ast::{self, QueryAst};
 
-pub type TermQuery = OneFieldMap<TermQueryValue>;
+#[derive(Deserialize, Clone, Eq, PartialEq, Debug)]
+#[serde(
+    from = "OneFieldMap<TermQueryParamsForDeserialization>",
+    into = "OneFieldMap<TermQueryValue>"
+)]
+pub struct TermQuery {
+    pub(crate) field: String,
+    pub(crate) params: TermQueryParams,
+}
 
 #[derive(PartialEq, Eq, Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct TermQueryValue {
+pub struct TermQueryParams {
+    #[serde(deserialize_with = "from_string_or_number")]
     pub value: String,
     #[serde(default)]
     pub boost: Option<NotNaNf32>,
@@ -37,7 +46,7 @@ pub struct TermQueryValue {
 pub fn term_query_from_field_value(field: impl ToString, value: impl ToString) -> TermQuery {
     TermQuery {
         field: field.to_string(),
-        value: TermQueryValue {
+        params: TermQueryParams {
             value: value.to_string(),
             boost: None,
         },
@@ -52,7 +61,7 @@ impl From<TermQuery> for ElasticQueryDslInner {
 
 impl ConvertableToQueryAst for TermQuery {
     fn convert_to_query_ast(self) -> anyhow::Result<QueryAst> {
-        let TermQueryValue { value, boost } = self.value;
+        let TermQueryParams { value, boost } = self.params;
         let term_ast: QueryAst = query_ast::TermQuery {
             field: self.field,
             value,
@@ -62,16 +71,109 @@ impl ConvertableToQueryAst for TermQuery {
     }
 }
 
+// --------------
+//
+// Below is the Deserialization code
+// We want to support the following JSON formats:
+//
+// `{"field": {"value": "term", "boost": null}}`
+// `{"field": "value"}`
+// `{"field": 123}`
+//
+// We don't use untagged enum to support this, in order to keep good errors.
+//
+// The code below is adapted from solution described here: https://serde.rs/string-or-struct.html
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub(crate) struct TermQueryParamsForDeserialization {
+    #[serde(deserialize_with = "string_or_struct")]
+    pub(crate) inner: TermQueryParams,
+}
+
+fn from_string_or_number<'de, D>(deserializer: D) -> Result<String, D::Error>
+where D: Deserializer<'de> {
+    let json_value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+    match json_value {
+        serde_json::Value::String(string) => Ok(string),
+        serde_json::Value::Number(number) => Ok(number.to_string()),
+        value => Err(serde::de::Error::custom(format!(
+            "Expected a string or a number, got {:?}",
+            value
+        ))),
+    }
+}
+
+impl From<OneFieldMap<TermQueryParamsForDeserialization>> for TermQuery {
+    fn from(term_query_params: OneFieldMap<TermQueryParamsForDeserialization>) -> Self {
+        let OneFieldMap { field, value } = term_query_params;
+        TermQuery {
+            field,
+            params: value.inner,
+        }
+    }
+}
+
+struct TermQueryValueStringOrStructVisitor;
+
+impl<'de> serde::de::Visitor<'de> for TermQueryValueStringOrStructVisitor {
+    type Value = TermQueryParams;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("string or map containing the parameters of a match query.")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where E: serde::de::Error {
+        Ok(TermQueryParams {
+            value: value.to_string(),
+            boost: None,
+        })
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where E: serde::de::Error {
+        Ok(TermQueryParams {
+            value: value.to_string(),
+            boost: None,
+        })
+    }
+
+    fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+    where M: serde::de::MapAccess<'de> {
+        Deserialize::deserialize(serde::de::value::MapAccessDeserializer::new(map))
+    }
+}
+
+fn string_or_struct<'de, D>(deserializer: D) -> Result<TermQueryParams, D::Error>
+where D: Deserializer<'de> {
+    deserializer.deserialize_any(TermQueryValueStringOrStructVisitor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_term_query_simple() {
-        let term_query_json = r#"{ "product_id": { "value": "61809" } }"#;
-        let term_query: TermQuery = serde_json::from_str(term_query_json).unwrap();
+        let term_query_json_1 = r#"{ "product_id": { "value": 61809, "boost": null } }"#;
+        let term_query_1: TermQuery = serde_json::from_str(term_query_json_1).unwrap();
         assert_eq!(
-            &term_query,
+            &term_query_1,
+            &term_query_from_field_value("product_id", "61809")
+        );
+
+        let term_query_json_2 = r#"{ "product_id": { "value": "61809" } }"#;
+        let term_query_2: TermQuery = serde_json::from_str(term_query_json_2).unwrap();
+        assert_eq!(
+            &term_query_2,
+            &term_query_from_field_value("product_id", "61809")
+        );
+
+        let term_query_json_3 = r#"{ "product_id": "61809" }"#;
+        let term_query_3: TermQuery = serde_json::from_str(term_query_json_3).unwrap();
+        assert_eq!(
+            &term_query_3,
             &term_query_from_field_value("product_id", "61809")
         );
     }

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0006-term_query.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0006-term_query.yaml
@@ -16,3 +16,34 @@ expected:
       relation: "eq"
     hits:
       $expect: "len(val) == 3"
+---
+# Support term int value
+params:
+  size: 10
+json:
+  query:
+    term:
+      actor.id:
+        value: 10791466
+expected:
+  hits:
+    total:
+      value: 1
+      relation: "eq"
+    hits:
+      $expect: "len(val) == 1"
+---
+# Support old term query format
+params:
+  size: 10
+json:
+  query:
+    term:
+      actor.id: "10791466"
+expected:
+  hits:
+    total:
+      value: 1
+      relation: "eq"
+    hits:
+      $expect: "len(val) == 1"


### PR DESCRIPTION
Fix #3900.

Tests added.

The PR is a bit lame... I mostly copy pasted the code used to deserialize the match query and adapted it to the term query.
We may want to find a generic way of handling this... I suggest to not do  it now unless there is an obvious way to do it (I'm not capable to see that right now). 
