### PR TITLE
Introduce a builder for Codegen

### DIFF
--- a/quickwit/quickwit-codegen/README.md
+++ b/quickwit/quickwit-codegen/README.md
@@ -38,13 +38,13 @@ quickwit-codegen = { workspace = true }
 use quickwit_codegen::Codegen;
 
 fn main() {
-    Codegen::run(
-        "src/hello.proto",
-        "src/",
-        "crate::HelloResult",
-        "crate::HelloError"
-        &[],
-    ).unwrap();
+    Codegen::builder()
+        .with_protos(&["src/hello.proto"])
+        .with_output_dir("src/")
+        .with_result_type_path("crate::HelloResult")
+        .with_error_type_path("crate::HelloError")
+        .run()
+        .unwrap();
 }
 ```
 
@@ -56,14 +56,14 @@ use quickwit_codegen::Codegen;
 fn main() {
     let mut config = prost_build::Config::default();
     config.bytes(["PingRequest.name", "PingResponse.name"]);
-    Codegen::run_with_config(
-        "src/hello.proto",
-        "src/",
-        "crate::HelloResult",
-        "crate::HelloError"
-        &[],
-        config
-    ).unwrap();
+    Codegen::builder()
+        .with_protos(&["src/hello.proto"])
+        .with_output_dir("src/codegen/")
+        .with_result_type_path("crate::HelloResult")
+        .with_error_type_path("crate::HelloError")
+        .with_prost_config(config)
+        .run()
+        .unwrap();
 }
 ```
 

--- a/quickwit/quickwit-codegen/example/build.rs
+++ b/quickwit/quickwit-codegen/example/build.rs
@@ -20,14 +20,13 @@
 use quickwit_codegen::Codegen;
 
 fn main() {
-    Codegen::run(
-        &["src/hello.proto"],
-        "src/codegen/",
-        "crate::HelloResult",
-        "crate::HelloError",
-        true,
-        true,
-        &[],
-    )
-    .unwrap();
+    Codegen::builder()
+        .with_protos(&["src/hello.proto"])
+        .with_output_dir("src/codegen/")
+        .with_result_type_path("crate::HelloResult")
+        .with_error_type_path("crate::HelloError")
+        .enable_extra_service_methods()
+        .enable_prom_label_for_requests()
+        .run()
+        .unwrap();
 }

--- a/quickwit/quickwit-codegen/src/codegen.rs
+++ b/quickwit/quickwit-codegen/src/codegen.rs
@@ -30,27 +30,6 @@ use crate::ProstConfig;
 pub struct Codegen;
 
 impl Codegen {
-    pub fn run(
-        protos: &[&str],
-        out_dir: &str,
-        result_type_path: &str,
-        error_type_path: &str,
-        generate_extra_service_methods: bool,
-        generate_prom_labels_for_requests: bool,
-        includes: &[&str],
-    ) -> anyhow::Result<()> {
-        Self::run_with_config(
-            protos,
-            out_dir,
-            result_type_path,
-            error_type_path,
-            generate_extra_service_methods,
-            generate_prom_labels_for_requests,
-            includes,
-            ProstConfig::default(),
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn run_with_config(
         protos: &[&str],
@@ -88,6 +67,88 @@ impl Codegen {
             prost_config.compile_protos(&[proto], includes)?;
         }
         Ok(())
+    }
+
+    pub fn builder() -> CodegenBuilder {
+        CodegenBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct CodegenBuilder {
+    protos: Vec<String>,
+    includes: Vec<String>,
+    out_dir: String,
+    prost_config: ProstConfig,
+    result_type_path: String,
+    error_type_path: String,
+    generate_extra_service_methods: bool,
+    generate_prom_label_for_requests: bool,
+}
+
+impl CodegenBuilder {
+    pub fn with_protos(mut self, protos: &[&str]) -> Self {
+        self.protos = protos.iter().map(|protos| protos.to_string()).collect();
+        self
+    }
+
+    pub fn with_includes(mut self, includes: &[&str]) -> Self {
+        self.includes = includes
+            .iter()
+            .map(|includes| includes.to_string())
+            .collect();
+        self
+    }
+
+    pub fn with_output_dir(mut self, path: &str) -> Self {
+        self.out_dir = path.into();
+        self
+    }
+
+    pub fn with_result_type_path(mut self, path: &str) -> Self {
+        self.result_type_path = path.into();
+        self
+    }
+
+    pub fn with_error_type_path(mut self, path: &str) -> Self {
+        self.error_type_path = path.into();
+        self
+    }
+
+    pub fn with_prost_config(mut self, prost_config: ProstConfig) -> Self {
+        self.prost_config = prost_config;
+        self
+    }
+
+    pub fn enable_extra_service_methods(mut self) -> Self {
+        self.generate_extra_service_methods = true;
+        self
+    }
+
+    pub fn enable_prom_label_for_requests(mut self) -> Self {
+        self.generate_prom_label_for_requests = true;
+        self
+    }
+
+    pub fn run(self) -> anyhow::Result<()> {
+        Codegen::run_with_config(
+            self.protos
+                .iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<&str>>()
+                .as_slice(),
+            &self.out_dir,
+            &self.result_type_path,
+            &self.error_type_path,
+            self.generate_extra_service_methods,
+            self.generate_prom_label_for_requests,
+            self.includes
+                .iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<&str>>()
+                .as_slice(),
+            self.prost_config,
+        )
     }
 }
 

--- a/quickwit/quickwit-ingest/build.rs
+++ b/quickwit/quickwit-ingest/build.rs
@@ -24,15 +24,12 @@ fn main() {
     let mut prost_config = ProstConfig::default();
     prost_config.bytes(["DocBatch.doc_buffer"]);
 
-    Codegen::run_with_config(
-        &["src/ingest_service.proto"],
-        "src/codegen/",
-        "crate::Result",
-        "crate::IngestServiceError",
-        false,
-        false,
-        &[],
-        prost_config,
-    )
-    .unwrap();
+    Codegen::builder()
+        .with_protos(&["src/ingest_service.proto"])
+        .with_output_dir("src/codegen/")
+        .with_result_type_path("crate::Result")
+        .with_error_type_path("crate::IngestServiceError")
+        .with_prost_config(prost_config)
+        .run()
+        .unwrap();
 }

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -27,28 +27,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // services.
     //
     // Control plane.
-    Codegen::run(
-        &["protos/quickwit/control_plane.proto"],
-        "src/codegen/quickwit",
-        "crate::control_plane::ControlPlaneResult",
-        "crate::control_plane::ControlPlaneError",
-        false,
-        false,
-        &["protos"],
-    )
-    .unwrap();
+    Codegen::builder()
+        .with_protos(&["protos/quickwit/control_plane.proto"])
+        .with_output_dir("src/codegen/quickwit")
+        .with_result_type_path("crate::control_plane::ControlPlaneResult")
+        .with_error_type_path("crate::control_plane::ControlPlaneError")
+        .with_includes(&["protos"])
+        .run()
+        .unwrap();
 
     // Indexing Service.
-    Codegen::run(
-        &["protos/quickwit/indexing.proto"],
-        "src/codegen/quickwit",
-        "crate::indexing::IndexingResult",
-        "crate::indexing::IndexingError",
-        false,
-        false,
-        &[],
-    )
-    .unwrap();
+    Codegen::builder()
+        .with_protos(&["protos/quickwit/indexing.proto"])
+        .with_output_dir("src/codegen/quickwit")
+        .with_result_type_path("crate::indexing::IndexingResult")
+        .with_error_type_path("crate::indexing::IndexingError")
+        .run()
+        .unwrap();
 
     // Metastore service.
     let mut metastore_api_config = prost_build::Config::default();
@@ -64,17 +59,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[serde(skip_serializing_if = \"Option::is_none\")]",
         );
 
-    Codegen::run_with_config(
-        &["protos/quickwit/metastore.proto"],
-        "src/codegen/quickwit",
-        "crate::metastore::MetastoreResult",
-        "crate::metastore::MetastoreError",
-        true,
-        true,
-        &["protos"],
-        metastore_api_config,
-    )
-    .unwrap();
+    Codegen::builder()
+        .with_protos(&["protos/quickwit/metastore.proto"])
+        .with_output_dir("src/codegen/quickwit")
+        .with_result_type_path("crate::metastore::MetastoreResult")
+        .with_error_type_path("crate::metastore::MetastoreError")
+        .enable_extra_service_methods()
+        .enable_prom_label_for_requests()
+        .with_includes(&["protos"])
+        .with_prost_config(metastore_api_config)
+        .run()
+        .unwrap();
 
     // Ingest service (metastore service proto should be generated before ingest).
     let mut prost_config = prost_build::Config::default();
@@ -103,20 +98,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[serde(default, skip_serializing_if = \"Option::is_none\")]",
         );
 
-    Codegen::run_with_config(
-        &[
+    Codegen::builder()
+        .with_protos(&[
             "protos/quickwit/ingester.proto",
             "protos/quickwit/router.proto",
-        ],
-        "src/codegen/quickwit",
-        "crate::ingest::IngestV2Result",
-        "crate::ingest::IngestV2Error",
-        false,
-        false,
-        &["protos"],
-        prost_config,
-    )
-    .unwrap();
+        ])
+        .with_output_dir("src/codegen/quickwit")
+        .with_result_type_path("crate::ingest::IngestV2Result")
+        .with_error_type_path("crate::ingest::IngestV2Error")
+        .with_includes(&["protos"])
+        .with_prost_config(prost_config)
+        .run()
+        .unwrap();
 
     // Search service.
     let mut prost_config = prost_build::Config::default();


### PR DESCRIPTION
Issue: #3995

### Description

I have implemented a builder for the `Codegen` following the example described in #3995. I also replaced existing calls to `Codegen::run` and `Codegen::run_with_config` with the builder.

I removed `Codegen::run` as it is never called and I am unsure if it even makes sense to keep `run_with_config` separate from the builder. What do you think?

There are conversions from &[&str] to Vec<String> and back again in the builder which I don't like. However, I think overall it is the simplest implementation in this case as we avoid lifetimes and trait bounds. Apart from just merging `run_with_config` with the builder.

Upon writing this I realized that I forgot to update the codegen readme. I will update the readme once the implementation is approved (to avoid having to keep updating it).

Let me  know what you think :)

### How was this PR tested?

Tested that everything still builds and existing tests pass. I have a few failing tests on my machine even without these changes so those will have to be tested during CI.