### PR TITLE
Set search after values in millis by default.

### DIFF
--- a/docs/reference/es_compatible_api.md
+++ b/docs/reference/es_compatible_api.md
@@ -169,7 +169,7 @@ following syntax.
 {
   // ...
   "sort" : [
-    { "timestamp" : {"format": "epoch_millis_as_int","order" : "asc"}},
+    { "timestamp" : {"order" : "asc"}},
     { "serial_number" : "desc" }
   ]
   // ...
@@ -186,9 +186,21 @@ It is also possible to not supply an order and rely on the default order using t
 }
 ```
 
-If no format is provided for timestamps, timestamps are returned with nanosecond precision. Beware
-this means the resulting json may contain high numbers for which there is loss of precision when
-using languages where all numbers are floats, such as JavaScript.
+If no format is provided for timestamps, timestamps are returned with milliseconds precision.
+
+If you need nanosecond precision, you can use the `epoch_nanos_int` format. Beware this means the resulting
+JSON may contain high numbers for which there is loss of precision when using languages where all numbers are
+floats, such as JavaScript.
+
+```json
+{
+  // ...
+  "sort" : [
+    { "timestamp" : {"format": "epoch_nanos_int","order" : "asc"}},
+    { "serial_number" : "desc" }
+  ]
+  // ...
+}
 
 #### Search after
 
@@ -204,7 +216,7 @@ When sorting results, the answer looks like the following
       {
         // ...
         "sort": [
-          1701962929199000000
+          1701962929199
         ]
       }
     ]
@@ -217,7 +229,7 @@ You can pass the `sort` value of the last hit in a subsequent request where othe
 {
   // keep all fields from the original request
   "seach_after": [
-    1701962929199000000
+    1701962929199
   ]
 }
 ```

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -270,6 +270,7 @@ enum SortOrder {
 // for future extension.
 enum SortDatetimeFormat {
   UNIX_TIMESTAMP_MILLIS = 0;
+  UNIX_TIMESTAMP_NANOS = 1;
 }
 
 message SearchResponse {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -703,6 +703,7 @@ impl SortOrder {
 #[repr(i32)]
 pub enum SortDatetimeFormat {
     UnixTimestampMillis = 0,
+    UnixTimestampNanos = 1,
 }
 impl SortDatetimeFormat {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -712,12 +713,14 @@ impl SortDatetimeFormat {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             SortDatetimeFormat::UnixTimestampMillis => "UNIX_TIMESTAMP_MILLIS",
+            SortDatetimeFormat::UnixTimestampNanos => "UNIX_TIMESTAMP_NANOS",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "UNIX_TIMESTAMP_MILLIS" => Some(Self::UnixTimestampMillis),
+            "UNIX_TIMESTAMP_NANOS" => Some(Self::UnixTimestampNanos),
             _ => None,
         }
     }

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -28,7 +28,7 @@ use quickwit_common::uri::Uri;
 use quickwit_common::PrettySample;
 use quickwit_config::build_doc_mapper;
 use quickwit_doc_mapper::tag_pruning::extract_tags_from_query;
-use quickwit_doc_mapper::{DocMapper, DYNAMIC_FIELD_NAME};
+use quickwit_doc_mapper::DYNAMIC_FIELD_NAME;
 use quickwit_metastore::{IndexMetadata, ListIndexesMetadataResponseExt, SplitMetadata};
 use quickwit_proto::metastore::{
     ListIndexesMetadataRequest, MetastoreService, MetastoreServiceClient,
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use tantivy::collector::Collector;
-use tantivy::schema::{FieldType, Schema};
+use tantivy::schema::{FieldEntry, FieldType, Schema};
 use tantivy::TantivyError;
 use tracing::{debug, error, info, info_span, instrument};
 
@@ -146,25 +146,40 @@ pub struct IndexMetasForLeafSearch {
 }
 
 pub(crate) type IndexesMetasForLeafSearch = HashMap<IndexUid, IndexMetasForLeafSearch>;
-type TimestampFieldOpt = Option<String>;
+
+#[derive(Debug)]
+struct RequestMetadata {
+    timestamp_field_opt: Option<String>,
+    query_ast_resolved: QueryAst,
+    indexes_meta_for_leaf_search: IndexesMetasForLeafSearch,
+    sort_fields_are_datetime_opt: Vec<Option<bool>>,
+}
 
 /// Validates request against each index's doc mapper and ensures that:
 /// - timestamp fields (if any) are equal across indexes.
 /// - resolved query ASTs are the same across indexes.
-/// - if a sort field has a datetime format specified, it must be a datetime field on all indexes.
+/// - if a sort field is of type datetime, it must be a datetime field on all indexes. This
+///   contraint come from the need to support datetime formatting on sort values.
 /// Returns the timestamp field, the resolved query AST and the indexes metadatas
 /// needed for leaf search requests.
 /// Note: the requirements on timestamp fields and resolved query ASTs can be lifted
 /// but it adds complexity that does not seem needed right now.
-fn validate_request_and_build_metadatas(
+fn validate_request_and_build_metadata(
     indexes_metadata: &[IndexMetadata],
     search_request: &SearchRequest,
-) -> crate::Result<(TimestampFieldOpt, QueryAst, IndexesMetasForLeafSearch)> {
-    let mut metadatas_for_leaf: HashMap<IndexUid, IndexMetasForLeafSearch> = HashMap::new();
+) -> crate::Result<RequestMetadata> {
+    validate_sort_by_fields_and_search_after(
+        &search_request.sort_fields,
+        &search_request.search_after,
+    )?;
     let query_ast: QueryAst = serde_json::from_str(&search_request.query_ast)
         .map_err(|err| SearchError::InvalidQuery(err.to_string()))?;
+    let mut indexes_meta_for_leaf_search: HashMap<IndexUid, IndexMetasForLeafSearch> =
+        HashMap::new();
     let mut query_ast_resolved_opt: Option<QueryAst> = None;
     let mut timestamp_field_opt: Option<String> = None;
+    let mut sort_fields_are_datetime_opt: Vec<Option<bool>> =
+        vec![None; search_request.sort_fields.len()];
 
     for index_metadata in indexes_metadata {
         let doc_mapper = build_doc_mapper(
@@ -209,7 +224,15 @@ fn validate_request_and_build_metadatas(
             }
         }
 
-        validate_request(&*doc_mapper, search_request)?;
+        // Validate request against the current index schema.
+        let schema = doc_mapper.schema();
+        validate_request(&schema, &doc_mapper.timestamp_field_name(), &search_request)?;
+
+        validate_sort_field_types(
+            &schema,
+            &search_request.sort_fields,
+            &mut sort_fields_are_datetime_opt,
+        )?;
 
         // Validates the query by effectively building it against the current schema.
         doc_mapper.query(doc_mapper.schema(), &query_ast_resolved_for_index, true)?;
@@ -220,7 +243,7 @@ fn validate_request_and_build_metadatas(
                 SearchError::Internal(format!("failed to serialize doc mapper. cause: {err}"))
             })?,
         };
-        metadatas_for_leaf.insert(
+        indexes_meta_for_leaf_search.insert(
             index_metadata.index_uid.clone(),
             index_metadata_for_leaf_search,
         );
@@ -232,7 +255,47 @@ fn validate_request_and_build_metadatas(
         )
     })?;
 
-    Ok((timestamp_field_opt, query_ast_resolved, metadatas_for_leaf))
+    Ok(RequestMetadata {
+        timestamp_field_opt,
+        query_ast_resolved,
+        indexes_meta_for_leaf_search,
+        sort_fields_are_datetime_opt,
+    })
+}
+
+/// Validate sort field types.
+fn validate_sort_field_types(
+    schema: &Schema,
+    sort_fields: &[SortField],
+    sort_fields_are_datetime_opt: &mut [Option<bool>],
+) -> crate::Result<()> {
+    assert_eq!(sort_fields.len(), sort_fields_are_datetime_opt.len());
+    for (sort_field, sort_field_is_datetime_opt) in sort_fields
+        .iter()
+        .zip(sort_fields_are_datetime_opt.iter_mut())
+    {
+        if let Some(sort_field_entry) = get_sort_by_field_entry(&sort_field.field_name, &schema)? {
+            validate_sort_by_field_type(
+                sort_field_entry,
+                sort_field.sort_datetime_format.is_some(),
+            )?;
+
+            // If sort field type is a date, ensure it's true for all indexes.
+            match sort_field_is_datetime_opt {
+                Some(is_date_type) if *is_date_type != sort_field_entry.field_type().is_date() => {
+                    return Err(SearchError::InvalidQuery(format!(
+                        "sort datetime field `{}` must be of type datetime on all indexes",
+                        sort_field_entry.name(),
+                    )));
+                }
+                None => {
+                    *sort_field_is_datetime_opt = Some(sort_field_entry.field_type().is_date());
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_requested_snippet_fields(
@@ -293,12 +356,11 @@ fn simplify_search_request_for_scroll_api(req: &SearchRequest) -> crate::Result<
 }
 
 /// Validates sort fields and search after values.
-/// - validate sort fields, see [`validate_sort_by_field`].
+/// - validate sort fields length.
 /// - search after values must be set for all sort fields.
 fn validate_sort_by_fields_and_search_after(
     sort_fields: &[SortField],
     search_after: &Option<PartialHit>,
-    schema: &Schema,
 ) -> crate::Result<()> {
     if sort_fields.is_empty() {
         return Ok(());
@@ -308,13 +370,6 @@ fn validate_sort_by_fields_and_search_after(
             "sort by field must be up to 2 fields, got {}",
             sort_fields.len()
         )));
-    }
-    for sort in sort_fields {
-        validate_sort_by_field(
-            &sort.field_name,
-            sort.sort_datetime_format.is_some(),
-            schema,
-        )?;
     }
     let Some(search_after_partial_hit) = search_after.as_ref() else {
         return Ok(());
@@ -344,14 +399,12 @@ fn validate_sort_by_fields_and_search_after(
     Ok(())
 }
 
-/// Validates sort field.
-fn validate_sort_by_field(
+fn get_sort_by_field_entry<'a>(
     field_name: &str,
-    has_timestamp_format: bool,
-    schema: &Schema,
-) -> crate::Result<()> {
+    schema: &'a Schema,
+) -> crate::Result<Option<&'a FieldEntry>> {
     if ["_score", "_shard_doc", "_doc"].contains(&field_name) {
-        return Ok(());
+        return Ok(None);
     }
     let dynamic_field_opt = schema.get_field(DYNAMIC_FIELD_NAME).ok();
     let (sort_by_field, _json_path) = schema
@@ -360,6 +413,15 @@ fn validate_sort_by_field(
             SearchError::InvalidArgument(format!("unknown field used in `sort by`: {field_name}"))
         })?;
     let sort_by_field_entry = schema.get_field_entry(sort_by_field);
+    Ok(Some(sort_by_field_entry))
+}
+
+/// Validates sort field type.
+fn validate_sort_by_field_type(
+    sort_by_field_entry: &FieldEntry,
+    has_timestamp_format: bool,
+) -> crate::Result<()> {
+    let field_name = sort_by_field_entry.name();
     if matches!(sort_by_field_entry.field_type(), FieldType::Str(_)) {
         return Err(SearchError::InvalidArgument(format!(
             "sort by field on type text is currently not supported `{field_name}`"
@@ -381,11 +443,11 @@ fn validate_sort_by_field(
 }
 
 fn validate_request(
-    doc_mapper: &dyn DocMapper,
+    schema: &Schema,
+    timestamp_field_name: &Option<&str>,
     search_request: &SearchRequest,
 ) -> crate::Result<()> {
-    let schema = doc_mapper.schema();
-    if doc_mapper.timestamp_field_name().is_none()
+    if timestamp_field_name.is_none()
         && (search_request.start_timestamp.is_some() || search_request.end_timestamp.is_some())
     {
         return Err(SearchError::InvalidQuery(format!(
@@ -396,12 +458,6 @@ fn validate_request(
     }
 
     validate_requested_snippet_fields(&schema, &search_request.snippet_fields)?;
-
-    validate_sort_by_fields_and_search_after(
-        &search_request.sort_fields,
-        &search_request.search_after,
-        &schema,
-    )?;
 
     if let Some(agg) = search_request.aggregation_request.as_ref() {
         let _aggs: QuickwitAggregations = serde_json::from_str(agg).map_err(|_err| {
@@ -901,23 +957,25 @@ pub async fn root_search(
         .iter()
         .map(|index_metadata| index_metadata.index_uid.clone())
         .collect_vec();
-    let (timestamp_field_opt, query_ast_resolved, indexes_metas_for_leaf_search) =
-        validate_request_and_build_metadatas(&indexes_metadata, &search_request)?;
-    search_request.query_ast = serde_json::to_string(&query_ast_resolved)?;
+    let request_metadata = validate_request_and_build_metadata(&indexes_metadata, &search_request)?;
+    search_request.query_ast = serde_json::to_string(&request_metadata.query_ast_resolved)?;
 
     // convert search_after datetime values from input datetime format to nanos.
-    convert_search_after_datetime_values(&mut search_request)?;
+    convert_search_after_datetime_values(
+        &mut search_request,
+        &request_metadata.sort_fields_are_datetime_opt,
+    )?;
 
     // update_search_after_datetime_in_nanos(&mut search_request)?;
-    if let Some(timestamp_field) = &timestamp_field_opt {
+    if let Some(timestamp_field) = &request_metadata.timestamp_field_opt {
         refine_start_end_timestamp_from_ast(
-            &query_ast_resolved,
+            &request_metadata.query_ast_resolved,
             timestamp_field,
             &mut search_request.start_timestamp,
             &mut search_request.end_timestamp,
         );
     }
-    let tag_filter_ast = extract_tags_from_query(query_ast_resolved);
+    let tag_filter_ast = extract_tags_from_query(request_metadata.query_ast_resolved);
 
     // TODO if search after is set, we sort by timestamp and we don't want to count all results,
     // we can refine more here. Same if we sort by _shard_doc
@@ -932,7 +990,7 @@ pub async fn root_search(
 
     let mut search_response = root_search_aux(
         searcher_context,
-        &indexes_metas_for_leaf_search,
+        &request_metadata.indexes_meta_for_leaf_search,
         search_request,
         split_metadatas,
         cluster_client,
@@ -944,7 +1002,31 @@ pub async fn root_search(
 }
 
 /// Converts search after with datetime format to nanoseconds (representation in tantivy).
-fn convert_search_after_datetime_values(search_request: &mut SearchRequest) -> crate::Result<()> {
+/// If the sort field is a datetime field and no datetime format is set, the default format is
+/// milliseconds.
+/// `sort_fields_are_datetime_opt` must be of the same length as `search_request.sort_fields`.
+fn convert_search_after_datetime_values(
+    search_request: &mut SearchRequest,
+    sort_fields_are_datetime_opt: &[Option<bool>],
+) -> crate::Result<()> {
+    assert_eq!(
+        search_request.sort_fields.len(),
+        sort_fields_are_datetime_opt.len()
+    );
+    // By default, sort fields on datetime fields are in milliseconds. This is the default behavior
+    // of ES on date field.
+    for (idx, sort_field_is_datetime_opt) in sort_fields_are_datetime_opt.iter().enumerate() {
+        if sort_field_is_datetime_opt.unwrap_or(false) {
+            let sort_field = search_request
+                .sort_fields
+                .get_mut(idx)
+                .expect("sort field must be set");
+            if sort_field.sort_datetime_format.is_none() {
+                sort_field.sort_datetime_format =
+                    Some(SortDatetimeFormat::UnixTimestampMillis as i32);
+            }
+        }
+    }
     if let Some(partial_hit) = search_request.search_after.as_mut() {
         let search_after_values = [
             partial_hit.sort_value.as_mut(),
@@ -988,6 +1070,9 @@ fn convert_sort_datetime_value_into_nanos(
                     ))
                 })?;
             }
+            SortDatetimeFormat::UnixTimestampNanos => {
+                // Nothing to do as the internal format is nanos.
+            }
         },
         SortValue::I64(value) => match input_format {
             SortDatetimeFormat::UnixTimestampMillis => {
@@ -998,6 +1083,9 @@ fn convert_sort_datetime_value_into_nanos(
                         value
                     ))
                 })?;
+            }
+            SortDatetimeFormat::UnixTimestampNanos => {
+                // Nothing to do as the internal format is nanos.
             }
         },
         _ => {
@@ -1021,10 +1109,16 @@ fn convert_sort_datetime_value(
             SortDatetimeFormat::UnixTimestampMillis => {
                 *value /= 1_000_000;
             }
+            SortDatetimeFormat::UnixTimestampNanos => {
+                // Nothing todo as the internal format is in nanos.
+            }
         },
         SortValue::I64(value) => match output_format {
             SortDatetimeFormat::UnixTimestampMillis => {
                 *value /= 1_000_000;
+            }
+            SortDatetimeFormat::UnixTimestampNanos => {
+                // Nothing todo as the internal format is in nanos.
             }
         },
         _ => {
@@ -1343,6 +1437,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_get_sort_by_field_entry() {
+        let mut schema_builder = Schema::builder();
+        schema_builder.add_text_field("title", TEXT);
+        schema_builder.add_text_field("desc", TEXT | STORED);
+        schema_builder.add_u64_field("timestamp", FAST | STORED);
+        let schema = schema_builder.build();
+        get_sort_by_field_entry("timestamp", &schema)
+            .unwrap()
+            .unwrap();
+        let sort_by_field_entry_err = get_sort_by_field_entry("doesnotexist", &schema).unwrap_err();
+        assert_eq!(
+            sort_by_field_entry_err.to_string(),
+            "Invalid argument: unknown field used in `sort by`: doesnotexist"
+        );
+        for sort_field_name in &["_doc", "_score", "_shard_doc"] {
+            assert!(get_sort_by_field_entry(sort_field_name, &schema)
+                .unwrap()
+                .is_none());
+        }
+    }
+
     fn index_metadata_for_multi_indexes_test(index_id: &str, index_uri: &str) -> IndexMetadata {
         let index_uri = Uri::from_str(index_uri).unwrap();
         let doc_mapping_json = r#"{
@@ -1385,6 +1501,18 @@ mod tests {
             query_ast: serde_json::to_string(&request_query_ast).unwrap(),
             max_hits: 10,
             start_offset: 10,
+            sort_fields: vec![
+                SortField {
+                    field_name: "timestamp".to_string(),
+                    sort_order: SortOrder::Desc as i32,
+                    sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampMillis as i32),
+                },
+                SortField {
+                    field_name: "_doc".to_string(),
+                    sort_order: SortOrder::Asc as i32,
+                    sort_datetime_format: None,
+                },
+            ],
             ..Default::default()
         };
         let index_metadata = IndexMetadata::for_test("test-index-1", "ram:///test-index-1");
@@ -1396,19 +1524,26 @@ mod tests {
             .index_config
             .doc_mapping
             .timestamp_field = None;
-        let (timestamp_field, query_ast, indexes_metas_for_leaf_req) =
-            validate_request_and_build_metadatas(
-                &[
-                    index_metadata,
-                    index_metadata_with_other_config,
-                    index_metadata_no_timestamp,
-                ],
-                &search_request,
-            )
-            .unwrap();
-        assert_eq!(timestamp_field, Some("timestamp".to_string()));
-        assert_eq!(query_ast, request_query_ast);
-        assert_eq!(indexes_metas_for_leaf_req.len(), 3);
+        let request_metadata = validate_request_and_build_metadata(
+            &[
+                index_metadata,
+                index_metadata_with_other_config,
+                index_metadata_no_timestamp,
+            ],
+            &search_request,
+        )
+        .unwrap();
+        assert_eq!(
+            request_metadata.timestamp_field_opt,
+            Some("timestamp".to_string())
+        );
+        assert_eq!(request_metadata.query_ast_resolved, request_query_ast);
+        assert_eq!(request_metadata.indexes_meta_for_leaf_search.len(), 3);
+        assert_eq!(request_metadata.sort_fields_are_datetime_opt.len(), 2);
+        assert_eq!(
+            request_metadata.sort_fields_are_datetime_opt,
+            vec![Some(true), None]
+        );
     }
 
     #[test]
@@ -1444,7 +1579,7 @@ mod tests {
             .index_config
             .search_settings
             .default_search_fields = Vec::new();
-        let timestamp_field_different = validate_request_and_build_metadatas(
+        let timestamp_field_different = validate_request_and_build_metadata(
             &[index_metadata_1, index_metadata_2],
             &search_request,
         )
@@ -1471,7 +1606,7 @@ mod tests {
             .index_config
             .search_settings
             .default_search_fields = vec!["owner".to_string()];
-        let timestamp_field_different = validate_request_and_build_metadatas(
+        let timestamp_field_different = validate_request_and_build_metadata(
             &[index_metadata_1, index_metadata_2],
             &search_request,
         )
@@ -1480,6 +1615,81 @@ mod tests {
             timestamp_field_different.to_string(),
             "resolved query ASTs must be the same across indexes. resolving queries with \
              different default fields are different between indexes is not supported"
+        );
+    }
+
+    fn index_metadata_for_multi_indexes_test_with_incompatible_sort_type(
+        index_id: &str,
+        index_uri: &str,
+    ) -> IndexMetadata {
+        let index_uri = Uri::from_str(index_uri).unwrap();
+        let doc_mapping_json = r#"{
+            "mode": "lenient",
+            "field_mappings": [
+                {
+                    "name": "timestamp",
+                    "type": "datetime",
+                    "fast": true
+                },
+                {
+                    "name": "body",
+                    "type": "text",
+                    "stored": true
+                },
+                {
+                    "name": "response_date",
+                    "type": "i64",
+                    "stored": true,
+                    "fast": true
+                }
+            ],
+            "timestamp_field": "timestamp",
+            "store_source": true
+        }"#;
+        let doc_mapping = serde_json::from_str(doc_mapping_json).unwrap();
+        let indexing_settings = IndexingSettings::default();
+        let search_settings = SearchSettings {
+            default_search_fields: vec!["body".to_string()],
+        };
+        IndexMetadata::new(IndexConfig {
+            index_id: index_id.to_string(),
+            index_uri,
+            doc_mapping,
+            indexing_settings,
+            search_settings,
+            retention_policy: Default::default(),
+        })
+    }
+
+    #[test]
+    fn test_validate_request_and_build_metadatas_fail_with_incompatible_sort_field_types() {
+        let request_query_ast = qast_helper("body:test", &[]);
+        let search_request = quickwit_proto::search::SearchRequest {
+            index_id_patterns: vec!["test-index".to_string()],
+            query_ast: serde_json::to_string(&request_query_ast).unwrap(),
+            max_hits: 10,
+            start_offset: 10,
+            sort_fields: vec![SortField {
+                field_name: "response_date".to_string(),
+                sort_order: SortOrder::Desc as i32,
+                sort_datetime_format: None,
+            }],
+            ..Default::default()
+        };
+        let index_metadata = IndexMetadata::for_test("test-index-1", "ram:///test-index-1");
+        let index_metadata_with_other_config =
+            index_metadata_for_multi_indexes_test_with_incompatible_sort_type(
+                "test-index-2",
+                "ram:///test-index-2",
+            );
+        let search_error = validate_request_and_build_metadata(
+            &[index_metadata, index_metadata_with_other_config],
+            &search_request,
+        )
+        .unwrap_err();
+        assert_eq!(
+            search_error.to_string(),
+            "sort datetime field `response_date` must be of type datetime on all indexes"
         );
     }
 
@@ -1550,61 +1760,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_sort_by_fields_with_datetime_format_ok() {
-        let sort_fields = vec![
-            SortField {
-                field_name: "timestamp".to_string(),
-                sort_order: 0,
-                sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampMillis as i32),
-            },
-            SortField {
-                field_name: "id".to_string(),
-                sort_order: 0,
-                sort_datetime_format: None,
-            },
-        ];
-        let mut schema_builder = Schema::builder();
-        schema_builder.add_date_field("timestamp", FAST);
-        schema_builder.add_u64_field("id", FAST);
-        let schema = schema_builder.build();
-        validate_sort_by_fields_and_search_after(&sort_fields, &None, &schema).unwrap();
-    }
-
-    #[test]
-    fn test_validate_sort_by_fields_and_search_after_ok() {
-        let sort_fields = vec![
-            SortField {
-                field_name: "timestamp".to_string(),
-                sort_order: 0,
-                sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampMillis as i32),
-            },
-            SortField {
-                field_name: "id".to_string(),
-                sort_order: 0,
-                sort_datetime_format: None,
-            },
-        ];
-        let mut schema_builder = Schema::builder();
-        schema_builder.add_date_field("timestamp", FAST);
-        schema_builder.add_u64_field("id", FAST);
-        let schema = schema_builder.build();
-        let partial_hit = PartialHit {
-            sort_value: Some(SortByValue {
-                sort_value: Some(SortValue::U64(1)),
-            }),
-            sort_value2: Some(SortByValue {
-                sort_value: Some(SortValue::U64(2)),
-            }),
-            split_id: "split1".to_string(),
-            segment_ord: 1,
-            doc_id: 1,
-        };
-        validate_sort_by_fields_and_search_after(&sort_fields, &Some(partial_hit), &schema)
-            .unwrap();
-    }
-
-    #[test]
-    fn test_validate_sort_by_docid() {
+    fn test_validate_sort_field_types_with_doc_and_shard_doc() {
         let sort_fields = vec![
             SortField {
                 field_name: "_doc".to_string(),
@@ -1621,7 +1777,159 @@ mod tests {
         schema_builder.add_date_field("timestamp", FAST);
         schema_builder.add_u64_field("id", FAST);
         let schema = schema_builder.build();
-        validate_sort_by_fields_and_search_after(&sort_fields, &None, &schema).unwrap();
+        let mut sort_field_are_datetime = [None, None];
+        validate_sort_field_types(&schema, &sort_fields, &mut sort_field_are_datetime).unwrap();
+        assert_eq!(sort_field_are_datetime, [None, None]);
+    }
+
+    #[test]
+    fn test_validate_sort_field_types_valid() {
+        let sort_fields = vec![
+            SortField {
+                field_name: "timestamp".to_string(),
+                sort_order: 0,
+                sort_datetime_format: None,
+            },
+            SortField {
+                field_name: "id".to_string(),
+                sort_order: 0,
+                sort_datetime_format: None,
+            },
+        ];
+        let mut schema_builder = Schema::builder();
+        schema_builder.add_date_field("timestamp", FAST);
+        schema_builder.add_u64_field("id", FAST);
+        let schema = schema_builder.build();
+        let mut sort_field_are_datetime = [None, None];
+        validate_sort_field_types(&schema, &sort_fields, &mut sort_field_are_datetime).unwrap();
+        assert_eq!(sort_field_are_datetime, [Some(true), Some(false)]);
+    }
+
+    #[test]
+    fn test_validate_sort_field_types_with_inconsistent_datetime_type() {
+        let sort_fields = vec![
+            SortField {
+                field_name: "timestamp".to_string(),
+                sort_order: 0,
+                sort_datetime_format: None,
+            },
+            SortField {
+                field_name: "id".to_string(),
+                sort_order: 0,
+                sort_datetime_format: None,
+            },
+        ];
+        let mut schema_builder = Schema::builder();
+        schema_builder.add_date_field("timestamp", FAST);
+        schema_builder.add_u64_field("id", FAST);
+        let schema = schema_builder.build();
+        {
+            let mut sort_field_are_datetime = [Some(false), None];
+            let error =
+                validate_sort_field_types(&schema, &sort_fields, &mut sort_field_are_datetime)
+                    .unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "sort datetime field `timestamp` must be of type datetime on all indexes"
+            );
+        }
+        {
+            let mut sort_field_are_datetime = [None, Some(true)];
+            let error =
+                validate_sort_field_types(&schema, &sort_fields, &mut sort_field_are_datetime)
+                    .unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "sort datetime field `id` must be of type datetime on all indexes"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_sort_by_fields_with_datetime_format_ok() {
+        let sort_fields = vec![
+            SortField {
+                field_name: "timestamp".to_string(),
+                sort_order: 0,
+                sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampMillis as i32),
+            },
+            SortField {
+                field_name: "id".to_string(),
+                sort_order: 0,
+                sort_datetime_format: None,
+            },
+        ];
+        validate_sort_by_fields_and_search_after(&sort_fields, &None).unwrap();
+    }
+
+    #[test]
+    fn test_validate_sort_by_fields_and_search_after_ok() {
+        let sort_fields = vec![
+            SortField {
+                field_name: "timestamp".to_string(),
+                sort_order: 0,
+                sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampMillis as i32),
+            },
+            SortField {
+                field_name: "id".to_string(),
+                sort_order: 0,
+                sort_datetime_format: None,
+            },
+        ];
+        let partial_hit = PartialHit {
+            sort_value: Some(SortByValue {
+                sort_value: Some(SortValue::U64(1)),
+            }),
+            sort_value2: Some(SortByValue {
+                sort_value: Some(SortValue::U64(2)),
+            }),
+            split_id: "split1".to_string(),
+            segment_ord: 1,
+            doc_id: 1,
+        };
+        validate_sort_by_fields_and_search_after(&sort_fields, &Some(partial_hit)).unwrap();
+    }
+
+    #[test]
+    fn test_validate_sort_by_field_type() {
+        let mut schema_builder = Schema::builder();
+        let timestamp_field = schema_builder.add_date_field("timestamp", FAST);
+        let id_field = schema_builder.add_u64_field("id", FAST);
+        let no_fast_field = schema_builder.add_u64_field("no_fast", STORED);
+        let text_field = schema_builder.add_text_field("text", STORED);
+        let schema = schema_builder.build();
+        {
+            let sort_by_field_entry = schema.get_field_entry(timestamp_field);
+            validate_sort_by_field_type(sort_by_field_entry, false).unwrap();
+            validate_sort_by_field_type(sort_by_field_entry, true).unwrap();
+        }
+        {
+            let sort_by_field_entry = schema.get_field_entry(id_field);
+            validate_sort_by_field_type(sort_by_field_entry, false).unwrap();
+            let error = validate_sort_by_field_type(sort_by_field_entry, true).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "Invalid argument: sort by field with a timestamp format must be a datetime field \
+                 and the field `id` is not"
+            );
+        }
+        {
+            let sort_by_field_entry = schema.get_field_entry(no_fast_field);
+            let error = validate_sort_by_field_type(sort_by_field_entry, true).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "Invalid argument: sort by field must be a fast field, please add the fast \
+                 property to your field `no_fast`"
+            );
+        }
+        {
+            let sort_by_field_entry = schema.get_field_entry(text_field);
+            let error = validate_sort_by_field_type(sort_by_field_entry, true).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "Invalid argument: sort by field on type text is currently not supported `text`"
+            );
+        }
     }
 
     #[test]
@@ -1639,10 +1947,6 @@ mod tests {
                 sort_datetime_format: None,
             },
         ];
-        let mut schema_builder = Schema::builder();
-        schema_builder.add_date_field("timestamp", FAST);
-        schema_builder.add_u64_field("id", FAST);
-        let schema = schema_builder.build();
         let partial_hit = PartialHit {
             sort_value: Some(SortByValue {
                 sort_value: Some(SortValue::U64(1)),
@@ -1653,8 +1957,7 @@ mod tests {
             doc_id: 1,
         };
         let error =
-            validate_sort_by_fields_and_search_after(&sort_fields, &Some(partial_hit), &schema)
-                .unwrap_err();
+            validate_sort_by_fields_and_search_after(&sort_fields, &Some(partial_hit)).unwrap_err();
         assert_eq!(
             error.to_string(),
             "Invalid argument: `search_after` must have the same number of sort values as sort by \
@@ -1664,36 +1967,6 @@ mod tests {
 
     #[test]
     fn test_validate_sort_by_fields_and_search_after_invalid_2() {
-        // sort non-datetime field with a datetime format is invalid.
-        let sort_fields = vec![SortField {
-            field_name: "timestamp".to_string(),
-            sort_order: 0,
-            sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampMillis as i32),
-        }];
-        let mut schema_builder = Schema::builder();
-        schema_builder.add_u64_field("timestamp", FAST);
-        let schema = schema_builder.build();
-        let partial_hit = PartialHit {
-            sort_value: Some(SortByValue {
-                sort_value: Some(SortValue::U64(1)),
-            }),
-            sort_value2: None,
-            split_id: "split1".to_string(),
-            segment_ord: 1,
-            doc_id: 1,
-        };
-        let error =
-            validate_sort_by_fields_and_search_after(&sort_fields, &Some(partial_hit), &schema)
-                .unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "Invalid argument: sort by field with a timestamp format must be a datetime field and \
-             the field `timestamp` is not"
-        );
-    }
-
-    #[test]
-    fn test_validate_sort_by_fields_and_search_after_invalid_3() {
         // 3 sort fields is not possible.
         let sort_fields = vec![
             SortField {
@@ -1712,9 +1985,7 @@ mod tests {
                 sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampMillis as i32),
             },
         ];
-        let schema = Schema::builder().build();
-        let error =
-            validate_sort_by_fields_and_search_after(&sort_fields, &None, &schema).unwrap_err();
+        let error = validate_sort_by_fields_and_search_after(&sort_fields, &None).unwrap_err();
         assert_eq!(
             error.to_string(),
             "Invalid argument: sort by field must be up to 2 fields, got 3"
@@ -2037,7 +2308,7 @@ mod tests {
             sort_fields: vec![SortField {
                 field_name: "response_date".to_string(),
                 sort_order: SortOrder::Asc.into(),
-                sort_datetime_format: None,
+                sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampNanos as i32),
             }],
             ..Default::default()
         };
@@ -2218,7 +2489,7 @@ mod tests {
             sort_fields: vec![SortField {
                 field_name: "response_date".to_string(),
                 sort_order: SortOrder::Desc.into(),
-                sort_datetime_format: None,
+                sort_datetime_format: Some(SortDatetimeFormat::UnixTimestampNanos as i32),
             }],
             ..Default::default()
         };

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -226,7 +226,7 @@ fn validate_request_and_build_metadata(
 
         // Validate request against the current index schema.
         let schema = doc_mapper.schema();
-        validate_request(&schema, &doc_mapper.timestamp_field_name(), &search_request)?;
+        validate_request(&schema, &doc_mapper.timestamp_field_name(), search_request)?;
 
         validate_sort_field_types(
             &schema,
@@ -274,7 +274,7 @@ fn validate_sort_field_types(
         .iter()
         .zip(sort_fields_are_datetime_opt.iter_mut())
     {
-        if let Some(sort_field_entry) = get_sort_by_field_entry(&sort_field.field_name, &schema)? {
+        if let Some(sort_field_entry) = get_sort_by_field_entry(&sort_field.field_name, schema)? {
             validate_sort_by_field_type(
                 sort_field_entry,
                 sort_field.sort_datetime_format.is_some(),
@@ -457,7 +457,7 @@ fn validate_request(
         )));
     }
 
-    validate_requested_snippet_fields(&schema, &search_request.snippet_fields)?;
+    validate_requested_snippet_fields(schema, &search_request.snippet_fields)?;
 
     if let Some(agg) = search_request.aggregation_request.as_ref() {
         let _aggs: QuickwitAggregations = serde_json::from_str(agg).map_err(|_err| {

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -269,7 +269,7 @@ fn validate_sort_field_types(
     sort_field_is_datetime: &mut HashMap<String, bool>,
 ) -> crate::Result<()> {
     for sort_field in sort_fields.iter() {
-        if let Some(sort_field_entry) = get_sort_by_field_entry(&sort_field.field_name, &schema)? {
+        if let Some(sort_field_entry) = get_sort_by_field_entry(&sort_field.field_name, schema)? {
             validate_sort_by_field_type(
                 sort_field_entry,
                 sort_field.sort_datetime_format.is_some(),
@@ -1010,11 +1010,9 @@ fn convert_search_after_datetime_values(
         if *sort_fields_is_datetime
             .get(&sort_field.field_name)
             .unwrap_or(&false)
+            && sort_field.sort_datetime_format.is_none()
         {
-            if sort_field.sort_datetime_format.is_none() {
-                sort_field.sort_datetime_format =
-                    Some(SortDatetimeFormat::UnixTimestampMillis as i32);
-            }
+            sort_field.sort_datetime_format = Some(SortDatetimeFormat::UnixTimestampMillis as i32);
         }
     }
     if let Some(partial_hit) = search_request.search_after.as_mut() {

--- a/quickwit/quickwit-serve/src/elastic_search_api/model/mod.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/model/mod.rs
@@ -52,17 +52,17 @@ pub struct SortField {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ElasticDateFormat {
-    /// We don't want to use the format `EpochMillis` as elasticsearch
-    /// returns milliseconds as strings when used. Instead, we support
-    /// `EpochMillisAsInt` which returns milliseconds as integers to
-    /// make it explicit for the user.
-    EpochMillisAsInt,
+    /// Sort values are in milliseconds by default to ease migration from ES.
+    /// We allow the user to sepecify nanoseconds if needed.
+    /// We add `Int` to the name to avoid confusion ES variant `EpochMillis` which,
+    /// returns milliseconds as strings.
+    EpochNanosInt,
 }
 
 impl From<ElasticDateFormat> for SortDatetimeFormat {
     fn from(date_format: ElasticDateFormat) -> Self {
         match date_format {
-            ElasticDateFormat::EpochMillisAsInt => SortDatetimeFormat::UnixTimestampMillis,
+            ElasticDateFormat::EpochNanosInt => SortDatetimeFormat::UnixTimestampNanos,
         }
     }
 }

--- a/quickwit/quickwit-serve/src/elastic_search_api/model/search_body.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/model/search_body.rs
@@ -174,7 +174,7 @@ mod tests {
         let json = r#"
         {
             "sort": [
-                { "timestamp": { "order": "desc", "format": "epoch_millis_as_int" } },
+                { "timestamp": { "order": "desc", "format": "epoch_nanos_int" } },
                 { "uid": { "order": "asc" } },
                 { "my_field": "asc" },
                 { "hello": {}},
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(sort_fields[0].order, SortOrder::Desc);
         assert_eq!(
             sort_fields[0].date_format,
-            Some(ElasticDateFormat::EpochMillisAsInt)
+            Some(ElasticDateFormat::EpochNanosInt)
         );
         assert_eq!(sort_fields[1].field, "uid");
         assert_eq!(sort_fields[1].order, SortOrder::Asc);

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0018-search_after.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0018-search_after.yaml
@@ -79,10 +79,6 @@ expected:
     hits:
       - sort: [9018]
 ---
-# Only works on quickwit engine as elasticsearch
-# expect timestamp value in milliseconds.
-engines:
-  - quickwit
 json:
   size: 100
   track_total_hits: true
@@ -91,17 +87,13 @@ json:
   sort:
     - created_at:
         order: asc
-  search_after: [1422748815000000000]
+  search_after: [1422748815000]
 expected:
   hits:
     hits:
       $expect: "len(val) == 4"
 ---
 # Quickwit should accept timestamp as string.
-# Only works on quickwit engine as elasticsearch
-# expect timestamp value in milliseconds.
-engines:
-  - quickwit
 json:
   size: 100
   track_total_hits: true
@@ -110,18 +102,12 @@ json:
   sort:
     - created_at:
         order: asc
-  search_after: ["1422748815000000000"]
+  search_after: ["1422748815000"]
 expected:
   hits:
     hits:
       $expect: "len(val) == 4"
 ---
-# Accept timestamp as string.
-# Quickwit should accept timestamp as string.
-# Only works on quickwit engine as elasticsearch
-# expect timestamp value in milliseconds.
-engines:
-  - quickwit
 json:
   size: 100
   track_total_hits: true
@@ -130,15 +116,14 @@ json:
   sort:
     - created_at:
         order: desc
-  search_after: ["1422748800001000000"]
+  search_after: ["1422748800001"]
 expected:
   hits:
     hits:
       $expect: "len(val) == 7"
 ---
-# Only works for quickwit engine.
-# Sadly, elasticsearch returns the same sort values
-# but as strings...
+# Only works for quickwit engine,
+# `epoch_nanos_int` format is quickwit specific
 engines:
   - quickwit
 json:
@@ -149,12 +134,12 @@ json:
   sort:
     - created_at:
         order: asc
-        format: epoch_millis_as_int
-  search_after: [1422748815000]
+        format: epoch_nanos_int
+  search_after: [1422748815000000000]
 expected:
   hits:
     hits:
-      - sort: [1422748816000]
-      - sort: [1422748816000]
-      - sort: [1422748816000]
-      - sort: [1422748816000]
+      - sort: [1422748816000000000]
+      - sort: [1422748816000000000]
+      - sort: [1422748816000000000]
+      - sort: [1422748816000000000]


### PR DESCRIPTION
The initial goal was to keep search after values in nanoseconds and use ES sort formatting.

But... the sort format is not supported in ES 7. To ease migration from ES/OS users, I set search after values in millis by default and added a sort format specific to quickwit to allow users to use search after values in nanoseconds.

