### PR TITLE
Fix indexes breadcrum link, fixes #4326

### DIFF
--- a/quickwit/quickwit-ui/src/views/IndexView.test.jsx
+++ b/quickwit/quickwit-ui/src/views/IndexView.test.jsx
@@ -17,12 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import { render, unmountComponentAtNode } from "react-dom";
-import { waitFor } from "@testing-library/react";
-import { screen } from '@testing-library/dom';
+import { unmountComponentAtNode } from "react-dom";
+import { render, waitFor, screen } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 import { Client } from "../services/client";
 import IndexView from "./IndexView";
+import { BrowserRouter } from "react-router-dom";
 
 jest.mock('../services/client');
 const mockedUsedNavigate = jest.fn();
@@ -32,20 +32,6 @@ jest.mock('react-router-dom', () => ({
     indexId: 'my-new-fresh-index-id'
   })
 }));
-
-let container = null;
-beforeEach(() => {
-  // setup a DOM element as a render target
-  container = document.createElement("div");
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  // cleanup on exiting
-  unmountComponentAtNode(container);
-  container.remove();
-  container = null;
-});
 
 test('renders IndexView', async () => {
   const index = {
@@ -59,7 +45,7 @@ test('renders IndexView', async () => {
   Client.prototype.getIndex.mockImplementation(() => Promise.resolve(index));
 
   await act(async () => {
-    render(<IndexView />, container);
+    render( <IndexView /> , {wrapper: BrowserRouter});
   });
 
   await waitFor(() => expect(screen.getByText(/my-new-fresh-index-uri/)).toBeInTheDocument());

--- a/quickwit/quickwit-ui/src/views/IndexView.tsx
+++ b/quickwit/quickwit-ui/src/views/IndexView.tsx
@@ -17,11 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import { Box, styled, Typography, Link, Tab } from '@mui/material';
+import { Box, styled, Typography, Tab } from '@mui/material';
+import Link, { LinkProps } from '@mui/material/Link';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Client } from '../services/client';
 import Loader from '../components/Loader';
-import { useParams } from 'react-router-dom';
+import { Link as RouterLink, useParams } from 'react-router-dom';
 import { Index } from '../utils/models';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { IndexSummary } from '../components/IndexSummary';
@@ -38,6 +39,16 @@ padding-left: 0;
 padding-right: 0;
 height: 100%;
 `;
+
+// NOTE : https://mui.com/material-ui/react-breadcrumbs/#integration-with-react-router
+interface LinkRouterProps extends LinkProps {
+  to: string;
+  replace?: boolean;
+}
+
+function LinkRouter(props: LinkRouterProps) {
+  return <Link {...props} component={RouterLink} />;
+}
 
 function IndexView() {
   const { indexId } = useParams();
@@ -123,9 +134,9 @@ function IndexView() {
     <ViewUnderAppBarBox>
       <FullBoxContainer>
         <QBreadcrumbs aria-label="breadcrumb">
-          <Link underline="hover" color="inherit" href="../indexes">
+          <LinkRouter underline="hover" color="inherit" to="/indexes">
             <Typography color="text.primary">Indexes</Typography>
-          </Link>
+          </LinkRouter>
           <Typography color="text.primary">{indexId}</Typography>
         </QBreadcrumbs>
         { renderFetchIndexResult() }


### PR DESCRIPTION
### Description

Use MUI's proposed react-router integration : https://mui.com/material-ui/react-breadcrumbs/#integration-with-react-router

### How was this PR tested?

- Checked _steps to reproduce_ in browser.
- Modified unit test to use a `BrowserRouter` context