### PR TITLE
Update query to order by split id when offset is provided

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_model.rs
@@ -67,6 +67,7 @@ impl PgIndex {
 #[allow(dead_code)]
 pub enum Splits {
     Table,
+    SplitId,
     SplitState,
     TimeRangeStart,
     TimeRangeEnd,


### PR DESCRIPTION
### Description

The change adds an order by clause to the sql query when the split id is provided. This fixes the bug reported by #4046 .

### How was this PR tested?

An unit test was to added to check if the correct query was being returned.
