### PR TITLE
Improve Lambda Merges

### DIFF
--- a/distribution/lambda/Makefile
+++ b/distribution/lambda/Makefile
@@ -56,7 +56,7 @@ indexer-package-path:
 searcher-package-path:
 	echo -n $(SEARCHER_PACKAGE_PATH)
 
-bootstrap: package check-env
+bootstrap:
 	cdk bootstrap aws://$$CDK_ACCOUNT/$$CDK_REGION
 
 deploy-hdfs: package check-env
@@ -65,17 +65,20 @@ deploy-hdfs: package check-env
 deploy-mock-data: package check-env
 	cdk deploy -a cdk/app.py MockDataStack
 
+print-mock-data-metastore: check-env
+	python -c 'from cdk import cli; cli.print_mock_data_metastore()'
+
 # address https://github.com/aws/aws-cdk/issues/20060
 before-destroy:
 	mkdir -p cdk.out
 	touch $(INDEXER_PACKAGE_PATH)
 	touch $(SEARCHER_PACKAGE_PATH)
 
-destroy-hdfs: before-destroy
+destroy-hdfs: before-destroy check-env
 	python -c 'from cdk import cli; cli.empty_hdfs_bucket()'
 	cdk destroy  --force -a cdk/app.py HdfsStack
 
-destroy-mock-data: before-destroy
+destroy-mock-data: before-destroy check-env
 	python -c 'from cdk import cli; cli.empty_mock_data_buckets()'
 	cdk destroy  --force -a cdk/app.py MockDataStack
 
@@ -108,6 +111,7 @@ bench-index:
 	done
 
 bench-search-term:
+	export QW_LAMBDA_LOG_SPAN_BOUNDARIES=true
 	mem_sizes=( 1024 2048 4096 8192 )
 	for mem_size in "$${mem_sizes[@]}"
 	do
@@ -117,6 +121,7 @@ bench-search-term:
 	done
 
 bench-search-histogram:
+	export QW_LAMBDA_LOG_SPAN_BOUNDARIES=true
 	mem_sizes=( 1024 2048 4096 8192 )
 	for mem_size in "$${mem_sizes[@]}"
 	do

--- a/distribution/lambda/cdk/cli.py
+++ b/distribution/lambda/cdk/cli.py
@@ -316,6 +316,15 @@ def empty_mock_data_buckets():
     _clean_s3_bucket(bucket_name)
 
 
+def print_mock_data_metastore():
+    bucket_name = _get_cloudformation_output_value(
+        app.MOCK_DATA_STACK_NAME, mock_data_stack.INDEX_STORE_BUCKET_NAME_EXPORT_NAME
+    )
+    s3 = session.client("s3")
+    response = s3.get_object(Bucket=bucket_name, Key="index/mock-sales/metastore.json")
+    print(response["Body"].read().decode())
+
+
 @cache
 def _git_commit():
     return subprocess.run(

--- a/distribution/lambda/cdk/stacks/examples/mock_data_stack.py
+++ b/distribution/lambda/cdk/stacks/examples/mock_data_stack.py
@@ -12,7 +12,7 @@ from aws_cdk import (
 from constructs import Construct
 import yaml
 
-from ..services.quickwit_service import QuickwitService
+from ..services import quickwit_service
 
 SEARCHER_FUNCTION_NAME_EXPORT_NAME = "mock-data-searcher-function-name"
 INDEX_STORE_BUCKET_NAME_EXPORT_NAME = "mock-data-index-store-bucket-name"
@@ -28,7 +28,7 @@ class Source(Construct):
         scope: Construct,
         construct_id: str,
         index_id: str,
-        qw_svc: QuickwitService,
+        qw_svc: quickwit_service.QuickwitService,
         **kwargs,
     ):
         super().__init__(scope, construct_id, **kwargs)
@@ -83,7 +83,7 @@ class SearchAPI(Construct):
         scope: Construct,
         construct_id: str,
         index_id: str,
-        qw_svc: QuickwitService,
+        qw_svc: quickwit_service.QuickwitService,
         api_key: str,
         **kwargs,
     ) -> None:
@@ -149,12 +149,15 @@ class MockDataStack(Stack):
             "mock-data-index-config",
             path=index_config_local_path,
         )
-        qw_svc = QuickwitService(
+        lambda_env = quickwit_service.extract_local_env()
+        qw_svc = quickwit_service.QuickwitService(
             self,
             "Quickwit",
             index_id=index_id,
             index_config_bucket=index_config.s3_bucket_name,
             index_config_key=index_config.s3_object_key,
+            indexer_environment=lambda_env,
+            searcher_environment=lambda_env,
             indexer_package_location=indexer_package_location,
             searcher_package_location=searcher_package_location,
         )

--- a/distribution/lambda/cdk/stacks/services/indexer_service.py
+++ b/distribution/lambda/cdk/stacks/services/indexer_service.py
@@ -32,7 +32,9 @@ class IndexerService(Construct):
                 "QW_LAMBDA_INDEX_CONFIG_URI": f"s3://{index_config_bucket}/{index_config_key}",
                 **environment,
             },
-            timeout=aws_cdk.Duration.minutes(15),
+            # use a strict timeout and retry policy to avoid unexpected costs
+            timeout=aws_cdk.Duration.minutes(1),
+            retry_attempts=0,
             reserved_concurrent_executions=1,
             memory_size=memory_size,
             ephemeral_storage_size=aws_cdk.Size.gibibytes(10),

--- a/distribution/lambda/cdk/stacks/services/quickwit_service.py
+++ b/distribution/lambda/cdk/stacks/services/quickwit_service.py
@@ -12,8 +12,12 @@ DEFAULT_LAMBDA_MEMORY_SIZE = 3008
 
 
 def extract_local_env() -> dict[str, str]:
-    """Extracts local environment variables that start with QW_LAMBDA_"""
-    return {k: os.environ[k] for k in os.environ.keys() if k.startswith("QW_LAMBDA_")}
+    """Extracts local environment variables QW_LAMBDA_* and QW_DISABLE_TELEMETRY"""
+    return {
+        k: os.environ[k]
+        for k in os.environ.keys()
+        if (k.startswith("QW_LAMBDA_") or k == "QW_DISABLE_TELEMETRY")
+    }
 
 
 class QuickwitService(Construct):

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -6050,6 +6050,7 @@ dependencies = [
  "quickwit-index-management",
  "quickwit-indexing",
  "quickwit-ingest",
+ "quickwit-janitor",
  "quickwit-metastore",
  "quickwit-proto",
  "quickwit-rest-client",

--- a/quickwit/quickwit-codegen/example/src/codegen/hello.rs
+++ b/quickwit/quickwit-codegen/example/src/codegen/hello.rs
@@ -744,7 +744,7 @@ where
             .hello(request)
             .await
             .map(|response| response.into_inner())
-            .map_err(crate::error::grpc_status_to_service_error)
+            .map_err(|error| error.into())
     }
     async fn goodbye(
         &mut self,
@@ -754,7 +754,7 @@ where
             .goodbye(request)
             .await
             .map(|response| response.into_inner())
-            .map_err(crate::error::grpc_status_to_service_error)
+            .map_err(|error| error.into())
     }
     async fn ping(
         &mut self,
@@ -766,9 +766,9 @@ where
             .map(|response| {
                 let streaming: tonic::Streaming<_> = response.into_inner();
                 let stream = quickwit_common::ServiceStream::from(streaming);
-                stream.map_err(crate::error::grpc_status_to_service_error)
+                stream.map_err(|error| error.into())
             })
-            .map_err(crate::error::grpc_status_to_service_error)
+            .map_err(|error| error.into())
     }
     async fn check_connectivity(&mut self) -> anyhow::Result<()> {
         if self.connection_addrs_rx.borrow().len() == 0 {
@@ -809,7 +809,7 @@ impl hello_grpc_server::HelloGrpc for HelloGrpcServerAdapter {
             .hello(request.into_inner())
             .await
             .map(tonic::Response::new)
-            .map_err(crate::error::grpc_error_to_grpc_status)
+            .map_err(|error| error.into())
     }
     async fn goodbye(
         &self,
@@ -820,7 +820,7 @@ impl hello_grpc_server::HelloGrpc for HelloGrpcServerAdapter {
             .goodbye(request.into_inner())
             .await
             .map(tonic::Response::new)
-            .map_err(crate::error::grpc_error_to_grpc_status)
+            .map_err(|error| error.into())
     }
     type PingStream = quickwit_common::ServiceStream<tonic::Result<PingResponse>>;
     async fn ping(
@@ -834,10 +834,8 @@ impl hello_grpc_server::HelloGrpc for HelloGrpcServerAdapter {
                 quickwit_common::ServiceStream::from(streaming)
             })
             .await
-            .map(|stream| tonic::Response::new(
-                stream.map_err(crate::error::grpc_error_to_grpc_status),
-            ))
-            .map_err(crate::error::grpc_error_to_grpc_status)
+            .map(|stream| tonic::Response::new(stream.map_err(|error| error.into())))
+            .map_err(|error| error.into())
     }
 }
 /// Generated client implementations.

--- a/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
+++ b/quickwit/quickwit-ingest/src/codegen/ingest_service.rs
@@ -803,21 +803,21 @@ where
             .ingest(request)
             .await
             .map(|response| response.into_inner())
-            .map_err(crate::error::grpc_status_to_service_error)
+            .map_err(|error| error.into())
     }
     async fn fetch(&mut self, request: FetchRequest) -> crate::Result<FetchResponse> {
         self.inner
             .fetch(request)
             .await
             .map(|response| response.into_inner())
-            .map_err(crate::error::grpc_status_to_service_error)
+            .map_err(|error| error.into())
     }
     async fn tail(&mut self, request: TailRequest) -> crate::Result<FetchResponse> {
         self.inner
             .tail(request)
             .await
             .map(|response| response.into_inner())
-            .map_err(crate::error::grpc_status_to_service_error)
+            .map_err(|error| error.into())
     }
 }
 #[derive(Debug)]
@@ -843,7 +843,7 @@ impl ingest_service_grpc_server::IngestServiceGrpc for IngestServiceGrpcServerAd
             .ingest(request.into_inner())
             .await
             .map(tonic::Response::new)
-            .map_err(crate::error::grpc_error_to_grpc_status)
+            .map_err(|error| error.into())
     }
     async fn fetch(
         &self,
@@ -854,7 +854,7 @@ impl ingest_service_grpc_server::IngestServiceGrpc for IngestServiceGrpcServerAd
             .fetch(request.into_inner())
             .await
             .map(tonic::Response::new)
-            .map_err(crate::error::grpc_error_to_grpc_status)
+            .map_err(|error| error.into())
     }
     async fn tail(
         &self,
@@ -865,7 +865,7 @@ impl ingest_service_grpc_server::IngestServiceGrpc for IngestServiceGrpcServerAd
             .tail(request.into_inner())
             .await
             .map(tonic::Response::new)
-            .map_err(crate::error::grpc_error_to_grpc_status)
+            .map_err(|error| error.into())
     }
 }
 /// Generated client implementations.

--- a/quickwit/quickwit-lambda/Cargo.toml
+++ b/quickwit/quickwit-lambda/Cargo.toml
@@ -51,6 +51,7 @@ quickwit-doc-mapper = { workspace = true }
 quickwit-index-management = { workspace = true }
 quickwit-indexing = { workspace = true }
 quickwit-ingest = { workspace = true }
+quickwit-janitor = { workspace = true }
 quickwit-metastore = { workspace = true }
 quickwit-proto = { workspace = true }
 quickwit-rest-client = { workspace = true }

--- a/quickwit/quickwit-lambda/src/bin/indexer.rs
+++ b/quickwit/quickwit-lambda/src/bin/indexer.rs
@@ -23,7 +23,7 @@ use quickwit_lambda::logger;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    logger::setup_lambda_tracer()?;
+    logger::setup_lambda_tracer(tracing::Level::INFO)?;
     let func = service_fn(handler);
     lambda_runtime::run(func)
         .await

--- a/quickwit/quickwit-lambda/src/bin/searcher.rs
+++ b/quickwit/quickwit-lambda/src/bin/searcher.rs
@@ -23,7 +23,7 @@ use quickwit_lambda::searcher::handler;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    logger::setup_lambda_tracer()?;
+    logger::setup_lambda_tracer(tracing::Level::INFO)?;
     let func = service_fn(handler);
     run(func).await.map_err(|e| anyhow::anyhow!(e))
 }

--- a/quickwit/quickwit-lambda/src/environment.rs
+++ b/quickwit/quickwit-lambda/src/environment.rs
@@ -21,20 +21,14 @@ use std::env::var;
 
 use once_cell::sync::Lazy;
 
-pub const CONFIGURATION_TEMPLATE: &str = "version: 0.6
-node_id: lambda-indexer
-cluster_id: lambda-ephemeral
-metastore_uri: s3://${QW_LAMBDA_METASTORE_BUCKET}/index
-default_index_root_uri: s3://${QW_LAMBDA_INDEX_BUCKET}/index
-data_dir: /tmp
-";
+pub static INDEX_ID: Lazy<String> =
+    Lazy::new(|| var("QW_LAMBDA_INDEX_ID").expect("QW_LAMBDA_INDEX_ID must be set"));
 
-pub static INDEX_CONFIG_URI: Lazy<String> = Lazy::new(|| {
-    var("QW_LAMBDA_INDEX_CONFIG_URI").expect("QW_LAMBDA_INDEX_CONFIG_URI must be set")
-});
+pub static LOG_SPAN_BOUNDARIES: Lazy<bool> =
+    Lazy::new(|| var("QW_LAMBDA_LOG_SPAN_BOUNDARIES").is_ok_and(|v| v.as_str() == "true"));
 
-pub static DISABLE_MERGE: Lazy<bool> =
-    Lazy::new(|| var("QW_LAMBDA_DISABLE_MERGE").is_ok_and(|v| v.as_str() == "true"));
+pub static OPENTELEMETRY_URL: Lazy<Option<String>> =
+    Lazy::new(|| var("QW_LAMBDA_OPENTELEMETRY_URL").ok());
 
-pub static DISABLE_JANITOR: Lazy<bool> =
-    Lazy::new(|| var("QW_LAMBDA_DISABLE_JANITOR").is_ok_and(|v| v.as_str() == "true"));
+pub static OPENTELEMETRY_AUTHORIZATION: Lazy<Option<String>> =
+    Lazy::new(|| var("QW_LAMBDA_OPENTELEMETRY_AUTHORIZATION").ok());

--- a/quickwit/quickwit-lambda/src/indexer/handler.rs
+++ b/quickwit/quickwit-lambda/src/indexer/handler.rs
@@ -21,9 +21,10 @@ use lambda_runtime::{Error, LambdaEvent};
 use serde_json::Value;
 use tracing::{debug_span, error, info, info_span, Instrument};
 
-use super::environment::{DISABLE_MERGE, INDEX_CONFIG_URI, INDEX_ID};
+use super::environment::{DISABLE_JANITOR, DISABLE_MERGE, INDEX_CONFIG_URI};
 use super::ingest::{ingest, IngestArgs};
 use super::model::IndexerEvent;
+use crate::environment::INDEX_ID;
 use crate::logger;
 use crate::utils::LambdaContainerContext;
 
@@ -37,6 +38,8 @@ async fn indexer_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
         input_format: quickwit_config::SourceInputFormat::Json,
         overwrite: false,
         vrl_script: None,
+        // TODO: instead of clearing the cache, we use a cache and set its max
+        // size with indexer_config.split_store_max_num_bytes
         clear_cache: true,
     })
     .instrument(debug_span!(
@@ -45,6 +48,7 @@ async fn indexer_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
         env.INDEX_CONFIG_URI = *INDEX_CONFIG_URI,
         env.INDEX_ID = *INDEX_ID,
         env.DISABLE_MERGE = *DISABLE_MERGE,
+        env.DISABLE_JANITOR = *DISABLE_JANITOR,
         cold = container_ctx.cold,
         container_id = container_ctx.container_id,
     ))

--- a/quickwit/quickwit-lambda/src/indexer/ingest/mod.rs
+++ b/quickwit/quickwit-lambda/src/indexer/ingest/mod.rs
@@ -1,0 +1,119 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod helpers;
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use anyhow::bail;
+use helpers::{
+    configure_source, create_empty_cluster, init_index_if_necessary, send_telemetry,
+    spawn_pipelines, spawn_services,
+};
+use quickwit_actors::Universe;
+use quickwit_cli::start_actor_runtimes;
+use quickwit_cli::tool::start_statistics_reporting_loop;
+use quickwit_common::runtimes::RuntimesConfig;
+use quickwit_config::service::QuickwitService;
+use quickwit_config::SourceInputFormat;
+use quickwit_index_management::clear_cache_directory;
+use quickwit_indexing::models::IndexingStatistics;
+use tracing::{debug, info};
+
+use crate::indexer::environment::CONFIGURATION_TEMPLATE;
+use crate::indexer::ingest::helpers::wait_for_merges;
+use crate::utils::load_node_config;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct IngestArgs {
+    pub input_path: PathBuf,
+    pub input_format: SourceInputFormat,
+    pub overwrite: bool,
+    pub vrl_script: Option<String>,
+    pub clear_cache: bool,
+}
+
+pub async fn ingest(args: IngestArgs) -> anyhow::Result<IndexingStatistics> {
+    debug!(args=?args, "lambda-ingest");
+
+    send_telemetry().await;
+
+    let (config, storage_resolver, mut metastore) =
+        load_node_config(CONFIGURATION_TEMPLATE).await?;
+
+    let source_config = configure_source(args.input_path, args.input_format, args.vrl_script);
+
+    init_index_if_necessary(
+        &mut metastore,
+        &storage_resolver,
+        &source_config,
+        &config.default_index_root_uri,
+        args.overwrite,
+    )
+    .await?;
+
+    let services = [QuickwitService::Indexer, QuickwitService::Janitor];
+    let cluster = create_empty_cluster(&config, &services).await?;
+    let universe = Universe::new();
+    let runtimes_config = RuntimesConfig::default();
+
+    start_actor_runtimes(runtimes_config, &HashSet::from_iter(services))?;
+
+    let (indexing_service_handle, _janitor_service_guard) = spawn_services(
+        &universe,
+        cluster,
+        metastore.clone(),
+        storage_resolver.clone(),
+        &config,
+        runtimes_config,
+    )
+    .await?;
+
+    let (indexing_pipeline_handle, merge_pipeline_handle) =
+        spawn_pipelines(indexing_service_handle.mailbox(), source_config).await?;
+
+    debug!("wait for indexing to complete");
+    let statistics = start_statistics_reporting_loop(indexing_pipeline_handle, false).await?;
+
+    debug!("wait for merges to complete");
+    wait_for_merges(merge_pipeline_handle).await?;
+
+    debug!("indexing completed, tearing down actors");
+    // TODO: is it really necessary to terminate the indexing service?
+    // Quitting the universe should be enough.
+    universe
+        .send_exit_with_success(indexing_service_handle.mailbox())
+        .await?;
+    indexing_service_handle.join().await;
+    debug!("quitting universe");
+    universe.quit().await;
+    debug!("universe.quit() awaited");
+
+    if args.clear_cache {
+        info!("clearing local cache directory");
+        clear_cache_directory(&config.data_dir_path).await?;
+        info!("local cache directory cleared");
+    }
+
+    if statistics.num_invalid_docs > 0 {
+        bail!("Failed to ingest {} documents", statistics.num_invalid_docs)
+    }
+    Ok(statistics)
+}

--- a/quickwit/quickwit-lambda/src/lib.rs
+++ b/quickwit/quickwit-lambda/src/lib.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+mod environment;
 pub mod indexer;
 pub mod logger;
 pub mod searcher;

--- a/quickwit/quickwit-lambda/src/searcher/environment.rs
+++ b/quickwit/quickwit-lambda/src/searcher/environment.rs
@@ -30,8 +30,5 @@ searcher:
   partial_request_cache_capacity: ${QW_LAMBDA_PARTIAL_REQUEST_CACHE_CAPACITY:-64M}
 ";
 
-pub(crate) static INDEX_ID: Lazy<String> =
-    Lazy::new(|| var("QW_LAMBDA_INDEX_ID").expect("QW_LAMBDA_INDEX_ID must be set"));
-
 pub(crate) static DISABLE_SEARCH_CACHE: Lazy<bool> =
     Lazy::new(|| var("QW_LAMBDA_DISABLE_SEARCH_CACHE").is_ok_and(|v| v.as_str() == "true"));

--- a/quickwit/quickwit-lambda/src/searcher/handler.rs
+++ b/quickwit/quickwit-lambda/src/searcher/handler.rs
@@ -26,8 +26,9 @@ use quickwit_search::SearchResponseRest;
 use quickwit_serve::SearchRequestQueryString;
 use tracing::{debug_span, error, info_span, instrument, Instrument};
 
-use super::environment::{DISABLE_SEARCH_CACHE, INDEX_ID};
+use super::environment::DISABLE_SEARCH_CACHE;
 use super::search::{search, SearchArgs};
+use crate::environment::INDEX_ID;
 use crate::logger;
 use crate::utils::LambdaContainerContext;
 

--- a/quickwit/quickwit-lambda/src/searcher/search.rs
+++ b/quickwit/quickwit-lambda/src/searcher/search.rs
@@ -35,7 +35,8 @@ use quickwit_telemetry::payload::{QuickwitFeature, QuickwitTelemetryInfo, Teleme
 use tokio::sync::OnceCell;
 use tracing::debug;
 
-use super::environment::{CONFIGURATION_TEMPLATE, DISABLE_SEARCH_CACHE, INDEX_ID};
+use super::environment::{CONFIGURATION_TEMPLATE, DISABLE_SEARCH_CACHE};
+use crate::environment::INDEX_ID;
 use crate::utils::load_node_config;
 
 static LAMBDA_SEARCH_CACHE: OnceCell<LambdaSearchCtx> = OnceCell::const_new();


### PR DESCRIPTION
### Description

Improve the actor shutdown on AWS Lambda runs so that merges go through.

### How was this PR tested?

I ran the Quickwit Lambda stack with the mock data generator for a few weeks with both:
- a 100k element per batch generator
- a 10 element per batch generator
Both ran without any error and all merges were properly  performed. 

This test also led to opening https://github.com/quickwit-oss/quickwit/issues/4734 as Cloudwatch logs costs where excessively high.