### PR TITLE
Fix clippy warnings (Rust 1.75)

### DIFF
--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -38,7 +38,6 @@ use super::field_mapping_entry::RAW_TOKENIZER_NAME;
 use super::DefaultDocMapperBuilder;
 use crate::default_doc_mapper::mapping_tree::{build_mapping_tree, MappingNode};
 use crate::default_doc_mapper::FieldMappingType;
-pub use crate::default_doc_mapper::QuickwitJsonOptions;
 use crate::doc_mapper::{JsonObject, Partition};
 use crate::query_builder::build_query;
 use crate::routing_expression::RoutingExpr;

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/mod.rs
@@ -33,11 +33,13 @@ pub use self::default_mapper::DefaultDocMapper;
 pub use self::default_mapper_builder::{DefaultDocMapperBuilder, Mode, ModeType};
 pub use self::field_mapping_entry::{
     BinaryFormat, FastFieldOptions, FieldMappingEntry, QuickwitBytesOptions, QuickwitJsonOptions,
-    QuickwitNumericOptions, QuickwitTextNormalizer, QuickwitTextOptions, TextIndexingOptions,
+    QuickwitTextNormalizer,
 };
 pub(crate) use self::field_mapping_entry::{
     FieldMappingEntryForSerialization, IndexRecordOptionSchema, QuickwitTextTokenizer,
 };
+#[cfg(all(test, feature = "multilang"))]
+pub(crate) use self::field_mapping_entry::{QuickwitTextOptions, TextIndexingOptions};
 pub use self::field_mapping_type::FieldMappingType;
 pub use self::tokenizer_entry::{analyze_text, TokenizerConfig, TokenizerEntry};
 pub(crate) use self::tokenizer_entry::{

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper.rs
@@ -571,7 +571,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "testsuite")]
+    #[cfg(feature = "multilang")]
     fn test_doc_mapper_query_with_multilang_field() {
         use quickwit_query::query_ast::TermQuery;
         use tantivy::schema::IndexRecordOption;


### PR DESCRIPTION
Those warnings show up when upgrading to Rust 1.75
