### PR TITLE
chore: log current Quickwit version

### DIFF
--- a/quickwit/quickwit-cli/src/generate_markdown.rs
+++ b/quickwit/quickwit-cli/src/generate_markdown.rs
@@ -24,11 +24,7 @@ use toml::Value;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let build_info = BuildInfo::get();
-    let version_text = format!(
-        "{} ({} {})",
-        build_info.cargo_pkg_version, build_info.cargo_pkg_version, build_info.commit_date,
-    );
+    let version_text = BuildInfo::get_version_text();
     let app = build_cli()
         .version(version_text)
         .disable_help_subcommand(true);

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -42,11 +42,7 @@ async fn main_impl() -> anyhow::Result<()> {
     openssl_probe::init_ssl_cert_env_vars();
 
     let about_text = about_text();
-    let build_info = BuildInfo::get();
-    let version_text = format!(
-        "{} ({} {})",
-        build_info.version, build_info.commit_short_hash, build_info.build_date
-    );
+    let version_text = BuildInfo::get_version_text();
 
     let app = build_cli().about(about_text).version(version_text);
     let matches = app.get_matches();
@@ -63,6 +59,7 @@ async fn main_impl() -> anyhow::Result<()> {
     #[cfg(feature = "jemalloc")]
     start_jemalloc_metrics_loop();
 
+    let build_info = BuildInfo::get();
     setup_logging_and_tracing(command.default_log_level(), ansi_colors, build_info)?;
     let return_code: i32 = if let Err(err) = command.execute().await {
         eprintln!("{} Command failed: {:?}\n", "✘".color(RED_COLOR), err);

--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -75,11 +75,7 @@ impl RunCliCommand {
 
     pub async fn execute(&self) -> anyhow::Result<()> {
         debug!(args = ?self, "run-service");
-        let build_info = BuildInfo::get();
-        let version_text = format!(
-            "{} ({} {})",
-            build_info.cargo_pkg_version, build_info.cargo_pkg_version, build_info.commit_date,
-        );
+        let version_text = BuildInfo::get_version_text();
         info!("quickwit version: {version_text}");
         let mut node_config = load_node_config(&self.config_uri).await?;
         let (storage_resolver, metastore_resolver) =

--- a/quickwit/quickwit-serve/src/build_info.rs
+++ b/quickwit/quickwit-serve/src/build_info.rs
@@ -81,6 +81,14 @@ impl BuildInfo {
             }
         })
     }
+
+    pub fn get_version_text() -> String {
+        let build_info = Self::get();
+        format!(
+            "{} ({} {})",
+            build_info.cargo_pkg_version, build_info.cargo_pkg_version, build_info.commit_date,
+        )
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, utoipa::ToSchema)]


### PR DESCRIPTION
### Description

Log current Quickwit version on startup

### How was this PR tested?

Launched Quickwit with the change
<img width="1219" alt="Screenshot 2024-02-06 at 21 51 45" src="https://github.com/quickwit-oss/quickwit/assets/3762201/232a0449-417e-40aa-8e55-391afa4d1b3b">
 
### Related issue
https://github.com/quickwit-oss/quickwit/issues/4526