### PR TITLE
Call `truncate` on leaders AND followers

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/gc.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/gc.rs
@@ -202,7 +202,8 @@ mod tests {
             mrecordlog.clone(),
             state.clone(),
         );
-        tokio::time::sleep(REMOVAL_GRACE_PERIOD * 2).await;
+        // Wait for the removal task to run.
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
         let state_guard = state.read().await;
         assert!(state_guard.primary_shards.is_empty());

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -131,7 +131,7 @@ pub(super) struct PrimaryShard {
 }
 
 impl PrimaryShard {
-    pub fn is_gc_candidate(&self) -> bool {
+    pub fn is_removable(&self) -> bool {
         self.shard_state.is_closed()
             && self.publish_position_inclusive >= self.primary_position_inclusive
     }
@@ -178,7 +178,7 @@ impl PrimaryShard {
 /// Records the state of a replica shard managed by a follower. See [`PrimaryShard`] for more
 /// details about the fields.
 pub(super) struct ReplicaShard {
-    pub leader_id: NodeId,
+    pub _leader_id: NodeId,
     pub shard_state: ShardState,
     pub publish_position_inclusive: Position,
     pub replica_position_inclusive: Position,
@@ -187,7 +187,7 @@ pub(super) struct ReplicaShard {
 }
 
 impl ReplicaShard {
-    pub fn is_gc_candidate(&self) -> bool {
+    pub fn is_removable(&self) -> bool {
         self.shard_state.is_closed()
             && self.publish_position_inclusive >= self.replica_position_inclusive
     }
@@ -267,7 +267,7 @@ impl ReplicaShard {
         let (shard_status_tx, shard_status_rx) = watch::channel(shard_status);
 
         Self {
-            leader_id: leader_id.into(),
+            _leader_id: leader_id.into(),
             shard_state,
             publish_position_inclusive,
             replica_position_inclusive,

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -85,7 +85,6 @@ message SynReplicationMessage {
     oneof message {
         OpenReplicationStreamRequest open_request = 1;
         ReplicateRequest replicate_request = 2;
-        TruncateRequest truncate_request = 3;
     }
 }
 
@@ -93,7 +92,6 @@ message AckReplicationMessage {
     oneof message {
         OpenReplicationStreamResponse open_response = 1;
         ReplicateResponse replicate_response = 3;
-        TruncateResponse truncate_response = 4;
     }
 }
 
@@ -142,7 +140,7 @@ message ReplicateFailure {
 }
 
 message TruncateRequest {
-    string leader_id = 1;
+    string ingester_id = 1;
     repeated TruncateSubrequest subrequests = 2;
 }
 

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -65,7 +65,7 @@ pub struct PersistFailure {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SynReplicationMessage {
-    #[prost(oneof = "syn_replication_message::Message", tags = "1, 2, 3")]
+    #[prost(oneof = "syn_replication_message::Message", tags = "1, 2")]
     pub message: ::core::option::Option<syn_replication_message::Message>,
 }
 /// Nested message and enum types in `SynReplicationMessage`.
@@ -79,15 +79,13 @@ pub mod syn_replication_message {
         OpenRequest(super::OpenReplicationStreamRequest),
         #[prost(message, tag = "2")]
         ReplicateRequest(super::ReplicateRequest),
-        #[prost(message, tag = "3")]
-        TruncateRequest(super::TruncateRequest),
     }
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AckReplicationMessage {
-    #[prost(oneof = "ack_replication_message::Message", tags = "1, 3, 4")]
+    #[prost(oneof = "ack_replication_message::Message", tags = "1, 3")]
     pub message: ::core::option::Option<ack_replication_message::Message>,
 }
 /// Nested message and enum types in `AckReplicationMessage`.
@@ -101,8 +99,6 @@ pub mod ack_replication_message {
         OpenResponse(super::OpenReplicationStreamResponse),
         #[prost(message, tag = "3")]
         ReplicateResponse(super::ReplicateResponse),
-        #[prost(message, tag = "4")]
-        TruncateResponse(super::TruncateResponse),
     }
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -188,7 +184,7 @@ pub struct ReplicateFailure {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TruncateRequest {
     #[prost(string, tag = "1")]
-    pub leader_id: ::prost::alloc::string::String,
+    pub ingester_id: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     pub subrequests: ::prost::alloc::vec::Vec<TruncateSubrequest>,
 }

--- a/quickwit/quickwit-proto/src/ingest/ingester.rs
+++ b/quickwit/quickwit-proto/src/ingest/ingester.rs
@@ -99,14 +99,6 @@ impl SynReplicationMessage {
             )),
         }
     }
-
-    pub fn new_truncate_request(truncate_request: TruncateRequest) -> Self {
-        Self {
-            message: Some(syn_replication_message::Message::TruncateRequest(
-                truncate_request,
-            )),
-        }
-    }
 }
 
 impl AckReplicationMessage {
@@ -131,14 +123,6 @@ impl AckReplicationMessage {
         Self {
             message: Some(ack_replication_message::Message::ReplicateResponse(
                 replicate_response,
-            )),
-        }
-    }
-
-    pub fn new_truncate_response(truncate_response: TruncateResponse) -> Self {
-        Self {
-            message: Some(ack_replication_message::Message::TruncateResponse(
-                truncate_response,
             )),
         }
     }


### PR DESCRIPTION
### Description
Before this change, indexers called truncate on leaders, and leaders replicated the truncation request on followers. After this change, indexers are responsible for calling `truncate` on both leaders and followers. Leaders are no longer in charge of replicating the request. 

That way, followers see their queues truncated even if leaders are unavailable. The code is also simplified.

### How was this PR tested?
Updated tests
