### PR TITLE
Remove `WeakIndexingSplitStore`

### DIFF
--- a/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -20,7 +20,7 @@
 #[cfg(any(test, feature = "testsuite"))]
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context;
@@ -66,18 +66,6 @@ struct InnerIndexingSplitStore {
     /// The remote storage.
     remote_storage: Arc<dyn Storage>,
     local_split_store: Arc<LocalSplitStore>,
-}
-
-pub struct WeakIndexingSplitStore {
-    inner: Weak<InnerIndexingSplitStore>,
-}
-
-impl WeakIndexingSplitStore {
-    pub fn upgrade(&self) -> Option<IndexingSplitStore> {
-        self.inner
-            .upgrade()
-            .map(|inner| IndexingSplitStore { inner })
-    }
 }
 
 impl IndexingSplitStore {
@@ -224,12 +212,6 @@ impl IndexingSplitStore {
             .instrument(info_span!("fetch_split_from_remote_storage", path=?path))
             .await?;
         get_tantivy_directory_from_split_bundle(&dest_filepath)
-    }
-
-    pub fn downgrade(&self) -> WeakIndexingSplitStore {
-        WeakIndexingSplitStore {
-            inner: Arc::downgrade(&self.inner),
-        }
     }
 
     /// Takes a snapshot of the cache view (only used for testing).

--- a/quickwit/quickwit-indexing/src/split_store/mod.rs
+++ b/quickwit/quickwit-indexing/src/split_store/mod.rs
@@ -21,6 +21,6 @@ mod indexing_split_store;
 mod local_split_store;
 mod split_store_quota;
 
-pub use indexing_split_store::{IndexingSplitStore, WeakIndexingSplitStore};
+pub use indexing_split_store::IndexingSplitStore;
 pub use local_split_store::{get_tantivy_directory_from_split_bundle, LocalSplitStore};
 pub use split_store_quota::SplitStoreQuota;


### PR DESCRIPTION
### Description
It is unused and triggers the following clippy warning on my machine after I ran `cargo clean`:
```bash
warning: unused import: `WeakIndexingSplitStore`
  --> quickwit-indexing/src/split_store/mod.rs:24:52
   |
24 | pub use indexing_split_store::{IndexingSplitStore, WeakIndexingSplitStore};
```

### How was this PR tested?
`make test-all`