### PR TITLE
update tantivy

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -953,6 +953,14 @@ dependencies = [
 
 [[package]]
 name = "bitpacking"
+version = "0.8.3"
+source = "git+https://github.com/quickwit-oss/bitpacking?rev=f730b75#f730b75598589d7c2a9c4eee3fc17025c59e2b2c"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "bitpacking"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8c7d2ac73c167c06af4a5f37e6e59d84148d57ccbe4480b76f0273eefea82d7"
@@ -4347,7 +4355,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7503,13 +7511,13 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.21.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "aho-corasick",
  "arc-swap",
  "async-trait",
  "base64 0.21.5",
- "bitpacking",
+ "bitpacking 0.8.3",
  "byteorder",
  "census",
  "crc32fast",
@@ -7558,15 +7566,15 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.5.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
- "bitpacking",
+ "bitpacking 0.8.4",
 ]
 
 [[package]]
 name = "tantivy-columnar"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "fastdivide",
  "fnv",
@@ -7581,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7604,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.21.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "nom",
 ]
@@ -7612,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "tantivy-common",
  "tantivy-fst",
@@ -7622,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -7631,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.2.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=ecb9a89#ecb9a89a9ff0573fba5c2cf8b83f353f35022310"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=927b443#927b4432c935b55cb8a2275daea3f77fc6823bd6"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -241,7 +241,7 @@ quickwit-serve = { version = "0.6.3", path = "./quickwit-serve" }
 quickwit-storage = { version = "0.6.3", path = "./quickwit-storage" }
 quickwit-telemetry = { version = "0.6.3", path = "./quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "ecb9a89", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "927b443", default-features = false, features = [
   "mmap",
   "lz4-compression",
   "zstd-compression",

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -41,11 +41,9 @@ use quickwit_proto::metastore::{
 };
 use quickwit_query::get_quickwit_fastfield_normalizer_manager;
 use quickwit_query::query_ast::QueryAst;
-use tantivy::directory::{DirectoryClone, MmapDirectory, RamDirectory};
+use tantivy::directory::{Advice, DirectoryClone, MmapDirectory, RamDirectory};
 use tantivy::tokenizer::TokenizerManager;
-use tantivy::{
-    Advice, DateTime, Directory, Index, IndexMeta, IndexWriter, SegmentId, SegmentReader,
-};
+use tantivy::{DateTime, Directory, Index, IndexMeta, IndexWriter, SegmentId, SegmentReader};
 use tokio::runtime::Handle;
 use tracing::{debug, info, instrument, warn};
 

--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -30,8 +30,8 @@ use quickwit_common::io::{IoControls, IoControlsAccess};
 use quickwit_common::uri::Uri;
 use quickwit_metastore::SplitMetadata;
 use quickwit_storage::{PutPayload, Storage, StorageResult};
-use tantivy::directory::MmapDirectory;
-use tantivy::{Advice, Directory};
+use tantivy::directory::{Advice, MmapDirectory};
+use tantivy::Directory;
 use time::OffsetDateTime;
 use tracing::{info, info_span, instrument, Instrument};
 

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -1227,8 +1227,9 @@ mod tests {
     }
 
     fn make_index() -> tantivy::Index {
+        use tantivy::indexer::UserOperation;
         use tantivy::schema::{NumericOptions, Schema};
-        use tantivy::{Index, UserOperation};
+        use tantivy::Index;
 
         let dataset = sort_dataset();
 


### PR DESCRIPTION
```
## BEFORE
➜  quickwit-indices cat github-jan-2015.json.zst | zstd -d | quickwit tool local-ingest --index github
❯ Ingesting documents locally...

---------------------------------------------------
 Connectivity checklist
 ✔ metastore storage
 ✔ metastore
 ✔ index storage
 ✔ _ingest-cli-source

 Num docs   19297 Parse errs     0 PublSplits   0 Input size    44MB Thrghput 44.12MB/s Time 00:00:01
 Num docs   19297 Parse errs     0 PublSplits   0 Input size    44MB Thrghput 22.07MB/s Time 00:00:02
 Num docs   38983 Parse errs     0 PublSplits   0 Input size    81MB Thrghput 27.30MB/s Time 00:00:03
 Num docs   56410 Parse errs     0 PublSplits   0 Input size   116MB Thrghput 29.13MB/s Time 00:00:04
 Num docs   74125 Parse errs     0 PublSplits   0 Input size   155MB Thrghput 27.78MB/s Time 00:00:05
 Num docs   88353 Parse errs     0 PublSplits   0 Input size   188MB Thrghput 36.09MB/s Time 00:00:06
 Num docs  104888 Parse errs     0 PublSplits   0 Input size   227MB Thrghput 36.36MB/s Time 00:00:07
 Num docs  119321 Parse errs     0 PublSplits   0 Input size   260MB Thrghput 36.03MB/s Time 00:00:08
 Num docs  133974 Parse errs     0 PublSplits   0 Input size   294MB Thrghput 34.86MB/s Time 00:00:09
 Num docs  149650 Parse errs     0 PublSplits   0 Input size   332MB Thrghput 36.08MB/s Time 00:00:10
 Num docs  163376 Parse errs     0 PublSplits   0 Input size   366MB Thrghput 34.69MB/s Time 00:00:11
 Num docs  177612 Parse errs     0 PublSplits   0 Input size   401MB Thrghput 35.14MB/s Time 00:00:12
 Num docs  192481 Parse errs     0 PublSplits   0 Input size   437MB Thrghput 35.59MB/s Time 00:00:13
 Num docs  206822 Parse errs     0 PublSplits   0 Input size   474MB Thrghput 35.36MB/s Time 00:00:14
 Num docs  221488 Parse errs     0 PublSplits   0 Input size   507MB Thrghput 35.35MB/s Time 00:00:15
^C⏎

## NOW
➜  quickwit-indices quickwit index create --index-config ./gh.yaml --overwrite
❯ Creating index...
✔ This operation will overwrite the index and delete all its data. Do you want to proceed? · yes
✔ Index successfully created.
➜  quickwit-indices cat github-jan-2015.json.zst | zstd -d | quickwit tool local-ingest --index github
❯ Ingesting documents locally...

---------------------------------------------------
 Connectivity checklist
 ✔ metastore storage
 ✔ metastore
 ✔ index storage
 ✔ _ingest-cli-source

 Num docs   22116 Parse errs     0 PublSplits   0 Input size    50MB Thrghput 25.00MB/s Time 00:00:02
 Num docs   48316 Parse errs     0 PublSplits   0 Input size   100MB Thrghput 33.35MB/s Time 00:00:03
 Num docs   71725 Parse errs     0 PublSplits   0 Input size   149MB Thrghput 37.43MB/s Time 00:00:04
 Num docs   93618 Parse errs     0 PublSplits   0 Input size   201MB Thrghput 40.28MB/s Time 00:00:05
 Num docs  114479 Parse errs     0 PublSplits   0 Input size   249MB Thrghput 49.90MB/s Time 00:00:06
 Num docs  134166 Parse errs     0 PublSplits   0 Input size   295MB Thrghput 48.79MB/s Time 00:00:07
 Num docs  154440 Parse errs     0 PublSplits   0 Input size   343MB Thrghput 48.56MB/s Time 00:00:08
 Num docs  174608 Parse errs     0 PublSplits   0 Input size   393MB Thrghput 48.11MB/s Time 00:00:09
 Num docs  195311 Parse errs     0 PublSplits   0 Input size   444MB Thrghput 48.63MB/s Time 00:00:10
 Num docs  216390 Parse errs     0 PublSplits   0 Input size   496MB Thrghput 50.32MB/s Time 00:00:11
 Num docs  238101 Parse errs     0 PublSplits   0 Input size   541MB Thrghput 49.49MB/s Time 00:00:12
 Num docs  260193 Parse errs     0 PublSplits   0 Input size   590MB Thrghput 49.23MB/s Time 00:00:13
 Num docs  280021 Parse errs     0 PublSplits   0 Input size   637MB Thrghput 48.39MB/s Time 00:00:14
 Num docs  300571 Parse errs     0 PublSplits   0 Input size   688MB Thrghput 48.10MB/s Time 00:00:15
 Num docs  318454 Parse errs     0 PublSplits   0 Input size   734MB Thrghput 48.29MB/s Time 00:00:16
```