### PR TITLE
Add the index ID and source ID in the warn logs

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -400,7 +400,7 @@ impl DocProcessor {
             .doc_mapper
             .doc_from_json_obj(json_doc.json_obj)
             .map_err(|error| {
-                warn!(error=?error);
+                warn!(index_id=self.counters.index_id, source_id=self.counters.source_id, error=?error);
                 match error {
                     DocParsingError::RequiredField(_) => DocProcessorError::Schema,
                     _ => DocProcessorError::Parse,


### PR DESCRIPTION
### Description

As mentioned here  https://github.com/quickwit-oss/quickwit/issues/4113. To enhance warn log info.

### How was this PR tested?

Describe how you tested this PR.


```
2023-11-22T14:55:22.305Z  WARN quickwit_indexing::actors::doc_processor: index_id="gh-archive" source_id="_ingest-api-source" error=ValueError("created_at", "failed to parse datetime `2023-11-11 09:53:11.123456` using the following formats: `rfc3339`")
```