### PR TITLE
Remove dead --commit-timeout CLI argument

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -324,7 +324,6 @@ quickwit index ingest
     [--batch-size-limit <batch-size-limit>]
     [--wait]
     [--force]
-    [--commit-timeout <commit-timeout>]
 ```
 
 *Options*
@@ -336,7 +335,6 @@ quickwit index ingest
 | `--batch-size-limit` | Size limit of each submitted document batch. |
 | `--wait` | Wait for all documents to be commited and available for search before exiting |
 | `--force` | Force a commit after the last document is sent, and wait for all documents to be committed and available for search before exiting |
-| `--commit-timeout` | Duration of the commit timeout operation. |
 
 *Examples*
 

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -136,11 +136,6 @@ pub fn build_index_command() -> Command {
                         .help("Force a commit after the last document is sent, and wait for all documents to be committed and available for search before exiting")
                         .action(ArgAction::SetTrue)
                         .conflicts_with("wait"),
-                    Arg::new("commit-timeout")
-                        .long("commit-timeout")
-                        .help("Duration of the commit timeout operation.")
-                        .required(false)
-                        .global(true),
                 ])
             )
         .subcommand(
@@ -341,10 +336,6 @@ impl IndexCliCommand {
             (true, false) => CommitType::WaitFor,
             (true, true) => bail!("`--wait` and `--force` are mutually exclusive options"),
         };
-
-        if commit_type == CommitType::Auto && client_args.commit_timeout.is_some() {
-            bail!("`--commit-timeout` can only be used with --wait or --force options");
-        }
 
         Ok(Self::Ingest(IngestDocsArgs {
             client_args,

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -305,8 +305,6 @@ mod tests {
             "--wait",
             "--connect-timeout",
             "15s",
-            "--commit-timeout",
-            "4h",
         ])?;
         let command = CliCommand::parse_cli_args(matches)?;
         assert!(matches!(


### PR DESCRIPTION
### Description

The --commit-timeout is declared in the docs and the CLI but the provided value is not used. 

This change might break scripts that call the ingest CLI with this argument, but that's probably better than ignoring it.

### How was this PR tested?

Tried to hunt down every usage of this arg.
