### PR TITLE
Abort fetch stream tasks upon dropping multi fetch stream

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -338,6 +338,12 @@ impl MultiFetchStream {
     }
 }
 
+impl Drop for MultiFetchStream {
+    fn drop(&mut self) {
+        self.reset();
+    }
+}
+
 /// Chooses the ingester to stream records from, preferring "local" ingesters.
 fn select_preferred_and_failover_ingesters(
     self_node_id: &NodeId,


### PR DESCRIPTION
### Description
This partially fixes the deadlock observed in #4070. When the source shuts down, it does not close its connections to ingesters, which in turn can't shut down their gRPC servers.

To completely fix the issue, ingesters should close their shards and outgoing connections on shutdown. There's an issue already open.

### How was this PR tested?
I tested this PR on Paul's integration tests branch.
