### PR TITLE
Bound memory and disk usage of mrecordlog

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "mrecordlog"
 version = "0.4.0"
-source = "git+https://github.com/quickwit-oss/mrecordlog?rev=0d1a7aa#0d1a7aa2bdf11aec832919503cefaf282d70e0d8"
+source = "git+https://github.com/quickwit-oss/mrecordlog?rev=ebee0fd#ebee0fdb6556a18f7cb73eca32e40bf44b0c4c6c"
 dependencies = [
  "async-trait",
  "bytes",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -50,7 +50,10 @@ bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "1.3.0", features = ["serde"] }
 bytestring = "1.3.0"
 chitchat = "0.7"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = [
+  "clock",
+  "std",
+] }
 clap = { version = "4.4.1", features = ["env", "string"] }
 colored = "2.0.0"
 console-subscriber = "0.1.8"
@@ -96,12 +99,19 @@ libz-sys = "1.1.8"
 lru = "0.12"
 lindera-core = "0.27.0"
 lindera-dictionary = "0.27.0"
-lindera-tokenizer = { version = "0.27.0", features = ["ipadic", "ipadic-compress", "cc-cedict", "cc-cedict-compress", "ko-dic", "ko-dic-compress"] }
+lindera-tokenizer = { version = "0.27.0", features = [
+  "cc-cedict-compress",
+  "cc-cedict",
+  "ipadic-compress",
+  "ipadic",
+  "ko-dic-compress",
+  "ko-dic",
+] }
 matches = "0.1.9"
 md5 = "0.7"
 mime_guess = "2.0.4"
 mockall = "0.11"
-mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "0d1a7aa" }
+mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "ebee0fd" }
 new_string_template = "1.4.0"
 nom = "7.1.3"
 num_cpus = "1"
@@ -113,7 +123,9 @@ opentelemetry = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.12.0"
 pin-project = "1.1.0"
 pnet = { version = "0.33.0", features = ["std"] }
-postcard = { version = "1.0.4", features = ["use-std"], default-features = false}
+postcard = { version = "1.0.4", features = [
+  "use-std",
+], default-features = false }
 predicates = "3"
 prettyplease = "0.2.0"
 proc-macro2 = "1.0.50"
@@ -124,7 +136,11 @@ prost = { version = "0.11.6", default-features = false, features = [
 ] }
 prost-build = "0.11.6"
 prost-types = "0.11.6"
-pulsar = { git = "https://github.com/quickwit-oss/pulsar-rs.git", rev = "f9eff04", default-features = false, features = ["compression", "tokio-runtime", "auth-oauth2"] }
+pulsar = { git = "https://github.com/quickwit-oss/pulsar-rs.git", rev = "f9eff04", default-features = false, features = [
+  "auth-oauth2",
+  "compression",
+  "tokio-runtime",
+] }
 quote = "1.0.23"
 rand = "0.8"
 rand_distr = "0.4"
@@ -143,7 +159,10 @@ reqwest = { version = "0.11", default-features = false, features = [
 ] }
 rust-embed = "6.8.1"
 sea-query = { version = "0" }
-sea-query-binder = { version = "0", features = ["sqlx-postgres", "runtime-tokio-rustls",] }
+sea-query-binder = { version = "0", features = [
+  "runtime-tokio-rustls",
+  "sqlx-postgres",
+] }
 # ^1.0.184 due to serde-rs/serde#2538
 serde = { version = "1.0.184", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -152,12 +171,12 @@ serde_with = "3.4.0"
 serde_yaml = "0.9"
 siphasher = "0.3"
 sqlx = { version = "0.7", features = [
-  "runtime-tokio-rustls",
-  "postgres",
   "migrate",
+  "postgres",
+  "runtime-tokio-rustls",
   "time",
 ] }
-syn = { version = "2.0.11", features = [ "extra-traits", "full", "parsing" ]}
+syn = { version = "2.0.11", features = ["extra-traits", "full", "parsing"] }
 sync_wrapper = "0.1.2"
 tabled = { version = "0.8", features = ["color"] }
 tempfile = "3"
@@ -173,14 +192,20 @@ tokio-util = { version = "0.7", features = ["full"] }
 toml = "0.7.6"
 tonic = { version = "0.9.0", features = ["gzip"] }
 tonic-build = "0.9.0"
-tower = { version = "0.4.13", features = ["balance", "buffer", "load", "retry", "util"] }
+tower = { version = "0.4.13", features = [
+  "balance",
+  "buffer",
+  "load",
+  "retry",
+  "util",
+] }
 tower-http = { version = "0.4.0", features = ["compression-gzip", "cors"] }
 tracing = "0.1.37"
 tracing-opentelemetry = "0.19.0"
 tracing-subscriber = { version = "0.3.16", features = [
-  "time",
-  "std",
   "env-filter",
+  "std",
+  "time",
 ] }
 ttl_cache = "0.5"
 typetag = "0.2"
@@ -199,7 +224,9 @@ whichlang = { git = "https://github.com/quickwit-oss/whichlang", rev = "fe406416
 wiremock = "0.5"
 
 aws-config = "0.55.0"
-aws-credential-types = { version = "0.55.0", features = ["hardcoded-credentials"] }
+aws-credential-types = { version = "0.55.0", features = [
+  "hardcoded-credentials",
+] }
 aws-sdk-kinesis = "0.28.0"
 aws-sdk-s3 = "0.28.0"
 aws-smithy-async = "0.55.0"
@@ -209,8 +236,12 @@ aws-smithy-types = "0.55.0"
 aws-types = "0.55.0"
 
 azure_core = { version = "0.13.0", features = ["enable_reqwest_rustls"] }
-azure_storage = { version = "0.13.0", default-features = false, features = ["enable_reqwest_rustls"] }
-azure_storage_blobs = { version = "0.13.0", default-features = false, features = ["enable_reqwest_rustls"] }
+azure_storage = { version = "0.13.0", default-features = false, features = [
+  "enable_reqwest_rustls",
+] }
+azure_storage_blobs = { version = "0.13.0", default-features = false, features = [
+  "enable_reqwest_rustls",
+] }
 
 quickwit-actors = { version = "0.6.3", path = "./quickwit-actors" }
 quickwit-aws = { version = "0.6.3", path = "./quickwit-aws" }
@@ -242,10 +273,10 @@ quickwit-storage = { version = "0.6.3", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.6.3", path = "./quickwit-telemetry" }
 
 tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "927b443", default-features = false, features = [
-  "mmap",
   "lz4-compression",
-  "zstd-compression",
+  "mmap",
   "quickwit",
+  "zstd-compression",
 ] }
 
 # This is actually not used directly the goal is to fix the version

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -188,7 +188,7 @@ pub struct IngestApiConfig {
     pub max_queue_memory_usage: ByteSize,
     pub max_queue_disk_usage: ByteSize,
     pub replication_factor: usize,
-    pub content_length_limit: u64,
+    pub content_length_limit: ByteSize,
 }
 
 impl Default for IngestApiConfig {
@@ -197,7 +197,7 @@ impl Default for IngestApiConfig {
             max_queue_memory_usage: ByteSize::gib(2), // TODO maybe we want more?
             max_queue_disk_usage: ByteSize::gib(4),   // TODO maybe we want more?
             replication_factor: 1,
-            content_length_limit: ByteSize::mib(10).as_u64(),
+            content_length_limit: ByteSize::mib(10),
         }
     }
 }

--- a/quickwit/quickwit-ingest/Cargo.toml
+++ b/quickwit/quickwit-ingest/Cargo.toml
@@ -9,6 +9,7 @@ description = "Quickwit is a cost-efficient search engine."
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
+bytesize = { workspace = true }
 dyn-clone = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
@@ -35,7 +36,6 @@ quickwit-config = { workspace = true }
 quickwit-proto = { workspace = true }
 
 [dev-dependencies]
-bytesize = { workspace = true }
 itertools = { workspace = true }
 mockall = { workspace = true }
 rand = { workspace = true }

--- a/quickwit/quickwit-ingest/src/ingest_v2/mrecord.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mrecord.rs
@@ -28,14 +28,17 @@ pub enum HeaderVersion {
     V0 = 0,
 }
 
+/// Length of the header of a [`MRecord`] in bytes.
+pub(super) const MRECORD_HEADER_LEN: usize = 2;
+
 /// `Doc` header v0 composed of the header version and the `Doc = 0` record type.
-const DOC_HEADER_V0: &[u8; 2] = &[HeaderVersion::V0 as u8, 0];
+const DOC_HEADER_V0: &[u8; MRECORD_HEADER_LEN] = &[HeaderVersion::V0 as u8, 0];
 
 /// `Commit` header v0 composed of the header version and the `Commit = 1` record type.
-const COMMIT_HEADER_V0: &[u8; 2] = &[HeaderVersion::V0 as u8, 1];
+const COMMIT_HEADER_V0: &[u8; MRECORD_HEADER_LEN] = &[HeaderVersion::V0 as u8, 1];
 
 /// `Eof` header v0 composed of the header version and the `Eof = 2` record type.
-const EOF_HEADER_V0: &[u8; 2] = &[HeaderVersion::V0 as u8, 2];
+const EOF_HEADER_V0: &[u8; MRECORD_HEADER_LEN] = &[HeaderVersion::V0 as u8, 2];
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum MRecord {

--- a/quickwit/quickwit-ingest/src/ingest_v2/mrecordlog_utils.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mrecordlog_utils.rs
@@ -1,0 +1,159 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use bytesize::ByteSize;
+use mrecordlog::error::{AppendError, MissingQueue};
+use mrecordlog::MultiRecordLog;
+use quickwit_proto::types::QueueId;
+use tracing::warn;
+
+use super::mrecord::is_eof_mrecord;
+use crate::MRecord;
+
+/// Appends an EOF record to the queue if it is empty or the last record is not an EOF
+/// record.
+pub(super) async fn append_eof_record_if_necessary(
+    mrecordlog: &mut MultiRecordLog,
+    queue_id: &QueueId,
+) {
+    let should_append_eof_record = match mrecordlog.last_record(queue_id) {
+        Ok(Some((_, last_mrecord))) => !is_eof_mrecord(&last_mrecord),
+        Ok(None) => true,
+        Err(MissingQueue(_)) => {
+            warn!("failed to append EOF record to queue `{queue_id}`: queue does not exist");
+            return;
+        }
+    };
+    if should_append_eof_record {
+        match mrecordlog
+            .append_record(queue_id, None, MRecord::Eof.encode())
+            .await
+        {
+            Ok(_) | Err(AppendError::MissingQueue(_)) => {}
+            Err(error) => {
+                warn!("failed to append EOF record to queue `{queue_id}`: {error}");
+            }
+        }
+    }
+}
+
+/// Error returned when the mrecordlog does not have enough capacity to store some records.
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+pub(super) enum NotEnoughCapacityError {
+    #[error(
+        "write-ahead log is full, capacity: usage: {usage}, capacity: {capacity}, requested: \
+         {requested}"
+    )]
+    Disk {
+        usage: ByteSize,
+        capacity: ByteSize,
+        requested: ByteSize,
+    },
+    #[error(
+        "write-ahead log memory buffer is full, usage: {usage}, capacity: {capacity}, requested: \
+         {requested}"
+    )]
+    Memory {
+        usage: ByteSize,
+        capacity: ByteSize,
+        requested: ByteSize,
+    },
+}
+
+/// Checks whether the log has enough capacity to store some records.
+pub(super) fn check_enough_capacity(
+    mrecordlog: &MultiRecordLog,
+    disk_capacity: ByteSize,
+    memory_capacity: ByteSize,
+    requested_capacity: ByteSize,
+) -> Result<(), NotEnoughCapacityError> {
+    let disk_usage = ByteSize(mrecordlog.disk_usage() as u64);
+
+    if disk_usage + requested_capacity > disk_capacity {
+        return Err(NotEnoughCapacityError::Disk {
+            usage: disk_usage,
+            capacity: disk_capacity,
+            requested: requested_capacity,
+        });
+    }
+    let memory_usage = ByteSize(mrecordlog.memory_usage() as u64);
+
+    if memory_usage + requested_capacity > memory_capacity {
+        return Err(NotEnoughCapacityError::Memory {
+            usage: memory_usage,
+            capacity: memory_capacity,
+            requested: requested_capacity,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_append_eof_record_if_necessary() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut mrecordlog = MultiRecordLog::open(tempdir.path()).await.unwrap();
+
+        append_eof_record_if_necessary(&mut mrecordlog, &"queue-not-found".to_string()).await;
+
+        mrecordlog.create_queue("test-queue").await.unwrap();
+        append_eof_record_if_necessary(&mut mrecordlog, &"test-queue".to_string()).await;
+
+        let (last_position, last_record) = mrecordlog.last_record("test-queue").unwrap().unwrap();
+        assert_eq!(last_position, 0);
+        assert!(is_eof_mrecord(&last_record));
+
+        append_eof_record_if_necessary(&mut mrecordlog, &"test-queue".to_string()).await;
+        let (last_position, last_record) = mrecordlog.last_record("test-queue").unwrap().unwrap();
+        assert_eq!(last_position, 0);
+        assert!(is_eof_mrecord(&last_record));
+
+        mrecordlog.truncate("test-queue", 0).await.unwrap();
+
+        append_eof_record_if_necessary(&mut mrecordlog, &"test-queue".to_string()).await;
+        let (last_position, last_record) = mrecordlog.last_record("test-queue").unwrap().unwrap();
+        assert_eq!(last_position, 1);
+        assert!(is_eof_mrecord(&last_record));
+    }
+
+    #[tokio::test]
+    async fn test_check_enough_capacity() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mrecordlog = MultiRecordLog::open(tempdir.path()).await.unwrap();
+
+        let disk_error =
+            check_enough_capacity(&mrecordlog, ByteSize(0), ByteSize(0), ByteSize(12)).unwrap_err();
+
+        assert!(matches!(disk_error, NotEnoughCapacityError::Disk { .. }));
+
+        let memory_error =
+            check_enough_capacity(&mrecordlog, ByteSize::mb(256), ByteSize(11), ByteSize(12))
+                .unwrap_err();
+
+        assert!(matches!(
+            memory_error,
+            NotEnoughCapacityError::Memory { .. }
+        ));
+
+        check_enough_capacity(&mrecordlog, ByteSize::mb(256), ByteSize(12), ByteSize(12)).unwrap();
+    }
+}

--- a/quickwit/quickwit-ingest/src/queue.rs
+++ b/quickwit/quickwit-ingest/src/queue.rs
@@ -209,11 +209,11 @@ impl Queues {
     }
 
     pub(crate) fn disk_usage(&self) -> usize {
-        self.record_log.on_disk_size()
+        self.record_log.disk_usage()
     }
 
     pub(crate) fn memory_usage(&self) -> usize {
-        self.record_log.in_memory_size()
+        self.record_log.memory_usage()
     }
 }
 

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -145,13 +145,19 @@ message ReplicateSuccess {
   quickwit.ingest.Position replication_position_inclusive = 5;
 }
 
+enum ReplicateFailureReason {
+  REPLICATE_FAILURE_REASON_UNSPECIFIED = 0;
+  REPLICATE_FAILURE_REASON_SHARD_CLOSED = 1;
+  reserved 2; // REPLICATE_FAILURE_REASON_RATE_LIMITED = 2;
+  REPLICATE_FAILURE_REASON_RESOURCE_EXHAUSTED = 3;
+}
+
 message ReplicateFailure {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
   uint64 shard_id = 4;
-  // ingest.DocBatchV2 doc_batch = 4;
-  // ingest.IngestError error = 5;
+  ReplicateFailureReason reason = 5;
 }
 
 message TruncateRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -194,10 +194,10 @@ pub struct ReplicateFailure {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    /// ingest.DocBatchV2 doc_batch = 4;
-    /// ingest.IngestError error = 5;
     #[prost(uint64, tag = "4")]
     pub shard_id: u64,
+    #[prost(enumeration = "ReplicateFailureReason", tag = "5")]
+    pub reason: i32,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -316,6 +316,43 @@ impl PersistFailureReason {
             "PERSIST_FAILURE_REASON_SHARD_CLOSED" => Some(Self::ShardClosed),
             "PERSIST_FAILURE_REASON_RATE_LIMITED" => Some(Self::RateLimited),
             "PERSIST_FAILURE_REASON_RESOURCE_EXHAUSTED" => Some(Self::ResourceExhausted),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ReplicateFailureReason {
+    Unspecified = 0,
+    ShardClosed = 1,
+    ResourceExhausted = 3,
+}
+impl ReplicateFailureReason {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ReplicateFailureReason::Unspecified => "REPLICATE_FAILURE_REASON_UNSPECIFIED",
+            ReplicateFailureReason::ShardClosed => {
+                "REPLICATE_FAILURE_REASON_SHARD_CLOSED"
+            }
+            ReplicateFailureReason::ResourceExhausted => {
+                "REPLICATE_FAILURE_REASON_RESOURCE_EXHAUSTED"
+            }
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "REPLICATE_FAILURE_REASON_UNSPECIFIED" => Some(Self::Unspecified),
+            "REPLICATE_FAILURE_REASON_SHARD_CLOSED" => Some(Self::ShardClosed),
+            "REPLICATE_FAILURE_REASON_RESOURCE_EXHAUSTED" => {
+                Some(Self::ResourceExhausted)
+            }
             _ => None,
         }
     }

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -79,7 +79,7 @@ fn ingest_filter(
     warp::path!(String / "ingest")
         .and(warp::post())
         .and(warp::body::content_length_limit(
-            config.content_length_limit,
+            config.content_length_limit.as_u64(),
         ))
         .and(warp::body::bytes())
         .and(serde_qs::warp::query::<IngestOptions>(
@@ -103,7 +103,7 @@ fn ingest_v2_filter(
     warp::path!(String / "ingest-v2")
         .and(warp::post())
         .and(warp::body::content_length_limit(
-            config.content_length_limit,
+            config.content_length_limit.as_u64(),
         ))
         .and(warp::body::bytes())
         .and(serde_qs::warp::query::<IngestOptions>(
@@ -355,7 +355,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_ingest_api_return_413_if_above_content_limit() {
         let config = IngestApiConfig {
-            content_length_limit: 1,
+            content_length_limit: ByteSize(1),
             ..Default::default()
         };
         let (universe, _temp_dir, ingest_service, _) =

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -572,6 +572,8 @@ async fn setup_ingest_v2(
             self_node_id.clone(),
             ingester_pool.clone(),
             &wal_dir_path,
+            config.ingest_api_config.max_queue_disk_usage,
+            config.ingest_api_config.max_queue_memory_usage,
             replication_factor,
         )
         .await?;


### PR DESCRIPTION
### Description
Bound memory and disk usage of mrecordlog.

There remain a few things to implement for the functionality to work correctly:
- handle `ResourceExhausted` failures in the router and control plane
- Replicate records on follower first then on leader (as opposed to leader first then follower currently)

I'll tackle those in two separate PRs.

### How was this PR tested?
- Updated existing unit tests
- Added unit tests
