### PR TITLE
Fix fetch task not signaling shard EOF

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -630,11 +630,14 @@ pub(super) mod tests {
         let client_id = "test-client".to_string();
         let index_uid: IndexUid = IndexUid::for_test("test-index", 0);
         let source_id = "test-source".to_string();
+        let shard_id = ShardId::from(1);
+        let queue_id = queue_id(&index_uid, &source_id, &shard_id);
+
         let open_fetch_stream_request = OpenFetchStreamRequest {
             client_id: client_id.clone(),
             index_uid: Some(index_uid.clone()),
             source_id: source_id.clone(),
-            shard_id: Some(ShardId::from(1)),
+            shard_id: Some(shard_id.clone()),
             from_position_exclusive: Some(Position::Beginning),
         };
         let (shard_status_tx, shard_status_rx) = watch::channel(ShardStatus::default());
@@ -644,8 +647,6 @@ pub(super) mod tests {
             shard_status_rx,
             1024,
         );
-        let queue_id = queue_id(&index_uid, &source_id, &ShardId::from(1));
-
         let mut mrecordlog_guard = mrecordlog.write().await;
 
         mrecordlog_guard
@@ -674,8 +675,8 @@ pub(super) mod tests {
         let fetch_payload = into_fetch_payload(fetch_message);
 
         assert_eq!(fetch_payload.index_uid(), &index_uid);
-        assert_eq!(fetch_payload.source_id, "test-source");
-        assert_eq!(fetch_payload.shard_id(), ShardId::from(1));
+        assert_eq!(fetch_payload.source_id, source_id);
+        assert_eq!(fetch_payload.shard_id(), shard_id);
         assert_eq!(fetch_payload.from_position_exclusive(), Position::Beginning);
         assert_eq!(
             fetch_payload.to_position_inclusive(),
@@ -809,8 +810,8 @@ pub(super) mod tests {
         let fetch_eof = into_fetch_eof(fetch_message);
 
         assert_eq!(fetch_eof.index_uid(), &index_uid);
-        assert_eq!(fetch_eof.source_id, "test-source");
-        assert_eq!(fetch_eof.shard_id(), ShardId::from(1));
+        assert_eq!(fetch_eof.source_id, source_id);
+        assert_eq!(fetch_eof.shard_id(), shard_id);
         assert_eq!(fetch_eof.eof_position, Some(Position::eof(3u64)));
 
         fetch_task_handle.await.unwrap();
@@ -889,11 +890,14 @@ pub(super) mod tests {
         let client_id = "test-client".to_string();
         let index_uid: IndexUid = IndexUid::for_test("test-index", 0);
         let source_id = "test-source".to_string();
+        let shard_id = ShardId::from(1);
+        let queue_id = queue_id(&index_uid, &source_id, &shard_id);
+
         let open_fetch_stream_request = OpenFetchStreamRequest {
             client_id: client_id.clone(),
             index_uid: Some(index_uid.clone()),
             source_id: source_id.clone(),
-            shard_id: Some(ShardId::from(1)),
+            shard_id: Some(shard_id.clone()),
             from_position_exclusive: Some(Position::Beginning),
         };
         let (shard_status_tx, shard_status_rx) = watch::channel(ShardStatus::default());
@@ -903,8 +907,6 @@ pub(super) mod tests {
             shard_status_rx,
             1024,
         );
-        let queue_id = queue_id(&index_uid, &source_id, &ShardId::from(1));
-
         let mut mrecordlog_guard = mrecordlog.write().await;
 
         mrecordlog_guard
@@ -926,8 +928,8 @@ pub(super) mod tests {
         let fetch_eof = into_fetch_eof(fetch_message);
 
         assert_eq!(fetch_eof.index_uid(), &index_uid);
-        assert_eq!(fetch_eof.source_id, "test-source");
-        assert_eq!(fetch_eof.shard_id(), ShardId::from(1));
+        assert_eq!(fetch_eof.source_id, source_id);
+        assert_eq!(fetch_eof.shard_id(), shard_id);
         assert_eq!(fetch_eof.eof_position, Some(Position::Beginning.as_eof()));
 
         fetch_task_handle.await.unwrap();
@@ -942,11 +944,14 @@ pub(super) mod tests {
         let client_id = "test-client".to_string();
         let index_uid: IndexUid = IndexUid::for_test("test-index", 0);
         let source_id = "test-source".to_string();
+        let shard_id = ShardId::from(1);
+        let queue_id = queue_id(&index_uid, &source_id, &shard_id);
+
         let open_fetch_stream_request = OpenFetchStreamRequest {
             client_id: client_id.clone(),
             index_uid: Some(index_uid.clone()),
             source_id: source_id.clone(),
-            shard_id: Some(ShardId::from(1)),
+            shard_id: Some(shard_id.clone()),
             from_position_exclusive: Some(Position::offset(0u64)),
         };
         let (shard_status_tx, shard_status_rx) = watch::channel(ShardStatus::default());
@@ -956,8 +961,6 @@ pub(super) mod tests {
             shard_status_rx,
             1024,
         );
-        let queue_id = queue_id(&index_uid, &source_id, &ShardId::from(1));
-
         let mut mrecordlog_guard = mrecordlog.write().await;
 
         mrecordlog_guard
@@ -1018,8 +1021,8 @@ pub(super) mod tests {
         let fetch_payload = into_fetch_payload(fetch_message);
 
         assert_eq!(fetch_payload.index_uid(), &index_uid);
-        assert_eq!(fetch_payload.source_id, "test-source");
-        assert_eq!(fetch_payload.shard_id(), ShardId::from(1));
+        assert_eq!(fetch_payload.source_id, source_id);
+        assert_eq!(fetch_payload.shard_id(), shard_id);
         assert_eq!(
             fetch_payload.from_position_exclusive(),
             Position::offset(0u64)
@@ -1051,11 +1054,13 @@ pub(super) mod tests {
         let client_id = "test-client".to_string();
         let index_uid: IndexUid = IndexUid::for_test("test-index", 0);
         let source_id = "test-source".to_string();
+        let shard_id = ShardId::from(1);
+
         let open_fetch_stream_request = OpenFetchStreamRequest {
             client_id: client_id.clone(),
             index_uid: Some(index_uid.clone()),
             source_id: source_id.clone(),
-            shard_id: Some(ShardId::from(1)),
+            shard_id: Some(shard_id.clone()),
             from_position_exclusive: Some(Position::Beginning),
         };
         let (_shard_status_tx, shard_status_rx) = watch::channel(ShardStatus::default());
@@ -1084,11 +1089,14 @@ pub(super) mod tests {
         let client_id = "test-client".to_string();
         let index_uid: IndexUid = IndexUid::for_test("test-index", 0);
         let source_id = "test-source".to_string();
+        let shard_id = ShardId::from(1);
+        let queue_id = queue_id(&index_uid, &source_id, &shard_id);
+
         let open_fetch_stream_request = OpenFetchStreamRequest {
             client_id: client_id.clone(),
             index_uid: Some(index_uid.clone()),
             source_id: source_id.clone(),
-            shard_id: Some(ShardId::from(1)),
+            shard_id: Some(shard_id.clone()),
             from_position_exclusive: Some(Position::Beginning),
         };
         let (shard_status_tx, shard_status_rx) = watch::channel(ShardStatus::default());
@@ -1098,8 +1106,6 @@ pub(super) mod tests {
             shard_status_rx,
             30,
         );
-        let queue_id = queue_id(&index_uid, &source_id, &ShardId::from(1));
-
         let mut mrecordlog_guard = mrecordlog.write().await;
 
         mrecordlog_guard
@@ -1227,8 +1233,8 @@ pub(super) mod tests {
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             mrecord_batch: MRecordBatch::for_test(["\0\0test-doc-foo"]),
             from_position_exclusive: Some(Position::offset(0u64)),
             to_position_inclusive: Some(Position::offset(1u64)),
@@ -1238,8 +1244,8 @@ pub(super) mod tests {
 
         let fetch_eof = FetchEof {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             eof_position: Some(Position::eof(1u64)),
         };
         let fetch_message = FetchMessage::new_eof(fetch_eof);
@@ -1339,8 +1345,8 @@ pub(super) mod tests {
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             mrecord_batch: MRecordBatch::for_test(["\0\0test-doc-foo"]),
             from_position_exclusive: Some(Position::offset(0u64)),
             to_position_inclusive: Some(Position::offset(1u64)),
@@ -1350,8 +1356,8 @@ pub(super) mod tests {
 
         let fetch_eof = FetchEof {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             eof_position: Some(Position::eof(1u64)),
         };
         let fetch_message = FetchMessage::new_eof(fetch_eof);
@@ -1450,8 +1456,8 @@ pub(super) mod tests {
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             mrecord_batch: MRecordBatch::for_test(["\0\0test-doc-foo"]),
             from_position_exclusive: Some(Position::offset(0u64)),
             to_position_inclusive: Some(Position::offset(1u64)),
@@ -1464,8 +1470,8 @@ pub(super) mod tests {
 
         let fetch_eof = FetchEof {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             eof_position: Some(Position::eof(1u64)),
         };
         let fetch_message = FetchMessage::new_eof(fetch_eof);
@@ -1636,8 +1642,8 @@ pub(super) mod tests {
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             mrecord_batch: MRecordBatch::for_test(["\0\0test-doc-foo"]),
             from_position_exclusive: Some(Position::offset(0u64)),
             to_position_inclusive: Some(Position::offset(1u64)),
@@ -1650,8 +1656,8 @@ pub(super) mod tests {
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
-            source_id: "test-source".into(),
-            shard_id: Some(ShardId::from(1)),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
             mrecord_batch: MRecordBatch::for_test(["\0\0test-doc-bar"]),
             from_position_exclusive: Some(Position::offset(1u64)),
             to_position_inclusive: Some(Position::offset(2u64)),


### PR DESCRIPTION
### Description
The statement `has_reached_eof = shard_state.is_closed() && to_position_inclusive >= *replication_position` was broken for shards closed while already drained because the initialization value of `to_position_inclusive` was `Beginning`.

### How was this PR tested?
Added unit test
Tested on Cicada, it helps, but there is another issue
