### PR TITLE
Fixing bug that was causing the Indexer to stay busy in cooperative m…

### DIFF
--- a/quickwit/quickwit-actors/src/actor_context.rs
+++ b/quickwit/quickwit-actors/src/actor_context.rs
@@ -191,15 +191,7 @@ impl<A: Actor> ActorContext<A> {
         self.actor_state.get_state()
     }
 
-    pub(crate) fn process(&self) {
-        self.actor_state.process();
-    }
-
-    pub(crate) fn idle(&self) {
-        self.actor_state.idle();
-    }
-
-    pub(crate) fn pause(&self) {
+    pub fn pause(&self) {
         self.actor_state.pause();
     }
 

--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -349,11 +349,6 @@ impl<A: Actor> Inbox<A> {
         None
     }
 
-    #[allow(dead_code)] // temporary
-    pub(crate) fn try_recv_cmd_and_scheduled_msg_only(&self) -> Result<Envelope<A>, RecvError> {
-        self.rx.try_recv_high_priority_message()
-    }
-
     /// Destroys the inbox and returns the list of pending messages or commands
     /// in the low priority channel.
     ///

--- a/quickwit/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit/quickwit-actors/src/spawn_builder.rs
@@ -236,14 +236,8 @@ async fn recv_envelope<A: Actor>(inbox: &mut Inbox<A>, ctx: &ActorContext<A>) ->
     }
 }
 
-fn try_recv_envelope<A: Actor>(inbox: &mut Inbox<A>, ctx: &ActorContext<A>) -> Option<Envelope<A>> {
-    if ctx.state().is_running() {
-        inbox.try_recv()
-    } else {
-        // The actor is paused. We only process command and scheduled message.
-        inbox.try_recv_cmd_and_scheduled_msg_only()
-    }
-    .ok()
+fn try_recv_envelope<A: Actor>(inbox: &mut Inbox<A>) -> Option<Envelope<A>> {
+    inbox.try_recv().ok()
 }
 
 struct ActorExecutionEnv<A: Actor> {
@@ -294,19 +288,25 @@ impl<A: Actor> ActorExecutionEnv<A> {
     async fn process_all_available_messages(&mut self) -> Result<(), ActorExitStatus> {
         self.yield_and_check_if_killed().await?;
         let envelope = recv_envelope(&mut self.inbox, &self.ctx).await;
-        self.ctx.process();
         self.process_one_message(envelope).await?;
-        loop {
-            while let Some(envelope) = try_recv_envelope(&mut self.inbox, &self.ctx) {
-                self.process_one_message(envelope).await?;
+        // If the actor is Running (not Paused), we consume all of the message in the mailbox
+        // and call `on_drained_message`.
+        if self.ctx.state().is_running() {
+            loop {
+                while let Some(envelope) = try_recv_envelope(&mut self.inbox) {
+                    self.process_one_message(envelope).await?;
+                }
+                // We have reached the last message.
+                // Let's still yield and see if we have more messages:
+                // an upstream actor might have been experience backpressure, and is now waiting for our mailbox
+                // to have some room.
+                self.ctx.yield_now().await;
+                if self.inbox.is_empty() {
+                    break;
+                }
             }
-            self.ctx.yield_now().await;
-            if self.inbox.is_empty() {
-                break;
-            }
+            self.actor.get_mut().on_drained_messages(&self.ctx).await?;
         }
-        self.actor.get_mut().on_drained_messages(&self.ctx).await?;
-        self.ctx.idle();
         if self.ctx.mailbox().is_last_mailbox() {
             // We double check here that the mailbox does not contain any messages,
             // as someone on different runtime thread could have added a last message

--- a/quickwit/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit/quickwit-actors/src/spawn_builder.rs
@@ -298,8 +298,8 @@ impl<A: Actor> ActorExecutionEnv<A> {
                 }
                 // We have reached the last message.
                 // Let's still yield and see if we have more messages:
-                // an upstream actor might have experienced backpressure, and is now waiting for our mailbox
-                // to have some room.
+                // an upstream actor might have experienced backpressure, and is now waiting for our
+                // mailbox to have some room.
                 self.ctx.yield_now().await;
                 if self.inbox.is_empty() {
                     break;

--- a/quickwit/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit/quickwit-actors/src/spawn_builder.rs
@@ -289,7 +289,7 @@ impl<A: Actor> ActorExecutionEnv<A> {
         self.yield_and_check_if_killed().await?;
         let envelope = recv_envelope(&mut self.inbox, &self.ctx).await;
         self.process_one_message(envelope).await?;
-        // If the actor is Running (not Paused), we consume all of the message in the mailbox
+        // If the actor is Running (not Paused), we consume all the messages in the mailbox
         // and call `on_drained_message`.
         if self.ctx.state().is_running() {
             loop {
@@ -298,7 +298,7 @@ impl<A: Actor> ActorExecutionEnv<A> {
                 }
                 // We have reached the last message.
                 // Let's still yield and see if we have more messages:
-                // an upstream actor might have been experience backpressure, and is now waiting for our mailbox
+                // an upstream actor might have experienced backpressure, and is now waiting for our mailbox
                 // to have some room.
                 self.ctx.yield_now().await;
                 if self.inbox.is_empty() {

--- a/quickwit/quickwit-actors/src/supervisor.rs
+++ b/quickwit/quickwit-actors/src/supervisor.rs
@@ -22,9 +22,7 @@ use serde::Serialize;
 use tracing::{info, warn};
 
 use crate::mailbox::Inbox;
-use crate::{
-    Actor, ActorContext, ActorExitStatus, ActorHandle, ActorState, Handler, Health, Supervisable,
-};
+use crate::{Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, Health, Supervisable};
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize)]
 pub struct SupervisorMetrics {
@@ -151,7 +149,7 @@ impl<A: Actor> Supervisor<A> {
         // The actor is failing we need to restart it.
         let actor_handle = self.handle_opt.take().unwrap();
         let actor_mailbox = actor_handle.mailbox().clone();
-        let (actor_exit_status, _last_state) = if actor_handle.state() == ActorState::Processing {
+        let (actor_exit_status, _last_state) = if !actor_handle.state().is_exit() {
             // The actor is probably frozen.
             // Let's kill it.
             warn!("killing");

--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -1079,9 +1079,13 @@ mod tests {
             })
             .await
             .unwrap();
-        universe.sleep(Duration::from_secs(3)).await;
         let mut indexer_counters: IndexerCounters = Default::default();
         for _ in 0..100 {
+            // When a lot of unit tests are running concurrently we have a race condition here.
+            // It is very difficult to assess when drain will actually be called.
+            //
+            // Therefore we check that it happens "eventually".
+            universe.sleep(Duration::from_secs(1)).await;
             tokio::task::yield_now().await;
             indexer_counters = indexer_handle.observe().await.state;
             indexer_counters.pipeline_metrics_opt = None;

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -372,7 +372,7 @@ impl IndexingService {
         self.indexing_pipelines
             .retain(|pipeline_uid, pipeline_handle| {
                 match pipeline_handle.handle.state() {
-                    ActorState::Idle | ActorState::Paused | ActorState::Processing => true,
+                    ActorState::Paused | ActorState::Running => true,
                     ActorState::Success => {
                         info!(
                             pipeline_uid=%pipeline_uid,


### PR DESCRIPTION
…ode.

Removing the difference between Idle and Processing.
It was originally introduced with the idea of measure how long actors
where busy or idle, but tokio-console does that job very well now.

The code was relying on the enforcement of the non trivial state machine:
calling .idle() in the pause state had no effect for instance.

The real bug however showed up with the following sequence of event:
- indexer drains its queue
- on_drain is called
- indexer "goes to sleep" by putting itself in the Pause state.
- a low priority message is queued into the low priority queue.
- indexer receives a high priority message (Observe is sent every second).
- indexer would go through the loop logic consuming the entire pipeline,
  but only consuming high priority messages. The `inbox.is_empty()` exit
  condiition is never satisfied, so that this loop would keep going,
  yielding at each iteration, until the Resume Command is received.

This is done on the indexer runtime.
The task would always be busy, but yield all of the time, consuming the
whatever room is available on the thread it is consuming.

Closes https://github.com/quickwit-oss/quickwit/issues/4448


# Test

The bug was doing a using yielding loop, so unit testing is a difficult.
I tested locally and on k8s.

A small pipeline of 100KB/s now takes <1% cpu vs 1 full core before.
Outside of merges, indexing 100*200kb=20MB on a single node takes 1 cpu instead of 4.
Outside of merges, indexing 1000*200kb=20MB on a 10 nodes takes 1 cpu instead of 4.
