### PR TITLE
Stop deleting queue on truncate at EOF

### DIFF
--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -188,7 +188,7 @@ impl IngestController {
                     index_id=%index_uid.index_id(),
                     source_id=%source_id,
                     shard_ids=?PrettySample::new(&closed_shard_ids, 5),
-                    "closed {} shards reported by router",
+                    "closed {} shard(s) reported by router",
                     closed_shard_ids.len()
                 );
             }

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -105,28 +105,19 @@ impl fmt::Debug for SoloShard {
     }
 }
 
-impl Default for SoloShard {
-    fn default() -> Self {
+impl SoloShard {
+    pub fn new(shard_state: ShardState, replication_position_inclusive: Position) -> Self {
         let (new_records_tx, new_records_rx) = watch::channel(());
         Self {
-            shard_state: ShardState::Open,
-            replication_position_inclusive: Position::Beginning,
+            shard_state,
+            replication_position_inclusive,
             new_records_tx,
             new_records_rx,
         }
     }
 }
 
-impl SoloShard {
-    pub fn new(shard_state: ShardState, replication_position_inclusive: Position) -> Self {
-        Self {
-            shard_state,
-            replication_position_inclusive,
-            ..Default::default()
-        }
-    }
-}
-
+#[derive(Debug)]
 pub(super) enum IngesterShard {
     /// A primary shard hosted on a leader and replicated on a follower.
     Primary(PrimaryShard),
@@ -190,5 +181,20 @@ impl IngesterShard {
         }
         .send(())
         .expect("channel should be open");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_solo_shard() {
+        let solo_shard = SoloShard::new(ShardState::Closed, Position::from(42u64));
+        assert_eq!(solo_shard.shard_state, ShardState::Closed);
+        assert_eq!(
+            solo_shard.replication_position_inclusive,
+            Position::from(42u64)
+        );
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -38,7 +38,7 @@ use quickwit_proto::ingest::router::{
 use quickwit_proto::ingest::{CommitTypeV2, IngestV2Error, IngestV2Result};
 use quickwit_proto::types::{IndexUid, NodeId, ShardId, SourceId, SubrequestId};
 use tokio::sync::RwLock;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use super::ingester::PERSIST_REQUEST_TIMEOUT;
 use super::shard_table::ShardTable;
@@ -132,6 +132,18 @@ impl IngestRouter {
                 };
                 get_open_shards_subrequests.push(subrequest);
             }
+        }
+        if !closed_shards.is_empty() {
+            info!(
+                "reporting {} closed shard(s) to control-plane",
+                closed_shards.len()
+            )
+        }
+        if !unavailable_leaders.is_empty() {
+            info!(
+                "reporting {} unavailable leader(s) to control-plane",
+                unavailable_leaders.len()
+            );
         }
         GetOrCreateOpenShardsRequest {
             subrequests: get_open_shards_subrequests,


### PR DESCRIPTION
### Description
If we delete the queue of a closed shard on truncate at EOF  and then the node crashes, upon restarting, the node is no longer aware of the closed shard, and any router that is also not aware of the shard being closed can recreate it...

### How was this PR tested?
- Updated unit tests
- This scenario could use an integration test