### PR TITLE
Stop building Azure storage as part of `testsuite` feature

### DIFF
--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -71,9 +71,11 @@ azure = [
   "azure_storage_blobs/enable_reqwest_rustls",
 ]
 ci-test = []
-testsuite = [
+integration-testsuite = [
   "azure",
   "azure_core/azurite_workaround",
   "azure_storage_blobs/azurite_workaround",
+]
+testsuite = [
   "mockall",
 ]

--- a/quickwit/quickwit-storage/src/lib.rs
+++ b/quickwit/quickwit-storage/src/lib.rs
@@ -79,7 +79,7 @@ pub use self::storage::MockStorage;
 pub use self::storage_factory::MockStorageFactory;
 pub use self::storage_factory::{StorageFactory, UnsupportedStorage};
 pub use self::storage_resolver::StorageResolver;
-#[cfg(feature = "testsuite")]
+#[cfg(feature = "integration-testsuite")]
 pub use self::test_suite::{
     storage_test_multi_part_upload, storage_test_single_part_upload, storage_test_suite,
     test_write_and_bulk_delete,
@@ -105,7 +105,7 @@ pub async fn load_file(
     Ok(bytes)
 }
 
-#[cfg(any(test, feature = "testsuite"))]
+#[cfg(any(test, feature = "testsuite", feature = "integration-testsuite"))]
 mod for_test {
     use std::sync::Arc;
 
@@ -117,7 +117,7 @@ mod for_test {
     }
 }
 
-#[cfg(any(test, feature = "testsuite"))]
+#[cfg(any(test, feature = "testsuite", feature = "integration-testsuite"))]
 pub use for_test::storage_for_test;
 
 #[cfg(test)]
@@ -143,7 +143,7 @@ mod tests {
     }
 }
 
-#[cfg(any(test, feature = "testsuite"))]
+#[cfg(any(test, feature = "integration-testsuite"))]
 pub(crate) mod test_suite {
 
     use std::path::Path;
@@ -335,7 +335,7 @@ pub(crate) mod test_suite {
     }
 
     /// Generic single-part upload test.
-    #[cfg(feature = "testsuite")]
+    #[cfg(feature = "integration-testsuite")]
     pub async fn storage_test_single_part_upload(storage: &mut dyn Storage) -> anyhow::Result<()> {
         use std::ops::Range;
 
@@ -364,7 +364,7 @@ pub(crate) mod test_suite {
     }
 
     /// Generic multi-part upload test.
-    #[cfg(feature = "testsuite")]
+    #[cfg(feature = "integration-testsuite")]
     pub async fn storage_test_multi_part_upload(storage: &mut dyn Storage) -> anyhow::Result<()> {
         let test_path = Path::new("hello_large.txt");
         let test_buffer = vec![0u8; 15_000_000];

--- a/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
@@ -129,7 +129,7 @@ impl AzureBlobStorage {
     }
 
     /// Creates an emulated storage for testing.
-    #[cfg(feature = "testsuite")]
+    #[cfg(feature = "integration-testsuite")]
     pub fn new_emulated(container: &str) -> Self {
         use std::str::FromStr;
 

--- a/quickwit/quickwit-storage/tests/azure_storage.rs
+++ b/quickwit/quickwit-storage/tests/azure_storage.rs
@@ -21,10 +21,10 @@
 // to Azurite (the emulated azure blob storage environment)
 // with default `loose` config is possible.
 
-#[cfg(feature = "testsuite")]
+#[cfg(feature = "integration-testsuite")]
 #[tokio::test]
 #[cfg_attr(not(feature = "ci-test"), ignore)]
-async fn test_suite_on_azure_storage() -> anyhow::Result<()> {
+async fn azure_storage_test_suite() -> anyhow::Result<()> {
     use std::path::PathBuf;
 
     use anyhow::Context;

--- a/quickwit/quickwit-storage/tests/s3_storage.rs
+++ b/quickwit/quickwit-storage/tests/s3_storage.rs
@@ -18,123 +18,136 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 // This file is an integration test that assumes that the environment
-// makes it possible to connect to Amazon S3's quickwit-integration-test bucket.
+// makes it po
 
-use std::path::PathBuf;
-use std::str::FromStr;
+#[cfg(feature = "integration-testsuite")]
+pub mod s3_storage_test_suite {
 
-use anyhow::Context;
-use once_cell::sync::OnceCell;
-use quickwit_common::rand::append_random_suffix;
-use quickwit_common::setup_logging_for_tests;
-use quickwit_common::uri::Uri;
-use quickwit_config::S3StorageConfig;
-use quickwit_storage::{MultiPartPolicy, S3CompatibleObjectStorage};
-use tokio::runtime::Runtime;
+    use std::path::PathBuf;
+    use std::str::FromStr;
 
-// Introducing a common runtime for the unit tests in this file.
-//
-// By default, tokio creates a new runtime, for each unit test.
-// Here, we want to use the singleton `AwsSdkConfig` object.
-// This object packs a smithy connector which itself includes a
-// hyper client pool. A hyper client cannot be used from multiple runtimes.
-fn test_runtime_singleton() -> &'static Runtime {
-    static RUNTIME_CACHE: OnceCell<tokio::runtime::Runtime> = OnceCell::new();
-    RUNTIME_CACHE.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .enable_all()
-            .build()
-            .unwrap()
-    })
-}
+    use anyhow::Context;
+    use once_cell::sync::OnceCell;
+    use quickwit_common::setup_logging_for_tests;
+    use quickwit_common::uri::Uri;
+    use quickwit_config::S3StorageConfig;
+    use quickwit_storage::{MultiPartPolicy, S3CompatibleObjectStorage};
+    use tokio::runtime::Runtime;
 
-#[cfg(feature = "testsuite")]
-async fn run_s3_storage_test_suite(s3_storage_config: S3StorageConfig, bucket_uri: &str) {
-    setup_logging_for_tests();
+    // Introducing a common runtime for the unit tests in this file.
+    //
+    // By default, tokio creates a new runtime, for each unit test.
+    // Here, we want to use the singleton `AwsSdkConfig` object.
+    // This object packs a smithy connector which itself includes a
+    // hyper client pool. A hyper client cannot be used from multiple runtimes.
+    fn test_runtime_singleton() -> &'static Runtime {
+        static RUNTIME_CACHE: OnceCell<tokio::runtime::Runtime> = OnceCell::new();
+        RUNTIME_CACHE.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .unwrap()
+        })
+    }
 
-    let storage_uri = Uri::from_str(bucket_uri).unwrap();
-    let mut object_storage = S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri)
-        .await
-        .unwrap();
+    async fn run_s3_storage_test_suite(s3_storage_config: S3StorageConfig, bucket_uri: &str) {
+        setup_logging_for_tests();
 
-    quickwit_storage::storage_test_suite(&mut object_storage)
-        .await
-        .context("S3 storage test suite failed")
-        .unwrap();
-
-    let mut object_storage = S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri)
-        .await
-        .unwrap()
-        .with_prefix(PathBuf::from("test-s3-compatible-storage"));
-
-    quickwit_storage::storage_test_single_part_upload(&mut object_storage)
-        .await
-        .context("test single-part upload failed")
-        .unwrap();
-
-    object_storage.set_policy(MultiPartPolicy {
-        target_part_num_bytes: 5 * 1_024 * 1_024, //< the minimum on S3 is 5MB.
-        max_num_parts: 10_000,
-        multipart_threshold_num_bytes: 10_000_000,
-        max_object_num_bytes: 5_000_000_000_000,
-        max_concurrent_uploads: 100,
-    });
-
-    quickwit_storage::storage_test_multi_part_upload(&mut object_storage)
-        .await
-        .context("test multipart upload failed")
-        .unwrap();
-}
-
-#[cfg(feature = "testsuite")]
-#[test]
-#[cfg_attr(not(feature = "ci-test"), ignore)]
-fn test_suite_on_s3_storage_path_style_access() {
-    let s3_storage_config = S3StorageConfig {
-        force_path_style_access: true,
-        ..Default::default()
-    };
-    let bucket_uri = append_random_suffix("s3://quickwit-integration-tests/test-path-style-access");
-    let test_runtime = test_runtime_singleton();
-    test_runtime.block_on(run_s3_storage_test_suite(s3_storage_config, &bucket_uri));
-}
-
-#[cfg(feature = "testsuite")]
-#[test]
-#[cfg_attr(not(feature = "ci-test"), ignore)]
-fn test_suite_on_s3_storage_virtual_hosted_style_access() {
-    let s3_storage_config = S3StorageConfig {
-        force_path_style_access: false,
-        ..Default::default()
-    };
-    let bucket_uri =
-        append_random_suffix("s3://quickwit-integration-tests/test-virtual-hosted-style-access");
-    let test_runtime = test_runtime_singleton();
-    test_runtime.block_on(run_s3_storage_test_suite(s3_storage_config, &bucket_uri));
-}
-
-#[cfg(feature = "testsuite")]
-#[test]
-#[cfg_attr(not(feature = "ci-test"), ignore)]
-fn test_suite_on_s3_storage_bulk_delete_single_object_delete_api() {
-    let s3_storage_config = S3StorageConfig {
-        disable_multi_object_delete: true,
-        ..Default::default()
-    };
-    let bucket_uri = append_random_suffix(
-        "s3://quickwit-integration-tests/test-bulk-delete-single-object-delete-api",
-    );
-    let storage_uri = Uri::from_str(&bucket_uri).unwrap();
-    let test_runtime = test_runtime_singleton();
-    test_runtime.block_on(async move {
+        let storage_uri = Uri::from_str(bucket_uri).unwrap();
         let mut object_storage =
             S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri)
                 .await
                 .unwrap();
-        quickwit_storage::test_write_and_bulk_delete(&mut object_storage)
+
+        quickwit_storage::storage_test_suite(&mut object_storage)
             .await
-            .context("test bulk delete single-object delete API failed")
+            .context("S3 storage test suite failed")
             .unwrap();
-    });
+
+        let mut object_storage =
+            S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri)
+                .await
+                .unwrap()
+                .with_prefix(PathBuf::from("test-s3-compatible-storage"));
+
+        quickwit_storage::storage_test_single_part_upload(&mut object_storage)
+            .await
+            .context("test single-part upload failed")
+            .unwrap();
+
+        object_storage.set_policy(MultiPartPolicy {
+            target_part_num_bytes: 5 * 1_024 * 1_024, //< the minimum on S3 is 5MB.
+            max_num_parts: 10_000,
+            multipart_threshold_num_bytes: 10_000_000,
+            max_object_num_bytes: 5_000_000_000_000,
+            max_concurrent_uploads: 100,
+        });
+
+        quickwit_storage::storage_test_multi_part_upload(&mut object_storage)
+            .await
+            .context("test multipart upload failed")
+            .unwrap();
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "ci-test"), ignore)]
+    fn test_suite_on_s3_storage_path_style_access() {
+        use quickwit_common::rand::append_random_suffix;
+
+        let s3_storage_config = S3StorageConfig {
+            force_path_style_access: true,
+            ..Default::default()
+        };
+        let bucket_uri =
+            append_random_suffix("s3://quickwit-integration-tests/test-path-style-access");
+        let test_runtime = test_runtime_singleton();
+        test_runtime.block_on(run_s3_storage_test_suite(s3_storage_config, &bucket_uri));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "ci-test"), ignore)]
+    fn test_suite_on_s3_storage_virtual_hosted_style_access() {
+        use quickwit_common::rand::append_random_suffix;
+
+        let s3_storage_config = S3StorageConfig {
+            force_path_style_access: false,
+            ..Default::default()
+        };
+        let bucket_uri = append_random_suffix(
+            "s3://quickwit-integration-tests/test-virtual-hosted-style-access",
+        );
+        let test_runtime = test_runtime_singleton();
+        test_runtime.block_on(run_s3_storage_test_suite(s3_storage_config, &bucket_uri));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "ci-test"), ignore)]
+    fn test_suite_on_s3_storage_bulk_delete_single_object_delete_api() {
+        use std::str::FromStr;
+
+        use anyhow::Context;
+        use quickwit_common::rand::append_random_suffix;
+        use quickwit_common::uri::Uri;
+
+        let s3_storage_config = S3StorageConfig {
+            disable_multi_object_delete: true,
+            ..Default::default()
+        };
+        let bucket_uri = append_random_suffix(
+            "s3://quickwit-integration-tests/test-bulk-delete-single-object-delete-api",
+        );
+        let storage_uri = Uri::from_str(&bucket_uri).unwrap();
+        let test_runtime = test_runtime_singleton();
+        test_runtime.block_on(async move {
+            let mut object_storage =
+                S3CompatibleObjectStorage::from_uri(&s3_storage_config, &storage_uri)
+                    .await
+                    .unwrap();
+            quickwit_storage::test_write_and_bulk_delete(&mut object_storage)
+                .await
+                .context("test bulk delete single-object delete API failed")
+                .unwrap();
+        });
+    }
 }


### PR DESCRIPTION
I noticed I was building the Azure deps when testing `quickwit-ingest`.