### PR TITLE
Ignore index not found error in file-backed index polling task

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/file_backed/store_operations.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/store_operations.rs
@@ -25,7 +25,7 @@ use quickwit_storage::{Storage, StorageError, StorageErrorKind};
 use crate::metastore::file_backed::file_backed_index::FileBackedIndex;
 
 /// Index metastore file managed by [`FileBackedMetastore`](crate::FileBackedMetastore).
-const METASTORE_FILE_NAME: &str = "metastore.json";
+pub(super) const METASTORE_FILE_NAME: &str = "metastore.json";
 
 /// Path to the metadata file from the given index ID.
 pub(super) fn metastore_filepath(index_id: &str) -> PathBuf {


### PR DESCRIPTION
### Description
While running the REST API test suite, I observed a bunch of errors emitted by the file-backed indexes polling tasks. 

### How was this PR tested?
Ran the REST API test suite, and the error logs no longer appear.
