### PR TITLE
implement  search after

### DIFF
--- a/quickwit/quickwit-common/src/binary_heap.rs
+++ b/quickwit/quickwit-common/src/binary_heap.rs
@@ -129,7 +129,7 @@ pub trait SortKeyMapper<Value> {
 #[derive(Clone)]
 pub struct TopK<T, O: Ord, S> {
     heap: BinaryHeap<Reverse<OrderItemPair<O, T>>>,
-    sort_key_mapper: S,
+    pub sort_key_mapper: S,
     k: usize,
 }
 

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -97,6 +97,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[serde(default, skip_serializing_if = \"Option::is_none\")]",
         )
         .type_attribute(".", "#[derive(Serialize, Deserialize, utoipa::ToSchema)]")
+        .type_attribute("PartialHit", "#[derive(Eq, Hash)]")
         .type_attribute("PartialHit.sort_value", "#[derive(Copy)]")
         .type_attribute("SearchRequest", "#[derive(Eq, Hash)]")
         .type_attribute("Shard", "#[derive(Eq)]")

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -167,8 +167,9 @@ message SearchRequest {
   optional uint32 scroll_ttl_secs = 15;
 
   // Document with sort tuple smaller or equal to this are discarded to
-  // enable pagination
-  repeated SortByValue search_after = 16;
+  // enable pagination.
+  // If split_id is empty, no comparhison with _shard_doc should be done
+  optional PartialHit search_after = 16;
 }
 
 message SortField {

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -165,6 +165,10 @@ message SearchRequest {
   // that will make it possible to paginate through the results
   // in a consistent manner.
   optional uint32 scroll_ttl_secs = 15;
+
+  // Document with sort tuple smaller or equal to this are discarded to
+  // enable pagination
+  repeated SortByValue search_after = 16;
 }
 
 message SortField {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -102,6 +102,10 @@ pub struct SearchRequest {
     /// in a consistent manner.
     #[prost(uint32, optional, tag = "15")]
     pub scroll_ttl_secs: ::core::option::Option<u32>,
+    /// Document with sort tuple smaller or equal to this are discarded to
+    /// enable pagination
+    #[prost(message, repeated, tag = "16")]
+    pub search_after: ::prost::alloc::vec::Vec<SortByValue>,
 }
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[derive(Eq, Hash)]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -103,9 +103,10 @@ pub struct SearchRequest {
     #[prost(uint32, optional, tag = "15")]
     pub scroll_ttl_secs: ::core::option::Option<u32>,
     /// Document with sort tuple smaller or equal to this are discarded to
-    /// enable pagination
-    #[prost(message, repeated, tag = "16")]
-    pub search_after: ::prost::alloc::vec::Vec<SortByValue>,
+    /// enable pagination.
+    /// If split_id is empty, no comparhison with _shard_doc should be done
+    #[prost(message, optional, tag = "16")]
+    pub search_after: ::core::option::Option<PartialHit>,
 }
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[derive(Eq, Hash)]
@@ -253,6 +254,7 @@ pub struct Hit {
 /// - the segment_ord,
 /// - the doc id.
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Eq, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartialHit {

--- a/quickwit/quickwit-proto/src/search/mod.rs
+++ b/quickwit/quickwit-proto/src/search/mod.rs
@@ -67,6 +67,26 @@ impl From<SortValue> for SortByValue {
     }
 }
 
+impl SortByValue {
+    pub fn into_json(self) -> serde_json::Value {
+        use serde_json::Value::*;
+        match self.sort_value {
+            Some(SortValue::U64(num)) => Number(num.into()),
+            Some(SortValue::I64(num)) => Number(num.into()),
+            Some(SortValue::F64(num)) => {
+                if let Some(num) = serde_json::Number::from_f64(num) {
+                    Number(num)
+                } else {
+                    // TODO is there a better way to handle infinite/nan?
+                    Null
+                }
+            }
+            Some(SortValue::Boolean(b)) => Bool(b),
+            None => Null,
+        }
+    }
+}
+
 impl Copy for SortValue {}
 impl Eq for SortValue {}
 

--- a/quickwit/quickwit-proto/src/search/mod.rs
+++ b/quickwit/quickwit-proto/src/search/mod.rs
@@ -104,7 +104,6 @@ impl SortByValue {
                     return None;
                 }
             }
-            // TODO this means we actually ignore _shard_doc
             String(_) | Array(_) | Object(_) => return None,
         };
         Some(SortByValue { sort_value })

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -50,30 +50,7 @@ pub(crate) enum SortByComponent {
         order: SortOrder,
     },
 }
-impl From<SortByComponent> for SortByPair {
-    fn from(value: SortByComponent) -> Self {
-        Self {
-            first: value,
-            second: None,
-        }
-    }
-}
-#[derive(Clone)]
-pub(crate) struct SortByPair {
-    first: SortByComponent,
-    second: Option<SortByComponent>,
-}
-impl SortByPair {
-    pub fn sort_orders(&self) -> (SortOrder, SortOrder) {
-        (
-            self.first.sort_order(),
-            self.second
-                .as_ref()
-                .map(|sort_by| sort_by.sort_order())
-                .unwrap_or(SortOrder::Desc),
-        )
-    }
-}
+
 impl SortByComponent {
     fn to_sorting_field_extractor_component(
         &self,
@@ -173,39 +150,6 @@ impl SortingFieldExtractorComponent {
     }
 }
 
-impl From<SortingFieldExtractorComponent> for SortingFieldExtractorPair {
-    fn from(value: SortingFieldExtractorComponent) -> Self {
-        Self {
-            first: value,
-            second: None,
-        }
-    }
-}
-
-pub(crate) struct SortingFieldExtractorPair {
-    first: SortingFieldExtractorComponent,
-    second: Option<SortingFieldExtractorComponent>,
-}
-
-impl SortingFieldExtractorPair {
-    /// Returns the list of sort values for the given element
-    ///
-    /// See also [`SortingFieldExtractorComponent::extract_typed_sort_value_opt`] for more
-    /// information.
-    fn extract_typed_sort_value(
-        &self,
-        doc_id: DocId,
-        score: Score,
-    ) -> (Option<SortValue>, Option<SortValue>) {
-        let first = self.first.extract_typed_sort_value_opt(doc_id, score);
-        let second = self
-            .second
-            .as_ref()
-            .and_then(|second| second.extract_typed_sort_value_opt(doc_id, score));
-        (first, second)
-    }
-}
-
 impl TryFrom<ColumnType> for SortFieldType {
     type Error = tantivy::TantivyError;
 
@@ -227,19 +171,13 @@ impl TryFrom<ColumnType> for SortFieldType {
 /// Takes a user-defined sorting criteria and resolves it to a
 /// segment specific `SortingFieldExtractorPair`.
 fn get_score_extractor(
-    sort_by: &SortByPair,
+    sort_by: &[SortByComponent],
     segment_reader: &SegmentReader,
-) -> tantivy::Result<SortingFieldExtractorPair> {
-    Ok(SortingFieldExtractorPair {
-        first: sort_by
-            .first
-            .to_sorting_field_extractor_component(segment_reader)?,
-        second: sort_by
-            .second
-            .as_ref()
-            .map(|first| first.to_sorting_field_extractor_component(segment_reader))
-            .transpose()?,
-    })
+) -> tantivy::Result<Vec<SortingFieldExtractorComponent>> {
+    sort_by
+        .iter()
+        .map(|sort_by| sort_by.to_sorting_field_extractor_component(segment_reader))
+        .collect()
 }
 
 /// PartialHitHeapItem order is the inverse of the natural order
@@ -293,25 +231,38 @@ enum AggregationSegmentCollectors {
 pub struct QuickwitSegmentCollector {
     num_hits: u64,
     split_id: String,
-    score_extractor: SortingFieldExtractorPair,
+    score_extractors: Vec<SortingFieldExtractorComponent>,
     // PartialHits in this heap don't contain a split_id yet.
     top_k_hits: TopK<PartialHit, PartialHitSortingKey, HitSortingMapper>,
     segment_ord: u32,
     timestamp_filter_opt: Option<TimestampFilter>,
     aggregation: Option<AggregationSegmentCollectors>,
+    search_after: Option<Vec<Option<SortValue>>>,
 }
 
 impl QuickwitSegmentCollector {
     #[inline]
     fn collect_top_k(&mut self, doc_id: DocId, score: Score) {
-        let (sort_value, sort_value2) =
-            self.score_extractor.extract_typed_sort_value(doc_id, score);
+        let sort_values: Vec<_> = self
+            .score_extractors
+            .iter()
+            .map(|extractor| extractor.extract_typed_sort_value_opt(doc_id, score))
+            .collect();
+
+        if let Some(_search_after) = &self.search_after {
+            // TODO compare and return if should be skipped
+        }
+
+        // TODO better partial hit, again
+        let mut sort_values = sort_values.into_iter();
+        let sort_value = sort_values.next().flatten();
+        let sort_value2 = sort_values.next().flatten();
 
         let hit = PartialHit {
             sort_value: sort_value.map(Into::into),
             sort_value2: sort_value2.map(Into::into),
             // we actually know the split_id, but the hit is likely to be discarded, so clonning it
-            // would cause a probably useless allocation. TODO use an Arc<str> instead?
+            // would cause a probably useless allocation. TODO use an Arc<str>/Rc<str> instead?
             split_id: String::new(),
             segment_ord: self.segment_ord,
             doc_id,
@@ -321,6 +272,7 @@ impl QuickwitSegmentCollector {
 
     #[inline]
     fn accept_document(&self, doc_id: DocId) -> bool {
+        // We don't reject document based on search after because they should be counted.
         if let Some(ref timestamp_filter) = self.timestamp_filter_opt {
             return timestamp_filter.is_within_range(doc_id);
         }
@@ -420,18 +372,18 @@ pub(crate) struct QuickwitCollector {
     pub split_id: String,
     pub start_offset: usize,
     pub max_hits: usize,
-    pub sort_by: SortByPair,
+    pub sort_by: Vec<SortByComponent>,
     timestamp_filter_builder_opt: Option<TimestampFilterBuilder>,
     pub aggregation: Option<QuickwitAggregations>,
     pub aggregation_limits: AggregationLimits,
+    search_after: Option<Vec<Option<SortValue>>>,
 }
 
 impl QuickwitCollector {
     pub fn fast_field_names(&self) -> HashSet<String> {
         let mut fast_field_names = HashSet::default();
-        self.sort_by.first.add_fast_field(&mut fast_field_names);
-        if let Some(sort_by_second) = &self.sort_by.second {
-            sort_by_second.add_fast_field(&mut fast_field_names);
+        for sort_by in &self.sort_by {
+            sort_by.add_fast_field(&mut fast_field_names);
         }
         if let Some(aggregations) = &self.aggregation {
             fast_field_names.extend(aggregations.fast_field_names());
@@ -485,17 +437,22 @@ impl Collector for QuickwitCollector {
             ),
             None => None,
         };
-        let score_extractor = get_score_extractor(&self.sort_by, segment_reader)?;
-        let (order1, order2) = self.sort_by.sort_orders();
-        let sort_key_mapper = HitSortingMapper { order1, order2 };
+        let score_extractors = get_score_extractor(&self.sort_by, segment_reader)?;
+        let orders = self
+            .sort_by
+            .iter()
+            .map(|sort_by| sort_by.sort_order())
+            .collect();
+        let sort_key_mapper = HitSortingMapper { orders };
         Ok(QuickwitSegmentCollector {
             num_hits: 0u64,
             split_id: self.split_id.clone(),
-            score_extractor,
+            score_extractors,
             top_k_hits: TopK::new(leaf_max_hits, sort_key_mapper),
             segment_ord,
             timestamp_filter_opt,
             aggregation,
+            search_after: self.search_after.clone(),
         })
     }
 
@@ -503,13 +460,9 @@ impl Collector for QuickwitCollector {
         // We do not need BM25 scoring in Quickwit if it is not opted-in.
         // By returning false, we inform tantivy that it does not need to decompress
         // term frequencies.
-        self.sort_by.first.requires_scoring()
-            || self
-                .sort_by
-                .second
-                .as_ref()
-                .map(|sort_by| sort_by.requires_scoring())
-                .unwrap_or(false)
+        self.sort_by
+            .iter()
+            .any(|sort_by| sort_by.requires_scoring())
     }
 
     fn merge_fruits(
@@ -522,14 +475,13 @@ impl Collector for QuickwitCollector {
         // All leaves will return their top [0..start_offset + max_hits) documents.
         // We compute the overall [0..start_offset + max_hits) documents ...
         let num_hits = self.start_offset + self.max_hits;
-        let (sort_order1, sort_order2) = self.sort_by.sort_orders();
-        let mut merged_leaf_response = merge_leaf_responses(
-            &self.aggregation,
-            segment_fruits?,
-            sort_order1,
-            sort_order2,
-            num_hits,
-        )?;
+        let sort_orders = self
+            .sort_by
+            .iter()
+            .map(|sort_by| sort_by.sort_order())
+            .collect();
+        let mut merged_leaf_response =
+            merge_leaf_responses(&self.aggregation, segment_fruits?, sort_orders, num_hits)?;
         // ... and drop the first [..start_offsets) hits.
         // note that self.start_offset is 0 when merging from leaf_search, and is only set when
         // merging from root_search, so as to remove the firsts elements only once.
@@ -597,8 +549,7 @@ fn merge_intermediate_aggregation_result<'a>(
 fn merge_leaf_responses(
     aggregations_opt: &Option<QuickwitAggregations>,
     mut leaf_responses: Vec<LeafSearchResponse>,
-    sort_order1: SortOrder,
-    sort_order2: SortOrder,
+    sort_orders: Vec<SortOrder>,
     max_hits: usize,
 ) -> tantivy::Result<LeafSearchResponse> {
     // Optimization: No merging needed if there is only one result.
@@ -629,12 +580,8 @@ fn merge_leaf_responses(
         .into_iter()
         .flat_map(|leaf_response| leaf_response.partial_hits)
         .collect();
-    let top_k_partial_hits: Vec<PartialHit> = top_k_partial_hits(
-        all_partial_hits.into_iter(),
-        sort_order1,
-        sort_order2,
-        max_hits,
-    );
+    let top_k_partial_hits: Vec<PartialHit> =
+        top_k_partial_hits(all_partial_hits.into_iter(), sort_orders, max_hits);
     Ok(LeafSearchResponse {
         intermediate_aggregation_result: merged_intermediate_aggregation_result,
         num_hits,
@@ -650,11 +597,10 @@ fn merge_leaf_responses(
 /// TODO we could possibly optimize the sort away (but I doubt it matters).
 fn top_k_partial_hits(
     partial_hits: impl Iterator<Item = PartialHit>,
-    order1: SortOrder,
-    order2: SortOrder,
+    orders: Vec<SortOrder>,
     num_hits: usize,
 ) -> Vec<PartialHit> {
-    let sort_key_mapper = HitSortingMapper { order1, order2 };
+    let sort_key_mapper = HitSortingMapper { orders };
     let mut top_k_hits = TopK::new(num_hits, sort_key_mapper);
 
     partial_hits.for_each(|hit| top_k_hits.add_entry(hit));
@@ -662,7 +608,7 @@ fn top_k_partial_hits(
     top_k_hits.finalize()
 }
 
-pub(crate) fn sort_by_from_request(search_request: &SearchRequest) -> SortByPair {
+pub(crate) fn sort_by_from_request(search_request: &SearchRequest) -> Vec<SortByComponent> {
     let to_sort_by_component = |field_name: &str, order| {
         if field_name == "_score" {
             SortByComponent::Score { order }
@@ -674,24 +620,19 @@ pub(crate) fn sort_by_from_request(search_request: &SearchRequest) -> SortByPair
         }
     };
 
-    let num_sort_fields = search_request.sort_fields.len();
-    if num_sort_fields == 0 {
-        SortByComponent::DocId.into()
-    } else if num_sort_fields == 1 {
-        let sort_field = &search_request.sort_fields[0];
-        let order = SortOrder::from_i32(sort_field.sort_order).unwrap_or(SortOrder::Desc);
-        to_sort_by_component(&sort_field.field_name, order).into()
-    } else if num_sort_fields == 2 {
-        let sort_field1 = &search_request.sort_fields[0];
-        let order1 = SortOrder::from_i32(sort_field1.sort_order).unwrap_or(SortOrder::Desc);
-        let sort_field2 = &search_request.sort_fields[1];
-        let order2 = SortOrder::from_i32(sort_field2.sort_order).unwrap_or(SortOrder::Desc);
-        SortByPair {
-            first: to_sort_by_component(&sort_field1.field_name, order1),
-            second: Some(to_sort_by_component(&sort_field2.field_name, order2)),
-        }
+    if search_request.sort_fields.is_empty() {
+        // TODO removing that branch makes root::tests::test_root_search_with_scroll and I don't
+        // know why.
+        vec![SortByComponent::DocId]
     } else {
-        panic!("Sort by more than 2 fields is not supported yet.")
+        search_request
+            .sort_fields
+            .iter()
+            .map(|sort_field| {
+                let order = SortOrder::from_i32(sort_field.sort_order).unwrap_or(SortOrder::Desc);
+                to_sort_by_component(&sort_field.field_name, order)
+            })
+            .collect()
     }
 }
 
@@ -712,6 +653,19 @@ pub(crate) fn make_collector_for_split(
         search_request.end_timestamp,
     );
     let sort_by = sort_by_from_request(search_request);
+
+    let search_after = if search_request.search_after.is_empty() {
+        None
+    } else {
+        Some(
+            search_request
+                .search_after
+                .iter()
+                .map(|sort_by_value| sort_by_value.sort_value)
+                .collect(),
+        )
+    };
+
     Ok(QuickwitCollector {
         split_id,
         start_offset: search_request.start_offset as usize,
@@ -720,6 +674,7 @@ pub(crate) fn make_collector_for_split(
         timestamp_filter_builder_opt,
         aggregation,
         aggregation_limits,
+        search_after,
     })
 }
 
@@ -733,6 +688,18 @@ pub(crate) fn make_merge_collector(
         None => None,
     };
     let sort_by = sort_by_from_request(search_request);
+    let search_after = if search_request.search_after.is_empty() {
+        None
+    } else {
+        Some(
+            search_request
+                .search_after
+                .iter()
+                .map(|sort_by_value| sort_by_value.sort_value)
+                .collect(),
+        )
+    };
+
     Ok(QuickwitCollector {
         split_id: String::default(),
         start_offset: search_request.start_offset as usize,
@@ -741,40 +708,37 @@ pub(crate) fn make_merge_collector(
         timestamp_filter_builder_opt: None,
         aggregation,
         aggregation_limits: aggregation_limits.clone(),
+        search_after,
     })
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PartialHitSortingKey {
-    sort_value: Option<SortValue>,
-    sort_value2: Option<SortValue>,
+    sort_values: Vec<Option<SortValue>>,
     address: GlobalDocAddress,
-    sort_order: SortOrder,
-    sort_order2: SortOrder,
+    sort_orders: Vec<SortOrder>,
 }
 
 impl Ord for PartialHitSortingKey {
     fn cmp(&self, other: &PartialHitSortingKey) -> Ordering {
         assert_eq!(
-            self.sort_order, other.sort_order,
-            "comparing two PartialHitSortingKey of different ordering"
-        );
-        assert_eq!(
-            self.sort_order2, other.sort_order2,
+            self.sort_orders, other.sort_orders,
             "comparing two PartialHitSortingKey of different ordering"
         );
 
-        let order = self
-            .sort_order
-            .compare_opt(&self.sort_value, &other.sort_value);
+        for (index, order) in self.sort_orders.iter().enumerate() {
+            match order.compare_opt(&self.sort_values[index], &other.sort_values[index]) {
+                Ordering::Equal => continue,
+                other => return other,
+            }
+        }
 
-        let order2 = self
-            .sort_order2
-            .compare_opt(&self.sort_value2, &other.sort_value2);
-
-        let order_addr = self.sort_order.compare(&self.address, &other.address);
-
-        order.then(order2).then(order_addr)
+        // TODO unwrap or &SortOrder::Asc makes this work for
+        // root::tests::test_root_search_with_scroll, but it seems wrong
+        self.sort_orders
+            .first()
+            .unwrap_or(&SortOrder::Desc)
+            .compare(&self.address, &other.address)
     }
 }
 
@@ -786,19 +750,26 @@ impl PartialOrd for PartialHitSortingKey {
 
 #[derive(Clone)]
 struct HitSortingMapper {
-    order1: SortOrder,
-    order2: SortOrder,
+    // good candidate for a SmallVec
+    orders: Vec<SortOrder>,
 }
 
 impl SortKeyMapper<PartialHit> for HitSortingMapper {
     type Key = PartialHitSortingKey;
     fn get_sort_key(&self, partial_hit: &PartialHit) -> PartialHitSortingKey {
+        let sort_values = match self.orders.len() {
+            0 => Vec::new(),
+            1 => vec![partial_hit.sort_value.and_then(|v| v.sort_value)],
+            2 => vec![
+                partial_hit.sort_value.and_then(|v| v.sort_value),
+                partial_hit.sort_value2.and_then(|v| v.sort_value),
+            ],
+            _ => todo!("use Vec in PartialHit too"),
+        };
         PartialHitSortingKey {
-            sort_value: partial_hit.sort_value.and_then(|v| v.sort_value),
-            sort_value2: partial_hit.sort_value2.and_then(|v| v.sort_value),
+            sort_values,
             address: GlobalDocAddress::from_partial_hit(partial_hit),
-            sort_order: self.order1,
-            sort_order2: self.order2,
+            sort_orders: self.orders.clone(),
         }
     }
 }
@@ -817,8 +788,12 @@ pub(crate) struct IncrementalCollector {
 impl IncrementalCollector {
     /// Create a new incremental collector
     pub(crate) fn new(inner: QuickwitCollector) -> Self {
-        let (order1, order2) = inner.sort_by.sort_orders();
-        let sort_key_mapper = HitSortingMapper { order1, order2 };
+        let orders = inner
+            .sort_by
+            .iter()
+            .map(|sort_by| sort_by.sort_order())
+            .collect();
+        let sort_key_mapper = HitSortingMapper { orders };
         IncrementalCollector {
             top_k_hits: TopK::new(inner.max_hits + inner.start_offset, sort_key_mapper),
             inner,
@@ -956,8 +931,7 @@ mod tests {
         assert_eq!(
             top_k_partial_hits(
                 vec![make_doc(1u64), make_doc(3u64), make_doc(2u64),].into_iter(),
-                SortOrder::Asc,
-                SortOrder::Asc,
+                vec![SortOrder::Asc, SortOrder::Asc],
                 2
             ),
             vec![make_doc(1), make_doc(2)]
@@ -981,8 +955,7 @@ mod tests {
                     make_hit_given_split_id(2u64),
                 ]
                 .into_iter(),
-                SortOrder::Desc,
-                SortOrder::Desc,
+                vec![SortOrder::Desc, SortOrder::Desc],
                 2
             ),
             &[make_hit_given_split_id(3), make_hit_given_split_id(2)]
@@ -995,8 +968,7 @@ mod tests {
                     make_hit_given_split_id(2u64),
                 ]
                 .into_iter(),
-                SortOrder::Asc,
-                SortOrder::Asc,
+                vec![SortOrder::Asc, SortOrder::Asc],
                 2
             ),
             &[make_hit_given_split_id(1), make_hit_given_split_id(2)]

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -262,6 +262,8 @@ impl QuickwitSegmentCollector {
                 &search_after_values,
             );
             if !search_after.split_id.is_empty() {
+                // TODO actually it's not first, it should be what's in _shard_doc then first then
+                // default
                 let order = self
                     .top_k_hits
                     .sort_key_mapper
@@ -745,6 +747,8 @@ impl Ord for PartialHitSortingKey {
         let fields_res = compare_fields(&self.sort_orders, &self.sort_values, &other.sort_values);
 
         let doc_id_res = || {
+            // TODO actually it's not first, it should be what's in _shard_doc then first then
+            // default
             self.sort_orders
                 .first()
                 .unwrap_or(&SortOrder::Desc)

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -648,22 +648,14 @@ pub(crate) fn sort_by_from_request(search_request: &SearchRequest) -> Vec<SortBy
         }
     };
 
-    if search_request.sort_fields.is_empty() {
-        // TODO removing that branch makes root::tests::test_root_search_with_scroll and I don't
-        // know why.
-        vec![SortByComponent::DocId {
-            order: SortOrder::Desc,
-        }]
-    } else {
-        search_request
-            .sort_fields
-            .iter()
-            .map(|sort_field| {
-                let order = SortOrder::from_i32(sort_field.sort_order).unwrap_or(SortOrder::Desc);
-                to_sort_by_component(&sort_field.field_name, order)
-            })
-            .collect()
-    }
+    search_request
+        .sort_fields
+        .iter()
+        .map(|sort_field| {
+            let order = SortOrder::from_i32(sort_field.sort_order).unwrap_or(SortOrder::Desc);
+            to_sort_by_component(&sort_field.field_name, order)
+        })
+        .collect()
 }
 
 /// Builds the QuickwitCollector, in function of the information that was requested by the user.
@@ -752,8 +744,6 @@ impl Ord for PartialHitSortingKey {
 
         let fields_res = compare_fields(&self.sort_orders, &self.sort_values, &other.sort_values);
 
-        // TODO unwrap or &SortOrder::Asc makes this work for
-        // root::tests::test_root_search_with_scroll, but it seems wrong
         let doc_id_res = || {
             self.sort_orders
                 .first()

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -718,6 +718,8 @@ pub async fn root_search(
     }
     let tag_filter_ast = extract_tags_from_query(query_ast_resolved);
 
+    // TODO if search after is set, we sort by timestamp and we don't want to count all results,
+    // we can refine more here.
     let split_metadatas: Vec<SplitMetadata> = list_relevant_splits(
         index_uids,
         search_request.start_timestamp,

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -291,9 +291,9 @@ fn simplify_search_request_for_scroll_api(req: &SearchRequest) -> SearchRequest 
         snippet_fields: Vec::new(),
         // We remove the scroll ttl parameter. It is irrelevant to process later request
         scroll_ttl_secs: None,
-        // TODO not currently used, but should probably be stripped as it will end up being
-        // generated internally in the future
-        search_after: Vec::new(),
+        // TODO unclear as to what we should do when scroll and search after are mixed. I guess
+        // honor search_after?
+        search_after: req.search_after.clone(),
     }
 }
 
@@ -719,7 +719,7 @@ pub async fn root_search(
     let tag_filter_ast = extract_tags_from_query(query_ast_resolved);
 
     // TODO if search after is set, we sort by timestamp and we don't want to count all results,
-    // we can refine more here.
+    // we can refine more here. Same if we sort by _shard_doc
     let split_metadatas: Vec<SplitMetadata> = list_relevant_splits(
         index_uids,
         search_request.start_timestamp,

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1315,6 +1315,20 @@ mod tests {
         }
     }
 
+    fn mock_partial_hit_opt_sort_value(
+        split_id: &str,
+        sort_value: Option<u64>,
+        doc_id: u32,
+    ) -> quickwit_proto::search::PartialHit {
+        quickwit_proto::search::PartialHit {
+            sort_value: sort_value.map(|sort_value| SortValue::U64(sort_value).into()),
+            sort_value2: None,
+            split_id: split_id.to_string(),
+            segment_ord: 1,
+            doc_id,
+        }
+    }
+
     fn get_doc_for_fetch_req(
         fetch_docs_req: quickwit_proto::search::FetchDocsRequest,
     ) -> Vec<quickwit_proto::search::LeafHit> {
@@ -2718,18 +2732,15 @@ mod tests {
             "ram:///test-index-2" => (TOTAL_NUM_HITS_INDEX_2, "split2"),
             _ => panic!("unexpected index uri"),
         };
-        let truncate_range = hit_range.start.min(num_total_hits)..hit_range.end.min(num_total_hits);
+
+        let doc_ids = (0..num_total_hits)
+            .rev()
+            .skip(hit_range.start)
+            .take(hit_range.end - hit_range.start);
         quickwit_proto::search::LeafSearchResponse {
             num_hits: num_total_hits as u64,
-            partial_hits: truncate_range
-                .map(|doc_id| {
-                    let sort_value = match index_uri {
-                        "ram:///test-index-1" => u64::MAX - doc_id as u64,
-                        "ram:///test-index-2" => (TOTAL_NUM_HITS_INDEX_2 - doc_id) as u64,
-                        _ => panic!("unexpected index uri"),
-                    };
-                    mock_partial_hit(split_id, sort_value, doc_id as u32)
-                })
+            partial_hits: doc_ids
+                .map(|doc_id| mock_partial_hit_opt_sort_value(split_id, None, doc_id as u32))
                 .collect(),
             num_attempted_splits: 1,
             ..Default::default()
@@ -2854,10 +2865,18 @@ mod tests {
                 (TOTAL_NUM_HITS_INDEX_1 + TOTAL_NUM_HITS_INDEX_2) as u64
             );
             assert_eq!(search_response.hits.len(), MAX_HITS_PER_PAGE);
-            for (i, hit) in search_response.hits.iter().enumerate() {
+            let expected = (0..TOTAL_NUM_HITS_INDEX_2)
+                .rev()
+                .zip(std::iter::repeat("split2"))
+                .chain(
+                    (0..TOTAL_NUM_HITS_INDEX_1)
+                        .rev()
+                        .zip(std::iter::repeat("split1")),
+                );
+            for (hit, (doc_id, split)) in search_response.hits.iter().zip(expected) {
                 assert_eq!(
                     hit.partial_hit.as_ref().unwrap(),
-                    &mock_partial_hit("split1", u64::MAX - i as u64, i as u32)
+                    &mock_partial_hit_opt_sort_value(split, None, doc_id as u32)
                 );
             }
             count_seen_hits += search_response.hits.len();
@@ -2876,25 +2895,20 @@ mod tests {
                 scroll_resp.num_hits,
                 (TOTAL_NUM_HITS_INDEX_1 + TOTAL_NUM_HITS_INDEX_2) as u64
             );
-            for (i, hit) in scroll_resp.hits.iter().enumerate() {
-                let doc = (page * MAX_HITS_PER_PAGE as u64) + i as u64;
-                if doc < TOTAL_NUM_HITS_INDEX_1 as u64 {
-                    assert_eq!(
-                        hit.partial_hit.as_ref().unwrap(),
-                        &mock_partial_hit("split1", u64::MAX - doc, doc as u32)
-                    );
-                } else {
-                    // Docs from index 2 come after the ones from index 1.
-                    let doc = doc - TOTAL_NUM_HITS_INDEX_1 as u64;
-                    assert_eq!(
-                        hit.partial_hit.as_ref().unwrap(),
-                        &mock_partial_hit(
-                            "split2",
-                            TOTAL_NUM_HITS_INDEX_2 as u64 - doc,
-                            doc as u32
-                        )
-                    );
-                }
+            let expected = (0..TOTAL_NUM_HITS_INDEX_2)
+                .rev()
+                .zip(std::iter::repeat("split2"))
+                .chain(
+                    (0..TOTAL_NUM_HITS_INDEX_1)
+                        .rev()
+                        .zip(std::iter::repeat("split1")),
+                )
+                .skip(page * MAX_HITS_PER_PAGE);
+            for (hit, (doc_id, split)) in scroll_resp.hits.iter().zip(expected) {
+                assert_eq!(
+                    hit.partial_hit.as_ref().unwrap(),
+                    &mock_partial_hit_opt_sort_value(split, None, doc_id as u32)
+                );
             }
             scroll_id = scroll_resp.scroll_id.unwrap();
             count_seen_hits += scroll_resp.hits.len();

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -291,6 +291,9 @@ fn simplify_search_request_for_scroll_api(req: &SearchRequest) -> SearchRequest 
         snippet_fields: Vec::new(),
         // We remove the scroll ttl parameter. It is irrelevant to process later request
         scroll_ttl_secs: None,
+        // TODO not currently used, but should probably be stripped as it will end up being
+        // generated internally in the future
+        search_after: Vec::new(),
     }
 }
 

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -1870,3 +1870,17 @@ async fn test_search_in_text_field_with_custom_tokenizer() -> anyhow::Result<()>
     test_sandbox.assert_quit().await;
     Ok(())
 }
+
+#[test]
+fn test_global_doc_address_ser_deser() {
+    let doc_address = GlobalDocAddress {
+        split: "split_id".to_string(),
+        doc_addr: DocAddress {
+            segment_ord: 0,
+            doc_id: 123456,
+        },
+    };
+    let doc_address_string = doc_address.to_string();
+    let doc_address_deser: GlobalDocAddress = doc_address_string.parse().unwrap();
+    assert_eq!(doc_address_deser, doc_address);
+}

--- a/quickwit/quickwit-serve/src/elastic_search_api/model/search_body.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/model/search_body.rs
@@ -69,6 +69,8 @@ pub struct SearchBody {
     pub track_total_hits: Option<TrackTotalHits>,
     #[serde(default)]
     pub stored_fields: Option<BTreeSet<String>>,
+    #[serde(default)]
+    pub search_after: Vec<serde_json::Value>,
 }
 
 struct FieldSortVecVisitor;

--- a/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
@@ -30,7 +30,7 @@ use hyper::StatusCode;
 use itertools::Itertools;
 use quickwit_common::truncate_str;
 use quickwit_config::{validate_index_id_pattern, NodeConfig};
-use quickwit_proto::search::{ScrollRequest, SearchResponse};
+use quickwit_proto::search::{ScrollRequest, SearchResponse, SortByValue};
 use quickwit_proto::ServiceErrorCode;
 use quickwit_query::query_ast::{QueryAst, UserInputQuery};
 use quickwit_query::BooleanOperand;
@@ -175,6 +175,11 @@ fn build_request_for_es_api(
 
     let scroll_duration: Option<Duration> = search_params.parse_scroll_ttl()?;
     let scroll_ttl_secs: Option<u32> = scroll_duration.map(|duration| duration.as_secs() as u32);
+    let search_after = search_body
+        .search_after
+        .into_iter()
+        .filter_map(SortByValue::try_from_json)
+        .collect();
 
     Ok(quickwit_proto::search::SearchRequest {
         index_id_patterns,
@@ -187,6 +192,7 @@ fn build_request_for_es_api(
         end_timestamp: None,
         snippet_fields: Vec::new(),
         scroll_ttl_secs,
+        search_after,
     })
 }
 

--- a/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
@@ -30,7 +30,7 @@ use hyper::StatusCode;
 use itertools::Itertools;
 use quickwit_common::truncate_str;
 use quickwit_config::{validate_index_id_pattern, NodeConfig};
-use quickwit_proto::search::{ScrollRequest, SearchResponse, SortByValue};
+use quickwit_proto::search::{PartialHit, ScrollRequest, SearchResponse, SortByValue};
 use quickwit_proto::ServiceErrorCode;
 use quickwit_query::query_ast::{QueryAst, UserInputQuery};
 use quickwit_query::BooleanOperand;
@@ -130,7 +130,7 @@ fn build_request_for_es_api(
     index_id_patterns: Vec<String>,
     search_params: SearchQueryParams,
     search_body: SearchBody,
-) -> Result<quickwit_proto::search::SearchRequest, ElasticSearchError> {
+) -> Result<(quickwit_proto::search::SearchRequest, bool), ElasticSearchError> {
     let default_operator = search_params.default_operator.unwrap_or(BooleanOperand::Or);
     // The query string, if present, takes priority over what can be in the request
     // body.
@@ -175,26 +175,61 @@ fn build_request_for_es_api(
 
     let scroll_duration: Option<Duration> = search_params.parse_scroll_ttl()?;
     let scroll_ttl_secs: Option<u32> = scroll_duration.map(|duration| duration.as_secs() as u32);
-    // TODO validate number of params against number of sort clauses. Error on invalid search close
-    let search_after = search_body
-        .search_after
-        .into_iter()
-        .filter_map(SortByValue::try_from_json)
-        .collect();
+    let (search_after, include_shard_doc) =
+        partial_hit_from_search_after_param(search_body.search_after, &sort_fields)?;
 
-    Ok(quickwit_proto::search::SearchRequest {
-        index_id_patterns,
-        query_ast: serde_json::to_string(&query_ast).expect("Failed to serialize QueryAst"),
-        max_hits,
-        start_offset,
-        aggregation_request,
-        sort_fields,
-        start_timestamp: None,
-        end_timestamp: None,
-        snippet_fields: Vec::new(),
-        scroll_ttl_secs,
-        search_after,
-    })
+    Ok((
+        quickwit_proto::search::SearchRequest {
+            index_id_patterns,
+            query_ast: serde_json::to_string(&query_ast).expect("Failed to serialize QueryAst"),
+            max_hits,
+            start_offset,
+            aggregation_request,
+            sort_fields,
+            start_timestamp: None,
+            end_timestamp: None,
+            snippet_fields: Vec::new(),
+            scroll_ttl_secs,
+            search_after,
+        },
+        include_shard_doc,
+    ))
+}
+
+fn partial_hit_from_search_after_param(
+    search_after: Vec<serde_json::Value>,
+    sort_order: &[quickwit_proto::search::SortField],
+) -> Result<(Option<PartialHit>, bool), ElasticSearchError> {
+    let field_is_doc_id = |field: &quickwit_proto::search::SortField| {
+        field.field_name == "_shard_doc" || field.field_name == "_doc"
+    };
+    if search_after.is_empty() {
+        return Ok((None, sort_order.iter().any(field_is_doc_id)));
+    }
+
+    let mut parsed_search_after = PartialHit::default();
+    for (value, field) in search_after.into_iter().zip(sort_order) {
+        if field_is_doc_id(field) {
+            if let Some(value_str) = value.as_str() {
+                let address: quickwit_search::GlobalDocAddress = value_str.parse().expect("TODO");
+                parsed_search_after.split_id = address.split;
+                parsed_search_after.segment_ord = address.doc_addr.segment_ord;
+                parsed_search_after.doc_id = address.doc_addr.doc_id;
+                return Ok((Some(parsed_search_after), true));
+            } else {
+                todo!();
+            }
+        } else {
+            let value = SortByValue::try_from_json(value).expect("TODO");
+            // TODO make cleaner once we support Vec
+            if parsed_search_after.sort_value.is_none() {
+                parsed_search_after.sort_value = Some(value);
+            } else {
+                parsed_search_after.sort_value2 = Some(value);
+            }
+        }
+    }
+    Ok((Some(parsed_search_after), false))
 }
 
 async fn es_compat_index_search(
@@ -204,16 +239,17 @@ async fn es_compat_index_search(
     search_service: Arc<dyn SearchService>,
 ) -> Result<ElasticSearchResponse, ElasticSearchError> {
     let start_instant = Instant::now();
-    let search_request = build_request_for_es_api(index_id_patterns, search_params, search_body)?;
+    let (search_request, append_shard_doc) =
+        build_request_for_es_api(index_id_patterns, search_params, search_body)?;
     let search_response: SearchResponse = search_service.root_search(search_request).await?;
     let elapsed = start_instant.elapsed();
     let mut search_response_rest: ElasticSearchResponse =
-        convert_to_es_search_response(search_response);
+        convert_to_es_search_response(search_response, append_shard_doc);
     search_response_rest.took = elapsed.as_millis() as u32;
     Ok(search_response_rest)
 }
 
-fn convert_hit(hit: quickwit_proto::search::Hit) -> ElasticHit {
+fn convert_hit(hit: quickwit_proto::search::Hit, append_shard_doc: bool) -> ElasticHit {
     let fields: BTreeMap<String, serde_json::Value> =
         serde_json::from_str(&hit.json).unwrap_or_default();
     let mut sort = Vec::new();
@@ -224,10 +260,11 @@ fn convert_hit(hit: quickwit_proto::search::Hit) -> ElasticHit {
         if let Some(sort_value2) = partial_hit.sort_value2 {
             sort.push(sort_value2.into_json());
         }
-        // TODO this is akin to a `_shard_doc`. We should only set that if the client requested it
-        sort.push(serde_json::Value::String(
-            quickwit_search::GlobalDocAddress::from_partial_hit(&partial_hit).to_string(),
-        ));
+        if append_shard_doc {
+            sort.push(serde_json::Value::String(
+                quickwit_search::GlobalDocAddress::from_partial_hit(&partial_hit).to_string(),
+            ));
+        }
     }
 
     ElasticHit {
@@ -297,16 +334,23 @@ async fn es_compat_index_multi_search(
             build_request_for_es_api(index_ids_patterns, search_query_params, search_body)?;
         search_requests.push(es_request);
     }
-    let futures = search_requests.into_iter().map(|search_request| async {
-        let start_instant = Instant::now();
-        let search_response: SearchResponse =
-            search_service.clone().root_search(search_request).await?;
-        let elapsed = start_instant.elapsed();
-        let mut search_response_rest: ElasticSearchResponse =
-            convert_to_es_search_response(search_response);
-        search_response_rest.took = elapsed.as_millis() as u32;
-        Ok::<_, ElasticSearchError>(search_response_rest)
-    });
+    // TODO: forced to do weird referencing to work arround https://github.com/rust-lang/rust/issues/100905
+    // otherwise append_shard_doc is captured by ref, and we get lifetime issues
+    let futures = search_requests
+        .into_iter()
+        .map(|(search_request, append_shard_doc)| {
+            let search_service = &search_service;
+            async move {
+                let start_instant = Instant::now();
+                let search_response: SearchResponse =
+                    search_service.clone().root_search(search_request).await?;
+                let elapsed = start_instant.elapsed();
+                let mut search_response_rest: ElasticSearchResponse =
+                    convert_to_es_search_response(search_response, append_shard_doc);
+                search_response_rest.took = elapsed.as_millis() as u32;
+                Ok::<_, ElasticSearchError>(search_response_rest)
+            }
+        });
     let max_concurrent_searches =
         multi_search_params.max_concurrent_searches.unwrap_or(10) as usize;
     let search_responses = futures::stream::iter(futures)
@@ -344,14 +388,22 @@ async fn es_scroll(
         scroll_ttl_secs,
     };
     let search_response: SearchResponse = search_service.scroll(scroll_request).await?;
+    // TODO maybe put _shard_doc??
     let mut search_response_rest: ElasticSearchResponse =
-        convert_to_es_search_response(search_response);
+        convert_to_es_search_response(search_response, false);
     search_response_rest.took = start_instant.elapsed().as_millis() as u32;
     Ok(search_response_rest)
 }
 
-fn convert_to_es_search_response(resp: SearchResponse) -> ElasticSearchResponse {
-    let hits: Vec<ElasticHit> = resp.hits.into_iter().map(convert_hit).collect();
+fn convert_to_es_search_response(
+    resp: SearchResponse,
+    append_shard_doc: bool,
+) -> ElasticSearchResponse {
+    let hits: Vec<ElasticHit> = resp
+        .hits
+        .into_iter()
+        .map(|hit| convert_hit(hit, append_shard_doc))
+        .collect();
     let aggregations: Option<serde_json::Value> = if let Some(aggregation_json) = resp.aggregation {
         serde_json::from_str(&aggregation_json).ok()
     } else {

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -241,6 +241,9 @@ pub fn search_request_from_api_request(
             .map(|agg| serde_json::to_string(&agg).expect("could not serialize JsonValue")),
         sort_fields: search_request.sort_by.sort_fields,
         scroll_ttl_secs: None,
+        // TODO do we want to support search_after on QW api? If so, what should the request look
+        // like????
+        search_after: Vec::new(),
     };
     Ok(search_request)
 }

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -243,7 +243,7 @@ pub fn search_request_from_api_request(
         scroll_ttl_secs: None,
         // TODO do we want to support search_after on QW api? If so, what should the request look
         // like????
-        search_after: Vec::new(),
+        search_after: None,
     };
     Ok(search_request)
 }

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0018-search_after.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0018-search_after.yaml
@@ -1,0 +1,46 @@
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - actor.id:
+        order: desc
+expected:
+  hits:
+    total:
+      value: 100
+      relation: eq
+    hits:
+      - sort: [10791502]
+---
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - actor.id:
+        order: desc
+  search_after: [10791502]
+expected:
+  hits:
+    total:
+      value: 100
+      relation: eq
+    hits:
+      - sort: [10791466]
+---
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - actor.id:
+        order: asc
+  search_after: [5688]
+expected:
+  hits:
+    total:
+      value: 100
+      relation: eq
+    hits:
+      - sort: [9018]


### PR DESCRIPTION
### Description

fix #3523
implement ES search_after

### How was this PR tested?

added unit test and rest-api test


fix a test on scroll which was made unrepresentative of what's really happening due to desync between mocking and real code behaviour.
start supporting more than 2 sort values in collector (but not yet outside of it), as it makes easier to reason about the code than having two Option<>