### PR TITLE
Add parameter to configure content limit for ingest api

### DIFF
--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -178,6 +178,7 @@ pub struct IngestApiConfig {
     pub max_queue_memory_usage: Byte,
     pub max_queue_disk_usage: Byte,
     pub replication_factor: usize,
+    pub content_length_limit: u64
 }
 
 impl Default for IngestApiConfig {
@@ -186,6 +187,7 @@ impl Default for IngestApiConfig {
             max_queue_memory_usage: Byte::from_bytes(2 * 1024 * 1024 * 1024), /* 2 GiB // TODO maybe we want more? */
             max_queue_disk_usage: Byte::from_bytes(4 * 1024 * 1024 * 1024), /* 4 GiB // TODO maybe we want more? */
             replication_factor: 1,
+            content_length_limit: 10 * 1024 * 1024 /* 10 MB */
         }
     }
 }

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -178,7 +178,7 @@ pub struct IngestApiConfig {
     pub max_queue_memory_usage: Byte,
     pub max_queue_disk_usage: Byte,
     pub replication_factor: usize,
-    pub content_length_limit: u64
+    pub content_length_limit: u64,
 }
 
 impl Default for IngestApiConfig {
@@ -187,7 +187,7 @@ impl Default for IngestApiConfig {
             max_queue_memory_usage: Byte::from_bytes(2 * 1024 * 1024 * 1024), /* 2 GiB // TODO maybe we want more? */
             max_queue_disk_usage: Byte::from_bytes(4 * 1024 * 1024 * 1024), /* 4 GiB // TODO maybe we want more? */
             replication_factor: 1,
-            content_length_limit: 10 * 1024 * 1024 /* 10 MB */
+            content_length_limit: 10 * 1024 * 1024, // 10 MB
         }
     }
 }

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -18,7 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use quickwit_config::INGEST_SOURCE_ID;
+use quickwit_config::{INGEST_SOURCE_ID, IngestApiConfig};
 use quickwit_ingest::{
     CommitType, DocBatchBuilder, FetchResponse, IngestRequest, IngestResponse, IngestService,
     IngestServiceClient, IngestServiceError, TailRequest,
@@ -56,8 +56,6 @@ struct InvalidUtf8;
 
 impl warp::reject::Reject for InvalidUtf8 {}
 
-const CONTENT_LENGTH_LIMIT: u64 = 10 * 1024 * 1024; // 10MiB
-
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 struct IngestOptions {
     #[serde(alias = "commit")]
@@ -68,17 +66,19 @@ struct IngestOptions {
 pub(crate) fn ingest_api_handlers(
     ingest_router: IngestRouterServiceClient,
     ingest_service: IngestServiceClient,
+    config: IngestApiConfig
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    ingest_handler(ingest_service.clone())
+    ingest_handler(ingest_service.clone(), config.clone())
         .or(tail_handler(ingest_service))
-        .or(ingest_v2_handler(ingest_router))
+        .or(ingest_v2_handler(ingest_router, config))
 }
 
 fn ingest_filter(
+    config: IngestApiConfig
 ) -> impl Filter<Extract = (String, Bytes, IngestOptions), Error = Rejection> + Clone {
     warp::path!(String / "ingest")
         .and(warp::post())
-        .and(warp::body::content_length_limit(CONTENT_LENGTH_LIMIT))
+        .and(warp::body::content_length_limit(config.content_length_limit))
         .and(warp::body::bytes())
         .and(serde_qs::warp::query::<IngestOptions>(
             serde_qs::Config::default(),
@@ -87,18 +87,20 @@ fn ingest_filter(
 
 fn ingest_handler(
     ingest_service: IngestServiceClient,
+    config: IngestApiConfig
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    ingest_filter()
+    ingest_filter(config)
         .and(with_arg(ingest_service))
         .then(ingest)
         .map(|result| make_json_api_response(result, BodyFormat::default()))
 }
 
 fn ingest_v2_filter(
+    config: IngestApiConfig
 ) -> impl Filter<Extract = (String, Bytes, IngestOptions), Error = Rejection> + Clone {
     warp::path!(String / "ingest-v2")
         .and(warp::post())
-        .and(warp::body::content_length_limit(CONTENT_LENGTH_LIMIT))
+        .and(warp::body::content_length_limit(config.content_length_limit))
         .and(warp::body::bytes())
         .and(serde_qs::warp::query::<IngestOptions>(
             serde_qs::Config::default(),
@@ -107,8 +109,9 @@ fn ingest_v2_filter(
 
 fn ingest_v2_handler(
     ingest_router: IngestRouterServiceClient,
+    config: IngestApiConfig
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    ingest_v2_filter()
+    ingest_v2_filter(config)
         .and(with_arg(ingest_router))
         .then(ingest_v2)
         .and(with_arg(BodyFormat::default()))
@@ -267,7 +270,7 @@ pub(crate) mod tests {
         let (universe, _temp_dir, ingest_service, _) =
             setup_ingest_service(&["my-index"], &IngestApiConfig::default()).await;
         let ingest_router = IngestRouterServiceClient::mock().into();
-        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service);
+        let ingest_api_handlers = ingest_api_handlers(ingest_router,ingest_service, IngestApiConfig::default());
         let resp = warp::test::request()
             .path("/my-index/ingest")
             .method("POST")
@@ -302,7 +305,7 @@ pub(crate) mod tests {
         let (universe, _temp_dir, ingest_service, _) =
             setup_ingest_service(&["my-index"], &IngestApiConfig::default()).await;
         let ingest_router = IngestRouterServiceClient::mock().into();
-        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service);
+        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service, IngestApiConfig::default());
         let payload = r#"
             {"id": 1, "message": "push"}
             {"id": 2, "message": "push"}
@@ -329,7 +332,7 @@ pub(crate) mod tests {
         let (universe, _temp_dir, ingest_service, _) =
             setup_ingest_service(&["my-index"], &config).await;
         let ingest_router = IngestRouterServiceClient::mock().into();
-        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service);
+        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service, IngestApiConfig::default());
         let resp = warp::test::request()
             .path("/my-index/ingest")
             .method("POST")
@@ -346,7 +349,7 @@ pub(crate) mod tests {
         let (universe, _temp_dir, ingest_service_client, ingest_service_mailbox) =
             setup_ingest_service(&["my-index"], &IngestApiConfig::default()).await;
         let ingest_router = IngestRouterServiceClient::mock().into();
-        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service_client);
+        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service_client, IngestApiConfig::default());
         let handle = tokio::spawn(async move {
             let resp = warp::test::request()
                 .path("/my-index/ingest?commit=wait_for")
@@ -391,7 +394,7 @@ pub(crate) mod tests {
         let (universe, _temp_dir, ingest_service_client, ingest_service_mailbox) =
             setup_ingest_service(&["my-index"], &IngestApiConfig::default()).await;
         let ingest_router = IngestRouterServiceClient::mock().into();
-        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service_client);
+        let ingest_api_handlers = ingest_api_handlers(ingest_router, ingest_service_client, IngestApiConfig::default());
         let handle = tokio::spawn(async move {
             let resp = warp::test::request()
                 .path("/my-index/ingest?commit=force")

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -106,7 +106,11 @@ pub(crate) async fn start_rest_server(
         .or(search_stream_handler(
             quickwit_services.search_service.clone(),
         ))
-        .or(ingest_api_handlers(ingest_router, ingest_service.clone()))
+        .or(ingest_api_handlers(
+            ingest_router,
+            ingest_service.clone(),
+            quickwit_services.node_config.ingest_api_config.clone()
+        ))
         .or(index_management_handlers(
             quickwit_services.index_manager.clone(),
             quickwit_services.node_config.clone(),

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -109,7 +109,7 @@ pub(crate) async fn start_rest_server(
         .or(ingest_api_handlers(
             ingest_router,
             ingest_service.clone(),
-            quickwit_services.node_config.ingest_api_config.clone()
+            quickwit_services.node_config.ingest_api_config.clone(),
         ))
         .or(index_management_handlers(
             quickwit_services.index_manager.clone(),


### PR DESCRIPTION
### Description

Describe the proposed changes made in this PR.

This change adds the ability for the user to configure the content limit for the ingest api. It is related to the feature request made in #3797.

### How was this PR tested?

I have tried adding unit tests but they were not working as expected. I wanted the PR out to get the initial comments, I will add the tests in a follow-up commit to this PR.
