### PR TITLE
document scroll based on search after and docstore config

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -517,6 +517,8 @@ This section describes indexing settings for a given index.
 | `split_num_docs_target` | Target number of docs per split.   | `10000000` |
 | `merge_policy` | Describes the strategy used to trigger split merge operations (see [Merge policies](#merge-policies) section below). |
 | `resources.heap_size`      | Indexer heap size per source per index.   | `2000000000` |
+| `docstore_compression_level` | Level of compression used by zstd for the docstore. Lower values may increase ingest speed, at the cost of index size | `8` |
+| `docstore_blocksize` | Size of blocks in the docstore, in bytes. Lower values may improve doc retrieval speed, at the cost of index size | `1000000` |
 
 ### Merge policies
 

--- a/docs/reference/es_compatible_api.md
+++ b/docs/reference/es_compatible_api.md
@@ -278,12 +278,6 @@ First, the client needs to call the `search api` with a `scroll` query parameter
 
 Each subsequent call to the `_search/scroll` endpoint will return a new `scroll_id` pointing to the next page.
 
-:::caution
-
-The scroll API should not be used to fetch above the 10,000th result.
-
-:::
-
 ## Query DSL
 
 [Elasticsearch Query DSL reference](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/query-dsl.html).

--- a/quickwit/quickwit-search/src/scroll_context.rs
+++ b/quickwit/quickwit-search/src/scroll_context.rs
@@ -222,6 +222,9 @@ impl FromStr for ScrollKeyAndStartOffset {
         let scroll_ulid = u128::from_le_bytes(scroll_ulid_bytes.try_into().unwrap()).into();
         let from = u64::from_le_bytes(from_bytes.try_into().unwrap());
         let max_hits = u32::from_le_bytes(max_hits_bytes.try_into().unwrap());
+        if max_hits > 10_000 {
+            return Err("scroll id is malformed");
+        }
         let search_after =
             serde_json::from_slice(&base64_decoded[28..]).map_err(|_| "scroll id is malformed")?;
         Ok(ScrollKeyAndStartOffset {

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -382,8 +382,6 @@ pub(crate) async fn scroll(
 
     let cached_results = scroll_context.get_cached_partial_hits(start_doc..end_doc);
     partial_hits.extend_from_slice(cached_results);
-    // TODO if max_hits_per_page is corrupted by the client, we could be forced to allocate an
-    // arbitrarily large buffer.
     if (partial_hits.len() as u64) < current_scroll.max_hits_per_page as u64 {
         let search_after = partial_hits
             .last()

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -382,6 +382,8 @@ pub(crate) async fn scroll(
 
     let cached_results = scroll_context.get_cached_partial_hits(start_doc..end_doc);
     partial_hits.extend_from_slice(cached_results);
+    // TODO if max_hits_per_page is corrupted by the client, we could be forced to allocate an
+    // arbitrarily large buffer.
     if (partial_hits.len() as u64) < current_scroll.max_hits_per_page as u64 {
         let search_after = partial_hits
             .last()


### PR DESCRIPTION
### Description

fix #4717
fix #4718
fix out of memory on crafted scroll_id causing to allocate up to 2**32-1 partial hits (roughly 200GB)