### PR TITLE
Increase the gRPC payload limits from 10MiB to 20MiB.

### DIFF
--- a/quickwit/quickwit-codegen/example/src/codegen/hello.rs
+++ b/quickwit/quickwit-codegen/example/src/codegen/hello.rs
@@ -126,8 +126,8 @@ impl HelloClient {
     ) -> HelloClient {
         let connection_keys_watcher = balance_channel.connection_keys_watcher();
         let client = hello_grpc_client::HelloGrpcClient::new(balance_channel)
-            .max_decoding_message_size(10 * 1024 * 1024)
-            .max_encoding_message_size(10 * 1024 * 1024);
+            .max_decoding_message_size(20 * 1024 * 1024)
+            .max_encoding_message_size(20 * 1024 * 1024);
         let adapter = HelloGrpcClientAdapter::new(client, connection_keys_watcher);
         Self::new(adapter)
     }

--- a/quickwit/quickwit-codegen/src/codegen.rs
+++ b/quickwit/quickwit-codegen/src/codegen.rs
@@ -588,8 +588,8 @@ fn generate_client(context: &CodegenContext) -> TokenStream {
             {
                 let connection_keys_watcher = balance_channel.connection_keys_watcher();
                 let client = #grpc_client_package_name::#grpc_client_name::new(balance_channel)
-                    .max_decoding_message_size(10 * 1024 * 1024)
-                    .max_encoding_message_size(10 * 1024 * 1024);
+                    .max_decoding_message_size(20 * 1024 * 1024)
+                    .max_encoding_message_size(20 * 1024 * 1024);
                 let adapter = #grpc_client_adapter_name::new(client, connection_keys_watcher);
                 Self::new(adapter)
             }

--- a/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
+++ b/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
@@ -238,8 +238,8 @@ impl IngestServiceClient {
         let client = ingest_service_grpc_client::IngestServiceGrpcClient::new(
                 balance_channel,
             )
-            .max_decoding_message_size(10 * 1024 * 1024)
-            .max_encoding_message_size(10 * 1024 * 1024);
+            .max_decoding_message_size(20 * 1024 * 1024)
+            .max_encoding_message_size(20 * 1024 * 1024);
         let adapter = IngestServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
@@ -193,8 +193,8 @@ impl ControlPlaneServiceClient {
         let client = control_plane_service_grpc_client::ControlPlaneServiceGrpcClient::new(
                 balance_channel,
             )
-            .max_decoding_message_size(10 * 1024 * 1024)
-            .max_encoding_message_size(10 * 1024 * 1024);
+            .max_decoding_message_size(20 * 1024 * 1024)
+            .max_encoding_message_size(20 * 1024 * 1024);
         let adapter = ControlPlaneServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
@@ -93,8 +93,8 @@ impl IndexingServiceClient {
         let client = indexing_service_grpc_client::IndexingServiceGrpcClient::new(
                 balance_channel,
             )
-            .max_decoding_message_size(10 * 1024 * 1024)
-            .max_encoding_message_size(10 * 1024 * 1024);
+            .max_decoding_message_size(20 * 1024 * 1024)
+            .max_encoding_message_size(20 * 1024 * 1024);
         let adapter = IndexingServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -575,8 +575,8 @@ impl IngesterServiceClient {
         let client = ingester_service_grpc_client::IngesterServiceGrpcClient::new(
                 balance_channel,
             )
-            .max_decoding_message_size(10 * 1024 * 1024)
-            .max_encoding_message_size(10 * 1024 * 1024);
+            .max_decoding_message_size(20 * 1024 * 1024)
+            .max_encoding_message_size(20 * 1024 * 1024);
         let adapter = IngesterServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
@@ -180,8 +180,8 @@ impl IngestRouterServiceClient {
         let client = ingest_router_service_grpc_client::IngestRouterServiceGrpcClient::new(
                 balance_channel,
             )
-            .max_decoding_message_size(10 * 1024 * 1024)
-            .max_encoding_message_size(10 * 1024 * 1024);
+            .max_decoding_message_size(20 * 1024 * 1024)
+            .max_encoding_message_size(20 * 1024 * 1024);
         let adapter = IngestRouterServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -752,8 +752,8 @@ impl MetastoreServiceClient {
         let client = metastore_service_grpc_client::MetastoreServiceGrpcClient::new(
                 balance_channel,
             )
-            .max_decoding_message_size(10 * 1024 * 1024)
-            .max_encoding_message_size(10 * 1024 * 1024);
+            .max_decoding_message_size(20 * 1024 * 1024)
+            .max_encoding_message_size(20 * 1024 * 1024);
         let adapter = MetastoreServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,


### PR DESCRIPTION
By default our REST client sends batch of 10MiB that gets expanded to a little bit more after the lines are identified and the batch is converted to a different format.

If the ingest request is sent to a searcher (like when we use helm with an ingress pointing to a searcher), it has to be forwarded to an ingester via gRPC.

This solution is imperfect as the rest payload is actually configurable.

