### PR TITLE
Improve readability of the `index describe`

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -122,20 +122,21 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi-str"
-version = "0.3.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50acdf02a3ac61856d5c8d576a8b5fb452a6549f667ca29fefaa18c2cd05135"
+checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
 dependencies = [
  "ansitok",
 ]
 
 [[package]]
 name = "ansitok"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c6eb31f539d8fc1df948eb26452d6c781be4c9883663e7acb258644b71d5b1"
+checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
 dependencies = [
  "nom",
+ "vte 0.10.1",
 ]
 
 [[package]]
@@ -1943,6 +1944,12 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "duct"
@@ -4025,6 +4032,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "numfmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7467e47de9fb6ea5b3f47dc34c1cf0b86359f072a46f6278119544cdbd0021"
+dependencies = [
+ "dtoa",
+ "itoa",
+]
+
+[[package]]
 name = "oauth2"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,14 +4363,14 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.5.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453cf71f2a37af495a1a124bf30d4d7469cfbea58e9f2479be9d222396a518a2"
+checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
 dependencies = [
  "ansi-str",
+ "ansitok",
  "bytecount",
  "fnv",
- "strip-ansi-escapes 0.1.1",
  "unicode-width",
 ]
 
@@ -5142,6 +5159,7 @@ dependencies = [
  "bytes",
  "bytesize",
  "chitchat",
+ "chrono",
  "clap",
  "colored",
  "console-subscriber",
@@ -5150,6 +5168,7 @@ dependencies = [
  "humantime",
  "indicatif",
  "itertools 0.12.0",
+ "numfmt",
  "once_cell",
  "openssl-probe",
  "opentelemetry",
@@ -7381,15 +7400,6 @@ dependencies = [
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
-dependencies = [
- "vte 0.10.1",
-]
-
-[[package]]
-name = "strip-ansi-escapes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
@@ -7482,11 +7492,12 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.8.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b2f8c37d26d87d2252187b0a45ea3cbf42baca10377c7e7eaaa2800fa9bf97"
+checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
 dependencies = [
  "ansi-str",
+ "ansitok",
  "papergrid",
  "tabled_derive",
  "unicode-width",
@@ -7494,9 +7505,9 @@ dependencies = [
 
 [[package]]
 name = "tabled_derive"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ee618502f497abf593e1c5c9577f34775b111480009ffccd7ad70d23fcaba8"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -8583,7 +8594,7 @@ dependencies = [
  "sha2",
  "sha3",
  "snafu",
- "strip-ansi-escapes 0.2.0",
+ "strip-ansi-escapes",
  "syslog_loose",
  "termcolor",
  "thiserror",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -115,6 +115,7 @@ mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "ebee0f
 new_string_template = "1.4.0"
 nom = "7.1.3"
 num_cpus = "1"
+numfmt = "1.1.1"
 once_cell = "1"
 oneshot = "0.1.5"
 openssl = { version = "0.10.55", default-features = false }

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -178,7 +178,7 @@ sqlx = { version = "0.7", features = [
 ] }
 syn = { version = "2.0.11", features = ["extra-traits", "full", "parsing"] }
 sync_wrapper = "0.1.2"
-tabled = { version = "0.8", features = ["color"] }
+tabled = { version = "0.14", features = ["color"] }
 tempfile = "3"
 termcolor = "1"
 thiserror = "1"

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -32,6 +32,7 @@ futures = { workspace = true }
 humantime = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
+numfmt = { workspace = true }
 once_cell = { workspace = true }
 openssl-probe = { workspace = true, optional = true }
 opentelemetry = { workspace = true }

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = { workspace = true }
 bytesize = { workspace = true }
 bytes = { workspace = true }
 chitchat = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
 console-subscriber = { workspace = true, optional = true }

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -596,12 +596,16 @@ fn display_option_in_table(opt: &Option<impl Display>) -> String {
     }
 }
 
-fn display_timestamp_range(range: &Option<(i64, i64)>) -> String {
-    match range {
-        Some((timestamp_min, timestamp_max)) => {
-            format!("{timestamp_min} -> {timestamp_max}")
+fn display_timestamp(timestamp: &Option<i64>) -> String {
+    match timestamp {
+        Some(timestamp) => {
+            let datetime = chrono::NaiveDateTime::from_timestamp_millis(*timestamp * 1000)
+                .map_or("Invalid timestamp!".to_string(), |datetime| {
+                    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+                });
+            format!("{} (Timestamp: {})", datetime, timestamp)
         }
-        _ => "Range does not exist for the index.".to_string(),
+        _ => "Timestamp does not exist for the index.".to_string(),
     }
 }
 

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -576,15 +576,15 @@ impl Tabled for IndexStats {
 
     fn headers() -> Vec<Cow<'static, str>> {
         [
-            "Index ID: ",
-            "Index URI: ",
-            "Number of published documents: ",
-            "Size of published documents (uncompressed): ",
-            "Number of published splits: ",
-            "Size of published splits: ",
-            "Timestamp field: ",
-            "Timestamp range start: ",
-            "Timestamp range end: ",
+            "Index ID",
+            "Index URI",
+            "Number of published documents",
+            "Size of published documents (uncompressed)",
+            "Number of published splits",
+            "Size of published splits",
+            "Timestamp field",
+            "Timestamp range start",
+            "Timestamp range end",
         ]
         .into_iter()
         .map(|header| header.into())

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -601,7 +601,7 @@ fn separate_thousands(num: impl numfmt::Numeric) -> String {
     let mut thousands_separator_formatter = Formatter::new()
         .separator(',')
         // NOTE: .separator(sep) only panics if sep.len_utf8() != 1
-        .expect("Valid separator")
+        .expect("`,` separator should be valid")
         .precision(numfmt::Precision::Significance(3));
 
     thousands_separator_formatter.fmt2(num).to_string()

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -33,6 +33,7 @@ use colored::{ColoredString, Colorize};
 use humantime::format_duration;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
+use numfmt::{Formatter, Scales};
 use quickwit_actors::ActorHandle;
 use quickwit_common::uri::Uri;
 use quickwit_config::{ConfigFormat, IndexConfig};
@@ -571,6 +572,16 @@ impl Tabled for IndexStats {
             "Timestamp range: ".to_string(),
         ]
     }
+}
+
+fn separate_thousands(num: impl numfmt::Numeric) -> String {
+    let mut thousands_separator_formatter = Formatter::new()
+        .separator(',')
+        // NOTE: .separator(sep) only panics if sep.len_utf8() != 1
+        .expect("Valid separator")
+        .precision(numfmt::Precision::Significance(3));
+
+    thousands_separator_formatter.fmt2(num).to_string()
 }
 
 fn display_option_in_table(opt: &Option<impl Display>) -> String {

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -21,6 +21,7 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::io::{stdout, Stdout, Write};
+use std::ops::Div;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -782,6 +783,7 @@ impl DescriptiveStats {
             // We separate tables with a newline already, this is to separate quantile part of the
             // table further away from the next table.
             .with(Footer::new("\n"));
+
         table
     }
 }
@@ -805,6 +807,19 @@ pub struct SummaryStats {
     max_val: u64,
 }
 
+impl Div<f32> for SummaryStats {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        Self {
+            mean_val: self.mean_val / rhs,
+            std_val: self.std_val / rhs,
+            min_val: self.min_val / rhs as u64,
+            max_val: self.max_val / rhs as u64,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Quantiles {
     q1: f32,
@@ -814,7 +829,17 @@ pub struct Quantiles {
     q99: f32,
 }
 
+impl Div<f32> for Quantiles {
+    type Output = Self;
 
+    fn div(self, rhs: f32) -> Self::Output {
+        Self {
+            q1: self.q1 / rhs,
+            q25: self.q25 / rhs,
+            q50: self.q50 / rhs,
+            q75: self.q75 / rhs,
+            q99: self.q99 / rhs,
+        }
     }
 }
 

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -618,9 +618,8 @@ fn display_timestamp(timestamp: &Option<i64>) -> String {
     match timestamp {
         Some(timestamp) => {
             let datetime = chrono::NaiveDateTime::from_timestamp_millis(*timestamp * 1000)
-                .map_or("Invalid timestamp!".to_string(), |datetime| {
-                    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
-                });
+                .map(|datetime| datetime.format("%Y-%m-%d %H:%M:%S").to_string())
+                .unwrap_or_else(|| "Invalid timestamp!".to_string());
             format!("{} (Timestamp: {})", datetime, timestamp)
         }
         _ => "Timestamp does not exist for the index.".to_string(),

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -574,6 +574,11 @@ impl Tabled for IndexStats {
     }
 }
 
+fn format_to_si_scale(num: impl numfmt::Numeric) -> String {
+    let mut si_scale_formatter = Formatter::new().scales(Scales::metric());
+    si_scale_formatter.fmt2(num).to_string()
+}
+
 fn separate_thousands(num: impl numfmt::Numeric) -> String {
     let mut thousands_separator_formatter = Formatter::new()
         .separator(',')

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -709,13 +709,13 @@ impl IndexStats {
         tables.push(index_stats_table);
 
         if let Some(docs_stats) = &self.num_docs_descriptive {
-            let doc_stats_table = docs_stats.into_table("Document count stats (published)");
+            let doc_stats_table = docs_stats.into_table("Published documents count stats");
             tables.push(doc_stats_table);
         }
 
         if let Some(size_stats) = &self.num_bytes_descriptive {
             let size_stats_in_mb = size_stats / 1_000_000.0;
-            let size_stats_table = size_stats_in_mb.into_table("Size in MB stats (published)");
+            let size_stats_table = size_stats_in_mb.into_table("Published splits size stats (MB)");
             tables.push(size_stats_table);
         }
 

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -704,7 +704,7 @@ impl IndexStats {
     }
 
     pub fn display_as_table(&self) -> String {
-        let index_stats_table = create_table(self, "General Information");
+        let index_stats_table = create_table(self, "General Information", true);
 
         let index_stats_table = if let Some(docs_stats) = &self.num_docs_descriptive {
             let doc_stats_table = create_table(docs_stats, "Document count stats (published)");
@@ -736,22 +736,33 @@ impl IndexStats {
     }
 }
 
-fn create_table(table: impl Tabled, header: &str) -> Table {
-    Table::new(vec![table])
-        .with(Rotate::Left)
-        .with(Rotate::Bottom)
-        .with(
-            Modify::new(Columns::first())
-                .with(Format::new(|column| column.color(GREEN_COLOR).to_string())),
-        )
+fn create_table(table: impl Tabled, header: &str, is_vertical: bool) -> Table {
+    let mut table = Table::new(vec![table]);
+
+    // Make the field names GREEN :D
+    table.with(Modify::new(Rows::first()).with(Format::content(|column| {
+        column.color(GREEN_COLOR).to_string()
+    })));
+
+    if is_vertical {
+        table.with(Rotate::Left).with(Rotate::Bottom);
+    }
+
+    table
+        .with(Panel::header(header))
+        // Makes the table header bright green and bold.
+        .with(Modify::new(Rows::first()).with(Format::content(|header| {
+            header.bright_green().bold().to_string()
+        })))
         .with(
             Modify::new(Segment::all())
                 .with(Alignment::left())
                 .with(Alignment::top()),
         )
-        .with(Panel(header, 0))
-        .with(Style::psql())
-        .with(Panel("\n", 0))
+        .with(Footer::new("\n"))
+        .with(Style::psql());
+
+    table
 }
 
 #[derive(Debug)]

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -764,6 +764,8 @@ fn create_table(table: impl Tabled, header: &str, is_vertical: bool) -> Table {
 pub struct DescriptiveStats {
     summary_stats: SummaryStats,
     quantiles: Quantiles,
+}
+
 impl DescriptiveStats {
     pub fn into_table(self, header: &str) -> Table {
         let summary_stats_table = create_table(self.summary_stats, header, true);

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -608,7 +608,7 @@ fn separate_thousands(num: impl numfmt::Numeric) -> String {
 
 fn display_option_in_table(opt: &Option<impl Display>) -> String {
     match opt {
-        Some(opt_val) => format!("{opt_val}"),
+        Some(opt_val) => format!("\"{opt_val}\""),
         None => "Field does not exist for the index.".to_string(),
     }
 }

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -40,8 +40,10 @@ use quickwit_rest_client::models::Timeout;
 use quickwit_rest_client::rest_client::{QuickwitClient, QuickwitClientBuilder, DEFAULT_BASE_URL};
 use quickwit_storage::{load_file, StorageResolver};
 use reqwest::Url;
-use tabled::object::Rows;
-use tabled::{Alignment, Header, Modify, Style, Table, Tabled};
+use tabled::settings::object::Rows;
+use tabled::settings::panel::Header;
+use tabled::settings::{Alignment, Modify, Style};
+use tabled::{Table, Tabled};
 use tracing::info;
 
 use crate::checklist::run_checklist;
@@ -297,11 +299,9 @@ pub fn make_table<T: Tabled>(
     rows: impl IntoIterator<Item = T>,
     transpose: bool,
 ) -> Table {
-    let table = if transpose {
-        let mut index_builder = Table::builder(rows).index();
-        index_builder.set_index(0);
-        index_builder.transpose();
-        index_builder.build()
+    let mut table = if transpose {
+        let index_builder = Table::builder(rows).index();
+        index_builder.column(0).transpose().build()
     } else {
         Table::builder(rows).build()
     };
@@ -309,8 +309,10 @@ pub fn make_table<T: Tabled>(
     table
         .with(Modify::new(Rows::new(1..)).with(Alignment::left()))
         .with(Style::ascii())
-        .with(Header(header))
-        .with(Modify::new(Rows::single(0)).with(Alignment::center()))
+        .with(Header::new(header))
+        .with(Modify::new(Rows::single(0)).with(Alignment::center()));
+
+    table
 }
 
 /// Prompts user for confirmation.


### PR DESCRIPTION
## CSS is easier

Disclaimer: I _tried_ to push a good commit history; however, git is my greatest enemy. I failed miserably.

The new version looks like this:
![image](https://github.com/quickwit-oss/quickwit/assets/44371603/50c0e2b4-69d9-47c7-869c-2e4d8cd2d266)

Changes:
- Well, I think it satisfies every criterion on the #3999 
- Updated `tabled` version
- Uses `chrono` for parsing the timestamp

I know the question that everyone who sees the screenshot will ask. It's blatant;

**Q: WOW! That font looks so COOL! You must be a really cool person! A retro monospace font with some modern vibes to it?!?!?**
A: I know, I know. I really am cool. Thanks for asking. The font is [Berkeley Mono](https://berkeleygraphics.com/typefaces/berkeley-mono/). No I'm not sponsored

_Hopefully closes #3999_ 