### PR TITLE
Add  ingester close shards gRPC

### DIFF
--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -25,12 +25,12 @@ use itertools::Itertools;
 use quickwit_common::{PrettySample, Progress};
 use quickwit_ingest::IngesterPool;
 use quickwit_proto::control_plane::{
-    ClosedShards, ControlPlaneError, ControlPlaneResult, GetOrCreateOpenShardsFailure,
+    ControlPlaneError, ControlPlaneResult, GetOrCreateOpenShardsFailure,
     GetOrCreateOpenShardsFailureReason, GetOrCreateOpenShardsRequest,
     GetOrCreateOpenShardsResponse, GetOrCreateOpenShardsSuccess,
 };
 use quickwit_proto::ingest::ingester::{IngesterService, PingRequest};
-use quickwit_proto::ingest::{IngestV2Error, ShardState};
+use quickwit_proto::ingest::{ClosedShards, IngestV2Error, ShardState};
 use quickwit_proto::metastore;
 use quickwit_proto::metastore::{MetastoreService, MetastoreServiceClient};
 use quickwit_proto::types::{IndexUid, NodeId};

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -513,13 +513,13 @@ async fn fault_tolerant_fetch_task(
 }
 
 #[derive(Debug, Clone, Copy)]
-struct FetchRange {
+pub(crate) struct FetchRange {
     from_position_exclusive_opt: Option<u64>,
     to_position_inclusive_opt: Option<u64>,
 }
 
 impl FetchRange {
-    fn new(from_position_exclusive: Position, to_position_inclusive: Position) -> Self {
+    pub(crate) fn new(from_position_exclusive: Position, to_position_inclusive: Position) -> Self {
         Self {
             from_position_exclusive_opt: from_position_exclusive.as_u64(),
             to_position_inclusive_opt: to_position_inclusive.as_u64(),

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -513,13 +513,13 @@ async fn fault_tolerant_fetch_task(
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct FetchRange {
+pub(super) struct FetchRange {
     from_position_exclusive_opt: Option<u64>,
     to_position_inclusive_opt: Option<u64>,
 }
 
 impl FetchRange {
-    pub(crate) fn new(from_position_exclusive: Position, to_position_inclusive: Position) -> Self {
+    pub(super) fn new(from_position_exclusive: Position, to_position_inclusive: Position) -> Self {
         Self {
             from_position_exclusive_opt: from_position_exclusive.as_u64(),
             to_position_inclusive_opt: to_position_inclusive.as_u64(),

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -33,16 +33,17 @@ use mrecordlog::MultiRecordLog;
 use quickwit_common::tower::Pool;
 use quickwit_common::ServiceStream;
 use quickwit_proto::ingest::ingester::{
-    AckReplicationMessage, FetchResponseV2, IngesterService, IngesterServiceClient,
-    IngesterServiceStream, OpenFetchStreamRequest, OpenReplicationStreamRequest,
-    OpenReplicationStreamResponse, PersistFailure, PersistFailureReason, PersistRequest,
-    PersistResponse, PersistSuccess, PingRequest, PingResponse, ReplicateRequest,
-    ReplicateSubrequest, SynReplicationMessage, TruncateRequest, TruncateResponse,
+    AckReplicationMessage, CloseShardsRequest, CloseShardsResponse, FetchResponseV2,
+    IngesterService, IngesterServiceClient, IngesterServiceStream, OpenFetchStreamRequest,
+    OpenReplicationStreamRequest, OpenReplicationStreamResponse, PersistFailure,
+    PersistFailureReason, PersistRequest, PersistResponse, PersistSuccess, PingRequest,
+    PingResponse, ReplicateRequest, ReplicateSubrequest, SynReplicationMessage, TruncateRequest,
+    TruncateResponse,
 };
 use quickwit_proto::ingest::{CommitTypeV2, IngestV2Error, IngestV2Result, ShardState};
 use quickwit_proto::types::{NodeId, Position, QueueId};
 use tokio::sync::RwLock;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use super::fetch::FetchTask;
 use super::models::{IngesterShard, PrimaryShard};
@@ -396,11 +397,6 @@ impl IngesterService for Ingester {
                 persist_successes.push(persist_success);
             }
         }
-        let _state_guard = self.state.write().await;
-
-        for persist_success in &persist_successes {
-            let _queue_id = persist_success.queue_id();
-        }
         let leader_id = self.self_node_id.to_string();
         let persist_response = PersistResponse {
             leader_id,
@@ -537,6 +533,30 @@ impl IngesterService for Ingester {
         let truncate_response = TruncateResponse {};
         Ok(truncate_response)
     }
+
+    async fn close_shards(
+        &mut self,
+        close_shards_request: CloseShardsRequest,
+    ) -> IngestV2Result<CloseShardsResponse> {
+        let mut state_guard = self.state.write().await;
+        for close_shard in close_shards_request.closed_shards {
+            for queue_id in close_shard.queue_ids() {
+                if !state_guard.mrecordlog.queue_exists(&queue_id) {
+                    warn!("shard `{}` not found", queue_id);
+                    continue;
+                }
+                append_eof_record_if_necessary(&mut state_guard.mrecordlog, &queue_id).await;
+                let shard = state_guard
+                    .shards
+                    .get_mut(&queue_id)
+                    .expect("shard must exist");
+                // Notify fetch task so eof record is sent to the replica.
+                shard.notify_new_records();
+                shard.close();
+            }
+        }
+        Ok(CloseShardsResponse {})
+    }
 }
 
 /// Appends an EOF record to the queue if the it is empty or the last record is not an EOF
@@ -574,11 +594,12 @@ mod tests {
         IngesterServiceGrpcServer, IngesterServiceGrpcServerAdapter, PersistSubrequest,
         TruncateSubrequest,
     };
-    use quickwit_proto::ingest::DocBatchV2;
+    use quickwit_proto::ingest::{ClosedShards, DocBatchV2};
     use quickwit_proto::types::queue_id;
     use tonic::transport::{Endpoint, Server};
 
     use super::*;
+    use crate::ingest_v2::fetch::FetchRange;
     use crate::ingest_v2::test_utils::{IngesterShardTestExt, MultiRecordLogTestExt};
 
     #[tokio::test]
@@ -1247,5 +1268,121 @@ mod tests {
         state_guard
             .mrecordlog
             .assert_records_eq(&queue_id_02, .., &[]);
+    }
+
+    #[tokio::test]
+    async fn test_ingester_close_shards() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let self_node_id: NodeId = "test-ingester-0".into();
+        let ingester_pool = IngesterPool::default();
+        let wal_dir_path = tempdir.path();
+        let replication_factor = 1;
+        let mut ingester = Ingester::try_new(
+            self_node_id.clone(),
+            ingester_pool,
+            wal_dir_path,
+            replication_factor,
+        )
+        .await
+        .unwrap();
+
+        let queue_id_01 = queue_id("test-index:0", "test-source:0", 1);
+        let queue_id_02 = queue_id("test-index:0", "test-source:0", 2);
+        let queue_id_03 = queue_id("test-index:1", "test-source:1", 3);
+
+        let mut state_guard = ingester.state.write().await;
+        for queue_id in &[&queue_id_01, &queue_id_02, &queue_id_03] {
+            ingester
+                .create_shard(&mut state_guard, queue_id, &self_node_id, None)
+                .await
+                .unwrap();
+            let records = [
+                MRecord::new_doc("test-doc-010").encode(),
+                MRecord::new_doc("test-doc-011").encode(),
+            ]
+            .into_iter();
+            state_guard
+                .mrecordlog
+                .append_records(&queue_id_01, None, records)
+                .await
+                .unwrap();
+        }
+
+        drop(state_guard);
+
+        let client_id = "test-client".to_string();
+        let open_fetch_stream_request = OpenFetchStreamRequest {
+            client_id: client_id.clone(),
+            index_uid: "test-index:0".to_string(),
+            source_id: "test-source:0".to_string(),
+            shard_id: 1,
+            from_position_exclusive: None,
+            to_position_inclusive: None,
+        };
+
+        let mut fetch_stream = ingester
+            .open_fetch_stream(open_fetch_stream_request)
+            .await
+            .unwrap();
+        let fetch_response = fetch_stream.next().await.unwrap().unwrap();
+        assert_eq!(
+            fetch_response.from_position_exclusive(),
+            Position::Beginning
+        );
+
+        let close_shard_1 = ClosedShards {
+            index_uid: "test-index:0".to_string(),
+            source_id: "test-source:0".to_string(),
+            shard_ids: vec![1, 2],
+        };
+        let close_shard_2 = ClosedShards {
+            index_uid: "test-index:1".to_string(),
+            source_id: "test-source:1".to_string(),
+            shard_ids: vec![3],
+        };
+        let close_shard_with_no_queue = ClosedShards {
+            index_uid: "test-index:2".to_string(),
+            source_id: "test-source:2".to_string(),
+            shard_ids: vec![4],
+        };
+        let closed_shards = vec![
+            close_shard_1.clone(),
+            close_shard_2.clone(),
+            close_shard_with_no_queue,
+        ];
+        let close_shards_request = CloseShardsRequest {
+            closed_shards: closed_shards.clone(),
+        };
+        ingester.close_shards(close_shards_request).await.unwrap();
+
+        // Check that shards are closed and EOF records are appended.
+        let state_guard = ingester.state.read().await;
+        for shard in state_guard.shards.values() {
+            shard.assert_is_closed();
+        }
+        for closed_shards in [&close_shard_1, &close_shard_2] {
+            for queue_id in closed_shards.queue_ids() {
+                let last_position = state_guard
+                    .mrecordlog
+                    .range(
+                        &queue_id,
+                        FetchRange::new(Position::Beginning, Position::Beginning),
+                    )
+                    .unwrap()
+                    .last()
+                    .unwrap();
+                assert!(is_eof_mrecord(&last_position.1));
+            }
+        }
+
+        // Check that fetch task is notified.
+        // Note: fetch stream should not block if the close shard call notified the fetch task.
+        let fetch_response =
+            tokio::time::timeout(std::time::Duration::from_secs(2), fetch_stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+        assert_eq!(fetch_response.to_position_inclusive(), Position::Eof);
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -1378,7 +1378,7 @@ mod tests {
         // Check that fetch task is notified.
         // Note: fetch stream should not block if the close shard call notified the fetch task.
         let fetch_response =
-            tokio::time::timeout(std::time::Duration::from_secs(2), fetch_stream.next())
+            tokio::time::timeout(std::time::Duration::from_millis(50), fetch_stream.next())
                 .await
                 .unwrap()
                 .unwrap()

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -43,7 +43,7 @@ use quickwit_proto::ingest::ingester::{
 use quickwit_proto::ingest::{CommitTypeV2, IngestV2Error, IngestV2Result, ShardState};
 use quickwit_proto::types::{NodeId, Position, QueueId};
 use tokio::sync::RwLock;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use super::fetch::FetchTask;
 use super::models::{IngesterShard, PrimaryShard};
@@ -542,7 +542,6 @@ impl IngesterService for Ingester {
         for close_shard in close_shards_request.closed_shards {
             for queue_id in close_shard.queue_ids() {
                 if !state_guard.mrecordlog.queue_exists(&queue_id) {
-                    warn!("shard `{}` not found", queue_id);
                     continue;
                 }
                 append_eof_record_if_necessary(&mut state_guard.mrecordlog, &queue_id).await;
@@ -550,7 +549,7 @@ impl IngesterService for Ingester {
                     .shards
                     .get_mut(&queue_id)
                     .expect("shard must exist");
-                // Notify fetch task so eof record is sent to the replica.
+                // Notify fetch task.
                 shard.notify_new_records();
                 shard.close();
             }

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -137,6 +137,15 @@ impl IngesterShard {
         .is_closed()
     }
 
+    pub fn close(&mut self) {
+        let shard_state = match self {
+            IngesterShard::Primary(primary_shard) => &mut primary_shard.shard_state,
+            IngesterShard::Replica(replica_shard) => &mut replica_shard.shard_state,
+            IngesterShard::Solo(solo_shard) => &mut solo_shard.shard_state,
+        };
+        *shard_state = ShardState::Closed;
+    }
+
     pub fn replication_position_inclusive(&self) -> Position {
         match self {
             IngesterShard::Primary(primary_shard) => &primary_shard.replication_position_inclusive,

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
 use futures::{Future, StreamExt};
 use quickwit_proto::control_plane::{
-    ClosedShards, ControlPlaneService, ControlPlaneServiceClient, GetOrCreateOpenShardsRequest,
+    ControlPlaneService, ControlPlaneServiceClient, GetOrCreateOpenShardsRequest,
     GetOrCreateOpenShardsSubrequest,
 };
 use quickwit_proto::ingest::ingester::{
@@ -35,7 +35,7 @@ use quickwit_proto::ingest::ingester::{
 use quickwit_proto::ingest::router::{
     IngestRequestV2, IngestResponseV2, IngestRouterService, IngestSubrequest,
 };
-use quickwit_proto::ingest::{CommitTypeV2, IngestV2Error, IngestV2Result};
+use quickwit_proto::ingest::{ClosedShards, CommitTypeV2, IngestV2Error, IngestV2Result};
 use quickwit_proto::types::{IndexUid, NodeId, ShardId, SourceId, SubrequestId};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};

--- a/quickwit/quickwit-ingest/src/ingest_v2/shard_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/shard_table.rs
@@ -20,8 +20,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use quickwit_proto::control_plane::ClosedShards;
-use quickwit_proto::ingest::{Shard, ShardState};
+use quickwit_proto::ingest::{ClosedShards, Shard, ShardState};
 use quickwit_proto::types::{IndexId, IndexUid, NodeId, ShardId, SourceId};
 use tracing::warn;
 

--- a/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
@@ -65,7 +65,7 @@ service ControlPlaneService {
 
 message GetOrCreateOpenShardsRequest {
   repeated GetOrCreateOpenShardsSubrequest subrequests = 1;
-  repeated ClosedShards closed_shards = 2;
+  repeated quickwit.ingest.ClosedShards closed_shards = 2;
   repeated string unavailable_leaders = 3;
 }
 
@@ -73,12 +73,6 @@ message GetOrCreateOpenShardsSubrequest {
   uint32 subrequest_id = 1;
   string index_id = 2;
   string source_id = 3;
-}
-
-message ClosedShards {
-  string index_uid = 1;
-  string source_id = 2;
-  repeated uint64 shard_ids = 3;
 }
 
 message GetOrCreateOpenShardsResponse {

--- a/quickwit/quickwit-proto/protos/quickwit/ingest.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingest.proto
@@ -78,3 +78,9 @@ message Shard {
   // For instance, if an indexer goes rogue, eventually the control plane will detect it and assign the shard to another indexer, which will override the publish token.
   optional string publish_token = 10;
 }
+
+message ClosedShards {
+  string index_uid = 1;
+  string source_id = 2;
+  repeated uint64 shard_ids = 3;
+}

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -35,6 +35,8 @@ service IngesterService {
 
   // rpc OpenWatchStream(OpenWatchStreamRequest) returns (stream WatchMessage);
 
+  rpc CloseShards(CloseShardsRequest) returns (CloseShardsResponse);
+
   // Pings an ingester to check if it is ready to host shards and serve requests.
   rpc Ping(PingRequest) returns (PingResponse);
 
@@ -184,6 +186,13 @@ message FetchResponseV2 {
   quickwit.ingest.MRecordBatch mrecord_batch = 4;
   quickwit.ingest.Position from_position_exclusive = 5;
   quickwit.ingest.Position to_position_inclusive = 6;
+}
+
+message CloseShardsRequest {
+  repeated quickwit.ingest.ClosedShards closed_shards = 1;
+}
+
+message CloseShardsResponse {
 }
 
 message PingRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
@@ -5,7 +5,7 @@ pub struct GetOrCreateOpenShardsRequest {
     #[prost(message, repeated, tag = "1")]
     pub subrequests: ::prost::alloc::vec::Vec<GetOrCreateOpenShardsSubrequest>,
     #[prost(message, repeated, tag = "2")]
-    pub closed_shards: ::prost::alloc::vec::Vec<ClosedShards>,
+    pub closed_shards: ::prost::alloc::vec::Vec<super::ingest::ClosedShards>,
     #[prost(string, repeated, tag = "3")]
     pub unavailable_leaders: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
@@ -19,17 +19,6 @@ pub struct GetOrCreateOpenShardsSubrequest {
     pub index_id: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-}
-#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ClosedShards {
-    #[prost(string, tag = "1")]
-    pub index_uid: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, repeated, tag = "3")]
-    pub shard_ids: ::prost::alloc::vec::Vec<u64>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
@@ -52,6 +52,17 @@ pub struct Shard {
     pub publish_token: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClosedShards {
+    #[prost(string, tag = "1")]
+    pub index_uid: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub source_id: ::prost::alloc::string::String,
+    #[prost(uint64, repeated, tag = "3")]
+    pub shard_ids: ::prost::alloc::vec::Vec<u64>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/quickwit/quickwit-proto/src/ingest/mod.rs
+++ b/quickwit/quickwit-proto/src/ingest/mod.rs
@@ -23,7 +23,7 @@ use self::ingester::FetchResponseV2;
 use super::types::NodeId;
 use super::{ServiceError, ServiceErrorCode};
 use crate::control_plane::ControlPlaneError;
-use crate::types::{queue_id, Position};
+use crate::types::{queue_id, Position, QueueId};
 
 pub mod ingester;
 pub mod router;
@@ -190,5 +190,13 @@ impl ShardState {
 
     pub fn is_closed(&self) -> bool {
         *self == ShardState::Closed
+    }
+}
+
+impl ClosedShards {
+    pub fn queue_ids(&self) -> impl Iterator<Item = QueueId> + '_ {
+        self.shard_ids
+            .iter()
+            .map(|shard_id| queue_id(&self.index_uid, &self.source_id, *shard_id))
     }
 }


### PR DESCRIPTION
Fix #4023 

When a `ClosedShardsRequest` is sent to the ingester, we close the related shards if any, and add the Eof record. The fetch task is notified so the follower will receive the Eof record.

Test added to check the closing, the Eof record and the notification.

Note: I did not handle the closing of the shard on the replica. We could send a replication request to the replica and handle the eof position on the replica.

