### PR TITLE
Add parameter to limit the size of a query string

### DIFF
--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -55,7 +55,8 @@
         "fast_field_cache_capacity": "10G",
         "split_footer_cache_capacity": "1G",
         "max_num_concurrent_split_streams": 120,
-        "max_num_concurrent_split_searches": 150
+        "max_num_concurrent_split_searches": 150,
+        "query_string_size_limit": "256B"
     },
     "jaeger": {
         "enable_endpoint": true,

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -46,6 +46,7 @@ fast_field_cache_capacity = "10G"
 split_footer_cache_capacity = "1G"
 max_num_concurrent_split_streams = 120
 max_num_concurrent_split_searches = 150
+query_string_size_limit = "256B"
 
 [jaeger]
 enable_endpoint = true

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -50,6 +50,7 @@ searcher:
   split_footer_cache_capacity: 1G
   max_num_concurrent_split_streams: 120
   max_num_concurrent_split_searches: 150
+  query_string_size_limit: 256B
 
 jaeger:
   enable_endpoint: true

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -170,6 +170,7 @@ pub struct SearcherConfig {
     pub partial_request_cache_capacity: ByteSize,
     pub max_num_concurrent_split_searches: usize,
     pub max_num_concurrent_split_streams: usize,
+    pub query_string_size_limit: ByteSize,
     // Strangely, if None, this will also have the effect of not forwarding
     // to searcher.
     // TODO document and fix if necessary.
@@ -187,6 +188,7 @@ impl Default for SearcherConfig {
             max_num_concurrent_split_searches: 100,
             aggregation_memory_limit: ByteSize::mb(500),
             aggregation_bucket_limit: 65000,
+            query_string_size_limit: ByteSize::b(1024),
             split_cache: None,
         }
     }

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -564,6 +564,7 @@ mod tests {
                 partial_request_cache_capacity: ByteSize::mb(64),
                 max_num_concurrent_split_searches: 150,
                 max_num_concurrent_split_streams: 120,
+                query_string_size_limit: ByteSize::b(256),
                 split_cache: None,
             }
         );


### PR DESCRIPTION
### Description

I added the parameter to limit the size of the query string in a user input. Further, I moved `validate_request` out of the for loop since many of the checks inside it did not require to be run for each index_metadata.

An alternate approach for checking the query size could be to match the enums in the serialized query_ast value and check the size of the actual user input.

### How was this PR tested?

New unit tests to check if the error is thrown.
