### PR TITLE
update shard_table position on ShardPositionsUpdate

### DIFF
--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -1594,7 +1594,6 @@ mod tests {
             shard_state.publish_position_inclusive(),
             Position::offset(1234u64)
         );
-        //let _ = client_inbox.drain_for_test();
         universe.assert_quit().await;
     }
 

--- a/quickwit/quickwit-control-plane/src/model/mod.rs
+++ b/quickwit/quickwit-control-plane/src/model/mod.rs
@@ -288,11 +288,11 @@ impl ControlPlaneModel {
     }
 
     /// Lists the shards of a given source. Returns `None` if the source does not exist.
-    pub fn get_mut_shards_for_source(
+    pub fn get_shards_for_source_mut(
         &mut self,
         source_uid: &SourceUid,
     ) -> Option<&mut FnvHashMap<ShardId, ShardEntry>> {
-        self.shard_table.get_mut_shards(source_uid)
+        self.shard_table.get_shards_mut(source_uid)
     }
 
     /// Inserts the shards that have just been opened by calling `open_shards` on the metastore.

--- a/quickwit/quickwit-control-plane/src/model/mod.rs
+++ b/quickwit/quickwit-control-plane/src/model/mod.rs
@@ -287,6 +287,14 @@ impl ControlPlaneModel {
         self.shard_table.get_shards(source_uid)
     }
 
+    /// Lists the shards of a given source. Returns `None` if the source does not exist.
+    pub fn get_mut_shards_for_source(
+        &mut self,
+        source_uid: &SourceUid,
+    ) -> Option<&mut FnvHashMap<ShardId, ShardEntry>> {
+        self.shard_table.get_mut_shards(source_uid)
+    }
+
     /// Inserts the shards that have just been opened by calling `open_shards` on the metastore.
     pub fn insert_shards(
         &mut self,

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -284,7 +284,7 @@ impl ShardTable {
     }
 
     /// Lists the shards of a given source. Returns `None` if the source does not exist.
-    pub fn get_mut_shards(
+    pub fn get_shards_mut(
         &mut self,
         source_uid: &SourceUid,
     ) -> Option<&mut FnvHashMap<ShardId, ShardEntry>> {

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -283,6 +283,16 @@ impl ShardTable {
             .map(|table_entry| &table_entry.shard_entries)
     }
 
+    /// Lists the shards of a given source. Returns `None` if the source does not exist.
+    pub fn get_mut_shards(
+        &mut self,
+        source_uid: &SourceUid,
+    ) -> Option<&mut FnvHashMap<ShardId, ShardEntry>> {
+        self.table_entries
+            .get_mut(source_uid)
+            .map(|table_entry| &mut table_entry.shard_entries)
+    }
+
     /// Inserts the shards into the shard table.
     pub fn insert_shards(
         &mut self,


### PR DESCRIPTION
### Description

fix #4623
position seemed to already be populated from metastore on restart (as per `/debugging`)

### How was this PR tested?

query `/debugging` while ingesting and verify that `.shard_table[].shards[].publish_position_inclusive` changes.
restart control_plane and verify position stays coherent/aren't reset