### PR TITLE
Update rust version to 1.75.0

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5601,6 +5601,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "siphasher",
  "tempfile",
  "thiserror",
  "tokio",

--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -31,6 +31,7 @@ prometheus = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
+siphasher = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/quickwit/quickwit-common/src/rendezvous_hasher.rs
+++ b/quickwit/quickwit-common/src/rendezvous_hasher.rs
@@ -63,8 +63,8 @@ mod tests {
         let mut socket_set3 = vec![socket1, socket4];
         sort_by_rendez_vous_hash(&mut socket_set3, "key");
 
-        assert_eq!(socket_set1, &[socket1, socket3, socket2, socket4]);
-        assert_eq!(socket_set2, &[socket1, socket2, socket4]);
-        assert_eq!(socket_set3, &[socket1, socket4]);
+        assert_eq!(socket_set1, &[socket4, socket3, socket1, socket2]);
+        assert_eq!(socket_set2, &[socket4, socket1, socket2]);
+        assert_eq!(socket_set3, &[socket4, socket1]);
     }
 }

--- a/quickwit/quickwit-common/src/rendezvous_hasher.rs
+++ b/quickwit/quickwit-common/src/rendezvous_hasher.rs
@@ -18,14 +18,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::cmp::Reverse;
-use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use siphasher::sip::SipHasher;
 
 /// Computes the affinity of a node for a given `key`.
 /// A higher value means a higher affinity.
 /// This is the `rendezvous hash`.
 pub fn node_affinity<T: Hash, U: Hash>(node: T, key: &U) -> u64 {
-    let mut state = DefaultHasher::new();
+    let mut state = SipHasher::new();
     key.hash(&mut state);
     node.hash(&mut state);
     state.finish()
@@ -54,7 +54,7 @@ mod tests {
         let socket3 = test_socket_addr(3);
         let socket4 = test_socket_addr(4);
 
-        let mut socket_set1 = vec![socket1, socket2, socket3, socket4];
+        let mut socket_set1 = vec![socket4, socket3, socket1, socket2];
         sort_by_rendez_vous_hash(&mut socket_set1, "key");
 
         let mut socket_set2 = vec![socket1, socket2, socket4];
@@ -63,8 +63,8 @@ mod tests {
         let mut socket_set3 = vec![socket1, socket4];
         sort_by_rendez_vous_hash(&mut socket_set3, "key");
 
-        assert_eq!(socket_set1, &[socket4, socket3, socket1, socket2]);
-        assert_eq!(socket_set2, &[socket4, socket1, socket2]);
-        assert_eq!(socket_set3, &[socket4, socket1]);
+        assert_eq!(socket_set1, &[socket1, socket2, socket3, socket4]);
+        assert_eq!(socket_set2, &[socket1, socket2, socket4]);
+        assert_eq!(socket_set3, &[socket1, socket4]);
     }
 }

--- a/quickwit/rust-toolchain.toml
+++ b/quickwit/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.72"
+channel = "1.75"
 components = ["cargo", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
### Description

Updates Rust to 1.75 (#4367).

**Note:** _missing from this PR is the removal of async_trait as it is not a straightforward removal and the appropriate change for each use (253 instances in the code base) needs to be evaluated on a case by case basis:_

https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html

Dynamic dispatch still requires `async_trait` and public traits require a `trait_variant` macro as outlined in the blog post.


### How was this PR tested?

Running `make test-all`