### PR TITLE
Fix docs to match linked dataset

### DIFF
--- a/docs/get-started/tutorials/tutorial-hdfs-logs.md
+++ b/docs/get-started/tutorials/tutorial-hdfs-logs.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-In this guide, we will index about 40 million log entries (13 GB decompressed) on a local machine. If you want to start a server with indexes on AWS S3 with several search nodes, check out the [tutorial for distributed search](tutorial-hdfs-logs-distributed-search-aws-s3.md).
+In this guide, we will index about 20 million log entries (7 GB decompressed) on a local machine. If you want to start a server with indexes on AWS S3 with several search nodes, check out the [tutorial for distributed search](tutorial-hdfs-logs-distributed-search-aws-s3.md).
 
 Here is an example of a log entry:
 ```json


### PR DESCRIPTION
### Description

The linked dataset https://quickwit-datasets-public.s3.amazonaws.com/hdfs-logs-multitenants.json.gz is the half of what is specified in the docs.

### How was this PR tested?

Describe how you tested this PR.
