### PR TITLE
 optimize trace collector

### DIFF
--- a/quickwit/quickwit-common/src/binary_heap.rs
+++ b/quickwit/quickwit-common/src/binary_heap.rs
@@ -152,6 +152,10 @@ where
         self.heap.len() >= self.k
     }
 
+    pub fn max_len(&self) -> usize {
+        self.k
+    }
+
     /// Try to add new entries, if they are better than the current worst.
     pub fn add_entries(&mut self, mut items: impl Iterator<Item = T>) {
         if self.k == 0 {

--- a/quickwit/quickwit-search/src/find_trace_ids_collector.rs
+++ b/quickwit/quickwit-search/src/find_trace_ids_collector.rs
@@ -186,8 +186,7 @@ fn merge_segment_fruits(mut segment_fruits: Vec<Vec<Span>>, num_traces: usize) -
     let mut seen_trace_ids: FnvHashSet<TraceId> = FnvHashSet::default();
 
     for span in segment_fruits.into_iter().kmerge() {
-        if !seen_trace_ids.contains(&span.trace_id) {
-            seen_trace_ids.insert(span.trace_id);
+        if seen_trace_ids.insert(span.trace_id) {
             spans.push(span);
 
             if spans.len() == num_traces {
@@ -327,7 +326,6 @@ impl SelectTraceIds {
             return;
         }
         self.select();
-
         for trace_id in self.select_workbench.drain(..self.num_traces) {
             self.dedup_workbench
                 .insert(trace_id.term_ord, trace_id.span_timestamp);

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -442,11 +442,27 @@ enum CanSplitDoBetter {
     SplitIdHigher(Option<String>),
     SplitTimestampHigher(Option<i64>),
     SplitTimestampLower(Option<i64>),
+    FindTraceIdsAggregation(Option<i64>),
 }
 
 impl CanSplitDoBetter {
     /// Create a CanSplitDoBetter from a SearchRequest
     fn from_request(request: &SearchRequest, timestamp_field_name: Option<&str>) -> Self {
+        if request.max_hits == 0 {
+            if let Some(aggregation) = &request.aggregation_request {
+                if let Ok(crate::QuickwitAggregations::FindTraceIdsAggregation(
+                    find_trace_aggregation,
+                )) = serde_json::from_str(aggregation)
+                {
+                    if Some(find_trace_aggregation.span_timestamp_field_name.as_str())
+                        == timestamp_field_name
+                    {
+                        return CanSplitDoBetter::FindTraceIdsAggregation(None);
+                    }
+                }
+            }
+        }
+
         if request.sort_fields.is_empty() {
             CanSplitDoBetter::SplitIdHigher(None)
         } else if let Some((sort_by, timestamp_field)) =
@@ -480,7 +496,8 @@ impl CanSplitDoBetter {
             CanSplitDoBetter::SplitIdHigher(_) => {
                 splits.sort_unstable_by(|a, b| b.split_id.cmp(&a.split_id))
             }
-            CanSplitDoBetter::SplitTimestampHigher(_) => {
+            CanSplitDoBetter::SplitTimestampHigher(_)
+            | CanSplitDoBetter::FindTraceIdsAggregation(_) => {
                 splits.sort_unstable_by_key(|split| std::cmp::Reverse(split.timestamp_end()))
             }
             CanSplitDoBetter::SplitTimestampLower(_) => {
@@ -495,7 +512,8 @@ impl CanSplitDoBetter {
     fn can_be_better(&self, split: &SplitIdAndFooterOffsets) -> bool {
         match self {
             CanSplitDoBetter::SplitIdHigher(Some(split_id)) => split.split_id >= *split_id,
-            CanSplitDoBetter::SplitTimestampHigher(Some(timestamp)) => {
+            CanSplitDoBetter::SplitTimestampHigher(Some(timestamp))
+            | CanSplitDoBetter::FindTraceIdsAggregation(Some(timestamp)) => {
                 split.timestamp_end() > *timestamp
             }
             CanSplitDoBetter::SplitTimestampLower(Some(timestamp)) => {
@@ -512,7 +530,8 @@ impl CanSplitDoBetter {
         match self {
             CanSplitDoBetter::Uninformative => (),
             CanSplitDoBetter::SplitIdHigher(split_id) => *split_id = Some(hit.split_id.clone()),
-            CanSplitDoBetter::SplitTimestampHigher(timestamp) => {
+            CanSplitDoBetter::SplitTimestampHigher(timestamp)
+            | CanSplitDoBetter::FindTraceIdsAggregation(timestamp) => {
                 if let Some(SortValue::I64(timestamp_ns)) = hit.sort_value() {
                     // if we get a timestamp of, says 1.5s, we need to check up to 2s to make
                     // sure we don't throw away something like 1.2s, so we should round up while
@@ -549,13 +568,14 @@ pub async fn leaf_search(
 ) -> Result<LeafSearchResponse, SearchError> {
     info!(splits_num = splits.len(), split_offsets = ?PrettySample::new(&splits, 5));
 
-    // In the future this should become `request.aggregation_request.is_some() ||
-    // request.exact_count == true`
-    let run_all_splits =
-        request.aggregation_request.is_some() || request.count_hits() == CountHits::CountAll;
-
     let split_filter = CanSplitDoBetter::from_request(&request, doc_mapper.timestamp_field_name());
     split_filter.optimize_split_order(&mut splits);
+
+    // if client wants full count, or we are doing an aggregation, we want to run every splits.
+    // However if the aggregation is the tracing aggregation, we don't actually need all splits.
+    let run_all_splits = request.count_hits() == CountHits::CountAll
+        || (request.aggregation_request.is_some()
+            && !matches!(split_filter, CanSplitDoBetter::FindTraceIdsAggregation(_)));
 
     // Creates a collector which merges responses into one
     let merge_collector =
@@ -671,7 +691,10 @@ async fn leaf_search_single_split_wrapper(
         }),
     }
     if let Some(last_hit) = locked_incremental_merge_collector.peek_worst_hit() {
-        split_filter.lock().unwrap().record_new_worst_hit(last_hit);
+        split_filter
+            .lock()
+            .unwrap()
+            .record_new_worst_hit(last_hit.as_ref());
     }
 }
 


### PR DESCRIPTION
### Description

fix #3998 

### How was this PR tested?

build a "large" index of spans (~40m spans), set `searcher.max_num_concurrent_split_searches: 1` in quickwit.yaml, and verify most splits don't get searched at all. Query went from ~530ms to ~1.8ms (the newest splits underwent less merges, so they are much faster to search than some of the older splits)

