### PR TITLE
Allowing the second query of `find_traces` jaeger request to run without

### DIFF
--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -170,6 +170,12 @@ message SearchRequest {
   // enable pagination.
   // If split_id is empty, no comparison with _shard_doc should be done
   optional PartialHit search_after = 16;
+
+  // Pick the leaf search semaphore in priority.
+  // This flag should be used when running a multi-step query.
+  // In this case, it makes sense to reduce the average latency by acquiring the permit in priority for all steps
+  // apart from the first one. This is especially useful when working with traces, as the a single
+  bool priority = 17;
 }
 
 message SortField {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -107,6 +107,12 @@ pub struct SearchRequest {
     /// If split_id is empty, no comparison with _shard_doc should be done
     #[prost(message, optional, tag = "16")]
     pub search_after: ::core::option::Option<PartialHit>,
+    /// Pick the leaf search semaphore in priority.
+    /// This flag should be used when running a multi-step query.
+    /// In this case, it makes sense to reduce the average latency by acquiring the permit in priority for all steps
+    /// apart from the first one. This is especially useful when working with traces, as the a single
+    #[prost(bool, tag = "17")]
+    pub priority: bool,
 }
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[derive(Eq, Hash)]

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -306,6 +306,7 @@ fn simplify_search_request_for_scroll_api(req: &SearchRequest) -> crate::Result<
         // We remove the scroll ttl parameter. It is irrelevant to process later request
         scroll_ttl_secs: None,
         search_after: None,
+        priority: req.priority,
     })
 }
 

--- a/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
@@ -193,6 +193,7 @@ fn build_request_for_es_api(
             snippet_fields: Vec::new(),
             scroll_ttl_secs,
             search_after,
+            priority: false,
         },
         has_doc_id_field,
     ))

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -242,6 +242,7 @@ pub fn search_request_from_api_request(
         sort_fields: search_request.sort_by.sort_fields,
         scroll_ttl_secs: None,
         search_after: None,
+        priority: false,
     };
     Ok(search_request)
 }


### PR DESCRIPTION
acquiring any permit
