### PR TITLE
Improve otel traces index config, fixes #4218

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -321,6 +321,8 @@ type: bytes
 stored: true
 indexed: true
 fast: true
+input_format: hex
+output_foramt: hex
 ```
 
 **Parameters for bytes field**
@@ -331,6 +333,8 @@ fast: true
 | `stored`    | Whether value is stored in the document store | `true` |
 | `indexed`   | Whether value is indexed | `true` |
 | `fast`     | Whether value is stored in a fast field. Only on 1:1 cardinality, not supported on `array<bytes>` fields | `false` |
+| `input_format`   | Formats used to parse input bytesn either `hex` or `base64` | `base64` |
+| `output_format`   |  Format used to display bytes in search results, either `hex` or `base64` | `base64` |
 
 #### `json` type
 

--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -333,8 +333,8 @@ output_foramt: hex
 | `stored`    | Whether value is stored in the document store | `true` |
 | `indexed`   | Whether value is indexed | `true` |
 | `fast`     | Whether value is stored in a fast field. Only on 1:1 cardinality, not supported on `array<bytes>` fields | `false` |
-| `input_format`   | Formats used to parse input bytesn either `hex` or `base64` | `base64` |
-| `output_format`   |  Format used to display bytes in search results, either `hex` or `base64` | `base64` |
+| `input_format`   | Encoding used to represent input bytes, either `hex` or `base64` | `base64` |
+| `output_format`   |  Encoding used to represent bytes in search results, either `hex` or `base64` | `base64` |
 
 #### `json` type
 

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5782,7 +5782,6 @@ version = "0.6.5-dev"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.5",
  "hex",
  "once_cell",
  "prost",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1425,7 +1425,7 @@ checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost",
  "prost-types",
- "tonic 0.9.2",
+ "tonic",
  "tracing-core",
 ]
 
@@ -1447,7 +1447,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -1761,19 +1761,6 @@ dependencies = [
  "darling_core 0.20.3",
  "quote",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -2568,7 +2555,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
 ]
@@ -2584,7 +2571,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
 ]
@@ -2597,7 +2584,7 @@ checksum = "9d905d01fe815c6894b309b18a1ba152371e2e2ba7fcc81f4d22e48865b3014c"
 dependencies = [
  "prost",
  "prost-types",
- "tonic 0.9.2",
+ "tonic",
 ]
 
 [[package]]
@@ -2608,7 +2595,7 @@ checksum = "2a3b24a3f57be08afc02344e693afb55e48172c9c2ab86ff3fdb8efff550e4b9"
 dependencies = [
  "prost",
  "prost-types",
- "tonic 0.9.2",
+ "tonic",
 ]
 
 [[package]]
@@ -4234,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -4244,45 +4231,54 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
- "futures",
- "futures-util",
+ "futures-core",
  "http",
- "opentelemetry",
  "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
  "thiserror",
  "tokio",
- "tonic 0.8.3",
+ "tonic",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
 dependencies = [
- "futures",
- "futures-util",
- "opentelemetry",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
- "tonic 0.8.3",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
+dependencies = [
+ "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry_api"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
 dependencies = [
- "fnv",
  "futures-channel",
  "futures-util",
  "indexmap 1.9.3",
+ "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -4291,21 +4287,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "once_cell",
  "opentelemetry_api",
+ "ordered-float 3.9.2",
  "percent-encoding",
  "rand 0.8.5",
+ "regex",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4316,6 +4313,15 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
 ]
@@ -5225,7 +5231,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5251,7 +5257,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
  "ulid",
  "utoipa",
@@ -5294,7 +5300,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "utoipa",
 ]
@@ -5330,7 +5336,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
 ]
@@ -5402,7 +5408,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
  "ulid",
@@ -5605,7 +5611,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tracing",
  "ulid",
@@ -5641,6 +5647,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tonic",
  "tracing",
 ]
 
@@ -5674,7 +5681,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
 ]
 
@@ -5796,7 +5803,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
 ]
 
@@ -5826,7 +5833,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
- "tonic 0.9.2",
+ "tonic",
  "tonic-build",
  "tower",
  "tracing",
@@ -8055,38 +8062,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "prost-derive",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
@@ -8218,16 +8193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8251,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
+checksum = "fc09e402904a5261e42cf27aea09ccb7d5318c6717a9eec3d8e2e65c56b18f19"
 dependencies = [
  "once_cell",
  "opentelemetry",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -6002,7 +6002,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tower",
  "tower-http",
  "tracing",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5783,6 +5783,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.5",
+ "hex",
  "once_cell",
  "prost",
  "quickwit-actors",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -120,8 +120,8 @@ once_cell = "1"
 oneshot = "0.1.5"
 openssl = { version = "0.10.60", default-features = false }
 openssl-probe = "0.1.5"
-opentelemetry = { version = "0.19", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.12.0"
+opentelemetry = { version = "0.20", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.13.0"
 ouroboros = "0.18.0"
 percent-encoding = "2.3.1"
 pin-project = "1.1.0"
@@ -204,7 +204,7 @@ tower = { version = "0.4.13", features = [
 ] }
 tower-http = { version = "0.4.0", features = ["compression-gzip", "cors"] }
 tracing = "0.1.37"
-tracing-opentelemetry = "0.19.0"
+tracing-opentelemetry = "0.20.0"
 tracing-subscriber = { version = "0.3.16", features = [
   "env-filter",
   "std",

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -50,7 +50,7 @@ pub struct QuickwitObjectOptions {
 pub struct FieldMappingEntry {
     /// Field name in the index schema.
     pub name: String,
-    /// Property parameters which defines the type and the way the value must be indexed.
+    /// Property parameters which define the type and the way the value must be indexed.
     pub mapping_type: FieldMappingType,
 }
 
@@ -143,7 +143,7 @@ impl Default for QuickwitBoolOptions {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct QuickwitBytesOptions {
-    /// Optional description of bytes object.
+    /// Optional description of the bytes field.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -177,7 +177,7 @@ impl Default for QuickwitBytesOptions {
     }
 }
 
-/// Options associated to a numeric field.
+/// Available binary formats.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BinaryFormat {

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_entry.rs
@@ -51,7 +51,7 @@ pub struct FieldMappingEntry {
     /// Field name in the index schema.
     pub name: String,
     /// Property parameters which defines the type and the way the value must be indexed.
-    pub(crate) mapping_type: FieldMappingType,
+    pub mapping_type: FieldMappingType,
 }
 
 // Struct used for serialization and deserialization
@@ -139,20 +139,27 @@ impl Default for QuickwitBoolOptions {
     }
 }
 
+/// Options associated to a bytes field.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct QuickwitBytesOptions {
+    /// Optional description of bytes object.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// If true, the field will be stored in the doc store.
     #[serde(default = "default_as_true")]
     pub stored: bool,
+    /// If true, the field will be indexed.
     #[serde(default = "default_as_true")]
     pub indexed: bool,
+    /// If true, the field will be stored in columnar format.
     #[serde(default)]
     pub fast: bool,
+    /// Input format of the bytes field.
     #[serde(default)]
     pub input_format: BinaryFormat,
+    /// Output format of the bytes field.
     #[serde(default)]
     pub output_format: BinaryFormat,
 }
@@ -170,15 +177,19 @@ impl Default for QuickwitBytesOptions {
     }
 }
 
+/// Options associated to a numeric field.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BinaryFormat {
+    /// Base64 format.
     #[default]
     Base64,
+    /// Hexadecimal format.
     Hex,
 }
 
 impl BinaryFormat {
+    /// Returns the string representation of the format.
     pub fn as_str(&self) -> &str {
         match self {
             Self::Base64 => "base64",
@@ -186,6 +197,7 @@ impl BinaryFormat {
         }
     }
 
+    /// Returns representation of the format in `serde_json::Value`.
     pub fn format_to_json(&self, value: &[u8]) -> JsonValue {
         match self {
             Self::Base64 => BASE64_STANDARD.encode(value).into(),
@@ -193,6 +205,7 @@ impl BinaryFormat {
         }
     }
 
+    /// Parses the `serde_json::Value` into `tantivy::schema::Value`.
     pub fn parse_json(&self, json_val: JsonValue) -> Result<TantivyValue, String> {
         let byte_str = if let JsonValue::String(byte_str) = json_val {
             byte_str

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/field_mapping_type.rs
@@ -30,7 +30,7 @@ use crate::Cardinality;
 /// A `FieldMappingType` defines the type and indexing options
 /// of a mapping field.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum FieldMappingType {
+pub enum FieldMappingType {
     /// String mapping type configuration.
     Text(QuickwitTextOptions, Cardinality),
     /// Signed 64-bit integer mapping type configuration.
@@ -54,6 +54,7 @@ pub(crate) enum FieldMappingType {
 }
 
 impl FieldMappingType {
+    /// Returns the field mapping type name.
     pub fn quickwit_field_type(&self) -> QuickwitFieldType {
         let (primitive_type, cardinality) = match self {
             FieldMappingType::Text(_, cardinality) => (Type::Str, *cardinality),

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -34,11 +34,12 @@ pub use self::default_mapper_builder::{DefaultDocMapperBuilder, Mode, ModeType};
 pub use self::field_mapping_entry::{
     FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions,
     QuickwitNumericOptions, QuickwitTextNormalizer, QuickwitTextOptions, TextIndexingOptions,
+    BinaryFormat,
 };
 pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,
 };
-pub(crate) use self::field_mapping_type::FieldMappingType;
+pub use self::field_mapping_type::FieldMappingType;
 pub use self::tokenizer_entry::{analyze_text, TokenizerConfig, TokenizerEntry};
 pub(crate) use self::tokenizer_entry::{
     NgramTokenizerOption, RegexTokenizerOption, TokenFilterType, TokenizerType,

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -32,9 +32,8 @@ use regex::Regex;
 pub use self::default_mapper::DefaultDocMapper;
 pub use self::default_mapper_builder::{DefaultDocMapperBuilder, Mode, ModeType};
 pub use self::field_mapping_entry::{
-    FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions,
+    BinaryFormat, FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions,
     QuickwitNumericOptions, QuickwitTextNormalizer, QuickwitTextOptions, TextIndexingOptions,
-    BinaryFormat,
 };
 pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -36,7 +36,8 @@ pub mod tag_pruning;
 
 pub use default_doc_mapper::{
     analyze_text, DefaultDocMapper, DefaultDocMapperBuilder, FieldMappingEntry, Mode, ModeType,
-    QuickwitJsonOptions, TokenizerConfig, TokenizerEntry,
+    QuickwitJsonOptions, TokenizerConfig, TokenizerEntry, QuickwitBytesOptions, FieldMappingType,
+    BinaryFormat,
 };
 use default_doc_mapper::{
     FastFieldOptions, FieldMappingEntryForSerialization, IndexRecordOptionSchema,
@@ -60,9 +61,12 @@ const QW_RESERVED_FIELD_NAMES: &[&str] = &[
     FIELD_PRESENCE_FIELD_NAME,
 ];
 
+/// Cardinality of a field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum Cardinality {
+pub enum Cardinality {
+    /// Single value field.
     SingleValue,
+    /// Multi values field.
     MultiValues,
 }
 

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -64,9 +64,9 @@ const QW_RESERVED_FIELD_NAMES: &[&str] = &[
 /// Cardinality of a field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Cardinality {
-    /// Single value field.
+    /// Single-valued field.
     SingleValue,
-    /// Multi values field.
+    /// Multivalued field.
     MultiValues,
 }
 

--- a/quickwit/quickwit-doc-mapper/src/lib.rs
+++ b/quickwit/quickwit-doc-mapper/src/lib.rs
@@ -35,9 +35,9 @@ mod routing_expression;
 pub mod tag_pruning;
 
 pub use default_doc_mapper::{
-    analyze_text, DefaultDocMapper, DefaultDocMapperBuilder, FieldMappingEntry, Mode, ModeType,
-    QuickwitJsonOptions, TokenizerConfig, TokenizerEntry, QuickwitBytesOptions, FieldMappingType,
-    BinaryFormat,
+    analyze_text, BinaryFormat, DefaultDocMapper, DefaultDocMapperBuilder, FieldMappingEntry,
+    FieldMappingType, Mode, ModeType, QuickwitBytesOptions, QuickwitJsonOptions, TokenizerConfig,
+    TokenizerEntry,
 };
 use default_doc_mapper::{
     FastFieldOptions, FieldMappingEntryForSerialization, IndexRecordOptionSchema,

--- a/quickwit/quickwit-integration-tests/Cargo.toml
+++ b/quickwit/quickwit-integration-tests/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tonic = { workspace = true }
 tracing = { workspace = true }
 
 quickwit-actors = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -188,10 +188,6 @@ impl ClusterSandbox {
             // is formed.
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        println!(
-            "grpc client connecting {}",
-            indexer_config.node_config.grpc_listen_addr
-        );
         let channel = channel::Endpoint::from_str(&format!(
             "http://{}",
             indexer_config.node_config.grpc_listen_addr

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -34,6 +34,7 @@ use quickwit_common::uri::Uri as QuickwitUri;
 use quickwit_config::service::QuickwitService;
 use quickwit_config::NodeConfig;
 use quickwit_metastore::{MetastoreResolver, SplitState};
+use quickwit_proto::opentelemetry::proto::collector::trace::v1::trace_service_client::TraceServiceClient;
 use quickwit_rest_client::models::IngestSource;
 use quickwit_rest_client::rest_client::{
     CommitType, QuickwitClient, QuickwitClientBuilder, DEFAULT_BASE_URL,
@@ -44,6 +45,7 @@ use reqwest::Url;
 use tempfile::TempDir;
 use tokio::sync::watch::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
+use tonic::transport::channel;
 use tracing::debug;
 
 /// Configuration of a node made of a [`NodeConfig`] and a
@@ -89,6 +91,7 @@ pub struct ClusterSandbox {
     pub node_configs: Vec<TestNodeConfig>,
     pub searcher_rest_client: QuickwitClient,
     pub indexer_rest_client: QuickwitClient,
+    pub trace_client: TraceServiceClient<tonic::transport::Channel>,
     _temp_dir: TempDir,
     join_handles: Vec<JoinHandle<Result<HashMap<String, ActorExitStatus>, anyhow::Error>>>,
     shutdown_trigger: ClusterShutdownTrigger,
@@ -185,6 +188,16 @@ impl ClusterSandbox {
             // is formed.
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
+        println!(
+            "grpc client connecting {}",
+            indexer_config.node_config.grpc_listen_addr
+        );
+        let channel = channel::Endpoint::from_str(&format!(
+            "http://{}",
+            indexer_config.node_config.grpc_listen_addr
+        ))
+        .unwrap()
+        .connect_lazy();
         Ok(Self {
             node_configs,
             searcher_rest_client: QuickwitClientBuilder::new(transport_url(
@@ -195,6 +208,7 @@ impl ClusterSandbox {
                 indexer_config.node_config.rest_config.listen_addr,
             ))
             .build(),
+            trace_client: TraceServiceClient::new(channel),
             _temp_dir: temp_dir,
             join_handles,
             shutdown_trigger,
@@ -210,6 +224,17 @@ impl ClusterSandbox {
         let temp_dir = tempfile::tempdir()?;
         let services = QuickwitService::supported_services();
         let node_configs = build_node_configs(temp_dir.path().to_path_buf(), &[services]);
+        Self::start_cluster_with_configs(temp_dir, node_configs).await
+    }
+
+    pub async fn start_standalone_with_otlp_service() -> anyhow::Result<Self> {
+        let temp_dir = tempfile::tempdir()?;
+        let services = QuickwitService::supported_services();
+        let mut node_configs = build_node_configs(temp_dir.path().to_path_buf(), &[services]);
+        node_configs[0]
+            .node_config
+            .indexer_config
+            .enable_otlp_endpoint = true;
         Self::start_cluster_with_configs(temp_dir, node_configs).await
     }
 

--- a/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
@@ -26,6 +26,8 @@ use quickwit_config::ConfigFormat;
 use quickwit_indexing::actors::INDEXING_DIR_NAME;
 use quickwit_janitor::actors::DELETE_SERVICE_TASK_DIR_NAME;
 use quickwit_metastore::SplitState;
+use quickwit_proto::opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
+use quickwit_proto::opentelemetry::proto::trace::v1::{ResourceSpans, ScopeSpans, Span};
 use quickwit_rest_client::error::{ApiError, Error};
 use quickwit_rest_client::rest_client::CommitType;
 use quickwit_serve::SearchRequestQueryString;
@@ -603,4 +605,75 @@ async fn test_shutdown() {
         .await
         .unwrap()
         .unwrap();
+}
+
+#[tokio::test]
+async fn test_ingest_traces_with_otlp_grpc_api() {
+    quickwit_common::setup_logging_for_tests();
+    let sandbox = ClusterSandbox::start_standalone_with_otlp_service()
+        .await
+        .unwrap();
+    // Wait fo the pipelines to start (one for logs and one for traces)
+    sandbox.wait_for_indexing_pipelines(2).await.unwrap();
+
+    let scope_spans = vec![ScopeSpans {
+        spans: vec![
+            Span {
+                trace_id: vec![1; 16],
+                span_id: vec![2; 8],
+                start_time_unix_nano: 1_000_000_001,
+                end_time_unix_nano: 1_000_000_002,
+                ..Default::default()
+            },
+            Span {
+                trace_id: vec![3; 16],
+                span_id: vec![4; 8],
+                start_time_unix_nano: 2_000_000_001,
+                end_time_unix_nano: 2_000_000_002,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }];
+    let resource_spans = vec![ResourceSpans {
+        scope_spans,
+        ..Default::default()
+    }];
+    let request = ExportTraceServiceRequest { resource_spans };
+
+    // Send the spans on the default index.
+    {
+        let response = sandbox
+            .trace_client
+            .clone()
+            .export(request.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            response
+                .into_inner()
+                .partial_success
+                .unwrap()
+                .rejected_spans,
+            0
+        );
+    }
+
+    // Send the spans on a non existing index, should return an error.
+    {
+        let mut tonic_request = tonic::Request::new(request);
+        tonic_request.metadata_mut().insert(
+            "otel-traces-index",
+            tonic::metadata::MetadataValue::try_from("non-existing-index").unwrap(),
+        );
+        let status = sandbox
+            .trace_client
+            .clone()
+            .export(tonic_request)
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    sandbox.shutdown().await.unwrap();
 }

--- a/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_tests.rs
@@ -663,7 +663,7 @@ async fn test_ingest_traces_with_otlp_grpc_api() {
     {
         let mut tonic_request = tonic::Request::new(request);
         tonic_request.metadata_mut().insert(
-            "otel-traces-index",
+            "qw-otel-traces-index",
             tonic::metadata::MetadataValue::try_from("non-existing-index").unwrap(),
         );
         let status = sandbox

--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -2348,7 +2348,7 @@ mod tests {
         {
             let agg_result_json = r#"[
                 {
-                    "trace_id": "AQEBAQEBAQEBAQEBAQEBAQ==",
+                    "trace_id": "01010101010101010101010101010101",
                     "span_timestamp": 1684857492783747000
                 }
             ]"#;
@@ -2359,11 +2359,11 @@ mod tests {
         {
             let agg_result_json = r#"[
                 {
-                    "trace_id": "AQIDBAUGBwgJCgsMDQ4PEA==",
+                    "trace_id": "0102030405060708090a0b0c0d0e0f10",
                     "span_timestamp": 1684857492783747000
                 },
                 {
-                    "trace_id": "AgICAgICAgICAgICAgICAg==",
+                    "trace_id": "02020202020202020202020202020202",
                     "span_timestamp": 1684857826019627000
                 }
             ]"#;

--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -29,8 +29,9 @@ use prost::Message;
 use prost_types::{Duration as WellKnownDuration, Timestamp as WellKnownTimestamp};
 use quickwit_config::JaegerConfig;
 use quickwit_opentelemetry::otlp::{
-    Event as QwEvent, Link as QwLink, Span as QwSpan, SpanFingerprint, SpanId,
-    SpanKind as QwSpanKind, SpanStatus as QwSpanStatus, TraceId, OTEL_TRACES_INDEX_ID, OTEL_TRACES_INDEX_ID_PATTERN,
+    extract_otel_traces_index_patterns_from_metadata, Event as QwEvent, Link as QwLink,
+    Span as QwSpan, SpanFingerprint, SpanId, SpanKind as QwSpanKind, SpanStatus as QwSpanStatus,
+    TraceId, HEADER_NAME_OTEL_TRACES_INDEX, OTEL_TRACES_INDEX_ID,
 };
 use quickwit_proto::jaeger::api_v2::{
     KeyValue as JaegerKeyValue, Log as JaegerLog, Process as JaegerProcess, Span as JaegerSpan,
@@ -91,19 +92,19 @@ impl JaegerService {
     }
 
     #[instrument("get_services", skip_all)]
-    async fn get_services_inner(
+    pub async fn get_services_for_indexes(
         &self,
         request: GetServicesRequest,
+        index_id_patterns: Vec<String>,
     ) -> JaegerResult<GetServicesResponse> {
-        debug!(request=?request, "`get_services` request");
+        debug!(request=?request, index_ids=?index_id_patterns, "`get_services` request");
 
-        let index_id = OTEL_TRACES_INDEX_ID.to_string();
         let max_hits = Some(1_000);
         let start_timestamp =
             Some(OffsetDateTime::now_utc().unix_timestamp() - self.lookback_period_secs);
 
         let search_request = ListTermsRequest {
-            index_id_patterns: vec![index_id],
+            index_id_patterns,
             field: "service_name".to_string(),
             max_hits,
             start_timestamp,
@@ -124,13 +125,13 @@ impl JaegerService {
     }
 
     #[instrument("get_operations", skip_all, fields(service=%request.service, span_kind=%request.span_kind))]
-    async fn get_operations_inner(
+    pub async fn get_operations_for_indexes(
         &self,
         request: GetOperationsRequest,
+        index_id_patterns: Vec<String>,
     ) -> JaegerResult<GetOperationsResponse> {
-        debug!(request=?request, "`get_operations` request");
+        debug!(request=?request, request=?request, index_ids=?index_id_patterns, "`get_operations` request");
 
-        let index_id = OTEL_TRACES_INDEX_ID.to_string();
         let max_hits = Some(1_000);
         let start_timestamp =
             Some(OffsetDateTime::now_utc().unix_timestamp() - self.lookback_period_secs);
@@ -140,7 +141,7 @@ impl JaegerService {
         let end_key = SpanFingerprint::end_key(&request.service, span_kind_opt);
 
         let search_request = ListTermsRequest {
-            index_id_patterns: vec![index_id],
+            index_id_patterns,
             field: "span_fingerprint".to_string(),
             max_hits,
             start_timestamp,
@@ -164,17 +165,18 @@ impl JaegerService {
     }
 
     // Instrumentation happens in `find_trace_ids`.
-    async fn find_trace_ids_inner(
+    pub async fn find_trace_ids_for_indexes(
         &self,
         request: FindTraceIDsRequest,
+        index_id_patterns: Vec<String>,
     ) -> JaegerResult<FindTraceIDsResponse> {
-        debug!(request=?request, "`find_trace_ids` request");
+        debug!(request=?request, index_ids=?index_id_patterns, "`find_trace_ids` request");
 
         let trace_query = request
             .query
             .ok_or_else(|| Status::invalid_argument("Query is empty."))?;
 
-        let (trace_ids, _) = self.find_trace_ids(trace_query).await?;
+        let (trace_ids, _) = self.find_trace_ids(trace_query, index_id_patterns).await?;
         let trace_ids = trace_ids
             .into_iter()
             .map(|trace_id| trace_id.to_vec())
@@ -185,33 +187,43 @@ impl JaegerService {
     }
 
     #[instrument("find_traces", skip_all)]
-    async fn find_traces_inner(
+    pub async fn find_traces_for_indexes(
         &self,
         request: FindTracesRequest,
         operation_name: &'static str,
         request_start: Instant,
+        index_id_patterns: Vec<String>,
     ) -> JaegerResult<SpanStream> {
         debug!(request=?request, "`find_traces` request");
 
         let trace_query = request
             .query
             .ok_or_else(|| Status::invalid_argument("Trace query is empty."))?;
-        let (trace_ids, span_timestamps_range) = self.find_trace_ids(trace_query).await?;
+        let (trace_ids, span_timestamps_range) = self
+            .find_trace_ids(trace_query, index_id_patterns.clone())
+            .await?;
         let start = span_timestamps_range.start() - self.max_trace_duration_secs;
         let end = span_timestamps_range.end() + self.max_trace_duration_secs;
         let search_window = start..=end;
         let response = self
-            .stream_spans(&trace_ids, search_window, operation_name, request_start)
+            .stream_spans(
+                &trace_ids,
+                search_window,
+                operation_name,
+                request_start,
+                index_id_patterns,
+            )
             .await?;
         Ok(response)
     }
 
-    #[instrument("find_traces", skip_all)]
-    async fn get_trace_inner(
+    #[instrument("get_trace", skip_all)]
+    pub async fn get_trace_for_indexes(
         &self,
         request: GetTraceRequest,
         operation_name: &'static str,
         request_start: Instant,
+        index_id_patterns: Vec<String>,
     ) -> JaegerResult<SpanStream> {
         debug!(request=?request, "`get_trace` request");
         debug_assert_eq!(request.trace_id.len(), 16);
@@ -221,7 +233,13 @@ impl JaegerService {
         let start = end - self.lookback_period_secs;
         let search_window = start..=end;
         let response = self
-            .stream_spans(&[trace_id], search_window, operation_name, request_start)
+            .stream_spans(
+                &[trace_id],
+                search_window,
+                operation_name,
+                request_start,
+                index_id_patterns,
+            )
             .await?;
         Ok(response)
     }
@@ -230,6 +248,7 @@ impl JaegerService {
     async fn find_trace_ids(
         &self,
         trace_query: TraceQueryParameters,
+        index_id_patterns: Vec<String>,
     ) -> Result<(Vec<TraceId>, TimeIntervalSecs), Status> {
         let span_kind_opt = None;
         let min_span_start_timestamp_secs_opt = trace_query.start_time_min.map(|ts| ts.seconds);
@@ -255,7 +274,7 @@ impl JaegerService {
         let aggregation_query = build_aggregations_query(trace_query.num_traces as usize);
         let max_hits = 0;
         let search_request = SearchRequest {
-            index_id_patterns: vec![OTEL_TRACES_INDEX_ID_PATTERN.to_string()],
+            index_id_patterns,
             query_ast,
             aggregation_request: Some(aggregation_query),
             max_hits,
@@ -282,6 +301,7 @@ impl JaegerService {
         search_window: TimeIntervalSecs,
         operation_name: &'static str,
         request_start: Instant,
+        index_id_patterns: Vec<String>,
     ) -> Result<SpanStream, Status> {
         if trace_ids.is_empty() {
             let (_tx, rx) = mpsc::channel(1);
@@ -304,7 +324,7 @@ impl JaegerService {
             serde_json::to_string(&query_ast).map_err(|err| Status::internal(err.to_string()))?;
 
         let search_request = SearchRequest {
-            index_id_patterns: vec![OTEL_TRACES_INDEX_ID_PATTERN.to_string()],
+            index_id_patterns,
             query_ast,
             start_timestamp: Some(*search_window.start()),
             end_timestamp: Some(*search_window.end()),
@@ -459,8 +479,13 @@ impl SpanReaderPlugin for JaegerService {
         &self,
         request: Request<GetServicesRequest>,
     ) -> Result<Response<GetServicesResponse>, Status> {
+        let index_id_patterns = extract_otel_traces_index_patterns_from_metadata(
+            request.metadata(),
+            HEADER_NAME_OTEL_TRACES_INDEX,
+        )?;
         metrics!(
-            self.get_services_inner(request.into_inner()).await,
+            self.get_services_for_indexes(request.into_inner(), index_id_patterns)
+                .await,
             [get_services, OTEL_TRACES_INDEX_ID]
         );
     }
@@ -469,8 +494,13 @@ impl SpanReaderPlugin for JaegerService {
         &self,
         request: Request<GetOperationsRequest>,
     ) -> Result<Response<GetOperationsResponse>, Status> {
+        let index_id_patterns = extract_otel_traces_index_patterns_from_metadata(
+            request.metadata(),
+            HEADER_NAME_OTEL_TRACES_INDEX,
+        )?;
         metrics!(
-            self.get_operations_inner(request.into_inner()).await,
+            self.get_operations_for_indexes(request.into_inner(), index_id_patterns)
+                .await,
             [get_operations, OTEL_TRACES_INDEX_ID]
         );
     }
@@ -479,8 +509,13 @@ impl SpanReaderPlugin for JaegerService {
         &self,
         request: Request<FindTraceIDsRequest>,
     ) -> Result<Response<FindTraceIDsResponse>, Status> {
+        let index_id_patterns = extract_otel_traces_index_patterns_from_metadata(
+            request.metadata(),
+            HEADER_NAME_OTEL_TRACES_INDEX,
+        )?;
         metrics!(
-            self.find_trace_ids_inner(request.into_inner()).await,
+            self.find_trace_ids_for_indexes(request.into_inner(), index_id_patterns)
+                .await,
             [find_trace_ids, OTEL_TRACES_INDEX_ID]
         );
     }
@@ -489,18 +524,36 @@ impl SpanReaderPlugin for JaegerService {
         &self,
         request: Request<FindTracesRequest>,
     ) -> Result<Response<Self::FindTracesStream>, Status> {
-        self.find_traces_inner(request.into_inner(), "find_traces", Instant::now())
-            .await
-            .map(Response::new)
+        let index_id_patterns = extract_otel_traces_index_patterns_from_metadata(
+            request.metadata(),
+            HEADER_NAME_OTEL_TRACES_INDEX,
+        )?;
+        self.find_traces_for_indexes(
+            request.into_inner(),
+            "find_traces",
+            Instant::now(),
+            index_id_patterns,
+        )
+        .await
+        .map(Response::new)
     }
 
     async fn get_trace(
         &self,
         request: Request<GetTraceRequest>,
     ) -> Result<Response<Self::GetTraceStream>, Status> {
-        self.get_trace_inner(request.into_inner(), "get_trace", Instant::now())
-            .await
-            .map(Response::new)
+        let index_id_patterns = extract_otel_traces_index_patterns_from_metadata(
+            request.metadata(),
+            HEADER_NAME_OTEL_TRACES_INDEX,
+        )?;
+        self.get_trace_for_indexes(
+            request.into_inner(),
+            "get_trace",
+            Instant::now(),
+            index_id_patterns,
+        )
+        .await
+        .map(Response::new)
     }
 }
 
@@ -1027,6 +1080,9 @@ where T: Deserialize<'a> {
 
 #[cfg(test)]
 mod tests {
+    use quickwit_opentelemetry::otlp::{
+        HEADER_NAME_OTEL_TRACES_INDEX, OTEL_TRACES_INDEX_ID_PATTERN,
+    };
     use quickwit_proto::jaeger::api_v2::ValueType;
     use quickwit_search::{encode_term_for_test, MockSearchService, QuickwitAggregations};
     use serde_json::json;
@@ -2378,7 +2434,7 @@ mod tests {
         service
             .expect_root_list_terms()
             .withf(|req| {
-                req.index_id_patterns == vec![OTEL_TRACES_INDEX_ID]
+                req.index_id_patterns == vec![OTEL_TRACES_INDEX_ID_PATTERN]
                     && req.field == "service_name"
                     && req.start_timestamp.is_some()
             })
@@ -2399,6 +2455,41 @@ mod tests {
         let jaeger = JaegerService::new(JaegerConfig::default(), service);
 
         let request = tonic::Request::new(GetServicesRequest {});
+        let response = jaeger.get_services(request).await.unwrap().into_inner();
+        assert_eq!(response.services, &["service1", "service2", "service3"]);
+    }
+
+    #[tokio::test]
+    async fn test_get_services_on_custom_indexes() {
+        let mut service = MockSearchService::new();
+        service
+            .expect_root_list_terms()
+            .withf(|req| {
+                req.index_id_patterns == vec!["index-1", "index-3*"]
+                    && req.field == "service_name"
+                    && req.start_timestamp.is_some()
+            })
+            .return_once(|_| {
+                Ok(quickwit_proto::search::ListTermsResponse {
+                    num_hits: 3,
+                    terms: vec![
+                        encode_term_for_test!("service1"),
+                        encode_term_for_test!("service2"),
+                        encode_term_for_test!("service3"),
+                    ],
+                    elapsed_time_micros: 0,
+                    errors: Vec::new(),
+                })
+            });
+
+        let service = Arc::new(service);
+        let jaeger = JaegerService::new(JaegerConfig::default(), service);
+
+        let mut request = tonic::Request::new(GetServicesRequest {});
+        request.metadata_mut().insert(
+            HEADER_NAME_OTEL_TRACES_INDEX,
+            "index-1,index-3*".parse().unwrap(),
+        );
         let response = jaeger.get_services(request).await.unwrap().into_inner();
         assert_eq!(response.services, &["service1", "service2", "service3"]);
     }

--- a/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.down.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.down.sql
@@ -1,6 +1,9 @@
 UPDATE 
    indexes
 SET 
-   index_metadata_json = REPLACE(index_metadata_json, '"output_format":"hex"', '"output_format": "base64"')
+   index_metadata_json = REPLACE(
+      REPLACE(index_metadata_json, '"output_format":"hex"', '"output_format":"base64"'),
+      '"input_format":"hex"', '"input_format":"base64"'
+   )
 WHERE 
     index_id in ('otel-logs-v0_6', 'otel-traces-v0_6');

--- a/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.down.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.down.sql
@@ -1,0 +1,6 @@
+UPDATE 
+   indexes
+SET 
+   index_metadata_json = REPLACE(index_metadata_json, '"output_format":"hex"', '"output_format": "base64"')
+WHERE 
+    index_id in ('otel-logs-v0_6', 'otel-traces-v0_6');

--- a/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.up.sql
@@ -1,0 +1,6 @@
+UPDATE 
+   indexes
+SET 
+   index_metadata_json = REPLACE(index_metadata_json, '"output_format":"base64"', '"output_format": "hex"')
+WHERE 
+    index_id in ('otel-logs-v0_6', 'otel-traces-v0_6');

--- a/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/13_migrate-otel-indexes-v0_6.up.sql
@@ -1,6 +1,9 @@
 UPDATE 
    indexes
 SET 
-   index_metadata_json = REPLACE(index_metadata_json, '"output_format":"base64"', '"output_format": "hex"')
+   index_metadata_json = REPLACE(
+      REPLACE(index_metadata_json, '"output_format":"base64"', '"output_format":"hex"'),
+      '"input_format":"base64"', '"input_format":"hex"'
+   )
 WHERE 
     index_id in ('otel-logs-v0_6', 'otel-traces-v0_6');

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -946,28 +946,28 @@ mod tests {
             .index_config
             .doc_mapping
             .field_mappings;
-        assert!(
+        assert_eq!(
             field_mapping
                 .iter()
                 .filter(|field_mapping| field_mapping.name == "tenant_id")
-                .count()
-                == 1
+                .count(),
+            1
         );
-        assert!(
+        assert_eq!(
             field_mapping
                 .iter()
                 .filter(|field_mapping| field_mapping.name == "trace_id")
-                .count()
-                == 1
+                .count(),
+            1
         );
-        assert!(
+        assert_eq!(
             field_mapping
                 .iter()
                 .filter(|field_mapping| field_mapping.name == "span_id")
-                .count()
-                == 1
+                .count(),
+            1
         );
-        for field_mapping in field_mapping.iter() {
+        for field_mapping in &field_mapping {
             if field_mapping.name == "tenant_id" {
                 if let FieldMappingType::Bytes(bytes_options, _) = &field_mapping.mapping_type {
                     assert_eq!(bytes_options.input_format, BinaryFormat::Base64);

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
@@ -114,12 +114,13 @@ impl From<FileBackedIndexV0_6> for FileBackedIndex {
                 .filter(|field_mapping| {
                     field_mapping.name == "trace_id" || field_mapping.name == "span_id"
                 })
-                .for_each(|field_mapping| match &mut field_mapping.mapping_type {
-                    FieldMappingType::Bytes(bytes_options, _) => {
+                .for_each(|field_mapping| {
+                    if let FieldMappingType::Bytes(bytes_options, _) =
+                        &mut field_mapping.mapping_type
+                    {
                         bytes_options.input_format = BinaryFormat::Hex;
                         bytes_options.output_format = BinaryFormat::Hex;
                     }
-                    _ => {}
                 });
         }
         // Override split index_id to support old SplitMetadata format.

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
@@ -20,6 +20,7 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
+use quickwit_doc_mapper::{FieldMappingType, BinaryFormat};
 use quickwit_proto::types::SourceId;
 use serde::{Deserialize, Serialize};
 
@@ -100,6 +101,24 @@ impl From<FileBackedIndex> for FileBackedIndexV0_6 {
 
 impl From<FileBackedIndexV0_6> for FileBackedIndex {
     fn from(mut index: FileBackedIndexV0_6) -> Self {
+        // if the index is otel-traces-v0_6, convert set bytes fields input and output format to hex
+        // to be compatible with the v0_6 version.
+        // TODO: remove after 0.8 release.
+        if index.metadata.index_id() == "otel-traces-v0_6" {
+            index.metadata.index_config.doc_mapping
+                .field_mappings
+                .iter_mut()
+                .filter(|field_mapping| field_mapping.name == "trace_id" || field_mapping.name == "span_id")
+                .for_each(|field_mapping| {
+                    match &mut field_mapping.mapping_type {
+                        FieldMappingType::Bytes(bytes_options, _) => {
+                            bytes_options.input_format = BinaryFormat::Hex;
+                            bytes_options.output_format = BinaryFormat::Hex;
+                        }
+                        _ => {}
+                    }
+                });
+        }
         // Override split index_id to support old SplitMetadata format.
         for split in index.splits.iter_mut() {
             if split.split_metadata.index_uid.is_empty() {

--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/serialize.rs
@@ -20,7 +20,7 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use quickwit_doc_mapper::{FieldMappingType, BinaryFormat};
+use quickwit_doc_mapper::{BinaryFormat, FieldMappingType};
 use quickwit_proto::types::SourceId;
 use serde::{Deserialize, Serialize};
 
@@ -105,18 +105,21 @@ impl From<FileBackedIndexV0_6> for FileBackedIndex {
         // to be compatible with the v0_6 version.
         // TODO: remove after 0.8 release.
         if index.metadata.index_id() == "otel-traces-v0_6" {
-            index.metadata.index_config.doc_mapping
+            index
+                .metadata
+                .index_config
+                .doc_mapping
                 .field_mappings
                 .iter_mut()
-                .filter(|field_mapping| field_mapping.name == "trace_id" || field_mapping.name == "span_id")
-                .for_each(|field_mapping| {
-                    match &mut field_mapping.mapping_type {
-                        FieldMappingType::Bytes(bytes_options, _) => {
-                            bytes_options.input_format = BinaryFormat::Hex;
-                            bytes_options.output_format = BinaryFormat::Hex;
-                        }
-                        _ => {}
+                .filter(|field_mapping| {
+                    field_mapping.name == "trace_id" || field_mapping.name == "span_id"
+                })
+                .for_each(|field_mapping| match &mut field_mapping.mapping_type {
+                    FieldMappingType::Bytes(bytes_options, _) => {
+                        bytes_options.input_format = BinaryFormat::Hex;
+                        bytes_options.output_format = BinaryFormat::Hex;
                     }
+                    _ => {}
                 });
         }
         // Override split index_id to support old SplitMetadata format.

--- a/quickwit/quickwit-opentelemetry/Cargo.toml
+++ b/quickwit/quickwit-opentelemetry/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://quickwit.io/docs/"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
 once_cell = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }

--- a/quickwit/quickwit-opentelemetry/Cargo.toml
+++ b/quickwit/quickwit-opentelemetry/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-base64 = { workspace = true }
 hex = { workspace = true }
 once_cell = { workspace = true }
 prost = { workspace = true }

--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -83,8 +83,12 @@ doc_mapping:
       indexed: false
     - name: trace_id
       type: bytes
+      input_format: hex
+      output_format: hex
     - name: span_id
       type: bytes
+      input_format: hex
+      output_format: hex
     - name: trace_flags
       type: u64
       indexed: false

--- a/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
@@ -170,7 +170,7 @@ pub fn extract_otel_traces_index_id_patterns_from_metadata(
                 "failed to extract index ID from request header: {error}",
             ))
         })?
-        .unwrap_or_else(|| OTEL_TRACES_INDEX_ID_PATTERN);
+        .unwrap_or(OTEL_TRACES_INDEX_ID_PATTERN);
     let mut index_id_patterns = Vec::new();
     for index_id_pattern in comma_separated_index_id_patterns.split(',') {
         if index_id_pattern.is_empty() {
@@ -201,7 +201,7 @@ pub(crate) fn extract_otel_index_id_from_metadata(
             ))
         })?
         .unwrap_or_else(|| otel_signal.default_index_id());
-    validate_identifier("index_id", &index_id).map_err(|error| {
+    validate_identifier("index_id", index_id).map_err(|error| {
         Status::internal(format!(
             "Invalid index ID pattern in request metadata: {}",
             error

--- a/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
@@ -41,7 +41,7 @@ pub use trace_id::{TraceId, TryFromTraceIdError};
 pub use traces::{
     parse_otlp_spans_json, parse_otlp_spans_protobuf, Event, JsonSpanIterator, Link,
     OtlpGrpcTracesService, OtlpTraceError, Span, SpanFingerprint, SpanKind, SpanStatus,
-    OTEL_TRACES_INDEX_ID,
+    OTEL_TRACES_INDEX_ID, OTEL_TRACES_INDEX_ID_PATTERN,
 };
 
 impl From<OtlpTraceError> for tonic::Status {

--- a/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/mod.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 
+use quickwit_config::{validate_identifier, validate_index_id_pattern};
 use quickwit_proto::opentelemetry::proto::common::v1::any_value::Value as OtlpValue;
 use quickwit_proto::opentelemetry::proto::common::v1::{
     AnyValue as OtlpAnyValue, ArrayValue as OtlpArrayValue, KeyValue as OtlpKeyValue,
@@ -37,11 +38,12 @@ pub use logs::{OtlpGrpcLogsService, OTEL_LOGS_INDEX_ID};
 pub use span_id::{SpanId, TryFromSpanIdError};
 #[cfg(any(test, feature = "testsuite"))]
 pub use test_utils::make_resource_spans_for_test;
+use tonic::Status;
 pub use trace_id::{TraceId, TryFromTraceIdError};
 pub use traces::{
     parse_otlp_spans_json, parse_otlp_spans_protobuf, Event, JsonSpanIterator, Link,
     OtlpGrpcTracesService, OtlpTraceError, Span, SpanFingerprint, SpanKind, SpanStatus,
-    OTEL_TRACES_INDEX_ID, OTEL_TRACES_INDEX_ID_PATTERN,
+    HEADER_NAME_OTEL_TRACES_INDEX, OTEL_TRACES_INDEX_ID, OTEL_TRACES_INDEX_ID_PATTERN,
 };
 
 impl From<OtlpTraceError> for tonic::Status {
@@ -133,6 +135,62 @@ pub(crate) fn parse_log_record_body(body: OtlpAnyValue) -> Option<JsonValue> {
 
 fn is_zero(count: &u32) -> bool {
     *count == 0
+}
+
+pub fn extract_otel_traces_index_patterns_from_metadata(
+    metadata: &tonic::metadata::MetadataMap,
+    otel_index_header_name: &str,
+) -> Result<Vec<String>, Status> {
+    let comma_separated_index_id_patterns = metadata
+        .get(otel_index_header_name)
+        .map(|index| index.to_str().map(|index| index.to_string()))
+        .transpose()
+        .map_err(|error| {
+            Status::internal(format!(
+                "Failed to extract index ID from request metadata: {}",
+                error
+            ))
+        })?
+        .unwrap_or_else(|| OTEL_TRACES_INDEX_ID_PATTERN.to_string());
+    let mut index_id_patterns = Vec::new();
+    for index_id_pattern in comma_separated_index_id_patterns.split(',') {
+        validate_index_id_pattern(index_id_pattern).map_err(|error| {
+            Status::internal(format!(
+                "Invalid index ID pattern in request metadata: {}",
+                error
+            ))
+        })?;
+        index_id_patterns.push(index_id_pattern.to_string());
+    }
+    Ok(index_id_patterns)
+}
+
+pub(crate) fn extract_otel_traces_index_from_metadata(
+    metadata: &tonic::metadata::MetadataMap,
+    otel_index_header_name: &str,
+) -> Result<String, Status> {
+    let index_id = metadata
+        .get(otel_index_header_name)
+        .map(
+            |index: &tonic::metadata::MetadataValue<tonic::metadata::Ascii>| {
+                index.to_str().map(|index| index.to_string())
+            },
+        )
+        .transpose()
+        .map_err(|error| {
+            Status::internal(format!(
+                "Failed to extract index ID from request metadata: {}",
+                error
+            ))
+        })?
+        .unwrap_or_else(|| OTEL_TRACES_INDEX_ID.to_string());
+    validate_identifier("index_id", &index_id).map_err(|error| {
+        Status::internal(format!(
+            "Invalid index ID pattern in request metadata: {}",
+            error
+        ))
+    })?;
+    Ok(index_id)
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-opentelemetry/src/otlp/span_id.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/span_id.rs
@@ -17,15 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct SpanId([u8; 8]);
 
 impl SpanId {
-    pub const BASE64_LENGTH: usize = 12;
+    pub const HEX_LENGTH: usize = 16;
 
     pub fn new(bytes: [u8; 8]) -> Self {
         Self(bytes)
@@ -42,33 +40,29 @@ impl SpanId {
 
 impl Serialize for SpanId {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let b64span_id = BASE64_STANDARD.encode(self.0);
-        serializer.serialize_str(&b64span_id)
+        let hexspan_id = hex::encode(self.0);
+        serializer.serialize_str(&hexspan_id)
     }
 }
 
 impl<'de> Deserialize<'de> for SpanId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
-        let b64span_id = String::deserialize(deserializer)?;
+        let hexspan_id = String::deserialize(deserializer)?;
 
-        if b64span_id.len() != SpanId::BASE64_LENGTH {
+        if hexspan_id.len() != SpanId::HEX_LENGTH {
             let message = format!(
-                "base64 span ID must be {} bytes long, got {}",
-                SpanId::BASE64_LENGTH,
-                b64span_id.len()
+                "hex span ID must be {} bytes long, got {}",
+                SpanId::HEX_LENGTH,
+                hexspan_id.len()
             );
             return Err(de::Error::custom(message));
         }
         let mut span_id = [0u8; 8];
-        BASE64_STANDARD
-            // Using the unchecked version here because otherwise the engine gets the wrong size
-            // estimate and fails.
-            .decode_slice_unchecked(b64span_id.as_bytes(), &mut span_id)
-            .map_err(|error| {
-                let message = format!("failed to decode base64 span ID: {:?}", error);
-                de::Error::custom(message)
-            })?;
+        hex::decode_to_slice(hexspan_id, &mut span_id).map_err(|error| {
+            let message = format!("failed to decode hex span ID: {:?}", error);
+            de::Error::custom(message)
+        })?;
         Ok(SpanId(span_id))
     }
 }
@@ -104,7 +98,7 @@ mod tests {
     fn test_span_id_serde() {
         let expected_span_id = SpanId::new([1; 8]);
         let span_id_json = serde_json::to_string(&expected_span_id).unwrap();
-        assert_eq!(span_id_json, r#""AQEBAQEBAQE=""#);
+        assert_eq!(span_id_json, r#""0101010101010101""#);
 
         let span_id = serde_json::from_str::<SpanId>(&span_id_json).unwrap();
         assert_eq!(span_id, expected_span_id,);

--- a/quickwit/quickwit-opentelemetry/src/otlp/span_id.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/span_id.rs
@@ -60,7 +60,7 @@ impl<'de> Deserialize<'de> for SpanId {
         }
         let mut span_id = [0u8; 8];
         hex::decode_to_slice(hexspan_id, &mut span_id).map_err(|error| {
-            let message = format!("failed to decode hex span ID: {:?}", error);
+            let message = format!("failed to decode hex span ID: {error:?}");
             de::Error::custom(message)
         })?;
         Ok(SpanId(span_id))

--- a/quickwit/quickwit-opentelemetry/src/otlp/trace_id.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/trace_id.rs
@@ -68,7 +68,7 @@ impl<'de> Deserialize<'de> for TraceId {
             }
             let mut trace_id_bytes = [0u8; 16];
             hex::decode_to_slice(hextrace_id, &mut trace_id_bytes).map_err(|error| {
-                let message = format!("failed to decode hex span ID: {:?}", error);
+                let message = format!("failed to decode hex span ID: {error:?}");
                 de::Error::custom(message)
             })?;
             Ok(TraceId(trace_id_bytes))

--- a/quickwit/quickwit-opentelemetry/src/otlp/trace_id.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/trace_id.rs
@@ -20,14 +20,13 @@
 use base64::display::Base64Display;
 use base64::engine::GeneralPurpose;
 use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct TraceId([u8; 16]);
 
 impl TraceId {
-    pub const BASE64_LENGTH: usize = 24;
+    pub const HEX_LENGTH: usize = 32;
 
     pub fn new(bytes: [u8; 16]) -> Self {
         Self(bytes)
@@ -49,8 +48,8 @@ impl TraceId {
 impl Serialize for TraceId {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if serializer.is_human_readable() {
-            let b64trace_id = BASE64_STANDARD.encode(self.0);
-            serializer.serialize_str(&b64trace_id)
+            let hextrace_id = hex::encode(self.0);
+            serializer.serialize_str(&hextrace_id)
         } else {
             self.0.serialize(serializer)
         }
@@ -61,24 +60,20 @@ impl<'de> Deserialize<'de> for TraceId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
         if deserializer.is_human_readable() {
-            let b64trace_id = String::deserialize(deserializer)?;
-            if b64trace_id.len() != TraceId::BASE64_LENGTH {
+            let hextrace_id = String::deserialize(deserializer)?;
+            if hextrace_id.len() != TraceId::HEX_LENGTH {
                 let message = format!(
-                    "base64 trace ID must be {} bytes long, got {}",
-                    TraceId::BASE64_LENGTH,
-                    b64trace_id.len()
+                    "hex trace ID must be {} bytes long, got {}",
+                    TraceId::HEX_LENGTH,
+                    hextrace_id.len()
                 );
                 return Err(de::Error::custom(message));
             }
             let mut trace_id_bytes = [0u8; 16];
-            BASE64_STANDARD
-                // Using the unchecked version here because otherwise the engine gets the wrong size
-                // estimate and fails.
-                .decode_slice_unchecked(b64trace_id.as_bytes(), &mut trace_id_bytes)
-                .map_err(|error| {
-                    let message = format!("failed to decode base64 trace ID: {:?}", error);
-                    de::Error::custom(message)
-                })?;
+            hex::decode_to_slice(hextrace_id, &mut trace_id_bytes).map_err(|error| {
+                let message = format!("failed to decode hex span ID: {:?}", error);
+                de::Error::custom(message)
+            })?;
             Ok(TraceId(trace_id_bytes))
         } else {
             let trace_id_bytes: [u8; 16] = <[u8; 16]>::deserialize(deserializer)?;
@@ -118,7 +113,7 @@ mod tests {
     fn test_trace_id_serde() {
         let expected_trace_id = TraceId::new([1; 16]);
         let trace_id_json = serde_json::to_string(&expected_trace_id).unwrap();
-        assert_eq!(trace_id_json, r#""AQEBAQEBAQEBAQEBAQEBAQ==""#);
+        assert_eq!(trace_id_json, r#""01010101010101010101010101010101""#);
 
         let trace_id = serde_json::from_str::<TraceId>(&trace_id_json).unwrap();
         assert_eq!(trace_id, expected_trace_id,);

--- a/quickwit/quickwit-opentelemetry/src/otlp/trace_id.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/trace_id.rs
@@ -17,9 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use base64::display::Base64Display;
-use base64::engine::GeneralPurpose;
-use base64::prelude::BASE64_STANDARD;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -40,8 +37,8 @@ impl TraceId {
         self.0.to_vec()
     }
 
-    pub fn base64_display(&self) -> Base64Display<'_, '_, GeneralPurpose> {
-        Base64Display::new(&self.0, &BASE64_STANDARD)
+    pub fn hex_display(&self) -> String {
+        hex::encode(self.0)
     }
 }
 

--- a/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
@@ -47,7 +47,7 @@ use super::{is_zero, TryFromSpanIdError, TryFromTraceIdError};
 use crate::otlp::metrics::OTLP_SERVICE_METRICS;
 use crate::otlp::{extract_attributes, SpanId, TraceId};
 
-pub const OTEL_TRACES_INDEX_ID: &str = "otel-traces-v0_6";
+pub const OTEL_TRACES_INDEX_ID: &str = "otel-traces-v0_7";
 
 const OTEL_TRACES_INDEX_CONFIG: &str = r#"
 version: 0.6
@@ -91,6 +91,7 @@ doc_mapping:
     - name: span_name
       type: text
       tokenizer: raw
+      fast: true
     - name: span_fingerprint
       type: text
       tokenizer: raw
@@ -111,10 +112,10 @@ doc_mapping:
       type: u64
       indexed: false
       fast: true
-      stored: false
     - name: span_attributes
       type: json
       tokenizer: raw
+      fast: true
     - name: span_dropped_attributes_count
       type: u64
       indexed: false
@@ -133,6 +134,7 @@ doc_mapping:
     - name: events
       type: array<json>
       tokenizer: raw
+      fast: true
     - name: event_names
       type: array<text>
       tokenizer: default

--- a/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
@@ -59,6 +59,8 @@ doc_mapping:
   field_mappings:
     - name: trace_id
       type: bytes
+      input_format: hex
+      output_format: hex
       fast: true
     - name: trace_state
       type: text
@@ -86,6 +88,8 @@ doc_mapping:
       indexed: false
     - name: span_id
       type: bytes
+      input_format: hex
+      output_format: hex
     - name: span_kind
       type: u64
     - name: span_name
@@ -130,6 +134,8 @@ doc_mapping:
       indexed: true
     - name: parent_span_id
       type: bytes
+      input_format: hex
+      output_format: hex
       indexed: false
     - name: events
       type: array<json>

--- a/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
@@ -48,6 +48,7 @@ use crate::otlp::metrics::OTLP_SERVICE_METRICS;
 use crate::otlp::{extract_attributes, SpanId, TraceId};
 
 pub const OTEL_TRACES_INDEX_ID: &str = "otel-traces-v0_7";
+pub const OTEL_TRACES_INDEX_ID_PATTERN: &str = "otel-traces-v0_*";
 
 const OTEL_TRACES_INDEX_CONFIG: &str = r#"
 version: 0.6

--- a/quickwit/quickwit-search/src/find_trace_ids_collector.rs
+++ b/quickwit/quickwit-search/src/find_trace_ids_collector.rs
@@ -226,7 +226,7 @@ impl SegmentCollector for FindTraceIdsSegmentCollector {
     }
 
     fn harvest(self) -> Self::Fruit {
-        let mut buffer = Vec::with_capacity(TraceId::BASE64_LENGTH);
+        let mut buffer = Vec::with_capacity(TraceId::HEX_LENGTH);
         self.select_trace_ids
             .harvest()
             .into_iter()

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -480,7 +480,7 @@ async fn test_single_node_without_timestamp_with_query_start_timestamp_enabled(
     let start_timestamp = OffsetDateTime::now_utc().unix_timestamp();
     for i in 0..30 {
         let body = format!("info @ t:{}", i + 1);
-        docs.push(json!({"body": body}));
+        docs.push(json!({ "body": body }));
     }
     test_sandbox.add_documents(docs).await?;
 
@@ -1783,6 +1783,8 @@ async fn test_single_node_find_trace_ids_collector() {
               - name: trace_id
                 type: bytes
                 fast: true
+                input_format: hex
+                output_format: hex
               - name: span_timestamp_secs
                 type: datetime
                 fast: true

--- a/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
@@ -55,11 +55,11 @@ pub(crate) struct JaegerApi;
 ///
 /// This is where all Jaeger handlers
 /// should be registered.
-/// Request are executed on the `otel traces v0_6` index.
+/// Request are executed on the `otel traces v0_7` index.
 pub(crate) fn jaeger_api_handlers(
     jaeger_service_opt: Option<JaegerService>,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    let jaeger_api_root_url = warp::path!("otel-traces-v0_6" / "jaeger" / "api" / ..);
+    let jaeger_api_root_url = warp::path!("otel-traces-v0_7" / "jaeger" / "api" / ..);
     jaeger_api_root_url.and(
         jaeger_services_handler(jaeger_service_opt.clone())
             .or(jaeger_service_operations_handler(
@@ -73,7 +73,7 @@ pub(crate) fn jaeger_api_handlers(
 #[utoipa::path(
     get,
     tag = "Jaeger",
-    path = "/otel-traces-v0_6/jaeger/api/services",
+    path = "/otel-traces-v0_7/jaeger/api/services",
     responses(
         (status = 200, description = "Successfully fetched services names.", body = JaegerResponseBody )
     )
@@ -91,7 +91,7 @@ pub fn jaeger_services_handler(
 #[utoipa::path(
     get,
     tag = "Jaeger",
-    path = "/otel-traces-v0_6/jaeger/api/services/{service}/operations",
+    path = "/otel-traces-v0_7/jaeger/api/services/{service}/operations",
     responses(
         (status = 200, description = "Successfully fetched operations names the given service.", body = JaegerResponseBody )
     )
@@ -109,7 +109,7 @@ pub fn jaeger_service_operations_handler(
 #[utoipa::path(
     get,
     tag = "Jaeger",
-    path = "/otel-traces-v0_6/jaeger/api/traces?service={service}&start={start_in_ns}&end={end_in_ns}&lookback=custom",
+    path = "/otel-traces-v0_7/jaeger/api/traces?service={service}&start={start_in_ns}&end={end_in_ns}&lookback=custom",
     responses(
         (status = 200, description = "Successfully fetched traces information.", body = JaegerResponseBody )
     ),
@@ -139,7 +139,7 @@ pub fn jaeger_traces_search_handler(
 #[utoipa::path(
     get,
     tag = "Jaeger",
-    path = "/otel-traces-v0_6/jaeger/api/traces/{id}",
+    path = "/otel-traces-v0_7/jaeger/api/traces/{id}",
     responses(
         (status = 200, description = "Successfully fetched traces spans for the provided trace ID.", body = JaegerResponseBody )
     )
@@ -318,7 +318,7 @@ mod tests {
     async fn test_when_jaeger_not_found() {
         let jaeger_api_handler = jaeger_api_handlers(None).recover(recover_fn);
         let resp = warp::test::request()
-            .path("/otel-traces-v0_6/jaeger/api/services")
+            .path("/otel-traces-v0_7/jaeger/api/services")
             .reply(&jaeger_api_handler)
             .await;
         let error_body = serde_json::from_slice::<HashMap<String, String>>(resp.body()).unwrap();
@@ -350,7 +350,7 @@ mod tests {
 
         let jaeger_api_handler = jaeger_api_handlers(Some(jaeger)).recover(recover_fn);
         let resp = warp::test::request()
-            .path("/otel-traces-v0_6/jaeger/api/services")
+            .path("/otel-traces-v0_7/jaeger/api/services")
             .reply(&jaeger_api_handler)
             .await;
         assert_eq!(resp.status(), 200);
@@ -386,7 +386,7 @@ mod tests {
         let jaeger = JaegerService::new(JaegerConfig::default(), mock_search_service);
         let jaeger_api_handler = jaeger_api_handlers(Some(jaeger)).recover(recover_fn);
         let resp = warp::test::request()
-            .path("/otel-traces-v0_6/jaeger/api/services/service1/operations")
+            .path("/otel-traces-v0_7/jaeger/api/services/service1/operations")
             .reply(&jaeger_api_handler)
             .await;
         assert_eq!(resp.status(), 200);
@@ -434,7 +434,7 @@ mod tests {
         let jaeger_api_handler = jaeger_api_handlers(Some(jaeger)).recover(recover_fn);
         let resp = warp::test::request()
             .path(
-                "/otel-traces-v0_6/jaeger/api/traces?service=quickwit&\
+                "/otel-traces-v0_7/jaeger/api/traces?service=quickwit&\
                  operation=delete_splits_marked_for_deletion&minDuration=500us&maxDuration=1.2s&\
                  tags=%7B%22tag.first%22%3A%22common%22%2C%22tag.second%22%3A%22true%22%7D&\
                  limit=1&start=1702352106016000&end=1702373706016000&lookback=custom",
@@ -465,7 +465,7 @@ mod tests {
 
         let jaeger_api_handler = jaeger_api_handlers(Some(jaeger)).recover(recover_fn);
         let resp = warp::test::request()
-            .path("/otel-traces-v0_6/jaeger/api/traces/1506026ddd216249555653218dc88a6c")
+            .path("/otel-traces-v0_7/jaeger/api/traces/1506026ddd216249555653218dc88a6c")
             .reply(&jaeger_api_handler)
             .await;
 

--- a/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
@@ -77,7 +77,7 @@ fn jaeger_api_path_filter() -> impl Filter<Extract = (Vec<String>,), Error = Rej
 #[utoipa::path(
     get,
     tag = "Jaeger",
-    path = "/{otel-traces-index}/jaeger/api/services",
+    path = "/{otel-traces-index-id}/jaeger/api/services",
     responses(
         (status = 200, description = "Successfully fetched services names.", body = JaegerResponseBody )
     )
@@ -95,7 +95,7 @@ pub fn jaeger_services_handler(
 #[utoipa::path(
     get,
     tag = "Jaeger",
-    path = "/{otel-traces-index}/jaeger/api/services/{service}/operations",
+    path = "/{otel-traces-index-id}/jaeger/api/services/{service}/operations",
     responses(
         (status = 200, description = "Successfully fetched operations names the given service.", body = JaegerResponseBody )
     )
@@ -143,7 +143,7 @@ pub fn jaeger_traces_search_handler(
 #[utoipa::path(
     get,
     tag = "Jaeger",
-    path = "/{otel-trace-index}/jaeger/api/traces/{id}",
+    path = "/{otel-trace-index-id}/jaeger/api/traces/{id}",
     responses(
         (status = 200, description = "Successfully fetched traces spans for the provided trace ID.", body = JaegerResponseBody )
     )
@@ -189,7 +189,7 @@ async fn jaeger_service_operations(
         .await
         .map_err(|error| JaegerError {
             status: StatusCode::INTERNAL_SERVER_ERROR,
-            message: format!("failed to fetch services: {}", error),
+            message: format!("failed to fetch services: {error}"),
         })?;
 
     let operations = get_operations_response
@@ -299,7 +299,7 @@ async fn jaeger_get_trace_by_id(
             )
             .await
             .map_err(|error| {
-                error!(error = ?error, "failed to fetch trace `{}`", trace_id_string.clone());
+                error!(error = ?error, "failed to fetch trace `{trace_id_string}`");
                 JaegerError {
                     status: StatusCode::INTERNAL_SERVER_ERROR,
                     message: "failed to fetch trace".to_string(),

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -58,10 +58,6 @@ pub struct SearchApi;
 pub(crate) async fn extract_index_id_patterns(
     comma_separated_index_id_patterns: String,
 ) -> Result<Vec<String>, Rejection> {
-    println!(
-        "comma_separated_index_id_patterns: {}",
-        comma_separated_index_id_patterns
-    );
     let percent_decoded_comma_separated_index_id_patterns =
         percent_decode_str(&comma_separated_index_id_patterns)
             .decode_utf8()

--- a/quickwit/quickwit-serve/src/search_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/search_api/rest_handler.rs
@@ -58,6 +58,10 @@ pub struct SearchApi;
 pub(crate) async fn extract_index_id_patterns(
     comma_separated_index_id_patterns: String,
 ) -> Result<Vec<String>, Rejection> {
+    println!(
+        "comma_separated_index_id_patterns: {}",
+        comma_separated_index_id_patterns
+    );
     let percent_decoded_comma_separated_index_id_patterns =
         percent_decode_str(&comma_separated_index_id_patterns)
             .decode_utf8()


### PR DESCRIPTION
- [x] Added fast fields.
- [x] removed `stored:false` for `span_duration_millis`.
- [x] renamed index.
- [x] input and output format of the bytes field as hex
- [x] jaeger gRPC API should hit both indexes otel-traces-v0_6 and otel-traces-v0_7 by using the pattern otel-traces-v0_*
- [x] migrate 0.6 input/output format to hex for bytes fields to be able to query both 0.6 and 0.7 indexes. 
- [x] allow to ingest using the OTLP gRPC API on a custom index by specifying the header `otel-traces-index` or `otel-logs-index.`
- [x] allow the use of Jaeger gRCP API on a custom index by adding the header `otel-traces-index` when starting jaeger-query
- [x] allow the use of Jaeger REST API on a custom index 
- [ ] ~~ensure that we don't validate the index schema if not splits are hit~~
- [x] update the endpoint of the REST Jaeger API so that we can hit `otel-traces-v0_7` index.

Tests:
- [x] integration test added to the otlp gRCP API.
- [x] started jaeger and query both `otel-traces-v0_6` and `otel-traces-v0_7` 


