### PR TITLE
feat: Rename fast field precision parameter to fast_precision [Closes #3946]

### DIFF
--- a/.github/actions/cargo-build-macos-binary/action.yml
+++ b/.github/actions/cargo-build-macos-binary/action.yml
@@ -20,6 +20,8 @@ runs:
         node-version: 18
         cache: "yarn"
         cache-dependency-path: quickwit/quickwit-ui/yarn.lock
+    - run: yarn global add node-gyp
+      shell: bash
     - run: make build-ui
       shell: bash
     - name: Install protoc

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -20,6 +20,8 @@ runs:
         node-version: 18
         cache: "yarn"
         cache-dependency-path: quickwit/quickwit-ui/yarn.lock
+    - run: yarn global add node-gyp
+      shell: bash
     - run: make build-ui
       shell: bash
     - name: Install rustup

--- a/config/tutorials/gh-archive/index-config-for-clickhouse.yaml
+++ b/config/tutorials/gh-archive/index-config-for-clickhouse.yaml
@@ -16,7 +16,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: event_type
       type: text

--- a/config/tutorials/gh-archive/index-config.yaml
+++ b/config/tutorials/gh-archive/index-config.yaml
@@ -37,7 +37,7 @@ doc_mapping:
       fast: true
       input_formats:
         - rfc3339
-      precision: seconds
+      fast_precision: seconds
   timestamp_field: created_at
 
 indexing_settings:

--- a/config/tutorials/hdfs-logs/index-config-partitioned.yaml
+++ b/config/tutorials/hdfs-logs/index-config-partitioned.yaml
@@ -13,7 +13,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: tenant_id
       type: u64

--- a/config/tutorials/hdfs-logs/index-config-retention-policy.yaml
+++ b/config/tutorials/hdfs-logs/index-config-retention-policy.yaml
@@ -13,7 +13,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: tenant_id
       type: u64

--- a/config/tutorials/hdfs-logs/index-config.yaml
+++ b/config/tutorials/hdfs-logs/index-config.yaml
@@ -13,7 +13,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: tenant_id
       type: u64

--- a/config/tutorials/otel-trace/index-config.yaml
+++ b/config/tutorials/otel-trace/index-config.yaml
@@ -34,7 +34,7 @@ doc_mapping:
     - name: span_start_timestamp_secs
       type: datetime
       indexed: true
-      precision: seconds
+      fast_precision: seconds
       fast: true
       input_formats: [unix_timestamp]
       output_format: unix_timestamp_secs

--- a/config/tutorials/stackoverflow/index-config.yaml
+++ b/config/tutorials/stackoverflow/index-config.yaml
@@ -22,7 +22,7 @@ doc_mapping:
       fast: true
       input_formats:
         - rfc3339
-      precision: seconds
+      fast_precision: seconds
   timestamp_field: creationDate
 
 search_settings:

--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -34,7 +34,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: severity_text
       type: text
@@ -222,7 +222,7 @@ The timezone name format specifier (`%Z`) is not supported currently.
 Converting timestamps from float to integer values may occurs with a loss of precision.
 :::
 
-When a `datetime` field is stored as a fast field, the `precision` parameter indicates the precision used to truncate the values before encoding, which improves compression (truncation here means zeroing). The `precision` parameter can take the following values: `seconds`, `milliseconds`, `microseconds`, or `nanoseconds`. It only affects what is stored in fast fields when a `datetime` field is marked as "fast". Finally, operations on `datetime` fast fields, e.g. via aggregations, need to be done at the nanosecond level.
+When a `datetime` field is stored as a fast field, the `fast_precision` parameter indicates the precision used to truncate the values before encoding, which improves compression (truncation here means zeroing). The `fast_precision` parameter can take the following values: `seconds`, `milliseconds`, `microseconds`, or `nanoseconds`. It only affects what is stored in fast fields when a `datetime` field is marked as "fast". Finally, operations on `datetime` fast fields, e.g. via aggregations, need to be done at the nanosecond level.
 
 :::info
 Internally `datetime` is stored in `nanoseconds` in fast fields and in the docstore, and in `seconds` in the term dictionary.
@@ -248,7 +248,7 @@ output_format: unix_timestamp_secs
 stored: true
 indexed: true
 fast: true
-precision: milliseconds
+fast_precision: milliseconds
 ```
 
 **Parameters for datetime field**
@@ -260,7 +260,7 @@ precision: milliseconds
 | `stored`        | Whether the field values are stored in the document store | `true` |
 | `indexed`       | Whether the field values are indexed | `true` |
 | `fast`          | Whether the field values are stored in a fast field | `false` |
-| `precision`     | The precision (`seconds`, `milliseconds`, `microseconds`, or `nanoseconds`) used to store the fast values. | `seconds` |
+| `fast_precision`     | The precision (`seconds`, `milliseconds`, `microseconds`, or `nanoseconds`) used to store the fast values. | `seconds` |
 
 #### `bool` type
 

--- a/docs/distributed-tracing/otel-service.md
+++ b/docs/distributed-tracing/otel-service.md
@@ -84,7 +84,7 @@ doc_mapping:
       input_formats: [unix_timestamp]
       indexed: false
       fast: true
-      precision: seconds
+      fast_precision: seconds
       stored: false
     - name: span_duration_millis
       type: u64

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -108,7 +108,7 @@ doc_mapping:
       fast: true
       input_formats:
         - rfc3339
-      precision: seconds
+      fast_precision: seconds
   timestamp_field: creationDate
 
 search_settings:

--- a/docs/get-started/tutorials/add-full-text-search-to-your-olap-db.md
+++ b/docs/get-started/tutorials/add-full-text-search-to-your-olap-db.md
@@ -68,7 +68,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: event_type
       type: text

--- a/docs/get-started/tutorials/tutorial-hdfs-logs-distributed-search-aws-s3.md
+++ b/docs/get-started/tutorials/tutorial-hdfs-logs-distributed-search-aws-s3.md
@@ -106,7 +106,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: tenant_id
       type: u64

--- a/docs/get-started/tutorials/tutorial-hdfs-logs.md
+++ b/docs/get-started/tutorials/tutorial-hdfs-logs.md
@@ -95,7 +95,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: tenant_id
       type: u64

--- a/docs/guides/schemaless.md
+++ b/docs/guides/schemaless.md
@@ -37,7 +37,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: server
       type: text
@@ -125,7 +125,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: user_id
       type: text
@@ -159,7 +159,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: user_id
       type: text
@@ -230,7 +230,7 @@ doc_mapping:
       input_formats:
         - unix_timestamp
       output_format: unix_timestamp_secs
-      precision: seconds
+      fast_precision: seconds
       fast: true
     - name: Attributes
       type: json

--- a/docs/ingest-data/kafka.md
+++ b/docs/ingest-data/kafka.md
@@ -58,7 +58,7 @@ doc_mapping:
       fast: true
       input_formats:
         - rfc3339
-      precision: seconds
+      fast_precision: seconds
   timestamp_field: created_at
 
 indexing_settings:

--- a/docs/ingest-data/kinesis.md
+++ b/docs/ingest-data/kinesis.md
@@ -68,7 +68,7 @@ doc_mapping:
       fast: true
       input_formats:
         - rfc3339
-      precision: seconds
+      fast_precision: seconds
   timestamp_field: created_at
 
 indexing_settings:

--- a/docs/ingest-data/pulsar.md
+++ b/docs/ingest-data/pulsar.md
@@ -105,7 +105,7 @@ doc_mapping:
       fast: true
       input_formats:
         - rfc3339
-      precision: seconds
+      fast_precision: seconds
   timestamp_field: creationDate
 
 search_settings:

--- a/docs/log-management/otel-service.md
+++ b/docs/log-management/otel-service.md
@@ -36,7 +36,7 @@ doc_mapping:
       input_formats: [unix_timestamp]
       indexed: false
       fast: true
-      precision: seconds
+      fast_precision: seconds
       stored: false
     - name: timestamp_nanos
       type: u64

--- a/docs/log-management/send-logs/using-vector.md
+++ b/docs/log-management/send-logs/using-vector.md
@@ -61,7 +61,7 @@ doc_mapping:
       output_format: unix_timestamp_nanos
       indexed: false
       fast: true
-      precision: milliseconds
+      fast_precision: milliseconds
     - name: observed_timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -262,7 +262,7 @@ curl -XPOST http://0.0.0.0:8080/api/v1/indexes --data @index_config.json -H "Con
                 "name": "timestamp",
                 "type": "datetime",
                 "input_formats": ["unix_timestamp"],
-                "precision": "seconds",
+                "fast_precision": "seconds",
                 "fast": true
             },
             {

--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -50,7 +50,7 @@ const DEFAULT_INDEX_CONFIG: &str = r#"
           input_formats:
             - unix_timestamp
           output_format: unix_timestamp_secs
-          precision: seconds
+          fast_precision: seconds
           fast: true
         - name: level
           type: text

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -1455,7 +1455,7 @@ mod tests {
                 "type": "datetime",
                 "input_formats": ["rfc3339", "unix_timestamp"],
                 "output_format": "rfc3339",
-                "precision": "seconds",
+                "fast_precision": "seconds",
                 "stored": true,
                 "indexed": true,
                 "fast": false,
@@ -1470,7 +1470,7 @@ mod tests {
             {
                 "name": "my_field_name",
                 "type": "array<datetime>",
-                "precision": "milliseconds"
+                "fast_precision": "milliseconds"
             }
             "#,
         )
@@ -1483,7 +1483,7 @@ mod tests {
                 "type": "array<datetime>",
                 "input_formats": ["rfc3339", "unix_timestamp"],
                 "output_format": "rfc3339",
-                "precision": "milliseconds",
+                "fast_precision": "milliseconds",
                 "stored": true,
                 "indexed": true,
                 "fast": false,

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mapping_tree.rs
@@ -600,7 +600,7 @@ fn get_date_time_options(quickwit_date_time_options: &QuickwitDateTimeOptions) -
     if quickwit_date_time_options.fast {
         date_time_options = date_time_options.set_fast();
     }
-    date_time_options.set_precision(quickwit_date_time_options.precision)
+    date_time_options.set_precision(quickwit_date_time_options.fast_precision)
 }
 
 fn get_bytes_options(quickwit_numeric_options: &QuickwitBytesOptions) -> BytesOptions {

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.expected.json
@@ -47,7 +47,7 @@
             ],
             "name": "timestamp",
             "output_format": "rfc3339",
-            "precision": "seconds",
+            "fast_precision": "seconds",
             "stored": true,
             "type": "datetime"
           },

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.4.json
@@ -38,7 +38,7 @@
             ],
             "name": "timestamp",
             "output_format": "rfc3339",
-            "precision": "seconds",
+            "fast_precision": "seconds",
             "stored": true,
             "type": "datetime"
           },

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.expected.json
@@ -47,7 +47,7 @@
             ],
             "name": "timestamp",
             "output_format": "rfc3339",
-            "precision": "seconds",
+            "fast_precision": "seconds",
             "stored": true,
             "type": "datetime"
           },

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.5.json
@@ -38,7 +38,7 @@
             ],
             "name": "timestamp",
             "output_format": "rfc3339",
-            "precision": "seconds",
+            "fast_precision": "seconds",
             "stored": true,
             "type": "datetime"
           },

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -47,7 +47,7 @@
             ],
             "name": "timestamp",
             "output_format": "rfc3339",
-            "precision": "seconds",
+            "fast_precision": "seconds",
             "stored": true,
             "type": "datetime"
           },

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -47,7 +47,7 @@
             ],
             "name": "timestamp",
             "output_format": "rfc3339",
-            "precision": "seconds",
+            "fast_precision": "seconds",
             "stored": true,
             "type": "datetime"
           },

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4.expected.json
@@ -37,7 +37,7 @@
           ],
           "name": "timestamp",
           "output_format": "rfc3339",
-          "precision": "seconds",
+          "fast_precision": "seconds",
           "stored": true,
           "type": "datetime"
         },

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.4.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.4.json
@@ -24,7 +24,7 @@
           ],
           "name": "timestamp",
           "output_format": "rfc3339",
-          "precision": "seconds",
+          "fast_precision": "seconds",
           "stored": true,
           "type": "datetime"
         },

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.5.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.5.expected.json
@@ -37,7 +37,7 @@
           ],
           "name": "timestamp",
           "output_format": "rfc3339",
-          "precision": "seconds",
+          "fast_precision": "seconds",
           "stored": true,
           "type": "datetime"
         },

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.5.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.5.json
@@ -24,7 +24,7 @@
           ],
           "name": "timestamp",
           "output_format": "rfc3339",
-          "precision": "seconds",
+          "fast_precision": "seconds",
           "stored": true,
           "type": "datetime"
         },

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.expected.json
@@ -36,7 +36,7 @@
           ],
           "name": "timestamp",
           "output_format": "rfc3339",
-          "precision": "seconds",
+          "fast_precision": "seconds",
           "stored": true,
           "type": "datetime"
         },

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.6.json
@@ -36,7 +36,7 @@
           ],
           "name": "timestamp",
           "output_format": "rfc3339",
-          "precision": "seconds",
+          "fast_precision": "seconds",
           "stored": true,
           "type": "datetime"
         },

--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -56,7 +56,7 @@ doc_mapping:
       output_format: unix_timestamp_nanos
       indexed: false
       fast: true
-      precision: milliseconds
+      fast_precision: milliseconds
     - name: observed_timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]

--- a/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
@@ -99,7 +99,7 @@ doc_mapping:
       output_format: unix_timestamp_nanos
       indexed: false
       fast: true
-      precision: milliseconds
+      fast_precision: milliseconds
     - name: span_end_timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -1771,7 +1771,7 @@ async fn test_single_node_find_trace_ids_collector() {
               - name: span_timestamp_secs
                 type: datetime
                 fast: true
-                precision: seconds
+                fast_precision: seconds
         "#;
     let foo_trace_id = TraceId::new([1u8; 16]);
     let bar_trace_id = TraceId::new([2u8; 16]);

--- a/quickwit/rest-api-tests/scenarii/aggregations/_setup.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/_setup.quickwit.yaml
@@ -19,7 +19,7 @@ json:
         type: datetime
         input_formats:
           - rfc3339
-        precision: seconds
+        fast_precision: seconds
         fast: true
 ---
 # Ingest documents


### PR DESCRIPTION
Closes #3946 

I have renamed the fast field `precision` parameter to `fast_precision` in a backward-compatible manner. For preserving backward compatibility, I added a `serde alias` attribute on the renamed `fast_precision` field. I also created tests to ensure that the field is deserialized with either `fast_precision` or `precision` as field names in the JSON.