### PR TITLE
Populates the control plane model will closed and open shards

### DIFF
--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -107,6 +107,10 @@ impl ShardTableEntry {
     pub fn from_shards(shards: Vec<Shard>, next_shard_id: NextShardId) -> Self {
         let shard_entries = shards
             .into_iter()
+            .filter(|shard| {
+                let shard_state = shard.shard_state();
+                shard_state == ShardState::Open || shard_state == ShardState::Closed
+            })
             .map(|shard| (shard.shard_id, shard.into()))
             .collect();
         Self {

--- a/quickwit/quickwit-proto/protos/quickwit/ingest.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingest.proto
@@ -55,7 +55,7 @@ enum ShardState {
   // The ingester hosting the shard is unavailable.
   SHARD_STATE_UNAVAILABLE = 2;
   // The shard is closed and cannot be written to.
-  // It can be safely deleted if the publish position is superior or equal to the replication position.
+  // It can be safely deleted if the publish position is superior or equal to `~eof`.
   SHARD_STATE_CLOSED = 3;
 }
 

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
@@ -108,7 +108,7 @@ pub enum ShardState {
     /// The ingester hosting the shard is unavailable.
     Unavailable = 2,
     /// The shard is closed and cannot be written to.
-    /// It can be safely deleted if the publish position is superior or equal to the replication position.
+    /// It can be safely deleted if the publish position is superior or equal to `~eof`.
     Closed = 3,
 }
 impl ShardState {


### PR DESCRIPTION
as opposed to only open ones.

Closes shards are not necessarily entirely indexed yet. With this change, after a reload, the closed shards will be scheduling for indexing as usual, and will get cleaned up once they reach eof.

Closes #4176
