### PR TITLE
fix index pattern matching in fieldcaps

### DIFF
--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -830,7 +830,7 @@ fn finalize_aggregation_if_any(
 /// We put this check here and not in the metastore to make sure the logic is independent
 /// of the metastore implementation, and some different use cases could require different
 /// behaviors. This specification was principally motivated by #4042.
-fn check_all_index_metadata_found(
+pub fn check_all_index_metadata_found(
     index_metadatas: &[IndexMetadata],
     index_id_patterns: &[String],
 ) -> crate::Result<()> {

--- a/quickwit/rest-api-tests/scenarii/es_field_capabilities/0001-field-capabilities.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_field_capabilities/0001-field-capabilities.yaml
@@ -271,4 +271,63 @@ expected:
         metadata_field: false
         searchable: true
         aggregatable: true
+---
+# Wildcard on index name
+method: [GET]
+engines:
+  - quickwit
+  - elasticsearch
+endpoint: fieldca*/_field_caps?fields=date
+expected:
+  indices:
+  - fieldcaps
+  fields:
+    date:
+      date_nanos:
+        type: date_nanos
+        metadata_field: false
+        searchable: true
+        aggregatable: true
+---
+# Wildcard on index name + Wildcard without match
+method: [GET]
+engines:
+  - quickwit
+  - elasticsearch
+endpoint: fieldca*,blub*/_field_caps?fields=date
+expected:
+  indices:
+  - fieldcaps
+  fields:
+    date:
+      date_nanos:
+        type: date_nanos
+        metadata_field: false
+        searchable: true
+        aggregatable: true
+
+---
+# Exact match index + Non matching excact index
+method: [GET]
+engines:
+  - quickwit
+  - elasticsearch
+endpoint: fieldcaps,blub/_field_caps?fields=date
+status_code: 404
+---
+# Compare ip field with elastic search
+method: [GET]
+engines:
+  - quickwit
+  - elasticsearch
+endpoint: doesnotexist/_field_caps?fields=date
+status_code: 404
+---
+# Compare ip field with elastic search
+method: [GET]
+engines:
+  - quickwit
+  - elasticsearch
+endpoint: doesno*texist/_field_caps?fields=date
+status_code: 200
 


### PR DESCRIPTION
align the index pattern matching behaviour to elasticsearch.
That means empty results if the index pattern matches nothing but
contains a wildcard.
Error if any index pattern matches nothing but is exact.

https://github.com/quickwit-oss/quickwit/issues/4298
