### PR TITLE
Automatically empty buckets in Lambda examples

### DIFF
--- a/distribution/lambda/Makefile
+++ b/distribution/lambda/Makefile
@@ -67,14 +67,17 @@ deploy-mock-data: package check-env
 
 # address https://github.com/aws/aws-cdk/issues/20060
 before-destroy:
+	mkdir -p cdk.out
 	touch $(INDEXER_PACKAGE_PATH)
 	touch $(SEARCHER_PACKAGE_PATH)
 
 destroy-hdfs: before-destroy
-	cdk destroy -a cdk/app.py HdfsStack
+	python -c 'from cdk import cli; cli.empty_hdfs_bucket()'
+	cdk destroy  --force -a cdk/app.py HdfsStack
 
 destroy-mock-data: before-destroy
-	cdk destroy -a cdk/app.py MockDataStack
+	python -c 'from cdk import cli; cli.empty_mock_data_buckets()'
+	cdk destroy  --force -a cdk/app.py MockDataStack
 
 clean:
 	rm -rf cdk.out

--- a/distribution/lambda/cdk/stacks/examples/mock_data_stack.py
+++ b/distribution/lambda/cdk/stacks/examples/mock_data_stack.py
@@ -15,6 +15,8 @@ import yaml
 from ..services.quickwit_service import QuickwitService
 
 SEARCHER_FUNCTION_NAME_EXPORT_NAME = "mock-data-searcher-function-name"
+INDEX_STORE_BUCKET_NAME_EXPORT_NAME = "mock-data-index-store-bucket-name"
+SOURCE_BUCKET_NAME_EXPORT_NAME = "mock-data-source-bucket-name"
 
 
 class Source(Construct):
@@ -65,6 +67,12 @@ class Source(Construct):
         mock_data_bucket.grant_read(qw_svc.indexer.lambda_function)
         mock_data_bucket.add_object_created_notification(
             aws_s3_notifications.LambdaDestination(qw_svc.indexer.lambda_function)
+        )
+        aws_cdk.CfnOutput(
+            self,
+            "source-bucket-name",
+            value=mock_data_bucket.bucket_name,
+            export_name=SOURCE_BUCKET_NAME_EXPORT_NAME,
         )
 
 
@@ -164,6 +172,12 @@ class MockDataStack(Stack):
                 api_key=search_api_key,
             )
 
+        aws_cdk.CfnOutput(
+            self,
+            "index-store-bucket-name",
+            value=qw_svc.bucket.bucket_name,
+            export_name=INDEX_STORE_BUCKET_NAME_EXPORT_NAME,
+        )
         aws_cdk.CfnOutput(
             self,
             "searcher-function-name",

--- a/docs/guides/e2e-serverless-aws-lambda.md
+++ b/docs/guides/e2e-serverless-aws-lambda.md
@@ -143,7 +143,9 @@ curl -d '{"query":"quantity:>5", "max_hits": 10}' \
     --compressed
 ```
 
+:::note
 The index is not created until the first run of the Indexer, so you might need a few minutes before your first search request succeeds. The API Gateway key configuration also takes a minute or two to propagate, so the first requests might receive an authorization error response.
+:::
 
 Because the JSON query responses are often quite verbose, the Searcher Lambda always compresses them before sending them on the wire. It is crucial to keep this size low, both to avoid hitting the Lambda payload size limit of 6MB and to avoid egress costs at around $0.10/GB. We do this regardless of the `accept-encoding` request header, this is why the `--compressed` flag needs to be set to `curl`.
 


### PR DESCRIPTION
### Description

Currently, when destroying the stacks the buckets cannot be removed before emptying them manually. This PR improves the makefile to perform the bucket clean up automatically

### How was this PR tested?

Tested on both HDFS and mock data stack
