### PR TITLE
Bugfix #4336: ingester leaving pool

### DIFF
--- a/quickwit/quickwit-common/src/tower/pool.rs
+++ b/quickwit/quickwit-common/src/tower/pool.rs
@@ -178,7 +178,7 @@ where
     }
 
     /// Removes a value from the pool.
-    pub fn remove(&self, key: &K) {
+    fn remove(&self, key: &K) {
         self.pool
             .write()
             .expect("lock should not be poisoned")

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -273,9 +273,7 @@ impl Ingester {
                     "failed to create mrecordlog queue `{}`: {}",
                     queue_id, io_error
                 );
-                return Err(IngestV2Error::IngesterUnavailable {
-                    ingester_id: shard.leader_id.into(),
-                });
+                return Err(IngestV2Error::Internal(format!("Io Error: {io_error}")));
             }
         };
         let rate_limiter = RateLimiter::from_settings(self.rate_limiter_settings);

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -34,9 +34,7 @@ use quickwit_proto::indexing::ShardPositionsUpdate;
 use quickwit_proto::ingest::ingester::{
     IngesterService, PersistFailureReason, PersistRequest, PersistResponse, PersistSubrequest,
 };
-use quickwit_proto::ingest::router::{
-    IngestRequestV2, IngestResponseV2, IngestRouterService, IngestSubrequest,
-};
+use quickwit_proto::ingest::router::{IngestRequestV2, IngestResponseV2, IngestRouterService};
 use quickwit_proto::ingest::{CommitTypeV2, IngestV2Error, IngestV2Result, ShardIds, ShardState};
 use quickwit_proto::types::{IndexUid, NodeId, ShardId, SourceId, SubrequestId};
 use tokio::sync::RwLock;
@@ -109,7 +107,6 @@ impl IngestRouter {
 
     pub fn subscribe(&self, event_broker: &EventBroker) {
         let weak_router_state = WeakRouterState(Arc::downgrade(&self.state));
-
         event_broker
             .subscribe::<LocalShardsUpdate>(weak_router_state.clone())
             .forever();
@@ -122,7 +119,7 @@ impl IngestRouter {
     /// [`GetOrCreateOpenShardsRequest`] request if open shards do not exist for all the them.
     async fn make_get_or_create_open_shard_request(
         &self,
-        subrequests: impl Iterator<Item = &IngestSubrequest>,
+        workbench: &mut IngestWorkbench,
         ingester_pool: &IngesterPool,
     ) -> GetOrCreateOpenShardsRequest {
         let mut get_open_shards_subrequests = Vec::new();
@@ -130,17 +127,23 @@ impl IngestRouter {
         // `closed_shards` and `unavailable_leaders` are populated by calls to `has_open_shards`
         // as we're looking for open shards to route the subrequests to.
         let mut closed_shards: Vec<ShardIds> = Vec::new();
-        let mut unavailable_leaders: HashSet<NodeId> = HashSet::new();
+        let unavailable_leaders: &mut HashSet<NodeId> = &mut workbench.unavailable_leaders;
 
         let state_guard = self.state.read().await;
 
-        for subrequest in subrequests {
+        for subrequest in workbench.subworkbenches.values().filter_map(|subworbench| {
+            if subworbench.is_pending() {
+                Some(&subworbench.subrequest)
+            } else {
+                None
+            }
+        }) {
             if !state_guard.routing_table.has_open_shards(
                 &subrequest.index_id,
                 &subrequest.source_id,
-                &mut closed_shards,
                 ingester_pool,
-                &mut unavailable_leaders,
+                &mut closed_shards,
+                unavailable_leaders,
             ) {
                 let subrequest = GetOrCreateOpenShardsSubrequest {
                     subrequest_id: subrequest.subrequest_id,
@@ -153,21 +156,18 @@ impl IngestRouter {
         drop(state_guard);
 
         if !closed_shards.is_empty() {
-            info!(
-                "reporting {} closed shard(s) to control plane",
-                closed_shards.len()
-            )
+            info!(closed_shards=?closed_shards, "reporting closed shard(s) to control plane");
         }
         if !unavailable_leaders.is_empty() {
-            info!(
-                "reporting {} unavailable leader(s) to control plane",
-                unavailable_leaders.len()
-            );
+            info!(unvailable_leaders=?unavailable_leaders, "reporting unavailable leader(s) to control plane");
         }
         GetOrCreateOpenShardsRequest {
             subrequests: get_open_shards_subrequests,
             closed_shards,
-            unavailable_leaders: unavailable_leaders.into_iter().map(Into::into).collect(),
+            unavailable_leaders: unavailable_leaders
+                .iter()
+                .map(|node_id| node_id.to_string())
+                .collect(),
         }
     }
 
@@ -230,7 +230,6 @@ impl IngestRouter {
                     }
                     for persist_failure in persist_response.failures {
                         workbench.record_persist_failure(&persist_failure);
-
                         if persist_failure.reason() == PersistFailureReason::ShardClosed {
                             let index_uid: IndexUid = persist_failure.index_uid.into();
                             let source_id: SourceId = persist_failure.source_id;
@@ -261,15 +260,19 @@ impl IngestRouter {
                         );
                     }
                     match persist_error {
-                        IngestV2Error::Timeout
-                        | IngestV2Error::Transport { .. }
-                        | IngestV2Error::IngesterUnavailable { .. } => {
+                        IngestV2Error::Transport(_) => {
+                            workbench
+                                .unavailable_leaders
+                                .insert(persist_summary.leader_id);
                             for subrequest_id in persist_summary.subrequest_ids {
-                                workbench.record_no_shards_available(subrequest_id);
+                                workbench.record_connection_error(subrequest_id);
                             }
-                            self.ingester_pool.remove(&persist_summary.leader_id);
                         }
-                        _ => {
+                        IngestV2Error::TooManyRequests
+                        | IngestV2Error::Internal(_)
+                        | IngestV2Error::ShardNotFound { .. }
+                        | IngestV2Error::IngesterUnavailable { .. }
+                        | IngestV2Error::Timeout => {
                             for subrequest_id in persist_summary.subrequest_ids {
                                 workbench.record_internal_error(
                                     subrequest_id,
@@ -299,10 +302,7 @@ impl IngestRouter {
 
     async fn batch_persist(&mut self, workbench: &mut IngestWorkbench, commit_type: CommitTypeV2) {
         let get_or_create_open_shards_request = self
-            .make_get_or_create_open_shard_request(
-                workbench.pending_subrequests(),
-                &self.ingester_pool,
-            )
+            .make_get_or_create_open_shard_request(workbench, &self.ingester_pool)
             .await;
 
         self.populate_routing_table(workbench, get_or_create_open_shards_request)
@@ -394,7 +394,6 @@ impl IngestRouter {
     ) -> IngestV2Result<IngestResponseV2> {
         let commit_type = ingest_request.commit_type();
         let mut workbench = IngestWorkbench::new(ingest_request.subrequests, max_num_attempts);
-
         while !workbench.is_complete() {
             workbench.new_attempt();
             self.batch_persist(&mut workbench, commit_type).await;
@@ -510,7 +509,6 @@ struct PersistRequestSummary {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
-    use std::iter;
     use std::sync::atomic::AtomicUsize;
 
     use quickwit_proto::control_plane::{
@@ -543,8 +541,9 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
         );
+        let mut workbench = IngestWorkbench::default();
         let get_or_create_open_shard_request = router
-            .make_get_or_create_open_shard_request(iter::empty(), &ingester_pool)
+            .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
             .await;
         assert!(get_or_create_open_shard_request.subrequests.is_empty());
 
@@ -578,7 +577,7 @@ mod tests {
         );
         drop(state_guard);
 
-        let ingest_subrequests = [
+        let ingest_subrequests: Vec<IngestSubrequest> = vec![
             IngestSubrequest {
                 subrequest_id: 0,
                 index_id: "test-index-0".to_string(),
@@ -592,8 +591,9 @@ mod tests {
                 ..Default::default()
             },
         ];
+        let mut workbench = IngestWorkbench::new(ingest_subrequests.clone(), 3);
         let get_or_create_open_shard_request = router
-            .make_get_or_create_open_shard_request(ingest_subrequests.iter(), &ingester_pool)
+            .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
             .await;
 
         assert_eq!(get_or_create_open_shard_request.subrequests.len(), 2);
@@ -623,25 +623,48 @@ mod tests {
             get_or_create_open_shard_request.unavailable_leaders[0],
             "test-ingester-0"
         );
+        assert_eq!(workbench.unavailable_leaders.len(), 1);
 
         ingester_pool.insert(
             "test-ingester-0".into(),
             IngesterServiceClient::mock().into(),
         );
+        {
+            // Ingester-0 has been marked as unavailable due to the previous requests.
+            let get_or_create_open_shard_request = router
+                .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
+                .await;
+            assert_eq!(get_or_create_open_shard_request.subrequests.len(), 2);
+            assert_eq!(workbench.unavailable_leaders.len(), 1);
+            assert_eq!(
+                workbench
+                    .unavailable_leaders
+                    .iter()
+                    .next()
+                    .unwrap()
+                    .to_string(),
+                "test-ingester-0"
+            );
+        }
 
-        let get_or_create_open_shard_request = router
-            .make_get_or_create_open_shard_request(ingest_subrequests.iter(), &ingester_pool)
-            .await;
+        {
+            // With a fresh workbench, the ingester is not marked as unavailable, and present in the
+            // pool.
+            let mut workbench = IngestWorkbench::new(ingest_subrequests, 3);
+            let get_or_create_open_shard_request = router
+                .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
+                .await;
+            assert_eq!(get_or_create_open_shard_request.subrequests.len(), 1);
 
-        let subrequest = &get_or_create_open_shard_request.subrequests[0];
-        assert_eq!(subrequest.index_id, "test-index-1");
-        assert_eq!(subrequest.source_id, "test-source");
+            let subrequest = &get_or_create_open_shard_request.subrequests[0];
+            assert_eq!(subrequest.index_id, "test-index-1");
+            assert_eq!(subrequest.source_id, "test-source");
 
-        assert_eq!(get_or_create_open_shard_request.subrequests.len(), 1);
-        assert_eq!(
-            get_or_create_open_shard_request.unavailable_leaders.len(),
-            0
-        );
+            assert_eq!(
+                get_or_create_open_shard_request.unavailable_leaders.len(),
+                0
+            );
+        }
     }
 
     #[tokio::test]
@@ -1015,7 +1038,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_router_process_persist_results_removes_unavailable_leaders() {
+    async fn test_router_process_persist_results_does_not_removes_unavailable_leaders() {
         let self_node_id = "test-router".into();
         let control_plane = ControlPlaneServiceClient::mock().into();
 
@@ -1067,12 +1090,14 @@ mod tests {
 
         let subworkbench = workbench.subworkbenches.get(&0).unwrap();
         assert!(matches!(
-            subworkbench.last_failure_opt,
-            Some(SubworkbenchFailure::NoShardsAvailable { .. })
+            &subworkbench.last_failure_opt,
+            &Some(SubworkbenchFailure::Internal(ref msg)) if msg.contains("timed out")
         ));
 
+        assert!(!workbench
+            .unavailable_leaders
+            .contains(&NodeId::from("test-ingester-1")));
         let persist_futures = FuturesUnordered::new();
-
         persist_futures.push(async {
             let persist_summary = PersistRequestSummary {
                 leader_id: "test-ingester-1".into(),
@@ -1085,13 +1110,19 @@ mod tests {
         router
             .process_persist_results(&mut workbench, persist_futures)
             .await;
+
+        // We do not remove the leader from the pool.
+        assert!(!ingester_pool.is_empty());
+        // ... but we mark it as unavailable.
+        assert!(workbench
+            .unavailable_leaders
+            .contains(&NodeId::from("test-ingester-1")));
+
         let subworkbench = workbench.subworkbenches.get(&1).unwrap();
         assert!(matches!(
             subworkbench.last_failure_opt,
-            Some(SubworkbenchFailure::NoShardsAvailable { .. })
+            Some(SubworkbenchFailure::ConnectionError)
         ));
-
-        assert!(ingester_pool.is_empty());
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -1121,7 +1121,7 @@ mod tests {
         let subworkbench = workbench.subworkbenches.get(&1).unwrap();
         assert!(matches!(
             subworkbench.last_failure_opt,
-            Some(SubworkbenchFailure::ConnectionError)
+            Some(SubworkbenchFailure::TransportError)
         ));
     }
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
@@ -41,7 +41,7 @@ pub(super) struct IngestWorkbench {
     pub num_attempts: usize,
     pub max_num_attempts: usize,
     // List of leaders that have been marked as temporarily unavailable.
-    // This leaders have encounterred a transport error during an attempt and will be treated as if
+    // These leaders have encountered a transport error during an attempt and will be treated as if
     // they were out of the pool for subsequent attempts.
     //
     // (The point here is to make sure we do not wait for the failure detection to kick the node

--- a/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashSet};
 
 use quickwit_proto::control_plane::{
     GetOrCreateOpenShardsFailure, GetOrCreateOpenShardsFailureReason,
@@ -27,24 +27,31 @@ use quickwit_proto::ingest::router::{
     IngestFailure, IngestFailureReason, IngestResponseV2, IngestSubrequest, IngestSuccess,
 };
 use quickwit_proto::ingest::IngestV2Result;
-use quickwit_proto::types::{ShardId, SubrequestId};
+use quickwit_proto::types::{NodeId, SubrequestId};
 use tracing::warn;
 
 /// A helper struct for managing the state of the subrequests of an ingest request during multiple
 /// persist attempts.
 #[derive(Default)]
 pub(super) struct IngestWorkbench {
-    pub subworkbenches: HashMap<SubrequestId, IngestSubworkbench>,
+    pub subworkbenches: BTreeMap<SubrequestId, IngestSubworkbench>,
     pub num_successes: usize,
     /// The number of batch persist attempts. This is not sum of the number of attempts for each
     /// subrequest.
     pub num_attempts: usize,
     pub max_num_attempts: usize,
+    // List of leaders that have been marked as temporarily unavailable.
+    // This leaders have encounterred a transport error during an attempt and will be treated as if
+    // they were out of the pool for subsequent attempts.
+    //
+    // (The point here is to make sure we do not wait for the failure detection to kick the node
+    // out of the ingest node.)
+    pub unavailable_leaders: HashSet<NodeId>,
 }
 
 impl IngestWorkbench {
     pub fn new(ingest_subrequests: Vec<IngestSubrequest>, max_num_attempts: usize) -> Self {
-        let subworkbenches: HashMap<SubrequestId, IngestSubworkbench> = ingest_subrequests
+        let subworkbenches: BTreeMap<SubrequestId, IngestSubworkbench> = ingest_subrequests
             .into_iter()
             .map(|subrequest| {
                 (
@@ -65,6 +72,8 @@ impl IngestWorkbench {
         self.num_attempts += 1;
     }
 
+    /// Returns true if all subrequests were successful or if the number of
+    /// attempts has been exhausted.
     pub fn is_complete(&self) -> bool {
         self.num_successes >= self.subworkbenches.len()
             || self.num_attempts >= self.max_num_attempts
@@ -96,18 +105,6 @@ impl IngestWorkbench {
         &mut self,
         open_shards_failure: GetOrCreateOpenShardsFailure,
     ) {
-        let Some(subworkbench) = self
-            .subworkbenches
-            .get_mut(&open_shards_failure.subrequest_id)
-        else {
-            warn!(
-                "could not find subrequest `{}` in workbench",
-                open_shards_failure.subrequest_id
-            );
-            return;
-        };
-        subworkbench.num_attempts += 1;
-
         let last_failure = match open_shards_failure.reason() {
             GetOrCreateOpenShardsFailureReason::IndexNotFound => SubworkbenchFailure::IndexNotFound,
             GetOrCreateOpenShardsFailureReason::SourceNotFound => {
@@ -121,7 +118,7 @@ impl IngestWorkbench {
                 SubworkbenchFailure::Internal("unspecified".to_string())
             }
         };
-        subworkbench.last_failure_opt = Some(last_failure);
+        self.record_failure(open_shards_failure.subrequest_id, last_failure);
     }
 
     pub fn record_persist_success(&mut self, persist_success: PersistSuccess) {
@@ -137,44 +134,39 @@ impl IngestWorkbench {
         subworkbench.persist_success_opt = Some(persist_success);
     }
 
-    pub fn record_persist_failure(&mut self, persist_failure: &PersistFailure) {
-        let Some(subworkbench) = self.subworkbenches.get_mut(&persist_failure.subrequest_id) else {
-            warn!(
-                "could not find subrequest `{}` in workbench",
-                persist_failure.subrequest_id
-            );
+    fn record_failure(&mut self, subrequest_id: SubrequestId, failure: SubworkbenchFailure) {
+        let Some(subworkbench) = self.subworkbenches.get_mut(&subrequest_id) else {
+            warn!("could not find subrequest `{}` in workbench", subrequest_id);
             return;
         };
         subworkbench.num_attempts += 1;
-        subworkbench.last_failure_opt = Some(SubworkbenchFailure::Persist((
-            persist_failure.shard_id,
-            persist_failure.reason(),
-        )));
+        subworkbench.last_failure_opt = Some(failure);
     }
 
     pub fn record_no_shards_available(&mut self, subrequest_id: SubrequestId) {
-        let Some(subworkbench) = self.subworkbenches.get_mut(&subrequest_id) else {
-            warn!("could not find subrequest `{}` in workbench", subrequest_id);
-            return;
-        };
-        subworkbench.num_attempts += 1;
-        subworkbench.last_failure_opt = Some(SubworkbenchFailure::NoShardsAvailable);
+        self.record_failure(subrequest_id, SubworkbenchFailure::NoShardsAvailable);
+    }
+
+    /// Marks a node as unavailable for the span of the workbench.
+    ///
+    /// Remaining attempts will treat the node as if it was not in the ingester pool.
+    pub fn record_connection_error(&mut self, subrequest_id: SubrequestId) {
+        self.record_failure(subrequest_id, SubworkbenchFailure::ConnectionError);
+    }
+
+    pub fn record_persist_failure(&mut self, persist_failure: &PersistFailure) {
+        let failure = SubworkbenchFailure::Persist(persist_failure.reason());
+        self.record_failure(persist_failure.subrequest_id, failure);
     }
 
     pub fn record_internal_error(&mut self, subrequest_id: SubrequestId, error_message: String) {
-        let Some(subworkbench) = self.subworkbenches.get_mut(&subrequest_id) else {
-            warn!("could not find subrequest `{}` in workbench", subrequest_id);
-            return;
-        };
-        subworkbench.num_attempts += 1;
-        subworkbench.last_failure_opt = Some(SubworkbenchFailure::Internal(error_message));
+        self.record_failure(subrequest_id, SubworkbenchFailure::Internal(error_message));
     }
 
     pub fn into_ingest_response(self) -> IngestV2Result<IngestResponseV2> {
         let num_subworkbenches = self.subworkbenches.len();
         let mut successes = Vec::with_capacity(self.num_successes);
         let mut failures = Vec::with_capacity(num_subworkbenches - self.num_successes);
-
         for subworkbench in self.subworkbenches.into_values() {
             if let Some(persist_success) = subworkbench.persist_success_opt {
                 let success = IngestSuccess {
@@ -195,8 +187,7 @@ impl IngestWorkbench {
                 failures.push(failure);
             }
         }
-        assert!(successes.len() + failures.len() == num_subworkbenches);
-
+        assert_eq!(successes.len() + failures.len(), num_subworkbenches);
         Ok(IngestResponseV2 {
             successes,
             failures,
@@ -225,7 +216,10 @@ pub(super) enum SubworkbenchFailure {
     IndexNotFound,
     SourceNotFound,
     NoShardsAvailable,
-    Persist((ShardId, PersistFailureReason)),
+    // Connection error: we failed to reach the ingester.
+    ConnectionError,
+    // This is an error supplied by the ingester.
+    Persist(PersistFailureReason),
     Internal(String),
 }
 
@@ -236,7 +230,10 @@ impl SubworkbenchFailure {
             Self::SourceNotFound => IngestFailureReason::SourceNotFound,
             Self::Internal(_) => IngestFailureReason::Internal,
             Self::NoShardsAvailable => IngestFailureReason::NoShardsAvailable,
-            Self::Persist((_shard_id, persist_failure_reason)) => (*persist_failure_reason).into(),
+            // In our last attempt, we did not manage to reach the ingester.
+            // We can consider that as a no shards available.
+            Self::ConnectionError => IngestFailureReason::NoShardsAvailable,
+            Self::Persist(persist_failure_reason) => (*persist_failure_reason).into(),
         }
     }
 }
@@ -262,13 +259,19 @@ impl IngestSubworkbench {
         self.persist_success_opt.is_none() && self.last_failure_is_transient()
     }
 
+    /// Returns `false` if and only if the last attempt suggest retrying will fail.
+    /// e.g.:
+    /// - the index does not exist
+    /// - the source does not exist.
     fn last_failure_is_transient(&self) -> bool {
         match self.last_failure_opt {
             Some(SubworkbenchFailure::IndexNotFound) => false,
             Some(SubworkbenchFailure::SourceNotFound) => false,
-            Some(SubworkbenchFailure::Internal(_)) => false,
-            Some(SubworkbenchFailure::NoShardsAvailable) => true,
+            Some(SubworkbenchFailure::Internal(_)) => true,
+            // No need to retry no shards were available.
+            Some(SubworkbenchFailure::NoShardsAvailable) => false,
             Some(SubworkbenchFailure::Persist(_)) => true,
+            Some(SubworkbenchFailure::ConnectionError) => true,
             None => true,
         }
     }
@@ -289,13 +292,31 @@ mod tests {
         assert!(subworkbench.is_pending());
         assert!(subworkbench.last_failure_is_transient());
 
-        subworkbench.last_failure_opt = Some(SubworkbenchFailure::NoShardsAvailable);
+        subworkbench.last_failure_opt = Some(SubworkbenchFailure::ConnectionError);
         assert!(subworkbench.is_pending());
         assert!(subworkbench.last_failure_is_transient());
+
+        subworkbench.last_failure_opt =
+            Some(SubworkbenchFailure::Internal("timed out".to_string()));
+        assert!(subworkbench.is_pending());
+        assert!(subworkbench.last_failure_is_transient());
+
+        subworkbench.last_failure_opt = Some(SubworkbenchFailure::NoShardsAvailable);
+        assert!(!subworkbench.is_pending());
+        assert!(!subworkbench.last_failure_is_transient());
 
         subworkbench.last_failure_opt = Some(SubworkbenchFailure::IndexNotFound);
         assert!(!subworkbench.is_pending());
         assert!(!subworkbench.last_failure_is_transient());
+        subworkbench.last_failure_opt = Some(SubworkbenchFailure::SourceNotFound);
+        assert!(!subworkbench.is_pending());
+        assert!(!subworkbench.last_failure_is_transient());
+
+        subworkbench.last_failure_opt = Some(SubworkbenchFailure::Persist(
+            PersistFailureReason::RateLimited,
+        ));
+        assert!(subworkbench.is_pending());
+        assert!(subworkbench.last_failure_is_transient());
 
         let persist_success = PersistSuccess {
             ..Default::default()
@@ -477,7 +498,7 @@ mod tests {
         let subworkbench = workbench.subworkbenches.get(&0).unwrap();
         assert!(matches!(
             subworkbench.last_failure_opt,
-            Some(SubworkbenchFailure::Persist((shard_id, reason))) if shard_id == 1 && reason == PersistFailureReason::ResourceExhausted
+            Some(SubworkbenchFailure::Persist(reason)) if reason == PersistFailureReason::ResourceExhausted
         ));
         assert_eq!(subworkbench.num_attempts, 1);
     }

--- a/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
@@ -66,6 +66,10 @@ service ControlPlaneService {
 message GetOrCreateOpenShardsRequest {
   repeated GetOrCreateOpenShardsSubrequest subrequests = 1;
   repeated quickwit.ingest.ShardIds closed_shards = 2;
+  // The control plane should return shards that are not present on the supplied leaders.
+  //
+  // The control plane does not change the status of those leaders just from this signal.
+  // It will check the status of its own ingester pool.
   repeated string unavailable_leaders = 3;
 }
 

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
@@ -6,6 +6,10 @@ pub struct GetOrCreateOpenShardsRequest {
     pub subrequests: ::prost::alloc::vec::Vec<GetOrCreateOpenShardsSubrequest>,
     #[prost(message, repeated, tag = "2")]
     pub closed_shards: ::prost::alloc::vec::Vec<super::ingest::ShardIds>,
+    /// The control plane should return shards that are not present on the supplied leaders.
+    ///
+    /// The control plane does not change the status of those leaders just from this signal.
+    /// It will check the status of its own ingester pool.
     #[prost(string, repeated, tag = "3")]
     pub unavailable_leaders: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }

--- a/quickwit/quickwit-proto/src/ingest/mod.rs
+++ b/quickwit/quickwit-proto/src/ingest/mod.rs
@@ -37,12 +37,15 @@ pub type IngestV2Result<T> = std::result::Result<T, IngestV2Error>;
 pub enum IngestV2Error {
     #[error("an internal error occurred: {0}")]
     Internal(String),
+    /// Emitted when an ingester was not available for a given operation,
+    /// either directly or through replication.
     #[error("failed to connect to ingester `{ingester_id}`")]
     IngesterUnavailable { ingester_id: NodeId },
     #[error("shard `{shard_id}` not found")]
     ShardNotFound { shard_id: ShardId },
     #[error("request timed out")]
     Timeout,
+    // This error is provoked by semaphore located on the router.
     #[error("too many requests")]
     TooManyRequests,
     // TODO: Merge `Transport` and `IngesterUnavailable` into a single `Unavailable` error.


### PR DESCRIPTION
    Avoid evicting ingester node from IngesterPool when facing or a transport error.

    Before when facing such error case, we were removing the faulty nodes from the pool, and
    Nn code path would re-add it to the ingester pool. The ingester pool is also used by the ingest
    source resulting in bug #4336.

    After this patch:

    When facing a transport error, we assume the targetted node is
    unreachable and chitchat has just not detected this just yet.

    In an ideal world we would inform chitchat about this, but it is a bit
    difficult to do codewise.

    Instead, we register the leader as unavailable for the span of the
    workbench. It will then react as if it was out of the pool for
    subsequent retries.

    A GetOrCreatedShard will carry the information that the node was
    unavailable, and the control plane will attempt to create a shard on a
    different node

    A timeout on the other hand is treated as a normal retryable error.

    Closes #4336