### PR TITLE
Decouple TimeRangeSelect component from search query

### DIFF
--- a/quickwit/quickwit-ui/src/components/QueryActionBar.tsx
+++ b/quickwit/quickwit-ui/src/components/QueryActionBar.tsx
@@ -39,7 +39,17 @@ export function QueryEditorActionBar(props: SearchComponentProps) {
         </Button>
       </Box>
       { shouldDisplayTimeRangeSelect && <TimeRangeSelect
-        { ...props } />
+          timeRange={{
+            startTimestamp:props.searchRequest.startTimestamp,
+            endTimestamp:props.searchRequest.endTimestamp
+          }}
+          onUpdate={
+            (timeRange)=>{
+              props.runSearch({...props.searchRequest, ...timeRange});
+            }
+          }
+          disabled={props.queryRunning || !props.searchRequest.indexId}
+       />
       }
     </Box>
   )


### PR DESCRIPTION
### Description

Make the TimeRangeSelect component reusable outside of the search scope by lifting its dependency on `SearchComponentProps`

### How was this PR tested?
Passes existing test suite (low bar). Fiddling in browser OK.