### PR TITLE
Experimental UI : Trace explorer

### DIFF
--- a/quickwit/quickwit-ui/config-overrides.js
+++ b/quickwit/quickwit-ui/config-overrides.js
@@ -17,12 +17,27 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+const path = require('path');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
-module.exports = function override(config, env) {
+function monaco(config) {
   config.plugins.push(new MonacoWebpackPlugin({
     languages: ['json']
   }));
   return config;
 }
 
+const {alias, aliasJest, configPaths} = require('react-app-rewire-alias')
+const aliasMap = configPaths('./tsconfig.paths.json') // or jsconfig.paths.json
+
+module.exports = function override(config) {
+  config = alias(aliasMap)(config);
+  config = monaco(config);
+  return config
+}
+
+module.exports.jest = function override(config) {
+  config = aliasJest(aliasMap)(config);
+  return config
+
+}

--- a/quickwit/quickwit-ui/package.json
+++ b/quickwit/quickwit-ui/package.json
@@ -36,6 +36,7 @@
     "swagger-ui-react": "^5.9.0",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
+    "zod": "^3.22.4"
   },
   "resolutions": {
     "@types/react": "17.0.20",

--- a/quickwit/quickwit-ui/package.json
+++ b/quickwit/quickwit-ui/package.json
@@ -20,6 +20,10 @@
     "@types/swagger-ui-react": "^4.18.2",
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",
+    "@visx/visx": "^3.6.1",
+    "d3": "^7.8.5",
+    "d3-cloud": "^1.2.7",
+    "d3-sankey": "^0.12.3",
     "dayjs": "^1.11.7",
     "monaco-editor": "^0.34.1",
     "monaco-editor-webpack-plugin": "^7.0.1",
@@ -31,11 +35,12 @@
     "react-number-format": "^4.9.3",
     "react-router-dom": "6",
     "react-scripts": "~5.0.1",
+    "react-spring": "^9.7.3",
     "styled-components": "^5.3.6",
     "styled-icons": "^10.47.0",
     "swagger-ui-react": "^5.9.0",
     "typescript": "^4.4.2",
-    "web-vitals": "^2.1.0"
+    "web-vitals": "^2.1.0",
     "zod": "^3.22.4"
   },
   "resolutions": {

--- a/quickwit/quickwit-ui/package.json
+++ b/quickwit/quickwit-ui/package.json
@@ -74,6 +74,7 @@
     "@testing-library/user-event": "^14.5.1",
     "cypress": "13.3.2",
     "jest": "^29.7.0",
+    "react-app-rewire-alias": "^1.1.7",
     "ts-jest": "^29.1.1"
   },
   "jest": {

--- a/quickwit/quickwit-ui/src/components/SideBar.tsx
+++ b/quickwit/quickwit-ui/src/components/SideBar.tsx
@@ -92,6 +92,10 @@ const SideBar = () => {
           <ListItemLink to="/cluster" primary={<Typography variant="body1">Cluster</Typography>} icon={<GroupWork size="18px" />} />
           <ListItemLink to="/node-info" primary={<Typography variant="body1">Node info</Typography>} icon={<Settings size="18px" />} />
           <ListItemLink to="/api-playground" primary={<Typography variant="body1">API </Typography>} icon={<CodeSSlash size="18px" />} />
+        <ListSubheader sx={{lineHeight: '25px', paddingTop: '10px'}}>
+          <Typography variant="body1">Experimental</Typography>
+        </ListSubheader>
+          <ListItemLink to="/traces" primary={<Typography variant="body1">Traces</Typography>} icon={<GroupWork size="18px" />} />
       </List>
     </SideBarWrapper>
   );

--- a/quickwit/quickwit-ui/src/components/TimeRangeSelect.tsx
+++ b/quickwit/quickwit-ui/src/components/TimeRangeSelect.tsx
@@ -27,8 +27,10 @@ import {
   ListItemIcon,
   ListItemText,
   Popover,
+  SxProps,
   TextField,
   TextFieldProps,
+  Theme,
 } from "@mui/material";
 import { AccessTime, ChevronRight, DateRange } from "@mui/icons-material";
 import { Dayjs, default as dayjs } from 'dayjs';
@@ -52,7 +54,7 @@ const TIME_RANGE_CHOICES = [
   ["Last year", 365 * 24 * 60 * 60],
 ];
 
-type TimeRange = {
+export type TimeRange = {
   startTimestamp: number | null,
   endTimestamp: number | null,
 }
@@ -60,6 +62,8 @@ type TimeRange = {
 export interface TimeRangeSelectProps {
   timeRange: TimeRange;
   disabled?: boolean;
+  variant?: "contained" | "outlined",
+  sx?: SxProps<Theme>,
   onUpdate(newTimeRange:TimeRange): void;
 }
 
@@ -69,7 +73,13 @@ interface TimeRangeSelectState {
   width: number;
 }
 
-export function TimeRangeSelect(props: TimeRangeSelectProps): JSX.Element {
+export function TimeRangeSelect(argProps: TimeRangeSelectProps): JSX.Element {
+  // Set defaut props
+  const [props, setProps] = useState<TimeRangeSelectProps>(argProps)
+  useEffect(()=>{
+    setProps({...{variant:'contained'}, ...argProps});
+  }, [argProps])
+
   const getInitialState = () => {return {width: 220, anchor: null, customDatesPanelOpen: false}};
   const initialState = useMemo(() => {return getInitialState(); }, []);
   const [state, setState] = useState<TimeRangeSelectState>(initialState);
@@ -113,9 +123,10 @@ export function TimeRangeSelect(props: TimeRangeSelectProps): JSX.Element {
   const id = open ? "time-range-select-popover" : undefined;
 
   return (
-    <div>
+    <Box sx={props.sx}>
       <Button
-        variant="contained"
+        sx={{width:'inherit'}}
+        variant={props.variant}
         disableElevation
         onClick={handleOpenClick}
         startIcon={<AccessTime />}
@@ -179,7 +190,7 @@ export function TimeRangeSelect(props: TimeRangeSelectProps): JSX.Element {
           </Box>
         </Box>
       </Popover>
-    </div>
+    </Box>
   );
 }
 

--- a/quickwit/quickwit-ui/src/services/base.ts
+++ b/quickwit/quickwit-ui/src/services/base.ts
@@ -1,0 +1,40 @@
+export class BaseApiClient {
+  protected readonly _host: string;
+  protected readonly _apiRoot: string;
+  constructor(host?:string, apiRoot?:string) {
+    this._host = host ? host : window.location.origin;
+    this._apiRoot = apiRoot ? apiRoot : "/api/v1/";
+  }
+
+  get baseURL(): string {
+    return this._host + this._apiRoot;
+  }
+
+  getURL(url:string): URL {
+    return new URL(this.baseURL+url);
+  }
+
+  protected getDefaultGetRequestParams(): RequestInit {
+    return {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      mode: "no-cors",
+      cache: "default",
+    };
+  }
+
+  async fetch<T>(url: URL|string, params: RequestInit): Promise<T> {
+    const _url = new URL(url, this.baseURL)
+
+    const response = await fetch(_url.href, params);
+    if (response.ok) {
+      return response.json() as Promise<T>;
+    }
+    const message = await response.text();
+    return await Promise.reject({
+      message: message,
+      status: response.status
+    });
+  }
+
+}

--- a/quickwit/quickwit-ui/src/services/jaeger_api.client.ts
+++ b/quickwit/quickwit-ui/src/services/jaeger_api.client.ts
@@ -1,0 +1,102 @@
+import { BaseApiClient } from "./base";
+
+import { z } from "zod";
+
+export type ServiceList = string[];
+export type ServiceOperationsList = string[];
+export interface TraceRequestParams {
+  service: string,
+  operation?: string,
+  tags?: string,
+  start?: number,
+  end?: number,
+  limit?: number,
+}
+
+//  Validators
+
+const HexString = z.string().regex(/^[0-9A-Fa-f]*$/).brand<"HexString">();
+
+const Span = z.object({
+  spanID: HexString,
+  processID: z.string(),
+  references: z.array(z.object({
+    traceID: HexString,
+    spanID: HexString,
+    refType: z.string(),
+  })),
+  operationName: z.string(),
+  startTime: z.number().transform((v)=>Math.floor(v/1000)).pipe(z.coerce.date()),
+  duration: z.number().transform((v)=>Math.ceil(v/1000)),
+}).transform(({operationName, ...rest})=>({
+  operation:operationName,
+  ...rest
+}))
+export type Span = z.infer<typeof Span>
+
+const Trace = z.object({
+  traceID: HexString,
+  // XXX : naive sorting 
+  spans: z.array(Span),
+  processes: z.object({}).catchall(
+    z.object({ serviceName: z.string() }).transform(({serviceName})=>({service:serviceName}))
+  )
+})
+export type Trace = z.infer<typeof Trace>
+
+
+const JaegerAPIResponse = z.object({
+  data:z.union([z.array(z.string()), z.array(Trace), Trace])
+})
+export type JaegerAPIResponse = z.infer<typeof JaegerAPIResponse>
+
+
+export class JaegerAPIClient extends BaseApiClient {
+  private readonly _source: string
+  constructor(source:string, host?:string, apiRoot?:string) {
+    super(host, apiRoot)
+    this._source = source;
+  }
+
+  get baseURL(): string {
+    return `${super.baseURL}/${ this._source}/jaeger/api/`;
+  }
+
+  // NOTE : client boilerplate, should be abstracted out
+  // Endpoint handlers
+
+  async getServices(): Promise<ServiceList> {
+    return await this.fetch(`./services`, this.getDefaultGetRequestParams())
+    .then(
+      (response)=>{return (response as JaegerAPIResponse).data as ServiceList}
+    )
+  }
+
+  async getServiceOperations(service:string): Promise<ServiceOperationsList> {
+    return await this.fetch(`./services/${service}/operations`, this.getDefaultGetRequestParams())
+    .then(
+      (response)=>{return (response as JaegerAPIResponse).data as ServiceOperationsList}
+    )
+  }
+
+  async getTraces(traceParams:TraceRequestParams): Promise<Trace[]> {
+    const url = this.getURL(`./traces?`);
+    if (traceParams.service) url.searchParams.append("service", traceParams.service)
+    if (traceParams.operation) url.searchParams.append("operation", traceParams.operation)
+    if (traceParams.start) url.searchParams.append("start", traceParams.start.toString())
+    if (traceParams.end) url.searchParams.append("end", traceParams.end.toString())
+    if (traceParams.tags) url.searchParams.append("tags", traceParams.tags.toString())
+    if (traceParams.limit) url.searchParams.append("limit", traceParams.limit.toString())
+
+    return await this.fetch(url, this.getDefaultGetRequestParams())
+    .then(
+      (response)=>{return JaegerAPIResponse.parse((response as JaegerAPIResponse)).data as Trace[]}
+    )
+  }
+
+  async getTrace(traceID:string): Promise<Trace> {
+    return await this.fetch(`./traces/${traceID}`, this.getDefaultGetRequestParams())
+    .then((response)=>((response as JaegerAPIResponse).data) as Trace)
+
+  }
+}

--- a/quickwit/quickwit-ui/src/traces/client.ts
+++ b/quickwit/quickwit-ui/src/traces/client.ts
@@ -1,0 +1,7 @@
+import { useMemo } from "react";
+import { JaegerAPIClient } from "../services/jaeger_api.client";
+ 
+export function useJaegerAPIClient(): JaegerAPIClient {
+  const jaegerClient = useMemo(()=>new JaegerAPIClient('otel-traces-v0_6'), []);
+  return jaegerClient;
+}

--- a/quickwit/quickwit-ui/src/traces/components/TraceSearch.tsx
+++ b/quickwit/quickwit-ui/src/traces/components/TraceSearch.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback, useEffect } from "react";
+import styled from "@emotion/styled";
+import { Autocomplete, Box, Button, Divider, TextField, Typography } from '@mui/material';
+
+import { TimeRange, TimeRangeSelect } from '@/components/TimeRangeSelect';
+import { JaegerAPIClient, ServiceList, ServiceOperationsList, TraceRequestParams } from "@/services/jaeger_api.client";
+import { ONE_SECOND } from "@/utils/date";
+
+const DEFAULT_RESULT_LIMIT = 20;
+
+const TraceSearchBarWrapper = styled('div')({
+  display: 'flex',
+  height: '100%',
+  flex: '0 0 260px',
+  maxWidth: '260px',
+  flexDirection: 'column',
+  borderRight: '1px solid rgba(0, 0, 0, 0.12)',
+  overflow: 'auto',
+});
+
+function QAutocomplete<T>(props:{
+    options:T[],
+    value?:T,
+    onUpdate(value?:T):void
+  }) {
+  const [value, setValue] = React.useState<T|null>(props.value||null)
+  useEffect(()=>{
+    setValue(props.value||null);
+  }, [props.value])
+  return (
+    <Autocomplete
+      size="small"
+      sx={{ width: '100%' }}
+      options={props.options}
+      value={value}
+      onChange={(_, updatedValue) => {
+        if (updatedValue == null) {
+          setValue(null);
+          props.onUpdate();
+        } else {
+          setValue(updatedValue);
+          props.onUpdate(updatedValue);
+        }
+      }}
+      renderInput={(params)=>(
+        <TextField {...params}></TextField>
+      )}
+      />
+  )
+}
+
+
+export function TraceSearchSidebar(props:{
+    jaegerClient:JaegerAPIClient,
+    onFetchTraces:(traceParams:TraceRequestParams)=>void
+  }) {
+  const [services, setServices] = React.useState<ServiceList>([])
+  const [service, setService] = React.useState<string>("")
+  const [operations, setOperations] = React.useState<ServiceOperationsList>([])
+  const [operation, setOperation] = React.useState<string>("all")
+  // const [limit, setLimit] = React.useState<number>(DEFAULT_RESULT_LIMIT)
+  const limit = DEFAULT_RESULT_LIMIT;
+  const [timeRange, setTimeRange] = React.useState<TimeRange>({startTimestamp:null, endTimestamp:null})
+
+
+ const fetchServices = useCallback(()=>{
+    props.jaegerClient.getServices().then(
+      (fetchedServices) => { setServices(fetchedServices); }
+    )
+  }, [props.jaegerClient])
+
+  const fetchServiceOperations = useCallback((service)=>{
+    if (service) {
+      props.jaegerClient.getServiceOperations(service).then(
+        (fetchedOperations) => { setOperations(fetchedOperations); }
+      );
+    }
+    else {
+      setOperations([])
+    }
+  }, [props.jaegerClient, service] );
+
+  useEffect(()=> {
+    fetchServices();
+  }, [fetchServices])
+
+  useEffect(()=>{
+    if (!service && services.length ) {
+      setService(services[0]!)
+    }
+  }, [services])
+
+  // Get operations for service
+  useEffect(()=>{
+    fetchServiceOperations(service);
+  }, [service])
+
+  // Render sidebar
+  return (
+    <TraceSearchBarWrapper>
+      <Box sx={{ px: 2, py: 2}}>
+        <Typography variant='body1' mb={1}>
+        Service:
+        </Typography>
+        <QAutocomplete
+          options={services}
+          value={service||""}
+          onUpdate={(updatedService)=>{
+            if (updatedService) setService(updatedService);
+          }}/>
+      </Box>
+      {service && ( <React.Fragment>
+        <Divider/>
+        <Box sx={{ flexGrow:1, padding: 2}}>
+          <Box sx={{mb:'1rem'}}>
+            <Typography variant='body1' mb={1}> Operation: </Typography>
+            <QAutocomplete
+              options={['all', ...operations]}
+              value={operation}
+              onUpdate={
+                (updatedOperation)=>{
+                  if (!updatedOperation)
+                    setOperation("all");
+                  else
+                    setOperation(updatedOperation);
+                  }
+              }/>
+          </Box>
+
+          <Box sx={{mb:'1rem'}}>
+            <Typography variant='body1' mb={1}> Tags: </Typography>
+            <TextField size="small" sx={{width:'100%'}}></TextField>
+          </Box>
+
+        </Box>
+
+        <Box sx={{padding:2}}>
+          <Box sx={{mb:'1rem'}}>
+            <TimeRangeSelect
+                sx={{width:'100%'}}
+                timeRange={timeRange}
+                onUpdate={ (newTimeRange)=>{ setTimeRange(newTimeRange) } }
+                variant="outlined"
+              />
+          </Box>
+          <Button variant="contained" sx={{width:'100%'}} onClick={
+            ()=>{
+              const params : TraceRequestParams = { service };
+              if (operation !== "all") { params.operation = operation; }
+              if (timeRange.startTimestamp) { params.start = timeRange.startTimestamp*ONE_SECOND; }
+              if (timeRange.endTimestamp) { params.end = timeRange.endTimestamp*ONE_SECOND; }
+              if (limit) { params.limit = limit; }
+              // if (tags) { params.tags = tags; }
+              
+              props.onFetchTraces(params) }
+          }>Find Traces</Button>
+        </Box>
+      </React.Fragment>)}
+    </TraceSearchBarWrapper>
+  )
+}

--- a/quickwit/quickwit-ui/src/traces/components/charts/TraceTimelineChart.tsx
+++ b/quickwit/quickwit-ui/src/traces/components/charts/TraceTimelineChart.tsx
@@ -1,0 +1,45 @@
+import { GlyphDot } from '@visx/glyph';
+import { Orientation } from '@visx/axis';
+import { XYChart, Axis, Grid, GlyphSeries } from '@visx/xychart';
+import { GlyphProps } from '@visx/xychart/lib/types';
+import { formatDuration } from '@/utils/date';
+
+export type ChartProps<T> = {
+  data: T[],
+  accessors:{
+    xAccessor: (d:T)=>number|Date,
+    yAccessor: (d:T)=>number,
+    size: (d:T)=>number,
+    color: (d?:T)=>string,
+  }
+  width: number,
+  height: number,
+};
+
+
+export default function TraceTimelineChart<T extends object>(props : ChartProps<T>) {
+  const glyphProps = {
+    dataKey:"L1",
+    xAccessor: props.accessors.xAccessor,
+    yAccessor: props.accessors.yAccessor,
+    colorAccessor: props.accessors.color, 
+    size: props.accessors.size, 
+    renderGlyph: ({x,y,size,color}:GlyphProps<T>)=>(
+      <GlyphDot left={x} top={y} r={size} fill={color} stroke={color} fillOpacity={0.5} strokeOpacity={0.8} />
+    )
+  }
+
+  return (
+      <XYChart
+          margin={{top:25, right:25, bottom:25, left:55}}
+          width={props.width} height={props.height}
+          xScale={{type:'time'}} yScale={{type:'linear'}}>
+        <Axis key={`scale-x`} orientation={Orientation.bottom} />
+        <Axis key={`scale-y`} orientation={Orientation.left}
+              numTicks={3}
+              tickFormat={(v:number)=>(formatDuration(v))} />
+        <Grid rows={false} strokeDasharray='3 3'/>
+        <GlyphSeries {...glyphProps} data={props.data}/>
+      </XYChart>
+  );
+}

--- a/quickwit/quickwit-ui/src/traces/views/TraceView.tsx
+++ b/quickwit/quickwit-ui/src/traces/views/TraceView.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "react-router-dom"
+
+import { ViewUnderAppBarBox } from "@/components/LayoutUtils";
+import { JsonEditor } from "@/components/JsonEditor";
+import { Trace } from "@/services/jaeger_api.client";
+
+import { useJaegerAPIClient } from '../client';
+
+export function TraceView(){
+  const {traceId} = useParams();
+  const jaegerClient = useJaegerAPIClient();
+  const [trace, setTrace] = useState<Trace>()
+  const fetchTrace = useCallback((traceID)=>{
+      jaegerClient.getTrace(traceID).then(
+        (fetchedTrace)=>{ setTrace(fetchedTrace); }
+      )
+  }, [jaegerClient])
+
+  useEffect(()=>{
+    if (traceId) fetchTrace(traceId);
+  }, [fetchTrace, traceId])
+
+  return (
+    <ViewUnderAppBarBox>
+      <JsonEditor content={trace} resizeOnMount></JsonEditor>
+    </ViewUnderAppBarBox>
+  )
+}

--- a/quickwit/quickwit-ui/src/traces/views/TracesView.tsx
+++ b/quickwit/quickwit-ui/src/traces/views/TracesView.tsx
@@ -1,0 +1,129 @@
+import { Box, Card, Chip, Divider, LinearProgress, Typography, useTheme } from '@mui/material';
+import { FullBoxContainer, ViewUnderAppBarBox } from '@/components/LayoutUtils';
+import { Trace, TraceRequestParams } from '../../services/jaeger_api.client';
+import { useJaegerAPIClient } from '../client';
+import { TraceSearchSidebar } from '../components/TraceSearch';
+import React, { useCallback, useState, useEffect, useRef } from "react";
+
+import TraceTimelineChart from '../components/charts/TraceTimelineChart';
+import { Link } from 'react-router-dom';
+import { formatDuration } from '@/utils/date';
+import { useSize } from '@/utils/hooks';
+
+type TraceDatum = {
+  id:string,
+  startTime:Date,
+  duration:number,
+  spanCount:number,
+  service: string,
+  operation: string,
+  body: Trace,
+}
+
+const clamp = (num:number, min:number, max:number)=>(Math.min(Math.max(num, min), max));
+// NOTE : log10(v**2) gives an idea of the magniture of the count.
+// floored, scaled 4x, clamped between 2 and 20 pixels
+const countToSize = (v:number):number => (clamp(Math.floor(Math.log10(v**2)*4), 2, 20));
+
+function TracesTimeline(props: {data: TraceDatum[]}) {
+  const elRef = useRef<HTMLDivElement>(null)
+  const size = useSize(elRef);
+  const theme = useTheme();
+
+  const chartProps = {
+    accessors:{
+      // XXX : see https://github.com/airbnb/visx/issues/1247
+      xAccessor:(d:TraceDatum)=>(d?.startTime.getTime()),
+      yAccessor:(d:TraceDatum)=>(d?.duration),
+      size:(d:TraceDatum)=>(d && countToSize(d.spanCount)),
+      color:()=>(theme.palette.primary.main),
+    },
+    ...size
+  };
+  return (
+    <Box sx={{minWidth:0, height:'200px', flexShrink:1, flexGrow:0}} ref={elRef}>
+      {props.data && <TraceTimelineChart data={props.data} {...chartProps}></TraceTimelineChart>}
+    </Box>
+  )
+}
+
+function TraceSnippet(props:{trace:TraceDatum, refDuration?:number}) {
+  const [durationPercent, setDurationPercent] = useState(0)
+
+  useEffect(()=>{
+    if (props.refDuration) {
+      setDurationPercent((props.trace.duration/props.refDuration)*100)
+    }
+  }, [props.trace, props.refDuration])
+  
+  return (
+    <Link to={`/traces/${props.trace.id}`} style={{textDecoration:"none"}}>
+      <Card variant="outlined" sx={{overflowY:"visible", background:"#eee", mb:1}}>
+        <Box sx={{ position:"relative", padding:1, display:"flex", flexDirection:"row", gap:1, alignItems:"baseline"}}>
+          <Box sx={{flexShrink:1, flexGrow:1, minWidth:0, overflow:"hidden", textOverflow:"ellipsis"}}>
+            {/* {dayjs(props.trace.date).fromNow()} */}
+            {props.trace.service}:{props.trace.operation}
+            <Typography component="span" sx={{fontSize:"0.6rem", color:"#888", lineHeight:"0.6rem"}}> {props.trace.id}</Typography>
+          </Box>
+          <Chip label={`${props.trace.spanCount} spans / ${formatDuration(props.trace.duration)} `} size="small"/>
+        </Box>
+        {props.refDuration && <LinearProgress variant="determinate" value={durationPercent}/>}
+      </Card>
+    </Link>
+  )
+}
+
+
+export function TracesView() {
+  const jaegerClient = useJaegerAPIClient();
+  const [traces, setTraces] = useState<TraceDatum[]>([])
+  const [maxDuration, setMaxDuration] = useState(0);
+
+  const fetchTraces = useCallback((traceParams:TraceRequestParams)=>{
+    jaegerClient.getTraces(traceParams)
+      .then((rawTraces:Trace[])=>{
+        const data = rawTraces.map((trace)=>{
+          const longestSpan = trace.spans.sort((t1, t2)=>t2.duration-t1.duration)[0]!;
+          return {
+            id: trace.traceID,
+            spanCount: trace.spans.length,
+            // Times are returned in ns, convert to µs
+            startTime: longestSpan.startTime,
+            duration: longestSpan.duration,
+            // Keep the source info
+            body:trace,
+            service: trace.processes[longestSpan.processID]!.service,
+            operation: longestSpan.operation,
+          }
+        }).sort((t1,t2)=>(t2.startTime.getTime() - t1.startTime.getTime()));
+        setTraces(data as TraceDatum[]);
+      })
+  },[jaegerClient])
+
+  useEffect(()=>{
+    const durations: number[] = traces.map((trace)=>(trace.duration as number));
+    setMaxDuration(Math.max(...durations));
+
+  }, [traces])
+
+  return(
+    <ViewUnderAppBarBox sx={{ flexDirection: 'row'}}>
+      <TraceSearchSidebar jaegerClient={jaegerClient}
+                          onFetchTraces={fetchTraces}>
+      </TraceSearchSidebar>
+      <FullBoxContainer sx={{padding:0, flexGrow:0, minWidth:0}} >
+        <TracesTimeline data={traces}/>
+        <Divider/>
+        <FullBoxContainer sx={{flexGrow:1, overflow:'scroll'}}>
+          <Box sx={{minHeight:0}}>
+            { traces && traces.map((trace)=>(
+              <React.Fragment key={`trace-snippet-${trace.id}`}>
+                <TraceSnippet key={`trace-snippet-${trace.id}`} trace={trace} refDuration={maxDuration}/>
+                </React.Fragment>
+            ))}
+          </Box>
+        </FullBoxContainer>
+      </FullBoxContainer>
+    </ViewUnderAppBarBox>
+  )
+}

--- a/quickwit/quickwit-ui/src/traces/views/index.tsx
+++ b/quickwit/quickwit-ui/src/traces/views/index.tsx
@@ -1,0 +1,10 @@
+import { Route } from "react-router-dom";
+import { TracesView } from "./TracesView";
+import { TraceView }  from "./TraceView";
+
+export const routes = (
+    <Route path="traces">
+        <Route index element={<TracesView/>} />
+        <Route path=":traceId" element={<TraceView/>} />
+    </Route>
+);

--- a/quickwit/quickwit-ui/src/utils/date.ts
+++ b/quickwit/quickwit-ui/src/utils/date.ts
@@ -1,0 +1,32 @@
+// NOTE: this format duration snippet is inspired by jaeger-ui's utils/date
+export const ONE_MILLISECOND = 1000 * 1;
+export const ONE_SECOND = 1000 * ONE_MILLISECOND;
+const ONE_MINUTE = 60 * ONE_SECOND;
+const ONE_HOUR = 60 * ONE_MINUTE;
+const ONE_DAY = 24 * ONE_HOUR;
+const UNIT_STEPS: { unit: string; ms: number; ofPreviousUnit: number }[] = [
+  { unit: 'd', ms: ONE_DAY, ofPreviousUnit: 24 },
+  { unit: 'h', ms: ONE_HOUR, ofPreviousUnit: 60 },
+  { unit: 'm', ms: ONE_MINUTE, ofPreviousUnit: 60 },
+  { unit: 's', ms: ONE_SECOND, ofPreviousUnit: 1000 },
+  { unit: 'ms', ms: ONE_MILLISECOND, ofPreviousUnit: 1000 },
+  { unit: 'µs', ms: 1, ofPreviousUnit: 1000 },
+];
+
+export function formatDuration(duration:number, precise?:boolean) : string {
+  // Skip units that are too large
+  let i=0;
+  while(i < UNIT_STEPS.length - 1) {
+    if (UNIT_STEPS[i]!.ms <= duration) break; i++;
+  }
+  const [primaryUnit, secondaryUnit] = UNIT_STEPS.slice(i)
+  // Format value
+  const primaryValue = Math.floor(duration / primaryUnit!.ms);
+  const primaryUnitString = `${primaryValue}${primaryUnit!.unit}`;
+  if (precise && secondaryUnit) {
+    const secondaryValue = Math.round((duration / secondaryUnit!.ms) % primaryUnit!.ofPreviousUnit);
+    const secondaryUnitString = `${secondaryValue}${secondaryUnit!.unit}`;
+    return secondaryValue === 0 ? primaryUnitString : `${primaryUnitString} ${secondaryUnitString}`;
+  }
+    return primaryUnitString;
+}

--- a/quickwit/quickwit-ui/src/utils/hooks/index.ts
+++ b/quickwit/quickwit-ui/src/utils/hooks/index.ts
@@ -1,0 +1,20 @@
+import { useState, useLayoutEffect } from "react";
+
+export function useSize(elRef:React.MutableRefObject<HTMLElement|null>) {
+  const [width, setWidth] = useState<number>(0);
+  const [height, setHeight] = useState<number>(0);
+
+  useLayoutEffect(()=>{
+    const updateSize = ()=>{
+      if (elRef.current){
+        setWidth(elRef.current?.offsetWidth);
+        setHeight(elRef.current?.offsetHeight);
+      }
+    };
+    window.addEventListener('resize', updateSize);
+    updateSize();
+    return () => window.removeEventListener('resize', updateSize);
+  }, [])
+
+  return { width, height }
+}

--- a/quickwit/quickwit-ui/src/views/App.tsx
+++ b/quickwit/quickwit-ui/src/views/App.tsx
@@ -30,6 +30,7 @@ import { LocalStorageProvider } from '../providers/LocalStorageProvider';
 import ClusterView from './ClusterView';
 import NodeInfoView from './NodeInfoView';
 import ApiView from './ApiView';
+import { routes as traceRoutes } from '../traces/views/';
 
 function App() {
   return (
@@ -47,6 +48,7 @@ function App() {
             <Route path="cluster" element={<ClusterView />} />
             <Route path="node-info" element={<NodeInfoView />} />
             <Route path="api-playground" element={<ApiView />} />
+            {traceRoutes}
           </Routes>
         </FullBoxContainer>
       </LocalStorageProvider>

--- a/quickwit/quickwit-ui/tsconfig.json
+++ b/quickwit/quickwit-ui/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "ESNext",
     "lib": [

--- a/quickwit/quickwit-ui/tsconfig.paths.json
+++ b/quickwit/quickwit-ui/tsconfig.paths.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "paths": {
+        "@/*": ["./src/*"]
+        }
+    }
+}


### PR DESCRIPTION
This branch explores the possibility to implement a trace explorer interface to quickwit-ui. 

## Current state
- Adds a jaeger-inspired trace explorer page with visx powered bubble-plot
- Hit quickwit's jaeger api to retrieve data, use zod for schema validation

## TODO :
- trace waterfall view
- improve UX

## Money shots :
![image](https://github.com/quickwit-oss/quickwit/assets/1690574/7946ed5e-bcfd-4ca2-aa33-7b6063652c7d)

*Branch currently in pause*