### PR TITLE
 Add local AGPL license link in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@ Copyright (C) 2023 Quickwit, Inc.
 
 Quickwit is offered under the [GNU Affero General Public License v3.0](https://opensource.org/licenses/AGPL-3.0)
 and as commercial software.
-A copy of the AGPL license can be found in LICENSE_AGPLv3.0.txt
+A copy of the AGPL license can be found in [LICENSE_AGPLv3.0.txt](LICENSE_AGPLv3.0.txt)
 
 # Commercial Licensing
 For commercial licensing, contact us at hello@quickwit.io.


### PR DESCRIPTION
### Description

This PR adds a link to the local `LICENSE_AGPLv3.0.txt` file in the `README.md` file. This allows users to easily access and read the full Affero General Public License version 3.0 that our project uses.

### How was this PR tested?

This PR was tested by clicking on the newly added link in the `README.md` file. The link correctly redirects to the `LICENSE_AGPLv3.0.txt` file, confirming that the link has been successfully added and is functioning as expected.
