### PR TITLE
Skip serializing empty shards

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index/mod.rs
@@ -476,8 +476,8 @@ impl FileBackedIndex {
 
         self.metadata.add_source(source_config)?;
 
-        self.per_source_shards
-            .insert(source_id.clone(), Shards::empty(index_uid, source_id));
+        let shards = Shards::empty(index_uid, source_id.clone());
+        self.per_source_shards.insert(source_id, shards);
         Ok(())
     }
 


### PR DESCRIPTION
### Description
Skip serializing empty shards since the feature is hidden and disabled by default. This way, we can still modify the serialization format without worrying about backward compatibility post `0.7`.