### PR TITLE
Fix the cluster change stream when nodes rejoin the cluster quickly

### DIFF
--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -51,6 +51,7 @@ use quickwit_indexing::IndexingPipeline;
 use quickwit_ingest::IngesterPool;
 use quickwit_metastore::Metastore;
 use quickwit_proto::search::SearchResponse;
+use quickwit_proto::NodeId;
 use quickwit_search::{single_node_search, SearchResponseRest};
 use quickwit_serve::{
     search_request_from_api_request, BodyFormat, SearchRequestQueryString, SortBy,
@@ -924,8 +925,9 @@ impl ThroughputCalculator {
 }
 
 async fn create_empty_cluster(config: &NodeConfig) -> anyhow::Result<Cluster> {
+    let node_id: NodeId = config.node_id.clone().into();
     let self_node = ClusterMember::new(
-        config.node_id.clone(),
+        node_id,
         quickwit_cluster::GenerationId::now(),
         false,
         HashSet::new(),

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -32,6 +32,7 @@ use chitchat::{
 use futures::Stream;
 use itertools::Itertools;
 use quickwit_proto::indexing::IndexingTask;
+use quickwit_proto::NodeId;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch, Mutex, RwLock};
 use tokio::time::timeout;
@@ -422,7 +423,7 @@ struct InnerCluster {
     cluster_id: String,
     self_chitchat_id: ChitchatId,
     chitchat_handle: ChitchatHandle,
-    live_nodes: BTreeMap<ChitchatId, ClusterNode>,
+    live_nodes: BTreeMap<NodeId, ClusterNode>,
     change_stream_subscribers: Vec<mpsc::UnboundedSender<ClusterChange>>,
     ready_members_rx: watch::Receiver<Vec<ClusterMember>>,
 }
@@ -496,7 +497,7 @@ pub async fn create_cluster_for_test_with_id(
     self_node_readiness: bool,
 ) -> anyhow::Result<Cluster> {
     let gossip_advertise_addr: SocketAddr = ([127, 0, 0, 1], node_id).into();
-    let node_id = format!("node_{node_id}");
+    let node_id: NodeId = format!("node_{node_id}").into();
     let self_node = ClusterMember::new(
         node_id,
         crate::GenerationId(1),

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -30,6 +30,7 @@ use chitchat::transport::UdpTransport;
 use chitchat::FailureDetectorConfig;
 use quickwit_config::service::QuickwitService;
 use quickwit_config::NodeConfig;
+use quickwit_proto::NodeId;
 use time::OffsetDateTime;
 
 pub use crate::change::ClusterChange;
@@ -64,7 +65,7 @@ pub async fn start_cluster_service(node_config: &NodeConfig) -> anyhow::Result<C
     let peer_seed_addrs = node_config.peer_seed_addrs().await?;
     let indexing_tasks = Vec::new();
 
-    let node_id = node_config.node_id.clone();
+    let node_id: NodeId = node_config.node_id.clone().into();
     let generation_id = GenerationId::now();
     let is_ready = false;
     let self_node = ClusterMember::new(

--- a/quickwit/quickwit-cluster/src/member.rs
+++ b/quickwit/quickwit-cluster/src/member.rs
@@ -24,6 +24,7 @@ use anyhow::{anyhow, Context};
 use chitchat::{ChitchatId, NodeState};
 use itertools::Itertools;
 use quickwit_proto::indexing::IndexingTask;
+use quickwit_proto::NodeId;
 use tracing::warn;
 
 use crate::{GenerationId, QuickwitService};
@@ -73,7 +74,7 @@ pub struct ClusterMember {
     /// A unique node ID across the cluster.
     /// The Chitchat node ID is the concatenation of the node ID and the start timestamp:
     /// `{node_id}/{start_timestamp}`.
-    pub node_id: String,
+    pub node_id: NodeId,
     /// The start timestamp (seconds) of the node.
     pub generation_id: GenerationId,
     /// Enabled services, i.e. services configured to run on the node. Depending on the node and
@@ -94,7 +95,7 @@ pub struct ClusterMember {
 
 impl ClusterMember {
     pub fn new(
-        node_id: String,
+        node_id: NodeId,
         generation_id: GenerationId,
         is_ready: bool,
         enabled_services: HashSet<QuickwitService>,
@@ -115,7 +116,7 @@ impl ClusterMember {
 
     pub fn chitchat_id(&self) -> ChitchatId {
         ChitchatId::new(
-            self.node_id.clone(),
+            self.node_id.clone().into(),
             self.generation_id.as_u64(),
             self.gossip_advertise_addr,
         )
@@ -149,7 +150,7 @@ pub(crate) fn build_cluster_member(
     let grpc_advertise_addr = node_state.grpc_advertise_addr()?;
     let indexing_tasks = parse_indexing_tasks(node_state, &chitchat_id.node_id);
     let member = ClusterMember::new(
-        chitchat_id.node_id,
+        chitchat_id.node_id.into(),
         chitchat_id.generation_id.into(),
         is_ready,
         enabled_services,

--- a/quickwit/quickwit-proto/src/types.rs
+++ b/quickwit/quickwit-proto/src/types.rs
@@ -162,7 +162,7 @@ impl AsRef<NodeIdRef> for NodeId {
 
 impl Borrow<str> for NodeId {
     fn borrow(&self) -> &str {
-        self.as_str()
+        &self.0
     }
 }
 
@@ -250,6 +250,12 @@ impl NodeIdRef {
 
 impl AsRef<str> for NodeIdRef {
     fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<String> for NodeId {
+    fn borrow(&self) -> &String {
         &self.0
     }
 }


### PR DESCRIPTION
### Description
The issue is that the cluster logic keeps track of nodes joining and leaving using (`node_id`, `incarnation_id`), while client pools keep track of nodes using only `node_id`.

When a node restarts and becomes ready quickly, the new node (`node_id` + `incarnation_id + 1`) joins the cluster before the previous node leaves and the following cluster change events are triggered:

1. Add (`node_id` + `incarnation_id + 1`)
2. Remove (`node_id` + `incarnation_id`)

It translates at the pool level to:
1. Add `node_id`
2. Remove `node_id`

The bug used to be less visible because we used to diff the whole pool for each Chitchat event, but now the diff is at the node level (incremental).

To fix the issue, I only emit a  `Remove` event when incarnation IDs match. Additionally, when a node rejoins the cluster, instead of doing nothing, I virtually emit two consecutive  `Remove` and then `Add` events to give the pools a chance to react to configuration changes.

### How was this PR tested?
- Updated unit tests
- Verified locally that the issue no longer occurs
