### PR TITLE
Fix nightly builds

### DIFF
--- a/.github/actions/cargo-build-macos-binary/action.yml
+++ b/.github/actions/cargo-build-macos-binary/action.yml
@@ -20,6 +20,8 @@ runs:
         node-version: 18
         cache: "yarn"
         cache-dependency-path: quickwit/quickwit-ui/yarn.lock
+    - run: yarn global add node-gyp
+      shell: bash
     - run: make build-ui
       shell: bash
     - name: Install protoc

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -20,6 +20,8 @@ runs:
         node-version: 18
         cache: "yarn"
         cache-dependency-path: quickwit/quickwit-ui/yarn.lock
+    - run: yarn global add node-gyp
+      shell: bash
     - run: make build-ui
       shell: bash
     - name: Install rustup


### PR DESCRIPTION
### Description

We are still having errors in the frontend build in the nightly CI after https://github.com/quickwit-oss/quickwit/pull/3877.

From the logs, it seems `node-gyp` is not installed. Even though yarn seems to install it automatically, when we compare the logs of various runs, it seems that it does so in parallel, and there might be some race condition there that would explain the transient failures. Eagerly installing `node-gyp` might help.

### How was this PR tested?

Describe how you tested this PR.
