### PR TITLE
Take `multilang` feature out of `quickwit-doc-mapper/testsuite`

### DIFF
--- a/quickwit/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit/quickwit-doc-mapper/Cargo.toml
@@ -43,11 +43,11 @@ serde_yaml = { workspace = true }
 time = { workspace = true }
 
 quickwit-proto = { workspace = true }
-quickwit-query = { workspace = true, features = ["testsuite"] }
+quickwit-query = { workspace = true, features = ["multilang"] }
 
 [features]
 multilang = ["quickwit-query/multilang"]
-testsuite = ["multilang"]
+testsuite = []
 
 [[bench]]
 name = "doc_to_json_bench"

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/tokenizer_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/tokenizer_entry.rs
@@ -18,8 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::Context;
-#[cfg(feature = "multilang")]
-use quickwit_query::MultiLangTokenizer;
 use quickwit_query::{CodeTokenizer, DEFAULT_REMOVE_TOKEN_LENGTH};
 use serde::{Deserialize, Serialize};
 use tantivy::tokenizer::{
@@ -51,9 +49,9 @@ impl TokenizerConfig {
     pub fn text_analyzer(&self) -> anyhow::Result<TextAnalyzer> {
         let mut text_analyzer_builder = match &self.tokenizer_type {
             TokenizerType::Simple => TextAnalyzer::builder(SimpleTokenizer::default()).dynamic(),
-            #[cfg(feature = "multilang")]
+            #[cfg(any(test, feature = "multilang"))]
             TokenizerType::Multilang => {
-                TextAnalyzer::builder(MultiLangTokenizer::default()).dynamic()
+                TextAnalyzer::builder(quickwit_query::MultiLangTokenizer::default()).dynamic()
             }
             TokenizerType::SourceCode => TextAnalyzer::builder(CodeTokenizer::default()).dynamic(),
             TokenizerType::Ngram(options) => {
@@ -127,7 +125,7 @@ impl TokenFilterType {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TokenizerType {
-    #[cfg(feature = "multilang")]
+    #[cfg(any(test, feature = "multilang"))]
     Multilang,
     Ngram(NgramTokenizerOption),
     Regex(RegexTokenizerOption),

--- a/quickwit/quickwit-query/Cargo.toml
+++ b/quickwit/quickwit-query/Cargo.toml
@@ -42,10 +42,6 @@ multilang = [
     "whichlang",
 ]
 
-testsuite = [
-    "multilang",
-]
-
 [[bench]]
 name = "tokenizers_bench"
 harness = false


### PR DESCRIPTION
I noticed `lindera` was compiled as I was testing `quickwit-ingest`.

Tested with:
`cargo test --manifest-path quickwit/Cargo.toml -p quickwit-query`
`cargo test --manifest-path quickwit/Cargo.toml -p quickwit-doc-mapper`
`cargo test --manifest-path quickwit/Cargo.toml -p quickwit-indexing`