### PR TITLE
Delete shards on truncate EOF

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,7 @@ services:
     # It is not an official docker image
     # if we prefer we can build a docker from the official docker image (gcloud cli)
     # and install the pubsub emulator https://cloud.google.com/pubsub/docs/emulator
-    image: thekevjames/gcloud-pubsub-emulator:${GCLOUD_EMULATOR:-7555256f2c}
+    image: thekevjames/gcloud-pubsub-emulator:${GCLOUD_EMULATOR:-455.0.0}
     container_name: gcp-pubsub-emulator
     ports:
       - "${MAP_HOST_GCLOUD_EMULATOR:-127.0.0.1}:8681:8681"

--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -433,7 +433,7 @@ where
         .iter()
         .map(|(partition_id, position)| CheckpointRow {
             partition_id: partition_id.0.to_string(),
-            offset: position.as_str().to_string(),
+            offset: position.to_string(),
         })
         .sorted_by(|left, right| left.partition_id.cmp(&right.partition_id));
     let checkpoint_table = make_table("Checkpoint", checkpoint_rows, false);
@@ -734,7 +734,9 @@ mod tests {
 
         let checkpoint: SourceCheckpoint = vec![("shard-000", ""), ("shard-001", "1234567890")]
             .into_iter()
-            .map(|(partition_id, offset)| (PartitionId::from(partition_id), Position::from(offset)))
+            .map(|(partition_id, offset)| {
+                (PartitionId::from(partition_id), Position::offset(offset))
+            })
             .collect();
         let sources = vec![SourceConfig {
             source_id: "foo-source".to_string(),

--- a/quickwit/quickwit-common/src/tower/rate_limit.rs
+++ b/quickwit/quickwit-common/src/tower/rate_limit.rs
@@ -276,7 +276,9 @@ mod tests {
             .call(Request { cost: 1 })
             .await
             .unwrap();
-        assert!(now.elapsed() < Duration::from_millis(1));
+        // The request should go through immediately but in some rare instance the test is slow to
+        // run and the call to `call` takes more than 1 ms.
+        assert!(now.elapsed() < Duration::from_millis(5));
 
         let now = Instant::now();
         // The first request goes through, but the second one is rate limited.

--- a/quickwit/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit/quickwit-indexing/src/actors/publisher.rs
@@ -271,7 +271,7 @@ mod tests {
             suggest_truncate_checkpoints[0]
                 .position_for_partition(&PartitionId::default())
                 .unwrap(),
-            &Position::from(2u64)
+            &Position::offset(2u64)
         );
 
         let merger_msgs: Vec<NewSplits> = merge_planner_inbox.drain_for_test_typed::<NewSplits>();
@@ -344,7 +344,7 @@ mod tests {
             suggest_truncate_checkpoints[0]
                 .position_for_partition(&PartitionId::default())
                 .unwrap(),
-            &Position::from(2u64)
+            &Position::offset(2u64)
         );
 
         let merger_msgs: Vec<NewSplits> = merge_planner_inbox.drain_for_test_typed::<NewSplits>();

--- a/quickwit/quickwit-indexing/src/models/shard_positions.rs
+++ b/quickwit/quickwit-indexing/src/models/shard_positions.rs
@@ -356,23 +356,23 @@ mod tests {
         ));
         event_broker1.publish(LocalShardPositionsUpdate::new(
             source_uid.clone(),
-            vec![(2, 10u64.into())],
+            vec![(2, Position::offset(10u64))],
         ));
         event_broker1.publish(LocalShardPositionsUpdate::new(
             source_uid.clone(),
-            vec![(1, 10u64.into())],
+            vec![(1, Position::offset(10u64))],
         ));
         event_broker2.publish(LocalShardPositionsUpdate::new(
             source_uid.clone(),
-            vec![(2, 10u64.into())],
+            vec![(2, Position::offset(10u64))],
         ));
         event_broker2.publish(LocalShardPositionsUpdate::new(
             source_uid.clone(),
-            vec![(2, 12u64.into())],
+            vec![(2, Position::offset(12u64))],
         ));
         event_broker2.publish(LocalShardPositionsUpdate::new(
             source_uid.clone(),
-            vec![(1, Position::Beginning), (2, 12u64.into())],
+            vec![(1, Position::Beginning), (2, Position::offset(12u64))],
         ));
 
         let mut updates1: Vec<Vec<(ShardId, Position)>> = Vec::new();
@@ -387,9 +387,9 @@ mod tests {
             updates1,
             vec![
                 vec![(1, Position::Beginning)],
-                vec![(1, Position::Beginning), (2, 10u64.into())],
-                vec![(1, 10u64.into()), (2, 10u64.into()),],
-                vec![(1, 10u64.into()), (2, 12u64.into()),],
+                vec![(1, Position::Beginning), (2, Position::offset(10u64))],
+                vec![(1, Position::offset(10u64)), (2, Position::offset(10u64)),],
+                vec![(1, Position::offset(10u64)), (2, Position::offset(12u64)),],
             ]
         );
 
@@ -403,10 +403,10 @@ mod tests {
         assert_eq!(
             updates2,
             vec![
-                vec![(2, 10u64.into())],
-                vec![(2, 12u64.into())],
-                vec![(1, Position::Beginning), (2, 12u64.into())],
-                vec![(1, 10u64.into()), (2, 12u64.into())],
+                vec![(2, Position::offset(10u64))],
+                vec![(2, Position::offset(12u64))],
+                vec![(1, Position::Beginning), (2, Position::offset(12u64))],
+                vec![(1, Position::offset(10u64)), (2, Position::offset(12u64))],
             ]
         );
 
@@ -446,16 +446,19 @@ mod tests {
                 source_uid.clone(),
                 vec![(1, Position::Beginning)],
             ));
-            tokio::time::sleep(Duration::from_millis(1000)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
             let value = cluster.get_self_key_value(&key).await.unwrap();
             assert_eq!(&value, r#"{"1":""}"#);
         }
         {
             event_broker.publish(LocalShardPositionsUpdate::new(
                 source_uid.clone(),
-                vec![(1, 1_000u64.into()), (2, 2000u64.into())],
+                vec![
+                    (1, Position::offset(1_000u64)),
+                    (2, Position::offset(2_000u64)),
+                ],
             ));
-            tokio::time::sleep(Duration::from_millis(1000)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
             let value = cluster.get_self_key_value(&key).await.unwrap();
             assert_eq!(
                 &value,
@@ -465,9 +468,12 @@ mod tests {
         {
             event_broker.publish(LocalShardPositionsUpdate::new(
                 source_uid.clone(),
-                vec![(1, 999u64.into()), (3, 3000u64.into())],
+                vec![
+                    (1, Position::offset(999u64)),
+                    (3, Position::offset(3_000u64)),
+                ],
             ));
-            tokio::time::sleep(Duration::from_millis(1000)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
             let value = cluster.get_self_key_value(&key).await.unwrap();
             // We do not update the position that got lower, nor the position that disappeared
             assert_eq!(

--- a/quickwit/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit/quickwit-indexing/src/source/file_source.rs
@@ -100,8 +100,8 @@ impl Source for FileSource {
                     .checkpoint_delta
                     .record_partition_delta(
                         partition_id,
-                        Position::from(self.counters.previous_offset),
-                        Position::from(self.counters.current_offset),
+                        Position::offset(self.counters.previous_offset),
+                        Position::offset(self.counters.current_offset),
                     )
                     .unwrap();
             }
@@ -364,8 +364,8 @@ mod tests {
         let partition_id = PartitionId::from(temp_file_path.to_string_lossy().to_string());
         let checkpoint_delta = SourceCheckpointDelta::from_partition_delta(
             partition_id,
-            Position::from(0u64),
-            Position::from(4u64),
+            Position::offset(0u64),
+            Position::offset(4u64),
         )
         .unwrap();
         checkpoint.try_apply_delta(checkpoint_delta).unwrap();

--- a/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
@@ -182,9 +182,9 @@ impl Source for IngestApiSource {
                 partition_id,
                 self.counters
                     .previous_offset
-                    .map(Position::from)
-                    .unwrap_or(Position::Beginning),
-                Position::from(current_offset),
+                    .map(Position::offset)
+                    .unwrap_or_default(),
+                Position::offset(current_offset),
             )
             .map_err(anyhow::Error::from)?;
 
@@ -408,8 +408,8 @@ mod tests {
         let partition_id: PartitionId = ingest_api_service.ask(GetPartitionId).await?.into();
         let checkpoint_delta = SourceCheckpointDelta::from_partition_delta(
             partition_id.clone(),
-            Position::from(0u64),
-            Position::from(1200u64),
+            Position::offset(0u64),
+            Position::offset(1200u64),
         )
         .unwrap();
         checkpoint.try_apply_delta(checkpoint_delta).unwrap();
@@ -686,7 +686,7 @@ mod tests {
 
         let partition_id = ingest_api_service.ask(GetPartitionId).await?.into();
         let mut source_checkpoint = SourceCheckpoint::default();
-        source_checkpoint.add_partition(partition_id, Position::from(10u64));
+        source_checkpoint.add_partition(partition_id, Position::offset(10u64));
         let ingest_api_source = IngestApiSource::try_new(ctx, source_checkpoint).await?;
         let ingest_api_source_actor = SourceActor {
             source: Box::new(ingest_api_source),

--- a/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kinesis/kinesis_source.rs
@@ -153,7 +153,7 @@ impl KinesisSource {
         let from_sequence_number_exclusive = match &position {
             Position::Beginning => None,
             Position::Offset(offset) => Some(offset.to_string()),
-            Position::Eof => panic!("position of a Kinesis shard should never be EOF"),
+            Position::Eof(_) => panic!("position of a Kinesis shard should never be EOF"),
         };
         let shard_consumer = ShardConsumer::new(
             self.stream_name.clone(),
@@ -331,13 +331,11 @@ impl Source for KinesisSource {
     }
 
     fn observable_state(&self) -> JsonValue {
-        let shard_consumer_positions: Vec<(&ShardId, &str)> = self
+        let shard_consumer_positions: Vec<(&ShardId, &Position)> = self
             .state
             .shard_consumers
             .iter()
-            .map(|(shard_id, shard_consumer_state)| {
-                (shard_id, shard_consumer_state.position.as_str())
-            })
+            .map(|(shard_id, shard_consumer_state)| (shard_id, &shard_consumer_state.position))
             .sorted()
             .collect();
         json!({

--- a/quickwit/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit/quickwit-indexing/src/source/vec_source.rs
@@ -82,7 +82,7 @@ fn position_from_offset(offset: usize) -> Position {
     if offset == 0 {
         return Position::Beginning;
     }
-    Position::from(offset - 1)
+    Position::offset(offset - 1)
 }
 
 #[async_trait]

--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast.rs
@@ -194,9 +194,9 @@ impl BroadcastLocalShardsTask {
                 source_id,
             };
             // Shard ingestion rate in MiB/s.
-            let ingestion_rate_u64 =
-                rate_meter.harvest().rescale(Duration::from_secs(1)).work() / ONE_MIB.as_u64();
-            let ingestion_rate = RateMibPerSec(ingestion_rate_u64 as u16);
+            let ingestion_rate_per_sec = rate_meter.harvest().rescale(Duration::from_secs(1));
+            let ingestion_rate_mib_per_sec_u64 = ingestion_rate_per_sec.work() / ONE_MIB.as_u64();
+            let ingestion_rate = RateMibPerSec(ingestion_rate_mib_per_sec_u64 as u16);
 
             let shard_info = ShardInfo {
                 shard_id,
@@ -471,7 +471,8 @@ mod tests {
         let mut state_guard = state.write().await;
 
         let queue_id_01 = queue_id("test-index:0", "test-source", 1);
-        let shard = IngesterShard::new_solo(ShardState::Open, Position::Beginning, Position::Eof);
+        let shard =
+            IngesterShard::new_solo(ShardState::Open, Position::Beginning, Position::Beginning);
         state_guard.shards.insert(queue_id_01.clone(), shard);
 
         let rate_limiter = RateLimiter::from_settings(RateLimiterSettings::default());

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -1082,14 +1082,14 @@ mod tests {
                             index_uid: "test-index-0:0".to_string(),
                             source_id: "test-source".to_string(),
                             shard_id: 1,
-                            replication_position_inclusive: Some(Position::from(1u64)),
+                            replication_position_inclusive: Some(Position::offset(1u64)),
                         },
                         PersistSuccess {
                             subrequest_id: 1,
                             index_uid: "test-index-1:0".to_string(),
                             source_id: "test-source".to_string(),
                             shard_id: 1,
-                            replication_position_inclusive: Some(Position::from(0u64)),
+                            replication_position_inclusive: Some(Position::offset(0u64)),
                         },
                     ],
                     failures: Vec::new(),
@@ -1122,7 +1122,7 @@ mod tests {
                         index_uid: "test-index-0:0".to_string(),
                         source_id: "test-source".to_string(),
                         shard_id: 1,
-                        replication_position_inclusive: Some(Position::from(3u64)),
+                        replication_position_inclusive: Some(Position::offset(3u64)),
                     }],
                     failures: Vec::new(),
                 };
@@ -1158,7 +1158,7 @@ mod tests {
                         index_uid: "test-index-1:0".to_string(),
                         source_id: "test-source".to_string(),
                         shard_id: 2,
-                        replication_position_inclusive: Some(Position::from(0u64)),
+                        replication_position_inclusive: Some(Position::offset(0u64)),
                     }],
                     failures: Vec::new(),
                 };
@@ -1293,7 +1293,7 @@ mod tests {
                         index_uid: "test-index-0:0".to_string(),
                         source_id: "test-source".to_string(),
                         shard_id: 1,
-                        replication_position_inclusive: Some(Position::from(0u64)),
+                        replication_position_inclusive: Some(Position::offset(0u64)),
                     }],
                     failures: Vec::new(),
                 };

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -405,7 +405,7 @@ mod tests {
         // for the pipeline state to be updated.
         test_sandbox
             .universe()
-            .sleep(OBSERVE_PIPELINE_INTERVAL * 3)
+            .sleep(OBSERVE_PIPELINE_INTERVAL * 5)
             .await;
         let pipeline_state = pipeline_handler.process_pending_and_observe().await.state;
         assert_eq!(pipeline_state.delete_task_planner.metrics.num_errors, 1);

--- a/quickwit/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit/quickwit-metastore/src/checkpoint.rs
@@ -196,7 +196,7 @@ impl SourceCheckpoint {
 /// let checkpoint: SourceCheckpoint = [(0u64, 0u64), (1u64, 2u64)]
 ///     .into_iter()
 ///     .map(|(partition_id, offset)| {
-///         (PartitionId::from(partition_id), Position::from(offset))
+///         (PartitionId::from(partition_id), Position::offset(offset))
 ///     })
 ///     .collect();
 /// ```
@@ -214,7 +214,7 @@ impl Serialize for SourceCheckpoint {
     where S: serde::Serializer {
         let mut map = serializer.serialize_map(Some(self.per_partition.len()))?;
         for (partition, position) in &self.per_partition {
-            map.serialize_entry(&*partition.0, position.as_str())?;
+            map.serialize_entry(&*partition.0, position)?;
         }
         map.end()
     }
@@ -344,7 +344,7 @@ impl fmt::Debug for SourceCheckpoint {
         for (i, (partition_id, position)) in self.per_partition.iter().enumerate() {
             f.write_str(&partition_id.0)?;
             f.write_str(":")?;
-            f.write_str(position.as_str())?;
+            write!(f, "{}", position)?;
             let is_last = i == self.per_partition.len() - 1;
             if !is_last {
                 f.write_str(" ")?;
@@ -404,9 +404,7 @@ impl fmt::Debug for SourceCheckpointDelta {
             write!(
                 f,
                 "{}:({}..{}]",
-                partition_id.0,
-                partition_delta.from.as_str(),
-                partition_delta.to.as_str()
+                partition_id.0, partition_delta.from, partition_delta.to,
             )?;
             if i != self.per_partition.len() - 1 {
                 f.write_str(" ")?;
@@ -426,12 +424,12 @@ impl TryFrom<Range<u64>> for SourceCheckpointDelta {
         let from_position = if range.start == 0 {
             Position::Beginning
         } else {
-            Position::from(range.start - 1)
+            Position::offset(range.start - 1)
         };
         let to_position = if range.end == 0 {
             Position::Beginning
         } else {
-            Position::from(range.end - 1)
+            Position::offset(range.end - 1)
         };
         SourceCheckpointDelta::from_partition_delta(
             PartitionId::default(),
@@ -565,15 +563,15 @@ mod tests {
         let delta = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("a"),
-                Position::from(123u64),
-                Position::from(128u64),
+                Position::offset(123u64),
+                Position::offset(128u64),
             )
             .unwrap();
             delta
                 .record_partition_delta(
                     PartitionId::from("b"),
-                    Position::from(60002u64),
-                    Position::from(60187u64),
+                    Position::offset(60002u64),
+                    Position::offset(60187u64),
                 )
                 .unwrap();
             delta
@@ -597,14 +595,14 @@ mod tests {
         let delta1 = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("a"),
-                Position::from("00123"),
-                Position::from("00128"),
+                Position::offset("00123"),
+                Position::offset("00128"),
             )
             .unwrap();
             delta.record_partition_delta(
                 PartitionId::from("b"),
-                Position::from("60002"),
-                Position::from("60187"),
+                Position::offset("60002"),
+                Position::offset("60187"),
             )?;
             delta
         };
@@ -612,14 +610,14 @@ mod tests {
         let delta2 = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("a"),
-                Position::from("00128"),
-                Position::from("00129"),
+                Position::offset("00128"),
+                Position::offset("00129"),
             )
             .unwrap();
             delta.record_partition_delta(
                 PartitionId::from("b"),
-                Position::from("50099"),
-                Position::from("60002"),
+                Position::offset("50099"),
+                Position::offset("60002"),
             )?;
             delta
         };
@@ -638,14 +636,14 @@ mod tests {
         let delta1 = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("a"),
-                Position::from("00123"),
-                Position::from("00128"),
+                Position::offset("00123"),
+                Position::offset("00128"),
             )
             .unwrap();
             delta.record_partition_delta(
                 PartitionId::from("b"),
-                Position::from("60002"),
-                Position::from("60187"),
+                Position::offset("60002"),
+                Position::offset("60187"),
             )?;
             delta
         };
@@ -653,14 +651,14 @@ mod tests {
         let delta3 = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("b"),
-                Position::from("60187"),
-                Position::from("60190"),
+                Position::offset("60187"),
+                Position::offset("60190"),
             )
             .unwrap();
             delta.record_partition_delta(
                 PartitionId::from("c"),
-                Position::from("20001"),
-                Position::from("20008"),
+                Position::offset("20001"),
+                Position::offset("20008"),
             )?;
             delta
         };
@@ -674,15 +672,15 @@ mod tests {
         let mut delta1 = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("a"),
-                Position::from("00123"),
-                Position::from("00128"),
+                Position::offset("00123"),
+                Position::offset("00128"),
             )
             .unwrap();
             delta
                 .record_partition_delta(
                     PartitionId::from("b"),
-                    Position::from("60002"),
-                    Position::from("60187"),
+                    Position::offset("60002"),
+                    Position::offset("60187"),
                 )
                 .unwrap();
             delta
@@ -690,15 +688,15 @@ mod tests {
         let delta2 = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("b"),
-                Position::from("60187"),
-                Position::from("60348"),
+                Position::offset("60187"),
+                Position::offset("60348"),
             )
             .unwrap();
             delta
                 .record_partition_delta(
                     PartitionId::from("c"),
-                    Position::from("20001"),
-                    Position::from("20008"),
+                    Position::offset("20001"),
+                    Position::offset("20008"),
                 )
                 .unwrap();
             delta
@@ -706,22 +704,22 @@ mod tests {
         let delta3 = {
             let mut delta = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("a"),
-                Position::from("00123"),
-                Position::from("00128"),
+                Position::offset("00123"),
+                Position::offset("00128"),
             )
             .unwrap();
             delta
                 .record_partition_delta(
                     PartitionId::from("b"),
-                    Position::from("60002"),
-                    Position::from("60348"),
+                    Position::offset("60002"),
+                    Position::offset("60348"),
                 )
                 .unwrap();
             delta
                 .record_partition_delta(
                     PartitionId::from("c"),
-                    Position::from("20001"),
-                    Position::from("20008"),
+                    Position::offset("20001"),
+                    Position::offset("20008"),
                 )
                 .unwrap();
             delta
@@ -731,8 +729,8 @@ mod tests {
 
         let delta4 = SourceCheckpointDelta::from_partition_delta(
             PartitionId::from("a"),
-            Position::from("00130"),
-            Position::from("00142"),
+            Position::offset("00130"),
+            Position::offset("00142"),
         )
         .unwrap();
         let result = delta1.extend(delta4);
@@ -740,16 +738,10 @@ mod tests {
             result,
             Err(PartitionDeltaError::from(IncompatibleCheckpointDelta {
                 partition_id: PartitionId::from("a"),
-                partition_position: Position::from("00128"),
-                delta_from_position: Position::from("00130")
+                partition_position: Position::offset("00128"),
+                delta_from_position: Position::offset("00130")
             }))
         );
-    }
-
-    #[test]
-    fn test_position_u64() {
-        let pos = Position::from(4u64);
-        assert_eq!(pos.as_str(), "00000000000000000004");
     }
 
     #[test]
@@ -757,8 +749,8 @@ mod tests {
         {
             let delta_error = SourceCheckpointDelta::from_partition_delta(
                 PartitionId::from("a"),
-                Position::from("20"),
-                Position::from("20"),
+                Position::offset("20"),
+                Position::offset("20"),
             )
             .unwrap_err();
             matches!(
@@ -771,8 +763,8 @@ mod tests {
             let delta_error = delta
                 .record_partition_delta(
                     PartitionId::from("a"),
-                    Position::from("20"),
-                    Position::from("10"),
+                    Position::offset("20"),
+                    Position::offset("10"),
                 )
                 .unwrap_err();
             matches!(
@@ -810,14 +802,14 @@ mod tests {
         let partition = PartitionId::from("a");
         let delta = SourceCheckpointDelta::from_partition_delta(
             partition.clone(),
-            Position::from(42u64),
-            Position::from(43u64),
+            Position::offset(42u64),
+            Position::offset(43u64),
         )
         .unwrap();
         let checkpoint: SourceCheckpoint = delta.get_source_checkpoint();
         assert_eq!(
             checkpoint.position_for_partition(&partition).unwrap(),
-            &Position::from(43u64)
+            &Position::offset(43u64)
         );
     }
 }

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/shards.rs
@@ -215,7 +215,7 @@ impl Shards {
         for shard_id in subrequest.shard_ids {
             if let Entry::Occupied(entry) = self.shards.entry(shard_id) {
                 let shard = entry.get();
-                if !force && shard.publish_position_inclusive() != Position::Eof {
+                if !force && !shard.publish_position_inclusive().is_eof() {
                     let message = format!("shard `{shard_id}` is not deletable");
                     return Err(MetastoreError::InvalidArgument { message });
                 }
@@ -284,7 +284,7 @@ impl Shards {
         for (shard_id, publish_position_inclusive) in shard_ids {
             let shard = self.get_shard_mut(shard_id).expect("shard should exist");
 
-            if publish_position_inclusive == Position::Eof {
+            if publish_position_inclusive.is_eof() {
                 shard.shard_state = ShardState::Closed as i32;
             }
             shard.publish_position_inclusive = Some(publish_position_inclusive);

--- a/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
@@ -145,7 +145,7 @@ impl TestableForRegression for IndexMetadata {
         let delta = SourceCheckpointDelta::from_partition_delta(
             PartitionId::from(0i64),
             Position::Beginning,
-            Position::from(42u64),
+            Position::offset(42u64),
         )
         .unwrap();
         source_checkpoint.try_apply_delta(delta).unwrap();

--- a/quickwit/quickwit-metastore/src/tests/mod.rs
+++ b/quickwit/quickwit-metastore/src/tests/mod.rs
@@ -943,7 +943,7 @@ pub async fn test_metastore_publish_splits_empty_splits_array_is_allowed<
             source_checkpoint
                 .position_for_partition(&PartitionId::default())
                 .unwrap(),
-            &Position::from(100u64 - 1)
+            &Position::offset(100u64 - 1)
         );
         cleanup_index(&mut metastore, index_uid).await;
     }
@@ -1565,7 +1565,7 @@ pub async fn test_metastore_publish_splits_concurrency<
                 let source_delta = SourceCheckpointDelta::from_partition_delta(
                     PartitionId::from(partition_id as u64),
                     Position::Beginning,
-                    Position::from(partition_id as u64),
+                    Position::offset(partition_id as u64),
                 )
                 .unwrap();
                 let checkpoint_delta = IndexCheckpointDelta {

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -32,7 +32,7 @@ service IngesterService {
 
   // Streams records from a leader or a follower. The client can optionally specify a range of positions to fetch,
   // otherwise the stream will go undefinitely or until the shard is closed.
-  rpc OpenFetchStream(OpenFetchStreamRequest) returns (stream FetchResponseV2);
+  rpc OpenFetchStream(OpenFetchStreamRequest) returns (stream FetchMessage);
 
   // Streams status updates, called "observations", from an ingester.
   rpc OpenObservationStream(OpenObservationStreamRequest) returns (stream ObservationMessage);
@@ -211,13 +211,27 @@ message OpenFetchStreamRequest {
   quickwit.ingest.Position from_position_exclusive = 5;
 }
 
-message FetchResponseV2 {
+message FetchMessage {
+  oneof message {
+    FetchPayload payload = 1;
+    FetchEof eof = 2;
+  }
+}
+
+message FetchPayload {
   string index_uid = 1;
   string source_id = 2;
   uint64 shard_id = 3;
   quickwit.ingest.MRecordBatch mrecord_batch = 4;
   quickwit.ingest.Position from_position_exclusive = 5;
   quickwit.ingest.Position to_position_inclusive = 6;
+}
+
+message FetchEof {
+  string index_uid = 1;
+  string source_id = 2;
+  uint64 shard_id = 3;
+  quickwit.ingest.Position eof_position = 4;
 }
 
 message InitShardsRequest {

--- a/quickwit/quickwit-proto/src/ingest/ingester.rs
+++ b/quickwit/quickwit-proto/src/ingest/ingester.rs
@@ -23,7 +23,31 @@ include!("../codegen/quickwit/quickwit.ingest.ingester.rs");
 
 pub use ingester_service_grpc_server::IngesterServiceGrpcServer;
 
-impl FetchResponseV2 {
+impl FetchMessage {
+    pub fn new_payload(payload: FetchPayload) -> Self {
+        assert!(
+            matches!(&payload.mrecord_batch, Some(batch) if !batch.mrecord_lengths.is_empty()),
+            "`mrecord_batch` must be set and non-empty"
+        );
+
+        Self {
+            message: Some(fetch_message::Message::Payload(payload)),
+        }
+    }
+
+    pub fn new_eof(eof: FetchEof) -> Self {
+        assert!(
+            matches!(eof.eof_position, Some(Position::Eof(_))),
+            "`eof_position` must be set"
+        );
+
+        Self {
+            message: Some(fetch_message::Message::Eof(eof)),
+        }
+    }
+}
+
+impl FetchPayload {
     pub fn queue_id(&self) -> QueueId {
         queue_id(&self.index_uid, &self.source_id, self.shard_id)
     }
@@ -34,6 +58,20 @@ impl FetchResponseV2 {
         } else {
             0
         }
+    }
+
+    pub fn from_position_exclusive(&self) -> Position {
+        self.from_position_exclusive.clone().unwrap_or_default()
+    }
+
+    pub fn to_position_inclusive(&self) -> Position {
+        self.to_position_inclusive.clone().unwrap_or_default()
+    }
+}
+
+impl FetchEof {
+    pub fn eof_position(&self) -> Position {
+        self.eof_position.clone().unwrap_or_default()
     }
 }
 

--- a/quickwit/quickwit-proto/src/ingest/mod.rs
+++ b/quickwit/quickwit-proto/src/ingest/mod.rs
@@ -19,7 +19,7 @@
 
 use bytes::Bytes;
 
-use self::ingester::{FetchResponseV2, PersistFailureReason, ReplicateFailureReason};
+use self::ingester::{PersistFailureReason, ReplicateFailureReason};
 use self::router::IngestFailureReason;
 use super::types::NodeId;
 use super::{ServiceError, ServiceErrorCode};
@@ -123,16 +123,6 @@ impl DocBatchV2 {
     }
 }
 
-impl FetchResponseV2 {
-    pub fn from_position_exclusive(&self) -> Position {
-        self.from_position_exclusive.clone().unwrap_or_default()
-    }
-
-    pub fn to_position_inclusive(&self) -> Position {
-        self.to_position_inclusive.clone().unwrap_or_default()
-    }
-}
-
 impl MRecordBatch {
     pub fn encoded_mrecords(&self) -> impl Iterator<Item = Bytes> + '_ {
         self.mrecord_lengths
@@ -155,6 +145,21 @@ impl MRecordBatch {
 
     pub fn num_mrecords(&self) -> usize {
         self.mrecord_lengths.len()
+    }
+
+    #[cfg(any(test, feature = "testsuite"))]
+    pub fn for_test(mrecords: impl IntoIterator<Item = &'static str>) -> Option<Self> {
+        let mut mrecord_buffer = Vec::new();
+        let mut mrecord_lengths = Vec::new();
+
+        for mrecord in mrecords {
+            mrecord_buffer.extend(mrecord.as_bytes());
+            mrecord_lengths.push(mrecord.len() as u32);
+        }
+        Some(Self {
+            mrecord_lengths,
+            mrecord_buffer: Bytes::from(mrecord_buffer),
+        })
     }
 }
 


### PR DESCRIPTION
### Description
1. Change the signature of fetch stream, which is now a `oneof` of `{FetchPayload, FetchEof}`
1. Change `Position::Eof` to `Position::Eof(Option<Offset>)`
1. Delete shards on truncate `EOF` and stop appending `EOF` records

- `1.` Generates more boilerplate but is safer because the compiler forces us to handle `EOF` messages explicitly. I caught two bugs.
- `2.` Made my life easier when debugging some tests because we no longer lose the offset when a position is at `EOF`.

### How was this PR tested?
Updated unit tests
