### PR TITLE
Use same lock for mrecordlog and ingester state

### DIFF
--- a/quickwit/quickwit-doc-mapper/benches/doc_to_json_bench.rs
+++ b/quickwit/quickwit-doc-mapper/benches/doc_to_json_bench.rs
@@ -19,6 +19,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use quickwit_doc_mapper::DocMapper;
+use tantivy::TantivyDocument;
 
 const JSON_TEST_DATA: &str = include_str!("data/simple-parse-bench.json");
 
@@ -40,25 +41,18 @@ pub fn simple_json_to_doc_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("simple-json-to-doc");
     group.throughput(Throughput::Bytes(JSON_TEST_DATA.len() as u64));
-    group.bench_function("simple-json-to-doc-donothing", |b| {
-        b.iter(|| {
-            let _lines: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
-        })
-    });
     group.bench_function("simple-json-to-doc", |b| {
         b.iter(|| {
-            let lines: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
-            for line in lines {
-                doc_mapper.doc_from_json_str(&line).unwrap();
+            for line in &lines {
+                doc_mapper.doc_from_json_str(line).unwrap();
             }
         })
     });
     group.bench_function("simple-json-to-doc-tantivy", |b| {
         b.iter(|| {
-            let lines: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
             let schema = doc_mapper.schema();
-            for line in lines {
-                let _doc = schema.parse_document(&line).unwrap();
+            for line in &lines {
+                let _doc = TantivyDocument::parse_json(&schema, line).unwrap();
             }
         })
     });

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -91,7 +91,7 @@ message SynReplicationMessage {
 message AckReplicationMessage {
     oneof message {
         OpenReplicationStreamResponse open_response = 1;
-        ReplicateResponse replicate_response = 3;
+        ReplicateResponse replicate_response = 2;
     }
 }
 

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -85,7 +85,7 @@ pub mod syn_replication_message {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AckReplicationMessage {
-    #[prost(oneof = "ack_replication_message::Message", tags = "1, 3")]
+    #[prost(oneof = "ack_replication_message::Message", tags = "1, 2")]
     pub message: ::core::option::Option<ack_replication_message::Message>,
 }
 /// Nested message and enum types in `AckReplicationMessage`.
@@ -97,7 +97,7 @@ pub mod ack_replication_message {
     pub enum Message {
         #[prost(message, tag = "1")]
         OpenResponse(super::OpenReplicationStreamResponse),
-        #[prost(message, tag = "3")]
+        #[prost(message, tag = "2")]
         ReplicateResponse(super::ReplicateResponse),
     }
 }


### PR DESCRIPTION
### Description
Use a single lock for mrecordlog and ingester state to avoid deadlocks.

### How was this PR tested?
Updated unit tests but no functional changes. 
