### PR TITLE
append compatible elastic header

### DIFF
--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -303,6 +303,7 @@ impl Default for JaegerConfig {
 pub struct NodeConfig {
     pub cluster_id: String,
     pub node_id: String,
+    pub enable_elastic_header: bool,
     pub enabled_services: HashSet<QuickwitService>,
     pub rest_listen_addr: SocketAddr,
     pub gossip_listen_addr: SocketAddr,
@@ -375,7 +376,12 @@ impl NodeConfig {
 
     #[cfg(any(test, feature = "testsuite"))]
     pub fn for_test() -> Self {
-        serialize::node_config_for_test()
+        serialize::node_config_for_test(false)
+    }
+
+    #[cfg(any(test, feature = "testsuite"))]
+    pub fn for_test_elastic_header() -> Self {
+        serialize::node_config_for_test(true)
     }
 }
 

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -59,6 +59,10 @@ fn default_node_id() -> ConfigValue<String, QW_NODE_ID> {
     ConfigValue::with_default(node_id)
 }
 
+fn default_enable_elastic_header() -> ConfigValue<bool, QW_ENABLE_ELSTIC_HEADER> {
+    ConfigValue::with_default(false)
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 struct List(Vec<String>);
 
@@ -163,6 +167,8 @@ struct NodeConfigBuilder {
     cluster_id: ConfigValue<String, QW_CLUSTER_ID>,
     #[serde(default = "default_node_id")]
     node_id: ConfigValue<String, QW_NODE_ID>,
+    #[serde(default = "default_enable_elastic_header")]
+    enable_elastic_header: ConfigValue<bool, QW_ENABLE_ELSTIC_HEADER>,
     #[serde(default = "default_enabled_services")]
     enabled_services: ConfigValue<List, QW_ENABLED_SERVICES>,
     #[serde(default = "default_listen_address")]
@@ -271,6 +277,7 @@ impl NodeConfigBuilder {
         let node_config = NodeConfig {
             cluster_id: self.cluster_id.resolve(env_vars)?,
             node_id: self.node_id.resolve(env_vars)?,
+            enable_elastic_header: self.enable_elastic_header.resolve(env_vars)?,
             enabled_services,
             rest_listen_addr,
             gossip_listen_addr,
@@ -318,6 +325,7 @@ impl Default for NodeConfigBuilder {
             cluster_id: default_cluster_id(),
             node_id: default_node_id(),
             enabled_services: default_enabled_services(),
+            enable_elastic_header: default_enable_elastic_header(),
             listen_address: default_listen_address(),
             rest_listen_port: default_rest_listen_port(),
             gossip_listen_port: ConfigValue::none(),
@@ -339,7 +347,7 @@ impl Default for NodeConfigBuilder {
 }
 
 #[cfg(any(test, feature = "testsuite"))]
-pub fn node_config_for_test() -> NodeConfig {
+pub fn node_config_for_test(enable_es_header: bool) -> NodeConfig {
     let enabled_services = QuickwitService::supported_services();
 
     let listen_address = Host::default();
@@ -371,6 +379,7 @@ pub fn node_config_for_test() -> NodeConfig {
     NodeConfig {
         cluster_id: default_cluster_id().unwrap(),
         node_id: default_node_id().unwrap(),
+        enable_elastic_header: enable_es_header,
         enabled_services,
         gossip_advertise_addr: gossip_listen_addr,
         grpc_advertise_addr: grpc_listen_addr,

--- a/quickwit/quickwit-config/src/qw_env_vars.rs
+++ b/quickwit/quickwit-config/src/qw_env_vars.rs
@@ -59,7 +59,8 @@ qw_env_vars!(
     QW_PEER_SEEDS,
     QW_DATA_DIR,
     QW_METASTORE_URI,
-    QW_DEFAULT_INDEX_ROOT_URI
+    QW_DEFAULT_INDEX_ROOT_URI,
+    QW_ENABLE_ELSTIC_HEADER
 );
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

We will get `the client noticed that the server is not Elasticsearch and we do not support this unknown product` error message when querying the Qucikwit with the Golang client.

That's because some Elasticsearch clients will check the response header whether the heads contain `X-Elastic-Product` and the value is `Elasticsearch`


Source code in Elasticsearch clients
- Java https://github.com/elastic/elasticsearch-java/blob/2d0e3a5fe76285f91b28784ba19adf124327d533/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java#L437
- Python https://github.com/elastic/elasticsearch-py/blob/a6bb5f3808ef8616afde81ebc1dc53f98011a2b8/elasticsearch/_sync/client/_base.py#L325
- Golang https://github.com/elastic/go-elasticsearch/blob/537d09014a37fd1288919bd43eb7f1ab1bd374ae/elasticsearch.go#L364

### How was this PR tested?

test code https://github.com/quickwit-oss/quickwit/compare/es_header?expand=1#diff-ff71f681357dc97850f21fb99bd77c44304e9c20b043c1de8182e48ef206208fR415