### PR TITLE
Avoiding base64 translation when serializing Traces with postcard

### DIFF
--- a/quickwit/quickwit-jaeger/Cargo.toml
+++ b/quickwit/quickwit-jaeger/Cargo.toml
@@ -44,7 +44,7 @@ quickwit-indexing = { workspace = true, features = ["testsuite"] }
 quickwit-ingest = { workspace = true }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-search = { workspace = true, features = ["testsuite"] }
-quickwit-storage = { workspace = true }
+quickwit-storage = { workspace = true, features = ["testsuite"] }
 
 [features]
 testsuite = []


### PR DESCRIPTION
Avoiding base64 translation when serializing Traces with postcard

This PR also adds unit tests/proptest checking the serializing of
Vec<Span> with postcard.