### PR TITLE
Don't failfast in nightly build matrices

### DIFF
--- a/.github/workflows/publish_nightly_packages.yml
+++ b/.github/workflows/publish_nightly_packages.yml
@@ -10,6 +10,7 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
     steps:
@@ -21,6 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   build-linux-binaries:
     strategy:
+      fail-fast: false
       matrix:
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
     name: Build ${{ matrix.target }}


### PR DESCRIPTION
### Description

The currently nightly build fails on ARM and no packages are published. It would be better to still get the X86 artifacts.

### How was this PR tested?

Describe how you tested this PR.
