### PR TITLE
Issue/4469 limit concurrent merges

### DIFF
--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -340,13 +340,19 @@ impl<A: Actor> Inbox<A> {
         self.rx.try_recv()
     }
 
-    pub async fn recv_typed_message<M: 'static>(&self) -> Option<M> {
-        while let Ok(mut envelope) = self.rx.recv().await {
-            if let Some(msg) = envelope.message_typed() {
-                return Some(msg);
+    pub async fn recv_typed_message<M: 'static>(&self) -> Result<M, RecvError> {
+        loop {
+            match self.rx.recv().await {
+                Ok(mut envelope) => {
+                    if let Some(msg) = envelope.message_typed() {
+                        return Ok(msg);
+                    }
+                }
+                Err(err) => {
+                    return Err(err);
+                }
             }
         }
-        None
     }
 
     /// Destroys the inbox and returns the list of pending messages or commands

--- a/quickwit/quickwit-actors/src/mailbox.rs
+++ b/quickwit/quickwit-actors/src/mailbox.rs
@@ -340,6 +340,7 @@ impl<A: Actor> Inbox<A> {
         self.rx.try_recv()
     }
 
+    #[cfg(any(test, feature = "testsuite"))]
     pub async fn recv_typed_message<M: 'static>(&self) -> Result<M, RecvError> {
         loop {
             match self.rx.recv().await {

--- a/quickwit/quickwit-actors/src/universe.rs
+++ b/quickwit/quickwit-actors/src/universe.rs
@@ -89,6 +89,16 @@ impl Universe {
         self.spawn_ctx.registry.get_one::<A>()
     }
 
+    pub fn get_or_spawn_one<A: Actor + Default>(&self) -> Mailbox<A> {
+        if let Some(actor_mailbox) = self.spawn_ctx.registry.get_one::<A>() {
+            actor_mailbox
+        } else {
+            let actor_default = A::default();
+            let (mailbox, _handler) = self.spawn_builder().spawn(actor_default);
+            mailbox
+        }
+    }
+
     pub async fn observe(&self, timeout: Duration) -> Vec<ActorObservation> {
         self.spawn_ctx.registry.observe(timeout).await
     }

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.json
@@ -48,7 +48,8 @@
         "split_store_max_num_bytes": "1T",
         "split_store_max_num_splits": 10000,
         "max_concurrent_split_uploads": 8,
-        "max_merge_write_throughput": "100mb"
+        "max_merge_write_throughput": "100mb",
+        "merge_concurrency": 2
     },
     "ingest_api": {
         "replication_factor": 2

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.toml
@@ -39,6 +39,7 @@ split_store_max_num_bytes = "1T"
 split_store_max_num_splits = 10_000
 max_concurrent_split_uploads = 8
 max_merge_write_throughput = "100mb"
+merge_concurrency = 2
 
 [ingest_api]
 replication_factor = 2

--- a/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/config/quickwit.yaml
@@ -43,6 +43,7 @@ indexer:
   split_store_max_num_splits: 10000
   max_concurrent_split_uploads: 8
   max_merge_write_throughput: 100mb
+  merge_concurrency: 2
 
 ingest_api:
   replication_factor: 2

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -455,7 +455,7 @@ pub fn node_config_for_test() -> NodeConfig {
 mod tests {
     use std::env;
     use std::net::Ipv4Addr;
-    use std::num::NonZeroU64;
+    use std::num::{NonZeroU64, NonZeroUsize};
     use std::path::Path;
 
     use bytesize::ByteSize;
@@ -554,6 +554,7 @@ mod tests {
                 split_store_max_num_bytes: ByteSize::tb(1),
                 split_store_max_num_splits: 10_000,
                 max_concurrent_split_uploads: 8,
+                merge_concurrency: NonZeroUsize::new(2).unwrap(),
                 cpu_capacity: IndexerConfig::default_cpu_capacity(),
                 enable_cooperative_indexing: false,
                 max_merge_write_throughput: Some(ByteSize::mb(100)),

--- a/quickwit/quickwit-indexing/src/actors/index_serializer.rs
+++ b/quickwit/quickwit-indexing/src/actors/index_serializer.rs
@@ -95,7 +95,7 @@ impl Handler<IndexedSplitBatchBuilder> for IndexSerializer {
             checkpoint_delta_opt: batch_builder.checkpoint_delta_opt,
             publish_lock: batch_builder.publish_lock,
             publish_token_opt: batch_builder.publish_token_opt,
-            merge_operation_opt: None,
+            merge_task_opt: None,
             batch_parent_span: batch_builder.batch_parent_span,
         };
         ctx.send_message(&self.packager_mailbox, indexed_split_batch)

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -898,6 +898,7 @@ mod tests {
             merge_policy: default_merge_policy(),
             max_concurrent_split_uploads: 2,
             merge_io_throughput_limiter_opt: None,
+            merge_scheduler_service: universe.get_or_spawn_one(),
             event_broker: Default::default(),
         };
         let merge_pipeline = MergePipeline::new(merge_pipeline_params, universe.spawn_ctx());

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -85,19 +85,19 @@ impl Actor for MergeExecutor {
 impl Handler<MergeScratch> for MergeExecutor {
     type Reply = ();
 
-    #[instrument(level = "info", name = "merge_executor", parent = merge_scratch.merge_operation.merge_parent_span.id(), skip_all)]
+    #[instrument(level = "info", name = "merge_executor", parent = merge_scratch.merge_task.merge_parent_span.id(), skip_all)]
     async fn handle(
         &mut self,
         merge_scratch: MergeScratch,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         let start = Instant::now();
-        let merge_op = merge_scratch.merge_operation;
-        let indexed_split_opt: Option<IndexedSplit> = match merge_op.operation_type {
+        let merge_task = merge_scratch.merge_task;
+        let indexed_split_opt: Option<IndexedSplit> = match merge_task.operation_type {
             MergeOperationType::Merge => Some(
                 self.process_merge(
-                    merge_op.merge_split_id.clone(),
-                    merge_op.splits.clone(),
+                    merge_task.merge_split_id.clone(),
+                    merge_task.splits.clone(),
                     merge_scratch.tantivy_dirs,
                     merge_scratch.merge_scratch_directory,
                     ctx,
@@ -106,14 +106,14 @@ impl Handler<MergeScratch> for MergeExecutor {
             ),
             MergeOperationType::DeleteAndMerge => {
                 assert_eq!(
-                    merge_op.splits.len(),
+                    merge_task.splits.len(),
                     1,
                     "Delete tasks can be applied only on one split."
                 );
                 assert_eq!(merge_scratch.tantivy_dirs.len(), 1);
-                let split_with_docs_to_delete = merge_op.splits[0].clone();
+                let split_with_docs_to_delete = merge_task.splits[0].clone();
                 self.process_delete_and_merge(
-                    merge_op.merge_split_id.clone(),
+                    merge_task.merge_split_id.clone(),
                     split_with_docs_to_delete,
                     merge_scratch.tantivy_dirs,
                     merge_scratch.merge_scratch_directory,
@@ -126,7 +126,7 @@ impl Handler<MergeScratch> for MergeExecutor {
             info!(
                 merged_num_docs = %indexed_split.split_attrs.num_docs,
                 elapsed_secs = %start.elapsed().as_secs_f32(),
-                operation_type = %merge_op.operation_type,
+                operation_type = %merge_task.operation_type,
                 "merge-operation-success"
             );
             ctx.send_message(
@@ -136,8 +136,8 @@ impl Handler<MergeScratch> for MergeExecutor {
                     checkpoint_delta_opt: Default::default(),
                     publish_lock: PublishLock::default(),
                     publish_token_opt: None,
-                    batch_parent_span: merge_op.merge_parent_span.clone(),
-                    merge_operation_opt: Some(merge_op),
+                    batch_parent_span: merge_task.merge_parent_span.clone(),
+                    merge_task_opt: Some(merge_task),
                 },
             )
             .await?;
@@ -566,10 +566,10 @@ mod tests {
         DeleteQuery, ListSplitsRequest, PublishSplitsRequest, StageSplitsRequest,
     };
     use serde_json::Value as JsonValue;
-    use tantivy::{Document, Inventory, ReloadPolicy, TantivyDocument};
+    use tantivy::{Document, ReloadPolicy, TantivyDocument};
 
     use super::*;
-    use crate::merge_policy::MergeOperation;
+    use crate::merge_policy::{MergeOperation, MergeTask};
     use crate::{get_tantivy_directory_from_split_bundle, new_split_id, TestSandbox};
 
     #[tokio::test]
@@ -623,11 +623,10 @@ mod tests {
                 .await?;
             tantivy_dirs.push(get_tantivy_directory_from_split_bundle(&dest_filepath).unwrap())
         }
-        let merge_ops_inventory = Inventory::new();
-        let merge_operation =
-            merge_ops_inventory.track(MergeOperation::new_merge_operation(split_metas));
+        let merge_operation = MergeOperation::new_merge_operation(split_metas);
+        let merge_task = MergeTask::from_merge_operation_for_test(merge_operation);
         let merge_scratch = MergeScratch {
-            merge_operation,
+            merge_task,
             tantivy_dirs,
             merge_scratch_directory,
             downloaded_splits_directory,
@@ -772,12 +771,10 @@ mod tests {
             .copy_to_file(Path::new(&split_filename), &dest_filepath)
             .await?;
         let tantivy_dir = get_tantivy_directory_from_split_bundle(&dest_filepath).unwrap();
-        let merge_ops_inventory = Inventory::new();
-        let merge_operation = merge_ops_inventory.track(
-            MergeOperation::new_delete_and_merge_operation(new_split_metadata),
-        );
+        let merge_operation = MergeOperation::new_delete_and_merge_operation(new_split_metadata);
+        let merge_task = MergeTask::from_merge_operation_for_test(merge_operation);
         let merge_scratch = MergeScratch {
-            merge_operation,
+            merge_task,
             tantivy_dirs: vec![tantivy_dir],
             merge_scratch_directory,
             downloaded_splits_directory,

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -17,14 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use itertools::Itertools;
-use quickwit_actors::channel_with_priority::TrySendError;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
 use quickwit_metastore::SplitMetadata;
 use quickwit_proto::indexing::IndexingPipelineId;
@@ -33,9 +30,10 @@ use tantivy::Inventory;
 use time::OffsetDateTime;
 use tracing::{info, warn};
 
+use super::MergeSchedulerService;
+use crate::actors::merge_scheduler_service::schedule_merge;
 use crate::actors::MergeSplitDownloader;
 use crate::merge_policy::MergeOperation;
-use crate::metrics::INDEXER_METRICS;
 use crate::models::NewSplits;
 use crate::MergePolicy;
 
@@ -61,13 +59,16 @@ pub struct MergePlanner {
     /// We incrementally build this set, by adding new splits to it.
     /// When it becomes too large, we entirely rebuild it.
     known_split_ids: HashSet<String>,
+    known_split_ids_recompute_attempt_id: usize,
 
     merge_policy: Arc<dyn MergePolicy>,
     merge_split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
+    merge_scheduler_service: Mailbox<MergeSchedulerService>,
 
     /// Inventory of ongoing merge operations. If everything goes well,
     /// a merge operation is dropped after the publish of the merged split.
-    /// Used for observability.
+    ///
+    /// It is used to GC the known_split_ids set.
     ongoing_merge_operations_inventory: Inventory<MergeOperation>,
 
     /// We use the actor start_time as a way to identify incarnations.
@@ -75,27 +76,14 @@ pub struct MergePlanner {
     /// Since we recycle the mailbox of the merge planner, this incarnation
     /// makes it possible to ignore messages that where emitted from the previous
     /// instantiation.
-    ///
-    /// In particular, it is necessary to avoid ever increasing the number
-    /// `RefreshMetrics` loop, every time the `MergePlanner` is respawned.
     incarnation_started_at: Instant,
 }
 
 #[async_trait]
 impl Actor for MergePlanner {
-    type ObservableState = MergePlannerState;
+    type ObservableState = ();
 
-    fn observable_state(&self) -> Self::ObservableState {
-        let ongoing_merge_operations = self
-            .ongoing_merge_operations_inventory
-            .list()
-            .iter()
-            .map(|tracked_operation| tracked_operation.as_ref().clone())
-            .collect_vec();
-        MergePlannerState {
-            ongoing_merge_operations,
-        }
-    }
+    fn observable_state(&self) -> Self::ObservableState {}
 
     fn name(&self) -> String {
         "MergePlanner".to_string()
@@ -106,13 +94,6 @@ impl Actor for MergePlanner {
     }
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
-        self.handle(
-            RefreshMetrics {
-                incarnation_started_at: self.incarnation_started_at,
-            },
-            ctx,
-        )
-        .await?;
         // We do not call the handle method directly and instead queue the message in order to drain
         // the recycled mailbox and get a consolidated vision of the set of published
         // splits, before scheduling any merge operation. See #3847 for more details.
@@ -159,27 +140,17 @@ impl Handler<NewSplits> for MergePlanner {
     ) -> Result<(), ActorExitStatus> {
         self.record_splits_if_necessary(new_splits.new_splits);
         self.send_merge_ops(ctx).await?;
-        if self.known_split_ids.len() >= self.num_known_splits_rebuild_threshold() {
-            self.known_split_ids = self.rebuild_known_split_ids();
-        }
         self.recompute_known_splits_if_necessary();
         Ok(())
     }
 }
 
-fn max_merge_ops(merge_op: &MergeOperation) -> usize {
-    merge_op
-        .splits_as_slice()
-        .iter()
-        .map(|split_metadata| split_metadata.num_merge_ops)
-        .max()
-        .unwrap_or(0)
-}
-
 impl MergePlanner {
     pub fn queue_capacity() -> QueueCapacity {
-        // We cannot have a Queue capacity of 0 here because `try_send_self`
-        // would never succeed.
+        // The query planner handler will block until merge operation are scheduled.
+        //
+        // This queue capacity amounts to the number of "non-running" but merge operations
+        // we are willing to have at the same time.
         QueueCapacity::Bounded(1)
     }
 
@@ -188,6 +159,7 @@ impl MergePlanner {
         published_splits: Vec<SplitMetadata>,
         merge_policy: Arc<dyn MergePolicy>,
         merge_split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
+        merge_scheduler_service: Mailbox<MergeSchedulerService>,
     ) -> MergePlanner {
         let published_splits: Vec<SplitMetadata> = published_splits
             .into_iter()
@@ -195,10 +167,13 @@ impl MergePlanner {
             .collect();
         let mut merge_planner = MergePlanner {
             known_split_ids: Default::default(),
+            known_split_ids_recompute_attempt_id: 0,
             partitioned_young_splits: Default::default(),
             merge_policy,
             merge_split_downloader_mailbox,
+            merge_scheduler_service,
             ongoing_merge_operations_inventory: Inventory::default(),
+
             incarnation_started_at: Instant::now(),
         };
         merge_planner.record_splits_if_necessary(published_splits);
@@ -206,8 +181,7 @@ impl MergePlanner {
     }
 
     fn rebuild_known_split_ids(&self) -> HashSet<String> {
-        let mut known_split_ids: HashSet<String> =
-            HashSet::with_capacity(self.num_known_splits_rebuild_threshold());
+        let mut known_split_ids: HashSet<String> = HashSet::default();
         // Add splits that in `partitioned_young_splits`.
         for young_split_partition in self.partitioned_young_splits.values() {
             for split in young_split_partition {
@@ -242,43 +216,13 @@ impl MergePlanner {
         true
     }
 
+    // No need to rebuild every time, we do once out of 100 times.
     fn recompute_known_splits_if_necessary(&mut self) {
-        if self.known_split_ids.len() >= self.num_known_splits_rebuild_threshold() {
+        self.known_split_ids_recompute_attempt_id += 1;
+        if self.known_split_ids_recompute_attempt_id % 100 == 0 {
             self.known_split_ids = self.rebuild_known_split_ids();
+            self.known_split_ids_recompute_attempt_id = 0;
         }
-        if cfg!(test) {
-            let merge_operation = self.ongoing_merge_operations_inventory.list();
-            let mut young_splits = HashSet::new();
-            for (&partition_id, young_splits_in_partition) in &self.partitioned_young_splits {
-                for split_metadata in young_splits_in_partition {
-                    assert_eq!(split_metadata.partition_id, partition_id);
-                    young_splits.insert(split_metadata.split_id());
-                }
-            }
-            for merge_op in merge_operation {
-                assert!(!self.known_split_ids.contains(&merge_op.merge_split_id));
-                for split_in_merge in merge_op.splits_as_slice() {
-                    assert!(self.known_split_ids.contains(split_in_merge.split_id()));
-                }
-            }
-            assert!(self.known_split_ids.len() <= self.num_known_splits_rebuild_threshold() + 1);
-        }
-    }
-
-    /// Whenever the number of known splits exceeds this threshold, we rebuild the `known_split_ids`
-    /// set.
-    ///
-    /// We have this function to return a number that is higher than 2 times the len of
-    /// `known_split_ids` after a rebuild to get amortization.
-    fn num_known_splits_rebuild_threshold(&self) -> usize {
-        // The idea behind this formula is that we expect the max legitimate of splits after a
-        // rebuild to be  `num_young_splits` + `num_splits_merge`.
-        // The capacity of `partioned_young_splits` is a good upper bound for the number of
-        // partition.
-        //
-        // We can expect a maximum of 100 ongoing splits in merge per partition. (We oversize this
-        // because it actually depends on the merge factor.
-        1 + self.num_young_splits() + (1 + self.partitioned_young_splits.capacity()) * 20
     }
 
     // Record a split. This function does NOT check if the split is mature or not, or if the split
@@ -331,70 +275,24 @@ impl MergePlanner {
         Ok(merge_operations)
     }
 
-    fn num_young_splits(&self) -> usize {
-        self.partitioned_young_splits
-            .values()
-            .map(|splits| splits.len())
-            .sum()
-    }
-
     async fn send_merge_ops(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
-        // We do not want to simply schedule all available merge operations here.
+        // We identify all of the merge operations we want to run and leave it
+        // to the merge scheduler to decide in which order these should be scheduled.
         //
-        // The reason is that in presence of partitioning, it is very possible
-        // to receive a set of splits opening the opportunity to run a lot "large" merge
-        // operations at the same time.
-        //
-        // These large merge operation will in turn prevent small merge operations
-        // from being executed, when in fact small merge operations should be executed
-        // in priority.
-        //
-        // As an alternative approach, this function push merge operations until it starts
-        // experience some push back, and then just "loops".
-        let mut merge_ops = self.compute_merge_ops(ctx).await?;
-        // We run smaller merges in priority.
-        merge_ops.sort_by_cached_key(|merge_op| Reverse(max_merge_ops(merge_op)));
-        while let Some(merge_operation) = merge_ops.pop() {
-            info!(merge_operation=?merge_operation, "planned merge operation");
+        // The merge scheduler has the merit of knowing about merge operations from other
+        // index as well.
+        let merge_ops = self.compute_merge_ops(ctx).await?;
+        for merge_operation in merge_ops {
+            info!(merge_operation=?merge_operation, "schedule merge operation");
             let tracked_merge_operation = self
                 .ongoing_merge_operations_inventory
                 .track(merge_operation);
-            if let Err(try_send_err) = self
-                .merge_split_downloader_mailbox
-                .try_send_message(tracked_merge_operation)
-            {
-                match try_send_err {
-                    TrySendError::Disconnected => {
-                        return Err(ActorExitStatus::DownstreamClosed);
-                    }
-                    TrySendError::Full(merge_op) => {
-                        ctx.send_message(&self.merge_split_downloader_mailbox, merge_op)
-                            .await?;
-                        break;
-                    }
-                }
-            }
-        }
-        if !merge_ops.is_empty() {
-            // We experienced some push back and decided to stop queueing too
-            // many merge operation. (For more detail see #2348)
-            //
-            // We need to re-record the related split, so that we
-            // perform a merge in the future.
-            for merge_op in merge_ops {
-                for split in merge_op.splits {
-                    self.record_split(split);
-                }
-            }
-            // We try_self_send a `PlanMerge` message in order to ensure that
-            // progress on our merges.
-            //
-            // If `try_send_self_message` returns an error, it means that the
-            // the self queue is full, which means that the `PlanMerge`
-            // message is not really needed anyway.
-            let _ignored_result = ctx.try_send_self_message(PlanMerge {
-                incarnation_started_at: self.incarnation_started_at,
-            });
+            schedule_merge(
+                &self.merge_scheduler_service,
+                tracked_merge_operation,
+                self.merge_split_downloader_mailbox.clone(),
+            )
+            .await?
         }
         Ok(())
     }
@@ -408,40 +306,8 @@ fn belongs_to_pipeline(pipeline_id: &IndexingPipelineId, split: &SplitMetadata) 
 }
 
 #[derive(Debug)]
-struct RefreshMetrics {
-    incarnation_started_at: Instant,
-}
-
-#[derive(Debug)]
 struct PlanMerge {
     incarnation_started_at: Instant,
-}
-
-#[async_trait]
-impl Handler<RefreshMetrics> for MergePlanner {
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        refresh_metric: RefreshMetrics,
-        ctx: &ActorContext<Self>,
-    ) -> Result<(), ActorExitStatus> {
-        if self.incarnation_started_at != refresh_metric.incarnation_started_at {
-            // This message was emitted by a different incarnation.
-            // (See `Self::incarnation_started_at`)
-            return Ok(());
-        }
-        INDEXER_METRICS
-            .ongoing_merge_operations
-            .set(self.ongoing_merge_operations_inventory.list().len() as i64);
-        ctx.schedule_self_msg(
-            *quickwit_actors::HEARTBEAT,
-            RefreshMetrics {
-                incarnation_started_at: self.incarnation_started_at,
-            },
-        );
-        Ok(())
-    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -463,12 +329,11 @@ mod tests {
     use quickwit_metastore::{SplitMaturity, SplitMetadata};
     use quickwit_proto::indexing::IndexingPipelineId;
     use quickwit_proto::types::{IndexUid, PipelineUid};
-    use tantivy::TrackedObject;
     use time::OffsetDateTime;
 
     use crate::actors::MergePlanner;
     use crate::merge_policy::{
-        merge_policy_from_settings, MergeOperation, MergePolicy, StableLogMergePolicy,
+        merge_policy_from_settings, MergePolicy, MergeTask, StableLogMergePolicy,
     };
     use crate::models::NewSplits;
 
@@ -521,6 +386,7 @@ mod tests {
             Vec::new(),
             merge_policy,
             merge_split_downloader_mailbox,
+            universe.get_or_spawn_one(),
         );
 
         let (merge_planner_mailbox, merge_planner_handle) =
@@ -561,8 +427,7 @@ mod tests {
             };
             merge_planner_mailbox.send_message(message).await?;
             merge_planner_handle.process_pending_and_observe().await;
-            let operations = merge_split_downloader_inbox
-                .drain_for_test_typed::<TrackedObject<MergeOperation>>();
+            let operations = merge_split_downloader_inbox.drain_for_test_typed::<MergeTask>();
             assert_eq!(operations.len(), 2);
             let mut merge_operations = operations.into_iter().sorted_by(|left_op, right_op| {
                 left_op.splits[0]
@@ -579,155 +444,6 @@ mod tests {
         universe.assert_quit().await;
 
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_merge_planner_priority() -> anyhow::Result<()> {
-        let universe = Universe::with_accelerated_time();
-        let (merge_split_downloader_mailbox, merge_split_downloader_inbox) =
-            universe.create_test_mailbox();
-        let index_uid = IndexUid::new_with_random_ulid("test-index");
-        let pipeline_id = IndexingPipelineId {
-            index_uid: index_uid.clone(),
-            source_id: "test-source".to_string(),
-            node_id: "test-node".to_string(),
-            pipeline_uid: PipelineUid::default(),
-        };
-        let merge_policy_config = ConstWriteAmplificationMergePolicyConfig {
-            merge_factor: 2,
-            max_merge_factor: 2,
-            max_merge_ops: 3,
-            ..Default::default()
-        };
-        let indexing_settings = IndexingSettings {
-            merge_policy: MergePolicyConfig::ConstWriteAmplification(merge_policy_config),
-            ..Default::default()
-        };
-        let merge_policy: Arc<dyn MergePolicy> = merge_policy_from_settings(&indexing_settings);
-        let merge_planner = MergePlanner::new(
-            pipeline_id,
-            Vec::new(),
-            merge_policy,
-            merge_split_downloader_mailbox,
-        );
-        let (merge_planner_mailbox, merge_planner_handle) =
-            universe.spawn_builder().spawn(merge_planner);
-        // send 4 splits, offering 2 merge opportunities.
-        let message = NewSplits {
-            new_splits: vec![
-                split_metadata_for_test(&index_uid, "2_a", 2, 100, 2),
-                split_metadata_for_test(&index_uid, "2_b", 2, 100, 2),
-                split_metadata_for_test(&index_uid, "1_a", 1, 10, 1),
-                split_metadata_for_test(&index_uid, "1_b", 1, 10, 1),
-            ],
-        };
-        merge_planner_mailbox.send_message(message).await?;
-        merge_planner_handle.process_pending_and_observe().await;
-        let merge_ops: Vec<TrackedObject<MergeOperation>> =
-            merge_split_downloader_inbox.drain_for_test_typed();
-        assert_eq!(merge_ops.len(), 2);
-        assert_eq!(merge_ops[0].splits_as_slice()[0].num_merge_ops, 1);
-        assert_eq!(merge_ops[1].splits_as_slice()[0].num_merge_ops, 2);
-        universe.assert_quit().await;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_merge_planner_priority_only_queue_up_to_capacity() {
-        let universe = Universe::with_accelerated_time();
-        let (merge_split_downloader_mailbox, merge_split_downloader_inbox) = universe
-            .spawn_ctx()
-            .create_mailbox("MergeSplitDownloader", QueueCapacity::Bounded(2));
-        let index_uid = IndexUid::new_with_random_ulid("test-index");
-        let pipeline_id = IndexingPipelineId {
-            index_uid: index_uid.clone(),
-            source_id: "test-source".to_string(),
-            node_id: "test-node".to_string(),
-            pipeline_uid: PipelineUid::default(),
-        };
-        let merge_policy_config = ConstWriteAmplificationMergePolicyConfig {
-            merge_factor: 2,
-            max_merge_factor: 2,
-            max_merge_ops: 3,
-            ..Default::default()
-        };
-        let indexing_settings = IndexingSettings {
-            merge_policy: MergePolicyConfig::ConstWriteAmplification(merge_policy_config),
-            ..Default::default()
-        };
-        let merge_policy: Arc<dyn MergePolicy> = merge_policy_from_settings(&indexing_settings);
-        let merge_planner = MergePlanner::new(
-            pipeline_id,
-            Vec::new(),
-            merge_policy,
-            merge_split_downloader_mailbox,
-        );
-        let universe = Universe::with_accelerated_time();
-        let (merge_planner_mailbox, _) = universe.spawn_builder().spawn(merge_planner);
-        tokio::task::spawn(async move {
-            // Sending 20 splits offering 10 split opportunities
-            let messages_with_merge_ops2 = NewSplits {
-                new_splits: (0..10)
-                    .flat_map(|partition_id| {
-                        [
-                            split_metadata_for_test(
-                                &index_uid,
-                                &format!("{partition_id}_a_large"),
-                                partition_id,
-                                1_000_000,
-                                2,
-                            ),
-                            split_metadata_for_test(
-                                &index_uid,
-                                &format!("{partition_id}_b_large"),
-                                partition_id,
-                                1_000_000,
-                                2,
-                            ),
-                        ]
-                    })
-                    .collect(),
-            };
-            merge_planner_mailbox
-                .send_message(messages_with_merge_ops2)
-                .await
-                .unwrap();
-            let messages_with_merge_ops1 = NewSplits {
-                new_splits: (0..10)
-                    .flat_map(|partition_id| {
-                        [
-                            split_metadata_for_test(
-                                &index_uid,
-                                &format!("{partition_id}_a_small"),
-                                partition_id,
-                                100_000,
-                                1,
-                            ),
-                            split_metadata_for_test(
-                                &index_uid,
-                                &format!("{partition_id}_b_small"),
-                                partition_id,
-                                100_000,
-                                1,
-                            ),
-                        ]
-                    })
-                    .collect(),
-            };
-            merge_planner_mailbox
-                .send_message(messages_with_merge_ops1)
-                .await
-                .unwrap();
-        });
-        tokio::task::spawn_blocking(move || {
-            let mut merge_ops: Vec<TrackedObject<MergeOperation>> = Vec::new();
-            while merge_ops.len() < 20 {
-                merge_ops.extend(merge_split_downloader_inbox.drain_for_test_typed());
-            }
-        })
-        .await
-        .unwrap();
-        universe.assert_quit().await;
     }
 
     #[tokio::test]
@@ -770,16 +486,17 @@ mod tests {
             pre_existing_splits.clone(),
             merge_policy,
             merge_split_downloader_mailbox,
+            universe.get_or_spawn_one(),
         );
         let (merge_planner_mailbox, merge_planner_handle) =
             universe.spawn_builder().spawn(merge_planner);
 
         // We wait for the first merge ops. If we sent the Quit message right away, it would have
         // been queue before first `PlanMerge` message.
-        let merge_op = merge_split_downloader_inbox
-            .recv_typed_message::<TrackedObject<MergeOperation>>()
+        let merge_task_res = merge_split_downloader_inbox
+            .recv_typed_message::<MergeTask>()
             .await;
-        assert!(merge_op.is_some());
+        assert!(merge_task_res.is_ok());
 
         // We make sure that the known splits filtering set filters out splits are currently in
         // merge.
@@ -791,8 +508,7 @@ mod tests {
 
         let _ = merge_planner_handle.process_pending_and_observe().await;
 
-        let merge_ops =
-            merge_split_downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
+        let merge_ops = merge_split_downloader_inbox.drain_for_test_typed::<MergeTask>();
 
         assert!(merge_ops.is_empty());
 
@@ -800,8 +516,7 @@ mod tests {
 
         let (exit_status, _last_state) = merge_planner_handle.join().await;
         assert!(matches!(exit_status, ActorExitStatus::Quit));
-        let merge_ops =
-            merge_split_downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
+        let merge_ops = merge_split_downloader_inbox.drain_for_test_typed::<MergeTask>();
         assert!(merge_ops.is_empty());
         universe.assert_quit().await;
         Ok(())
@@ -858,6 +573,7 @@ mod tests {
             pre_existing_splits.clone(),
             merge_policy,
             merge_split_downloader_mailbox,
+            universe.get_or_spawn_one(),
         );
         let (merge_planner_mailbox, merge_planner_handle) =
             universe.spawn_builder().spawn(merge_planner);
@@ -865,10 +581,9 @@ mod tests {
         merge_planner_mailbox.send_message(Command::Quit).await?;
         let (exit_status, _last_state) = merge_planner_handle.join().await;
         assert!(matches!(exit_status, ActorExitStatus::Quit));
-        let merge_ops =
-            merge_split_downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
+        let merge_tasks = merge_split_downloader_inbox.drain_for_test_typed::<MergeTask>();
 
-        assert!(merge_ops.is_empty());
+        assert!(merge_tasks.is_empty());
         universe.assert_quit().await;
         Ok(())
     }
@@ -914,8 +629,8 @@ mod tests {
             pre_existing_splits.clone(),
             merge_policy,
             merge_split_downloader_mailbox,
+            universe.get_or_spawn_one(),
         );
-        let universe = Universe::with_accelerated_time();
 
         // We create a fake old mailbox that contains two new splits and a PlanMerge message from an
         // old incarnation. This could happen in real life if the merge pipeline failed
@@ -935,87 +650,18 @@ mod tests {
         // sent in the initialize method.
 
         // Instead, we wait for the first merge ops.
-        let merge_ops = merge_split_downloader_inbox
-            .recv_typed_message::<TrackedObject<MergeOperation>>()
+        let merge_task_res = merge_split_downloader_inbox
+            .recv_typed_message::<MergeTask>()
             .await;
-        assert!(merge_ops.is_some());
+        assert!(merge_task_res.is_ok());
 
         // At this point, our merge has been initialized.
         merge_planner_mailbox.send_message(Command::Quit).await?;
         let (exit_status, _last_state) = merge_planner_handle.join().await;
 
         assert!(matches!(exit_status, ActorExitStatus::Quit));
-        let merge_ops =
-            merge_split_downloader_inbox.drain_for_test_typed::<TrackedObject<MergeOperation>>();
-        assert!(merge_ops.is_empty());
-
-        universe.assert_quit().await;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_merge_planner_known_splits_set_size_stays_bounded() -> anyhow::Result<()> {
-        let universe = Universe::with_accelerated_time();
-        let (merge_split_downloader_mailbox, merge_split_downloader_inbox) = universe
-            .spawn_ctx()
-            .create_mailbox("MergeSplitDownloader", QueueCapacity::Unbounded);
-        let index_uid = IndexUid::new_with_random_ulid("test-index");
-        let pipeline_id = IndexingPipelineId {
-            index_uid: index_uid.clone(),
-            source_id: "test-source".to_string(),
-            node_id: "test-node".to_string(),
-            pipeline_uid: PipelineUid::default(),
-        };
-        let merge_policy_config = ConstWriteAmplificationMergePolicyConfig {
-            merge_factor: 2,
-            max_merge_factor: 2,
-            max_merge_ops: 3,
-            ..Default::default()
-        };
-        let indexing_settings = IndexingSettings {
-            merge_policy: MergePolicyConfig::ConstWriteAmplification(merge_policy_config),
-            ..Default::default()
-        };
-        let merge_policy: Arc<dyn MergePolicy> = merge_policy_from_settings(&indexing_settings);
-        let merge_planner = MergePlanner::new(
-            pipeline_id,
-            Vec::new(),
-            merge_policy,
-            merge_split_downloader_mailbox,
-        );
-        let universe = Universe::with_accelerated_time();
-
-        // We spawn our merge planner with this recycled mailbox.
-        let (merge_planner_mailbox, merge_planner_handle) =
-            universe.spawn_builder().spawn(merge_planner);
-
-        for j in 0..100 {
-            for i in 0..10 {
-                merge_planner_mailbox
-                    .ask(NewSplits {
-                        new_splits: vec![split_metadata_for_test(
-                            &index_uid,
-                            &format!("split_{}", j * 10 + i),
-                            0,
-                            1_000_000,
-                            1,
-                        )],
-                    })
-                    .await
-                    .unwrap();
-            }
-            // We drain the merge_ops to make sure merge ops are dropped (as if merges where
-            // successful) and that we are properly testing that the known_splits_set is
-            // bounded.
-            let merge_ops = merge_split_downloader_inbox
-                .drain_for_test_typed::<TrackedObject<MergeOperation>>();
-            assert_eq!(merge_ops.len(), 5);
-        }
-
-        // At this point, our merge has been initialized.
-        merge_planner_mailbox.send_message(Command::Quit).await?;
-        let (exit_status, _last_state) = merge_planner_handle.join().await;
-        assert!(matches!(exit_status, ActorExitStatus::Quit));
+        let merge_tasks = merge_split_downloader_inbox.drain_for_test_typed::<MergeTask>();
+        assert!(merge_tasks.is_empty());
 
         universe.assert_quit().await;
         Ok(())

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -147,10 +147,8 @@ impl Handler<NewSplits> for MergePlanner {
 
 impl MergePlanner {
     pub fn queue_capacity() -> QueueCapacity {
-        // The query planner handler will block until merge operation are scheduled.
-        //
-        // This queue capacity amounts to the number of "non-running" but merge operations
-        // we are willing to have at the same time.
+        // We cannot have a Queue capacity of 0 here because `try_send_self`
+        // would never succeed.
         QueueCapacity::Bounded(1)
     }
 

--- a/quickwit/quickwit-indexing/src/actors/merge_scheduler_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_scheduler_service.rs
@@ -1,0 +1,463 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::cmp::Reverse;
+use std::collections::binary_heap::PeekMut;
+use std::collections::BinaryHeap;
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox};
+use tantivy::TrackedObject;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::error;
+
+use super::MergeSplitDownloader;
+use crate::merge_policy::{MergeOperation, MergeTask};
+
+pub struct MergePermit {
+    _semaphore_permit: Option<OwnedSemaphorePermit>,
+    merge_scheduler_mailbox: Option<Mailbox<MergeSchedulerService>>,
+}
+
+impl MergePermit {
+    #[cfg(test)]
+    pub fn for_test() -> MergePermit {
+        MergePermit {
+            _semaphore_permit: None,
+            merge_scheduler_mailbox: None,
+        }
+    }
+}
+
+impl Drop for MergePermit {
+    fn drop(&mut self) {
+        let Some(merge_scheduler_mailbox) = self.merge_scheduler_mailbox.take() else {
+            return;
+        };
+        if merge_scheduler_mailbox
+            .send_message_with_high_priority(PermitReleased)
+            .is_err()
+        {
+            error!("schedule merge service is dead");
+        }
+    }
+}
+
+pub async fn schedule_merge(
+    merge_scheduler_service: &Mailbox<MergeSchedulerService>,
+    merge_operation: TrackedObject<MergeOperation>,
+    merge_split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
+) -> anyhow::Result<()> {
+    let schedule_merge = ScheduleMerge::new(merge_operation, merge_split_downloader_mailbox);
+    // TODO add backpressure.
+    merge_scheduler_service
+        .ask(schedule_merge)
+        .await
+        .context("failed to acquire permit")?;
+    Ok(())
+}
+
+struct ScheduledMerge {
+    score: u64,
+    id: u64, //< just for total ordering.
+    merge_operation: TrackedObject<MergeOperation>,
+    split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
+}
+
+impl ScheduledMerge {
+    fn order_key(&self) -> (u64, Reverse<u64>) {
+        (self.score, std::cmp::Reverse(self.id))
+    }
+}
+
+impl Eq for ScheduledMerge {}
+
+impl PartialEq for ScheduledMerge {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+
+impl PartialOrd for ScheduledMerge {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ScheduledMerge {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.order_key().cmp(&other.order_key())
+    }
+}
+
+/// The merge scheduler service is in charge of keeping track of all scheduled merge operation,
+/// and schedule them in the best possible order, and respecting the `merge_concurrency` limit.
+///
+/// This actor is not supervised, and should stay as simple as possible.
+/// In particular,
+/// - the `ScheduleMerge` handler should reply in microseconds.
+/// - the task should never be dropped before reaching its `split_downloader_mailbox` destination
+/// as it would break the consistency of `MergePlanner` with the metastore (ie: several splits will
+/// never) be merged.
+pub struct MergeSchedulerService {
+    merge_semaphore: Arc<Semaphore>,
+    merge_concurrency: usize,
+    pending_merge_queue: BinaryHeap<ScheduledMerge>,
+    next_merge_id: u64,
+    pending_merge_bytes: u64,
+}
+
+impl Default for MergeSchedulerService {
+    fn default() -> MergeSchedulerService {
+        MergeSchedulerService::new(3)
+    }
+}
+
+impl MergeSchedulerService {
+    pub fn new(merge_concurrency: usize) -> MergeSchedulerService {
+        let merge_semaphore = Arc::new(Semaphore::new(merge_concurrency));
+        MergeSchedulerService {
+            merge_semaphore,
+            merge_concurrency,
+            pending_merge_queue: BinaryHeap::default(),
+            next_merge_id: 0,
+            pending_merge_bytes: 0,
+        }
+    }
+
+    fn schedule_pending_merges(&mut self, ctx: &ActorContext<Self>) {
+        // We schedule as many pending merge as we can,
+        // until there are no permit available or no merge to schedule.
+        loop {
+            let merge_semaphore = self.merge_semaphore.clone();
+            let Some(next_merge) = self.pending_merge_queue.peek_mut() else {
+                // No merge to schedule.
+                break;
+            };
+            let Ok(semaphore_permit) = Semaphore::try_acquire_owned(merge_semaphore) else {
+                // No permit available right away.
+                break;
+            };
+            let merge_permit = MergePermit {
+                _semaphore_permit: Some(semaphore_permit),
+                merge_scheduler_mailbox: Some(ctx.mailbox().clone()),
+            };
+            let ScheduledMerge {
+                merge_operation,
+                split_downloader_mailbox,
+                ..
+            } = PeekMut::pop(next_merge);
+            let merge_task = MergeTask {
+                merge_operation,
+                _merge_permit: merge_permit,
+            };
+            self.pending_merge_bytes -= merge_task.merge_operation.total_num_bytes();
+            crate::metrics::INDEXER_METRICS
+                .pending_merge_operations
+                .set(self.pending_merge_queue.len() as i64);
+            crate::metrics::INDEXER_METRICS
+                .pending_merge_bytes
+                .set(self.pending_merge_bytes as i64);
+            match split_downloader_mailbox.try_send_message(merge_task) {
+                Ok(_) => {}
+                Err(quickwit_actors::TrySendError::Full(_)) => {
+                    // The split downloader mailbox has an unbounded queue capacity,
+                    error!("split downloader queue is full: please report");
+                }
+                Err(quickwit_actors::TrySendError::Disconnected) => {
+                    // It means the split downloader is dead.
+                    // This is fine, the merge pipeline has probably been restarted.
+                }
+            }
+        }
+        let num_merges =
+            self.merge_concurrency as i64 - self.merge_semaphore.available_permits() as i64;
+        crate::metrics::INDEXER_METRICS
+            .ongoing_merge_operations
+            .set(num_merges);
+    }
+}
+
+#[async_trait]
+impl Actor for MergeSchedulerService {
+    type ObservableState = ();
+
+    fn observable_state(&self) {}
+
+    async fn initialize(&mut self, _ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ScheduleMerge {
+    score: u64,
+    merge_operation: TrackedObject<MergeOperation>,
+    split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
+}
+
+/// The higher, the sooner we will execute the merge operation.
+/// A good merge operation
+/// - strongly reduces the number splits
+/// - is light.
+fn score_merge_operation(merge_operation: &MergeOperation) -> u64 {
+    let total_num_bytes: u64 = merge_operation.total_num_bytes();
+    if total_num_bytes == 0 {
+        // Silly corner case that should never happen.
+        return u64::MAX;
+    }
+    // We will remove splits.len() and add 1 merge splits.
+    let delta_num_splits = (merge_operation.splits.len() - 1) as u64;
+    // We use integer arithmetic to avoid `f64 are not ordered` silliness.
+    dbg!(delta_num_splits, total_num_bytes);
+    (delta_num_splits << 48)
+        .checked_div(total_num_bytes)
+        .unwrap_or(1u64)
+}
+
+impl ScheduleMerge {
+    pub fn new(
+        merge_operation: TrackedObject<MergeOperation>,
+        split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
+    ) -> ScheduleMerge {
+        let score = score_merge_operation(&merge_operation);
+        ScheduleMerge {
+            score,
+            merge_operation,
+            split_downloader_mailbox,
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<ScheduleMerge> for MergeSchedulerService {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        schedule_merge: ScheduleMerge,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        let ScheduleMerge {
+            score,
+            merge_operation,
+            split_downloader_mailbox,
+        } = schedule_merge;
+        let merge_id = self.next_merge_id;
+        self.next_merge_id += 1;
+        let scheduled_merge = ScheduledMerge {
+            score,
+            id: merge_id,
+            merge_operation,
+            split_downloader_mailbox,
+        };
+        self.pending_merge_bytes += scheduled_merge.merge_operation.total_num_bytes();
+        self.pending_merge_queue.push(scheduled_merge);
+        crate::metrics::INDEXER_METRICS
+            .pending_merge_operations
+            .set(self.pending_merge_queue.len() as i64);
+        crate::metrics::INDEXER_METRICS
+            .pending_merge_bytes
+            .set(self.pending_merge_bytes as i64);
+        self.schedule_pending_merges(ctx);
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct PermitReleased;
+
+#[async_trait]
+impl Handler<PermitReleased> for MergeSchedulerService {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _: PermitReleased,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        self.schedule_pending_merges(ctx);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use quickwit_actors::Universe;
+    use quickwit_metastore::SplitMetadata;
+    use tantivy::Inventory;
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::merge_policy::{MergeOperation, MergeTask};
+
+    fn build_merge_operation(num_splits: usize, num_bytes_per_split: u64) -> MergeOperation {
+        let splits: Vec<SplitMetadata> = std::iter::repeat_with(|| SplitMetadata {
+            footer_offsets: num_bytes_per_split..num_bytes_per_split,
+            ..Default::default()
+        })
+        .take(num_splits)
+        .collect();
+        MergeOperation::new_merge_operation(splits)
+    }
+
+    #[test]
+    fn test_score_merge_operation() {
+        let score_merge_operation_aux = |num_splits, num_bytes_per_split| {
+            let merge_operation = build_merge_operation(num_splits, num_bytes_per_split);
+            score_merge_operation(&merge_operation)
+        };
+        assert!(score_merge_operation_aux(10, 10_000_000) < score_merge_operation_aux(10, 999_999));
+        assert!(
+            score_merge_operation_aux(10, 10_000_000) > score_merge_operation_aux(9, 10_000_000)
+        );
+        assert_eq!(
+            // 9 - 1 = 8 splits removed.
+            score_merge_operation_aux(9, 10_000_000),
+            // 5 - 1  = 4 splits removed.
+            score_merge_operation_aux(5, 10_000_000 * 9 / 10)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_schedule_service_prioritize() {
+        let universe = Universe::new();
+        let (merge_scheduler_service, _) = universe
+            .spawn_builder()
+            .spawn(MergeSchedulerService::new(2));
+        let inventory = Inventory::new();
+
+        let (merge_split_downloader_mailbox, merge_split_downloader_inbox) =
+            universe.create_test_mailbox();
+        {
+            let large_merge_operation = build_merge_operation(10, 4_000_000);
+            let tracked_large_merge_operation = inventory.track(large_merge_operation);
+            schedule_merge(
+                &merge_scheduler_service,
+                tracked_large_merge_operation,
+                merge_split_downloader_mailbox.clone(),
+            )
+            .await
+            .unwrap();
+        }
+        {
+            let large_merge_operation2 = build_merge_operation(10, 3_000_000);
+            let tracked_large_merge_operation2 = inventory.track(large_merge_operation2);
+            schedule_merge(
+                &merge_scheduler_service,
+                tracked_large_merge_operation2,
+                merge_split_downloader_mailbox.clone(),
+            )
+            .await
+            .unwrap();
+        }
+        {
+            let large_merge_operation2 = build_merge_operation(10, 5_000_000);
+            let tracked_large_merge_operation2 = inventory.track(large_merge_operation2);
+            schedule_merge(
+                &merge_scheduler_service,
+                tracked_large_merge_operation2,
+                merge_split_downloader_mailbox.clone(),
+            )
+            .await
+            .unwrap();
+        }
+        {
+            let large_merge_operation2 = build_merge_operation(10, 2_000_000);
+            let tracked_large_merge_operation2 = inventory.track(large_merge_operation2);
+            schedule_merge(
+                &merge_scheduler_service,
+                tracked_large_merge_operation2,
+                merge_split_downloader_mailbox.clone(),
+            )
+            .await
+            .unwrap();
+        }
+        {
+            let large_merge_operation2 = build_merge_operation(10, 1_000_000);
+            let tracked_large_merge_operation2 = inventory.track(large_merge_operation2);
+            schedule_merge(
+                &merge_scheduler_service,
+                tracked_large_merge_operation2,
+                merge_split_downloader_mailbox.clone(),
+            )
+            .await
+            .unwrap();
+        }
+        {
+            let merge_task: MergeTask = merge_split_downloader_inbox
+                .recv_typed_message::<MergeTask>()
+                .await
+                .unwrap();
+            assert_eq!(
+                merge_task.merge_operation.splits[0].footer_offsets.end,
+                4_000_000
+            );
+            let merge_task2: MergeTask = merge_split_downloader_inbox
+                .recv_typed_message::<MergeTask>()
+                .await
+                .unwrap();
+            assert_eq!(
+                merge_task2.merge_operation.splits[0].footer_offsets.end,
+                3_000_000
+            );
+            assert!(timeout(
+                Duration::from_millis(200),
+                merge_split_downloader_inbox.recv_typed_message::<MergeTask>()
+            )
+            .await
+            .is_err());
+        }
+        {
+            let merge_task: MergeTask = merge_split_downloader_inbox
+                .recv_typed_message::<MergeTask>()
+                .await
+                .unwrap();
+            assert_eq!(
+                merge_task.merge_operation.splits[0].footer_offsets.end,
+                1_000_000
+            );
+        }
+        {
+            let merge_task: MergeTask = merge_split_downloader_inbox
+                .recv_typed_message::<MergeTask>()
+                .await
+                .unwrap();
+            assert_eq!(
+                merge_task.merge_operation.splits[0].footer_offsets.end,
+                2_000_000
+            );
+        }
+        {
+            let merge_task: MergeTask = merge_split_downloader_inbox
+                .recv_typed_message::<MergeTask>()
+                .await
+                .unwrap();
+            assert_eq!(
+                merge_task.merge_operation.splits[0].footer_offsets.end,
+                5_000_000
+            );
+        }
+        universe.assert_quit().await;
+    }
+}

--- a/quickwit/quickwit-indexing/src/actors/merge_split_downloader.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_split_downloader.rs
@@ -24,11 +24,11 @@ use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, Qu
 use quickwit_common::io::IoControls;
 use quickwit_common::temp_dir::{self, TempDirectory};
 use quickwit_metastore::SplitMetadata;
-use tantivy::{Directory, TrackedObject};
+use tantivy::Directory;
 use tracing::{debug, info, instrument};
 
 use super::MergeExecutor;
-use crate::merge_policy::MergeOperation;
+use crate::merge_policy::MergeTask;
 use crate::models::MergeScratch;
 use crate::split_store::IndexingSplitStore;
 
@@ -45,7 +45,7 @@ impl Actor for MergeSplitDownloader {
     fn observable_state(&self) -> Self::ObservableState {}
 
     fn queue_capacity(&self) -> QueueCapacity {
-        QueueCapacity::Bounded(1)
+        QueueCapacity::Unbounded
     }
 
     fn name(&self) -> String {
@@ -54,17 +54,17 @@ impl Actor for MergeSplitDownloader {
 }
 
 #[async_trait]
-impl Handler<TrackedObject<MergeOperation>> for MergeSplitDownloader {
+impl Handler<MergeTask> for MergeSplitDownloader {
     type Reply = ();
 
     #[instrument(
         name = "merge_split_downloader",
-        parent = merge_operation.merge_parent_span.id(),
+        parent = merge_task.merge_parent_span.id(),
         skip_all,
     )]
     async fn handle(
         &mut self,
-        merge_operation: TrackedObject<MergeOperation>,
+        merge_task: MergeTask,
         ctx: &ActorContext<Self>,
     ) -> Result<(), quickwit_actors::ActorExitStatus> {
         let merge_scratch_directory = temp_dir::Builder::default()
@@ -78,13 +78,13 @@ impl Handler<TrackedObject<MergeOperation>> for MergeSplitDownloader {
             .map_err(|error| anyhow::anyhow!(error))?;
         let tantivy_dirs = self
             .download_splits(
-                merge_operation.splits_as_slice(),
+                merge_task.splits_as_slice(),
                 downloaded_splits_directory.path(),
                 ctx,
             )
             .await?;
         let msg = MergeScratch {
-            merge_operation,
+            merge_task,
             merge_scratch_directory,
             downloaded_splits_directory,
             tantivy_dirs,
@@ -139,9 +139,9 @@ mod tests {
     use quickwit_actors::Universe;
     use quickwit_common::split_file;
     use quickwit_storage::{PutPayload, RamStorageBuilder, SplitPayloadBuilder};
-    use tantivy::Inventory;
 
     use super::*;
+    use crate::merge_policy::MergeOperation;
     use crate::new_split_id;
 
     #[tokio::test]
@@ -179,10 +179,10 @@ mod tests {
         };
         let (merge_split_downloader_mailbox, merge_split_downloader_handler) =
             universe.spawn_builder().spawn(merge_split_downloader);
-        let inventory = Inventory::new();
-        let merge_operation = inventory.track(MergeOperation::new_merge_operation(splits_to_merge));
+        let merge_operation: MergeOperation = MergeOperation::new_merge_operation(splits_to_merge);
+        let merge_task = MergeTask::from_merge_operation_for_test(merge_operation);
         merge_split_downloader_mailbox
-            .send_message(merge_operation)
+            .send_message(merge_task)
             .await?;
         merge_split_downloader_handler
             .process_pending_and_observe()
@@ -195,8 +195,8 @@ mod tests {
             .unwrap()
             .downcast::<MergeScratch>()
             .unwrap();
-        assert_eq!(merge_scratch.merge_operation.splits_as_slice().len(), 10);
-        for split in merge_scratch.merge_operation.splits_as_slice() {
+        assert_eq!(merge_scratch.merge_task.splits_as_slice().len(), 10);
+        for split in merge_scratch.merge_task.splits_as_slice() {
             let split_filename = split_file(split.split_id());
             let split_filepath = merge_scratch
                 .downloaded_splits_directory

--- a/quickwit/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/mod.rs
@@ -25,6 +25,7 @@ mod indexing_service;
 mod merge_executor;
 mod merge_pipeline;
 mod merge_planner;
+mod merge_scheduler_service;
 mod merge_split_downloader;
 mod packager;
 mod publisher;
@@ -43,6 +44,7 @@ pub use indexing_service::{
 pub use merge_executor::{combine_partition_ids, merge_split_attrs, MergeExecutor};
 pub use merge_pipeline::MergePipeline;
 pub use merge_planner::MergePlanner;
+pub use merge_scheduler_service::{schedule_merge, MergePermit, MergeSchedulerService};
 pub use merge_split_downloader::MergeSplitDownloader;
 pub use packager::Packager;
 pub use publisher::{Publisher, PublisherCounters, PublisherType};

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -159,7 +159,7 @@ impl Handler<IndexedSplitBatch> for Packager {
                 batch.checkpoint_delta_opt,
                 batch.publish_lock,
                 batch.publish_token_opt,
-                batch.merge_operation_opt,
+                batch.merge_task_opt,
                 batch.batch_parent_span,
             ),
         )
@@ -573,7 +573,7 @@ mod tests {
                 checkpoint_delta_opt: IndexCheckpointDelta::for_test("source_id", 10..20).into(),
                 publish_lock: PublishLock::default(),
                 publish_token_opt: None,
-                merge_operation_opt: None,
+                merge_task_opt: None,
                 batch_parent_span: Span::none(),
             })
             .await?;

--- a/quickwit/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit/quickwit-indexing/src/actors/publisher.rs
@@ -251,7 +251,7 @@ mod tests {
                 }),
                 publish_lock: PublishLock::default(),
                 publish_token_opt: None,
-                merge_operation: None,
+                merge_task: None,
                 parent_span: tracing::Span::none(),
             })
             .await
@@ -322,7 +322,7 @@ mod tests {
                 }),
                 publish_lock: PublishLock::default(),
                 publish_token_opt: None,
-                merge_operation: None,
+                merge_task: None,
                 parent_span: tracing::Span::none(),
             })
             .await
@@ -386,7 +386,7 @@ mod tests {
             checkpoint_delta_opt: None,
             publish_lock: PublishLock::default(),
             publish_token_opt: None,
-            merge_operation: None,
+            merge_task: None,
             parent_span: Span::none(),
         };
         assert!(publisher_mailbox
@@ -428,7 +428,7 @@ mod tests {
                 checkpoint_delta_opt: None,
                 publish_lock,
                 publish_token_opt: None,
-                merge_operation: None,
+                merge_task: None,
                 parent_span: Span::none(),
             })
             .await

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -29,6 +29,7 @@ use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_storage::StorageResolver;
 use tracing::info;
 
+use crate::actors::MergeSchedulerService;
 pub use crate::actors::{
     IndexingError, IndexingPipeline, IndexingPipelineParams, IndexingService, PublisherType,
     Sequencer, SplitsUpdateMailbox,
@@ -70,13 +71,15 @@ pub async fn start_indexing_service(
     num_blocking_threads: usize,
     cluster: Cluster,
     metastore: MetastoreServiceClient,
-    ingest_api_service: Mailbox<IngestApiService>,
     ingester_pool: IngesterPool,
     storage_resolver: StorageResolver,
     event_broker: EventBroker,
 ) -> anyhow::Result<Mailbox<IndexingService>> {
     info!("starting indexer service");
-
+    let ingest_api_service_mailbox = universe.get_one::<IngestApiService>();
+    let (merge_scheduler_mailbox, _) = universe.spawn_builder().spawn(MergeSchedulerService::new(
+        config.indexer_config.merge_concurrency.get(),
+    ));
     // Spawn indexing service.
     let indexing_service = IndexingService::new(
         config.node_id.clone(),
@@ -85,13 +88,13 @@ pub async fn start_indexing_service(
         num_blocking_threads,
         cluster,
         metastore.clone(),
-        Some(ingest_api_service),
+        ingest_api_service_mailbox,
+        merge_scheduler_mailbox,
         ingester_pool,
         storage_resolver,
         event_broker,
     )
     .await?;
     let (indexing_service, _) = universe.spawn_builder().spawn(indexing_service);
-
     Ok(indexing_service)
 }

--- a/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/stable_log_merge_policy.rs
@@ -700,6 +700,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_simulate_stable_log_merge_planner_edge_case() {
+        let merge_policy = StableLogMergePolicy::default();
+        let batch_num_docs = vec![
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+        ];
+        aux_test_simulate_merge_planner_num_docs(
+            Arc::new(merge_policy.clone()),
+            &batch_num_docs,
+            |splits| {
+                let num_docs = splits.iter().map(|split| split.num_docs as u64).sum();
+                assert!(splits.len() <= merge_policy.max_num_splits_worst_case(num_docs));
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_simulate_stable_log_merge_planner_ideal_case() -> anyhow::Result<()> {
         let merge_policy = StableLogMergePolicy::default();
         aux_test_simulate_merge_planner_num_docs(

--- a/quickwit/quickwit-indexing/src/metrics.rs
+++ b/quickwit/quickwit-indexing/src/metrics.rs
@@ -28,6 +28,8 @@ pub struct IndexerMetrics {
     pub backpressure_micros: IntCounterVec<1>,
     pub available_concurrent_upload_permits: IntGaugeVec<1>,
     pub ongoing_merge_operations: IntGauge,
+    pub pending_merge_operations: IntGauge,
+    pub pending_merge_bytes: IntGauge,
 }
 
 impl Default for IndexerMetrics {
@@ -63,6 +65,16 @@ impl Default for IndexerMetrics {
             ongoing_merge_operations: new_gauge(
                 "ongoing_merge_operations",
                 "Number of ongoing merge operations",
+                "quickwit_indexing",
+            ),
+            pending_merge_operations: new_gauge(
+                "pending_merge_operations",
+                "Number of pending merge operations",
+                "quickwit_indexing",
+            ),
+            pending_merge_bytes: new_gauge(
+                "pending_merge_bytes",
+                "Number of pending merge bytes",
                 "quickwit_indexing",
             ),
         }

--- a/quickwit/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit/quickwit-indexing/src/models/indexed_split.rs
@@ -26,11 +26,11 @@ use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_proto::indexing::IndexingPipelineId;
 use quickwit_proto::types::{IndexUid, PublishToken};
 use tantivy::directory::MmapDirectory;
-use tantivy::{IndexBuilder, TrackedObject};
+use tantivy::IndexBuilder;
 use tracing::{instrument, Span};
 
 use crate::controlled_directory::ControlledDirectory;
-use crate::merge_policy::MergeOperation;
+use crate::merge_policy::MergeTask;
 use crate::models::{PublishLock, SplitAttrs};
 use crate::new_split_id;
 
@@ -157,11 +157,11 @@ pub struct IndexedSplitBatch {
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
     pub publish_token_opt: Option<PublishToken>,
-    /// A [`MergeOperation`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
+    /// A [`MergeTask`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
     /// in the `MergePipeline` or `DeleteTaskPipeline`.
     /// See planners docs to understand the usage.
     /// If `None`, the split batch was built in the `IndexingPipeline`.
-    pub merge_operation_opt: Option<TrackedObject<MergeOperation>>,
+    pub merge_task_opt: Option<MergeTask>,
     pub batch_parent_span: Span,
 }
 

--- a/quickwit/quickwit-indexing/src/models/merge_scratch.rs
+++ b/quickwit/quickwit-indexing/src/models/merge_scratch.rs
@@ -18,15 +18,15 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use quickwit_common::temp_dir::TempDirectory;
-use tantivy::{Directory, TrackedObject};
+use tantivy::Directory;
 
-use crate::merge_policy::MergeOperation;
+use crate::merge_policy::MergeTask;
 
 #[derive(Debug)]
 pub struct MergeScratch {
-    /// A [`MergeOperation`] tracked by either the `MergePlannner` or the `DeleteTaksPlanner`
+    /// A [`MergeTask`] tracked by either the `MergePlannner` or the `DeleteTaksPlanner`
     /// See planners docs to understand the usage.
-    pub merge_operation: TrackedObject<MergeOperation>,
+    pub merge_task: MergeTask,
     /// Scratch directory for computing the merge.
     pub merge_scratch_directory: TempDirectory,
     pub downloaded_splits_directory: TempDirectory,

--- a/quickwit/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit/quickwit-indexing/src/models/packaged_split.rs
@@ -24,10 +24,9 @@ use itertools::Itertools;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_proto::types::{IndexUid, PublishToken, SplitId};
-use tantivy::TrackedObject;
 use tracing::Span;
 
-use crate::merge_policy::MergeOperation;
+use crate::merge_policy::MergeTask;
 use crate::models::{PublishLock, SplitAttrs};
 
 pub struct PackagedSplit {
@@ -66,11 +65,11 @@ pub struct PackagedSplitBatch {
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
     pub publish_token_opt: Option<PublishToken>,
-    /// A [`MergeOperation`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
+    /// A [`MergeTask`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
     /// in the `MergePipeline` or `DeleteTaskPipeline`.
     /// See planners docs to understand the usage.
     /// If `None`, the split batch was built in the `IndexingPipeline`.
-    pub merge_operation_opt: Option<TrackedObject<MergeOperation>>,
+    pub merge_task_opt: Option<MergeTask>,
     pub batch_parent_span: Span,
 }
 
@@ -84,7 +83,7 @@ impl PackagedSplitBatch {
         checkpoint_delta_opt: Option<IndexCheckpointDelta>,
         publish_lock: PublishLock,
         publish_token_opt: Option<PublishToken>,
-        merge_operation_opt: Option<TrackedObject<MergeOperation>>,
+        merge_task_opt: Option<MergeTask>,
         batch_parent_span: Span,
     ) -> Self {
         assert!(!splits.is_empty());
@@ -100,7 +99,7 @@ impl PackagedSplitBatch {
             checkpoint_delta_opt,
             publish_lock,
             publish_token_opt,
-            merge_operation_opt,
+            merge_task_opt,
             batch_parent_span,
         }
     }

--- a/quickwit/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit/quickwit-indexing/src/models/publisher_message.rs
@@ -23,10 +23,9 @@ use itertools::Itertools;
 use quickwit_metastore::checkpoint::IndexCheckpointDelta;
 use quickwit_metastore::SplitMetadata;
 use quickwit_proto::types::{IndexUid, PublishToken};
-use tantivy::TrackedObject;
 use tracing::Span;
 
-use crate::merge_policy::MergeOperation;
+use crate::merge_policy::MergeTask;
 use crate::models::PublishLock;
 
 pub struct SplitsUpdate {
@@ -36,11 +35,11 @@ pub struct SplitsUpdate {
     pub checkpoint_delta_opt: Option<IndexCheckpointDelta>,
     pub publish_lock: PublishLock,
     pub publish_token_opt: Option<PublishToken>,
-    /// A [`MergeOperation`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
+    /// A [`MergeTask`] tracked by either the `MergePlanner` or the `DeleteTaskPlanner`
     /// in the `MergePipeline` or `DeleteTaskPipeline`.
     /// See planners docs to understand the usage.
     /// If `None`, the split batch was built in the `IndexingPipeline`.
-    pub merge_operation: Option<TrackedObject<MergeOperation>>,
+    pub merge_task: Option<MergeTask>,
     pub parent_span: Span,
 }
 

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -109,6 +109,7 @@ impl TestSandbox {
             .into();
         let storage = storage_resolver.resolve(&index_uri).await?;
         let universe = Universe::with_accelerated_time();
+        let merge_scheduler_mailbox = universe.get_or_spawn_one();
         let queues_dir_path = temp_dir.path().join(QUEUES_DIR_NAME);
         let ingest_api_service =
             init_ingest_api(&universe, &queues_dir_path, &IngestApiConfig::default()).await?;
@@ -120,6 +121,7 @@ impl TestSandbox {
             cluster,
             metastore.clone(),
             Some(ingest_api_service),
+            merge_scheduler_mailbox,
             IngesterPool::default(),
             storage_resolver.clone(),
             EventBroker::default(),

--- a/quickwit/quickwit-jaeger/src/integration_tests.rs
+++ b/quickwit/quickwit-jaeger/src/integration_tests.rs
@@ -27,6 +27,7 @@ use quickwit_cluster::{create_cluster_for_test, ChannelTransport, Cluster};
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::uri::Uri;
 use quickwit_config::{IndexerConfig, IngestApiConfig, JaegerConfig, SearcherConfig, SourceConfig};
+use quickwit_indexing::actors::MergeSchedulerService;
 use quickwit_indexing::models::SpawnPipeline;
 use quickwit_indexing::IndexingService;
 use quickwit_ingest::{
@@ -346,6 +347,7 @@ async fn indexer_for_test(
         cluster,
         metastore,
         Some(ingester_service),
+        universe.get_or_spawn_one::<MergeSchedulerService>(),
         ingester_pool,
         storage_resolver,
         EventBroker::default(),

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -23,7 +23,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use quickwit_actors::{
-    Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, Supervisor, SupervisorState,
+    Actor, ActorContext, ActorExitStatus, ActorHandle, Handler, Mailbox, Supervisor,
+    SupervisorState,
 };
 use quickwit_common::io::IoControls;
 use quickwit_common::pubsub::EventBroker;
@@ -31,8 +32,8 @@ use quickwit_common::temp_dir::{self};
 use quickwit_common::uri::Uri;
 use quickwit_config::build_doc_mapper;
 use quickwit_indexing::actors::{
-    MergeExecutor, MergeSplitDownloader, Packager, Publisher, PublisherCounters, Uploader,
-    UploaderCounters, UploaderType,
+    MergeExecutor, MergeSchedulerService, MergeSplitDownloader, Packager, Publisher,
+    PublisherCounters, Uploader, UploaderCounters, UploaderType,
 };
 use quickwit_indexing::merge_policy::merge_policy_from_settings;
 use quickwit_indexing::{IndexingSplitStore, PublisherType, SplitsUpdateMailbox};
@@ -86,6 +87,7 @@ pub struct DeleteTaskPipeline {
     handles: Option<DeletePipelineHandle>,
     max_concurrent_split_uploads: usize,
     state: DeleteTaskPipelineState,
+    merge_scheduler_service: Mailbox<MergeSchedulerService>,
     event_broker: EventBroker,
 }
 
@@ -127,6 +129,7 @@ impl Actor for DeleteTaskPipeline {
 }
 
 impl DeleteTaskPipeline {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         index_uid: IndexUid,
         metastore: MetastoreServiceClient,
@@ -134,6 +137,7 @@ impl DeleteTaskPipeline {
         index_storage: Arc<dyn Storage>,
         delete_service_task_dir: PathBuf,
         max_concurrent_split_uploads: usize,
+        merge_scheduler_service: Mailbox<MergeSchedulerService>,
         event_broker: EventBroker,
     ) -> Self {
         Self {
@@ -145,6 +149,7 @@ impl DeleteTaskPipeline {
             handles: Default::default(),
             max_concurrent_split_uploads,
             state: DeleteTaskPipelineState::default(),
+            merge_scheduler_service,
             event_broker,
         }
     }
@@ -230,6 +235,7 @@ impl DeleteTaskPipeline {
             self.metastore.clone(),
             self.search_job_placer.clone(),
             downloader_mailbox,
+            self.merge_scheduler_service.clone(),
         );
         let (_, task_planner_supervisor_handler) = ctx.spawn_actor().supervise(task_planner);
         self.handles = Some(DeletePipelineHandle {
@@ -279,9 +285,10 @@ impl Handler<Observe> for DeleteTaskPipeline {
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use quickwit_actors::Handler;
+    use quickwit_actors::{Handler, Universe};
     use quickwit_common::pubsub::EventBroker;
     use quickwit_common::temp_dir::TempDirectory;
+    use quickwit_indexing::actors::MergeSchedulerService;
     use quickwit_indexing::TestSandbox;
     use quickwit_metastore::{ListSplitsRequestExt, MetastoreServiceStreamSplitsExt, SplitState};
     use quickwit_proto::metastore::{DeleteQuery, ListSplitsRequest, MetastoreService};
@@ -336,6 +343,8 @@ mod tests {
         )
         .await
         .unwrap();
+        let universe: &Universe = test_sandbox.universe();
+        let merge_scheduler_service = universe.get_or_spawn_one::<MergeSchedulerService>();
         let index_uid = test_sandbox.index_uid();
         let docs = vec![
             serde_json::json!({"body": "info", "ts": 0 }),
@@ -386,19 +395,16 @@ mod tests {
             test_sandbox.storage(),
             delete_service_task_dir.path().into(),
             4,
+            merge_scheduler_service,
             EventBroker::default(),
         );
 
-        let (pipeline_mailbox, pipeline_handler) =
-            test_sandbox.universe().spawn_builder().spawn(pipeline);
+        let (pipeline_mailbox, pipeline_handler) = universe.spawn_builder().spawn(pipeline);
         // Ensure that the message sent by initialize method is processed.
         let _ = pipeline_handler.process_pending_and_observe().await.state;
         // Pipeline will first fail and we need to wait a OBSERVE_PIPELINE_INTERVAL * some number
         // for the pipeline state to be updated.
-        test_sandbox
-            .universe()
-            .sleep(OBSERVE_PIPELINE_INTERVAL * 5)
-            .await;
+        universe.sleep(OBSERVE_PIPELINE_INTERVAL * 5).await;
         let pipeline_state = pipeline_handler.process_pending_and_observe().await.state;
         assert_eq!(pipeline_state.delete_task_planner.metrics.num_errors, 1);
         assert_eq!(pipeline_state.downloader.metrics.num_errors, 0);
@@ -440,6 +446,8 @@ mod tests {
         let test_sandbox = TestSandbox::create(index_id, doc_mapping_yaml, "{}", &["body"])
             .await
             .unwrap();
+        let universe: &Universe = test_sandbox.universe();
+        let merge_scheduler_mailbox = universe.get_or_spawn_one::<MergeSchedulerService>();
         let metastore = test_sandbox.metastore();
         let mut mock_search_service = MockSearchService::new();
         mock_search_service
@@ -468,16 +476,13 @@ mod tests {
             test_sandbox.storage(),
             delete_service_task_dir.path().into(),
             4,
+            merge_scheduler_mailbox,
             EventBroker::default(),
         );
 
-        let (_pipeline_mailbox, pipeline_handler) =
-            test_sandbox.universe().spawn_builder().spawn(pipeline);
+        let (_pipeline_mailbox, pipeline_handler) = universe.spawn_builder().spawn(pipeline);
         pipeline_handler.quit().await;
-        let observations = test_sandbox
-            .universe()
-            .observe(OBSERVE_PIPELINE_INTERVAL)
-            .await;
+        let observations = universe.observe(OBSERVE_PIPELINE_INTERVAL).await;
         assert!(observations.into_iter().all(
             |observation| observation.type_name != std::any::type_name::<DeleteTaskPipeline>()
         ));

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -22,6 +22,7 @@
 use quickwit_actors::{Mailbox, Universe};
 use quickwit_common::pubsub::EventBroker;
 use quickwit_config::NodeConfig;
+use quickwit_indexing::actors::MergeSchedulerService;
 use quickwit_metastore::SplitInfo;
 use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_search::SearchJobPlacer;
@@ -64,6 +65,7 @@ pub async fn start_janitor_service(
         storage_resolver,
         config.data_dir_path.clone(),
         config.indexer_config.max_concurrent_split_uploads,
+        universe.get_or_spawn_one::<MergeSchedulerService>(),
         event_broker,
     )
     .await?;

--- a/quickwit/quickwit-lambda/src/indexer/ingest.rs
+++ b/quickwit/quickwit-lambda/src/indexer/ingest.rs
@@ -197,11 +197,11 @@ pub async fn ingest(args: IngestArgs) -> anyhow::Result<IndexingStatistics> {
         runtimes_config,
         &HashSet::from_iter([QuickwitService::Indexer]),
     )?;
-    let merge_scheduler_service = MergeSchedulerService::new(indexer_config.merge_concurrency.get());
+    let merge_scheduler_service =
+        MergeSchedulerService::new(indexer_config.merge_concurrency.get());
     let universe = Universe::new();
-    let (merge_scheduler_service_mailbox, _) = universe
-        .spawn_builder()
-        .spawn(merge_scheduler_service);
+    let (merge_scheduler_service_mailbox, _) =
+        universe.spawn_builder().spawn(merge_scheduler_service);
     let indexing_server = IndexingService::new(
         config.node_id.clone(),
         config.data_dir_path.clone(),

--- a/quickwit/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit/quickwit-metastore/src/split_metadata.rs
@@ -133,8 +133,9 @@ pub struct SplitMetadata {
     /// this split.
     pub num_merge_ops: usize,
 }
+
 impl fmt::Debug for SplitMetadata {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut debug_struct = f.debug_struct("SplitMetadata");
         debug_struct.field("split_id", &self.split_id);
         debug_struct.field("index_uid", &self.index_uid);
@@ -219,8 +220,8 @@ impl SplitMetadata {
 
     #[cfg(any(test, feature = "testsuite"))]
     /// Returns an instance of `SplitMetadata` for testing.
-    pub fn for_test(split_id: String) -> Self {
-        Self {
+    pub fn for_test(split_id: String) -> SplitMetadata {
+        SplitMetadata {
             split_id,
             ..Default::default()
         }

--- a/quickwit/quickwit-query/src/tokenizers/chinese_compatible.rs
+++ b/quickwit/quickwit-query/src/tokenizers/chinese_compatible.rs
@@ -205,7 +205,7 @@ mod tests {
             },
         ];
 
-        assert_eq!(dbg!(res), dbg!(expected));
+        assert_eq!(res, expected);
     }
 
     #[test]

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -77,8 +77,8 @@ use quickwit_indexing::models::ShardPositionsService;
 use quickwit_indexing::start_indexing_service;
 use quickwit_ingest::{
     setup_local_shards_update_listener, start_ingest_api_service, wait_for_ingester_decommission,
-    GetMemoryCapacity, IngestApiService, IngestRequest, IngestRouter, IngestServiceClient,
-    Ingester, IngesterPool, LocalShardsUpdate,
+    GetMemoryCapacity, IngestRequest, IngestRouter, IngestServiceClient, Ingester, IngesterPool,
+    LocalShardsUpdate,
 };
 use quickwit_jaeger::JaegerService;
 use quickwit_janitor::{start_janitor_service, JanitorService};
@@ -387,16 +387,12 @@ pub async fn serve_quickwit(
     let ingest_service = start_ingest_client_if_needed(&node_config, &universe, &cluster).await?;
 
     let indexing_service_opt = if node_config.is_service_enabled(QuickwitService::Indexer) {
-        let ingest_api_service: Mailbox<IngestApiService> = universe
-            .get_one()
-            .context("Ingest API Service should have been started.")?;
         let indexing_service = start_indexing_service(
             &universe,
             &node_config,
             runtimes_config.num_threads_blocking,
             cluster.clone(),
             metastore_through_control_plane.clone(),
-            ingest_api_service.clone(),
             ingester_pool.clone(),
             storage_resolver.clone(),
             event_broker.clone(),


### PR DESCRIPTION
Introducing the merge scheduler to schedule merge operation in a global manner.

Closes  #4469 
Closes #4471

It was tested on a 10 pod cluster indexing 1000 indexes.