### PR TITLE
add extra_filters parameter to ES API

### DIFF
--- a/quickwit/quickwit-query/src/query_ast/bool_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/bool_query.rs
@@ -30,9 +30,9 @@ use crate::InvalidQuery;
 /// - named queries
 ///
 /// Edge cases of BooleanQuery are not obvious,
-/// and different beahvior could be justified.
+/// and different behavior could be justified.
 ///
-/// Here we aligne ourselves with Elasticsearch.
+/// Here we align ourselves with Elasticsearch.
 /// A boolean query is to be interpreted like a filtering predicate
 /// over the set of documents.
 ///

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/search_query_params.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/search_query_params.rs
@@ -77,6 +77,13 @@ pub struct SearchQueryParams {
     #[serde(serialize_with = "to_simple_list")]
     #[serde(deserialize_with = "from_simple_list")]
     #[serde(default)]
+    /// Additional filters to be applied to the query.
+    /// Useful for permissions and other use cases.
+    /// This is not part of the official Elasticsearch API.
+    pub extra_filters: Option<Vec<String>>,
+    #[serde(serialize_with = "to_simple_list")]
+    #[serde(deserialize_with = "from_simple_list")]
+    #[serde(default)]
     pub filter_path: Option<Vec<String>>,
     #[serde(default)]
     pub force_synthetic_source: Option<bool>,

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0023-extra_filters.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0023-extra_filters.yaml
@@ -1,0 +1,45 @@
+# Extra filters are additional filters that are applied to the query. Useful for permissions and other use cases. 
+json:
+  query:
+      match_all: {}
+params:
+  extra_filters: "type:PushEvent"
+expected:
+  hits:
+    total:
+      value: 60
+--- # 2 extra filters
+json:
+  query:
+      match_all: {}
+params:
+  extra_filters: "type:PushEvent,actor.login:jadonk"
+expected:
+  hits:
+    total:
+      value: 2
+--- # Test mixing
+json:
+  query:
+    query_string:
+      query: "type:PushEvent"
+params:
+  extra_filters: "actor.login:jadonk"
+expected:
+  hits:
+    total:
+      value: 2
+--- # Test mixing
+json:
+  query:
+    query_string:
+      query: "type:PushEvent"
+params:
+  extra_filters: "type:PushEvent,actor.login:jadonk"
+expected:
+  hits:
+    total:
+      value: 2
+
+
+


### PR DESCRIPTION
add extra_filters to ES API. Useful for permission handling.

Closes #4576

