### PR TITLE
Fixing unit tests.

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/mod.rs
@@ -287,10 +287,8 @@ fn group_shards_into_pipelines(
     let min_num_pipelines: u32 =
         (num_shards + max_num_shards_per_pipeline.get() - 1) / max_num_shards_per_pipeline;
     assert!(min_num_pipelines > 0);
-    let max_num_pipelines: u32 = min_num_pipelines.max(
-        (num_shards * load_per_shard + LOAD_PER_PIPELINE_LOW_THRESHOLD - 1)
-            / LOAD_PER_PIPELINE_LOW_THRESHOLD,
-    );
+    let max_num_pipelines: u32 =
+        min_num_pipelines.max(num_shards * load_per_shard / LOAD_PER_PIPELINE_LOW_THRESHOLD);
     let previous_num_pipelines = previous_indexing_tasks.len() as u32;
     let num_pipelines: u32 = if previous_num_pipelines > min_num_pipelines {
         previous_num_pipelines.min(max_num_pipelines)

--- a/quickwit/quickwit-integration-tests/Cargo.toml
+++ b/quickwit/quickwit-integration-tests/Cargo.toml
@@ -32,7 +32,7 @@ quickwit-cluster = { workspace = true, features = ["testsuite"] }
 quickwit-common = { workspace = true, features = ["testsuite"] }
 quickwit-config = { workspace = true, features = ["testsuite"] }
 quickwit-indexing = { workspace = true, features = ["testsuite"] }
-quickwit-janitor = { workspace = true }
+quickwit-janitor = { workspace = true, features= ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-search = { workspace = true, features = ["testsuite"] }
 quickwit-storage = { workspace = true, features = ["testsuite"] }


### PR DESCRIPTION
The testsuite feature flag has for effect to change the janitor poll period. It is why one of the unit test was not passing when running cargo test from the `quickwit-integration-tests` directory.
