### PR TITLE
Fix the NO_COLOR environment variable interpretation.

### DIFF
--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -30,6 +30,7 @@ use crate::tool::{build_tool_command, ToolCliCommand};
 pub fn build_cli() -> Command {
     Command::new("Quickwit")
         .arg(
+            // Following https://no-color.org/
             Arg::new("no-color")
                 .long("no-color")
                 .help(
@@ -37,6 +38,7 @@ pub fn build_cli() -> Command {
                      output",
                 )
                 .env("NO_COLOR")
+                .value_parser(clap::builder::FalseyValueParser::new())
                 .global(true)
                 .action(ArgAction::SetTrue),
         )

--- a/quickwit/quickwit-cli/src/logger.rs
+++ b/quickwit/quickwit-cli/src/logger.rs
@@ -37,7 +37,7 @@ use crate::QW_ENABLE_TOKIO_CONSOLE_ENV_KEY;
 
 pub fn setup_logging_and_tracing(
     level: Level,
-    ansi: bool,
+    ansi_colors: bool,
     build_info: &BuildInfo,
 ) -> anyhow::Result<()> {
     #[cfg(feature = "tokio-console")]
@@ -88,7 +88,7 @@ pub fn setup_logging_and_tracing(
             .with(
                 tracing_subscriber::fmt::layer()
                     .event_format(event_format)
-                    .with_ansi(ansi),
+                    .with_ansi(ansi_colors),
             )
             .try_init()
             .context("Failed to set up tracing.")?;
@@ -97,7 +97,7 @@ pub fn setup_logging_and_tracing(
             .with(
                 tracing_subscriber::fmt::layer()
                     .event_format(event_format)
-                    .with_ansi(ansi),
+                    .with_ansi(ansi_colors),
             )
             .try_init()
             .context("Failed to set up tracing.")?;


### PR DESCRIPTION
Before this PR, NO_COLOR had to be true or false.
This PR interprets the environment variable as true for any value that is non empty as described in https://no-color.org/

This fixes the config in our own configuration:
https://github.com/quickwit-oss/quickwit/blob/kzf2f6aacca1cd645a473b7a9ec0707a6efc6e323/docs/log-management/send-logs/using-otel-collector-with-helm.md?plain=1#L75
