### PR TITLE
Documentation Update for GitHub Codespaces Support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,24 @@ You will be notified by email from the CI system if any issues are discovered, b
 3. To build docs run `make build-docs`.
 
 # Development
+
 ## Setup & run tests
+
+### Local Development
+
 1. Install Rust, CMake, Docker (https://docs.docker.com/engine/install/) and Docker Compose (https://docs.docker.com/compose/install/)
 2. Install node@18 and `npm install -g yarn`
 3. Install awslocal https://github.com/localstack/awscli-local
 4. Install protoc https://grpc.io/docs/protoc-installation/ (you may need to install the latest binaries rather than your distro's flavor)
-5. Run all tests using `make test-all`
+
+### GitHub Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/quickwit-oss/quickwit?devcontainer_path=.devcontainer/devcontainer.json)
+
+GitHub Codespaces provides a fully configured development environment in the cloud, making it easy to get started with Quickwit development. By clicking the badge above, you can create a codespace with all the necessary tools installed and configured.
+
+### Running tests
+Run `make test-all` to run all tests.
 
 ## Useful commands
 * `make test-all` - starts necessary Docker services and runs all tests.

--- a/README.md
+++ b/README.md
@@ -136,12 +136,14 @@ Our business model relies on our commercial license. There is no plan to become 
 
 We are always thrilled to receive contributions: code, documentation, issues, or feedback. Here's how you can help us build the future of log management:
 
-- Check out the [GitHub issues labeled "Good first issue"](https://github.com/quickwit-oss/quickwit/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) for a great place to start.
-- Familiarize yourself with our [Contributor Covenant Code of Conduct](https://github.com/quickwit-oss/quickwit/blob/0add0562f08e4edd46f5c5537e8ef457d42a508e/CODE_OF_CONDUCT.md).
-- Delve into our [contributing guide](CONTRIBUTING.md).
-- [Create a fork of Quickwit](https://github.com/quickwit-oss/quickwit/fork) and submit your pull request!
+- Start by checking out the [GitHub issues labeled "Good first issue"](https://github.com/quickwit-oss/quickwit/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). These are a great place for newcomers to contribute.
+- Read our [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md) to understand our community standards.
+- [Create a fork of Quickwit](https://github.com/quickwit-oss/quickwit/fork) to have your own copy of the repository where you can make changes.
+- To understand how to contribute, read our [contributing guide](./CONTRIBUTING.md).
+- Set up your development environment following our [development setup guide](./CONTRIBUTING.md#development).
+- Once you've made your changes and tested them, you can contribute by [submitting a pull request](./CONTRIBUTING.md#submitting-a-pr).
 
-✨ And to thank you for your contributions, claim your swag by emailing us at hello@quickwit.io.
+✨ After your contributions are accepted, don't forget to claim your swag by emailing us at hello@quickwit.io. Thank you for contributing!
 
 # 💬 Join Our Community
 


### PR DESCRIPTION
### Description

Closes #4163
This pull request updates the documentation to reflect the existing support for GitHub Codespaces in Quickwit. The aim is to guide contributors on how to leverage GitHub Codespaces for their development work on Quickwit.

The changes include:

- Updated the `README.md` to make it more clear
- Added a new section in the `CONTRIBUTING.md` file to highlight the support for GitHub Codespaces.
- Included a 'Open in GitHub Codespaces' badge in the `CONTRIBUTING.md` file for easy access.
These updates will help contributors easily understand how to use GitHub Codespaces when contributing to Quickwit, making the process more streamlined and accessible.

### How was this PR tested?

Manually testing the added links and badges and ensuring that they work as intended
