### PR TITLE
Rate limit ingestion per shard to 5 MB/s

### DIFF
--- a/quickwit/quickwit-common/src/tower/rate.rs
+++ b/quickwit/quickwit-common/src/tower/rate.rs
@@ -41,17 +41,20 @@ impl ConstantRate {
     ///
     /// # Panics
     ///
-    /// This function panics if `work` is equal to zero or `period` is < 1ms.
+    /// This function panics if `period` is < 1ms.
     pub fn new(work: u64, period: Duration) -> Self {
-        assert!(work > 0);
         assert!(period.as_millis() > 0);
 
         Self { work, period }
     }
 
-    pub fn from_bytes(bytes: ByteSize, period: Duration) -> Self {
+    pub fn bytes_per_period(bytes: ByteSize, period: Duration) -> Self {
         let work = bytes.as_u64();
         Self::new(work, period)
+    }
+
+    pub fn bytes_per_sec(bytes: ByteSize) -> Self {
+        Self::bytes_per_period(bytes, Duration::from_secs(1))
     }
 }
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -628,6 +628,7 @@ mod tests {
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
+            rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
         }));
@@ -797,6 +798,7 @@ mod tests {
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
+            rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
         }));
@@ -836,6 +838,7 @@ mod tests {
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
+            rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
         }));
@@ -902,6 +905,7 @@ mod tests {
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
+            rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
         }));

--- a/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
@@ -22,6 +22,7 @@ mod ingester;
 mod models;
 mod mrecord;
 mod mrecordlog_utils;
+mod rate_limiter;
 mod replication;
 mod router;
 mod shard_table;
@@ -39,6 +40,7 @@ pub use self::fetch::{FetchStreamError, MultiFetchStream};
 pub use self::ingester::Ingester;
 use self::mrecord::MRECORD_HEADER_LEN;
 pub use self::mrecord::{decoded_mrecords, MRecord};
+pub use self::rate_limiter::RateLimiterSettings;
 pub use self::router::IngestRouter;
 
 pub type IngesterPool = Pool<NodeId, IngesterServiceClient>;

--- a/quickwit/quickwit-ingest/src/ingest_v2/rate_limiter.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/rate_limiter.rs
@@ -1,0 +1,179 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::{Duration, Instant};
+
+use bytesize::ByteSize;
+use quickwit_common::tower::{ConstantRate, Rate};
+
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimiterSettings {
+    // After a long period of inactivity, the rate limiter can accumulate some "credits"
+    // up to what we call a `burst_limit`.
+    //
+    // Until these credits are expired, the rate limiter may exceed temporarily its rate limit.
+    pub burst_limit: ByteSize,
+    pub rate_limit: ConstantRate,
+    // The refill period has an effect on the resolution at which the
+    // rate limiting is enforced.
+    //
+    // `Instant::now()` is guaranteed to be called at most once per refill_period.
+    pub refill_period: Duration,
+}
+
+impl Default for RateLimiterSettings {
+    fn default() -> Self {
+        // 10 MB burst limit.
+        let burst_limit = ByteSize::mb(10);
+        // 5 MB/s rate limit.
+        let rate_limit = ConstantRate::bytes_per_sec(ByteSize::mb(5));
+        // Refill every 100ms.
+        let refill_period = Duration::from_millis(100);
+
+        Self {
+            burst_limit,
+            rate_limit,
+            refill_period,
+        }
+    }
+}
+
+/// A bursty token-based rate limiter.
+#[derive(Debug, Clone)]
+pub(super) struct RateLimiter {
+    capacity: u64,
+    available: u64,
+    refill_amount: u64,
+    refill_period: Duration,
+    refill_period_micros: u64,
+    refill_at: Instant,
+}
+
+impl RateLimiter {
+    pub fn from_settings(settings: RateLimiterSettings) -> Self {
+        let capacity = settings.burst_limit.as_u64();
+
+        let work = settings.rate_limit.work() as u128;
+        let refill_period = settings.refill_period;
+        let rate_limit_period = settings.rate_limit.period();
+        let refill_amount = work * refill_period.as_nanos() / rate_limit_period.as_nanos();
+
+        Self {
+            capacity,
+            available: capacity,
+            refill_amount: refill_amount as u64,
+            refill_period,
+            refill_period_micros: refill_period.as_micros() as u64,
+            refill_at: Instant::now() + refill_period,
+        }
+    }
+
+    pub fn acquire(&mut self, capacity: ByteSize) -> bool {
+        if self.acquire_inner(capacity.as_u64()) {
+            true
+        } else {
+            self.refill(Instant::now());
+            self.acquire_inner(capacity.as_u64())
+        }
+    }
+
+    fn acquire_inner(&mut self, capacity: u64) -> bool {
+        if self.available >= capacity {
+            self.available -= capacity;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn refill(&mut self, now: Instant) {
+        if now < self.refill_at {
+            return;
+        }
+        let elapsed = (now - self.refill_at).as_micros() as u64;
+        // More than one refill period may have elapsed so we need to take that into account.
+        let refill = self.refill_amount + self.refill_amount * elapsed / self.refill_period_micros;
+        self.available = std::cmp::min(self.available + refill, self.capacity);
+        self.refill_at = now + self.refill_period;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rate_limiter() {
+        let settings = RateLimiterSettings {
+            burst_limit: ByteSize::mb(2),
+            rate_limit: ConstantRate::bytes_per_sec(ByteSize::mb(1)),
+            refill_period: Duration::from_millis(100),
+        };
+        let mut rate_limiter = RateLimiter::from_settings(settings);
+        assert_eq!(rate_limiter.capacity, ByteSize::mb(2).as_u64());
+        assert_eq!(rate_limiter.available, ByteSize::mb(2).as_u64());
+        assert_eq!(rate_limiter.refill_amount, ByteSize::kb(100).as_u64());
+        assert_eq!(rate_limiter.refill_period, Duration::from_millis(100));
+
+        assert!(rate_limiter.acquire(ByteSize::mb(1)));
+        assert!(rate_limiter.acquire(ByteSize::mb(1)));
+        assert!(!rate_limiter.acquire(ByteSize::kb(1)));
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        assert!(rate_limiter.acquire(ByteSize::kb(100)));
+        assert!(!rate_limiter.acquire(ByteSize::kb(20)));
+
+        std::thread::sleep(Duration::from_millis(250));
+
+        assert!(rate_limiter.acquire(ByteSize::kb(125)));
+        assert!(rate_limiter.acquire(ByteSize::kb(125)));
+        assert!(!rate_limiter.acquire(ByteSize::kb(20)));
+    }
+
+    #[test]
+    fn test_rate_limiter_refill() {
+        let settings = RateLimiterSettings {
+            burst_limit: ByteSize::mb(2),
+            rate_limit: ConstantRate::bytes_per_sec(ByteSize::mb(1)),
+            refill_period: Duration::from_millis(100),
+        };
+        let mut rate_limiter = RateLimiter::from_settings(settings);
+
+        rate_limiter.available = 0;
+        let now = Instant::now();
+        rate_limiter.refill(now);
+        assert_eq!(rate_limiter.available, 0);
+
+        rate_limiter.available = 0;
+        let now = now + Duration::from_millis(100);
+        rate_limiter.refill(now);
+        assert_eq!(rate_limiter.available, ByteSize::kb(100).as_u64());
+
+        rate_limiter.available = 0;
+        let now = now + Duration::from_millis(110);
+        rate_limiter.refill(now);
+        assert_eq!(rate_limiter.available, ByteSize::kb(110).as_u64());
+
+        rate_limiter.available = 0;
+        let now = now + Duration::from_millis(210);
+        rate_limiter.refill(now);
+        assert_eq!(rate_limiter.available, ByteSize::kb(210).as_u64());
+    }
+}

--- a/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
@@ -674,6 +674,7 @@ mod tests {
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
+            rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
         }));
@@ -837,6 +838,7 @@ mod tests {
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
+            rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
         }));
@@ -917,6 +919,7 @@ mod tests {
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
+            rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
         }));

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -69,7 +69,7 @@ use quickwit_indexing::actors::IndexingService;
 use quickwit_indexing::start_indexing_service;
 use quickwit_ingest::{
     start_ingest_api_service, GetMemoryCapacity, IngestApiService, IngestRequest, IngestRouter,
-    IngestServiceClient, Ingester, IngesterPool,
+    IngestServiceClient, Ingester, IngesterPool, RateLimiterSettings,
 };
 use quickwit_janitor::{start_janitor_service, JanitorService};
 use quickwit_metastore::{
@@ -574,6 +574,7 @@ async fn setup_ingest_v2(
             &wal_dir_path,
             config.ingest_api_config.max_queue_disk_usage,
             config.ingest_api_config.max_queue_memory_usage,
+            RateLimiterSettings::default(),
             replication_factor,
         )
         .await?;


### PR DESCRIPTION
### Description
Rate limit ingestion per shard to 5 MB/s, allowing bursts of 10 MB. Requests are rejected immediately to enable routers to retry another shard.

I will implement the router and control plane logic to handle rate limiting in separate PRs.

### How was this PR tested?
- Added unit tests
