### PR TITLE
Changing the shutdown logic for the rest server.

### DIFF
--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -335,8 +335,6 @@ impl ClusterSandbox {
     pub async fn shutdown(self) -> Result<Vec<HashMap<String, ActorExitStatus>>, anyhow::Error> {
         // We need to drop rest clients first because reqwest can hold connections open
         // preventing rest server's graceful shutdown.
-        drop(self.searcher_rest_client);
-        drop(self.indexer_rest_client);
         self.shutdown_trigger.shutdown();
         let result = future::join_all(self.join_handles).await;
         let mut statuses = Vec::new();


### PR DESCRIPTION
Instead of relying on the hyper graceful shutdown, which does not shutdown in the presence of existing http connections.

Closes #4169
