### PR TITLE
Fix ARM Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,9 @@ WORKDIR /quickwit
 
 RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CARGO_PROFILE'" \
     && cargo build \
+        -p quickwit-cli \
         --features $CARGO_FEATURES \
+        --bin quickwit \
         $(test "$CARGO_PROFILE" = "release" && echo "--release") \
     && echo "Copying binaries to /quickwit/bin" \
     && mkdir -p /quickwit/bin \

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![recursion_limit = "256"]
+
 mod build_info;
 mod cluster_api;
 mod debugging_api;

--- a/quickwit/rust-toolchain.toml
+++ b/quickwit/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75"
+channel = "1.76"
 components = ["cargo", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
### Description
ARM Docker image build fails consistently, hitting a recursion limit when evaluating `warp` filters:
- https://github.com/quickwit-oss/quickwit/actions/runs/8204806383/job/22440231908
- https://github.com/quickwit-oss/quickwit/actions/runs/8204258038/job/22440352796 (2 attempts)

- Set new recursion limit to 256 (default is 128)
- Upgraded Rust to 1.76
- Stop compiling some workspace crates (`lambda`, `codegen-example`, ...) that are unnecessary for generating the binary

### How was this PR tested?
https://github.com/quickwit-oss/quickwit/actions/runs/8206050080/job/22444278462
