### PR TITLE
Perform a single mutation per index in file-backed metastore

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
@@ -285,17 +285,13 @@ impl Shards {
                 return Err(MetastoreError::InvalidArgument { message });
             }
         }
-        if mutation_occurred {
-            Ok(MutationOccurred::Yes(()))
-        } else {
-            Ok(MutationOccurred::No(()))
-        }
+        Ok(MutationOccurred::from(mutation_occurred))
     }
 
     pub(super) fn list_shards(
         &self,
         subrequest: ListShardsSubrequest,
-    ) -> MetastoreResult<MutationOccurred<ListShardsSubresponse>> {
+    ) -> MetastoreResult<ListShardsSubresponse> {
         let shards = self.list_shards_inner(subrequest.shard_state);
         let response = ListShardsSubresponse {
             index_uid: subrequest.index_uid,
@@ -303,7 +299,7 @@ impl Shards {
             shards,
             next_shard_id: self.next_shard_id,
         };
-        Ok(MutationOccurred::No(response))
+        Ok(response)
     }
 
     pub(super) fn try_apply_delta(
@@ -463,9 +459,7 @@ mod tests {
             source_id: source_id.clone(),
             shard_state: None,
         };
-        let MutationOccurred::No(subresponse) = shards.list_shards(subrequest).unwrap() else {
-            panic!("Expected `MutationOccured::No`");
-        };
+        let subresponse = shards.list_shards(subrequest).unwrap();
         assert_eq!(subresponse.index_uid, index_uid.as_str());
         assert_eq!(subresponse.source_id, source_id);
         assert_eq!(subresponse.shards.len(), 0);
@@ -492,9 +486,7 @@ mod tests {
             source_id: source_id.clone(),
             shard_state: None,
         };
-        let MutationOccurred::No(mut subresponse) = shards.list_shards(subrequest).unwrap() else {
-            panic!("Expected `MutationOccured::No`");
-        };
+        let mut subresponse = shards.list_shards(subrequest).unwrap();
         subresponse
             .shards
             .sort_unstable_by_key(|shard| shard.shard_id);
@@ -507,9 +499,7 @@ mod tests {
             source_id,
             shard_state: Some(ShardState::Closed as i32),
         };
-        let MutationOccurred::No(subresponse) = shards.list_shards(subrequest).unwrap() else {
-            panic!("Expected `MutationOccured::No`");
-        };
+        let subresponse = shards.list_shards(subrequest).unwrap();
         assert_eq!(subresponse.shards.len(), 1);
         assert_eq!(subresponse.shards[0].shard_id, 1);
     }


### PR DESCRIPTION
### Description
This change groups the subrequests by index UID and batches them.

### How was this PR tested?
No functional changes.
