### PR TITLE
limit number of warn logs

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -416,12 +416,13 @@ impl DocProcessor {
                     processed_docs.push(processed_doc);
                 }
                 Err(error) => {
-                    if self.rate_limiter.should_log() {
+                    let error_str = error.to_string();
+                    if self.rate_limiter.should_log(&error_str) {
                         warn!(
                             index_id = self.counters.index_id,
                             source_id = self.counters.source_id,
                             "{}",
-                            error
+                            error_str
                         );
                     }
                     self.counters.record_error(error, num_bytes as u64);

--- a/quickwit/quickwit-indexing/src/actors/log_rate_limiter.rs
+++ b/quickwit/quickwit-indexing/src/actors/log_rate_limiter.rs
@@ -16,39 +16,63 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-//
 
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::time::{Duration, Instant};
 
 /// `RateLimiter` will allow `max_per_minute` calls per minute.
 ///
 /// It does not keep a sliding window, so it is not very precise, but very cheap.
+///
+/// It allows the same log at most 3 times per minute.
 pub struct LogRateLimiter {
     count: usize,
     start_time: Instant,
     max_per_minute: usize,
+    // we store only the hash of the error message to avoid storing the whole string.
+    errors_logged: HashMap<u64, usize>,
 }
-
+fn hash_string(input: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    input.hash(&mut hasher);
+    hasher.finish()
+}
 impl LogRateLimiter {
     pub fn new(max_per_minute: usize) -> Self {
         LogRateLimiter {
             count: 0,
             start_time: Instant::now(),
             max_per_minute,
+            errors_logged: HashMap::new(),
         }
     }
 
-    pub fn should_log(&mut self) -> bool {
+    pub fn should_log(&mut self, error: &str) -> bool {
+        let hash = hash_string(error);
         let now = Instant::now();
         let elapsed = now.duration_since(self.start_time);
 
         if elapsed > Duration::from_secs(60) {
             self.count = 0;
             self.start_time = now;
+            self.errors_logged.clear();
+            self.errors_logged.insert(hash, 1);
             true
         } else {
             self.count += 1;
-            self.count < self.max_per_minute
+            if self.count > self.max_per_minute {
+                return false;
+            }
+            let error_count = self.errors_logged.entry(hash).or_insert(0);
+            *error_count += 1;
+            // if we have logged the same error more than 3 times, we stop logging it in this
+            // minute.
+            if *error_count > 3 {
+                return false;
+            }
+            true
         }
     }
 }

--- a/quickwit/quickwit-indexing/src/actors/log_rate_limiter.rs
+++ b/quickwit/quickwit-indexing/src/actors/log_rate_limiter.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use std::time::{Duration, Instant};
+
+/// `RateLimiter` will allow `max_per_minute` calls per minute.
+///
+/// It does not keep a sliding window, so it is not very precise, but very cheap.
+pub struct LogRateLimiter {
+    count: usize,
+    start_time: Instant,
+    max_per_minute: usize,
+}
+
+impl LogRateLimiter {
+    pub fn new(max_per_minute: usize) -> Self {
+        LogRateLimiter {
+            count: 0,
+            start_time: Instant::now(),
+            max_per_minute,
+        }
+    }
+
+    pub fn should_log(&mut self) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.start_time);
+
+        if elapsed > Duration::from_secs(60) {
+            self.count = 0;
+            self.start_time = now;
+            true
+        } else {
+            self.count += 1;
+            self.count < self.max_per_minute
+        }
+    }
+}

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -22,6 +22,7 @@ mod index_serializer;
 mod indexer;
 mod indexing_pipeline;
 mod indexing_service;
+mod log_rate_limiter;
 mod merge_executor;
 mod merge_pipeline;
 mod merge_planner;


### PR DESCRIPTION
- limit number of warn logs from doc processor to 20 per minute
- limit same error log to 3 per minute

The limit is on the doc processor level and not shared currently

closes #4461