### PR TITLE
Upgrade to latest main of mrecordlog

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "mrecordlog"
 version = "0.4.0"
-source = "git+https://github.com/quickwit-oss/mrecordlog?rev=ae1ca3f#ae1ca3f08fdfd721feec7a6bfab481df5ddb7f75"
+source = "git+https://github.com/quickwit-oss/mrecordlog?rev=0d1a7aa#0d1a7aa2bdf11aec832919503cefaf282d70e0d8"
 dependencies = [
  "async-trait",
  "bytes",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -100,7 +100,7 @@ matches = "0.1.9"
 md5 = "0.7"
 mime_guess = "2.0.4"
 mockall = "0.11"
-mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "ae1ca3f" }
+mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "0d1a7aa" }
 new_string_template = "1.4.0"
 nom = "7.1.3"
 num_cpus = "1"
@@ -416,4 +416,3 @@ sasl2-sys = { git = "https://github.com/quickwit-oss/rust-sasl/", rev = "daca921
 #tracing-log = { git = "https://github.com/trinity-1686a/tracing.git", rev = "6806cac3" }
 #tracing-opentelemetry = { git = "https://github.com/trinity-1686a/tracing.git", rev = "6806cac3" }
 #tracing-subscriber = { git = "https://github.com/trinity-1686a/tracing.git", rev = "6806cac3" }
-


### PR DESCRIPTION
### Description

The current pinned version ae1ca3f does not exist anymore.

![image](https://github.com/quickwit-oss/quickwit/assets/7913347/52e3d3da-d48e-49c9-8be0-ae6b5cedd19f)


### How was this PR tested?

Describe how you tested this PR.
