### PR TITLE
Some sanity rewrite of the LocalSplitStore

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -67,7 +67,7 @@ use super::merge_pipeline::{MergePipeline, MergePipelineParams};
 use super::{MergePlanner, MergeSchedulerService};
 use crate::models::{DetachIndexingPipeline, DetachMergePipeline, ObservePipeline, SpawnPipeline};
 use crate::source::{AssignShards, Assignment};
-use crate::split_store::{LocalSplitStore, SplitStoreQuota};
+use crate::split_store::{IndexingSplitCache, SplitStoreQuota};
 use crate::{IndexingPipeline, IndexingPipelineParams, IndexingSplitStore, IndexingStatistics};
 
 /// Name of the indexing directory, usually located at `<data_dir_path>/indexing`.
@@ -112,7 +112,7 @@ pub struct IndexingService {
     storage_resolver: StorageResolver,
     indexing_pipelines: HashMap<PipelineUid, PipelineHandle>,
     counters: IndexingServiceCounters,
-    local_split_store: Arc<LocalSplitStore>,
+    local_split_store: Arc<IndexingSplitCache>,
     max_concurrent_split_uploads: usize,
     merge_pipeline_handles: HashMap<MergePipelineId, MergePipelineHandle>,
     cooperative_indexing_permits: Option<Arc<Semaphore>>,
@@ -154,7 +154,7 @@ impl IndexingService {
             indexer_config.max_merge_write_throughput.map(io::limiter);
         let split_cache_dir_path = get_cache_directory_path(&data_dir_path);
         let local_split_store =
-            LocalSplitStore::open(split_cache_dir_path, split_store_space_quota).await?;
+            IndexingSplitCache::open(split_cache_dir_path, split_store_space_quota).await?;
         let indexing_root_directory =
             temp_dir::create_or_purge_directory(&data_dir_path.join(INDEXING_DIR_NAME)).await?;
         let queue_dir_path = data_dir_path.join(QUEUES_DIR_NAME);

--- a/quickwit/quickwit-indexing/src/split_store/mod.rs
+++ b/quickwit/quickwit-indexing/src/split_store/mod.rs
@@ -17,10 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+mod indexing_split_cache;
 mod indexing_split_store;
-mod local_split_store;
 mod split_store_quota;
 
+pub use indexing_split_cache::{get_tantivy_directory_from_split_bundle, IndexingSplitCache};
 pub use indexing_split_store::IndexingSplitStore;
-pub use local_split_store::{get_tantivy_directory_from_split_bundle, LocalSplitStore};
 pub use split_store_quota::SplitStoreQuota;


### PR DESCRIPTION
- Renaming  `LocalSplitStore` -> `IndexingSplitCache`.
- Removing of the useless BinaryHeap, HashMap, using instead a single BTreeMap
- Isolating quota and BTreeMap to ensure their transactionality.
- Logging eventual io errors.
