### PR TITLE
add env var to disable delete tasks service

### DIFF
--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -51,6 +51,7 @@ pub async fn start_janitor_service(
     search_job_placer: SearchJobPlacer,
     storage_resolver: StorageResolver,
     event_broker: EventBroker,
+    run_delete_task_service: bool,
 ) -> anyhow::Result<Mailbox<JanitorService>> {
     info!("starting janitor service");
     let garbage_collector = GarbageCollector::new(metastore.clone(), storage_resolver.clone());
@@ -59,17 +60,23 @@ pub async fn start_janitor_service(
     let retention_policy_executor = RetentionPolicyExecutor::new(metastore.clone());
     let (_, retention_policy_executor_handle) =
         universe.spawn_builder().spawn(retention_policy_executor);
-    let delete_task_service = DeleteTaskService::new(
-        metastore,
-        search_job_placer,
-        storage_resolver,
-        config.data_dir_path.clone(),
-        config.indexer_config.max_concurrent_split_uploads,
-        universe.get_or_spawn_one::<MergeSchedulerService>(),
-        event_broker,
-    )
-    .await?;
-    let (_, delete_task_service_handle) = universe.spawn_builder().spawn(delete_task_service);
+    let delete_task_service_handle = if run_delete_task_service {
+        let delete_task_service = DeleteTaskService::new(
+            metastore,
+            search_job_placer,
+            storage_resolver,
+            config.data_dir_path.clone(),
+            config.indexer_config.max_concurrent_split_uploads,
+            universe.get_or_spawn_one::<MergeSchedulerService>(),
+            event_broker,
+        )
+        .await?;
+        let (_, delete_task_service_handle) = universe.spawn_builder().spawn(delete_task_service);
+        Some(delete_task_service_handle)
+    } else {
+        tracing::warn!("Delete task service is disabled. Delete queries will not be processed.");
+        None
+    };
 
     let janitor_service = JanitorService::new(
         delete_task_service_handle,

--- a/quickwit/quickwit-janitor/src/lib.rs
+++ b/quickwit/quickwit-janitor/src/lib.rs
@@ -74,7 +74,7 @@ pub async fn start_janitor_service(
         let (_, delete_task_service_handle) = universe.spawn_builder().spawn(delete_task_service);
         Some(delete_task_service_handle)
     } else {
-        tracing::warn!("Delete task service is disabled. Delete queries will not be processed.");
+        tracing::warn!("delete task service is disabled: delete queries will not be processed");
         None
     };
 

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -126,6 +126,7 @@ const READINESS_REPORTING_INTERVAL: Duration = if cfg!(any(test, feature = "test
 
 const METASTORE_CLIENT_MAX_CONCURRENCY_ENV_KEY: &str = "QW_METASTORE_CLIENT_MAX_CONCURRENCY";
 const DEFAULT_METASTORE_CLIENT_MAX_CONCURRENCY: usize = 6;
+const DISABLE_DELETE_TASK_SERVICE_ENV_KEY: &str = "QW_DISABLE_DELETE_TASK_SERVICE";
 
 fn get_metastore_client_max_concurrency() -> usize {
     std::env::var(METASTORE_CLIENT_MAX_CONCURRENCY_ENV_KEY).ok()
@@ -514,6 +515,7 @@ pub async fn serve_quickwit(
             search_job_placer,
             storage_resolver.clone(),
             event_broker.clone(),
+            std::env::var(DISABLE_DELETE_TASK_SERVICE_ENV_KEY).is_err(),
         )
         .await?;
         Some(janitor_service)


### PR DESCRIPTION
### Description

the delete task service makes numerous request to the metastore on startup (proportional to the number of indexes), but in practice it is often not used at all. This PR adds an environment variable `QW_DISABLE_DELETE_TASK_SERVICE` to disable that service entirely

### How was this PR tested?

verified the delete task service isn't started when the env var is present