### PR TITLE
Make io limits for merges a node-level parameter.

### DIFF
--- a/quickwit/quickwit-common/src/io.rs
+++ b/quickwit/quickwit-common/src/io.rs
@@ -348,7 +348,6 @@ where A: IoControlsAccess
 mod tests {
     use std::io::{IoSlice, Write};
     use std::time::Duration;
-    use bytesize::ByteSize;
 
     use bytesize::ByteSize;
     use tokio::io::{sink, AsyncWriteExt};

--- a/quickwit/quickwit-common/src/io.rs
+++ b/quickwit/quickwit-common/src/io.rs
@@ -350,6 +350,7 @@ mod tests {
     use std::time::Duration;
     use bytesize::ByteSize;
 
+    use bytesize::ByteSize;
     use tokio::io::{sink, AsyncWriteExt};
     use tokio::time::Instant;
 

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -47,7 +47,8 @@
         "enable_otlp_endpoint": true,
         "split_store_max_num_bytes": "1T",
         "split_store_max_num_splits": 10000,
-        "max_concurrent_split_uploads": 8
+        "max_concurrent_split_uploads": 8,
+o
     },
     "ingest_api": {
         "replication_factor": 2

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -38,6 +38,7 @@ enable_otlp_endpoint = true
 split_store_max_num_bytes = "1T"
 split_store_max_num_splits = 10_000
 max_concurrent_split_uploads = 8
+max_merge_write_throughput = 100mb
 
 [ingest_api]
 replication_factor = 2

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -42,6 +42,7 @@ indexer:
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000
   max_concurrent_split_uploads: 8
+  max_merge_write_throughput: 100mb
 
 ingest_api:
   replication_factor: 2

--- a/quickwit/quickwit-config/src/index_config/serialize.rs
+++ b/quickwit/quickwit-config/src/index_config/serialize.rs
@@ -105,6 +105,7 @@ impl IndexConfigForSerialization {
         build_doc_mapper(&self.doc_mapping, &self.search_settings)?;
 
         self.indexing_settings.merge_policy.validate()?;
+        self.indexing_settings.resources.validate()?;
 
         Ok(IndexConfig {
             index_id: self.index_id,

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -92,7 +92,7 @@ pub struct IndexerConfig {
     #[serde(default = "IndexerConfig::default_max_concurrent_split_uploads")]
     pub max_concurrent_split_uploads: usize,
     /// Limits the IO throughput of the `SplitDownloader` and the `MergeExecutor`.
-    /// On hardware where IO is constraints, it makes sure that Merges (a batch operation)
+    /// On hardware where IO is constrained, it makes sure that Merges (a batch operation)
     /// does not starve indexing itself (as it is a latency sensitive operation).
     #[serde(default)]
     pub max_merge_write_throughput: Option<ByteSize>,

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -91,6 +91,11 @@ pub struct IndexerConfig {
     pub split_store_max_num_splits: usize,
     #[serde(default = "IndexerConfig::default_max_concurrent_split_uploads")]
     pub max_concurrent_split_uploads: usize,
+    /// Limits the IO throughput of the `SplitDownloader` and the `MergeExecutor`.
+    /// On hardware where IO is constraints, it makes sure that Merges (a batch operation)
+    /// does not starve indexing itself (as it is a latency sensitive operation).
+    #[serde(default)]
+    pub max_merge_write_throughput: Option<ByteSize>,
     /// Enables the OpenTelemetry exporter endpoint to ingest logs and traces via the OpenTelemetry
     /// Protocol (OTLP).
     #[serde(default = "IndexerConfig::default_enable_otlp_endpoint")]
@@ -143,6 +148,7 @@ impl IndexerConfig {
             split_store_max_num_splits: 3,
             max_concurrent_split_uploads: 4,
             cpu_capacity: PIPELINE_FULL_CAPACITY * 4u32,
+            max_merge_write_throughput: None,
         };
         Ok(indexer_config)
     }
@@ -157,6 +163,7 @@ impl Default for IndexerConfig {
             split_store_max_num_splits: Self::default_split_store_max_num_splits(),
             max_concurrent_split_uploads: Self::default_max_concurrent_split_uploads(),
             cpu_capacity: Self::default_cpu_capacity(),
+            max_merge_write_throughput: None,
         }
     }
 }

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -556,6 +556,7 @@ mod tests {
                 max_concurrent_split_uploads: 8,
                 cpu_capacity: IndexerConfig::default_cpu_capacity(),
                 enable_cooperative_indexing: false,
+                max_merge_write_throughput: None,
             }
         );
         assert_eq!(

--- a/quickwit/quickwit-indexing/src/actors/index_serializer.rs
+++ b/quickwit/quickwit-indexing/src/actors/index_serializer.rs
@@ -84,10 +84,7 @@ impl Handler<IndexedSplitBatchBuilder> for IndexSerializer {
                 let io_controls = IoControls::default()
                     .set_progress(ctx.progress().clone())
                     .set_kill_switch(ctx.kill_switch().clone())
-                    .set_index_and_component(
-                        split_builder.split_attrs.pipeline_id.index_uid.index_id(),
-                        "index_serializer",
-                    );
+                    .set_component("index_serializer");
                 controlled_directory.set_io_controls(io_controls);
             }
             let split = split_builder.finalize()?;

--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -125,7 +125,7 @@ impl IndexerState {
         let io_controls = IoControls::default()
             .set_progress(ctx.progress().clone())
             .set_kill_switch(ctx.kill_switch().clone())
-            .set_index_and_component(self.pipeline_id.index_uid.index_id(), "indexer");
+            .set_component("indexer");
 
         let indexed_split = IndexedSplitBuilder::new_in_dir(
             self.pipeline_id.clone(),

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -878,7 +878,7 @@ mod tests {
             split_store: split_store.clone(),
             merge_policy: default_merge_policy(),
             max_concurrent_split_uploads: 2,
-            merge_max_io_num_bytes_per_sec: None,
+            merge_io_throughput_limiter_opt: None,
             event_broker: Default::default(),
         };
         let merge_pipeline = MergePipeline::new(merge_pipeline_params, universe.spawn_ctx());

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -33,8 +33,9 @@ use quickwit_actors::{
 };
 use quickwit_cluster::Cluster;
 use quickwit_common::fs::get_cache_directory_path;
+use quickwit_common::io::Limiter;
 use quickwit_common::pubsub::EventBroker;
-use quickwit_common::temp_dir;
+use quickwit_common::{io, temp_dir};
 use quickwit_config::{
     build_doc_mapper, IndexConfig, IndexerConfig, SourceConfig, INGEST_API_SOURCE_ID,
 };
@@ -128,6 +129,7 @@ pub struct IndexingService {
     max_concurrent_split_uploads: usize,
     merge_pipeline_handles: HashMap<MergePipelineId, MergePipelineHandle>,
     cooperative_indexing_permits: Option<Arc<Semaphore>>,
+    merge_io_throughput_limiter_opt: Option<Limiter>,
     event_broker: EventBroker,
 }
 
@@ -160,6 +162,8 @@ impl IndexingService {
             indexer_config.split_store_max_num_splits,
             indexer_config.split_store_max_num_bytes,
         );
+        let merge_io_throughput_limiter_opt =
+            indexer_config.max_merge_write_throughput.map(io::limiter);
         let split_cache_dir_path = get_cache_directory_path(&data_dir_path);
         let local_split_store =
             LocalSplitStore::open(split_cache_dir_path, split_store_space_quota).await?;
@@ -185,6 +189,7 @@ impl IndexingService {
             counters: Default::default(),
             max_concurrent_split_uploads: indexer_config.max_concurrent_split_uploads,
             merge_pipeline_handles: HashMap::new(),
+            merge_io_throughput_limiter_opt,
             cooperative_indexing_permits,
             event_broker,
         })
@@ -293,10 +298,7 @@ impl IndexingService {
             metastore: self.metastore.clone(),
             split_store: split_store.clone(),
             merge_policy: merge_policy.clone(),
-            merge_max_io_num_bytes_per_sec: index_config
-                .indexing_settings
-                .resources
-                .max_merge_write_throughput,
+            merge_io_throughput_limiter_opt: self.merge_io_throughput_limiter_opt.clone(),
             max_concurrent_split_uploads: self.max_concurrent_split_uploads,
             event_broker: self.event_broker.clone(),
         };

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -194,19 +194,12 @@ impl DeleteTaskPipeline {
             pipeline_uid: PipelineUid::from_u128(0u128),
             source_id: "unknown".to_string(),
         };
-        let throughput_limit: f64 = index_config
-            .indexing_settings
-            .resources
-            .max_merge_write_throughput
-            .as_ref()
-            .map(|bytes_per_sec| bytes_per_sec.as_u64() as f64)
-            .unwrap_or(f64::INFINITY);
-        let delete_executor_io_controls = IoControls::default()
-            .set_throughput_limit(throughput_limit)
-            .set_index_and_component(self.index_uid.index_id(), "deleter");
+
+        let delete_executor_io_controls = IoControls::default().set_component("deleter");
+
         let split_download_io_controls = delete_executor_io_controls
             .clone()
-            .set_index_and_component(self.index_uid.index_id(), "split_downloader_delete");
+            .set_component("split_downloader_delete");
         let delete_executor = MergeExecutor::new(
             index_pipeline_id,
             self.metastore.clone(),


### PR DESCRIPTION
This PR also removes the index label from the IO metrics. It also removes the limits for the delete pipeline.

Closes #4439
