### PR TITLE
Extending the control plane model

### DIFF
--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -43,6 +43,7 @@ pub const CLI_INGEST_SOURCE_ID: &str = "_ingest-cli-source";
 pub const INGEST_API_SOURCE_ID: &str = "_ingest-api-source";
 
 /// Reserved source ID used for native Quickwit ingest.
+/// (this is for ingest v2)
 pub const INGEST_SOURCE_ID: &str = "_ingest-source";
 
 pub const RESERVED_SOURCE_IDS: &[&str] =

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -300,7 +300,7 @@ impl Handler<AddSourceRequest> for ControlPlane {
 
         self.model
             .add_source(&index_uid, source_config)
-            .context("Failed to add source.")?;
+            .context("failed to add source")?;
 
         // TODO: Refine the event. Notify index will have the effect to reload the entire state from
         // the metastore. We should update the state of the control plane.

--- a/quickwit/quickwit-control-plane/src/lib.rs
+++ b/quickwit/quickwit-control-plane/src/lib.rs
@@ -20,8 +20,8 @@
 pub mod control_plane;
 pub(crate) mod control_plane_model;
 pub mod indexing_plan;
+pub mod indexing_scheduler;
 pub mod ingest;
-pub mod scheduler;
 
 use async_trait::async_trait;
 use quickwit_common::pubsub::EventSubscriber;
@@ -29,7 +29,16 @@ use quickwit_common::tower::Pool;
 use quickwit_proto::control_plane::{ControlPlaneService, ControlPlaneServiceClient};
 use quickwit_proto::indexing::{IndexingServiceClient, IndexingTask};
 use quickwit_proto::metastore::{CloseShardsRequest, DeleteShardsRequest};
+use quickwit_proto::{IndexUid, SourceId};
 use tracing::error;
+
+/// It can however appear only once in a given index.
+/// In itself, `SourceId` is not unique, but the pair `(IndexUid, SourceId)` is.
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord, Hash, Clone)]
+pub struct SourceUid {
+    pub index_uid: IndexUid,
+    pub source_id: SourceId,
+}
 
 /// Indexer-node specific information stored in the pool of available indexer nodes
 #[derive(Debug, Clone)]

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -17,12 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
 use chitchat::transport::ChannelTransport;
+use fnv::FnvHashMap;
 use futures::{Stream, StreamExt};
 use quickwit_actors::{Inbox, Mailbox, Observe, Universe};
 use quickwit_cluster::{create_cluster_for_test, Cluster, ClusterChange};
@@ -38,7 +38,7 @@ use quickwit_proto::NodeId;
 use serde_json::json;
 
 use crate::control_plane::{ControlPlane, CONTROL_PLAN_LOOP_INTERVAL};
-use crate::scheduler::MIN_DURATION_BETWEEN_SCHEDULING;
+use crate::indexing_scheduler::MIN_DURATION_BETWEEN_SCHEDULING;
 use crate::IndexerNodeInfo;
 
 fn index_metadata_for_test(
@@ -72,7 +72,7 @@ fn index_metadata_for_test(
 
 pub fn test_indexer_change_stream(
     cluster_change_stream: impl Stream<Item = ClusterChange> + Send + 'static,
-    indexing_clients: HashMap<String, Mailbox<IndexingService>>,
+    indexing_clients: FnvHashMap<String, Mailbox<IndexingService>>,
 ) -> impl Stream<Item = Change<String, IndexerNodeInfo>> + Send + 'static {
     cluster_change_stream.filter_map(move |cluster_change| {
         let indexing_clients = indexing_clients.clone();
@@ -128,7 +128,7 @@ async fn start_control_plane(
     let indexer_pool = Pool::default();
     let ingester_pool = Pool::default();
     let change_stream = cluster.ready_nodes_change_stream().await;
-    let mut indexing_clients = HashMap::new();
+    let mut indexing_clients = FnvHashMap::default();
 
     for indexer in indexers {
         let (indexing_service_mailbox, indexing_service_inbox) = universe.create_test_mailbox();

--- a/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
@@ -55,8 +55,14 @@ pub struct IndexMetadata {
 impl IndexMetadata {
     /// Panics if `index_config` is missing `index_uri`.
     pub fn new(index_config: IndexConfig) -> Self {
+        let index_uid = IndexUid::new(index_config.index_id.clone());
+        IndexMetadata::new_with_index_uid(index_uid, index_config)
+    }
+
+    /// Panics if `index_config` is missing `index_uri`.
+    pub fn new_with_index_uid(index_uid: IndexUid, index_config: IndexConfig) -> Self {
         IndexMetadata {
-            index_uid: IndexUid::new(index_config.index_id.clone()),
+            index_uid,
             index_config,
             checkpoint: Default::default(),
             create_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
@@ -65,6 +71,8 @@ impl IndexMetadata {
     }
 
     /// Returns an [`IndexMetadata`] object with multiple hard coded values for tests.
+    ///
+    /// An incarnation id of `0` will be used to complete the index id into a index uuid.
     #[cfg(any(test, feature = "testsuite"))]
     pub fn for_test(index_id: &str, index_uri: &str) -> Self {
         let index_uid = IndexUid::from_parts(index_id, "0");

--- a/quickwit/quickwit-proto/src/types.rs
+++ b/quickwit/quickwit-proto/src/types.rs
@@ -60,13 +60,14 @@ pub fn split_queue_id(queue_id: &str) -> Option<(IndexUid, SourceId, ShardId)> {
 pub struct IndexUid(String);
 
 impl fmt::Display for IndexUid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
 impl IndexUid {
-    /// Creates a new index uid form index_id and incarnation_id
+    /// Creates a new index uid from index_id.
+    /// A random UUID will be used as incarnation
     pub fn new(index_id: impl Into<String>) -> Self {
         Self::from_parts(index_id, Ulid::new().to_string())
     }


### PR DESCRIPTION
The control plane model now offers a concise view of the Metastore.
The indexing scheduler query the metastore at all.
This also cleans up the hack the populates the list of indexing task with ingest v2 tasks by mutating the list of tasks

Refactoring:

We rely on SourceUid more broadly in the code.
The unit test were using IndexUid in a broken way in places.
This is now fixed.

This PR introduces a LogicalIndexTask. The idea is to have it hold all
information necessary for us to do the placement.
Right now this means only the max pipeline per index parameter (allowing
us to remove the ugly lookup in the source config map).
We will need to also add information about the desired number of pipeline, possibly the leader/follower for locality, etc.

In the next PR we will most likely also break the 1:1 relationship
between LogicalIndexTask and IndexTask.

The idea would be to have a single logical index task, and possibly break it into several IndexTask.