### PR TITLE
Initializing the shard positions actor with the existing cluster state

### DIFF
--- a/quickwit/quickwit-indexing/src/models/shard_positions.rs
+++ b/quickwit/quickwit-indexing/src/models/shard_positions.rs
@@ -143,11 +143,11 @@ impl Actor for ShardPositionsService {
                 .await,
         );
 
-        // We are now listening to new updates. However the cluster has been started earlier.
+        // We are now listening to new updates. However, the cluster has been started earlier.
         // It might have already received shard updates from other nodes.
         //
         // Let's also sync our `ShardPositionsService` with the current state of the cluster.
-        // Shard positions update are trivially idempotent, so we can just replay all the events,
+        // Shard position updates are trivially idempotent, so we can replay all the events,
         // without worrying about duplicates.
 
         let now = Instant::now();

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -396,6 +396,7 @@ impl Ingester {
     pub fn subscribe(&self, event_broker: &EventBroker) {
         let weak_ingester_state = self.state.weak();
         // This subscription is the one in charge of truncating the mrecordlog.
+        info!("subscribing ingester to shard positions updates");
         event_broker
             .subscribe_without_timeout::<ShardPositionsUpdate>(weak_ingester_state)
             .forever();

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -321,7 +321,7 @@ fn start_shard_positions_service(
     spawn_ctx: SpawnContext,
 ) {
     // We spawn a task here, because we need the ingester to be ready before spawning the
-    // the `ShardPositionsService`. If we don't all, all of the event we emit will be dismissed.
+    // the `ShardPositionsService`. If we don't, all the events we emit too early will be dismissed.
     tokio::spawn(async move {
         if let Some(ingester_service) = ingester_service_opt {
             if wait_for_ingester_status(ingester_service, IngesterStatus::Ready)


### PR DESCRIPTION
on startup.

Chitchat is started before everything else, so we might be missing some positions if we just start listening for updates.
