### PR TITLE
Remove seed resolution validation

### DIFF
--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -458,6 +458,9 @@ impl NodeConfig {
             }
             peer_seed_addrs.push(peer_seed_addr.to_string())
         }
+        if !self.peer_seeds.is_empty() && peer_seed_addrs.is_empty() {
+            warn!("failed to resolve all the peer seed addresses")
+        }
         Ok(peer_seed_addrs)
     }
 

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -458,12 +458,6 @@ impl NodeConfig {
             }
             peer_seed_addrs.push(peer_seed_addr.to_string())
         }
-        if !self.peer_seeds.is_empty() && peer_seed_addrs.is_empty() {
-            bail!(
-                "failed to resolve any of the peer seed addresses: `{}`",
-                self.peer_seeds.join(", ")
-            )
-        }
         Ok(peer_seed_addrs)
     }
 

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -865,16 +865,6 @@ mod tests {
         }
         {
             let node_config = NodeConfigBuilder {
-                peer_seeds: ConfigValue::for_test(List(vec!["unresolvable-host".to_string()])),
-                ..Default::default()
-            }
-            .build_and_validate(&HashMap::new())
-            .await
-            .unwrap();
-            assert!(node_config.peer_seed_addrs().await.is_err());
-        }
-        {
-            let node_config = NodeConfigBuilder {
                 rest_config_builder: RestConfigBuilder {
                     listen_port: Some(1789),
                     ..Default::default()


### PR DESCRIPTION
### Description

On ECS when using CloudMap the tasks register to the service DNS entries as they are started. This check might fail because the other peers haven't registered yet. But the the DNS-based discovery mechanism implemented in Chitchat would have built the cluster successfully.

### How was this PR tested?

Describe how you tested this PR.
