### PR TITLE
Feature: [Dev Experience] Add dev container configuration for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "Quickwit",
+    "image": "mcr.microsoft.com/devcontainers/rust:latest",
+    "customizations": {
+        "codespaces": {
+            "openFiles": [
+                "CONTRIBUTING.md"
+            ]
+        },
+        "vscode": {
+            "extensions": [
+                "rust-lang.rust-analyzer"
+            ]
+        }
+    },
+    "postCreateCommand": ".devcontainer/post-create.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,8 @@
             "version": "18"
         },
         "ghcr.io/devcontainers/features/aws-cli:1": {},
-        "ghcr.io/devcontainers-contrib/features/protoc:1": {}
+        "ghcr.io/devcontainers-contrib/features/protoc:1": {},
+        "ghcr.io/devcontainers-community/features/cmake": {}
     },
     "postCreateCommand": ".devcontainer/post-create.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,5 +13,9 @@
             ]
         }
     },
+    "hostRequirements": {
+      "cpus": 4,
+      "memory": "16gb"
+    },
     "postCreateCommand": ".devcontainer/post-create.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,28 @@
         }
     },
     "hostRequirements": {
-      "cpus": 4,
-      "memory": "16gb"
+        "cpus": 4,
+        "memory": "16gb"
+    },
+    "runArgs": [
+        "--init"
+    ],
+    "mounts": [
+        {
+            "source": "/var/run/docker.sock",
+            "target": "/var/run/docker.sock",
+            "type": "bind"
+        }
+    ],
+    "features": {
+        "docker-from-docker": {
+            "version": "latest",
+            "moby": true
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "18"
+        },
+        "ghcr.io/devcontainers/features/aws-cli:1": {}
     },
     "postCreateCommand": ".devcontainer/post-create.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,8 @@
         "ghcr.io/devcontainers/features/node:1": {
             "version": "18"
         },
-        "ghcr.io/devcontainers/features/aws-cli:1": {}
+        "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers-contrib/features/protoc:1": {}
     },
     "postCreateCommand": ".devcontainer/post-create.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,8 +36,7 @@
             "version": "18"
         },
         "ghcr.io/devcontainers/features/aws-cli:1": {},
-        "ghcr.io/devcontainers-contrib/features/protoc:1": {},
-        "ghcr.io/devcontainers-community/features/cmake": {}
+        "ghcr.io/devcontainers-contrib/features/protoc:1": {}
     },
     "postCreateCommand": ".devcontainer/post-create.sh"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -69,6 +69,7 @@ install_cmake
 configure_python_environment
 install_protoc
 install_rustup_toolchain_nightly
+sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
 
 
 # Check the success tracking variables

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -93,13 +93,13 @@ install_protoc() {
 install_rustup_toolchain_nightly() {
     echo "Installing Rustup nightly toolchain..."
     rustup toolchain install nightly
-    if [[ "$(rustup toolchain list)" =~ "nightly" ]]; then
-        echo "Rustup nightly toolchain installed successfully."
+    rustup component add rustfmt --toolchain nightly
+    if [[ "$(rustup toolchain list)" =~ "nightly" && "$(rustup component list --toolchain nightly | grep rustfmt)" =~ "installed" ]]; then
+        echo "Rustup nightly toolchain and rustfmt installed successfully."
     else
-        echo "Rustup nightly toolchain installation failed. Please install it manually."
+        echo "Rustup nightly toolchain and/or rustfmt installation failed. Please install them manually."
     fi
 }
-
 # Call the functions
 install_cmake
 install_docker

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -69,6 +69,8 @@ install_cmake
 configure_python_environment
 install_protoc
 install_rustup_toolchain_nightly
+
+# Copy our custom welcome message to replace the default github welcome message
 sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
 
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -90,12 +90,23 @@ install_protoc() {
     fi
 }
 
+install_rustup_toolchain_nightly() {
+    echo "Installing Rustup nightly toolchain..."
+    rustup toolchain install nightly
+    if [[ "$(rustup toolchain list)" =~ "nightly" ]]; then
+        echo "Rustup nightly toolchain installed successfully."
+    else
+        echo "Rustup nightly toolchain installation failed. Please install it manually."
+    fi
+}
+
 # Call the functions
 install_cmake
 install_docker
 install_node_yarn
 install_awslocal
 install_protoc
+install_rustup_toolchain_nightly
 
 # Check the success tracking variables
 if $cmakeInstalled && $dockerInstalled && $dockerComposeInstalled && $nodeInstalled && $yarnInstalled && $awslocalInstalled && $protocInstalled; then

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -75,16 +75,6 @@ sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run
 # Check the success tracking variables
 if $cmakeInstalled && $protocInstalled && $rustupToolchainNightlyInstalled; then
     echo -e "${SUCCESS_COLOR}All tools installed successfully.${RESET_COLOR}"
-    echo "Useful commands:"
-    echo "  - make test-all: Starts necessary Docker services and runs all tests."
-    echo "  - make -k test-all docker-compose-down: The same as above, but tears down the Docker services after running all the tests."
-    echo "  - make fmt: Runs formatter (requires the nightly toolchain to be installed by running rustup toolchain install nightly)."
-    echo "  - make fix: Runs formatter and clippy checks."
-    echo "  - make typos: Runs the spellcheck tool over the codebase (install by running cargo install typos)."
-    echo "  - make build-docs: Builds docs."
-    echo "  - make docker-compose-up: Starts Docker services."
-    echo "  - make docker-compose-down: Stops Docker services."
-    echo "  - make docker-compose-logs: Shows Docker logs."
 else
     echo -e "${ERROR_COLOR}One or more tools failed to install. Please check the output for errors and install the failed tools manually.${RESET_COLOR}"
 fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -22,31 +22,6 @@ install_cmake() {
     fi
 }
 
-install_docker() {
-    echo "Installing Docker..."
-    curl -fsSL https://get.docker.com -o get-docker.sh
-    sudo sh get-docker.sh
-    if [[ "$(docker --version)" =~ "Docker version" ]]; then
-        echo "Docker installed successfully."
-        dockerInstalled=true
-    else
-        echo "Docker installation failed. Please install it manually."
-    fi
-    
-    # Clean up
-    rm -f get-docker.sh
-
-    echo "Installing Docker Compose..."
-    sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    sudo chmod +x /usr/local/bin/docker-compose
-    if [[ "$(docker-compose --version)" =~ "docker-compose version" ]]; then
-        echo "Docker Compose installed successfully."
-        dockerComposeInstalled=true
-    else
-        echo "Docker Compose installation failed. Please install it manually."
-    fi
-}
-
 install_node_yarn() {
     echo "Installing Node v18 and Yarn..."
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
@@ -124,25 +99,8 @@ install_rustup_toolchain_nightly() {
 }
 # Call the functions
 install_cmake
-install_docker
 install_node_yarn
 install_awslocal
 install_protoc
 install_rustup_toolchain_nightly
 
-# Check the success tracking variables
-if $cmakeInstalled && $dockerInstalled && $dockerComposeInstalled && $nodeInstalled && $yarnInstalled && $awslocalInstalled && $protocInstalled; then
-    echo "All tools installed successfully."
-    echo "Useful commands:"
-    echo "make test-all - starts necessary Docker services and runs all tests."
-    echo "make -k test-all docker-compose-down - the same as above, but tears down the Docker services after running all the tests."
-    echo "make fmt - runs formatter, this command requires the nightly toolchain to be installed by running rustup toolchain install nightly."
-    echo "make fix - runs formatter and clippy checks."
-    echo "make typos - runs the spellcheck tool over the codebase. (Install by running cargo install typos)"
-    echo "make build-docs - builds docs."
-    echo "make docker-compose-up - starts Docker services."
-    echo "make docker-compose-down - stops Docker services."
-    echo "make docker-compose-logs - shows Docker logs."
-else
-    echo "One or more tools failed to install. Please check the output for errors and install the failed tools manually."
-fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,7 +7,6 @@ RESET_COLOR="\e[0m"
 
 # Define success tracking variables
 cmakeInstalled=false
-protocInstalled=false
 rustupToolchainNightlyInstalled=false
 
 
@@ -25,33 +24,6 @@ install_cmake() {
 }
 
 
-configure_python_environment() {
-    if command -v python3 &> /dev/null; then
-        echo -e "${SUCCESS_COLOR}Python 3 is installed${RESET_COLOR}"
-        # Create a symbolic link from python to python3
-        sudo ln -s /usr/bin/python3 /usr/bin/python
-    else
-        echo -e "${ERROR_COLOR}Python 3 is not installed. Please install it manually.${RESET_COLOR}"
-    fi
-}
-
-install_protoc() {
-    echo -e "Installing protoc..."
-    PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-    curl -LO $PB_REL/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip > /dev/null 2>&1
-    unzip protoc-3.15.8-linux-x86_64.zip -d $HOME/.local > /dev/null 2>&1
-    export PATH="$PATH:$HOME/.local/bin"
-    if [[ "$(protoc --version)" =~ "libprotoc 3.15.8" ]]; then
-        echo -e "${SUCCESS_COLOR}protoc installed successfully.${RESET_COLOR}"
-        protocInstalled=true
-    else
-        echo -e "${ERROR_COLOR}protoc installation failed. Please install it manually.${RESET_COLOR}"
-    fi
-
-    # Clean up
-    rm -f protoc-3.15.8-linux-x86_64.zip
-}
-
 install_rustup_toolchain_nightly() {
     echo -e "Installing Rustup nightly toolchain..."
     rustup toolchain install nightly > /dev/null 2>&1
@@ -66,8 +38,6 @@ install_rustup_toolchain_nightly() {
 
 # Install tools
 install_cmake
-configure_python_environment
-install_protoc
 install_rustup_toolchain_nightly
 
 # Copy our custom welcome message to replace the default github welcome message
@@ -75,7 +45,7 @@ sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run
 
 
 # Check the success tracking variables
-if $cmakeInstalled && $protocInstalled && $rustupToolchainNightlyInstalled; then
+if $cmakeInstalled && $rustupToolchainNightlyInstalled; then
     echo -e "${SUCCESS_COLOR}All tools installed successfully.${RESET_COLOR}"
 else
     echo -e "${ERROR_COLOR}One or more tools failed to install. Please check the output for errors and install the failed tools manually.${RESET_COLOR}"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -52,6 +52,7 @@ install_node_yarn() {
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
     source ~/.bashrc
     nvm install 18
+    nvm use 18
     npm install -g yarn
     if [[ "$(node --version)" =~ "v18." && "$(yarn --version)" =~ "." ]]; then
         echo "Node v18 and Yarn installed successfully."
@@ -62,9 +63,28 @@ install_node_yarn() {
     fi
 }
 
+configure_python_environment() {
+    if command -v python3 &> /dev/null; then
+        echo "Python 3 is installed"
+        # Create a symbolic link from python to python3
+        sudo ln -s /usr/bin/python3 /usr/bin/python
+    else
+        echo "Python 3 is not installed. Please install it manually."
+    fi
+}
+
 install_awslocal() {
+    echo "Setting up python environment"
+    configure_python_environment
+
     echo "Installing awslocal..."
-    pip install awscli-local
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    sudo ./aws/install
+
+    # Clean up
+    rm -f awscliv2.zip
+    
     if [[ "$(awslocal --version)" =~ "aws-cli" ]]; then
         echo "awslocal installed successfully."
         awslocalInstalled=true

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -33,7 +33,7 @@ install_docker() {
         echo "Docker installation failed. Please install it manually."
     
     # Clean up
-    rm get-docker.sh
+    rm -f get-docker.sh
     fi
     
     echo "Installing Docker Compose..."
@@ -86,7 +86,7 @@ install_protoc() {
         echo "protoc installation failed. Please install it manually."
 
     # Clean up
-    rm protoc-3.15.8-linux-x86_64.zip
+    rm -f protoc-3.15.8-linux-x86_64.zip
     fi
 }
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -31,11 +31,11 @@ install_docker() {
         dockerInstalled=true
     else
         echo "Docker installation failed. Please install it manually."
+    fi
     
     # Clean up
     rm -f get-docker.sh
-    fi
-    
+
     echo "Installing Docker Compose..."
     sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     sudo chmod +x /usr/local/bin/docker-compose
@@ -84,10 +84,10 @@ install_protoc() {
         protocInstalled=true
     else
         echo "protoc installation failed. Please install it manually."
-
+    fi
+    
     # Clean up
     rm -f protoc-3.15.8-linux-x86_64.zip
-    fi
 }
 
 install_rustup_toolchain_nightly() {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -84,6 +84,7 @@ install_awslocal() {
 
     # Clean up
     rm -f awscliv2.zip
+    rm -rf aws
     
     if [[ "$(awslocal --version)" =~ "aws-cli" ]]; then
         echo "awslocal installed successfully."

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -84,6 +84,7 @@ install_awslocal() {
 
     # Clean up
     rm -f awscliv2.zip
+    # Installation files are stored in /usr/local/aws-cli, so we need to remove them
     rm -rf aws
     
     if [[ "$(awslocal --version)" =~ "aws-cli" ]]; then

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,106 +1,89 @@
 #!/bin/bash
 
+# Define success and error color codes
+SUCCESS_COLOR="\e[32m"
+ERROR_COLOR="\e[31m"
+RESET_COLOR="\e[0m"
+
 # Define success tracking variables
 cmakeInstalled=false
-dockerInstalled=false
-dockerComposeInstalled=false
-nodeInstalled=false
-yarnInstalled=false
-awslocalInstalled=false
 protocInstalled=false
+rustupToolchainNightlyInstalled=false
+
 
 # Define installation functions
 install_cmake() {
-    echo "Installing CMake..."
+    echo -e "Installing CMake..."
     sudo apt-get update
-    sudo apt-get install -y cmake
+    sudo apt-get install -y cmake > /dev/null 2>&1
     if [[ "$(cmake --version)" =~ "cmake version" ]]; then
-        echo "CMake installed successfully."
+        echo -e "${SUCCESS_COLOR}CMake installed successfully.${RESET_COLOR}"
         cmakeInstalled=true
     else
-        echo "CMake installation failed. Please install it manually."
+        echo -e "${ERROR_COLOR}CMake installation failed. Please install it manually.${RESET_COLOR}"
     fi
 }
 
-install_node_yarn() {
-    echo "Installing Node v18 and Yarn..."
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-    source ~/.bashrc
-    nvm install 18
-    nvm use 18
-    npm install -g yarn
-    if [[ "$(node --version)" =~ "v18." && "$(yarn --version)" =~ "." ]]; then
-        echo "Node v18 and Yarn installed successfully."
-        nodeInstalled=true
-        yarnInstalled=true
-    else
-        echo "Node v18 and/or Yarn installation failed. Please install them manually."
-    fi
-}
 
 configure_python_environment() {
     if command -v python3 &> /dev/null; then
-        echo "Python 3 is installed"
+        echo -e "${SUCCESS_COLOR}Python 3 is installed${RESET_COLOR}"
         # Create a symbolic link from python to python3
         sudo ln -s /usr/bin/python3 /usr/bin/python
     else
-        echo "Python 3 is not installed. Please install it manually."
-    fi
-}
-
-install_awslocal() {
-    echo "Setting up python environment"
-    configure_python_environment
-
-    echo "Installing awslocal..."
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    unzip awscliv2.zip
-    sudo ./aws/install
-
-    # Clean up
-    rm -f awscliv2.zip
-    # Installation files are stored in /usr/local/aws-cli, so we need to remove them
-    rm -rf aws
-    
-    if [[ "$(aws --version)" =~ "aws-cli" ]]; then
-        echo "awslocal installed successfully."
-        awslocalInstalled=true
-    else
-        echo "awslocal installation failed. Please install it manually."
+        echo -e "${ERROR_COLOR}Python 3 is not installed. Please install it manually.${RESET_COLOR}"
     fi
 }
 
 install_protoc() {
-    echo "Installing protoc..."
+    echo -e "Installing protoc..."
     PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-    curl -LO $PB_REL/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip
-    unzip protoc-3.15.8-linux-x86_64.zip -d $HOME/.local
+    curl -LO $PB_REL/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip > /dev/null 2>&1
+    unzip protoc-3.15.8-linux-x86_64.zip -d $HOME/.local > /dev/null 2>&1
     export PATH="$PATH:$HOME/.local/bin"
     if [[ "$(protoc --version)" =~ "libprotoc 3.15.8" ]]; then
-        echo "protoc installed successfully."
+        echo -e "${SUCCESS_COLOR}protoc installed successfully.${RESET_COLOR}"
         protocInstalled=true
     else
-        echo "protoc installation failed. Please install it manually."
+        echo -e "${ERROR_COLOR}protoc installation failed. Please install it manually.${RESET_COLOR}"
     fi
-    
+
     # Clean up
     rm -f protoc-3.15.8-linux-x86_64.zip
 }
 
 install_rustup_toolchain_nightly() {
-    echo "Installing Rustup nightly toolchain..."
-    rustup toolchain install nightly
-    rustup component add rustfmt --toolchain nightly
+    echo -e "Installing Rustup nightly toolchain..."
+    rustup toolchain install nightly > /dev/null 2>&1
+    rustup component add rustfmt --toolchain nightly > /dev/null 2>&1
     if [[ "$(rustup toolchain list)" =~ "nightly" && "$(rustup component list --toolchain nightly | grep rustfmt)" =~ "installed" ]]; then
-        echo "Rustup nightly toolchain and rustfmt installed successfully."
+        echo -e "${SUCCESS_COLOR}Rustup nightly toolchain and rustfmt installed successfully.${RESET_COLOR}"
+        rustupToolchainNightlyInstalled=true
     else
-        echo "Rustup nightly toolchain and/or rustfmt installation failed. Please install them manually."
+        echo -e "${ERROR_COLOR}Rustup nightly toolchain and/or rustfmt installation failed. Please install them manually.${RESET_COLOR}"
     fi
 }
-# Call the functions
+
+# Install tools
 install_cmake
-install_node_yarn
-install_awslocal
+configure_python_environment
 install_protoc
 install_rustup_toolchain_nightly
 
+
+# Check the success tracking variables
+if $cmakeInstalled && $protocInstalled && $rustupToolchainNightlyInstalled; then
+    echo -e "${SUCCESS_COLOR}All tools installed successfully.${RESET_COLOR}"
+    echo "Useful commands:"
+    echo "  - make test-all: Starts necessary Docker services and runs all tests."
+    echo "  - make -k test-all docker-compose-down: The same as above, but tears down the Docker services after running all the tests."
+    echo "  - make fmt: Runs formatter (requires the nightly toolchain to be installed by running rustup toolchain install nightly)."
+    echo "  - make fix: Runs formatter and clippy checks."
+    echo "  - make typos: Runs the spellcheck tool over the codebase (install by running cargo install typos)."
+    echo "  - make build-docs: Builds docs."
+    echo "  - make docker-compose-up: Starts Docker services."
+    echo "  - make docker-compose-down: Stops Docker services."
+    echo "  - make docker-compose-logs: Shows Docker logs."
+else
+    echo -e "${ERROR_COLOR}One or more tools failed to install. Please check the output for errors and install the failed tools manually.${RESET_COLOR}"
+fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -87,7 +87,7 @@ install_awslocal() {
     # Installation files are stored in /usr/local/aws-cli, so we need to remove them
     rm -rf aws
     
-    if [[ "$(awslocal --version)" =~ "aws-cli" ]]; then
+    if [[ "$(aws --version)" =~ "aws-cli" ]]; then
         echo "awslocal installed successfully."
         awslocalInstalled=true
     else

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,9 +7,24 @@ RESET_COLOR="\e[0m"
 
 # Define success tracking variables
 rustupToolchainNightlyInstalled=false
+cmakeInstalled=false
 
 
 # Define installation functions
+
+#Installing manually for now until we figure out why "ghcr.io/devcontainers-community/features/cmake": {} is not working
+install_cmake() {
+    echo -e "Installing CMake..."
+    sudo apt-get update
+    sudo apt-get install -y cmake > /dev/null 2>&1
+    if [[ "$(cmake --version)" =~ "cmake version" ]]; then
+        echo -e "${SUCCESS_COLOR}CMake installed successfully.${RESET_COLOR}"
+        cmakeInstalled=true
+    else
+        echo -e "${ERROR_COLOR}CMake installation failed. Please install it manually.${RESET_COLOR}"
+    fi
+}
+
 install_rustup_toolchain_nightly() {
     echo -e "Installing Rustup nightly toolchain..."
     rustup toolchain install nightly > /dev/null 2>&1
@@ -31,7 +46,7 @@ sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run
 
 
 # Check the success tracking variables
-if $rustupToolchainNightlyInstalled; then
+if $rustupToolchainNightlyInstalled && $cmakeInstalled; then
     echo -e "${SUCCESS_COLOR}All tools installed successfully.${RESET_COLOR}"
 else
     echo -e "${ERROR_COLOR}One or more tools failed to install. Please check the output for errors and install the failed tools manually.${RESET_COLOR}"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,24 +6,10 @@ ERROR_COLOR="\e[31m"
 RESET_COLOR="\e[0m"
 
 # Define success tracking variables
-cmakeInstalled=false
 rustupToolchainNightlyInstalled=false
 
 
 # Define installation functions
-install_cmake() {
-    echo -e "Installing CMake..."
-    sudo apt-get update
-    sudo apt-get install -y cmake > /dev/null 2>&1
-    if [[ "$(cmake --version)" =~ "cmake version" ]]; then
-        echo -e "${SUCCESS_COLOR}CMake installed successfully.${RESET_COLOR}"
-        cmakeInstalled=true
-    else
-        echo -e "${ERROR_COLOR}CMake installation failed. Please install it manually.${RESET_COLOR}"
-    fi
-}
-
-
 install_rustup_toolchain_nightly() {
     echo -e "Installing Rustup nightly toolchain..."
     rustup toolchain install nightly > /dev/null 2>&1
@@ -45,7 +31,7 @@ sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run
 
 
 # Check the success tracking variables
-if $cmakeInstalled && $rustupToolchainNightlyInstalled; then
+if $rustupToolchainNightlyInstalled; then
     echo -e "${SUCCESS_COLOR}All tools installed successfully.${RESET_COLOR}"
 else
     echo -e "${ERROR_COLOR}One or more tools failed to install. Please check the output for errors and install the failed tools manually.${RESET_COLOR}"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Define success tracking variables
+cmakeInstalled=false
+dockerInstalled=false
+dockerComposeInstalled=false
+nodeInstalled=false
+yarnInstalled=false
+awslocalInstalled=false
+protocInstalled=false
+
+# Define installation functions
+install_cmake() {
+    echo "Installing CMake..."
+    sudo apt-get update
+    sudo apt-get install -y cmake
+    if [[ "$(cmake --version)" =~ "cmake version" ]]; then
+        echo "CMake installed successfully."
+        cmakeInstalled=true
+    else
+        echo "CMake installation failed. Please install it manually."
+    fi
+}
+
+install_docker() {
+    echo "Installing Docker..."
+    curl -fsSL https://get.docker.com -o get-docker.sh
+    sudo sh get-docker.sh
+    if [[ "$(docker --version)" =~ "Docker version" ]]; then
+        echo "Docker installed successfully."
+        dockerInstalled=true
+    else
+        echo "Docker installation failed. Please install it manually."
+    
+    # Clean up
+    rm get-docker.sh
+    fi
+    
+    echo "Installing Docker Compose..."
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    if [[ "$(docker-compose --version)" =~ "docker-compose version" ]]; then
+        echo "Docker Compose installed successfully."
+        dockerComposeInstalled=true
+    else
+        echo "Docker Compose installation failed. Please install it manually."
+    fi
+}
+
+install_node_yarn() {
+    echo "Installing Node v18 and Yarn..."
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+    source ~/.bashrc
+    nvm install 18
+    npm install -g yarn
+    if [[ "$(node --version)" =~ "v18." && "$(yarn --version)" =~ "." ]]; then
+        echo "Node v18 and Yarn installed successfully."
+        nodeInstalled=true
+        yarnInstalled=true
+    else
+        echo "Node v18 and/or Yarn installation failed. Please install them manually."
+    fi
+}
+
+install_awslocal() {
+    echo "Installing awslocal..."
+    pip install awscli-local
+    if [[ "$(awslocal --version)" =~ "aws-cli" ]]; then
+        echo "awslocal installed successfully."
+        awslocalInstalled=true
+    else
+        echo "awslocal installation failed. Please install it manually."
+    fi
+}
+
+install_protoc() {
+    echo "Installing protoc..."
+    PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+    curl -LO $PB_REL/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip
+    unzip protoc-3.15.8-linux-x86_64.zip -d $HOME/.local
+    export PATH="$PATH:$HOME/.local/bin"
+    if [[ "$(protoc --version)" =~ "libprotoc 3.15.8" ]]; then
+        echo "protoc installed successfully."
+        protocInstalled=true
+    else
+        echo "protoc installation failed. Please install it manually."
+
+    # Clean up
+    rm protoc-3.15.8-linux-x86_64.zip
+    fi
+}
+
+# Call the functions
+install_cmake
+install_docker
+install_node_yarn
+install_awslocal
+install_protoc
+
+# Check the success tracking variables
+if $cmakeInstalled && $dockerInstalled && $dockerComposeInstalled && $nodeInstalled && $yarnInstalled && $awslocalInstalled && $protocInstalled; then
+    echo "All tools installed successfully."
+    echo "Useful commands:"
+    echo "make test-all - starts necessary Docker services and runs all tests."
+    echo "make -k test-all docker-compose-down - the same as above, but tears down the Docker services after running all the tests."
+    echo "make fmt - runs formatter, this command requires the nightly toolchain to be installed by running rustup toolchain install nightly."
+    echo "make fix - runs formatter and clippy checks."
+    echo "make typos - runs the spellcheck tool over the codebase. (Install by running cargo install typos)"
+    echo "make build-docs - builds docs."
+    echo "make docker-compose-up - starts Docker services."
+    echo "make docker-compose-down - stops Docker services."
+    echo "make docker-compose-logs - shows Docker logs."
+else
+    echo "One or more tools failed to install. Please check the output for errors and install the failed tools manually."
+fi

--- a/.devcontainer/welcome.txt
+++ b/.devcontainer/welcome.txt
@@ -1,0 +1,13 @@
+👋 Welcome to the project! Here are some useful commands you can run:
+
+🔧 `make test-all` - starts necessary Docker services and runs all tests.
+🔧 `make -k test-all docker-compose-down` - the same as above, but tears down the Docker services after running all the tests.
+🔧 `make fmt` - runs formatter, this command requires the nightly toolchain to be installed by running `rustup toolchain install nightly`.
+🔧 `make fix` - runs formatter and clippy checks.
+🔧 `make typos` - runs the spellcheck tool over the codebase. (Install by running `cargo install typos`)
+🔧 `make build-docs` - builds docs.
+🔧 `make docker-compose-up` - starts Docker services.
+🔧 `make docker-compose-down` - stops Docker services.
+🔧 `make docker-compose-logs` - shows Docker logs.
+
+Happy coding 🧑🏻‍💻!

--- a/.devcontainer/welcome.txt
+++ b/.devcontainer/welcome.txt
@@ -1,4 +1,8 @@
-👋 Welcome to the project! Here are some useful commands you can run:
+👋 Welcome to the project!
+All the necessary tools have already been installed for you 🎉. 
+You can go ahead and start hacking! Happy coding experience! 🧑🏻‍💻
+
+ Here are some useful commands you can run:
 
 🔧 `make test-all` - starts necessary Docker services and runs all tests.
 🔧 `make -k test-all docker-compose-down` - the same as above, but tears down the Docker services after running all the tests.
@@ -10,4 +14,3 @@
 🔧 `make docker-compose-down` - stops Docker services.
 🔧 `make docker-compose-logs` - shows Docker logs.
 
-Happy coding 🧑🏻‍💻!

--- a/.devcontainer/welcome.txt
+++ b/.devcontainer/welcome.txt
@@ -1,6 +1,6 @@
 👋 Welcome to the project!
 All the necessary tools have already been installed for you 🎉. 
-You can go ahead and start hacking! Happy coding experience! 🧑🏻‍💻
+You can go ahead and start hacking! Happy coding💻.
 
  Here are some useful commands you can run:
 


### PR DESCRIPTION
### Description

Fixes #4163 

#### Motivation

 I would like to propose adding a dev container configuration for GitHub Codespaces. This would make it easier for developers to set up their environment and work on the project without much hassle and effort. Setting up the project for the first time requires CMake, Docker, node, yarn, awslocal protoc and other tools. However, installing and configuring these tools manually can be time-consuming and error-prone, especially for new contributors or low-end machines. 

#### Solution

 It would be nice to have a dev container configuration for GitHub Codespaces that would automate the setup of the development environment and provide a consistent and reproducible experience. This would make contributing to the project easier as it would:
 
- Lower the barrier to entry for new contributors due to the ability to quickly spin up a fully set up environment and focus on making a contribution instead of spending hours trying to get the right version of some tool installed. 

#### Tasks to make this happen

- [x] Add dev Container configuration
- [ ] Update `README.md` and `CONTRIBUTING.md` to include information on how to get started with a codespace

### How was this PR tested?

This Pr was testing by:
-  Creating a GitHub codespace using the generated devcontainer configuration and checking that all the required tools were set up successfully. 
- Running the common commands that a contributor will be expected to run and confirming that they worked.
