### PR TITLE
delay fast field type conversion to harvest phase

### DIFF
--- a/quickwit/rest-api-tests/run_tests.py
+++ b/quickwit/rest-api-tests/run_tests.py
@@ -137,7 +137,18 @@ def check_result(result, expected, context_path = ""):
 
 def check_result_list(result, expected, context_path=""):
     if len(result) != len(expected):
-        raise(Exception("Wrong length at context %s" % context_path))
+        if len(expected) != 0:
+            # get keys from the expected dicts and filter result to print only the keys that are in the expected dicts
+            expected_keys = set().union(*expected)
+            filtered_result = [{k: v for k, v in d.items() if k in expected_keys} for d in result]
+            # Check if the length differs by more than five
+            if abs(len(filtered_result) - len(expected)) > 5:
+                # Show only the first 5 elements followed by ellipsis if there are more
+                display_filtered_result = filtered_result[:5] + ['...'] if len(filtered_result) > 5 else filtered_result
+            else:
+                display_filtered_result = filtered_result
+            raise Exception("Wrong length at context %s. Expected: %s Received: %s,\n Expected \n%s \n Received \n%s" % (context_path, len(expected), len(result), display_filtered_result, expected))
+        raise Exception("Wrong length at context %s. Expected: %s Received: %s" % (context_path, len(expected), len(result)))
     for (i, (left, right)) in enumerate(zip(result, expected)):
         check_result(left, right, context_path + "[%s]" % i)
 
@@ -242,7 +253,7 @@ class Visitor:
                 num_steps_executed += 1
             except Exception as e:
                 print("🔴 %s" % scenario_path)
-                print("Failed at step %d" % i)
+                print(f"Failed at step '{step['desc']}'" if 'desc' in step else f"Failed at step {i}")
                 print(step)
                 print(e)
                 print("--------------")

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0018-search_after.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0018-search_after.yaml
@@ -143,3 +143,319 @@ expected:
       - sort: [1422748816000000000]
       - sort: [1422748816000000000]
       - sort: [1422748816000000000]
+--- # i64 to u64
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - val_u64:
+        order: asc
+  search_after: [-10]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [0]
+--- # f64 to u64
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - val_u64:
+        order: asc
+  search_after: [0.2]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [20]
+--- # u64 to i64
+endpoint: "search_after/_search"
+desc: "search after u64 to i64 asc"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: asc
+  search_after: [250]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [300]
+      - sort: [9223372036854775807]
+      - sort: [9223372036854775807]
+--- # u64 to i64
+endpoint: "search_after/_search"
+desc: "search after u64 to i64 desc"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: desc
+  search_after: [250]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [200]
+      - sort: [-100]
+--- # u64 to i64 corner case. We are exceeding i64::MAX, so we don't get any results.
+desc: "search after u64 to i64 corner case exceeding i64::MAX asc"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: asc
+  search_after: [18_000_000_000_000_000_000]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      $expect: "len(val) == 0"
+--- # u64 to i64 corner case.We are exceeding i64::MAX, but with desc we get ALL the results.
+desc: "search after u64 to i64 corner case exceeding i64::MAX desc"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: desc
+  search_after: [18_000_000_000_000_000_000]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [9_223_372_036_854_775_807]
+      - sort: [9_223_372_036_854_775_807]
+      - sort: [300]
+      - sort: [200]
+      - sort: [-100]
+--- # u64 to i64 corner case
+desc: "search after u64 to i64 corner case one below i64::MAX asc"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: asc
+  search_after: [9_223_372_036_854_775_806]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [9_223_372_036_854_775_807]
+---
+desc: "search after u64 to i64 corner case exactly i64::MAX asc"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: asc
+  search_after: [9_223_372_036_854_775_807]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      $expect: "len(val) == 0"
+---
+desc: "search after u64 to i64 corner case one above i64::MAX asc"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: asc
+  search_after: [9_223_372_036_854_775_808]
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      $expect: "len(val) == 0"
+---
+desc: "search after f64 to i64 corner case"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: asc
+  search_after: [9_223_372_036_854_500_000.5] # lower the value we seem to hit some f64 accuracy issue here
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [9_223_372_036_854_775_807]
+---
+desc: "search after f64 to i64 out of bounds asc match nothing"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 1
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: asc
+  search_after: [19_223_372_036_854_500_000.5] 
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      $expect: "len(val) == 0"
+---
+desc: "search after f64 to i64 out of bounds desc match everything"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - val_i64:
+        order: desc
+  search_after: [19_223_372_036_854_500_000.5] 
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [9_223_372_036_854_775_807]
+      - sort: [9_223_372_036_854_775_807]
+      - sort: [300]
+      - sort: [200]
+      - sort: [-100]
+---
+desc: "search after on mixed column asc"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - mixed_type:
+        order: asc
+  search_after: [-10] 
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [0]
+      - sort: [True]
+      - sort: [10.5]
+      - sort: [18000000000000000000]
+---
+desc: "search after on mixed column desc match nothing"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - mixed_type:
+        order: desc
+  search_after: [-10] 
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      $expect: "len(val) == 0"
+---
+desc: "search after on mixed column desc"
+endpoint: "search_after/_search"
+engines:
+  - quickwit
+json:
+  size: 5
+  query:
+      match_all: {}
+  sort:
+    - mixed_type:
+        order: desc
+  search_after: [2] 
+expected:
+  hits:
+    total:
+      value: 5
+      relation: eq
+    hits:
+      - sort: [True]
+      - sort: [0]
+      - sort: [-10]
+
+

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0020-stats.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0020-stats.yaml
@@ -65,12 +65,12 @@ expected:
   _all:
     primaries:
       docs:
-        count: 100
+        count: 105
     total:
       segments:
-        count: 1
+        count: 5
       docs:
-        count: 100
+        count: 105
   indices: 
     gharchive:
       primaries:

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0021-cat-indices.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0021-cat-indices.yaml
@@ -20,6 +20,8 @@ expected:
   docs.count: '0'
 - index: otel-traces-v0_7
   docs.count: '0'
+- index: search_after
+  docs.count: '5'
 ---
 method: [GET]
 engines:

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/_setup.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/_setup.quickwit.yaml
@@ -4,6 +4,12 @@ api_root: http://localhost:7280/api/v1/
 endpoint: indexes/gharchive
 status_code: null
 ---
+# Delete possibly remaining index
+method: DELETE
+api_root: http://localhost:7280/api/v1/
+endpoint: indexes/empty_index
+status_code: null
+---
 # Create index
 method: POST
 api_root: http://localhost:7280/api/v1/
@@ -16,6 +22,7 @@ json:
         - name: created_at
           type: datetime
           fast: true
+sleep_after: 3
 ---
 # Create index
 method: POST
@@ -55,3 +62,70 @@ params:
   refresh: "true"
 headers: {"Content-Type": "application/json", "content-encoding": "gzip"}
 body_from_file: gharchive-bulk.json.gz
+sleep_after: 3
+--- 
+# Delete possibly remaining index
+method: DELETE
+endpoint: indexes/search_after  
+status_code: null
+---
+# Create index
+method: POST
+api_root: http://localhost:7280/api/v1/
+endpoint: indexes/
+json:
+  version: "0.7"
+  index_id: search_after  
+  doc_mapping:
+    mode: dynamic
+    dynamic_mapping:
+      tokenizer: default
+      fast: true
+    field_mappings:
+      - name: val_u64
+        type: u64
+        fast: true
+      - name: val_f64
+        type: f64
+        fast: true
+      - name: val_i64
+        type: i64
+        fast: true
+sleep_after: 3
+---
+# Ingest documents split #1
+method: POST
+api_root: http://localhost:7280/api/v1/
+endpoint: search_after/ingest
+params:
+  commit: force
+ndjson:
+  - {"mixed_type": 18_000_000_000_000_000_000, "val_i64": -100, "val_f64": 100.5, "val_u64": 0} # mixed_type is a u64
+  - {"mixed_type": 0, "val_i64": 9_223_372_036_854_775_807, "val_f64": 110, "val_u64": 18_000_000_000_000_000_000} # to enforce u64 type on val_u64 we need a value > 2^63, or it will take i64 (maybe we should change this)
+---
+# Ingest documents split #2
+method: POST
+api_root: http://localhost:7280/api/v1/
+endpoint: search_after/ingest
+params:
+  commit: force
+ndjson:
+  - {"mixed_type": 10.5, "val_i64": 200, "val_f64": 200.0, "val_u64": 20} #mixed_type is a f64
+---
+# Ingest documents split #3
+method: POST
+api_root: http://localhost:7280/api/v1/
+endpoint: search_after/ingest
+params:
+  commit: force
+ndjson:
+  - {"mixed_type": -10, "val_i64": 300, "val_f64": 300.0, "val_u64": 0} #mixed_type is a i64
+---
+# Ingest documents split #4
+method: POST
+api_root: http://localhost:7280/api/v1/
+endpoint: search_after/ingest
+params:
+  commit: force
+ndjson:
+  - {"mixed_type": true, "val_i64": 9_223_372_036_854_775_807, "val_f64": 300.0, "val_u64": 0} # i64::MAX

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/_teardown.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/_teardown.quickwit.yaml
@@ -22,3 +22,8 @@ method: DELETE
 api_root: http://localhost:7280/api/v1/
 endpoint: indexes/test_index1
 status_code: null
+--- # Cleanup
+method: DELETE
+api_root: http://localhost:7280/api/v1/
+endpoint: indexes/search_after
+status_code: null


### PR DESCRIPTION
`extract_typed_sort_value_opt` is in the collect hot loop and very performance sensitive. Delay conversion from u64 to actual type to harvest phase.

The impact on the histogram query time seems a little odd, probably related to some inlining. The impact on other sort query times roughly what I'd expect.

![comparison](https://github.com/quickwit-oss/quickwit/assets/1109503/3aa39e6c-5326-4a91-aa34-85d787e2005d)

