### PR TITLE
add semaphore on reading http body

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_api_service.rs
+++ b/quickwit/quickwit-ingest/src/ingest_api_service.rs
@@ -241,6 +241,8 @@ impl IngestApiService {
             .await?;
 
         let memory_usage = self.queues.memory_usage();
+        // TODO trinity: i got `an attempt to subtract with overflow` once here. should investigate
+        // why (i was ingesting on 2k indexes at once)
         let new_capacity = self.memory_limit - memory_usage;
         self.memory_capacity.reset_capacity(new_capacity);
 

--- a/quickwit/quickwit-ingest/src/lib.rs
+++ b/quickwit/quickwit-ingest/src/lib.rs
@@ -47,6 +47,7 @@ pub use position::Position;
 pub use queue::Queues;
 use quickwit_actors::{Mailbox, Universe};
 use quickwit_config::IngestApiConfig;
+pub use semaphore_with_waiter::SemaphoreWithMaxWaiters;
 use tokio::sync::Mutex;
 
 pub const QUEUES_DIR_NAME: &str = "queues";

--- a/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
@@ -27,7 +27,7 @@ use super::model::{
     CatIndexQueryParams, FieldCapabilityQueryParams, FieldCapabilityRequestBody,
     MultiSearchQueryParams, SearchQueryParamsCount,
 };
-use crate::decompression::get_body_bytes;
+use crate::decompression::{get_body_bytes, Body};
 use crate::elasticsearch_api::model::{
     ElasticBulkOptions, ScrollQueryParams, SearchBody, SearchQueryParams,
 };
@@ -71,7 +71,7 @@ pub(crate) fn elasticsearch_filter(
     )
 )]
 pub(crate) fn elastic_bulk_filter(
-) -> impl Filter<Extract = (Bytes, ElasticBulkOptions), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (Body, ElasticBulkOptions), Error = Rejection> + Clone {
     warp::path!("_elastic" / "_bulk")
         .and(warp::post())
         .and(warp::body::content_length_limit(
@@ -94,7 +94,7 @@ pub(crate) fn elastic_bulk_filter(
     )
 )]
 pub(crate) fn elastic_index_bulk_filter(
-) -> impl Filter<Extract = (String, Bytes, ElasticBulkOptions), Error = Rejection> + Clone {
+) -> impl Filter<Extract = (String, Body, ElasticBulkOptions), Error = Rejection> + Clone {
     warp::path!("_elastic" / String / "_bulk")
         .and(warp::post())
         .and(warp::body::content_length_limit(

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -34,7 +34,7 @@ use warp::{redirect, Filter, Rejection, Reply};
 
 use crate::cluster_api::cluster_handler;
 use crate::debugging_api::debugging_handler;
-use crate::decompression::{CorruptedData, UnsupportedEncoding};
+use crate::decompression::{CorruptedData, TooManyRequests, UnsupportedEncoding};
 use crate::delete_task_api::delete_task_api_handlers;
 use crate::elasticsearch_api::elastic_api_handlers;
 use crate::health_check_api::health_check_handlers;
@@ -282,6 +282,11 @@ fn get_status_with_error(rejection: Rejection) -> RestApiError {
     } else if let Some(error) = rejection.find::<CorruptedData>() {
         RestApiError {
             service_code: ServiceErrorCode::BadRequest,
+            message: error.to_string(),
+        }
+    } else if let Some(error) = rejection.find::<TooManyRequests>() {
+        RestApiError {
+            service_code: ServiceErrorCode::RateLimited,
             message: error.to_string(),
         }
     } else if let Some(error) = rejection.find::<warp::reject::InvalidQuery>() {


### PR DESCRIPTION
### Description

while investigating #4615, i found when one of the ingest apis gets too many requests per second, it can end up consuming a lot of memory, due to many transient buffer used to store the request body being allocated at the same time (on per ongoing request).
this pr adds a semaphore to prevent having too many such bodies going arround

### How was this PR tested?

before, hammering the api with ~1k concurrent requests (most of which receiving 419) got quickwit to allocate ~8-9G of memory. Now there is no noticeable memory usage change between 100 concurrent requests and 1k