### PR TITLE
Improve error handling for corrupt checkpoints

### DIFF
--- a/quickwit/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kafka_source.rs
@@ -45,7 +45,7 @@ use serde_json::{json, Value as JsonValue};
 use tokio::sync::{mpsc, watch};
 use tokio::task::{spawn_blocking, JoinHandle};
 use tokio::time;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::actors::DocProcessor;
 use crate::models::{NewPublishLock, PublishLock};
@@ -380,9 +380,11 @@ impl KafkaSource {
             let next_offset = match &current_position {
                 Position::Beginning => Offset::Beginning,
                 Position::Offset(offset) => {
-                    let offset = offset
-                        .as_i64()
-                        .expect("Kafka offset should be stored as i64");
+                    let Some(offset) = offset.as_i64() else {
+                        error!("Kafka offset should be stored as i64, skipping partition");
+                        continue;
+                    };
+
                     Offset::Offset(offset + 1)
                 }
                 Position::Eof => {
@@ -619,11 +621,13 @@ fn spawn_consumer_poll_loop(
                         as i32;
                     // Quickwit positions are inclusive whereas Kafka offsets are exclusive, hence
                     // the increment by 1.
-                    let next_position = position
-                        .as_i64()
-                        .expect("Kafka offset should be stored as i64.")
-                        + 1;
-                    let offset = Offset::Offset(next_position);
+
+                    let Some(next_position) = position.as_i64() else {
+                        error!("Kafka offset should be stored as i64, skipping partition");
+                        continue;
+                    };
+
+                    let offset = Offset::Offset(next_position + 1);
                     tpl.add_partition_offset(&topic, partition, offset)
                         .expect("The offset should be valid.");
                 }


### PR DESCRIPTION
Issue: #4025

### Description

This PR improves handling of corrupt checkpoints by logging the error and skipping the corrupt partition instead of panicking.

I am not sure if this is what you had in mind so this is a draft PR. 

Questions: 

1. Is there any bookkeeping I am missing when skipping a partition?
2. What kind of information would you like to see in the error message? maybe the partition ID?
3. Do you have any thoughts on testing this?

Let me know what you think and I will apply the final version to the remaining panic cases :)

### How was this PR tested?

Not tested yet :(
