### PR TITLE
Make the ShardPositions model into a ShardPositionsService actor

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -326,6 +326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-write-file"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c232177ba50b16fe7a4588495bd474a62a9e45a8e4ca6fd7d0b7ac29d164631e"
+dependencies = [
+ "nix",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "bytes-utils"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
@@ -1313,18 +1323,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "46ca43acc1b21c6cc2d1d3129c19e323a613935b5bc28fb3b33b5b2e5fb00030"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1607,7 +1617,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -1769,7 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1777,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "data-url"
@@ -2290,9 +2300,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -2309,7 +2319,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
 dependencies = [
- "rustix 0.38.24",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -2490,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -2660,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-token"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcd62eb34e3de2f085bcc33a09c3e17c4f65650f36d53eb328b00d63bcb536a"
+checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
 dependencies = [
  "async-trait",
 ]
@@ -2713,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash 0.8.6",
  "allocator-api2",
@@ -2727,16 +2737,16 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.3"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b38e5c02b7c7be48c8dc5217c4f1634af2ea221caae2e024bffc7a7651c691"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.5",
  "byteorder",
  "flate2",
  "nom",
@@ -3020,9 +3030,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -3046,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -3147,7 +3157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.24",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -3195,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3308,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3606,11 +3616,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
 dependencies = [
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3705,6 +3715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -3871,6 +3890,19 @@ checksum = "d7359c5bee6fe9218ccd4988120a23dc79d291e95486756969112d45efdc97d1"
 dependencies = [
  "lazy_static",
  "regex",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -4467,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -4917,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -6328,7 +6360,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.2",
+ "webpki-roots 0.25.3",
  "winreg",
 ]
 
@@ -6415,9 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
+checksum = "6a3211b01eea83d80687da9eef70e39d65144a3894866a5153a2723e425a157f"
 dependencies = [
  "const-oid",
  "digest",
@@ -6479,9 +6511,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076ba1058b036d3ca8bcafb1d54d0b0572e99d7ecd3e4222723e18ca8e9ca9a8"
+checksum = "06676aec5ccb8fc1da723cc8c0f9a46549f21ebb8753d3915c6c41db1e7f1dc4"
 dependencies = [
  "arrayvec 0.7.4",
  "borsh",
@@ -6530,9 +6562,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.24"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -6693,9 +6725,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3e6bba153bb198646c8762c48414942a38db27d142e44735a133cabddcc820"
+checksum = "3472e143a83f7f03d306dcc62af88c5afdcd7e35f96ef0001a806fe244b3b15a"
 dependencies = [
  "inherent",
  "sea-query-derive",
@@ -6761,9 +6793,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -6780,9 +6812,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7162,9 +7194,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e50c216e3624ec8e7ecd14c6a6a6370aad6ee5d8cfc3ab30b5162eeeef2ed33"
+checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7175,9 +7207,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6753e460c998bbd4cd8c6f0ed9a64346fcca0723d6e75e52fdc351c5d2169d"
+checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
 dependencies = [
  "ahash 0.8.6",
  "atoi",
@@ -7214,14 +7246,14 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.24.0",
+ "webpki-roots 0.25.3",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a793bb3ba331ec8359c1853bd39eed32cdd7baaf22c35ccf5c92a7e8d1189ec"
+checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7232,10 +7264,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4ee1e104e00dedb6aa5ffdd1343107b0a4702e862a84320ee7cc74782d96fc"
+checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
 dependencies = [
+ "atomic-write-file",
  "dotenvy",
  "either",
  "heck",
@@ -7258,9 +7291,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864b869fdf56263f4c95c45483191ea0af340f9f3e3e7b4d57a61c7c87a970db"
+checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
  "base64 0.21.5",
@@ -7301,9 +7334,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7ae0e6a97fb3ba33b23ac2671a5ce6e3cabe003f451abd5a56e7951d975624"
+checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
  "base64 0.21.5",
@@ -7341,9 +7374,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59dc83cf45d89c555a577694534fcd1b55c545a816c816ce51f20bbe56a4f3f"
+checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
 dependencies = [
  "atoi",
  "flume",
@@ -7360,6 +7393,7 @@ dependencies = [
  "time",
  "tracing",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -7675,7 +7709,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall 0.4.1",
- "rustix 0.38.24",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -7965,7 +7999,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -8430,9 +8464,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -8470,9 +8504,9 @@ checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"
@@ -8723,9 +8757,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8733,9 +8767,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -8748,9 +8782,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8760,9 +8794,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8770,9 +8804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8783,9 +8817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-streams"
@@ -8831,18 +8865,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.24.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
-dependencies = [
- "rustls-webpki 0.101.7",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "which"
@@ -8853,7 +8878,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.24",
+ "rustix 0.38.25",
 ]
 
 [[package]]

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -69,7 +69,7 @@ pub struct Cluster {
     cluster_id: String,
     self_chitchat_id: ChitchatId,
     /// Socket address (UDP) the node listens on for receiving gossip messages.
-    gossip_listen_addr: SocketAddr,
+    pub gossip_listen_addr: SocketAddr,
     inner: Arc<RwLock<InnerCluster>>,
 }
 
@@ -379,7 +379,7 @@ impl Cluster {
         Ok(())
     }
 
-    async fn chitchat(&self) -> Arc<Mutex<Chitchat>> {
+    pub async fn chitchat(&self) -> Arc<Mutex<Chitchat>> {
         self.inner.read().await.chitchat_handle.chitchat()
     }
 }

--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -36,8 +36,5 @@ pub const DELETION_GRACE_PERIOD: Duration = Duration::from_secs(60 * 32); // 32 
 /// being requested.
 pub const SCROLL_BATCH_LEN: usize = 1_000;
 
-/// Prefix used in chitchat to broadcast the positions of the shards assigned to an indexer.
-pub const INDEXER_ASSIGNED_SHARDS_POSITIONS_PREFIX: &str = "indexer.assigned_shards_positions:";
-
 /// Prefix used in chitchat to broadcast the list of primary shards hosted by a leader.
 pub const INGESTER_PRIMARY_SHARDS_PREFIX: &str = "ingester.primary_shards:";

--- a/quickwit/quickwit-control-plane/src/control_plane_model.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane_model.rs
@@ -276,7 +276,6 @@ impl ControlPlaneModel {
     }
 
     /// Removes the shards identified by their index UID, source ID, and shard IDs.
-    #[allow(dead_code)] // Will remove this in a future PR.
     pub fn delete_shards(
         &mut self,
         index_uid: &IndexUid,
@@ -511,7 +510,9 @@ impl ShardTable {
         };
         if let Some(table_entry) = self.table_entries.get_mut(&source_uid) {
             for shard_id in shard_ids {
-                table_entry.shards.remove(shard_id);
+                if table_entry.shards.remove(shard_id).is_none() {
+                    warn!(shard = *shard_id, "deleting a non-existing shard");
+                }
             }
         }
     }

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -32,7 +32,7 @@ use quickwit_actors::{
 };
 use quickwit_cluster::Cluster;
 use quickwit_common::fs::get_cache_directory_path;
-use quickwit_common::pubsub::{EventBroker, EventSubscriptionHandle};
+use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir;
 use quickwit_config::{
     build_doc_mapper, IndexConfig, IndexerConfig, SourceConfig, INGEST_API_SOURCE_ID,
@@ -56,10 +56,7 @@ use tracing::{debug, error, info, warn};
 
 use super::merge_pipeline::{MergePipeline, MergePipelineParams};
 use super::MergePlanner;
-use crate::models::{
-    DetachIndexingPipeline, DetachMergePipeline, ObservePipeline, PublishedShardPositions,
-    SpawnPipeline,
-};
+use crate::models::{DetachIndexingPipeline, DetachMergePipeline, ObservePipeline, SpawnPipeline};
 use crate::source::{AssignShards, Assignment};
 use crate::split_store::{LocalSplitStore, SplitStoreQuota};
 use crate::{IndexingPipeline, IndexingPipelineParams, IndexingSplitStore, IndexingStatistics};
@@ -120,7 +117,6 @@ pub struct IndexingService {
     merge_pipeline_handles: HashMap<MergePipelineId, MergePipelineHandle>,
     cooperative_indexing_permits: Option<Arc<Semaphore>>,
     event_broker: EventBroker,
-    _event_subscription_handle: EventSubscriptionHandle,
 }
 
 impl Debug for IndexingService {
@@ -148,8 +144,6 @@ impl IndexingService {
         storage_resolver: StorageResolver,
         event_broker: EventBroker,
     ) -> anyhow::Result<IndexingService> {
-        let published_shard_positions = PublishedShardPositions::new(cluster.clone());
-        let event_subscription_handle = event_broker.subscribe(published_shard_positions);
         let split_store_space_quota = SplitStoreQuota::new(
             indexer_config.split_store_max_num_splits,
             indexer_config.split_store_max_num_bytes,
@@ -165,7 +159,7 @@ impl IndexingService {
         } else {
             None
         };
-        Ok(Self {
+        Ok(IndexingService {
             node_id,
             indexing_root_directory,
             queue_dir_path,
@@ -181,7 +175,6 @@ impl IndexingService {
             merge_pipeline_handles: HashMap::new(),
             cooperative_indexing_permits,
             event_broker,
-            _event_subscription_handle: event_subscription_handle,
         })
     }
 

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -50,7 +50,8 @@ pub use publish_lock::{NewPublishLock, PublishLock};
 pub use publisher_message::SplitsUpdate;
 use quickwit_proto::types::PublishToken;
 pub use raw_doc_batch::RawDocBatch;
-pub use shard_positions::{PublishedShardPositions, PublishedShardPositionsUpdate};
+pub(crate) use shard_positions::LocalShardPositionsUpdate;
+pub use shard_positions::ShardPositionsService;
 pub use split_attrs::{create_split_metadata, SplitAttrs};
 
 #[derive(Debug)]

--- a/quickwit/quickwit-indexing/src/models/shard_positions.rs
+++ b/quickwit/quickwit-indexing/src/models/shard_positions.rs
@@ -18,57 +18,198 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::btree_map::Entry;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 
+use anyhow::Context;
 use async_trait::async_trait;
+use chitchat::ListenerHandle;
 use fnv::FnvHashMap;
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, SpawnContext};
 use quickwit_cluster::Cluster;
-use quickwit_common::pubsub::{Event, EventSubscriber};
-use quickwit_common::shared_consts::INDEXER_ASSIGNED_SHARDS_POSITIONS_PREFIX;
-use quickwit_proto::types::{Position, ShardId, SourceUid};
-use tracing::warn;
+use quickwit_common::pubsub::{Event, EventBroker};
+use quickwit_proto::indexing::ShardPositionsUpdate;
+use quickwit_proto::types::{IndexUid, Position, ShardId, SourceUid};
+use tracing::{error, warn};
 
-#[derive(Debug, Clone)]
-pub struct PublishedShardPositionsUpdate {
-    pub source_uid: SourceUid,
-    pub published_positions_per_shard: Vec<(ShardId, Position)>,
+/// Prefix used in chitchat to publish the shard positions.
+const SHARD_POSITIONS_PREFIX: &str = "indexer.shard_positions:";
+
+/// This event means that a pipeline running in the current node (hence "local")
+/// performed a publish on an ingest pipeline, and hence the position of a shard has been updated.
+///
+/// This event is meant to be built by the `IngestSource`, upon reception of suggest truncate
+/// event. It should only be consumed by the `ShardPositionsService`.
+///
+/// (This is why its member are private).
+///
+/// The new position is to be exposed to the entire cluster via chitchat.
+///
+/// Consumers of such events should listen to the more `ShardPositionsUpdate` event instead.
+/// That event is broadcasted via the cluster event broker, and will include both local
+/// changes and changes from other nodes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocalShardPositionsUpdate {
+    source_uid: SourceUid,
+    // This list can be partial: not all shards for the source need to be listed here.
+    shard_positions: Vec<(ShardId, Position)>,
 }
 
-impl Event for PublishedShardPositionsUpdate {}
+impl LocalShardPositionsUpdate {
+    pub fn new(source_uid: SourceUid, shard_positions: Vec<(ShardId, Position)>) -> Self {
+        LocalShardPositionsUpdate {
+            source_uid,
+            shard_positions,
+        }
+    }
+}
+
+/// This event is an internal detail of the `ShardPositionsService`.
+///
+/// When a shard position change in the cluster is detected, a `ClusterShardPositionUpdate`
+/// message is queued into the `ShardPositionsService`
+#[derive(Debug)]
+struct ClusterShardPositionsUpdate {
+    pub source_uid: SourceUid,
+    // This list can be partial: not all shards for the source need to be listed here.
+    pub shard_positions: Vec<(ShardId, Position)>,
+}
+
+impl Event for LocalShardPositionsUpdate {}
 
 /// The published shard positions is a model unique to the indexer service instance that
 /// keeps track of the latest (known) published position for the shards of all managed sources.
 ///
 /// It receives updates through the event broker, and only keeps the maximum published position
 /// for each shard.
-pub struct PublishedShardPositions {
+pub struct ShardPositionsService {
     shard_positions_per_source: FnvHashMap<SourceUid, BTreeMap<ShardId, Position>>,
-    cluster_client: Cluster,
+    cluster: Cluster,
+    event_broker: EventBroker,
+    cluster_listener_handle_opt: Option<ListenerHandle>,
 }
 
-impl PublishedShardPositions {
-    pub fn new(cluster: Cluster) -> PublishedShardPositions {
-        PublishedShardPositions {
-            shard_positions_per_source: Default::default(),
-            cluster_client: cluster,
-        }
-    }
+fn parse_shard_positions_from_kv(
+    key: &str,
+    value: &str,
+) -> anyhow::Result<ClusterShardPositionsUpdate> {
+    let (index_uid_str, source_id) = key.rsplit_once(':').context("invalid key")?;
+    let index_uid = IndexUid::parse(index_uid_str)?;
+    let source_uid = SourceUid {
+        index_uid,
+        source_id: source_id.to_string(),
+    };
+    let shard_positions_map: HashMap<ShardId, Position> =
+        serde_json::from_str(value).context("failed to parse shard positions json")?;
+    let shard_positions = shard_positions_map.into_iter().collect();
+    Ok(ClusterShardPositionsUpdate {
+        source_uid,
+        shard_positions,
+    })
 }
+
 #[async_trait]
-impl EventSubscriber<PublishedShardPositionsUpdate> for PublishedShardPositions {
-    async fn handle_event(&mut self, update: PublishedShardPositionsUpdate) {
-        let source_uid = update.source_uid.clone();
-        let was_updated = self.apply_update(update);
-        if was_updated {
-            self.published_updated_positions_for_source(source_uid)
-                .await;
+impl Actor for ShardPositionsService {
+    type ObservableState = ();
+    fn observable_state(&self) {}
+
+    async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
+        let mailbox = ctx.mailbox().clone();
+        self.cluster_listener_handle_opt = Some(
+            self.cluster
+                .subscribe(SHARD_POSITIONS_PREFIX, move |key, value| {
+                    let shard_positions= match parse_shard_positions_from_kv(key, value) {
+                        Ok(shard_positions) => {
+                            shard_positions
+                        }
+                        Err(error) => {
+                            error!(key=key, value=value, error=%error, "failed to parse shard positions from cluster kv");
+                            return;
+                        }
+                    };
+                    if mailbox.try_send_message(shard_positions).is_err() {
+                        error!("failed to send shard positions to the shard positions service");
+                    }
+                })
+                .await
+        );
+        Ok(())
+    }
+}
+
+impl ShardPositionsService {
+    pub fn spawn(spawn_ctx: &SpawnContext, event_broker: EventBroker, cluster: Cluster) {
+        let shard_positions_service = ShardPositionsService::new(event_broker.clone(), cluster);
+        let (shard_positions_service_mailbox, _) =
+            spawn_ctx.spawn_builder().spawn(shard_positions_service);
+        event_broker
+            .subscribe::<LocalShardPositionsUpdate>(move |update| {
+                if shard_positions_service_mailbox
+                    .try_send_message(update)
+                    .is_err()
+                {
+                    error!("failed to send update to shard positions service");
+                }
+            })
+            .forever();
+    }
+
+    fn new(event_broker: EventBroker, cluster: Cluster) -> ShardPositionsService {
+        ShardPositionsService {
+            shard_positions_per_source: Default::default(),
+            cluster,
+            event_broker,
+            cluster_listener_handle_opt: None,
         }
     }
 }
 
-impl PublishedShardPositions {
-    async fn published_updated_positions_for_source(&self, source_uid: SourceUid) {
+#[async_trait]
+impl Handler<ClusterShardPositionsUpdate> for ShardPositionsService {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        update: ClusterShardPositionsUpdate,
+        _ctx: &ActorContext<Self>,
+    ) -> Result<Self::Reply, ActorExitStatus> {
+        let ClusterShardPositionsUpdate {
+            source_uid,
+            shard_positions,
+        } = update;
+        let was_updated = self.apply_update(&source_uid, shard_positions);
+        if was_updated {
+            self.publish_shard_updates_to_event_broker(source_uid);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<LocalShardPositionsUpdate> for ShardPositionsService {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        update: LocalShardPositionsUpdate,
+        _ctx: &ActorContext<Self>,
+    ) -> Result<Self::Reply, ActorExitStatus> {
+        let LocalShardPositionsUpdate {
+            source_uid,
+            shard_positions,
+        } = update;
+        let was_updated = self.apply_update(&source_uid, shard_positions);
+        if was_updated {
+            self.publish_positions_into_chitchat(source_uid.clone())
+                .await;
+            self.publish_shard_updates_to_event_broker(source_uid);
+        }
+        Ok(())
+    }
+}
+
+impl ShardPositionsService {
+    async fn publish_positions_into_chitchat(&self, source_uid: SourceUid) {
         let Some(shard_positions) = self.shard_positions_per_source.get(&source_uid) else {
             return;
         };
@@ -76,31 +217,42 @@ impl PublishedShardPositions {
             index_uid,
             source_id,
         } = &source_uid;
-        let key = format!("{INDEXER_ASSIGNED_SHARDS_POSITIONS_PREFIX}{index_uid}:{source_id}");
+        let key = format!("{SHARD_POSITIONS_PREFIX}{index_uid}:{source_id}");
         let shard_positions_json = serde_json::to_string(&shard_positions).unwrap();
-        self.cluster_client
+        self.cluster
             .set_self_key_value(key, shard_positions_json)
             .await;
     }
 
+    fn publish_shard_updates_to_event_broker(&self, source_uid: SourceUid) {
+        let Some(shard_positions_map) = self.shard_positions_per_source.get(&source_uid) else {
+            return;
+        };
+        let shard_positions: Vec<(ShardId, Position)> = shard_positions_map
+            .iter()
+            .map(|(&shard_id, position)| (shard_id, position.clone()))
+            .collect();
+        self.event_broker.publish(ShardPositionsUpdate {
+            source_uid,
+            shard_positions,
+        });
+    }
+
     /// Updates the internal model holding the last position per shard, and
     /// returns true if at least one of the publish position was updated.
-    fn apply_update(&mut self, update: PublishedShardPositionsUpdate) -> bool {
-        if update.published_positions_per_shard.is_empty() {
+    fn apply_update(
+        &mut self,
+        source_uid: &SourceUid,
+        published_positions_per_shard: Vec<(ShardId, Position)>,
+    ) -> bool {
+        if published_positions_per_shard.is_empty() {
             warn!("received an empty publish shard positions update");
             return false;
         }
         let mut was_modified = false;
-        let PublishedShardPositionsUpdate {
-            source_uid,
-            published_positions_per_shard,
-        } = update;
-        if published_positions_per_shard.is_empty() {
-            return false;
-        }
         let current_shard_positions = self
             .shard_positions_per_source
-            .entry(source_uid)
+            .entry(source_uid.clone())
             .or_default();
         for (shard, new_position) in published_positions_per_shard {
             match current_shard_positions.entry(shard) {
@@ -122,53 +274,188 @@ impl PublishedShardPositions {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use chitchat::transport::ChannelTransport;
+    use quickwit_actors::Universe;
     use quickwit_cluster::create_cluster_for_test;
     use quickwit_common::pubsub::EventBroker;
-    use quickwit_common::shared_consts::INDEXER_ASSIGNED_SHARDS_POSITIONS_PREFIX;
     use quickwit_proto::types::IndexUid;
 
     use super::*;
 
     #[tokio::test]
-    async fn test_shard_positions() {
+    async fn test_shard_positions_from_cluster() {
+        quickwit_common::setup_logging_for_tests();
+
         let transport = ChannelTransport::default();
-        let cluster: Cluster = create_cluster_for_test(Vec::new(), &[], &transport, true)
+        let universe1 = Universe::with_accelerated_time();
+        let universe2 = Universe::with_accelerated_time();
+        let cluster1 = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await
             .unwrap();
-        let shard_positions = PublishedShardPositions::new(cluster.clone());
-        let event_broker = EventBroker::default();
-        event_broker.subscribe(shard_positions).forever();
+        let cluster2 = create_cluster_for_test(
+            vec![cluster1.gossip_listen_addr.to_string()],
+            &["indexer", "metastore"],
+            &transport,
+            true,
+        )
+        .await
+        .unwrap();
+        cluster1
+            .wait_for_ready_members(|members| members.len() == 2, Duration::from_secs(5))
+            .await
+            .unwrap();
+        cluster2
+            .wait_for_ready_members(|members| members.len() == 2, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let event_broker1 = EventBroker::default();
+        let event_broker2 = EventBroker::default();
+        ShardPositionsService::spawn(
+            universe1.spawn_ctx(),
+            event_broker1.clone(),
+            cluster1.clone(),
+        );
+        ShardPositionsService::spawn(
+            universe2.spawn_ctx(),
+            event_broker2.clone(),
+            cluster2.clone(),
+        );
+
         let index_uid = IndexUid::new_with_random_ulid("index-test");
         let source_id = "test-source".to_string();
-        let key = format!("{INDEXER_ASSIGNED_SHARDS_POSITIONS_PREFIX}{index_uid}:{source_id}");
         let source_uid = SourceUid {
             index_uid,
             source_id,
         };
-        event_broker.publish(PublishedShardPositionsUpdate {
-            source_uid: source_uid.clone(),
-            published_positions_per_shard: vec![],
-        });
-        {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            assert!(cluster.get_self_key_value(&key).await.is_none());
+
+        let (tx1, mut rx1) = tokio::sync::mpsc::unbounded_channel::<ShardPositionsUpdate>();
+        let (tx2, mut rx2) = tokio::sync::mpsc::unbounded_channel::<ShardPositionsUpdate>();
+
+        event_broker1
+            .subscribe(move |update: ShardPositionsUpdate| {
+                tx1.send(update).unwrap();
+            })
+            .forever();
+
+        event_broker2
+            .subscribe(move |update: ShardPositionsUpdate| {
+                tx2.send(update).unwrap();
+            })
+            .forever();
+
+        // ----------------------
+        // One of the node publishes a given shard position update.
+        // This is done using a LocalPublishShardPositionUpdate
+
+        event_broker1.publish(LocalShardPositionsUpdate::new(
+            source_uid.clone(),
+            vec![(1, Position::Beginning)],
+        ));
+        event_broker1.publish(LocalShardPositionsUpdate::new(
+            source_uid.clone(),
+            vec![(2, 10u64.into())],
+        ));
+        event_broker1.publish(LocalShardPositionsUpdate::new(
+            source_uid.clone(),
+            vec![(1, 10u64.into())],
+        ));
+        event_broker2.publish(LocalShardPositionsUpdate::new(
+            source_uid.clone(),
+            vec![(2, 10u64.into())],
+        ));
+        event_broker2.publish(LocalShardPositionsUpdate::new(
+            source_uid.clone(),
+            vec![(2, 12u64.into())],
+        ));
+        event_broker2.publish(LocalShardPositionsUpdate::new(
+            source_uid.clone(),
+            vec![(1, Position::Beginning), (2, 12u64.into())],
+        ));
+
+        let mut updates1: Vec<Vec<(ShardId, Position)>> = Vec::new();
+        for _ in 0..4 {
+            let update = rx1.recv().await.unwrap();
+            assert_eq!(update.source_uid, source_uid);
+            updates1.push(update.shard_positions);
         }
+
+        // The updates as seen from the first node.
+        assert_eq!(
+            updates1,
+            vec![
+                vec![(1, Position::Beginning)],
+                vec![(1, Position::Beginning), (2, 10u64.into())],
+                vec![(1, 10u64.into()), (2, 10u64.into()),],
+                vec![(1, 10u64.into()), (2, 12u64.into()),],
+            ]
+        );
+
+        // The updates as seen from the second.
+        let mut updates2: Vec<Vec<(ShardId, Position)>> = Vec::new();
+        for _ in 0..4 {
+            let update = rx2.recv().await.unwrap();
+            assert_eq!(update.source_uid, source_uid);
+            updates2.push(update.shard_positions);
+        }
+        assert_eq!(
+            updates2,
+            vec![
+                vec![(2, 10u64.into())],
+                vec![(2, 12u64.into())],
+                vec![(1, Position::Beginning), (2, 12u64.into())],
+                vec![(1, 10u64.into()), (2, 12u64.into())],
+            ]
+        );
+
+        universe1.assert_quit().await;
+        universe2.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_shard_positions_local_updates_publish_to_cluster() {
+        quickwit_common::setup_logging_for_tests();
+        let universe = Universe::with_accelerated_time();
+        let transport = ChannelTransport::default();
+
+        let cluster: Cluster = create_cluster_for_test(Vec::new(), &[], &transport, true)
+            .await
+            .unwrap();
+        let event_broker = EventBroker::default();
+
+        ShardPositionsService::spawn(universe.spawn_ctx(), event_broker.clone(), cluster.clone());
+
+        let index_uid = IndexUid::new_with_random_ulid("index-test");
+        let source_id = "test-source".to_string();
+        let key = format!("{SHARD_POSITIONS_PREFIX}{index_uid}:{source_id}");
+        let source_uid = SourceUid {
+            index_uid,
+            source_id,
+        };
+        event_broker.publish(LocalShardPositionsUpdate::new(
+            source_uid.clone(),
+            Vec::new(),
+        ));
+
+        assert!(cluster.get_self_key_value(&key).await.is_none());
+
         {
-            event_broker.publish(PublishedShardPositionsUpdate {
-                source_uid: source_uid.clone(),
-                published_positions_per_shard: vec![(1, Position::Beginning)],
-            });
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            event_broker.publish(LocalShardPositionsUpdate::new(
+                source_uid.clone(),
+                vec![(1, Position::Beginning)],
+            ));
+            tokio::time::sleep(Duration::from_millis(1000)).await;
             let value = cluster.get_self_key_value(&key).await.unwrap();
             assert_eq!(&value, r#"{"1":""}"#);
         }
         {
-            event_broker.publish(PublishedShardPositionsUpdate {
-                source_uid: source_uid.clone(),
-                published_positions_per_shard: vec![(1, 1_000u64.into()), (2, 2000u64.into())],
-            });
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            event_broker.publish(LocalShardPositionsUpdate::new(
+                source_uid.clone(),
+                vec![(1, 1_000u64.into()), (2, 2000u64.into())],
+            ));
+            tokio::time::sleep(Duration::from_millis(1000)).await;
             let value = cluster.get_self_key_value(&key).await.unwrap();
             assert_eq!(
                 &value,
@@ -176,11 +463,11 @@ mod tests {
             );
         }
         {
-            event_broker.publish(PublishedShardPositionsUpdate {
-                source_uid: source_uid.clone(),
-                published_positions_per_shard: vec![(1, 999u64.into()), (3, 3000u64.into())],
-            });
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            event_broker.publish(LocalShardPositionsUpdate::new(
+                source_uid.clone(),
+                vec![(1, 999u64.into()), (3, 3000u64.into())],
+            ));
+            tokio::time::sleep(Duration::from_millis(1000)).await;
             let value = cluster.get_self_key_value(&key).await.unwrap();
             // We do not update the position that got lower, nor the position that disappeared
             assert_eq!(
@@ -188,5 +475,6 @@ mod tests {
                 r#"{"1":"00000000000000001000","2":"00000000000000002000","3":"00000000000000003000"}"#
             );
         }
+        universe.assert_quit().await;
     }
 }

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
@@ -212,23 +212,21 @@ impl Shards {
         force: bool,
     ) -> MetastoreResult<MutationOccurred<()>> {
         let mut mutation_occurred = false;
-
         for shard_id in subrequest.shard_ids {
             if let Entry::Occupied(entry) = self.shards.entry(shard_id) {
                 let shard = entry.get();
-                if force || shard.publish_position_inclusive() == Position::Eof {
-                    mutation_occurred = true;
-                    info!(
-                        index_id=%self.index_uid.index_id(),
-                        source_id=%self.source_id,
-                        shard_id=%shard.shard_id,
-                        "deleted shard",
-                    );
-                    entry.remove();
-                    continue;
+                if !force && shard.publish_position_inclusive() != Position::Eof {
+                    let message = format!("shard `{shard_id}` is not deletable");
+                    return Err(MetastoreError::InvalidArgument { message });
                 }
-                let message = format!("shard `{shard_id}` is not deletable");
-                return Err(MetastoreError::InvalidArgument { message });
+                info!(
+                    index_id=%self.index_uid.index_id(),
+                    source_id=%self.source_id,
+                    shard_id=%shard.shard_id,
+                    "deleted shard",
+                );
+                entry.remove();
+                mutation_occurred = true;
             }
         }
         Ok(MutationOccurred::from(mutation_occurred))

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -1842,7 +1842,7 @@ mod tests {
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
-                r#"SELECT * FROM "splits" WHERE "index_uid" = '{index_uid}' AND $$tag-1$$ = ANY(tags) AND ("time_range_end" > 90 OR "time_range_end" IS NULL)"#
+                r#"SELECT * FROM "splits" WHERE "index_uid" = '{index_uid}' AND ($$tag-1$$ = ANY(tags)) AND ("time_range_end" > 90 OR "time_range_end" IS NULL)"#
             )
         );
 

--- a/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -1766,7 +1766,7 @@ mod tests {
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
-                r#"SELECT * FROM "splits" WHERE "index_uid" = '{index_uid}' AND NOT ($$tag-2$$ = ANY(tags))"#
+                r#"SELECT * FROM "splits" WHERE "index_uid" = '{index_uid}' AND (NOT ($$tag-2$$ = ANY(tags)))"#
             )
         );
 

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -155,6 +155,8 @@ service MetastoreService {
   // list of acquired shards along with the positions to index from.
   rpc AcquireShards(AcquireShardsRequest) returns (AcquireShardsResponse);
 
+  // Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+  // If the shard did not exist to begin with, the operation is successful and does not return any error.
   rpc DeleteShards(DeleteShardsRequest) returns (DeleteShardsResponse);
 
   rpc ListShards(ListShardsRequest) returns (ListShardsResponse);

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -685,6 +685,8 @@ pub trait MetastoreService: std::fmt::Debug + dyn_clone::DynClone + Send + Sync 
         &mut self,
         request: AcquireShardsRequest,
     ) -> crate::metastore::MetastoreResult<AcquireShardsResponse>;
+    /// Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+    /// If the shard did not exist to begin with, the operation is successful and does not return any error.
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
@@ -4250,6 +4252,8 @@ pub mod metastore_service_grpc_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+        /// If the shard did not exist to begin with, the operation is successful and does not return any error.
         pub async fn delete_shards(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteShardsRequest>,
@@ -4456,6 +4460,8 @@ pub mod metastore_service_grpc_server {
             tonic::Response<super::AcquireShardsResponse>,
             tonic::Status,
         >;
+        /// Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+        /// If the shard did not exist to begin with, the operation is successful and does not return any error.
         async fn delete_shards(
             &self,
             request: tonic::Request<super::DeleteShardsRequest>,

--- a/quickwit/quickwit-proto/src/types/mod.rs
+++ b/quickwit/quickwit-proto/src/types/mod.rs
@@ -121,7 +121,8 @@ impl IndexUid {
         }
     }
 
-    pub fn parse(index_uid_str: String) -> Result<IndexUid, InvalidIndexUid> {
+    pub fn parse(index_uid_str: impl ToString) -> Result<IndexUid, InvalidIndexUid> {
+        let index_uid_str = index_uid_str.to_string();
         let count_colon = index_uid_str
             .as_bytes()
             .iter()

--- a/quickwit/quickwit-proto/src/types/position.rs
+++ b/quickwit/quickwit-proto/src/types/position.rs
@@ -18,7 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use bytes::Bytes;
 use bytestring::ByteString;
@@ -69,12 +69,23 @@ impl fmt::Display for Offset {
 ///
 /// The empty string can be used to represent the beginning of the source,
 /// if no position makes sense. It can be built via `Position::default()`.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Position {
     #[default]
     Beginning,
     Offset(Offset),
     Eof,
+}
+
+impl Debug for Position {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Beginning => write!(f, "Position::Beginning"),
+            // The derive implementation would show `Offset(Offset(0000001))` here.
+            Self::Offset(offset) => write!(f, "Position::Offset({})", offset.0),
+            Self::Eof => write!(f, "Position::Eof"),
+        }
+    }
 }
 
 impl Position {


### PR DESCRIPTION
Its purpose is to encapsulate all of the logic used to maintained a
distributed eventually consistent view of the published shard positions
over the cluster.

From the user point of view, after instantiation
- indexing pipelines need to feed it with updates. (this happens on
  suggest_truncate). This is done by publishing
  `LocalShardPositionsUpdates` to the event broker.
- clients interested in updates can just subscript the
  `ShardPositionsUpdate` object in the event broker. The event
  received can come from a local indexing pipeline or anywhere in the
  cluster.

The service takes care of deduping/ignoring updates when necessary.

The two object (Local and not) are very similar, but different in
semantics.

This PR includes the connection with the control plane deleting the shards from the metastore and updating its internal model too.

It however does not contains any path for the deletion in the ingester.

Tested manually for the moment, but will add integration test later.