### PR TITLE
Allow naming tasks to differentiate actors in tokio-console.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628a8f9bd1e24b4e0db2b4bc2d000b001e7dd032d54afa60a68836aeec5aa54a"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -256,19 +256,6 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
-]
-
-[[package]]
-name = "async-compat"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
-dependencies = [
- "futures-core",
- "futures-io",
- "once_cell",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -760,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "aws_lambda_events"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25e7620d59c7a9ed653439ec402218e3f6be118000f92802c5bbfc6da98e65b"
+checksum = "d5af275f3e5801892c4295a919c5edbe8d24134f91458269a77a2da12622c123"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -775,7 +762,7 @@ dependencies = [
  "serde",
  "serde_dynamo",
  "serde_json",
- "serde_with 3.5.0",
+ "serde_with 3.5.1",
 ]
 
 [[package]]
@@ -1272,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1282,7 +1269,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1309,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -1320,15 +1307,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -2727,9 +2714,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3396,9 +3387,9 @@ checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 
 [[package]]
 name = "lambda_http"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7732ab05100525c1716db7b48ccf2165da4dcd72340f679fea593766f4f042"
+checksum = "dacbb68e7ae5264884f114f79d4e0de33c66cb5a8f363ac93de7112f624d233d"
 dependencies = [
  "aws_lambda_events",
  "base64 0.21.7",
@@ -4330,12 +4321,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendal"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0ad72f7b44ca4ae59d27ea151fdc6f37305cf6efe099bdaedbb30ec34579c0"
+checksum = "4af824652d4d2ffabf606d337a071677ae621b05622adf35df9562f69d9b4498"
 dependencies = [
  "anyhow",
- "async-compat",
  "async-trait",
  "backon",
  "base64 0.21.7",
@@ -4348,9 +4338,7 @@ dependencies = [
  "log",
  "md-5",
  "once_cell",
- "parking_lot",
  "percent-encoding",
- "pin-project",
  "quick-xml 0.30.0",
  "reqsign",
  "reqwest",
@@ -4389,9 +4377,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.62"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -4430,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
@@ -4584,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50b637ffd883b2733a8483599fb6136b9dcedaa1850f7ac08b9b6f9f2061208"
+checksum = "97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -4595,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3633d65683f13b9bcfaa3150880b018899fb0e5d0542f4adaea4f503fdb5eabf"
+checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck",
  "itertools 0.12.0",
@@ -5192,9 +5180,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -5647,7 +5635,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_with 3.5.0",
+ "serde_with 3.5.1",
  "serde_yaml 0.9.30",
  "tokio",
  "toml",
@@ -6093,7 +6081,7 @@ dependencies = [
  "sea-query-binder",
  "serde",
  "serde_json",
- "serde_with 3.5.0",
+ "serde_with 3.5.1",
  "sqlx",
  "tempfile",
  "thiserror",
@@ -6186,7 +6174,7 @@ dependencies = [
  "quickwit-datetime",
  "serde",
  "serde_json",
- "serde_with 3.5.0",
+ "serde_with 3.5.1",
  "tantivy",
  "thiserror",
  "time",
@@ -6254,7 +6242,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "serde_with 3.5.0",
+ "serde_with 3.5.1",
  "tantivy",
  "tempfile",
  "thiserror",
@@ -6321,7 +6309,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs 0.12.0",
- "serde_with 3.5.0",
+ "serde_with 3.5.1",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -6590,13 +6578,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "regex-syntax 0.8.2",
 ]
 
@@ -6611,9 +6599,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7183,9 +7171,9 @@ dependencies = [
 
 [[package]]
 name = "serde_dynamo"
-version = "4.2.6"
+version = "4.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64307a9d3b5af5237b1a95c0b63fbeb45134d7d7c372c284847fa37a6ddee44"
+checksum = "8b652e4dd5549c24a4ec779981278cccae2f85b4d5649441c745d58866e20283"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -7279,9 +7267,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58c3a1b3e418f61c25b2aeb43fc6c95eaa252b8cecdda67f401943e9e08d33f"
+checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -7290,7 +7278,7 @@ dependencies = [
  "indexmap 2.1.0",
  "serde",
  "serde_json",
- "serde_with_macros 3.5.0",
+ "serde_with_macros 3.5.1",
  "time",
 ]
 
@@ -7308,9 +7296,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2068b437a31fc68f25dd7edc296b078f04b45145c199d8eed9866e45f1ff274"
+checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
@@ -7474,9 +7462,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "snafu"

--- a/quickwit/quickwit-actors/src/scheduler.rs
+++ b/quickwit/quickwit-actors/src/scheduler.rs
@@ -215,7 +215,7 @@ pub fn start_scheduler() -> SchedulerClient {
                 }
             }
         },
-        "Scheduler",
+        "scheduler",
     );
     scheduler_client
 }

--- a/quickwit/quickwit-actors/src/scheduler.rs
+++ b/quickwit/quickwit-actors/src/scheduler.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
+use quickwit_common::spawn_named_task;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -203,16 +204,19 @@ pub fn start_scheduler() -> SchedulerClient {
         }),
     };
     let mut scheduler = Scheduler::new(&scheduler_client);
-    tokio::spawn(async move {
-        while let Ok(scheduler_message) = rx.recv_async().await {
-            match scheduler_message {
-                SchedulerMessage::ProcessTime => scheduler.process_time(),
-                SchedulerMessage::Schedule { callback, timeout } => {
-                    scheduler.process_schedule(callback, timeout);
+    spawn_named_task(
+        async move {
+            while let Ok(scheduler_message) = rx.recv_async().await {
+                match scheduler_message {
+                    SchedulerMessage::ProcessTime => scheduler.process_time(),
+                    SchedulerMessage::Schedule { callback, timeout } => {
+                        scheduler.process_schedule(callback, timeout);
+                    }
                 }
             }
-        }
-    });
+        },
+        "Scheduler",
+    );
     scheduler_client
 }
 

--- a/quickwit/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit/quickwit-actors/src/spawn_builder.rs
@@ -181,7 +181,11 @@ impl<A: Actor> SpawnBuilder<A> {
         let ctx_clone = ctx.clone();
         let loop_async_actor_future =
             async move { actor_loop(actor, inbox, no_advance_time_guard, ctx).await };
-        let join_handle = ActorJoinHandle::new(runtime_handle.spawn(loop_async_actor_future));
+        let join_handle = ActorJoinHandle::new(quickwit_common::spawn_named_task_on(
+            loop_async_actor_future,
+            std::any::type_name::<A>(),
+            &runtime_handle,
+        ));
         ctx_clone.registry().register(&mailbox, join_handle.clone());
         let actor_handle = ActorHandle::new(state_rx, join_handle, ctx_clone);
         (mailbox, actor_handle)

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -86,6 +86,7 @@ quickwit-storage = { workspace = true, features = ["testsuite"] }
 jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemallocator"]
 ci-test = []
 openssl-support = ["openssl-probe"]
+# Requires to enable tokio unstable via RUSTFLAGS="--cfg tokio_unstable"
 tokio-console = ["console-subscriber", "quickwit-common/named_tasks"]
 release-feature-set = [
   "jemalloc",

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -86,7 +86,7 @@ quickwit-storage = { workspace = true, features = ["testsuite"] }
 jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemallocator"]
 ci-test = []
 openssl-support = ["openssl-probe"]
-tokio-console = ["console-subscriber"]
+tokio-console = ["console-subscriber", "quickwit-common/named_tasks"]
 release-feature-set = [
   "jemalloc",
   "openssl-support",

--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -41,6 +41,9 @@ tracing = { workspace = true }
 
 [features]
 testsuite = []
+named_tasks = ["tokio/tracing"]
+
+
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -43,10 +43,7 @@ tracing = { workspace = true }
 testsuite = []
 named_tasks = ["tokio/tracing"]
 
-
-
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-
 quickwit-macros = { workspace = true }

--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -199,6 +199,26 @@ pub const fn div_ceil(lhs: i64, rhs: i64) -> i64 {
     }
 }
 
+
+// The following are helpers to build named tasks.
+//
+// Named tasks require the tokio feature `tracing` to be enabled.
+// If the `named_tasks` feature is disabled, this is no-op.
+//
+// By default, these function will just ignore the name passed and just act
+// like a regular call to `tokio::spawn`.
+//
+// If the user compiles `quickwit-cli` with the `tokio-console` feature,
+// then tasks will automatically be named. This is not just "visual sugar".
+//
+// Without names, tasks will only show their spawn site on tokio-console.
+// This is a catastrophy for actors who all share the same spawn site.
+//
+// # Naming
+//
+// Actors will get named after their type, which is fine.
+// For other tasks, please use `snake_case`.
+
 #[cfg(not(feature = "named_tasks"))]
 pub fn spawn_named_task<F>(future: F, _name: &'static str) -> tokio::task::JoinHandle<F::Output>
 where

--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -199,7 +199,6 @@ pub const fn div_ceil(lhs: i64, rhs: i64) -> i64 {
     }
 }
 
-
 // The following are helpers to build named tasks.
 //
 // Named tasks require the tokio feature `tracing` to be enabled.
@@ -219,7 +218,7 @@ pub const fn div_ceil(lhs: i64, rhs: i64) -> i64 {
 // Actors will get named after their type, which is fine.
 // For other tasks, please use `snake_case`.
 
-#[cfg(not(feature = "named_tasks"))]
+#[cfg(not(all(tokio_unstable, feature = "named_tasks")))]
 pub fn spawn_named_task<F>(future: F, _name: &'static str) -> tokio::task::JoinHandle<F::Output>
 where
     F: Future + Send + 'static,
@@ -228,7 +227,7 @@ where
     tokio::task::spawn(future)
 }
 
-#[cfg(not(feature = "named_tasks"))]
+#[cfg(not(all(tokio_unstable, feature = "named_tasks")))]
 pub fn spawn_named_task_on<F>(
     future: F,
     _name: &'static str,
@@ -241,7 +240,7 @@ where
     runtime.spawn(future)
 }
 
-#[cfg(feature = "named_tasks")]
+#[cfg(all(tokio_unstable, feature = "named_tasks"))]
 pub fn spawn_named_task<F>(future: F, name: &'static str) -> tokio::task::JoinHandle<F::Output>
 where
     F: Future + Send + 'static,
@@ -253,7 +252,7 @@ where
         .unwrap()
 }
 
-#[cfg(feature = "named_tasks")]
+#[cfg(all(tokio_unstable, feature = "named_tasks"))]
 pub fn spawn_named_task_on<F>(
     future: F,
     name: &'static str,

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -30,6 +30,7 @@ use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
 use quickwit_common::pubsub::EventBroker;
+use quickwit_common::spawn_named_task;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::{SplitMetadata, StageSplitsRequestExt};
 use quickwit_proto::metastore::{MetastoreService, MetastoreServiceClient, StageSplitsRequest};
@@ -41,7 +42,6 @@ use tantivy::TrackedObject;
 use tokio::sync::oneshot::Sender;
 use tokio::sync::{oneshot, Semaphore, SemaphorePermit};
 use tracing::{debug, info, instrument, warn, Instrument, Span};
-use quickwit_common::spawn_named_task;
 
 use crate::actors::sequencer::{Sequencer, SequencerCommand};
 use crate::actors::Publisher;

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -41,6 +41,7 @@ use tantivy::TrackedObject;
 use tokio::sync::oneshot::Sender;
 use tokio::sync::{oneshot, Semaphore, SemaphorePermit};
 use tracing::{debug, info, instrument, warn, Instrument, Span};
+use quickwit_common::spawn_named_task;
 
 use crate::actors::sequencer::{Sequencer, SequencerCommand};
 use crate::actors::Publisher;
@@ -301,7 +302,7 @@ impl Handler<PackagedSplitBatch> for Uploader {
         let merge_policy = self.merge_policy.clone();
         debug!(split_ids=?split_ids, "start-stage-and-store-splits");
         let event_broker = self.event_broker.clone();
-        tokio::spawn(
+        spawn_named_task(
             async move {
                 fail_point!("uploader:intask:before");
 
@@ -383,6 +384,7 @@ impl Handler<PackagedSplitBatch> for Uploader {
                 Result::<(), anyhow::Error>::Ok(())
             }
             .instrument(Span::current()),
+            "upload-single-task"
         );
         fail_point!("uploader:intask:after");
         Ok(())

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -384,7 +384,7 @@ impl Handler<PackagedSplitBatch> for Uploader {
                 Result::<(), anyhow::Error>::Ok(())
             }
             .instrument(Span::current()),
-            "upload-single-task"
+            "upload_single_task"
         );
         fail_point!("uploader:intask:after");
         Ok(())


### PR DESCRIPTION
By default, tokio-console labels its task using its spawning point. Since all actors are spawned from the same place they end up with the same label.

This introduce an API to optionally name tasks.
For actors, the actor's struct Name is used automatically.

If tokio-console is not enabled, this is no cost.
