### PR TITLE
plug exact count optimization

### DIFF
--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -39,7 +39,7 @@ use quickwit_config::{ConfigFormat, IndexConfig};
 use quickwit_indexing::models::IndexingStatistics;
 use quickwit_indexing::IndexingPipeline;
 use quickwit_metastore::{IndexMetadata, Split, SplitState};
-use quickwit_proto::search::{SortField, SortOrder};
+use quickwit_proto::search::{CountHits, SortField, SortOrder};
 use quickwit_rest_client::models::IngestSource;
 use quickwit_rest_client::rest_client::{CommitType, IngestEvent};
 use quickwit_search::SearchResponseRest;
@@ -856,7 +856,7 @@ pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchRespons
         max_hits: args.max_hits as u64,
         start_offset: args.start_offset as u64,
         sort_by,
-        count_all: true,
+        count_all: CountHits::CountAll,
         ..Default::default()
     };
     let qw_client = args.client_args.search_client();

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -856,6 +856,7 @@ pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchRespons
         max_hits: args.max_hits as u64,
         start_offset: args.start_offset as u64,
         sort_by,
+        count_all: true,
         ..Default::default()
     };
     let qw_client = args.client_args.search_client();

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -50,7 +50,7 @@ use quickwit_indexing::IndexingPipeline;
 use quickwit_ingest::IngesterPool;
 use quickwit_metastore::IndexMetadataResponseExt;
 use quickwit_proto::metastore::{IndexMetadataRequest, MetastoreService, MetastoreServiceClient};
-use quickwit_proto::search::SearchResponse;
+use quickwit_proto::search::{CountHits, SearchResponse};
 use quickwit_proto::types::NodeId;
 use quickwit_search::{single_node_search, SearchResponseRest};
 use quickwit_serve::{
@@ -551,7 +551,7 @@ pub async fn local_search_cli(args: LocalSearchArgs) -> anyhow::Result<()> {
         aggs,
         format: BodyFormat::Json,
         sort_by,
-        count_all: true,
+        count_all: CountHits::CountAll,
     };
     let search_request =
         search_request_from_api_request(vec![args.index_id], search_request_query_string)?;

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -551,6 +551,7 @@ pub async fn local_search_cli(args: LocalSearchArgs) -> anyhow::Result<()> {
         aggs,
         format: BodyFormat::Json,
         sort_by,
+        count_all: true,
     };
     let search_request =
         search_request_from_api_request(vec![args.index_id], search_request_query_string)?;

--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -43,7 +43,7 @@ use quickwit_proto::jaeger::storage::v1::{
     SpansResponseChunk, TraceQueryParameters,
 };
 use quickwit_proto::opentelemetry::proto::trace::v1::status::StatusCode as OtlpStatusCode;
-use quickwit_proto::search::{ListTermsRequest, SearchRequest};
+use quickwit_proto::search::{CountHits, ListTermsRequest, SearchRequest};
 use quickwit_query::query_ast::{BoolQuery, QueryAst, RangeQuery, TermQuery};
 use quickwit_search::{FindTraceIdsCollector, SearchService};
 use serde::Deserialize;
@@ -261,6 +261,7 @@ impl JaegerService {
             max_hits,
             start_timestamp: min_span_start_timestamp_secs_opt,
             end_timestamp: max_span_start_timestamp_secs_opt,
+            count_hits: CountHits::Underestimate.into(),
             ..Default::default()
         };
         let search_response = self.search_service.root_search(search_request).await?;
@@ -308,6 +309,7 @@ impl JaegerService {
             start_timestamp: Some(*search_window.start()),
             end_timestamp: Some(*search_window.end()),
             max_hits: self.max_fetch_spans,
+            count_hits: CountHits::Underestimate.into(),
             ..Default::default()
         };
         let search_response = match self.search_service.root_search(search_request).await {

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -170,6 +170,16 @@ message SearchRequest {
   // enable pagination.
   // If split_id is empty, no comparison with _shard_doc should be done
   optional PartialHit search_after = 16;
+
+  CountHits count_hits = 17;
+}
+
+enum CountHits {
+  // Count all hits, querying all splits.
+  COUNT_ALL = 0;
+  // Give an underestimate of the number of hits, possibly skipping entire
+  // splits if they are otherwise not needed to fulfull a query.
+  UNDERESTIMATE = 1;
 }
 
 message SortField {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -107,6 +107,8 @@ pub struct SearchRequest {
     /// If split_id is empty, no comparison with _shard_doc should be done
     #[prost(message, optional, tag = "16")]
     pub search_after: ::core::option::Option<PartialHit>,
+    #[prost(enumeration = "CountHits", tag = "17")]
+    pub count_hits: i32,
 }
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[derive(Eq, Hash)]
@@ -496,6 +498,37 @@ pub struct LeafSearchStreamResponse {
     /// Split id.
     #[prost(string, tag = "2")]
     pub split_id: ::prost::alloc::string::String,
+}
+#[derive(Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CountHits {
+    /// Count all hits, querying all splits.
+    CountAll = 0,
+    /// Give an underestimate of the number of hits, possibly skipping entire
+    /// splits if they are otherwise not needed to fulfull a query.
+    Underestimate = 1,
+}
+impl CountHits {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            CountHits::CountAll => "COUNT_ALL",
+            CountHits::Underestimate => "UNDERESTIMATE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "COUNT_ALL" => Some(Self::CountAll),
+            "UNDERESTIMATE" => Some(Self::Underestimate),
+            _ => None,
+        }
+    }
 }
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -29,8 +29,8 @@ use quickwit_common::PrettySample;
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_doc_mapper::{DocMapper, TermRange, WarmupInfo};
 use quickwit_proto::search::{
-    LeafListTermsResponse, LeafSearchResponse, ListTermsRequest, PartialHit, SearchRequest,
-    SortOrder, SortValue, SplitIdAndFooterOffsets, SplitSearchError,
+    CountHits, LeafListTermsResponse, LeafSearchResponse, ListTermsRequest, PartialHit,
+    SearchRequest, SortOrder, SortValue, SplitIdAndFooterOffsets, SplitSearchError,
 };
 use quickwit_query::query_ast::QueryAst;
 use quickwit_storage::{
@@ -549,7 +549,8 @@ pub async fn leaf_search(
 
     // In the future this should become `request.aggregation_request.is_some() ||
     // request.exact_count == true`
-    let run_all_splits = true;
+    let run_all_splits = request.aggregation_request.is_some()
+        || request.count_hits == i32::from(CountHits::CountAll);
 
     let split_filter = CanSplitDoBetter::from_request(&request, doc_mapper.timestamp_field_name());
     split_filter.optimize_split_order(&mut splits);
@@ -597,6 +598,8 @@ pub async fn leaf_search(
         ));
     }
 
+    // TODO we could cancel running splits when !run_all_splits and the running split can no longer
+    // give better results after some other split answered.
     let split_search_results: Vec<Result<(), _>> =
         futures::future::join_all(leaf_search_single_split_futures).await;
 

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -549,8 +549,8 @@ pub async fn leaf_search(
 
     // In the future this should become `request.aggregation_request.is_some() ||
     // request.exact_count == true`
-    let run_all_splits = request.aggregation_request.is_some()
-        || request.count_hits == i32::from(CountHits::CountAll);
+    let run_all_splits =
+        request.aggregation_request.is_some() || request.count_hits() == CountHits::CountAll;
 
     let split_filter = CanSplitDoBetter::from_request(&request, doc_mapper.timestamp_field_name());
     split_filter.optimize_split_order(&mut splits);

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -306,6 +306,7 @@ fn simplify_search_request_for_scroll_api(req: &SearchRequest) -> crate::Result<
         // We remove the scroll ttl parameter. It is irrelevant to process later request
         scroll_ttl_secs: None,
         search_after: None,
+        count_hits: req.count_hits,
     })
 }
 

--- a/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
@@ -161,7 +161,7 @@ fn build_request_for_es_api(
         None => CountHits::Underestimate,
         Some(TrackTotalHits::Track(false)) => CountHits::Underestimate,
         Some(TrackTotalHits::Count(count)) if count <= max_hits as i64 => CountHits::Underestimate,
-        _ => CountHits::CountAll,
+        Some(TrackTotalHits::Track(true) | TrackTotalHits::Count(_)) => CountHits::CountAll,
     }
     .into();
 

--- a/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/rest_handler.rs
@@ -30,7 +30,7 @@ use hyper::StatusCode;
 use itertools::Itertools;
 use quickwit_common::truncate_str;
 use quickwit_config::{validate_index_id_pattern, NodeConfig};
-use quickwit_proto::search::{PartialHit, ScrollRequest, SearchResponse, SortByValue};
+use quickwit_proto::search::{CountHits, PartialHit, ScrollRequest, SearchResponse, SortByValue};
 use quickwit_proto::ServiceErrorCode;
 use quickwit_query::query_ast::{QueryAst, UserInputQuery};
 use quickwit_query::BooleanOperand;
@@ -46,6 +46,7 @@ use super::model::{
     ElasticSearchError, MultiSearchHeader, MultiSearchQueryParams, MultiSearchResponse,
     MultiSearchSingleResponse, ScrollQueryParams, SearchBody, SearchQueryParams,
 };
+use super::TrackTotalHits;
 use crate::format::BodyFormat;
 use crate::json_api_response::{make_json_api_response, ApiError, JsonApiResponse};
 use crate::{with_arg, BuildInfo};
@@ -156,6 +157,13 @@ fn build_request_for_es_api(
 
     let max_hits = search_params.size.or(search_body.size).unwrap_or(10);
     let start_offset = search_params.from.or(search_body.from).unwrap_or(0);
+    let count_hits = match search_params.track_total_hits {
+        None => CountHits::Underestimate,
+        Some(TrackTotalHits::Track(false)) => CountHits::Underestimate,
+        Some(TrackTotalHits::Count(count)) if count <= max_hits as i64 => CountHits::Underestimate,
+        _ => CountHits::CountAll,
+    }
+    .into();
 
     let sort_fields: Vec<quickwit_proto::search::SortField> = search_params
         .sort_fields()?
@@ -193,6 +201,7 @@ fn build_request_for_es_api(
             snippet_fields: Vec::new(),
             scroll_ttl_secs,
             search_after,
+            count_hits,
         },
         has_doc_id_field,
     ))


### PR DESCRIPTION
### Description

fix #3997
does not impact #3998 as it would need more work. Tracing uses aggregations, which don't profit from that optimization yet

### How was this PR tested?

created an index with single split documents, made a few query and verified `num_hits` was below what's expected when `count_all=false`, and normal when it's true or absent