### PR TITLE
Update sql strings with sea_query sql statements

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3021,6 +3021,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
+name = "inherent"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce243b1bfa62ffc028f1cc3b6034ec63d649f3031bc8a4fbbb004e1ac17d1f68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5528,6 +5539,8 @@ dependencies = [
  "quickwit-storage",
  "rand 0.8.5",
  "regex",
+ "sea-query",
+ "sea-query-binder",
  "serde",
  "serde_json",
  "serde_with 3.4.0",
@@ -6483,6 +6496,39 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring 0.17.5",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3e6bba153bb198646c8762c48414942a38db27d142e44735a133cabddcc820"
+dependencies = [
+ "inherent",
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-binder"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36bbb68df92e820e4d5aeb17b4acd5cc8b5d18b2c36a4dd6f4626aabfa7ab1b9"
+dependencies = [
+ "sea-query",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd78f2e0ee8e537e9195d1049b752e0433e2cac125426bccb7b5c3e508096117"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "thiserror",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -142,6 +142,8 @@ reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls",
 ] }
 rust-embed = "6.8.1"
+sea-query = { version = "0" }
+sea-query-binder = { version = "0", features = ["sqlx-postgres", "runtime-tokio-rustls",] }
 serde = { version = "= 1.0.171", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_qs = { version = "0.12", features = ["warp"] }

--- a/quickwit/quickwit-metastore/Cargo.toml
+++ b/quickwit/quickwit-metastore/Cargo.toml
@@ -24,6 +24,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 sqlx = { workspace = true, optional = true }
+sea-query = { workspace = true }
+sea-query-binder = { workspace = true }
 tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true }
 time = { workspace = true }

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 
 use quickwit_proto::metastore::{DeleteQuery, DeleteTask, MetastoreError, MetastoreResult};
 use quickwit_proto::types::IndexUid;
+use sea_query::{Iden, Write};
 use tracing::error;
 
 use crate::{IndexMetadata, Split, SplitMetadata, SplitState};
@@ -59,6 +60,31 @@ impl PgIndex {
         // values upon deserialization.
         index_metadata.create_timestamp = self.create_timestamp.assume_utc().unix_timestamp();
         Ok(index_metadata)
+    }
+}
+
+#[derive(Iden, Clone, Copy)]
+#[allow(dead_code)]
+pub enum Splits {
+    Table,
+    SplitState,
+    TimeRangeStart,
+    TimeRangeEnd,
+    CreateTimestamp,
+    UpdateTimestamp,
+    PublishTimestamp,
+    MaturityTimestamp,
+    Tags,
+    SplitMetadataJson,
+    IndexUid,
+    DeleteOpstamp,
+}
+
+pub struct ToTimestampFunc;
+
+impl Iden for ToTimestampFunc {
+    fn unquoted(&self, s: &mut dyn Write) {
+        write!(s, "TO_TIMESTAMP").unwrap()
     }
 }
 


### PR DESCRIPTION
### Description

This PR is a draft version to kickstart #3758. I used `sea_query` to update one sql query and I want to get the initial comments from @guilload on whether this is fine. If the `sea_query` implementation seems good, then I will continue with converting the remaining sql strings into the sea query orm syntax. Otherwise, I will try to reach other options.

### How was this PR tested?

This PR was tested using `cargo test --features=postgres`.
