### PR TITLE
Replace `shard_id: u64` with generic `shard_id: ShardId(ByteString)`

### DIFF
--- a/quickwit/clippy.toml
+++ b/quickwit/clippy.toml
@@ -1,3 +1,10 @@
 disallowed-methods = [
     "std::path::Path::exists"
 ]
+ignore-interior-mutability = [
+    "bytes::Bytes",
+    "bytestring::ByteString",
+    "quickwit_ingest::ShardInfo",
+    "quickwit_ingest::ShardInfos",
+    "quickwit_proto::types::ShardId",
+]

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -467,27 +467,23 @@ pub(crate) fn set_indexing_tasks_in_node_state(
 
 fn indexing_task_to_chitchat_kv(indexing_task: &IndexingTask) -> (String, String) {
     let IndexingTask {
-        pipeline_uid: _,
         index_uid,
         source_id,
         shard_ids,
+        pipeline_uid: _,
     } = indexing_task;
     let key = format!("{INDEXING_TASK_PREFIX}{}", indexing_task.pipeline_uid());
-    let shards_str = shard_ids.iter().sorted().join(",");
-    let value = format!("{index_uid}:{source_id}:{shards_str}");
+    let shard_ids_str = shard_ids.iter().sorted().join(",");
+    let value = format!("{index_uid}:{source_id}:{shard_ids_str}");
     (key, value)
 }
 
-fn parse_shards_str(shards_str: &str) -> Option<Vec<ShardId>> {
-    if shards_str.is_empty() {
-        return Some(Vec::new());
-    }
-    let mut shard_ids = Vec::new();
-    for shard_str in shards_str.split(',') {
-        let shard_id = shard_str.parse::<u64>().ok()?;
-        shard_ids.push(shard_id);
-    }
-    Some(shard_ids)
+fn parse_shard_ids_str(shard_ids_str: &str) -> Vec<ShardId> {
+    shard_ids_str
+        .split(',')
+        .filter(|shard_id_str| !shard_id_str.is_empty())
+        .map(ShardId::from)
+        .collect()
 }
 
 fn chitchat_kv_to_indexing_task(key: &str, value: &str) -> Option<IndexingTask> {
@@ -495,7 +491,7 @@ fn chitchat_kv_to_indexing_task(key: &str, value: &str) -> Option<IndexingTask> 
     let pipeline_uid = PipelineUid::from_str(pipeline_uid_str).ok()?;
     let (source_uid, shards_str) = value.rsplit_once(':')?;
     let (index_uid, source_id) = source_uid.rsplit_once(':')?;
-    let shard_ids = parse_shards_str(shards_str)?;
+    let shard_ids = parse_shard_ids_str(shards_str);
     Some(IndexingTask {
         index_uid: index_uid.to_string(),
         source_id: source_id.to_string(),
@@ -1095,7 +1091,7 @@ mod tests {
             );
             chitchat_guard.self_node_state().set(
                 format!("{INDEXING_TASK_PREFIX}01BX5ZZKBKACTAV9WEVGEMMVS1"),
-                "my_index:uid:my_source:3a,5".to_string(),
+                "my_index-uid-my_source:3,5".to_string(),
             );
         }
         node.wait_for_ready_members(|members| members.len() == 1, Duration::from_secs(5))
@@ -1211,7 +1207,7 @@ mod tests {
                 pipeline_uid: Some(PipelineUid::from_u128(1u128)),
                 index_uid: "test:test1".to_string(),
                 source_id: "my-source1".to_string(),
-                shard_ids: vec![1, 2],
+                shard_ids: vec![ShardId::from(1), ShardId::from(2)],
             }],
             &mut node_state,
         );
@@ -1221,7 +1217,7 @@ mod tests {
                 pipeline_uid: Some(PipelineUid::from_u128(2u128)),
                 index_uid: "test:test1".to_string(),
                 source_id: "my-source1".to_string(),
-                shard_ids: vec![1, 2, 3],
+                shard_ids: vec![ShardId::from(1), ShardId::from(2), ShardId::from(3)],
             }],
             &mut node_state,
         );
@@ -1231,13 +1227,13 @@ mod tests {
                     pipeline_uid: Some(PipelineUid::from_u128(1u128)),
                     index_uid: "test:test1".to_string(),
                     source_id: "my-source1".to_string(),
-                    shard_ids: vec![1, 2],
+                    shard_ids: vec![ShardId::from(1), ShardId::from(2)],
                 },
                 IndexingTask {
                     pipeline_uid: Some(PipelineUid::from_u128(2u128)),
                     index_uid: "test:test1".to_string(),
                     source_id: "my-source1".to_string(),
-                    shard_ids: vec![3, 4],
+                    shard_ids: vec![ShardId::from(3), ShardId::from(4)],
                 },
             ],
             &mut node_state,
@@ -1249,13 +1245,13 @@ mod tests {
                     pipeline_uid: Some(PipelineUid::from_u128(1u128)),
                     index_uid: "test:test1".to_string(),
                     source_id: "my-source1".to_string(),
-                    shard_ids: vec![1, 2],
+                    shard_ids: vec![ShardId::from(1), ShardId::from(2)],
                 },
                 IndexingTask {
                     pipeline_uid: Some(PipelineUid::from_u128(2u128)),
                     index_uid: "test:test2".to_string(),
                     source_id: "my-source1".to_string(),
-                    shard_ids: vec![3, 4],
+                    shard_ids: vec![ShardId::from(3), ShardId::from(4)],
                 },
             ],
             &mut node_state,
@@ -1267,13 +1263,13 @@ mod tests {
                     pipeline_uid: Some(PipelineUid::from_u128(1u128)),
                     index_uid: "test:test1".to_string(),
                     source_id: "my-source1".to_string(),
-                    shard_ids: vec![1, 2],
+                    shard_ids: vec![ShardId::from(1), ShardId::from(2)],
                 },
                 IndexingTask {
                     pipeline_uid: Some(PipelineUid::from_u128(2u128)),
                     index_uid: "test:test1".to_string(),
                     source_id: "my-source2".to_string(),
-                    shard_ids: vec![3, 4],
+                    shard_ids: vec![ShardId::from(3), ShardId::from(4)],
                 },
             ],
             &mut node_state,
@@ -1281,12 +1277,17 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_shards_str() {
-        assert!(parse_shards_str("").unwrap().is_empty());
-        assert_eq!(parse_shards_str("12").unwrap(), vec![12]);
-        assert_eq!(parse_shards_str("12,23").unwrap(), vec![12, 23]);
-        assert!(parse_shards_str("12,23,").is_none());
-        assert!(parse_shards_str("12,23a,32").is_none());
+    fn test_parse_shard_ids_str() {
+        assert!(parse_shard_ids_str("").is_empty());
+        assert!(parse_shard_ids_str(",").is_empty());
+        assert_eq!(
+            parse_shard_ids_str("00000000000000000012,"),
+            [ShardId::from(12)]
+        );
+        assert_eq!(
+            parse_shard_ids_str("00000000000000000012,00000000000000000023,"),
+            [ShardId::from(12), ShardId::from(23)]
+        );
     }
 
     #[test]
@@ -1296,7 +1297,7 @@ mod tests {
         );
         let task = super::chitchat_kv_to_indexing_task(
             "indexer.task:01BX5ZZKBKACTAV9WEVGEMMVS0",
-            "my_index:uid:my_source:1,3",
+            "my_index:uid:my_source:00000000000000000001,00000000000000000003",
         )
         .unwrap();
         assert_eq!(
@@ -1305,6 +1306,6 @@ mod tests {
         );
         assert_eq!(&task.index_uid, "my_index:uid");
         assert_eq!(&task.source_id, "my_source");
-        assert_eq!(&task.shard_ids, &[1, 3]);
+        assert_eq!(&task.shard_ids, &[ShardId::from(1), ShardId::from(3)]);
     }
 }

--- a/quickwit/quickwit-control-plane/src/indexing_plan.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_plan.rs
@@ -69,21 +69,13 @@ impl PhysicalIndexingPlan {
             for task in tasks.iter_mut() {
                 task.shard_ids.sort_unstable();
             }
-            tasks.sort_by(|left, right| {
+            tasks.sort_unstable_by(|left, right| {
                 left.index_uid
                     .cmp(&right.index_uid)
                     .then_with(|| left.source_id.cmp(&right.source_id))
-                    .then_with(|| {
-                        left.shard_ids
-                            .first()
-                            .copied()
-                            .cmp(&right.shard_ids.first().copied())
-                    })
-                    .then_with(|| left.pipeline_uid().cmp(&right.pipeline_uid()))
+                    .then_with(|| left.shard_ids.first().cmp(&right.shard_ids.first()))
+                    .then_with(|| left.pipeline_uid.cmp(&right.pipeline_uid))
             });
-            for task in tasks {
-                task.shard_ids.sort();
-            }
         }
     }
 }

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -144,7 +144,8 @@ fn get_sources_to_schedule(model: &ControlPlaneModel) -> Vec<SourceToSchedule> {
                 let shard_ids: Vec<ShardId> = model
                     .list_shards_for_source(&source_uid)
                     .expect("source should exist")
-                    .map(|shard| shard.shard_id)
+                    .map(|shard| shard.shard_id())
+                    .cloned()
                     .collect();
                 if shard_ids.is_empty() {
                     continue;
@@ -749,11 +750,11 @@ mod tests {
         let shard = Shard {
             index_uid: index_uid.to_string(),
             source_id: "ingest_v2".to_string(),
-            shard_id: 17,
+            shard_id: Some(ShardId::from(17)),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         };
-        model.insert_newly_opened_shards(&index_uid, &"ingest_v2".to_string(), vec![shard], 18);
+        model.insert_newly_opened_shards(&index_uid, &"ingest_v2".to_string(), vec![shard]);
         let shards: Vec<SourceToSchedule> = get_sources_to_schedule(&model);
         assert_eq!(shards.len(), 3);
     }

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/mod.rs
@@ -232,9 +232,9 @@ fn convert_scheduling_solution_to_physical_plan_single_node_single_source(
                 let shard_ids: Vec<ShardId> = previous_task
                     .shard_ids
                     .iter()
-                    .copied()
                     .filter(|shard_id| shard_ids.contains(shard_id))
                     .take(max_shard_in_pipeline)
+                    .cloned()
                     .collect();
                 remaining_num_shards_to_schedule_on_node -= shard_ids.len() as u32;
                 let new_task = IndexingTask {
@@ -384,8 +384,8 @@ fn convert_scheduling_solution_to_physical_plan(
                 if indexing_task.index_uid == source.source_uid.index_uid.as_str()
                     && indexing_task.source_id == source.source_uid.source_id
                 {
-                    indexing_task.shard_ids.retain(|&shard| {
-                        let shard_added = scheduled_shards.insert(shard);
+                    indexing_task.shard_ids.retain(|shard_id| {
+                        let shard_added = scheduled_shards.insert(shard_id.clone());
                         if shard_added {
                             true
                         } else {
@@ -405,7 +405,7 @@ fn convert_scheduling_solution_to_physical_plan(
         let missing_shards = shard_ids
             .iter()
             .filter(|shard_id| !scheduled_shards.contains(shard_id))
-            .copied();
+            .cloned();
 
         // Let's assign the missing shards.
 
@@ -621,7 +621,16 @@ mod tests {
         let source_0 = SourceToSchedule {
             source_uid: source_uid0.clone(),
             source_type: SourceToScheduleType::Sharded {
-                shard_ids: vec![0, 1, 2, 3, 4, 5, 6, 7],
+                shard_ids: vec![
+                    ShardId::from(0),
+                    ShardId::from(1),
+                    ShardId::from(2),
+                    ShardId::from(3),
+                    ShardId::from(4),
+                    ShardId::from(5),
+                    ShardId::from(6),
+                    ShardId::from(7),
+                ],
                 load_per_shard: NonZeroU32::new(1_000).unwrap(),
             },
         };
@@ -660,11 +669,20 @@ mod tests {
 
         assert_eq!(node2_plan.len(), 4);
         assert_eq!(&node2_plan[0].source_id, &source_uid0.source_id);
-        assert_eq!(&node2_plan[0].shard_ids, &[0, 1, 2]);
+        assert_eq!(
+            &node2_plan[0].shard_ids,
+            &[ShardId::from(0), ShardId::from(1), ShardId::from(2)]
+        );
         assert_eq!(&node2_plan[1].source_id, &source_uid0.source_id);
-        assert_eq!(&node2_plan[1].shard_ids, &[3, 4, 5]);
+        assert_eq!(
+            &node2_plan[1].shard_ids,
+            &[ShardId::from(3), ShardId::from(4), ShardId::from(5)]
+        );
         assert_eq!(&node2_plan[2].source_id, &source_uid0.source_id);
-        assert_eq!(&node2_plan[2].shard_ids, &[6, 7]);
+        assert_eq!(
+            &node2_plan[2].shard_ids,
+            &[ShardId::from(6), ShardId::from(7)]
+        );
         assert_eq!(&node2_plan[3].source_id, &source_uid2.source_id);
     }
 
@@ -727,14 +745,26 @@ mod tests {
         let indexing_tasks = make_indexing_tasks(
             &source_uid,
             &[
-                (PipelineUid::from_u128(1u128), &[1, 2]),
-                (PipelineUid::from_u128(2u128), &[3, 4, 5]),
+                (
+                    PipelineUid::from_u128(1u128),
+                    &[ShardId::from(1), ShardId::from(2)],
+                ),
+                (
+                    PipelineUid::from_u128(2u128),
+                    &[ShardId::from(3), ShardId::from(4), ShardId::from(5)],
+                ),
             ],
         );
         let sources = vec![SourceToSchedule {
             source_uid: source_uid.clone(),
             source_type: SourceToScheduleType::Sharded {
-                shard_ids: vec![0, 1, 3, 4, 5],
+                shard_ids: vec![
+                    ShardId::from(0),
+                    ShardId::from(1),
+                    ShardId::from(3),
+                    ShardId::from(4),
+                    ShardId::from(5),
+                ],
                 load_per_shard: NonZeroU32::new(1_000).unwrap(),
             },
         }];
@@ -751,13 +781,19 @@ mod tests {
         );
         let indexing_tasks = new_plan.indexer("node1").unwrap();
         assert_eq!(indexing_tasks.len(), 2);
-        assert_eq!(&indexing_tasks[0].shard_ids, &[0, 1]);
-        assert_eq!(&indexing_tasks[1].shard_ids, &[3, 4, 5]);
+        assert_eq!(
+            &indexing_tasks[0].shard_ids,
+            &[ShardId::from(0), ShardId::from(1)]
+        );
+        assert_eq!(
+            &indexing_tasks[1].shard_ids,
+            &[ShardId::from(3), ShardId::from(4), ShardId::from(5)]
+        );
     }
 
     fn group_shards_into_pipelines_aux(
         source_uid: &SourceUid,
-        shard_ids: &[ShardId],
+        shard_ids: &[u64],
         previous_pipeline_shards: &[(PipelineUid, &[ShardId])],
         load_per_shard: CpuCapacity,
     ) -> Vec<IndexingTask> {
@@ -765,7 +801,7 @@ mod tests {
         let sources = vec![SourceToSchedule {
             source_uid: source_uid.clone(),
             source_type: SourceToScheduleType::Sharded {
-                shard_ids: shard_ids.to_vec(),
+                shard_ids: shard_ids.iter().copied().map(ShardId::from).collect(),
                 load_per_shard: NonZeroU32::new(load_per_shard.cpu_millis()).unwrap(),
             },
         }];
@@ -783,7 +819,7 @@ mod tests {
         );
         let mut indexing_tasks = new_plan.indexer(NODE).unwrap().to_vec();
         // We sort indexing tasks for normalization purpose
-        indexing_tasks.sort_by_key(|task| task.shard_ids[0]);
+        indexing_tasks.sort_by_key(|task| task.shard_ids[0].clone());
         indexing_tasks
     }
 
@@ -805,8 +841,23 @@ mod tests {
             mcpu(400),
         );
         assert_eq!(indexing_tasks_1.len(), 2);
-        assert_eq!(&indexing_tasks_1[0].shard_ids, &[0, 1, 2, 3, 4, 5, 6, 7]);
-        assert_eq!(&indexing_tasks_1[1].shard_ids, &[8, 9, 10]);
+        assert_eq!(
+            &indexing_tasks_1[0].shard_ids,
+            &[
+                ShardId::from(0),
+                ShardId::from(1),
+                ShardId::from(2),
+                ShardId::from(3),
+                ShardId::from(4),
+                ShardId::from(5),
+                ShardId::from(6),
+                ShardId::from(7)
+            ]
+        );
+        assert_eq!(
+            &indexing_tasks_1[1].shard_ids,
+            &[ShardId::from(8), ShardId::from(9), ShardId::from(10)]
+        );
 
         let pipeline_tasks1: Vec<(PipelineUid, &[ShardId])> = indexing_tasks_1
             .iter()
@@ -821,9 +872,27 @@ mod tests {
             mcpu(600),
         );
         assert_eq!(indexing_tasks_2.len(), 3);
-        assert_eq!(&indexing_tasks_2[0].shard_ids, &[0, 1, 2, 3, 4]);
-        assert_eq!(&indexing_tasks_2[1].shard_ids, &[5, 6, 8, 9, 10]);
-        assert_eq!(&indexing_tasks_2[2].shard_ids, &[7]);
+        assert_eq!(
+            &indexing_tasks_2[0].shard_ids,
+            &[
+                ShardId::from(0),
+                ShardId::from(1),
+                ShardId::from(2),
+                ShardId::from(3),
+                ShardId::from(4)
+            ]
+        );
+        assert_eq!(
+            &indexing_tasks_2[1].shard_ids,
+            &[
+                ShardId::from(5),
+                ShardId::from(6),
+                ShardId::from(8),
+                ShardId::from(9),
+                ShardId::from(10)
+            ]
+        );
+        assert_eq!(&indexing_tasks_2[2].shard_ids, &[ShardId::from(7)]);
 
         // Now the load comes back to normal
         // The hysteresis takes effect. We do not switch back to 2 pipelines.
@@ -852,8 +921,27 @@ mod tests {
             mcpu(200),
         );
         assert_eq!(indexing_tasks_4.len(), 2);
-        assert_eq!(&indexing_tasks_4[0].shard_ids, &[0, 1, 2, 3, 4, 7]);
-        assert_eq!(&indexing_tasks_4[1].shard_ids, &[5, 6, 8, 9, 10]);
+        assert_eq!(
+            &indexing_tasks_4[0].shard_ids,
+            &[
+                ShardId::from(0),
+                ShardId::from(1),
+                ShardId::from(2),
+                ShardId::from(3),
+                ShardId::from(4),
+                ShardId::from(7)
+            ]
+        );
+        assert_eq!(
+            &indexing_tasks_4[1].shard_ids,
+            &[
+                ShardId::from(5),
+                ShardId::from(6),
+                ShardId::from(8),
+                ShardId::from(9),
+                ShardId::from(10)
+            ]
+        );
     }
 
     /// We want to make sure for small pipelines, we still reschedule them with the same
@@ -865,12 +953,12 @@ mod tests {
         let indexing_tasks = group_shards_into_pipelines_aux(
             &source_uid,
             &[12],
-            &[(pipeline_uid, &[12])],
+            &[(pipeline_uid, &[ShardId::from(12)])],
             mcpu(100),
         );
         assert_eq!(indexing_tasks.len(), 1);
         let indexing_task = &indexing_tasks[0];
-        assert_eq!(&indexing_task.shard_ids, &[12]);
+        assert_eq!(&indexing_task.shard_ids, &[ShardId::from(12)]);
         assert_eq!(indexing_task.pipeline_uid.unwrap(), pipeline_uid);
     }
 
@@ -908,7 +996,7 @@ mod tests {
                     source_id: "_ingest-source".to_string(),
                 },
                 source_type: SourceToScheduleType::Sharded {
-                    shard_ids: vec![1],
+                    shard_ids: vec![ShardId::from(1)],
                     load_per_shard: NonZeroU32::new(250).unwrap(),
                 },
             },
@@ -928,19 +1016,30 @@ mod tests {
             index_uid: source_uid.index_uid.to_string(),
             source_id: source_uid.source_id.to_string(),
             pipeline_uid: Some(PipelineUid::new()),
-            shard_ids: vec![1, 4, 5],
+            shard_ids: vec![ShardId::from(1), ShardId::from(4), ShardId::from(5)],
         };
         let previous_task2 = IndexingTask {
             index_uid: source_uid.index_uid.to_string(),
             source_id: source_uid.source_id.to_string(),
             pipeline_uid: Some(PipelineUid::new()),
-            shard_ids: vec![6, 7, 8, 9, 10],
+            shard_ids: vec![
+                ShardId::from(6),
+                ShardId::from(7),
+                ShardId::from(8),
+                ShardId::from(9),
+                ShardId::from(10),
+            ],
         };
         {
             let sharded_source = SourceToSchedule {
                 source_uid: source_uid.clone(),
                 source_type: SourceToScheduleType::Sharded {
-                    shard_ids: vec![1, 2, 4, 6],
+                    shard_ids: vec![
+                        ShardId::from(1),
+                        ShardId::from(2),
+                        ShardId::from(4),
+                        ShardId::from(6),
+                    ],
                     load_per_shard: NonZeroU32::new(1_000).unwrap(),
                 },
             };
@@ -950,17 +1049,22 @@ mod tests {
                 &sharded_source,
             );
             assert_eq!(tasks.len(), 2);
-            assert_eq!(&tasks[0].index_uid, source_uid.index_uid.as_str());
-            assert_eq!(&tasks[0].shard_ids, &[1, 4]);
-            assert_eq!(&tasks[1].index_uid, source_uid.index_uid.as_str());
-            assert_eq!(&tasks[1].shard_ids, &[6]);
+            assert_eq!(tasks[0].index_uid, source_uid.index_uid.as_str());
+            assert_eq!(tasks[0].shard_ids, [ShardId::from(1), ShardId::from(4)]);
+            assert_eq!(tasks[1].index_uid, source_uid.index_uid.as_str());
+            assert_eq!(tasks[1].shard_ids, [ShardId::from(6)]);
         }
         {
             // smaller shards force a merge into a single pipeline
             let sharded_source = SourceToSchedule {
                 source_uid: source_uid.clone(),
                 source_type: SourceToScheduleType::Sharded {
-                    shard_ids: vec![1, 2, 4, 6],
+                    shard_ids: vec![
+                        ShardId::from(1),
+                        ShardId::from(2),
+                        ShardId::from(4),
+                        ShardId::from(6),
+                    ],
                     load_per_shard: NonZeroU32::new(250).unwrap(),
                 },
             };
@@ -970,8 +1074,8 @@ mod tests {
                 &sharded_source,
             );
             assert_eq!(tasks.len(), 1);
-            assert_eq!(&tasks[0].index_uid, source_uid.index_uid.as_str());
-            assert_eq!(&tasks[0].shard_ids, &[1, 4]);
+            assert_eq!(tasks[0].index_uid, source_uid.index_uid.as_str());
+            assert_eq!(tasks[0].shard_ids, [ShardId::from(1), ShardId::from(4)]);
         }
     }
 
@@ -986,14 +1090,14 @@ mod tests {
             index_uid: source_uid.index_uid.to_string(),
             source_id: source_uid.source_id.to_string(),
             pipeline_uid: Some(pipeline_uid1),
-            shard_ids: vec![],
+            shard_ids: Vec::new(),
         };
         let pipeline_uid2 = PipelineUid::new();
         let previous_task2 = IndexingTask {
             index_uid: source_uid.index_uid.to_string(),
             source_id: source_uid.source_id.to_string(),
             pipeline_uid: Some(pipeline_uid2),
-            shard_ids: vec![],
+            shard_ids: Vec::new(),
         };
         {
             let sharded_source = SourceToSchedule {
@@ -1009,8 +1113,8 @@ mod tests {
                 &sharded_source,
             );
             assert_eq!(tasks.len(), 1);
-            assert_eq!(&tasks[0].index_uid, source_uid.index_uid.as_str());
-            assert!(&tasks[0].shard_ids.is_empty());
+            assert_eq!(tasks[0].index_uid, source_uid.index_uid.as_str());
+            assert!(tasks[0].shard_ids.is_empty());
             assert_eq!(tasks[0].pipeline_uid.as_ref().unwrap(), &pipeline_uid1);
         }
         {
@@ -1042,11 +1146,11 @@ mod tests {
                 &sharded_source,
             );
             assert_eq!(tasks.len(), 2);
-            assert_eq!(&tasks[0].index_uid, source_uid.index_uid.as_str());
-            assert!(&tasks[0].shard_ids.is_empty());
+            assert_eq!(tasks[0].index_uid, source_uid.index_uid.as_str());
+            assert!(tasks[0].shard_ids.is_empty());
             assert_eq!(tasks[0].pipeline_uid.as_ref().unwrap(), &pipeline_uid1);
-            assert_eq!(&tasks[1].index_uid, source_uid.index_uid.as_str());
-            assert!(&tasks[1].shard_ids.is_empty());
+            assert_eq!(tasks[1].index_uid, source_uid.index_uid.as_str());
+            assert!(tasks[1].shard_ids.is_empty());
             assert_eq!(tasks[1].pipeline_uid.as_ref().unwrap(), &pipeline_uid2);
         }
         {
@@ -1063,11 +1167,11 @@ mod tests {
                 &sharded_source,
             );
             assert_eq!(tasks.len(), 2);
-            assert_eq!(&tasks[0].index_uid, source_uid.index_uid.as_str());
-            assert!(&tasks[0].shard_ids.is_empty());
+            assert_eq!(tasks[0].index_uid, source_uid.index_uid.as_str());
+            assert!(tasks[0].shard_ids.is_empty());
             assert_eq!(tasks[0].pipeline_uid.as_ref().unwrap(), &pipeline_uid1);
-            assert_eq!(&tasks[1].index_uid, source_uid.index_uid.as_str());
-            assert!(&tasks[1].shard_ids.is_empty());
+            assert_eq!(tasks[1].index_uid, source_uid.index_uid.as_str());
+            assert!(tasks[1].shard_ids.is_empty());
             assert_ne!(tasks[1].pipeline_uid.as_ref().unwrap(), &pipeline_uid1);
         }
     }

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -42,6 +42,7 @@ use quickwit_proto::types::{IndexUid, NodeId, ShardId, SourceUid};
 use rand::seq::SliceRandom;
 use tokio::time::timeout;
 use tracing::{error, info, warn};
+use ulid::Ulid;
 
 use crate::ingest::wait_handle::WaitHandle;
 use crate::metrics::CONTROL_PLANE_METRICS;
@@ -147,7 +148,7 @@ impl IngestController {
             let shards_for_source = RetainShardsForSource {
                 index_uid: source_uid.index_uid.to_string(),
                 source_id: source_uid.source_id.clone(),
-                shard_ids: shard_ids.iter().copied().collect(),
+                shard_ids: shard_ids.iter().cloned().collect(),
             };
             retain_shards_req
                 .retain_shards_for_sources
@@ -378,7 +379,7 @@ impl IngestController {
                 get_or_create_open_shards_failures.push(get_or_create_open_shards_failure);
                 continue;
             };
-            let Some((open_shard_entries, next_shard_id)) = model.find_open_shards(
+            let Some(open_shard_entries) = model.find_open_shards(
                 &index_uid,
                 &get_open_shards_subrequest.source_id,
                 &unavailable_leaders,
@@ -413,13 +414,14 @@ impl IngestController {
                     .ok_or_else(|| {
                         ControlPlaneError::Unavailable("no ingester available".to_string())
                     })?;
+                let shard_id = ShardId::from(Ulid::new());
                 let open_shards_subrequest = metastore::OpenShardsSubrequest {
                     subrequest_id: get_open_shards_subrequest.subrequest_id,
                     index_uid: index_uid.into(),
                     source_id: get_open_shards_subrequest.source_id,
+                    shard_id: Some(shard_id),
                     leader_id: leader_id.into(),
                     follower_id: follower_id.map(|follower_id| follower_id.into()),
-                    next_shard_id,
                 };
                 open_shards_subrequests.push(open_shards_subrequest);
             }
@@ -442,9 +444,8 @@ impl IngestController {
                     &index_uid,
                     &source_id,
                     open_shards_subresponse.opened_shards,
-                    open_shards_subresponse.next_shard_id,
                 );
-                if let Some((open_shard_entries, _next_shard_id)) =
+                if let Some(open_shard_entries) =
                     model.find_open_shards(&index_uid, &source_id, &unavailable_leaders)
                 {
                     let open_shards = open_shard_entries
@@ -524,11 +525,6 @@ impl IngestController {
             source_id=%source_uid.source_id,
             "scaling up number of shards to {new_num_open_shards}"
         );
-        // Expect: the source should exist because we just acquired a permit.
-        let next_shard_id = model
-            .next_shard_id(&source_uid)
-            .expect("source should exist");
-
         let mut unavailable_leaders: FnvHashSet<NodeId> = FnvHashSet::default();
 
         let Some((leader_id, follower_id)) = self
@@ -539,13 +535,14 @@ impl IngestController {
             model.release_scaling_permits(&source_uid, ScalingMode::Up, NUM_PERMITS);
             return;
         };
+        let shard_id = ShardId::from(Ulid::new());
         let open_shards_subrequest = metastore::OpenShardsSubrequest {
             subrequest_id: 0,
             index_uid: source_uid.index_uid.clone().into(),
             source_id: source_uid.source_id.clone(),
+            shard_id: Some(shard_id),
             leader_id: leader_id.into(),
             follower_id: follower_id.map(Into::into),
-            next_shard_id,
         };
         let open_shards_request = metastore::OpenShardsRequest {
             subrequests: vec![open_shards_subrequest],
@@ -574,7 +571,6 @@ impl IngestController {
                 &index_uid,
                 &source_id,
                 open_shards_subresponse.opened_shards,
-                open_shards_subresponse.next_shard_id,
             );
         }
         let label_values = [source_uid.index_uid.index_id(), &source_uid.source_id];
@@ -619,7 +615,7 @@ impl IngestController {
         let shards = vec![ShardIds {
             index_uid: source_uid.index_uid.clone().into(),
             source_id: source_uid.source_id.clone(),
-            shard_ids: vec![shard_id],
+            shard_ids: vec![shard_id.clone()],
         }];
         let close_shards_request = CloseShardsRequest { shards };
 
@@ -642,7 +638,8 @@ impl IngestController {
 }
 
 /// Finds the shard with the highest ingestion rate on the ingester with the least number of open
-/// shards.
+/// shards. If multiple shards have the same ingestion rate, the shard with the highest shard ID is
+/// chosen.
 fn find_scale_down_candidate(
     source_uid: &SourceUid,
     model: &ControlPlaneModel,
@@ -656,7 +653,12 @@ fn find_scale_down_candidate(
                 .and_modify(|(num_shards, candidate)| {
                     *num_shards += 1;
 
-                    if candidate.ingestion_rate < shard.ingestion_rate {
+                    if shard
+                        .ingestion_rate
+                        .cmp(&candidate.ingestion_rate)
+                        .then_with(|| shard.shard_id.cmp(&candidate.shard_id))
+                        .is_gt()
+                    {
                         *candidate = shard;
                     }
                 })
@@ -666,7 +668,9 @@ fn find_scale_down_candidate(
     per_leader_candidates
         .into_iter()
         .min_by_key(|(_leader_id, (num_shards, _shard))| *num_shards)
-        .map(|(leader_id, (_num_shards, shard))| (leader_id.clone().into(), shard.shard_id))
+        .map(|(leader_id, (_num_shards, shard))| {
+            (leader_id.clone().into(), shard.shard_id().clone())
+        })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -927,12 +931,11 @@ mod tests {
                     opened_shards: vec![Shard {
                         index_uid: index_uid_1.clone().into(),
                         source_id: source_id.to_string(),
-                        shard_id: 1,
+                        shard_id: Some(ShardId::from(1)),
                         shard_state: ShardState::Open as i32,
                         leader_id: "test-ingester-2".to_string(),
                         ..Default::default()
                     }],
-                    next_shard_id: 2,
                 }];
                 let response = metastore::OpenShardsResponse { subresponses };
                 Ok(response)
@@ -958,7 +961,7 @@ mod tests {
                 assert_eq!(request.shards.len(), 1);
                 assert_eq!(request.shards[0].index_uid, "test-index-1:0");
                 assert_eq!(request.shards[0].source_id, "test-source");
-                assert_eq!(request.shards[0].shard_id, 1);
+                assert_eq!(request.shards[0].shard_id(), ShardId::from(1));
                 assert_eq!(request.shards[0].leader_id, "test-ingester-2");
 
                 Ok(InitShardsResponse {})
@@ -988,7 +991,7 @@ mod tests {
             Shard {
                 index_uid: index_uid_0.clone().into(),
                 source_id: source_id.to_string(),
-                shard_id: 1,
+                shard_id: Some(ShardId::from(1)),
                 leader_id: "test-ingester-0".to_string(),
                 shard_state: ShardState::Open as i32,
                 ..Default::default()
@@ -996,14 +999,14 @@ mod tests {
             Shard {
                 index_uid: index_uid_0.clone().into(),
                 source_id: source_id.to_string(),
-                shard_id: 2,
+                shard_id: Some(ShardId::from(2)),
                 leader_id: "test-ingester-1".to_string(),
                 shard_state: ShardState::Open as i32,
                 ..Default::default()
             },
         ];
 
-        model.insert_newly_opened_shards(&index_uid_0, &source_id.into(), shards, 3);
+        model.insert_newly_opened_shards(&index_uid_0, &source_id.into(), shards);
 
         let request = GetOrCreateOpenShardsRequest {
             subrequests: Vec::new(),
@@ -1061,7 +1064,7 @@ mod tests {
         assert_eq!(success.index_uid, index_uid_0.as_str());
         assert_eq!(success.source_id, source_id);
         assert_eq!(success.open_shards.len(), 1);
-        assert_eq!(success.open_shards[0].shard_id, 2);
+        assert_eq!(success.open_shards[0].shard_id(), ShardId::from(2));
         assert_eq!(success.open_shards[0].leader_id, "test-ingester-1");
 
         let success = &response.successes[1];
@@ -1069,7 +1072,7 @@ mod tests {
         assert_eq!(success.index_uid, index_uid_1.as_str());
         assert_eq!(success.source_id, source_id);
         assert_eq!(success.open_shards.len(), 1);
-        assert_eq!(success.open_shards[0].shard_id, 1);
+        assert_eq!(success.open_shards[0].shard_id(), ShardId::from(1));
         assert_eq!(success.open_shards[0].leader_id, "test-ingester-2");
 
         let failure = &response.failures[0];
@@ -1107,21 +1110,21 @@ mod tests {
         let source_id: SourceId = "test-source".into();
 
         let shards = vec![Shard {
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
             leader_id: "test-ingester-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         }];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 3);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
 
         let request = GetOrCreateOpenShardsRequest {
             subrequests: Vec::new(),
             closed_shards: vec![ShardIds {
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
-                shard_ids: vec![1, 2],
+                shard_ids: vec![ShardId::from(1), ShardId::from(2)],
             }],
             unavailable_leaders: Vec::new(),
         };
@@ -1134,7 +1137,7 @@ mod tests {
 
         let shard_1 = model
             .all_shards()
-            .find(|shard| shard.shard_id == 1)
+            .find(|shard| shard.shard_id() == ShardId::from(1))
             .unwrap();
         assert!(shard_1.is_closed());
     }
@@ -1158,31 +1161,31 @@ mod tests {
 
         let shards = vec![
             Shard {
-                shard_id: 1,
                 index_uid: index_uid.to_string(),
                 source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(1)),
                 leader_id: "test-ingester-0".to_string(),
                 shard_state: ShardState::Open as i32,
                 ..Default::default()
             },
             Shard {
-                shard_id: 2,
                 index_uid: index_uid.to_string(),
                 source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(2)),
                 leader_id: "test-ingester-0".to_string(),
                 shard_state: ShardState::Closed as i32,
                 ..Default::default()
             },
             Shard {
-                shard_id: 3,
                 index_uid: index_uid.to_string(),
                 source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(3)),
                 leader_id: "test-ingester-1".to_string(),
                 shard_state: ShardState::Open as i32,
                 ..Default::default()
             },
         ];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 4);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
 
         let request = GetOrCreateOpenShardsRequest {
             subrequests: Vec::new(),
@@ -1198,19 +1201,19 @@ mod tests {
 
         let shard_1 = model
             .all_shards()
-            .find(|shard| shard.shard_id == 1)
+            .find(|shard| shard.shard_id() == ShardId::from(1))
             .unwrap();
         assert!(shard_1.is_unavailable());
 
         let shard_2 = model
             .all_shards()
-            .find(|shard| shard.shard_id == 2)
+            .find(|shard| shard.shard_id() == ShardId::from(2))
             .unwrap();
         assert!(shard_2.is_closed());
 
         let shard_3 = model
             .all_shards()
-            .find(|shard| shard.shard_id == 3)
+            .find(|shard| shard.shard_id() == ShardId::from(3))
             .unwrap();
         assert!(shard_3.is_open());
     }
@@ -1237,12 +1240,12 @@ mod tests {
         let shards = vec![Shard {
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-ingester".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         }];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 2);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
         let shard_entries: Vec<ShardEntry> = model.all_shards().cloned().collect();
 
         assert_eq!(shard_entries.len(), 1);
@@ -1250,7 +1253,7 @@ mod tests {
 
         // Test update shard ingestion rate but no scale down because num open shards is 1.
         let shard_infos = BTreeSet::from_iter([ShardInfo {
-            shard_id: 1,
+            shard_id: ShardId::from(1),
             shard_state: ShardState::Open,
             ingestion_rate: RateMibPerSec(1),
         }]);
@@ -1269,14 +1272,14 @@ mod tests {
 
         // Test update shard ingestion rate with failing scale down.
         let shards = vec![Shard {
-            shard_id: 2,
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
-            leader_id: "test-ingester".to_string(),
+            shard_id: Some(ShardId::from(2)),
             shard_state: ShardState::Open as i32,
+            leader_id: "test-ingester".to_string(),
             ..Default::default()
         }];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 2);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
 
         let shard_entries: Vec<ShardEntry> = model.all_shards().cloned().collect();
         assert_eq!(shard_entries.len(), 2);
@@ -1287,7 +1290,7 @@ mod tests {
             assert_eq!(request.shards.len(), 1);
             assert_eq!(request.shards[0].index_uid, "test-index:0");
             assert_eq!(request.shards[0].source_id, "test-source");
-            assert_eq!(request.shards[0].shard_ids, vec![1]);
+            assert_eq!(request.shards[0].shard_ids, [ShardId::from(2)]);
 
             Err(IngestV2Error::Internal(
                 "failed to close shards".to_string(),
@@ -1302,12 +1305,12 @@ mod tests {
 
         let shard_infos = BTreeSet::from_iter([
             ShardInfo {
-                shard_id: 1,
+                shard_id: ShardId::from(1),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(1),
             },
             ShardInfo {
-                shard_id: 2,
+                shard_id: ShardId::from(2),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(1),
             },
@@ -1324,12 +1327,12 @@ mod tests {
         // Test update shard ingestion rate with failing scale up.
         let shard_infos = BTreeSet::from_iter([
             ShardInfo {
-                shard_id: 1,
+                shard_id: ShardId::from(1),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(4),
             },
             ShardInfo {
-                shard_id: 2,
+                shard_id: ShardId::from(2),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(4),
             },
@@ -1356,7 +1359,6 @@ mod tests {
                 assert_eq!(request.subrequests[0].index_uid, "test-index:0");
                 assert_eq!(request.subrequests[0].source_id, INGEST_V2_SOURCE_ID);
                 assert_eq!(request.subrequests[0].leader_id, "test-ingester");
-                assert_eq!(request.subrequests[0].next_shard_id, 1);
 
                 Err(MetastoreError::InvalidArgument {
                     message: "failed to open shards".to_string(),
@@ -1367,7 +1369,6 @@ mod tests {
             assert_eq!(request.subrequests[0].index_uid, "test-index:0");
             assert_eq!(request.subrequests[0].source_id, INGEST_V2_SOURCE_ID);
             assert_eq!(request.subrequests[0].leader_id, "test-ingester");
-            assert_eq!(request.subrequests[0].next_shard_id, 1);
 
             let subresponses = vec![metastore::OpenShardsSubresponse {
                 subrequest_id: 0,
@@ -1376,12 +1377,11 @@ mod tests {
                 opened_shards: vec![Shard {
                     index_uid: "test-index:0".into(),
                     source_id: INGEST_V2_SOURCE_ID.to_string(),
-                    shard_id: 1,
+                    shard_id: Some(ShardId::from(1)),
                     leader_id: "test-ingester".to_string(),
                     shard_state: ShardState::Open as i32,
                     ..Default::default()
                 }],
-                next_shard_id: 2,
             }];
             let response = metastore::OpenShardsResponse { subresponses };
             Ok(response)
@@ -1436,7 +1436,7 @@ mod tests {
                 assert_eq!(request.shards.len(), 1);
                 assert_eq!(request.shards[0].index_uid, "test-index:0");
                 assert_eq!(request.shards[0].source_id, INGEST_V2_SOURCE_ID);
-                assert_eq!(request.shards[0].shard_id, 1);
+                assert_eq!(request.shards[0].shard_id(), ShardId::from(1));
                 assert_eq!(request.shards[0].leader_id, "test-ingester");
 
                 Err(IngestV2Error::Internal("failed to init shards".to_string()))
@@ -1445,7 +1445,7 @@ mod tests {
             assert_eq!(request.shards.len(), 1);
             assert_eq!(request.shards[0].index_uid, "test-index:0");
             assert_eq!(request.shards[0].source_id, INGEST_V2_SOURCE_ID);
-            assert_eq!(request.shards[0].shard_id, 1);
+            assert_eq!(request.shards[0].shard_id(), ShardId::from(1));
             assert_eq!(request.shards[0].leader_id, "test-ingester");
 
             Ok(InitShardsResponse {})
@@ -1503,14 +1503,14 @@ mod tests {
             .await;
 
         let shards = vec![Shard {
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
             leader_id: "test-ingester".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         }];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 2);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
 
         // Test ingester is unavailable.
         ingest_controller
@@ -1526,7 +1526,7 @@ mod tests {
                 assert_eq!(request.shards.len(), 1);
                 assert_eq!(request.shards[0].index_uid, "test-index:0");
                 assert_eq!(request.shards[0].source_id, "test-source");
-                assert_eq!(request.shards[0].shard_ids, vec![1]);
+                assert_eq!(request.shards[0].shard_ids, [ShardId::from(1)]);
 
                 Err(IngestV2Error::Internal(
                     "failed to close shards".to_string(),
@@ -1539,7 +1539,7 @@ mod tests {
                 assert_eq!(request.shards.len(), 1);
                 assert_eq!(request.shards[0].index_uid, "test-index:0");
                 assert_eq!(request.shards[0].source_id, "test-source");
-                assert_eq!(request.shards[0].shard_ids, vec![1]);
+                assert_eq!(request.shards[0].shard_ids, [ShardId::from(1)]);
 
                 Ok(CloseShardsResponse {})
             });
@@ -1558,14 +1558,14 @@ mod tests {
         assert!(model.all_shards().all(|shard| shard.is_closed()));
 
         let shards = vec![Shard {
-            shard_id: 2,
+            shard_id: Some(ShardId::from(2)),
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
             leader_id: "test-ingester".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         }];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 3);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
 
         // Test rate limited.
         ingest_controller
@@ -1589,84 +1589,84 @@ mod tests {
 
         let shards = vec![
             Shard {
-                shard_id: 1,
-                leader_id: "test-ingester-0".to_string(),
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(1)),
                 shard_state: ShardState::Open as i32,
+                leader_id: "test-ingester-0".to_string(),
                 ..Default::default()
             },
             Shard {
-                shard_id: 2,
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
-                leader_id: "test-ingester-0".to_string(),
+                shard_id: Some(ShardId::from(2)),
                 shard_state: ShardState::Open as i32,
+                leader_id: "test-ingester-0".to_string(),
                 ..Default::default()
             },
             Shard {
-                shard_id: 3,
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
-                leader_id: "test-ingester-0".to_string(),
+                shard_id: Some(ShardId::from(3)),
                 shard_state: ShardState::Closed as i32,
+                leader_id: "test-ingester-0".to_string(),
                 ..Default::default()
             },
             Shard {
-                shard_id: 4,
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
-                leader_id: "test-ingester-1".to_string(),
+                shard_id: Some(ShardId::from(4)),
                 shard_state: ShardState::Open as i32,
+                leader_id: "test-ingester-1".to_string(),
                 ..Default::default()
             },
             Shard {
-                shard_id: 5,
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
-                leader_id: "test-ingester-1".to_string(),
+                shard_id: Some(ShardId::from(5)),
                 shard_state: ShardState::Open as i32,
+                leader_id: "test-ingester-1".to_string(),
                 ..Default::default()
             },
             Shard {
-                shard_id: 6,
                 index_uid: index_uid.clone().into(),
                 source_id: source_id.clone(),
-                leader_id: "test-ingester-1".to_string(),
+                shard_id: Some(ShardId::from(6)),
                 shard_state: ShardState::Open as i32,
+                leader_id: "test-ingester-1".to_string(),
                 ..Default::default()
             },
         ];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 7);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
 
         let shard_infos = BTreeSet::from_iter([
             ShardInfo {
-                shard_id: 1,
+                shard_id: ShardId::from(1),
                 shard_state: ShardState::Open,
                 ingestion_rate: quickwit_ingest::RateMibPerSec(1),
             },
             ShardInfo {
-                shard_id: 2,
+                shard_id: ShardId::from(2),
                 shard_state: ShardState::Open,
                 ingestion_rate: quickwit_ingest::RateMibPerSec(2),
             },
             ShardInfo {
-                shard_id: 3,
+                shard_id: ShardId::from(3),
                 shard_state: ShardState::Open,
                 ingestion_rate: quickwit_ingest::RateMibPerSec(3),
             },
             ShardInfo {
-                shard_id: 4,
+                shard_id: ShardId::from(4),
                 shard_state: ShardState::Open,
                 ingestion_rate: quickwit_ingest::RateMibPerSec(4),
             },
             ShardInfo {
-                shard_id: 5,
+                shard_id: ShardId::from(5),
                 shard_state: ShardState::Open,
                 ingestion_rate: quickwit_ingest::RateMibPerSec(5),
             },
             ShardInfo {
-                shard_id: 6,
+                shard_id: ShardId::from(6),
                 shard_state: ShardState::Open,
                 ingestion_rate: quickwit_ingest::RateMibPerSec(6),
             },
@@ -1675,7 +1675,7 @@ mod tests {
 
         let (leader_id, shard_id) = find_scale_down_candidate(&source_uid, &model).unwrap();
         assert_eq!(leader_id, "test-ingester-0");
-        assert_eq!(shard_id, 2);
+        assert_eq!(shard_id, ShardId::from(2));
     }
 
     #[tokio::test]
@@ -1692,34 +1692,34 @@ mod tests {
         let mut model = ControlPlaneModel::default();
         let shards = vec![
             Shard {
-                shard_id: 1,
                 index_uid: index_uid.to_string(),
                 source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(1)),
+                shard_state: ShardState::Open as i32,
                 leader_id: "node-1".to_string(),
                 follower_id: Some("node-2".to_string()),
-                shard_state: ShardState::Open as i32,
                 ..Default::default()
             },
             Shard {
-                shard_id: 2,
                 index_uid: index_uid.to_string(),
                 source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(2)),
+                shard_state: ShardState::Open as i32,
                 leader_id: "node-2".to_string(),
                 follower_id: Some("node-3".to_string()),
-                shard_state: ShardState::Open as i32,
                 ..Default::default()
             },
             Shard {
-                shard_id: 3,
                 index_uid: index_uid.to_string(),
                 source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(3)),
+                shard_state: ShardState::Open as i32,
                 leader_id: "node-2".to_string(),
                 follower_id: Some("node-1".to_string()),
-                shard_state: ShardState::Open as i32,
                 ..Default::default()
             },
         ];
-        model.insert_newly_opened_shards(&index_uid, &source_id, shards, 2);
+        model.insert_newly_opened_shards(&index_uid, &source_id, shards);
 
         let mut ingester_mock1 = IngesterServiceClient::mock();
         let ingester_mock2 = IngesterServiceClient::mock();
@@ -1730,11 +1730,13 @@ mod tests {
         ingester_mock1
             .expect_retain_shards()
             .once()
-            .returning(move |mut request| {
+            .returning(move |request| {
                 assert_eq!(request.retain_shards_for_sources.len(), 1);
-                let retain_shards_for_source = request.retain_shards_for_sources.pop().unwrap();
-                assert_eq!(&retain_shards_for_source.shard_ids, &[1, 3]);
-                count_calls_clone.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(
+                    request.retain_shards_for_sources[0].shard_ids,
+                    [ShardId::from(1), ShardId::from(3)]
+                );
+                count_calls_clone.fetch_add(1, Ordering::Release);
                 Ok(RetainShardsResponse {})
             });
         ingester_pool.insert("node-1".into(), ingester_mock1.into());
@@ -1743,6 +1745,6 @@ mod tests {
         let node_id = "node-1".into();
         let wait_handle = ingest_controller.sync_with_ingester(&node_id, &model);
         wait_handle.wait().await;
-        assert_eq!(count_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(count_calls.load(Ordering::Acquire), 1);
     }
 }

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -50,8 +50,6 @@ pub(crate) enum ScalingMode {
     Down,
 }
 
-pub(crate) type NextShardId = ShardId;
-
 #[derive(Debug, Clone)]
 pub(crate) struct ShardEntry {
     pub shard: Shard,
@@ -84,7 +82,6 @@ impl From<Shard> for ShardEntry {
 #[derive(Debug)]
 pub(crate) struct ShardTableEntry {
     shard_entries: FnvHashMap<ShardId, ShardEntry>,
-    next_shard_id: NextShardId,
     scaling_up_rate_limiter: RateLimiter,
     scaling_down_rate_limiter: RateLimiter,
 }
@@ -93,7 +90,6 @@ impl Default for ShardTableEntry {
     fn default() -> Self {
         Self {
             shard_entries: Default::default(),
-            next_shard_id: Self::DEFAULT_NEXT_SHARD_ID,
             scaling_up_rate_limiter: RateLimiter::from_settings(SCALING_UP_RATE_LIMITER_SETTINGS),
             scaling_down_rate_limiter: RateLimiter::from_settings(
                 SCALING_DOWN_RATE_LIMITER_SETTINGS,
@@ -103,30 +99,23 @@ impl Default for ShardTableEntry {
 }
 
 impl ShardTableEntry {
-    const DEFAULT_NEXT_SHARD_ID: NextShardId = 1; // `1` matches the PostgreSQL sequence min value.
-
-    pub fn from_shards(shards: Vec<Shard>, next_shard_id: NextShardId) -> Self {
+    pub fn from_shards(shards: Vec<Shard>) -> Self {
         let shard_entries = shards
             .into_iter()
             .filter(|shard| {
                 let shard_state = shard.shard_state();
                 shard_state == ShardState::Open || shard_state == ShardState::Closed
             })
-            .map(|shard| (shard.shard_id, shard.into()))
+            .map(|shard| (shard.shard_id().clone(), shard.into()))
             .collect();
         Self {
             shard_entries,
-            next_shard_id,
             ..Default::default()
         }
     }
 
     fn is_empty(&self) -> bool {
         self.shard_entries.is_empty()
-    }
-
-    fn is_default(&self) -> bool {
-        self.is_empty() && self.next_shard_id == Self::DEFAULT_NEXT_SHARD_ID
     }
 }
 
@@ -153,7 +142,7 @@ fn remove_shard_from_ingesters_internal(
             .get_mut(&node)
             .expect("shard table reached inconsistent state");
         let shard_ids = ingester_shards.get_mut(source_uid).unwrap();
-        shard_ids.remove(&shard.shard_id);
+        shard_ids.remove(shard.shard_id());
     }
 }
 
@@ -181,6 +170,7 @@ impl ShardTable {
     /// Checks whether the shard table is consistent.
     ///
     /// Panics if it is not.
+    #[allow(clippy::mutable_key_type)]
     fn check_invariant(&self) {
         // This function is expensive! Let's not call it in release mode.
         if !cfg!(debug_assertions) {
@@ -189,7 +179,7 @@ impl ShardTable {
         let mut shard_sets_in_shard_table = FnvHashSet::default();
         for (source_uid, shard_table_entry) in &self.table_entries {
             for (shard_id, shard_entry) in &shard_table_entry.shard_entries {
-                debug_assert_eq!(shard_id, &shard_entry.shard.shard_id);
+                debug_assert_eq!(shard_id, shard_entry.shard.shard_id());
                 debug_assert_eq!(source_uid.index_uid.as_str(), &shard_entry.shard.index_uid);
                 for node in shard_entry.shard.ingester_nodes() {
                     shard_sets_in_shard_table.insert((node, source_uid, shard_id));
@@ -248,7 +238,7 @@ impl ShardTable {
         let table_entry = ShardTableEntry::default();
         let previous_table_entry_opt = self.table_entries.insert(source_uid, table_entry);
         if let Some(previous_table_entry) = previous_table_entry_opt {
-            if !previous_table_entry.is_default() {
+            if !previous_table_entry.is_empty() {
                 error!(
                     "shard table entry for index `{}` and source `{}` already exists",
                     index_uid.index_id(),
@@ -305,19 +295,12 @@ impl ShardTable {
             .map(|table_entry| table_entry.shard_entries.values())
     }
 
-    pub fn next_shard_id(&self, source_uid: &SourceUid) -> Option<ShardId> {
-        self.table_entries
-            .get(source_uid)
-            .map(|table_entry| table_entry.next_shard_id)
-    }
-
     /// Updates the shard table.
     pub fn insert_newly_opened_shards(
         &mut self,
         index_uid: &IndexUid,
         source_id: &SourceId,
         opened_shards: Vec<Shard>,
-        next_shard_id: NextShardId,
     ) {
         let source_uid = SourceUid {
             index_uid: index_uid.clone(),
@@ -337,7 +320,7 @@ impl ShardTable {
             for node in shard.ingester_nodes() {
                 let ingester_shards = self.ingester_shards.entry(node).or_default();
                 let shard_ids = ingester_shards.entry(source_uid.clone()).or_default();
-                shard_ids.insert(shard.shard_id);
+                shard_ids.insert(shard.shard_id().clone());
             }
         }
         match self.table_entries.entry(source_uid) {
@@ -349,10 +332,9 @@ impl ShardTable {
                     // knows more about the state of the shards than the metastore.
                     table_entry
                         .shard_entries
-                        .entry(opened_shard.shard_id)
+                        .entry(opened_shard.shard_id().clone())
                         .or_insert(opened_shard.into());
                 }
-                table_entry.next_shard_id = next_shard_id;
             }
             // This should never happen if the control plane view is consistent with the state of
             // the metastore, so should we panic here? Warnings are most likely going to go
@@ -360,11 +342,10 @@ impl ShardTable {
             Entry::Vacant(entry) => {
                 let shard_entries: FnvHashMap<ShardId, ShardEntry> = opened_shards
                     .into_iter()
-                    .map(|shard| (shard.shard_id, shard.into()))
+                    .map(|shard| (shard.shard_id().clone(), shard.into()))
                     .collect();
                 let table_entry = ShardTableEntry {
                     shard_entries,
-                    next_shard_id,
                     ..Default::default()
                 };
                 entry.insert(table_entry);
@@ -380,7 +361,7 @@ impl ShardTable {
         index_uid: &IndexUid,
         source_id: &SourceId,
         unavailable_leaders: &FnvHashSet<NodeId>,
-    ) -> Option<(Vec<ShardEntry>, NextShardId)> {
+    ) -> Option<Vec<ShardEntry>> {
         let source_uid = SourceUid {
             index_uid: index_uid.clone(),
             source_id: source_id.clone(),
@@ -394,8 +375,7 @@ impl ShardTable {
             })
             .cloned()
             .collect();
-
-        Some((open_shards, table_entry.next_shard_id))
+        Some(open_shards)
     }
 
     pub fn update_shards(
@@ -452,7 +432,7 @@ impl ShardTable {
                 if let Some(shard_entry) = table_entry.shard_entries.get_mut(shard_id) {
                     if !shard_entry.is_closed() {
                         shard_entry.set_shard_state(ShardState::Closed);
-                        closed_shard_ids.push(*shard_id);
+                        closed_shard_ids.push(shard_id.clone());
                     }
                 }
             }
@@ -468,7 +448,7 @@ impl ShardTable {
                 if let Some(shard_entry) = table_entry.shard_entries.remove(shard_id) {
                     shard_entries_to_remove.push(shard_entry);
                 } else {
-                    warn!(shard = *shard_id, "deleting a non-existing shard");
+                    warn!(shard=%shard_id, "deleting a non-existing shard");
                 }
             }
         }
@@ -484,20 +464,15 @@ impl ShardTable {
 
     /// Set the shards for a given source.
     /// This function panics if an entry was previously associated to the source uid.
-    pub(crate) fn initialize_source_shards(
-        &mut self,
-        source_uid: SourceUid,
-        shards: Vec<Shard>,
-        next_shard_id: NextShardId,
-    ) {
+    pub(crate) fn initialize_source_shards(&mut self, source_uid: SourceUid, shards: Vec<Shard>) {
         for shard in &shards {
             for node in shard.ingester_nodes() {
                 let ingester_shards = self.ingester_shards.entry(node).or_default();
                 let shard_ids = ingester_shards.entry(source_uid.clone()).or_default();
-                shard_ids.insert(shard.shard_id);
+                shard_ids.insert(shard.shard_id().clone());
             }
         }
-        let table_entry = ShardTableEntry::from_shards(shards, next_shard_id);
+        let table_entry = ShardTableEntry::from_shards(shards);
         let previous_entry = self.table_entries.insert(source_uid, table_entry);
         assert!(previous_entry.is_none());
         self.check_invariant();
@@ -553,7 +528,7 @@ mod tests {
             self.shard_entries
                 .values()
                 .map(|shard_entry| shard_entry.shard.clone())
-                .sorted_unstable_by_key(|shard| shard.shard_id)
+                .sorted_unstable_by(|left, right| left.shard_id.cmp(&right.shard_id))
                 .collect()
         }
     }
@@ -564,11 +539,13 @@ mod tests {
             index_uid: &IndexUid,
             source_id: &SourceId,
             unavailable_leaders: &FnvHashSet<NodeId>,
-        ) -> Option<(Vec<ShardEntry>, NextShardId)> {
+        ) -> Option<Vec<ShardEntry>> {
             self.find_open_shards(index_uid, source_id, unavailable_leaders)
-                .map(|(mut shards, next_shard_id)| {
-                    shards.sort_by_key(|shard_entry| shard_entry.shard.shard_id);
-                    (shards, next_shard_id)
+                .map(|mut shards| {
+                    shards.sort_unstable_by(|left, right| {
+                        left.shard.shard_id.cmp(&right.shard.shard_id)
+                    });
+                    shards
                 })
         }
     }
@@ -612,7 +589,6 @@ mod tests {
         };
         let table_entry = shard_table.table_entries.get(&source_uid).unwrap();
         assert!(table_entry.shard_entries.is_empty());
-        assert_eq!(table_entry.next_shard_id, 1);
     }
 
     #[test]
@@ -634,12 +610,12 @@ mod tests {
         let shard_01 = Shard {
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Closed as i32,
             ..Default::default()
         };
-        shard_table.insert_newly_opened_shards(&index_uid, &source_id, vec![shard_01], 2);
+        shard_table.insert_newly_opened_shards(&index_uid, &source_id, vec![shard_01]);
 
         let shards = shard_table.list_shards(&source_uid).unwrap();
         assert_eq!(shards.count(), 1);
@@ -655,12 +631,12 @@ mod tests {
         let shard_01 = Shard {
             index_uid: index_uid_0.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         };
-        shard_table.insert_newly_opened_shards(&index_uid_0, &source_id, vec![shard_01.clone()], 2);
+        shard_table.insert_newly_opened_shards(&index_uid_0, &source_id, vec![shard_01.clone()]);
 
         assert_eq!(shard_table.table_entries.len(), 1);
 
@@ -672,21 +648,20 @@ mod tests {
         let shards = table_entry.shards();
         assert_eq!(shards.len(), 1);
         assert_eq!(shards[0], shard_01);
-        assert_eq!(table_entry.next_shard_id, 2);
 
         shard_table
             .table_entries
             .get_mut(&source_uid)
             .unwrap()
             .shard_entries
-            .get_mut(&1)
+            .get_mut(&ShardId::from(1))
             .unwrap()
             .set_shard_state(ShardState::Unavailable);
 
         let shard_02 = Shard {
             index_uid: index_uid_0.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 2,
+            shard_id: Some(ShardId::from(2)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
@@ -696,7 +671,6 @@ mod tests {
             &index_uid_0,
             &source_id,
             vec![shard_01.clone(), shard_02.clone()],
-            3,
         );
 
         assert_eq!(shard_table.table_entries.len(), 1);
@@ -710,7 +684,6 @@ mod tests {
         assert_eq!(shards.len(), 2);
         assert_eq!(shards[0].shard_state(), ShardState::Unavailable);
         assert_eq!(shards[1], shard_02);
-        assert_eq!(table_entry.next_shard_id, 3);
     }
 
     #[test]
@@ -723,16 +696,15 @@ mod tests {
 
         let mut unavailable_ingesters = FnvHashSet::default();
 
-        let (open_shards, next_shard_id) = shard_table
+        let open_shards = shard_table
             .find_open_shards_sorted(&index_uid, &source_id, &unavailable_ingesters)
             .unwrap();
         assert_eq!(open_shards.len(), 0);
-        assert_eq!(next_shard_id, 1);
 
         let shard_01 = Shard {
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Closed as i32,
             ..Default::default()
@@ -740,7 +712,7 @@ mod tests {
         let shard_02 = Shard {
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 2,
+            shard_id: Some(ShardId::from(2)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Unavailable as i32,
             ..Default::default()
@@ -748,7 +720,7 @@ mod tests {
         let shard_03 = Shard {
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 3,
+            shard_id: Some(ShardId::from(3)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
@@ -756,7 +728,7 @@ mod tests {
         let shard_04 = Shard {
             index_uid: index_uid.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 4,
+            shard_id: Some(ShardId::from(4)),
             leader_id: "test-leader-1".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
@@ -765,24 +737,21 @@ mod tests {
             &index_uid,
             &source_id,
             vec![shard_01, shard_02, shard_03.clone(), shard_04.clone()],
-            5,
         );
-        let (open_shards, next_shard_id) = shard_table
+        let open_shards = shard_table
             .find_open_shards_sorted(&index_uid, &source_id, &unavailable_ingesters)
             .unwrap();
         assert_eq!(open_shards.len(), 2);
         assert_eq!(open_shards[0].shard, shard_03);
         assert_eq!(open_shards[1].shard, shard_04);
-        assert_eq!(next_shard_id, 5);
 
         unavailable_ingesters.insert("test-leader-0".into());
 
-        let (open_shards, next_shard_id) = shard_table
+        let open_shards = shard_table
             .find_open_shards_sorted(&index_uid, &source_id, &unavailable_ingesters)
             .unwrap();
         assert_eq!(open_shards.len(), 1);
         assert_eq!(open_shards[0].shard, shard_04);
-        assert_eq!(next_shard_id, 5);
     }
 
     #[test]
@@ -795,28 +764,28 @@ mod tests {
         let shard_01 = Shard {
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         };
         let shard_02 = Shard {
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
-            shard_id: 2,
+            shard_id: Some(ShardId::from(2)),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         };
         let shard_03 = Shard {
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
-            shard_id: 3,
+            shard_id: Some(ShardId::from(3)),
             shard_state: ShardState::Unavailable as i32,
             ..Default::default()
         };
         let shard_04 = Shard {
             index_uid: index_uid.to_string(),
             source_id: source_id.clone(),
-            shard_id: 4,
+            shard_id: Some(ShardId::from(4)),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         };
@@ -824,7 +793,6 @@ mod tests {
             &index_uid,
             &source_id,
             vec![shard_01, shard_02, shard_03, shard_04],
-            5,
         );
         let source_uid = SourceUid {
             index_uid,
@@ -832,27 +800,27 @@ mod tests {
         };
         let shard_infos = BTreeSet::from_iter([
             ShardInfo {
-                shard_id: 1,
+                shard_id: ShardId::from(1),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(1),
             },
             ShardInfo {
-                shard_id: 2,
+                shard_id: ShardId::from(2),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(2),
             },
             ShardInfo {
-                shard_id: 3,
+                shard_id: ShardId::from(3),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(3),
             },
             ShardInfo {
-                shard_id: 4,
+                shard_id: ShardId::from(4),
                 shard_state: ShardState::Closed,
                 ingestion_rate: RateMibPerSec(4),
             },
             ShardInfo {
-                shard_id: 5,
+                shard_id: ShardId::from(5),
                 shard_state: ShardState::Open,
                 ingestion_rate: RateMibPerSec(5),
             },
@@ -865,26 +833,26 @@ mod tests {
             .list_shards(&source_uid)
             .unwrap()
             .cloned()
-            .sorted_by_key(|shard_entry| shard_entry.shard.shard_id)
+            .sorted_unstable_by(|left, right| left.shard.shard_id.cmp(&right.shard.shard_id))
             .collect();
         assert_eq!(shard_entries.len(), 4);
 
-        assert_eq!(shard_entries[0].shard.shard_id, 1);
+        assert_eq!(shard_entries[0].shard.shard_id(), ShardId::from(1));
         assert_eq!(shard_entries[0].shard.shard_state(), ShardState::Open);
         assert_eq!(shard_entries[0].ingestion_rate, RateMibPerSec(1));
 
-        assert_eq!(shard_entries[1].shard.shard_id, 2);
+        assert_eq!(shard_entries[1].shard.shard_id(), ShardId::from(2));
         assert_eq!(shard_entries[1].shard.shard_state(), ShardState::Open);
         assert_eq!(shard_entries[1].ingestion_rate, RateMibPerSec(2));
 
-        assert_eq!(shard_entries[2].shard.shard_id, 3);
+        assert_eq!(shard_entries[2].shard.shard_id(), ShardId::from(3));
         assert_eq!(
             shard_entries[2].shard.shard_state(),
             ShardState::Unavailable
         );
         assert_eq!(shard_entries[2].ingestion_rate, RateMibPerSec(3));
 
-        assert_eq!(shard_entries[3].shard.shard_id, 4);
+        assert_eq!(shard_entries[3].shard.shard_id(), ShardId::from(4));
         assert_eq!(shard_entries[3].shard.shard_state(), ShardState::Closed);
         assert_eq!(shard_entries[3].ingestion_rate, RateMibPerSec(4));
     }
@@ -900,7 +868,7 @@ mod tests {
         let shard_01 = Shard {
             index_uid: index_uid_0.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
@@ -908,7 +876,7 @@ mod tests {
         let shard_02 = Shard {
             index_uid: index_uid_0.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 2,
+            shard_id: Some(ShardId::from(2)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Closed as i32,
             ..Default::default()
@@ -916,25 +884,23 @@ mod tests {
         let shard_11 = Shard {
             index_uid: index_uid_1.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
         };
-        shard_table.insert_newly_opened_shards(
-            &index_uid_0,
-            &source_id,
-            vec![shard_01, shard_02],
-            3,
-        );
-        shard_table.insert_newly_opened_shards(&index_uid_1, &source_id, vec![shard_11], 2);
+        shard_table.insert_newly_opened_shards(&index_uid_0, &source_id, vec![shard_01, shard_02]);
+        shard_table.insert_newly_opened_shards(&index_uid_1, &source_id, vec![shard_11]);
 
         let source_uid_0 = SourceUid {
             index_uid: index_uid_0,
             source_id,
         };
-        let closed_shard_ids = shard_table.close_shards(&source_uid_0, &[1, 2, 3]);
-        assert_eq!(closed_shard_ids, &[1]);
+        let closed_shard_ids = shard_table.close_shards(
+            &source_uid_0,
+            &[ShardId::from(1), ShardId::from(2), ShardId::from(3)],
+        );
+        assert_eq!(closed_shard_ids, &[ShardId::from(1)]);
 
         let table_entry = shard_table.table_entries.get(&source_uid_0).unwrap();
         let shards = table_entry.shards();
@@ -952,7 +918,7 @@ mod tests {
         let shard_01 = Shard {
             index_uid: index_uid_0.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
@@ -960,7 +926,7 @@ mod tests {
         let shard_02 = Shard {
             index_uid: index_uid_0.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 2,
+            shard_id: Some(ShardId::from(2)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
@@ -968,7 +934,7 @@ mod tests {
         let shard_11 = Shard {
             index_uid: index_uid_1.clone().into(),
             source_id: source_id.clone(),
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             leader_id: "test-leader-0".to_string(),
             shard_state: ShardState::Open as i32,
             ..Default::default()
@@ -977,21 +943,20 @@ mod tests {
             &index_uid_0,
             &source_id,
             vec![shard_01.clone(), shard_02],
-            3,
         );
-        shard_table.insert_newly_opened_shards(&index_uid_1, &source_id, vec![shard_11], 2);
+        shard_table.insert_newly_opened_shards(&index_uid_1, &source_id, vec![shard_11]);
 
         let source_uid_0 = SourceUid {
             index_uid: index_uid_0.clone(),
             source_id: source_id.clone(),
         };
-        shard_table.delete_shards(&source_uid_0, &[2]);
+        shard_table.delete_shards(&source_uid_0, &[ShardId::from(2)]);
 
         let source_uid_1 = SourceUid {
             index_uid: index_uid_1.clone(),
             source_id: source_id.clone(),
         };
-        shard_table.delete_shards(&source_uid_1, &[1]);
+        shard_table.delete_shards(&source_uid_1, &[ShardId::from(1)]);
 
         assert_eq!(shard_table.table_entries.len(), 2);
 
@@ -999,11 +964,9 @@ mod tests {
         let shards = table_entry.shards();
         assert_eq!(shards.len(), 1);
         assert_eq!(shards[0], shard_01);
-        assert_eq!(table_entry.next_shard_id, 3);
 
         let table_entry = shard_table.table_entries.get(&source_uid_1).unwrap();
         assert!(table_entry.is_empty());
-        assert_eq!(table_entry.next_shard_id, 2);
     }
 
     #[test]

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -523,7 +523,7 @@ impl IndexingService {
                 continue;
             };
             let assignment = Assignment {
-                shard_ids: task.shard_ids.iter().copied().collect(),
+                shard_ids: task.shard_ids.iter().cloned().collect(),
             };
             let message = AssignShards(assignment);
 
@@ -665,7 +665,7 @@ impl IndexingService {
                     .last_observation()
                     .shard_ids
                     .iter()
-                    .copied()
+                    .cloned()
                     .collect(),
             })
             .collect();

--- a/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
@@ -280,6 +280,7 @@ impl IngestSubworkbench {
 #[cfg(test)]
 mod tests {
     use quickwit_proto::ingest::ingester::PersistFailureReason;
+    use quickwit_proto::types::ShardId;
 
     use super::*;
 
@@ -487,7 +488,7 @@ mod tests {
 
         let persist_failure = PersistFailure {
             subrequest_id: 0,
-            shard_id: 1,
+            shard_id: Some(ShardId::from(1)),
             reason: PersistFailureReason::ResourceExhausted as i32,
             ..Default::default()
         };

--- a/quickwit/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit/quickwit-metastore/src/checkpoint.rs
@@ -46,6 +46,10 @@ impl PartitionId {
     pub fn as_u64(&self) -> Option<u64> {
         self.0.parse().ok()
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl fmt::Display for PartitionId {

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.expected.json
@@ -142,21 +142,6 @@
     ],
     "version": "0.7"
   },
-  "shards": {
-    "_ingest-source": {
-      "next_shard_id": 2,
-      "shards": [
-        {
-          "follower_id": "follower-ingester",
-          "index_uid": "my-index:00000000000000000000000000",
-          "leader_id": "leader-ingester",
-          "shard_id": 1,
-          "shard_state": 0,
-          "source_id": "_ingest-source"
-        }
-      ]
-    }
-  },
   "splits": [
     {
       "create_timestamp": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.6.json
@@ -142,21 +142,6 @@
     ],
     "version": "0.6"
   },
-  "shards": {
-    "_ingest-source": {
-      "next_shard_id": 2,
-      "shards": [
-        {
-          "follower_id": "follower-ingester",
-          "index_uid": "my-index:00000000000000000000000000",
-          "leader_id": "leader-ingester",
-          "shard_id": 1,
-          "shard_state": 0,
-          "source_id": "_ingest-source"
-        }
-      ]
-    }
-  },
   "splits": [
     {
       "create_timestamp": 3,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.7.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.7.expected.json
@@ -143,19 +143,17 @@
     "version": "0.7"
   },
   "shards": {
-    "_ingest-source": {
-      "next_shard_id": 2,
-      "shards": [
-        {
-          "follower_id": "follower-ingester",
-          "index_uid": "my-index:00000000000000000000000000",
-          "leader_id": "leader-ingester",
-          "shard_id": 1,
-          "shard_state": 0,
-          "source_id": "_ingest-source"
-        }
-      ]
-    }
+    "_ingest-source": [
+      {
+        "index_uid": "my-index:00000000000000000000000000",
+        "source_id": "_ingest-source",
+        "shard_id": "00000000000000000001",
+        "shard_state": 1,
+        "leader_id": "leader-ingester",
+        "follower_id": "follower-ingester",
+        "publish_position_inclusive": ""
+      }
+    ]
   },
   "splits": [
     {

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.7.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.7.json
@@ -143,19 +143,17 @@
     "version": "0.7"
   },
   "shards": {
-    "_ingest-source": {
-      "next_shard_id": 2,
-      "shards": [
-        {
-          "follower_id": "follower-ingester",
-          "index_uid": "my-index:00000000000000000000000000",
-          "leader_id": "leader-ingester",
-          "shard_id": 1,
-          "shard_state": 0,
-          "source_id": "_ingest-source"
-        }
-      ]
-    }
+    "_ingest-source": [
+      {
+        "index_uid": "my-index:00000000000000000000000000",
+        "source_id": "_ingest-source",
+        "shard_id": "00000000000000000001",
+        "shard_state": 1,
+        "leader_id": "leader-ingester",
+        "follower_id": "follower-ingester",
+        "publish_position_inclusive": ""
+      }
+    ]
   },
   "splits": [
     {

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -38,14 +38,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Indexing Service.
     let mut prost_config = prost_build::Config::default();
-    prost_config.extern_path(
-        ".quickwit.indexing.PipelineUid",
-        "crate::types::PipelineUid",
-    );
+    prost_config
+        .extern_path(
+            ".quickwit.indexing.PipelineUid",
+            "crate::types::PipelineUid",
+        )
+        .extern_path(".quickwit.ingest.ShardId", "crate::types::ShardId");
 
     Codegen::builder()
         .with_prost_config(prost_config)
         .with_protos(&["protos/quickwit/indexing.proto"])
+        .with_includes(&["protos"])
         .with_output_dir("src/codegen/quickwit")
         .with_result_type_path("crate::indexing::IndexingResult")
         .with_error_type_path("crate::indexing::IndexingError")
@@ -55,6 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Metastore service.
     let mut prost_config = prost_build::Config::default();
     prost_config
+        .extern_path(".quickwit.ingest.ShardId", "crate::types::ShardId")
         .field_attribute("DeleteQuery.index_uid", "#[serde(alias = \"index_id\")]")
         .field_attribute("DeleteQuery.query_ast", "#[serde(alias = \"query\")]")
         .field_attribute(
@@ -87,6 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "Position.position",
         ])
         .extern_path(".quickwit.ingest.Position", "crate::types::Position")
+        .extern_path(".quickwit.ingest.ShardId", "crate::types::ShardId")
         .type_attribute("Shard", "#[derive(Eq)]")
         .field_attribute(
             "Shard.follower_id",

--- a/quickwit/quickwit-proto/protos/quickwit/indexing.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/indexing.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 
 package quickwit.indexing;
 
+import "quickwit/ingest.proto";
+
 service IndexingService {
   // Apply an indexing plan on the node.
   rpc ApplyIndexingPlan(ApplyIndexingPlanRequest) returns (ApplyIndexingPlanResponse);
@@ -42,7 +44,7 @@ message IndexingTask {
   // pipeline id
   PipelineUid pipeline_uid = 4;
   // The shards assigned to the indexer.
-  repeated uint64 shard_ids = 3;
+  repeated quickwit.ingest.ShardId shard_ids = 3;
 }
 
 message ApplyIndexingPlanResponse {}

--- a/quickwit/quickwit-proto/protos/quickwit/ingest.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingest.proto
@@ -29,6 +29,14 @@ message Position {
   bytes position = 1;
 }
 
+// The corresponding Rust struct [`crate::types::ShardId`] is defined manually and
+// externally provided during code generation (see `build.rs`).
+//
+// Modify at your own risk.
+message ShardId {
+  bytes shard_id = 1;
+}
+
 enum CommitTypeV2 {
   COMMIT_TYPE_V2_UNSPECIFIED = 0;
   COMMIT_TYPE_V2_AUTO = 1;
@@ -63,7 +71,7 @@ message Shard {
   // Immutable fields
   string index_uid = 1;
   string source_id = 2;
-  uint64 shard_id = 3;
+  ShardId shard_id = 3;
   // The node ID of the ingester to which all the write requests for this shard should be sent to.
   string leader_id = 4;
   // The node ID of the ingester holding a copy of the data.
@@ -83,5 +91,5 @@ message Shard {
 message ShardIds {
   string index_uid = 1;
   string source_id = 2;
-  repeated uint64 shard_ids = 3;
+  repeated ShardId shard_ids = 3;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -61,7 +61,7 @@ service IngesterService {
 message RetainShardsForSource {
   string index_uid = 1;
   string source_id = 2;
-  repeated uint64 shard_ids = 3;
+  repeated quickwit.ingest.ShardId shard_ids = 3;
 }
 
 message RetainShardsRequest {
@@ -81,7 +81,7 @@ message PersistSubrequest {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   quickwit.ingest.DocBatchV2 doc_batch = 5;
 }
 
@@ -95,7 +95,7 @@ message PersistSuccess {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   quickwit.ingest.Position replication_position_inclusive = 5;
 }
 
@@ -111,7 +111,7 @@ message PersistFailure {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   PersistFailureReason reason = 5;
 }
 
@@ -165,7 +165,7 @@ message ReplicateSubrequest {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   quickwit.ingest.Position from_position_exclusive = 5;
   quickwit.ingest.Position to_position_inclusive = 6;
   ingest.DocBatchV2 doc_batch = 7;
@@ -183,7 +183,7 @@ message ReplicateSuccess {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   quickwit.ingest.Position replication_position_inclusive = 5;
 }
 
@@ -199,7 +199,7 @@ message ReplicateFailure {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   ReplicateFailureReason reason = 5;
 }
 
@@ -211,7 +211,7 @@ message TruncateShardsRequest {
 message TruncateShardsSubrequest {
   string index_uid = 1;
   string source_id = 2;
-  uint64 shard_id = 3;
+  quickwit.ingest.ShardId shard_id = 3;
   // The position up to which the shard should be truncated (inclusive).
   quickwit.ingest.Position truncate_up_to_position_inclusive = 4;
 }
@@ -224,7 +224,7 @@ message OpenFetchStreamRequest {
   string client_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   quickwit.ingest.Position from_position_exclusive = 5;
 }
 
@@ -238,7 +238,7 @@ message FetchMessage {
 message FetchPayload {
   string index_uid = 1;
   string source_id = 2;
-  uint64 shard_id = 3;
+  quickwit.ingest.ShardId shard_id = 3;
   quickwit.ingest.MRecordBatch mrecord_batch = 4;
   quickwit.ingest.Position from_position_exclusive = 5;
   quickwit.ingest.Position to_position_inclusive = 6;
@@ -247,7 +247,7 @@ message FetchPayload {
 message FetchEof {
   string index_uid = 1;
   string source_id = 2;
-  uint64 shard_id = 3;
+  quickwit.ingest.ShardId shard_id = 3;
   quickwit.ingest.Position eof_position = 4;
 }
 

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -323,9 +323,9 @@ message OpenShardsSubrequest {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  string leader_id = 4;
-  optional string follower_id = 5;
-  uint64 next_shard_id = 6;
+  quickwit.ingest.ShardId shard_id = 4;
+  string leader_id = 5;
+  optional string follower_id = 6;
 }
 
 message OpenShardsResponse {
@@ -337,7 +337,6 @@ message OpenShardsSubresponse {
   string index_uid = 2;
   string source_id = 3;
   repeated quickwit.ingest.Shard opened_shards = 4;
-  uint64 next_shard_id = 5;
 }
 
 message AcquireShardsRequest {
@@ -347,7 +346,7 @@ message AcquireShardsRequest {
 message AcquireShardsSubrequest {
   string index_uid = 1;
   string source_id = 2;
-  repeated uint64 shard_ids = 3;
+  repeated quickwit.ingest.ShardId shard_ids = 3;
   string publish_token = 4;
 }
 
@@ -370,7 +369,7 @@ message DeleteShardsRequest {
 message DeleteShardsSubrequest {
   string index_uid = 1;
   string source_id = 2;
-  repeated uint64 shard_ids = 3;
+  repeated quickwit.ingest.ShardId shard_ids = 3;
 }
 
 message DeleteShardsResponse {
@@ -394,5 +393,4 @@ message ListShardsSubresponse {
   string index_uid = 1;
   string source_id = 2;
   repeated quickwit.ingest.Shard shards = 3;
-  uint64 next_shard_id = 4;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/router.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/router.proto
@@ -53,7 +53,7 @@ message IngestSuccess {
   uint32 subrequest_id = 1;
   string index_uid = 2;
   string source_id = 3;
-  uint64 shard_id = 4;
+  quickwit.ingest.ShardId shard_id = 4;
   // Replication position inclusive.
   quickwit.ingest.Position replication_position_inclusive = 5;
 }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.indexing.rs
@@ -19,8 +19,8 @@ pub struct IndexingTask {
     #[prost(message, optional, tag = "4")]
     pub pipeline_uid: ::core::option::Option<crate::types::PipelineUid>,
     /// The shards assigned to the indexer.
-    #[prost(uint64, repeated, tag = "3")]
-    pub shard_ids: ::prost::alloc::vec::Vec<u64>,
+    #[prost(message, repeated, tag = "3")]
+    pub shard_ids: ::prost::alloc::vec::Vec<crate::types::ShardId>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -6,8 +6,8 @@ pub struct RetainShardsForSource {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, repeated, tag = "3")]
-    pub shard_ids: ::prost::alloc::vec::Vec<u64>,
+    #[prost(message, repeated, tag = "3")]
+    pub shard_ids: ::prost::alloc::vec::Vec<crate::types::ShardId>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -41,8 +41,8 @@ pub struct PersistSubrequest {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "5")]
     pub doc_batch: ::core::option::Option<super::DocBatchV2>,
 }
@@ -67,8 +67,8 @@ pub struct PersistSuccess {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "5")]
     pub replication_position_inclusive: ::core::option::Option<crate::types::Position>,
 }
@@ -82,8 +82,8 @@ pub struct PersistFailure {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(enumeration = "PersistFailureReason", tag = "5")]
     pub reason: i32,
 }
@@ -193,8 +193,8 @@ pub struct ReplicateSubrequest {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "5")]
     pub from_position_exclusive: ::core::option::Option<crate::types::Position>,
     #[prost(message, optional, tag = "6")]
@@ -226,8 +226,8 @@ pub struct ReplicateSuccess {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "5")]
     pub replication_position_inclusive: ::core::option::Option<crate::types::Position>,
 }
@@ -241,8 +241,8 @@ pub struct ReplicateFailure {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(enumeration = "ReplicateFailureReason", tag = "5")]
     pub reason: i32,
 }
@@ -263,8 +263,8 @@ pub struct TruncateShardsSubrequest {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "3")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "3")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     /// The position up to which the shard should be truncated (inclusive).
     #[prost(message, optional, tag = "4")]
     pub truncate_up_to_position_inclusive: ::core::option::Option<
@@ -286,8 +286,8 @@ pub struct OpenFetchStreamRequest {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "5")]
     pub from_position_exclusive: ::core::option::Option<crate::types::Position>,
 }
@@ -319,8 +319,8 @@ pub struct FetchPayload {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "3")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "3")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "4")]
     pub mrecord_batch: ::core::option::Option<super::MRecordBatch>,
     #[prost(message, optional, tag = "5")]
@@ -336,8 +336,8 @@ pub struct FetchEof {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "3")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "3")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "4")]
     pub eof_position: ::core::option::Option<crate::types::Position>,
 }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
@@ -42,8 +42,8 @@ pub struct IngestSuccess {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "4")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     /// Replication position inclusive.
     #[prost(message, optional, tag = "5")]
     pub replication_position_inclusive: ::core::option::Option<crate::types::Position>,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
@@ -28,8 +28,8 @@ pub struct Shard {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "3")]
-    pub shard_id: u64,
+    #[prost(message, optional, tag = "3")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
     /// The node ID of the ingester to which all the write requests for this shard should be sent to.
     #[prost(string, tag = "4")]
     pub leader_id: ::prost::alloc::string::String,
@@ -60,8 +60,8 @@ pub struct ShardIds {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, repeated, tag = "3")]
-    pub shard_ids: ::prost::alloc::vec::Vec<u64>,
+    #[prost(message, repeated, tag = "3")]
+    pub shard_ids: ::prost::alloc::vec::Vec<crate::types::ShardId>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -263,12 +263,12 @@ pub struct OpenShardsSubrequest {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "4")]
+    #[prost(message, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<crate::types::ShardId>,
+    #[prost(string, tag = "5")]
     pub leader_id: ::prost::alloc::string::String,
-    #[prost(string, optional, tag = "5")]
+    #[prost(string, optional, tag = "6")]
     pub follower_id: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(uint64, tag = "6")]
-    pub next_shard_id: u64,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -289,8 +289,6 @@ pub struct OpenShardsSubresponse {
     pub source_id: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "4")]
     pub opened_shards: ::prost::alloc::vec::Vec<super::ingest::Shard>,
-    #[prost(uint64, tag = "5")]
-    pub next_shard_id: u64,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -307,8 +305,8 @@ pub struct AcquireShardsSubrequest {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, repeated, tag = "3")]
-    pub shard_ids: ::prost::alloc::vec::Vec<u64>,
+    #[prost(message, repeated, tag = "3")]
+    pub shard_ids: ::prost::alloc::vec::Vec<crate::types::ShardId>,
     #[prost(string, tag = "4")]
     pub publish_token: ::prost::alloc::string::String,
 }
@@ -348,8 +346,8 @@ pub struct DeleteShardsSubrequest {
     pub index_uid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source_id: ::prost::alloc::string::String,
-    #[prost(uint64, repeated, tag = "3")]
-    pub shard_ids: ::prost::alloc::vec::Vec<u64>,
+    #[prost(message, repeated, tag = "3")]
+    pub shard_ids: ::prost::alloc::vec::Vec<crate::types::ShardId>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -390,8 +388,6 @@ pub struct ListShardsSubresponse {
     pub source_id: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "3")]
     pub shards: ::prost::alloc::vec::Vec<super::ingest::Shard>,
-    #[prost(uint64, tag = "4")]
-    pub next_shard_id: u64,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]

--- a/quickwit/quickwit-proto/src/indexing/mod.rs
+++ b/quickwit/quickwit-proto/src/indexing/mod.rs
@@ -340,7 +340,7 @@ impl Event for ShardPositionsUpdate {}
 impl IndexingTask {
     pub fn pipeline_uid(&self) -> PipelineUid {
         self.pipeline_uid
-            .expect("Pipeline UID should always be present.")
+            .expect("`pipeline_uid` should be a required field")
     }
 }
 

--- a/quickwit/quickwit-proto/src/ingest/ingester.rs
+++ b/quickwit/quickwit-proto/src/ingest/ingester.rs
@@ -17,11 +17,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::types::{queue_id, Position, QueueId};
+use crate::types::{queue_id, Position, QueueId, ShardId};
 
 include!("../codegen/quickwit/quickwit.ingest.ingester.rs");
 
 pub use ingester_service_grpc_server::IngesterServiceGrpcServer;
+
+impl FetchEof {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
+    }
+}
 
 impl FetchMessage {
     pub fn new_payload(payload: FetchPayload) -> Self {
@@ -48,8 +56,14 @@ impl FetchMessage {
 }
 
 impl FetchPayload {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
+    }
+
     pub fn queue_id(&self) -> QueueId {
-        queue_id(&self.index_uid, &self.source_id, self.shard_id)
+        queue_id(&self.index_uid, &self.source_id, self.shard_id())
     }
 
     pub fn num_mrecords(&self) -> usize {
@@ -60,40 +74,74 @@ impl FetchPayload {
         }
     }
 
-    pub fn from_position_exclusive(&self) -> Position {
-        self.from_position_exclusive.clone().unwrap_or_default()
+    pub fn from_position_exclusive(&self) -> &Position {
+        self.from_position_exclusive
+            .as_ref()
+            .expect("`from_position_exclusive` should be a required field")
     }
 
-    pub fn to_position_inclusive(&self) -> Position {
-        self.to_position_inclusive.clone().unwrap_or_default()
+    pub fn to_position_inclusive(&self) -> &Position {
+        self.to_position_inclusive
+            .as_ref()
+            .expect("`to_position_inclusive` should be a required field")
     }
 }
 
 impl FetchEof {
-    pub fn eof_position(&self) -> Position {
-        self.eof_position.clone().unwrap_or_default()
+    pub fn eof_position(&self) -> &Position {
+        self.eof_position
+            .as_ref()
+            .expect("`eof_position` should be a required field")
     }
 }
 
 impl OpenFetchStreamRequest {
-    pub fn queue_id(&self) -> QueueId {
-        queue_id(&self.index_uid, &self.source_id, self.shard_id)
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
     }
 
-    pub fn from_position_exclusive(&self) -> Position {
-        self.from_position_exclusive.clone().unwrap_or_default()
+    pub fn queue_id(&self) -> QueueId {
+        queue_id(&self.index_uid, &self.source_id, self.shard_id())
+    }
+
+    pub fn from_position_exclusive(&self) -> &Position {
+        self.from_position_exclusive
+            .as_ref()
+            .expect("`from_position_exclusive` should be a required field")
     }
 }
 
 impl PersistSubrequest {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
+    }
+
     pub fn queue_id(&self) -> QueueId {
-        queue_id(&self.index_uid, &self.source_id, self.shard_id)
+        queue_id(&self.index_uid, &self.source_id, self.shard_id())
     }
 }
 
 impl PersistSuccess {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
+    }
+
     pub fn queue_id(&self) -> QueueId {
-        queue_id(&self.index_uid, &self.source_id, self.shard_id)
+        queue_id(&self.index_uid, &self.source_id, self.shard_id())
+    }
+}
+
+impl PersistFailure {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
     }
 }
 
@@ -164,35 +212,65 @@ impl AckReplicationMessage {
 }
 
 impl ReplicateSubrequest {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
+    }
+
     pub fn queue_id(&self) -> QueueId {
-        queue_id(&self.index_uid, &self.source_id, self.shard_id)
+        queue_id(&self.index_uid, &self.source_id, self.shard_id())
     }
 
-    pub fn from_position_exclusive(&self) -> Position {
-        self.from_position_exclusive.clone().unwrap_or_default()
+    pub fn from_position_exclusive(&self) -> &Position {
+        self.from_position_exclusive
+            .as_ref()
+            .expect("`from_position_exclusive` should be a required field")
     }
 
-    pub fn to_position_inclusive(&self) -> Position {
-        self.to_position_inclusive.clone().unwrap_or_default()
+    pub fn to_position_inclusive(&self) -> &Position {
+        self.to_position_inclusive
+            .as_ref()
+            .expect("`to_position_inclusive` should be a required field")
     }
 }
 
 impl ReplicateSuccess {
-    pub fn replication_position_inclusive(&self) -> Position {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
+    }
+
+    pub fn replication_position_inclusive(&self) -> &Position {
         self.replication_position_inclusive
-            .clone()
-            .unwrap_or_default()
+            .as_ref()
+            .expect("`replication_position_inclusive` should be a required field")
+    }
+}
+
+impl ReplicateFailure {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
     }
 }
 
 impl TruncateShardsSubrequest {
-    pub fn queue_id(&self) -> QueueId {
-        queue_id(&self.index_uid, &self.source_id, self.shard_id)
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
     }
 
-    pub fn truncate_up_to_position_inclusive(&self) -> Position {
+    pub fn queue_id(&self) -> QueueId {
+        queue_id(&self.index_uid, &self.source_id, self.shard_id())
+    }
+
+    pub fn truncate_up_to_position_inclusive(&self) -> &Position {
         self.truncate_up_to_position_inclusive
-            .clone()
-            .unwrap_or_default()
+            .as_ref()
+            .expect("`truncate_up_to_position_inclusive` should be a required field")
     }
 }

--- a/quickwit/quickwit-proto/src/ingest/mod.rs
+++ b/quickwit/quickwit-proto/src/ingest/mod.rs
@@ -195,6 +195,12 @@ impl MRecordBatch {
 }
 
 impl Shard {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
+    }
+
     pub fn is_open(&self) -> bool {
         self.shard_state().is_open()
     }
@@ -208,11 +214,13 @@ impl Shard {
     }
 
     pub fn queue_id(&self) -> super::types::QueueId {
-        queue_id(&self.index_uid, &self.source_id, self.shard_id)
+        queue_id(&self.index_uid, &self.source_id, self.shard_id())
     }
 
-    pub fn publish_position_inclusive(&self) -> Position {
-        self.publish_position_inclusive.clone().unwrap_or_default()
+    pub fn publish_position_inclusive(&self) -> &Position {
+        self.publish_position_inclusive
+            .as_ref()
+            .expect("`publish_position_inclusive` should be a required field")
     }
 }
 
@@ -253,7 +261,7 @@ impl ShardIds {
     pub fn queue_ids(&self) -> impl Iterator<Item = QueueId> + '_ {
         self.shard_ids
             .iter()
-            .map(|shard_id| queue_id(&self.index_uid, &self.source_id, *shard_id))
+            .map(|shard_id| queue_id(&self.index_uid, &self.source_id, shard_id))
     }
 }
 

--- a/quickwit/quickwit-proto/src/metastore/mod.rs
+++ b/quickwit/quickwit-proto/src/metastore/mod.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use quickwit_common::retry::Retryable;
 use serde::{Deserialize, Serialize};
 
-use crate::types::{IndexId, IndexUid, QueueId, SourceId, SplitId};
+use crate::types::{IndexId, IndexUid, QueueId, ShardId, SourceId, SplitId};
 use crate::{ServiceError, ServiceErrorCode};
 
 pub mod events;
@@ -112,9 +112,6 @@ pub enum MetastoreError {
     #[error("access forbidden: {message}")]
     Forbidden { message: String },
 
-    #[error("control plane state is inconsistent with that of the metastore")]
-    InconsistentControlPlaneState,
-
     #[error("internal error: {message}; cause: `{cause}`")]
     Internal { message: String, cause: String },
 
@@ -178,7 +175,6 @@ impl ServiceError for MetastoreError {
             Self::Db { .. } => ServiceErrorCode::Internal,
             Self::FailedPrecondition { .. } => ServiceErrorCode::BadRequest,
             Self::Forbidden { .. } => ServiceErrorCode::MethodNotAllowed,
-            Self::InconsistentControlPlaneState { .. } => ServiceErrorCode::BadRequest,
             Self::Internal { .. } => ServiceErrorCode::Internal,
             Self::InvalidArgument { .. } => ServiceErrorCode::BadRequest,
             Self::Io { .. } => ServiceErrorCode::Internal,
@@ -304,5 +300,13 @@ impl ListIndexesMetadataRequest {
         ListIndexesMetadataRequest {
             index_id_patterns: vec!["*".to_string()],
         }
+    }
+}
+
+impl OpenShardsSubrequest {
+    pub fn shard_id(&self) -> &ShardId {
+        self.shard_id
+            .as_ref()
+            .expect("`shard_id` should be a required field")
     }
 }

--- a/quickwit/quickwit-proto/src/types/mod.rs
+++ b/quickwit/quickwit-proto/src/types/mod.rs
@@ -30,17 +30,17 @@ pub use ulid::Ulid;
 
 mod pipeline_uid;
 mod position;
+mod shard_id;
 
 pub use pipeline_uid::PipelineUid;
 pub use position::Position;
+pub use shard_id::ShardId;
 
 pub type IndexId = String;
 
 pub type SourceId = String;
 
 pub type SplitId = String;
-
-pub type ShardId = u64;
 
 pub type SubrequestId = u32;
 
@@ -50,16 +50,20 @@ pub type PublishToken = String;
 /// Uniquely identifies a shard and its underlying mrecordlog queue.
 pub type QueueId = String; // <index_uid>/<source_id>/<shard_id>
 
-pub fn queue_id(index_uid: &str, source_id: &str, shard_id: u64) -> QueueId {
-    format!("{}/{}/{}", index_uid, source_id, shard_id)
+pub fn queue_id(index_uid: &str, source_id: &str, shard_id: &ShardId) -> QueueId {
+    format!("{index_uid}/{source_id}/{shard_id}")
 }
 
 pub fn split_queue_id(queue_id: &str) -> Option<(IndexUid, SourceId, ShardId)> {
     let mut parts = queue_id.split('/');
     let index_uid = parts.next()?;
     let source_id = parts.next()?;
-    let shard_id = parts.next()?.parse::<u64>().ok()?;
-    Some((index_uid.into(), source_id.to_string(), shard_id))
+    let shard_id = parts.next()?;
+    Some((
+        index_uid.into(),
+        source_id.to_string(),
+        ShardId::from(shard_id),
+    ))
 }
 
 /// Index identifiers that uniquely identify not only the index, but also
@@ -397,8 +401,8 @@ mod tests {
     #[test]
     fn test_queue_id() {
         assert_eq!(
-            queue_id("test-index:0", "test-source", 1),
-            "test-index:0/test-source/1"
+            queue_id("test-index:0", "test-source", &ShardId::from(1u64)),
+            "test-index:0/test-source/00000000000000000001"
         );
     }
 
@@ -410,14 +414,11 @@ mod tests {
         let splits = split_queue_id("test-index:0/test-source");
         assert!(splits.is_none());
 
-        let splits = split_queue_id("test-index:0/test-source/a");
-        assert!(splits.is_none());
-
         let (index_uid, source_id, shard_id) =
-            split_queue_id("test-index:0/test-source/1").unwrap();
+            split_queue_id("test-index:0/test-source/00000000000000000001").unwrap();
         assert_eq!(index_uid, "test-index:0");
         assert_eq!(source_id, "test-source");
-        assert_eq!(shard_id, 1);
+        assert_eq!(shard_id, ShardId::from(1u64));
     }
 
     #[test]

--- a/quickwit/quickwit-proto/src/types/position.rs
+++ b/quickwit/quickwit-proto/src/types/position.rs
@@ -223,6 +223,13 @@ impl<'de> Deserialize<'de> for Position {
     }
 }
 
+impl PartialEq<Position> for &Position {
+    #[inline]
+    fn eq(&self, other: &Position) -> bool {
+        *self == other
+    }
+}
+
 impl prost::Message for Position {
     fn encode_raw<B>(&self, buf: &mut B)
     where B: prost::bytes::BufMut {

--- a/quickwit/quickwit-proto/src/types/shard_id.rs
+++ b/quickwit/quickwit-proto/src/types/shard_id.rs
@@ -1,0 +1,168 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt;
+use std::fmt::Debug;
+
+use bytestring::ByteString;
+use prost::DecodeError;
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+/// Shard ID.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ShardId(ByteString);
+
+impl ShardId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn as_u64(&self) -> Option<u64> {
+        self.0.parse().ok()
+    }
+}
+
+impl fmt::Display for ShardId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl From<&str> for ShardId {
+    fn from(shard_id: &str) -> Self {
+        Self(ByteString::from(shard_id))
+    }
+}
+
+impl From<String> for ShardId {
+    fn from(shard_id: String) -> Self {
+        Self(ByteString::from(shard_id))
+    }
+}
+
+impl From<u64> for ShardId {
+    fn from(shard_id: u64) -> Self {
+        Self(ByteString::from(format!("{shard_id:0>20}")))
+    }
+}
+
+impl From<Ulid> for ShardId {
+    fn from(shard_id: Ulid) -> Self {
+        Self(ByteString::from(shard_id.to_string()))
+    }
+}
+
+impl Serialize for ShardId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for ShardId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let shard_id = String::deserialize(deserializer)?;
+        Ok(Self::from(shard_id))
+    }
+}
+
+impl prost::Message for ShardId {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where B: prost::bytes::BufMut {
+        prost::encoding::bytes::encode(1u32, &self.0.as_bytes().clone(), buf);
+    }
+
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: prost::encoding::WireType,
+        buf: &mut B,
+        ctx: prost::encoding::DecodeContext,
+    ) -> ::core::result::Result<(), prost::DecodeError>
+    where
+        B: prost::bytes::Buf,
+    {
+        const STRUCT_NAME: &str = "ShardId";
+
+        match tag {
+            1u32 => {
+                let mut value = Vec::new();
+                prost::encoding::bytes::merge(wire_type, &mut value, buf, ctx).map_err(
+                    |mut error| {
+                        error.push(STRUCT_NAME, "position");
+                        error
+                    },
+                )?;
+                let byte_string = ByteString::try_from(value)
+                    .map_err(|_| DecodeError::new("shard_id is not valid UTF-8"))?;
+                *self = Self(byte_string);
+                Ok(())
+            }
+            _ => prost::encoding::skip_field(wire_type, tag, buf, ctx),
+        }
+    }
+
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        prost::encoding::bytes::encoded_len(1u32, &self.0.as_bytes().clone())
+    }
+
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
+}
+
+impl PartialEq<ShardId> for &ShardId {
+    #[inline]
+    fn eq(&self, other: &ShardId) -> bool {
+        *self == other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use bytes::Bytes;
+    use prost::Message;
+
+    use super::*;
+
+    #[test]
+    fn test_shard_id_json_serde_roundtrip() {
+        let serialized = serde_json::to_string(&ShardId::from(0)).unwrap();
+        assert_eq!(serialized, r#""00000000000000000000""#);
+        let deserialized: ShardId = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, ShardId::from(0));
+    }
+
+    #[test]
+    fn test_shard_id_prost_serde_roundtrip() {
+        let ulid = Ulid::new();
+        let encoded = ShardId::from(ulid).encode_to_vec();
+        assert_eq!(
+            ShardId::decode(Bytes::from(encoded)).unwrap(),
+            ShardId::from(ulid)
+        );
+        let encoded = ShardId::from(ulid).encode_length_delimited_to_vec();
+        assert_eq!(
+            ShardId::decode_length_delimited(Bytes::from(encoded)).unwrap(),
+            ShardId::from(ulid)
+        );
+    }
+}

--- a/quickwit/quickwit-serve/src/elastic_search_api/bulk_v2.rs
+++ b/quickwit/quickwit-serve/src/elastic_search_api/bulk_v2.rs
@@ -103,7 +103,7 @@ mod tests {
     use quickwit_proto::ingest::router::{
         IngestFailure, IngestFailureReason, IngestResponseV2, IngestSuccess,
     };
-    use quickwit_proto::types::Position;
+    use quickwit_proto::types::{Position, ShardId};
     use warp::{Filter, Rejection, Reply};
 
     use super::*;
@@ -164,14 +164,14 @@ mod tests {
                             subrequest_id: 0,
                             index_uid: "my-index-1:0".to_string(),
                             source_id: INGEST_V2_SOURCE_ID.to_string(),
-                            shard_id: 1,
+                            shard_id: Some(ShardId::from(1)),
                             replication_position_inclusive: Some(Position::offset(1u64)),
                         },
                         IngestSuccess {
                             subrequest_id: 1,
                             index_uid: "my-index-2:0".to_string(),
                             source_id: INGEST_V2_SOURCE_ID.to_string(),
-                            shard_id: 1,
+                            shard_id: Some(ShardId::from(1)),
                             replication_position_inclusive: Some(Position::offset(0u64)),
                         },
                     ],
@@ -247,7 +247,7 @@ mod tests {
                         subrequest_id: 0,
                         index_uid: "my-index-1:0".to_string(),
                         source_id: INGEST_V2_SOURCE_ID.to_string(),
-                        shard_id: 1,
+                        shard_id: Some(ShardId::from(1)),
                         replication_position_inclusive: Some(Position::offset(0u64)),
                     }],
                     failures: Vec::new(),


### PR DESCRIPTION
The idea is to use an `Ulid` instead of a sequential `u64` to implement the Shard API for the PostgreSQL metastore (see design doc)

~~It also replaces `PartitionId` with `ShardId`, which paves the way for unifying the Checkpoint v1 and v2 APIs in the future.~~

Todo:
- [ ] ~~remove `PartitionId`~~
