### PR TITLE
Open shards metrics was only updated on scale up/down.

### DIFF
--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -513,6 +513,7 @@ impl Handler<DeleteIndexRequest> for ControlPlane {
         ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
         let index_uid: IndexUid = request.index_uid().clone();
+        info!(index=%index_uid, "delete index");
 
         if let Err(metastore_error) = self.metastore.delete_index(request).await {
             return convert_metastore_error(metastore_error);
@@ -557,6 +558,8 @@ impl Handler<AddSourceRequest> for ControlPlane {
                     return Ok(Err(ControlPlaneError::from(error)));
                 }
             };
+        info!(index=%index_uid, source_config=?source_config, "add source");
+
         if let Err(error) = self.metastore.add_source(request).await {
             return Ok(Err(ControlPlaneError::from(error)));
         };
@@ -588,6 +591,8 @@ impl Handler<ToggleSourceRequest> for ControlPlane {
         let index_uid: IndexUid = request.index_uid().clone();
         let source_id = request.source_id.clone();
         let enable = request.enable;
+
+        info!(index=%index_uid, source_id=%source_id, enable=enable, "toggle source");
 
         if let Err(error) = self.metastore.toggle_source(request).await {
             return Ok(Err(ControlPlaneError::from(error)));

--- a/quickwit/quickwit-control-plane/src/metrics.rs
+++ b/quickwit/quickwit-control-plane/src/metrics.rs
@@ -28,7 +28,7 @@ pub struct ControlPlaneMetrics {
     pub schedule_total: IntCounter,
     pub metastore_error_aborted: IntCounter,
     pub metastore_error_maybe_executed: IntCounter,
-    pub open_shards_total: IntGaugeVec<2>,
+    pub open_shards_total: IntGaugeVec<1>,
 }
 
 impl Default for ControlPlaneMetrics {
@@ -62,7 +62,7 @@ impl Default for ControlPlaneMetrics {
                 "Number of open shards per source.",
                 "control_plane",
                 &[],
-                ["index_id", "source_id"],
+                ["index_id"],
             ),
         }
     }

--- a/quickwit/quickwit-control-plane/src/model/mod.rs
+++ b/quickwit/quickwit-control-plane/src/model/mod.rs
@@ -252,8 +252,9 @@ impl ControlPlaneModel {
         Ok(has_changed)
     }
 
-    pub(crate) fn all_shards_mut(&mut self) -> impl Iterator<Item = &mut ShardEntry> + '_ {
-        self.shard_table.all_shards_mut()
+    pub(crate) fn set_shards_as_unavailable(&mut self, unavailable_leaders: &FnvHashSet<NodeId>) {
+        self.shard_table
+            .set_shards_as_unavailable(unavailable_leaders);
     }
 
     #[cfg(test)]


### PR DESCRIPTION
This PR also removes the source id label (as it will always be ingest
v2). This is not much of a win since the overall metric cardinality does
not change.

It also removes `.all_shards_mut()` which was error-prone
as a client could break all kinds of invariants.