### PR TITLE
Implement ingester graceful shutdown

### DIFF
--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -30,7 +30,7 @@ use quickwit_proto::control_plane::{
     GetOrCreateOpenShardsResponse, GetOrCreateOpenShardsSuccess,
 };
 use quickwit_proto::ingest::ingester::{IngesterService, PingRequest};
-use quickwit_proto::ingest::{ClosedShards, IngestV2Error, ShardState};
+use quickwit_proto::ingest::{IngestV2Error, ShardIds, ShardState};
 use quickwit_proto::metastore;
 use quickwit_proto::metastore::{MetastoreService, MetastoreServiceClient};
 use quickwit_proto::types::{IndexUid, NodeId};
@@ -172,11 +172,7 @@ impl IngestController {
         None
     }
 
-    fn handle_closed_shards(
-        &self,
-        closed_shards: Vec<ClosedShards>,
-        model: &mut ControlPlaneModel,
-    ) {
+    fn handle_closed_shards(&self, closed_shards: Vec<ShardIds>, model: &mut ControlPlaneModel) {
         for closed_shard in closed_shards {
             let index_uid: IndexUid = closed_shard.index_uid.into();
             let source_id = closed_shard.source_id;
@@ -764,7 +760,7 @@ mod tests {
 
         let request = GetOrCreateOpenShardsRequest {
             subrequests: Vec::new(),
-            closed_shards: vec![ClosedShards {
+            closed_shards: vec![ShardIds {
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
                 shard_ids: vec![1, 2],

--- a/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
+++ b/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
@@ -42,7 +42,7 @@ pub struct IngestResponse {
     #[prost(uint64, tag = "1")]
     pub num_docs_for_processing: u64,
 }
-/// Fetch messages that have position strictly after `start_after`.
+/// Fetch messages with position strictly after `start_after`.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -513,7 +513,9 @@ mod tests {
 
     use bytes::Bytes;
     use mrecordlog::MultiRecordLog;
-    use quickwit_proto::ingest::ingester::IngesterServiceClient;
+    use quickwit_proto::ingest::ingester::{
+        IngesterServiceClient, IngesterStatus, ObservationMessage,
+    };
     use quickwit_proto::types::queue_id;
     use tokio::time::timeout;
 
@@ -534,14 +536,17 @@ mod tests {
             shard_id: 1,
             from_position_exclusive: None,
         };
-        let (new_records_tx, new_records_rx) = watch::channel(());
+        let (observation_tx, _observation_rx) = watch::channel(Ok(ObservationMessage::default()));
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
             rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
+            status: IngesterStatus::Ready,
+            observation_tx,
         }));
+        let (new_records_tx, new_records_rx) = watch::channel(());
         let (mut fetch_stream, fetch_task_handle) = FetchStreamTask::spawn(
             open_fetch_stream_request,
             state.clone(),
@@ -700,14 +705,17 @@ mod tests {
             shard_id: 1,
             from_position_exclusive: Some(Position::from(0u64)),
         };
-        let (new_records_tx, new_records_rx) = watch::channel(());
+        let (observation_tx, _observation_rx) = watch::channel(Ok(ObservationMessage::default()));
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
             rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
+            status: IngesterStatus::Ready,
+            observation_tx,
         }));
+        let (new_records_tx, new_records_rx) = watch::channel(());
         let (mut fetch_stream, _fetch_task_handle) = FetchStreamTask::spawn(
             open_fetch_stream_request,
             state.clone(),
@@ -800,14 +808,17 @@ mod tests {
             shard_id: 1,
             from_position_exclusive: None,
         };
-        let (_new_records_tx, new_records_rx) = watch::channel(());
+        let (observation_tx, _observation_rx) = watch::channel(Ok(ObservationMessage::default()));
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
             rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
+            status: IngesterStatus::Ready,
+            observation_tx,
         }));
+        let (_new_records_tx, new_records_rx) = watch::channel(());
         let (mut fetch_stream, fetch_task_handle) = FetchStreamTask::spawn(
             open_fetch_stream_request,
             state.clone(),
@@ -838,12 +849,15 @@ mod tests {
             shard_id: 1,
             from_position_exclusive: None,
         };
+        let (observation_tx, _observation_rx) = watch::channel(Ok(ObservationMessage::default()));
         let state = Arc::new(RwLock::new(IngesterState {
             mrecordlog,
             shards: HashMap::new(),
             rate_limiters: HashMap::new(),
             replication_streams: HashMap::new(),
             replication_tasks: HashMap::new(),
+            status: IngesterStatus::Ready,
+            observation_tx,
         }));
         let (new_records_tx, new_records_rx) = watch::channel(());
         let (mut fetch_stream, _fetch_task_handle) =

--- a/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
@@ -37,7 +37,7 @@ use quickwit_proto::ingest::DocBatchV2;
 use quickwit_proto::types::NodeId;
 
 pub use self::fetch::{FetchStreamError, MultiFetchStream};
-pub use self::ingester::Ingester;
+pub use self::ingester::{wait_for_ingester_decommission, Ingester};
 use self::mrecord::MRECORD_HEADER_LEN;
 pub use self::mrecord::{decoded_mrecords, MRecord};
 pub use self::rate_limiter::RateLimiterSettings;

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -17,179 +17,96 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::fmt;
-
 use quickwit_proto::ingest::ShardState;
 use quickwit_proto::types::{NodeId, Position};
 use tokio::sync::watch;
 
-/// Shard hosted on a leader node and replicated on a follower node.
-pub(super) struct PrimaryShard {
-    pub follower_id: NodeId,
-    pub shard_state: ShardState,
-    /// Position of the last record written in the shard's mrecordlog queue.
-    pub replication_position_inclusive: Position,
-    pub new_records_tx: watch::Sender<()>,
-    pub new_records_rx: watch::Receiver<()>,
-}
-
-impl fmt::Debug for PrimaryShard {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("PrimaryShard")
-            .field("follower_id", &self.follower_id)
-            .field("shard_state", &self.shard_state)
-            .finish()
-    }
-}
-
-impl PrimaryShard {
-    pub fn new(follower_id: NodeId) -> Self {
-        let (new_records_tx, new_records_rx) = watch::channel(());
-        Self {
-            follower_id,
-            shard_state: ShardState::Open,
-            replication_position_inclusive: Position::Beginning,
-            new_records_tx,
-            new_records_rx,
-        }
-    }
-}
-
-/// Shard hosted on a follower node and replicated from a leader node.
-pub(super) struct ReplicaShard {
-    pub leader_id: NodeId,
-    pub shard_state: ShardState,
-    /// Position of the last record written in the shard's mrecordlog queue.
-    pub replication_position_inclusive: Position,
-    pub new_records_tx: watch::Sender<()>,
-    pub new_records_rx: watch::Receiver<()>,
-}
-
-impl fmt::Debug for ReplicaShard {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("ReplicaShard")
-            .field("leader_id", &self.leader_id)
-            .field("shard_state", &self.shard_state)
-            .finish()
-    }
-}
-
-impl ReplicaShard {
-    pub fn new(leader_id: NodeId) -> Self {
-        let (new_records_tx, new_records_rx) = watch::channel(());
-        Self {
-            leader_id,
-            shard_state: ShardState::Open,
-            replication_position_inclusive: Position::Beginning,
-            new_records_tx,
-            new_records_rx,
-        }
-    }
-}
-
-/// A shard hosted on a single node when the replication factor is set to 1. When a shard is
-/// recovered after a node failure, it is always recreated as a solo shard in closed state.
-pub(super) struct SoloShard {
-    pub shard_state: ShardState,
-    /// Position of the last record written in the shard's mrecordlog queue.
-    pub replication_position_inclusive: Position,
-    pub new_records_tx: watch::Sender<()>,
-    pub new_records_rx: watch::Receiver<()>,
-}
-
-impl fmt::Debug for SoloShard {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("SoloShard")
-            .field("shard_state", &self.shard_state)
-            .finish()
-    }
-}
-
-impl SoloShard {
-    pub fn new(shard_state: ShardState, replication_position_inclusive: Position) -> Self {
-        let (new_records_tx, new_records_rx) = watch::channel(());
-        Self {
-            shard_state,
-            replication_position_inclusive,
-            new_records_tx,
-            new_records_rx,
-        }
-    }
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(super) enum IngesterShardType {
+    /// A primary shard hosted on a leader and replicated on a follower.
+    Primary { follower_id: NodeId },
+    /// A replica shard hosted on a follower.
+    Replica { leader_id: NodeId },
+    /// A shard hosted on a single node when the replication factor is set to 1.
+    Solo,
 }
 
 #[derive(Debug)]
-pub(super) enum IngesterShard {
-    /// A primary shard hosted on a leader and replicated on a follower.
-    Primary(PrimaryShard),
-    /// A replica shard hosted on a follower.
-    Replica(ReplicaShard),
-    /// A shard hosted on a single node when the replication factor is set to 1.
-    Solo(SoloShard),
+pub(super) struct IngesterShard {
+    pub shard_type: IngesterShardType,
+    pub shard_state: ShardState,
+    /// Position of the last record written in the shard's mrecordlog queue.
+    pub replication_position_inclusive: Position,
+    /// Position up to which the shard has been truncated.
+    pub truncation_position_inclusive: Position,
+    pub new_records_tx: watch::Sender<()>,
+    pub new_records_rx: watch::Receiver<()>,
 }
 
 impl IngesterShard {
-    pub fn is_closed(&self) -> bool {
-        match self {
-            IngesterShard::Primary(primary_shard) => &primary_shard.shard_state,
-            IngesterShard::Replica(replica_shard) => &replica_shard.shard_state,
-            IngesterShard::Solo(solo_shard) => &solo_shard.shard_state,
+    pub fn new_primary(
+        follower_id: NodeId,
+        shard_state: ShardState,
+        replication_position_inclusive: Position,
+        truncation_position_inclusive: Position,
+    ) -> Self {
+        let (new_records_tx, new_records_rx) = watch::channel(());
+        Self {
+            shard_type: IngesterShardType::Primary { follower_id },
+            shard_state,
+            replication_position_inclusive,
+            truncation_position_inclusive,
+            new_records_tx,
+            new_records_rx,
         }
-        .is_closed()
     }
 
-    pub fn close(&mut self) {
-        let shard_state = match self {
-            IngesterShard::Primary(primary_shard) => &mut primary_shard.shard_state,
-            IngesterShard::Replica(replica_shard) => &mut replica_shard.shard_state,
-            IngesterShard::Solo(solo_shard) => &mut solo_shard.shard_state,
-        };
-        *shard_state = ShardState::Closed;
+    pub fn new_replica(
+        leader_id: NodeId,
+        shard_state: ShardState,
+        replication_position_inclusive: Position,
+        truncation_position_inclusive: Position,
+    ) -> Self {
+        let (new_records_tx, new_records_rx) = watch::channel(());
+        Self {
+            shard_type: IngesterShardType::Replica { leader_id },
+            shard_state,
+            replication_position_inclusive,
+            truncation_position_inclusive,
+            new_records_tx,
+            new_records_rx,
+        }
     }
 
-    pub fn replication_position_inclusive(&self) -> Position {
-        match self {
-            IngesterShard::Primary(primary_shard) => &primary_shard.replication_position_inclusive,
-            IngesterShard::Replica(replica_shard) => &replica_shard.replication_position_inclusive,
-            IngesterShard::Solo(solo_shard) => &solo_shard.replication_position_inclusive,
+    pub fn new_solo(
+        shard_state: ShardState,
+        replication_position_inclusive: Position,
+        truncation_position_inclusive: Position,
+    ) -> Self {
+        let (new_records_tx, new_records_rx) = watch::channel(());
+        Self {
+            shard_type: IngesterShardType::Solo,
+            shard_state,
+            replication_position_inclusive,
+            truncation_position_inclusive,
+            new_records_tx,
+            new_records_rx,
         }
-        .clone()
+    }
+
+    pub fn notify_new_records(&mut self) {
+        // `new_records_tx` is guaranteed to be open because `self` also holds a receiver.
+        self.new_records_tx
+            .send(())
+            .expect("channel should be open");
     }
 
     pub fn set_replication_position_inclusive(&mut self, replication_position_inclusive: Position) {
-        if self.replication_position_inclusive() == replication_position_inclusive {
+        if self.replication_position_inclusive == replication_position_inclusive {
             return;
         }
-        match self {
-            IngesterShard::Primary(primary_shard) => {
-                primary_shard.replication_position_inclusive = replication_position_inclusive;
-            }
-            IngesterShard::Replica(replica_shard) => {
-                replica_shard.replication_position_inclusive = replication_position_inclusive;
-            }
-            IngesterShard::Solo(solo_shard) => {
-                solo_shard.replication_position_inclusive = replication_position_inclusive;
-            }
-        };
+        self.replication_position_inclusive = replication_position_inclusive;
         self.notify_new_records();
-    }
-
-    pub fn new_records_rx(&self) -> watch::Receiver<()> {
-        match self {
-            IngesterShard::Primary(primary_shard) => &primary_shard.new_records_rx,
-            IngesterShard::Replica(replica_shard) => &replica_shard.new_records_rx,
-            IngesterShard::Solo(solo_shard) => &solo_shard.new_records_rx,
-        }
-        .clone()
-    }
-
-    pub fn notify_new_records(&self) {
-        match self {
-            IngesterShard::Primary(primary_shard) => &primary_shard.new_records_tx,
-            IngesterShard::Replica(replica_shard) => &replica_shard.new_records_tx,
-            IngesterShard::Solo(solo_shard) => &solo_shard.new_records_tx,
-        }
-        .send(())
-        .expect("channel should be open");
     }
 }
 
@@ -197,10 +114,100 @@ impl IngesterShard {
 mod tests {
     use super::*;
 
+    impl IngesterShard {
+        #[track_caller]
+        pub fn assert_is_solo(&self) {
+            assert!(matches!(self.shard_type, IngesterShardType::Solo { .. }))
+        }
+
+        #[track_caller]
+        pub fn assert_is_primary(&self) {
+            assert!(matches!(self.shard_type, IngesterShardType::Primary { .. }))
+        }
+
+        #[track_caller]
+        pub fn assert_is_replica(&self) {
+            assert!(matches!(self.shard_type, IngesterShardType::Replica { .. }))
+        }
+
+        #[track_caller]
+        pub fn assert_is_open(&self) {
+            assert!(self.shard_state.is_open())
+        }
+
+        #[track_caller]
+        pub fn assert_is_closed(&self) {
+            assert!(self.shard_state.is_closed())
+        }
+
+        #[track_caller]
+        pub fn assert_replication_position(
+            &self,
+            expected_replication_position: impl Into<Position>,
+        ) {
+            let expected_replication_position = expected_replication_position.into();
+
+            assert_eq!(
+                self.replication_position_inclusive, expected_replication_position,
+                "expected replication position at `{:?}`, got `{:?}`",
+                expected_replication_position, self.replication_position_inclusive
+            );
+        }
+
+        #[track_caller]
+        pub fn assert_truncation_position(
+            &self,
+            expected_truncation_position: impl Into<Position>,
+        ) {
+            let expected_truncation_position = expected_truncation_position.into();
+
+            assert_eq!(
+                self.truncation_position_inclusive, expected_truncation_position,
+                "expected truncation position at `{:?}`, got `{:?}`",
+                expected_truncation_position, self.truncation_position_inclusive
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_primary_shard() {
+        let primary_shard = IngesterShard::new_primary(
+            "test-follower".into(),
+            ShardState::Closed,
+            Position::from(42u64),
+            Position::Eof,
+        );
+        assert!(matches!(
+            primary_shard.shard_type,
+            IngesterShardType::Primary { .. }
+        ));
+        assert_eq!(primary_shard.shard_state, ShardState::Closed);
+        assert_eq!(primary_shard.truncation_position_inclusive, Position::Eof);
+        assert_eq!(
+            primary_shard.replication_position_inclusive,
+            Position::from(42u64)
+        );
+    }
+
+    #[test]
+    fn test_new_replica_shard() {
+        let solo_shard = IngesterShard::new_solo(ShardState::Closed, 42u64.into(), Position::Eof);
+        assert_eq!(solo_shard.shard_type, IngesterShardType::Solo);
+        assert_eq!(solo_shard.shard_state, ShardState::Closed);
+        assert_eq!(solo_shard.truncation_position_inclusive, Position::Eof);
+        assert_eq!(
+            solo_shard.replication_position_inclusive,
+            Position::from(42u64)
+        );
+    }
+
     #[test]
     fn test_new_solo_shard() {
-        let solo_shard = SoloShard::new(ShardState::Closed, Position::from(42u64));
+        let solo_shard =
+            IngesterShard::new_solo(ShardState::Closed, Position::from(42u64), Position::Eof);
+        assert_eq!(solo_shard.shard_type, IngesterShardType::Solo);
         assert_eq!(solo_shard.shard_state, ShardState::Closed);
+        assert_eq!(solo_shard.truncation_position_inclusive, Position::Eof);
         assert_eq!(
             solo_shard.replication_position_inclusive,
             Position::from(42u64)

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -35,7 +35,7 @@ use quickwit_proto::ingest::ingester::{
 use quickwit_proto::ingest::router::{
     IngestRequestV2, IngestResponseV2, IngestRouterService, IngestSubrequest,
 };
-use quickwit_proto::ingest::{ClosedShards, CommitTypeV2, IngestV2Error, IngestV2Result};
+use quickwit_proto::ingest::{CommitTypeV2, IngestV2Error, IngestV2Result, ShardIds};
 use quickwit_proto::types::{IndexUid, NodeId, ShardId, SourceId, SubrequestId};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
@@ -114,7 +114,7 @@ impl IngestRouter {
 
         // `closed_shards` and `unavailable_leaders` are populated by calls to `has_open_shards`
         // as we're looking for open shards to route the subrequests to.
-        let mut closed_shards: Vec<ClosedShards> = Vec::new();
+        let mut closed_shards: Vec<ShardIds> = Vec::new();
         let mut unavailable_leaders: HashSet<NodeId> = HashSet::new();
 
         for subrequest in subrequests {
@@ -135,13 +135,13 @@ impl IngestRouter {
         }
         if !closed_shards.is_empty() {
             info!(
-                "reporting {} closed shard(s) to control-plane",
+                "reporting {} closed shard(s) to control plane",
                 closed_shards.len()
             )
         }
         if !unavailable_leaders.is_empty() {
             info!(
-                "reporting {} unavailable leader(s) to control-plane",
+                "reporting {} unavailable leader(s) to control plane",
                 unavailable_leaders.len()
             );
         }
@@ -487,7 +487,7 @@ mod tests {
         assert_eq!(get_or_create_open_shard_request.closed_shards.len(), 1);
         assert_eq!(
             get_or_create_open_shard_request.closed_shards[0],
-            ClosedShards {
+            ShardIds {
                 index_uid: "test-index-0:0".into(),
                 source_id: "test-source".to_string(),
                 shard_ids: vec![1],

--- a/quickwit/quickwit-ingest/src/ingest_v2/shard_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/shard_table.rs
@@ -20,7 +20,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use quickwit_proto::ingest::{ClosedShards, Shard, ShardState};
+use quickwit_proto::ingest::{Shard, ShardIds, ShardState};
 use quickwit_proto::types::{IndexId, IndexUid, NodeId, ShardId, SourceId};
 use tracing::warn;
 
@@ -184,7 +184,7 @@ impl ShardTable {
         &self,
         index_id: impl Into<IndexId>,
         source_id: impl Into<SourceId>,
-        closed_shards: &mut Vec<ClosedShards>,
+        closed_shards: &mut Vec<ShardIds>,
         ingester_pool: &IngesterPool,
         unavailable_leaders: &mut HashSet<NodeId>,
     ) -> bool {
@@ -195,7 +195,7 @@ impl ShardTable {
                 entry.has_open_shards(&mut closed_shard_ids, ingester_pool, unavailable_leaders);
 
             if !closed_shard_ids.is_empty() {
-                closed_shards.push(ClosedShards {
+                closed_shards.push(ShardIds {
                     index_uid: entry.index_uid.clone().into(),
                     source_id: entry.source_id.clone(),
                     shard_ids: closed_shard_ids,

--- a/quickwit/quickwit-ingest/src/ingest_v2/test_utils.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/test_utils.rs
@@ -20,63 +20,6 @@
 use std::ops::RangeBounds;
 
 use mrecordlog::MultiRecordLog;
-use quickwit_proto::types::Position;
-
-use super::models::IngesterShard;
-
-pub(super) trait IngesterShardTestExt {
-    fn assert_is_solo(&self);
-
-    fn assert_is_primary(&self);
-
-    fn assert_is_replica(&self);
-
-    fn assert_is_open(&self);
-
-    fn assert_is_closed(&self);
-
-    fn assert_replication_position(&self, expected_replication_position: impl Into<Position>);
-}
-
-impl IngesterShardTestExt for IngesterShard {
-    #[track_caller]
-    fn assert_is_solo(&self) {
-        assert!(matches!(self, IngesterShard::Solo(_)))
-    }
-
-    #[track_caller]
-    fn assert_is_primary(&self) {
-        assert!(matches!(self, IngesterShard::Primary(_)))
-    }
-
-    #[track_caller]
-    fn assert_is_replica(&self) {
-        assert!(matches!(self, IngesterShard::Replica(_)))
-    }
-
-    #[track_caller]
-    fn assert_is_open(&self) {
-        assert!(!self.is_closed())
-    }
-
-    #[track_caller]
-    fn assert_is_closed(&self) {
-        assert!(self.is_closed())
-    }
-
-    #[track_caller]
-    fn assert_replication_position(&self, expected_replication_position: impl Into<Position>) {
-        let expected_replication_position = expected_replication_position.into();
-
-        assert_eq!(
-            self.replication_position_inclusive(),
-            expected_replication_position,
-            "expected replication position at `{:?}`, got `{:?}`",
-            expected_replication_position,
-            self.replication_position_inclusive()
-        );
-    }
-}
 
 pub(super) trait MultiRecordLogTestExt {
     fn assert_records_eq<R>(&self, queue_id: &str, range: R, expected_records: &[(u64, &str)])

--- a/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
@@ -65,7 +65,7 @@ service ControlPlaneService {
 
 message GetOrCreateOpenShardsRequest {
   repeated GetOrCreateOpenShardsSubrequest subrequests = 1;
-  repeated quickwit.ingest.ClosedShards closed_shards = 2;
+  repeated quickwit.ingest.ShardIds closed_shards = 2;
   repeated string unavailable_leaders = 3;
 }
 

--- a/quickwit/quickwit-proto/protos/quickwit/ingest.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingest.proto
@@ -79,7 +79,8 @@ message Shard {
   optional string publish_token = 10;
 }
 
-message ClosedShards {
+// A group of shards belonging to the same index and source.
+message ShardIds {
   string index_uid = 1;
   string source_id = 2;
   repeated uint64 shard_ids = 3;

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -24,24 +24,32 @@ package quickwit.ingest.ingester;
 import "quickwit/ingest.proto";
 
 service IngesterService {
-  // Persists batches of documents to primary shards owned by a leader.
+  // Persists batches of documents to primary shards hosted on a leader.
   rpc Persist(PersistRequest) returns (PersistResponse);
 
   // Opens a replication stream from a leader to a follower.
   rpc OpenReplicationStream(stream SynReplicationMessage) returns (stream AckReplicationMessage);
 
-  // Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch.
+  // Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch,
+  // otherwise the stream will go undefinitely or until the shard is closed.
   rpc OpenFetchStream(OpenFetchStreamRequest) returns (stream FetchResponseV2);
 
-  // rpc OpenWatchStream(OpenWatchStreamRequest) returns (stream WatchMessage);
+  // Streams status updates, called "observations", from an ingester.
+  rpc OpenObservationStream(OpenObservationStreamRequest) returns (stream ObservationMessage);
 
+  // Truncates a set of shards at the given positions. This RPC is called by indexers on leaders AND followers.
+  rpc TruncateShards(TruncateShardsRequest) returns (TruncateShardsResponse);
+
+  // Closes a set of shards. This RPC is called by the control plane.
   rpc CloseShards(CloseShardsRequest) returns (CloseShardsResponse);
 
   // Pings an ingester to check if it is ready to host shards and serve requests.
   rpc Ping(PingRequest) returns (PingResponse);
 
-  // Truncates the shards at the given positions. Indexers should call this RPC on leaders, which will replicate the request to followers.
-  rpc Truncate(TruncateRequest) returns (TruncateResponse);
+
+  // Decommissions the ingester.
+  rpc Decommission(DecommissionRequest) returns (DecommissionResponse);
+
 }
 
 message PersistRequest {
@@ -160,19 +168,19 @@ message ReplicateFailure {
   ReplicateFailureReason reason = 5;
 }
 
-message TruncateRequest {
+message TruncateShardsRequest {
   string ingester_id = 1;
-  repeated TruncateSubrequest subrequests = 2;
+  repeated TruncateShardsSubrequest subrequests = 2;
 }
 
-message TruncateSubrequest {
+message TruncateShardsSubrequest {
   string index_uid = 1;
   string source_id = 2;
   uint64 shard_id = 3;
   quickwit.ingest.Position to_position_inclusive = 4;
 }
 
-message TruncateResponse {
+message TruncateShardsResponse {
   // TODO
 }
 
@@ -194,7 +202,7 @@ message FetchResponseV2 {
 }
 
 message CloseShardsRequest {
-  repeated quickwit.ingest.ClosedShards closed_shards = 1;
+  repeated quickwit.ingest.ShardIds shards = 1;
 }
 
 message CloseShardsResponse {
@@ -206,4 +214,31 @@ message PingRequest {
 }
 
 message PingResponse {
+}
+
+message DecommissionRequest {
+}
+
+message DecommissionResponse {
+}
+
+message OpenObservationStreamRequest {
+}
+
+enum IngesterStatus {
+  INGESTER_STATUS_UNSPECIFIED = 0;
+  // The ingester is ready and accepts read and write requests.
+  INGESTER_STATUS_READY = 1;
+  // The ingester is being decommissioned. It accepts read requests but rejects write requests
+  // (open shards, persist, and replicate requests). It will transition to `Decommissioned` once
+  // all shards are fully indexed.
+  INGESTER_STATUS_DECOMMISSIONING = 2;
+  // The ingester no longer accepts read and write requests. It does not hold any data and can
+  // be safely removed from the cluster.
+  INGESTER_STATUS_DECOMMISSIONED = 3;
+}
+
+message ObservationMessage {
+  string node_id = 1;
+  IngesterStatus Status = 2;
 }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
@@ -5,7 +5,7 @@ pub struct GetOrCreateOpenShardsRequest {
     #[prost(message, repeated, tag = "1")]
     pub subrequests: ::prost::alloc::vec::Vec<GetOrCreateOpenShardsSubrequest>,
     #[prost(message, repeated, tag = "2")]
-    pub closed_shards: ::prost::alloc::vec::Vec<super::ingest::ClosedShards>,
+    pub closed_shards: ::prost::alloc::vec::Vec<super::ingest::ShardIds>,
     #[prost(string, repeated, tag = "3")]
     pub unavailable_leaders: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
@@ -51,10 +51,11 @@ pub struct Shard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub publish_token: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// A group of shards belonging to the same index and source.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ClosedShards {
+pub struct ShardIds {
     #[prost(string, tag = "1")]
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]

--- a/quickwit/quickwit-proto/src/ingest/ingester.rs
+++ b/quickwit/quickwit-proto/src/ingest/ingester.rs
@@ -140,7 +140,7 @@ impl ReplicateSuccess {
     }
 }
 
-impl TruncateSubrequest {
+impl TruncateShardsSubrequest {
     pub fn queue_id(&self) -> QueueId {
         queue_id(&self.index_uid, &self.source_id, self.shard_id)
     }

--- a/quickwit/quickwit-proto/src/ingest/mod.rs
+++ b/quickwit/quickwit-proto/src/ingest/mod.rs
@@ -193,7 +193,7 @@ impl ShardState {
     }
 }
 
-impl ClosedShards {
+impl ShardIds {
     pub fn queue_ids(&self) -> impl Iterator<Item = QueueId> + '_ {
         self.shard_ids
             .iter()


### PR DESCRIPTION
### Description
Add a `Decommission` RPC to ingesters. By default, ingesters are in `Ready` status. Upon receiving a decommissioning request, ingesters change their status to `Decommissioning`, close all their shards, become read-only and wait for them to be indexed by monitoring calls to `truncate`. When the indexing of all the shards is completed, ingesters transition to the `Decommissioned` status at which point they become safe to shut down.

I also added a `OpenObservationStream` RPC to ingesters, so we can track the status of the decommissioning process. In the future, we can enrich the `ObservationMessage` object to track more things.

### How was this PR tested?
- Updated unit tests
- Add unit tests
- Tested manually