### PR TITLE
Rename fast field `precision` parameter to `fast_precision`

### DIFF
--- a/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
@@ -99,13 +99,14 @@ doc_mapping:
       output_format: unix_timestamp_nanos
       indexed: false
       fast: true
-      precision: milliseconds
+      precision: nanoseconds
     - name: span_end_timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]
       output_format: unix_timestamp_nanos
       indexed: false
       fast: false
+      precision: nanoseconds
     - name: span_duration_millis
       type: u64
       indexed: false


### PR DESCRIPTION
The precision of `span_start_timestamp_nanos` and `span_end_timestamp_nanos` should be nanoseconds.

Edit from @guilload:
The conclusion of this conversation was to rename the fast field `precision` parameter to `fast_precision`. We can do so in a backward-compatible manner. The upcoming PR should also update the docs and the configuration examples in `config/`.