### PR TITLE
Handle index/source not found and timeout/transport errors

### DIFF
--- a/quickwit/quickwit-codegen/example/src/codegen/hello.rs
+++ b/quickwit/quickwit-codegen/example/src/codegen/hello.rs
@@ -105,6 +105,8 @@ impl HelloClient {
     ) -> hello_grpc_server::HelloGrpcServer<HelloGrpcServerAdapter> {
         let adapter = HelloGrpcServerAdapter::new(self.clone());
         hello_grpc_server::HelloGrpcServer::new(adapter)
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024)
     }
     pub fn from_channel(
         addr: std::net::SocketAddr,
@@ -123,10 +125,10 @@ impl HelloClient {
         balance_channel: quickwit_common::tower::BalanceChannel<std::net::SocketAddr>,
     ) -> HelloClient {
         let connection_keys_watcher = balance_channel.connection_keys_watcher();
-        let adapter = HelloGrpcClientAdapter::new(
-            hello_grpc_client::HelloGrpcClient::new(balance_channel),
-            connection_keys_watcher,
-        );
+        let client = hello_grpc_client::HelloGrpcClient::new(balance_channel)
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024);
+        let adapter = HelloGrpcClientAdapter::new(client, connection_keys_watcher);
         Self::new(adapter)
     }
     pub fn from_mailbox<A>(mailbox: quickwit_actors::Mailbox<A>) -> Self

--- a/quickwit/quickwit-codegen/src/codegen.rs
+++ b/quickwit/quickwit-codegen/src/codegen.rs
@@ -573,6 +573,8 @@ fn generate_client(context: &CodegenContext) -> TokenStream {
             pub fn as_grpc_service(&self) -> #grpc_server_package_name::#grpc_server_name<#grpc_server_adapter_name> {
                 let adapter = #grpc_server_adapter_name::new(self.clone());
                 #grpc_server_package_name::#grpc_server_name::new(adapter)
+                    .max_decoding_message_size(10 * 1024 * 1024)
+                    .max_encoding_message_size(10 * 1024 * 1024)
             }
 
             pub fn from_channel(addr: std::net::SocketAddr, channel: tonic::transport::Channel) -> Self
@@ -585,7 +587,10 @@ fn generate_client(context: &CodegenContext) -> TokenStream {
             pub fn from_balance_channel(balance_channel: quickwit_common::tower::BalanceChannel<std::net::SocketAddr>) -> #client_name
             {
                 let connection_keys_watcher = balance_channel.connection_keys_watcher();
-                let adapter = #grpc_client_adapter_name::new(#grpc_client_package_name::#grpc_client_name::new(balance_channel), connection_keys_watcher);
+                let client = #grpc_client_package_name::#grpc_client_name::new(balance_channel)
+                    .max_decoding_message_size(10 * 1024 * 1024)
+                    .max_encoding_message_size(10 * 1024 * 1024);
+                let adapter = #grpc_client_adapter_name::new(client, connection_keys_watcher);
                 Self::new(adapter)
             }
 

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -187,7 +187,7 @@ impl Default for IngestApiConfig {
             max_queue_memory_usage: Byte::from_bytes(2 * 1024 * 1024 * 1024), /* 2 GiB // TODO maybe we want more? */
             max_queue_disk_usage: Byte::from_bytes(4 * 1024 * 1024 * 1024), /* 4 GiB // TODO maybe we want more? */
             replication_factor: 1,
-            content_length_limit: 10 * 1024 * 1024, // 10 MB
+            content_length_limit: 10 * 1024 * 1024, // 10 MiB
         }
     }
 }

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -507,7 +507,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_control_plane_add_source() {
-        quickwit_common::setup_logging_for_tests();
         let universe = Universe::with_accelerated_time();
 
         let cluster_id = "test-cluster".to_string();
@@ -564,7 +563,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_control_plane_toggle_source() {
-        quickwit_common::setup_logging_for_tests();
         let universe = Universe::with_accelerated_time();
 
         let cluster_id = "test-cluster".to_string();
@@ -743,6 +741,7 @@ mod tests {
         );
         let get_open_shards_request = GetOrCreateOpenShardsRequest {
             subrequests: vec![GetOrCreateOpenShardsSubrequest {
+                subrequest_id: 0,
                 index_id: "test-index".to_string(),
                 source_id: INGEST_SOURCE_ID.to_string(),
             }],
@@ -753,9 +752,10 @@ mod tests {
             .ask_for_res(get_open_shards_request)
             .await
             .unwrap();
-        assert_eq!(get_open_shards_response.subresponses.len(), 1);
+        assert_eq!(get_open_shards_response.successes.len(), 1);
+        assert_eq!(get_open_shards_response.failures.len(), 0);
 
-        let subresponse = &get_open_shards_response.subresponses[0];
+        let subresponse = &get_open_shards_response.successes[0];
         assert_eq!(subresponse.index_uid, "test-index:0");
         assert_eq!(subresponse.source_id, INGEST_SOURCE_ID);
         assert_eq!(subresponse.open_shards.len(), 1);

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -156,7 +156,6 @@ async fn start_control_plane(
 
 #[tokio::test]
 async fn test_scheduler_scheduling_and_control_loop_apply_plan_again() {
-    quickwit_common::setup_logging_for_tests();
     let transport = ChannelTransport::default();
     let cluster =
         create_cluster_for_test(Vec::new(), &["indexer", "control_plane"], &transport, true)
@@ -251,7 +250,6 @@ async fn test_scheduler_scheduling_and_control_loop_apply_plan_again() {
 
 #[tokio::test]
 async fn test_scheduler_scheduling_no_indexer() {
-    quickwit_common::setup_logging_for_tests();
     let transport = ChannelTransport::default();
     let cluster = create_cluster_for_test(Vec::new(), &["control_plane"], &transport, true)
         .await
@@ -288,7 +286,6 @@ async fn test_scheduler_scheduling_no_indexer() {
 
 #[tokio::test]
 async fn test_scheduler_scheduling_multiple_indexers() {
-    quickwit_common::setup_logging_for_tests();
     let transport = ChannelTransport::default();
     let cluster = create_cluster_for_test(Vec::new(), &["control_plane"], &transport, true)
         .await

--- a/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
+++ b/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
@@ -214,6 +214,8 @@ impl IngestServiceClient {
     > {
         let adapter = IngestServiceGrpcServerAdapter::new(self.clone());
         ingest_service_grpc_server::IngestServiceGrpcServer::new(adapter)
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024)
     }
     pub fn from_channel(
         addr: std::net::SocketAddr,
@@ -232,8 +234,13 @@ impl IngestServiceClient {
         balance_channel: quickwit_common::tower::BalanceChannel<std::net::SocketAddr>,
     ) -> IngestServiceClient {
         let connection_keys_watcher = balance_channel.connection_keys_watcher();
+        let client = ingest_service_grpc_client::IngestServiceGrpcClient::new(
+                balance_channel,
+            )
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024);
         let adapter = IngestServiceGrpcClientAdapter::new(
-            ingest_service_grpc_client::IngestServiceGrpcClient::new(balance_channel),
+            client,
             connection_keys_watcher,
         );
         Self::new(adapter)

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -117,7 +117,7 @@ impl FetchTask {
             fetch_range=?self.fetch_range,
             "spawning fetch task"
         );
-        let mut has_drained_queue = true;
+        let mut has_drained_queue = false;
         let mut has_reached_eof = false;
         let mut num_records_total = 0;
 
@@ -644,12 +644,6 @@ mod tests {
             .await
             .unwrap();
         drop(state_guard);
-
-        timeout(Duration::from_millis(50), fetch_stream.next())
-            .await
-            .unwrap_err();
-
-        new_records_tx.send(()).unwrap();
 
         let fetch_response = timeout(Duration::from_millis(50), fetch_stream.next())
             .await

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -211,7 +211,7 @@ impl Ingester {
             .next()
             .await
             .expect("TODO")
-            .expect("")
+            .expect("TODO")
             .into_open_response()
             .expect("first message should be an open response");
 

--- a/quickwit/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit/quickwit-metastore/src/checkpoint.rs
@@ -286,7 +286,6 @@ impl SourceCheckpoint {
         &self,
         delta: &SourceCheckpointDelta,
     ) -> Result<(), IncompatibleCheckpointDelta> {
-        info!(delta=?delta, checkpoint=?self);
         for (delta_partition, delta_position) in &delta.per_partition {
             let Some(position) = self.per_partition.get(delta_partition) else {
                 continue;
@@ -329,6 +328,8 @@ impl SourceCheckpoint {
         delta: SourceCheckpointDelta,
     ) -> Result<(), IncompatibleCheckpointDelta> {
         self.check_compatibility(&delta)?;
+        info!(delta=?delta, checkpoint=?self, "applying delta to checkpoint");
+
         for (partition_id, partition_position) in delta.per_partition {
             self.per_partition
                 .insert(partition_id, partition_position.to);

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
@@ -158,6 +158,7 @@ impl Shards {
         let next_shard_id = self.next_shard_id;
 
         let response = OpenShardsSubresponse {
+            subrequest_id: subrequest.subrequest_id,
             index_uid: subrequest.index_uid,
             source_id: subrequest.source_id,
             opened_shards,
@@ -335,6 +336,7 @@ mod tests {
         let mut shards = Shards::empty(index_uid.clone(), source_id.clone());
 
         let subrequest = OpenShardsSubrequest {
+            subrequest_id: 0,
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
             leader_id: "leader_id".to_string(),
@@ -371,6 +373,7 @@ mod tests {
         assert_eq!(shards.next_shard_id, 2);
 
         let subrequest = OpenShardsSubrequest {
+            subrequest_id: 0,
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
             leader_id: "leader_id".to_string(),
@@ -397,6 +400,7 @@ mod tests {
         assert_eq!(shards.next_shard_id, 3);
 
         let subrequest = OpenShardsSubrequest {
+            subrequest_id: 0,
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
             leader_id: "leader_id".to_string(),

--- a/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
@@ -70,8 +70,9 @@ message GetOrCreateOpenShardsRequest {
 }
 
 message GetOrCreateOpenShardsSubrequest {
-    string index_id = 1;
-    string source_id = 2;
+  uint32 subrequest_id = 1;
+  string index_id = 2;
+  string source_id = 3;
 }
 
 message ClosedShards {
@@ -80,13 +81,27 @@ message ClosedShards {
   repeated uint64 shard_ids = 3;
 }
 
-// TODO: Handle partial failures.
 message GetOrCreateOpenShardsResponse {
-  repeated GetOpenShardsSubresponse subresponses = 1;
+  repeated GetOrCreateOpenShardsSuccess successes = 1;
+  repeated GetOrCreateOpenShardsFailure failures = 2;
 }
 
-message GetOpenShardsSubresponse {
-    string index_uid = 1;
-    string source_id = 2;
-    repeated quickwit.ingest.Shard open_shards = 3;
+message GetOrCreateOpenShardsSuccess {
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  repeated quickwit.ingest.Shard open_shards = 4;
+}
+
+enum GetOrCreateOpenShardsFailureReason {
+  GET_OR_CREATE_OPEN_SHARDS_FAILURE_REASON_UNSPECIFIED = 0;
+  GET_OR_CREATE_OPEN_SHARDS_FAILURE_REASON_INDEX_NOT_FOUND = 1;
+  GET_OR_CREATE_OPEN_SHARDS_FAILURE_REASON_SOURCE_NOT_FOUND = 2;
+}
+
+message GetOrCreateOpenShardsFailure {
+  uint32 subrequest_id = 1;
+  string index_id = 2;
+  string source_id = 3;
+  GetOrCreateOpenShardsFailureReason reason = 4;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/ingest.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingest.proto
@@ -30,51 +30,51 @@ message Position {
 }
 
 enum CommitTypeV2 {
-    COMMIT_TYPE_V2_UNSPECIFIED = 0;
-    COMMIT_TYPE_V2_AUTO = 1;
-    COMMIT_TYPE_V2_WAIT = 2;
-    COMMIT_TYPE_V2_FORCE = 3;
+  COMMIT_TYPE_V2_UNSPECIFIED = 0;
+  COMMIT_TYPE_V2_AUTO = 1;
+  COMMIT_TYPE_V2_WAIT = 2;
+  COMMIT_TYPE_V2_FORCE = 3;
 }
 
 message DocBatchV2 {
-    bytes doc_buffer = 1;
-    repeated uint32 doc_lengths = 2;
+  bytes doc_buffer = 1;
+  repeated uint32 doc_lengths = 2;
 }
 
 message MRecordBatch {
-    // Buffer of encoded and then concatenated mrecords.
-    bytes mrecord_buffer = 1;
-    // Lengths of the mrecords in the buffer.
-    repeated uint32 mrecord_lengths = 2;
+  // Buffer of encoded and then concatenated mrecords.
+  bytes mrecord_buffer = 1;
+  // Lengths of the mrecords in the buffer.
+  repeated uint32 mrecord_lengths = 2;
 }
 
 enum ShardState {
-    SHARD_STATE_UNSPECIFIED = 0;
-    // The shard is open and accepts write requests.
-    SHARD_STATE_OPEN = 1;
-    // The ingester hosting the shard is unavailable.
-    SHARD_STATE_UNAVAILABLE = 2;
-    // The shard is closed and cannot be written to.
-    // It can be safely deleted if the publish position is superior or equal to the replication position.
-    SHARD_STATE_CLOSED = 3;
+  SHARD_STATE_UNSPECIFIED = 0;
+  // The shard is open and accepts write requests.
+  SHARD_STATE_OPEN = 1;
+  // The ingester hosting the shard is unavailable.
+  SHARD_STATE_UNAVAILABLE = 2;
+  // The shard is closed and cannot be written to.
+  // It can be safely deleted if the publish position is superior or equal to the replication position.
+  SHARD_STATE_CLOSED = 3;
 }
 
 message Shard {
-    // Immutable fields
-    string index_uid = 1;
-    string source_id = 2;
-    uint64 shard_id = 3;
-    // The node ID of the ingester to which all the write requests for this shard should be sent to.
-    string leader_id = 4;
-    // The node ID of the ingester holding a copy of the data.
-    optional string follower_id = 5;
+  // Immutable fields
+  string index_uid = 1;
+  string source_id = 2;
+  uint64 shard_id = 3;
+  // The node ID of the ingester to which all the write requests for this shard should be sent to.
+  string leader_id = 4;
+  // The node ID of the ingester holding a copy of the data.
+  optional string follower_id = 5;
 
-    // Mutable fields
-    ShardState shard_state = 8;
-    // Position up to which indexers have indexed and published the records stored in the shard.
-    // It is updated asynchronously in a best effort manner by the indexers and indicates the position up to which the log can be safely truncated.
-    Position publish_position_inclusive = 9;
-    // A publish token that ensures only one indexer works on a given shard at a time.
-    // For instance, if an indexer goes rogue, eventually the control plane will detect it and assign the shard to another indexer, which will override the publish token.
-    optional string publish_token = 10;
+  // Mutable fields
+  ShardState shard_state = 8;
+  // Position up to which indexers have indexed and published the records stored in the shard.
+  // It is updated asynchronously in a best effort manner by the indexers and indicates the position up to which the log can be safely truncated.
+  Position publish_position_inclusive = 9;
+  // A publish token that ensures only one indexer works on a given shard at a time.
+  // For instance, if an indexer goes rogue, eventually the control plane will detect it and assign the shard to another indexer, which will override the publish token.
+  optional string publish_token = 10;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -24,171 +24,171 @@ package quickwit.ingest.ingester;
 import "quickwit/ingest.proto";
 
 service IngesterService {
-    // Persists batches of documents to primary shards owned by a leader.
-    rpc Persist(PersistRequest) returns (PersistResponse);
+  // Persists batches of documents to primary shards owned by a leader.
+  rpc Persist(PersistRequest) returns (PersistResponse);
 
-    // Opens a replication stream from a leader to a follower.
-    rpc OpenReplicationStream(stream SynReplicationMessage) returns (stream AckReplicationMessage);
+  // Opens a replication stream from a leader to a follower.
+  rpc OpenReplicationStream(stream SynReplicationMessage) returns (stream AckReplicationMessage);
 
-    // Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
-    rpc OpenFetchStream(OpenFetchStreamRequest) returns (stream FetchResponseV2);
+  // Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
+  rpc OpenFetchStream(OpenFetchStreamRequest) returns (stream FetchResponseV2);
 
-    // rpc OpenWatchStream(OpenWatchStreamRequest) returns (stream WatchMessage);
+  // rpc OpenWatchStream(OpenWatchStreamRequest) returns (stream WatchMessage);
 
-    // Pings an ingester to check if it is ready to host shards and serve requests.
-    rpc Ping(PingRequest) returns (PingResponse);
+  // Pings an ingester to check if it is ready to host shards and serve requests.
+  rpc Ping(PingRequest) returns (PingResponse);
 
-    // Truncates the shards at the given positions. Indexers should call this RPC on leaders, which will replicate the request to followers.
-    rpc Truncate(TruncateRequest) returns (TruncateResponse);
+  // Truncates the shards at the given positions. Indexers should call this RPC on leaders, which will replicate the request to followers.
+  rpc Truncate(TruncateRequest) returns (TruncateResponse);
 }
 
 message PersistRequest {
-    string leader_id = 1;
-    quickwit.ingest.CommitTypeV2 commit_type = 3;
-    repeated PersistSubrequest subrequests = 4;
+  string leader_id = 1;
+  quickwit.ingest.CommitTypeV2 commit_type = 3;
+  repeated PersistSubrequest subrequests = 4;
 }
 
 message PersistSubrequest {
-    uint32 subrequest_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    optional string follower_id = 5;
-    quickwit.ingest.DocBatchV2 doc_batch = 6;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  optional string follower_id = 5;
+  quickwit.ingest.DocBatchV2 doc_batch = 6;
 }
 
 message PersistResponse {
-    string leader_id = 1;
-    repeated PersistSuccess successes = 2;
-    repeated PersistFailure failures = 3;
+  string leader_id = 1;
+  repeated PersistSuccess successes = 2;
+  repeated PersistFailure failures = 3;
 }
 
 message PersistSuccess {
-    uint32 subrequest_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    quickwit.ingest.Position replication_position_inclusive = 5;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  quickwit.ingest.Position replication_position_inclusive = 5;
 }
 
 enum PersistFailureReason {
-    PERSIST_FAILURE_REASON_UNSPECIFIED = 0;
-    PERSIST_FAILURE_REASON_SHARD_CLOSED = 1;
-    PERSIST_FAILURE_REASON_RATE_LIMITED = 2;
-    PERSIST_FAILURE_REASON_RESOURCE_EXHAUSTED = 3;
+  PERSIST_FAILURE_REASON_UNSPECIFIED = 0;
+  PERSIST_FAILURE_REASON_SHARD_CLOSED = 1;
+  PERSIST_FAILURE_REASON_RATE_LIMITED = 2;
+  PERSIST_FAILURE_REASON_RESOURCE_EXHAUSTED = 3;
 }
 
 message PersistFailure {
-    uint32 subrequest_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    PersistFailureReason reason = 5;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  PersistFailureReason reason = 5;
 }
 
 message SynReplicationMessage {
-    oneof message {
-        OpenReplicationStreamRequest open_request = 1;
-        ReplicateRequest replicate_request = 2;
-    }
+  oneof message {
+    OpenReplicationStreamRequest open_request = 1;
+    ReplicateRequest replicate_request = 2;
+  }
 }
 
 message AckReplicationMessage {
-    oneof message {
-        OpenReplicationStreamResponse open_response = 1;
-        ReplicateResponse replicate_response = 2;
-    }
+  oneof message {
+    OpenReplicationStreamResponse open_response = 1;
+    ReplicateResponse replicate_response = 2;
+  }
 }
 
 message OpenReplicationStreamRequest {
-    string leader_id = 1;
-    string follower_id = 2;
+  string leader_id = 1;
+  string follower_id = 2;
 }
 
 message OpenReplicationStreamResponse {
 }
 
 message ReplicateRequest {
-    string leader_id = 1;
-    string follower_id = 2;
-    quickwit.ingest.CommitTypeV2 commit_type = 3;
-    repeated ReplicateSubrequest subrequests = 4;
-    // Position of the request in the replication stream.
-    uint64 replication_seqno = 5;
+  string leader_id = 1;
+  string follower_id = 2;
+  quickwit.ingest.CommitTypeV2 commit_type = 3;
+  repeated ReplicateSubrequest subrequests = 4;
+  // Position of the request in the replication stream.
+  uint64 replication_seqno = 5;
 }
 
 message ReplicateSubrequest {
-    uint32 subrequest_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    quickwit.ingest.Position from_position_exclusive = 5;
-    quickwit.ingest.Position to_position_inclusive = 6;
-    ingest.DocBatchV2 doc_batch = 7;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  quickwit.ingest.Position from_position_exclusive = 5;
+  quickwit.ingest.Position to_position_inclusive = 6;
+  ingest.DocBatchV2 doc_batch = 7;
 }
 
 message ReplicateResponse {
-    string follower_id = 1;
-    repeated ReplicateSuccess successes = 2;
-    repeated ReplicateFailure failures = 3;
-    // Position of the response in the replication stream. It should match the position of the request.
-    uint64 replication_seqno = 4;
+  string follower_id = 1;
+  repeated ReplicateSuccess successes = 2;
+  repeated ReplicateFailure failures = 3;
+  // Position of the response in the replication stream. It should match the position of the request.
+  uint64 replication_seqno = 4;
 }
 
 message ReplicateSuccess {
-    uint32 subrequest_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    quickwit.ingest.Position replication_position_inclusive = 5;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  quickwit.ingest.Position replication_position_inclusive = 5;
 }
 
 message ReplicateFailure {
-    uint32 subrequest_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    // ingest.DocBatchV2 doc_batch = 4;
-    // ingest.IngestError error = 5;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  // ingest.DocBatchV2 doc_batch = 4;
+  // ingest.IngestError error = 5;
 }
 
 message TruncateRequest {
-    string ingester_id = 1;
-    repeated TruncateSubrequest subrequests = 2;
+  string ingester_id = 1;
+  repeated TruncateSubrequest subrequests = 2;
 }
 
 message TruncateSubrequest {
-    string index_uid = 1;
-    string source_id = 2;
-    uint64 shard_id = 3;
-    quickwit.ingest.Position to_position_inclusive = 4;
+  string index_uid = 1;
+  string source_id = 2;
+  uint64 shard_id = 3;
+  quickwit.ingest.Position to_position_inclusive = 4;
 }
 
 message TruncateResponse {
-    // TODO
+  // TODO
 }
 
 message OpenFetchStreamRequest {
-    string client_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    quickwit.ingest.Position from_position_exclusive = 5;
-    quickwit.ingest.Position to_position_inclusive = 6;
+  string client_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  quickwit.ingest.Position from_position_exclusive = 5;
+  quickwit.ingest.Position to_position_inclusive = 6;
 }
 
 message FetchResponseV2 {
-    string index_uid = 1;
-    string source_id = 2;
-    uint64 shard_id = 3;
-    quickwit.ingest.MRecordBatch mrecord_batch = 4;
-    quickwit.ingest.Position from_position_exclusive = 5;
-    quickwit.ingest.Position to_position_inclusive = 6;
+  string index_uid = 1;
+  string source_id = 2;
+  uint64 shard_id = 3;
+  quickwit.ingest.MRecordBatch mrecord_batch = 4;
+  quickwit.ingest.Position from_position_exclusive = 5;
+  quickwit.ingest.Position to_position_inclusive = 6;
 }
 
 message PingRequest {
-    string leader_id = 1;
-    optional string follower_id = 2;
+  string leader_id = 1;
+  optional string follower_id = 2;
 }
 
 message PingResponse {

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -125,8 +125,8 @@ message CreateIndexResponse {
 }
 
 message ListIndexesMetadataRequest {
-    reserved  1;
-    repeated string index_id_patterns = 2;
+  reserved  1;
+  repeated string index_id_patterns = 2;
 }
 
 message ListIndexesMetadataResponse {
@@ -263,11 +263,12 @@ message OpenShardsRequest {
 }
 
 message OpenShardsSubrequest {
-    string index_uid = 1;
-    string source_id = 2;
-    string leader_id = 3;
-    optional string follower_id = 4;
-    uint64 next_shard_id = 5;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  string leader_id = 4;
+  optional string follower_id = 5;
+  uint64 next_shard_id = 6;
 }
 
 message OpenShardsResponse {
@@ -275,10 +276,11 @@ message OpenShardsResponse {
 }
 
 message OpenShardsSubresponse {
-    string index_uid = 1;
-    string source_id = 2;
-    repeated quickwit.ingest.Shard opened_shards = 3;
-    uint64 next_shard_id = 4;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  repeated quickwit.ingest.Shard opened_shards = 4;
+  uint64 next_shard_id = 5;
 }
 
 message AcquireShardsRequest {
@@ -286,10 +288,10 @@ message AcquireShardsRequest {
 }
 
 message AcquireShardsSubrequest {
-    string index_uid = 1;
-    string source_id = 2;
-    repeated uint64 shard_ids = 3;
-    string publish_token = 4;
+  string index_uid = 1;
+  string source_id = 2;
+  repeated uint64 shard_ids = 3;
+  string publish_token = 4;
 }
 
 message AcquireShardsResponse {
@@ -297,9 +299,9 @@ message AcquireShardsResponse {
 }
 
 message AcquireShardsSubresponse {
-    string index_uid = 1;
-    string source_id = 2;
-    repeated quickwit.ingest.Shard acquired_shards = 3;
+  string index_uid = 1;
+  string source_id = 2;
+  repeated quickwit.ingest.Shard acquired_shards = 3;
 }
 
 message DeleteShardsRequest {
@@ -308,9 +310,9 @@ message DeleteShardsRequest {
 }
 
 message DeleteShardsSubrequest {
-    string index_uid = 1;
-    string source_id = 2;
-    repeated uint64 shard_ids = 3;
+  string index_uid = 1;
+  string source_id = 2;
+  repeated uint64 shard_ids = 3;
 }
 
 message DeleteShardsResponse {
@@ -321,18 +323,18 @@ message ListShardsRequest {
 }
 
 message ListShardsSubrequest {
-    string index_uid = 1;
-    string source_id = 2;
-    optional quickwit.ingest.ShardState shard_state = 3;
+  string index_uid = 1;
+  string source_id = 2;
+  optional quickwit.ingest.ShardState shard_state = 3;
 }
 
 message ListShardsResponse {
-    repeated ListShardsSubresponse subresponses = 1;
+  repeated ListShardsSubresponse subresponses = 1;
 }
 
 message ListShardsSubresponse {
-    string index_uid = 1;
-    string source_id = 2;
-    repeated quickwit.ingest.Shard shards = 3;
-    uint64 next_shard_id = 4;
+  string index_uid = 1;
+  string source_id = 2;
+  repeated quickwit.ingest.Shard shards = 3;
+  uint64 next_shard_id = 4;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/router.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/router.proto
@@ -24,48 +24,53 @@ package quickwit.ingest.router;
 import "quickwit/ingest.proto";
 
 service IngestRouterService {
-    // Ingests batches of documents for one or multiple indexes.
-    // TODO: Describe error cases and how to handle them.
-    rpc Ingest(IngestRequestV2) returns (IngestResponseV2);
+  // Ingests batches of documents for one or multiple indexes.
+  // TODO: Describe error cases and how to handle them.
+  rpc Ingest(IngestRequestV2) returns (IngestResponseV2);
 }
 
 message IngestRequestV2 {
-    repeated IngestSubrequest subrequests = 1;
-    quickwit.ingest.CommitTypeV2 commit_type = 2;
+  repeated IngestSubrequest subrequests = 1;
+  quickwit.ingest.CommitTypeV2 commit_type = 2;
 }
 
 message IngestSubrequest {
-    // The subrequest ID is used to identify the various subrequests and responses
-    // (ingest, persist, replicate) at play during the ingest and replication
-    // process.
-    uint32 subrequest_id = 1;
-    string index_id = 2;
-    string source_id = 3;
-    quickwit.ingest.DocBatchV2 doc_batch = 4;
+  // The subrequest ID is used to identify the various subrequests and responses
+  // (ingest, persist, replicate) at play during the ingest and replication
+  // process.
+  uint32 subrequest_id = 1;
+  string index_id = 2;
+  string source_id = 3;
+  quickwit.ingest.DocBatchV2 doc_batch = 4;
 }
 
 message IngestResponseV2 {
-    repeated IngestSuccess successes  = 1;
-    repeated IngestFailure failures  = 2;
+  repeated IngestSuccess successes  = 1;
+  repeated IngestFailure failures  = 2;
 }
 
 message IngestSuccess {
-    uint32 subrequest_id = 1;
-    string index_uid = 2;
-    string source_id = 3;
-    uint64 shard_id = 4;
-    // Replication position inclusive.
-    quickwit.ingest.Position replication_position_inclusive = 5;
+  uint32 subrequest_id = 1;
+  string index_uid = 2;
+  string source_id = 3;
+  uint64 shard_id = 4;
+  // Replication position inclusive.
+  quickwit.ingest.Position replication_position_inclusive = 5;
 }
 
 enum IngestFailureReason {
-    INGEST_FAILURE_REASON_UNSPECIFIED = 0;
-    INGEST_FAILURE_REASON_NO_SHARDS_AVAILABLE = 1;
+  INGEST_FAILURE_REASON_UNSPECIFIED = 0;
+  INGEST_FAILURE_REASON_INDEX_NOT_FOUND = 1;
+  INGEST_FAILURE_REASON_SOURCE_NOT_FOUND = 2;
+  INGEST_FAILURE_REASON_INTERNAL = 3;
+  INGEST_FAILURE_REASON_NO_SHARDS_AVAILABLE = 4;
+  INGEST_FAILURE_REASON_RATE_LIMITED = 5;
+  INGEST_FAILURE_REASON_RESOURCE_EXHAUSTED = 6;
 }
 
 message IngestFailure {
-    uint32 subrequest_id = 1;
-    string index_id = 2;
-    string source_id = 3;
-    IngestFailureReason reason = 5;
+  uint32 subrequest_id = 1;
+  string index_id = 2;
+  string source_id = 3;
+  IngestFailureReason reason = 5;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -76,9 +76,9 @@ service SearchService {
 
 /// Scroll Request
 message ScrollRequest {
-    /// The `scroll_id` is the given in the response of a search request including a scroll.
-    string scroll_id = 1;
-    optional uint32 scroll_ttl_secs = 2;
+  /// The `scroll_id` is the given in the response of a search request including a scroll.
+  string scroll_id = 1;
+  optional uint32 scroll_ttl_secs = 2;
 }
 
 message PutKVRequest {
@@ -90,23 +90,23 @@ message PutKVRequest {
 message PutKVResponse {}
 
 message GetKVRequest {
-    bytes key = 1;
+  bytes key = 1;
 }
 
 message GetKVResponse {
-    optional bytes payload = 1;
+  optional bytes payload = 1;
 }
 
 
 message ReportSplit {
-    // Split id (ULID format `01HAV29D4XY3D462FS3D8K5Q2H`)
-    string split_id = 2;
-    // The storage uri. This URI does NOT include the split id.
-    string storage_uri = 1;
+  // Split id (ULID format `01HAV29D4XY3D462FS3D8K5Q2H`)
+  string split_id = 2;
+  // The storage uri. This URI does NOT include the split id.
+  string storage_uri = 1;
 }
 
 message ReportSplitsRequest {
-    repeated ReportSplit report_splits = 1;
+  repeated ReportSplit report_splits = 1;
 }
 
 message ReportSplitsResponse {}
@@ -188,10 +188,10 @@ message SortField {
 }
 
 enum SortOrder {
-    // Ascending order.
-    ASC = 0;
-    // Descending order.
-    DESC = 1; //< This will be the default value;
+  // Ascending order.
+  ASC = 0;
+  // Descending order.
+  DESC = 1; //< This will be the default value;
 }
 
 message SearchResponse {
@@ -325,10 +325,10 @@ message PartialHit {
 
 message SortByValue {
   oneof sort_value {
-    uint64 u64 = 1;
-    int64 i64 = 2;
-    double f64 = 3;
-    bool boolean = 4;
+  uint64 u64 = 1;
+  int64 i64 = 2;
+  double f64 = 3;
+  bool boolean = 4;
   }
   // Room for eventual future sorted key types.
   reserved 5 to 20;
@@ -449,12 +449,12 @@ message LeafListTermsResponse {
 // -- Stream -------------------
 
 enum OutputFormat {
-    // Comma Separated Values format (https://datatracker.ietf.org/doc/html/rfc4180).
-    // The delimiter is `,`.
-    CSV = 0; //< This will be the default value
-    // Format data by row in ClickHouse binary format.
-    // https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary
-    CLICK_HOUSE_ROW_BINARY = 1;
+  // Comma Separated Values format (https://datatracker.ietf.org/doc/html/rfc4180).
+  // The delimiter is `,`.
+  CSV = 0; //< This will be the default value
+  // Format data by row in ClickHouse binary format.
+  // https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary
+  CLICK_HOUSE_ROW_BINARY = 1;
 }
 
 message SearchStreamRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
@@ -67,6 +67,8 @@ impl IndexingServiceClient {
     > {
         let adapter = IndexingServiceGrpcServerAdapter::new(self.clone());
         indexing_service_grpc_server::IndexingServiceGrpcServer::new(adapter)
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024)
     }
     pub fn from_channel(
         addr: std::net::SocketAddr,
@@ -85,10 +87,13 @@ impl IndexingServiceClient {
         balance_channel: quickwit_common::tower::BalanceChannel<std::net::SocketAddr>,
     ) -> IndexingServiceClient {
         let connection_keys_watcher = balance_channel.connection_keys_watcher();
-        let adapter = IndexingServiceGrpcClientAdapter::new(
-            indexing_service_grpc_client::IndexingServiceGrpcClient::new(
+        let client = indexing_service_grpc_client::IndexingServiceGrpcClient::new(
                 balance_channel,
-            ),
+            )
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024);
+        let adapter = IndexingServiceGrpcClientAdapter::new(
+            client,
             connection_keys_watcher,
         );
         Self::new(adapter)

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -376,6 +376,8 @@ impl IngesterServiceClient {
     > {
         let adapter = IngesterServiceGrpcServerAdapter::new(self.clone());
         ingester_service_grpc_server::IngesterServiceGrpcServer::new(adapter)
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024)
     }
     pub fn from_channel(
         addr: std::net::SocketAddr,
@@ -394,10 +396,13 @@ impl IngesterServiceClient {
         balance_channel: quickwit_common::tower::BalanceChannel<std::net::SocketAddr>,
     ) -> IngesterServiceClient {
         let connection_keys_watcher = balance_channel.connection_keys_watcher();
-        let adapter = IngesterServiceGrpcClientAdapter::new(
-            ingester_service_grpc_client::IngesterServiceGrpcClient::new(
+        let client = ingester_service_grpc_client::IngesterServiceGrpcClient::new(
                 balance_channel,
-            ),
+            )
+            .max_decoding_message_size(10 * 1024 * 1024)
+            .max_encoding_message_size(10 * 1024 * 1024);
+        let adapter = IngesterServiceGrpcClientAdapter::new(
+            client,
             connection_keys_watcher,
         );
         Self::new(adapter)

--- a/quickwit/quickwit-proto/src/control_plane/mod.rs
+++ b/quickwit/quickwit-proto/src/control_plane/mod.rs
@@ -31,7 +31,7 @@ pub type ControlPlaneResult<T> = std::result::Result<T, ControlPlaneError>;
 pub enum ControlPlaneError {
     #[error("an internal error occurred: {0}")]
     Internal(String),
-    #[error("an internal error occurred: {0}")]
+    #[error("a metastore error occurred: {0}")]
     Metastore(#[from] MetastoreError),
     #[error("control plane is unavailable: {0}")]
     Unavailable(String),
@@ -41,7 +41,7 @@ impl From<ControlPlaneError> for MetastoreError {
     fn from(error: ControlPlaneError) -> Self {
         match error {
             ControlPlaneError::Internal(message) => MetastoreError::Internal {
-                message: "todo".to_string(),
+                message: "an internal metastore error occurred".to_string(),
                 cause: message,
             },
             ControlPlaneError::Metastore(error) => error,


### PR DESCRIPTION
### Description
- Split `GetOrCreateOpenShardsReponse` into `successes` and `failures` to keep track of indexes/sources not found
- Remove leaders from ingester pool on transport error

### How was this PR tested?
- Added unit tests
- Tested locally
