### PR TITLE
Compress `ListIndexesMetadataResponse` payload and list shards in batches

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -6101,6 +6101,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "bytesize",
  "dotenv",
  "futures",

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -948,9 +948,7 @@ mod tests {
             });
         mock_metastore
             .expect_list_indexes_metadata()
-            .returning(|_| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(Vec::new()).unwrap())
-            });
+            .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
         let cluster_config = ClusterConfig::for_test();
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
         let (control_plane_mailbox, _control_plane_handle) = ControlPlane::spawn(
@@ -992,9 +990,7 @@ mod tests {
             .returning(|_| Ok(EmptyResponse {}));
         mock_metastore
             .expect_list_indexes_metadata()
-            .returning(|_| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(Vec::new()).unwrap())
-            });
+            .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
 
         let cluster_config = ClusterConfig::for_test();
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
@@ -1044,10 +1040,9 @@ mod tests {
         mock_metastore
             .expect_list_indexes_metadata()
             .returning(move |_| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
 
         let cluster_config = ClusterConfig::for_test();
@@ -1090,12 +1085,7 @@ mod tests {
         index_metadata.add_source(test_source_config).unwrap();
         mock_metastore
             .expect_list_indexes_metadata()
-            .return_once(|_| {
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(vec![index_metadata])
-                        .unwrap(),
-                )
-            });
+            .return_once(|_| Ok(ListIndexesMetadataResponse::for_test(vec![index_metadata])));
 
         let index_uid_clone = index_uid.clone();
         mock_metastore
@@ -1171,9 +1161,7 @@ mod tests {
             .returning(|_| Ok(EmptyResponse {}));
         mock_metastore
             .expect_list_indexes_metadata()
-            .returning(|_| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(Vec::new()).unwrap())
-            });
+            .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
 
         let cluster_config = ClusterConfig::for_test();
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
@@ -1217,10 +1205,7 @@ mod tests {
                 let mut source_config = SourceConfig::ingest_v2();
                 source_config.enabled = true;
                 index_metadata.add_source(source_config).unwrap();
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(vec![index_metadata])
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(vec![index_metadata]))
             });
         let index_uid_clone = index_uid.clone();
         mock_metastore
@@ -1300,7 +1285,7 @@ mod tests {
             .times(2) // 1 for the first initialization, 1 after the respawn of the control plane.
             .returning(|list_indexes_request: ListIndexesMetadataRequest| {
                 assert_eq!(list_indexes_request, ListIndexesMetadataRequest::all());
-                Ok(ListIndexesMetadataResponse::empty())
+                Ok(ListIndexesMetadataResponse::for_test(Vec::new()))
             });
         mock_metastore.expect_list_shards().return_once(
             |_list_shards_request: ListShardsRequest| {
@@ -1439,10 +1424,9 @@ mod tests {
         mock_metastore.expect_list_indexes_metadata().return_once(
             move |list_indexes_request: ListIndexesMetadataRequest| {
                 assert_eq!(list_indexes_request, ListIndexesMetadataRequest::all());
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_0_clone.clone()
-                ])
-                .unwrap())
+                ]))
             },
         );
         let index_uid_clone = index_0.index_uid.clone();
@@ -1588,10 +1572,9 @@ mod tests {
         mock_metastore.expect_list_indexes_metadata().return_once(
             move |list_indexes_request: ListIndexesMetadataRequest| {
                 assert_eq!(list_indexes_request, ListIndexesMetadataRequest::all());
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_0_clone.clone()
-                ])
-                .unwrap())
+                ]))
             },
         );
 
@@ -1673,10 +1656,9 @@ mod tests {
         mock_metastore.expect_list_indexes_metadata().return_once(
             move |list_indexes_request: ListIndexesMetadataRequest| {
                 assert_eq!(list_indexes_request, ListIndexesMetadataRequest::all());
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_0_clone.clone()
-                ])
-                .unwrap())
+                ]))
             },
         );
         let index_uid_clone = index_0.index_uid.clone();
@@ -1758,10 +1740,9 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(move |list_indexes_request: ListIndexesMetadataRequest| {
                 assert_eq!(list_indexes_request, ListIndexesMetadataRequest::all());
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_0_clone.clone()
-                ])
-                .unwrap())
+                ]))
             });
         mock_metastore
             .expect_list_shards()
@@ -1886,10 +1867,9 @@ mod tests {
         mock_metastore.expect_list_indexes_metadata().return_once(
             move |list_indexes_request: ListIndexesMetadataRequest| {
                 assert_eq!(list_indexes_request, ListIndexesMetadataRequest::all());
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_0_clone.clone()
-                ])
-                .unwrap())
+                ]))
             },
         );
 
@@ -1955,9 +1935,7 @@ mod tests {
 
         mock_metastore
             .expect_list_indexes_metadata()
-            .return_once(|_| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(Vec::new()).unwrap())
-            });
+            .return_once(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
 
         mock_metastore
             .expect_find_index_template_matches()
@@ -2086,9 +2064,7 @@ mod tests {
         let mut mock_metastore = MetastoreServiceClient::mock();
         mock_metastore
             .expect_list_indexes_metadata()
-            .return_once(|_| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(Vec::new()).unwrap())
-            });
+            .return_once(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
         let metastore = MetastoreServiceClient::from(mock_metastore);
         let (_control_plane_mailbox, control_plane_handle) = ControlPlane::spawn(
             &universe,

--- a/quickwit/quickwit-control-plane/src/model/mod.rs
+++ b/quickwit/quickwit-control-plane/src/model/mod.rs
@@ -21,6 +21,7 @@ mod shard_table;
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::mem;
 use std::ops::Deref;
 use std::time::Instant;
 
@@ -82,6 +83,8 @@ impl ControlPlaneModel {
         metastore: &mut MetastoreServiceClient,
         progress: &Progress,
     ) -> ControlPlaneResult<()> {
+        const LIST_SHARDS_BATCH_SIZE: usize = 500;
+
         let now = Instant::now();
         self.clear();
 
@@ -90,19 +93,19 @@ impl ControlPlaneModel {
             .await?
             .deserialize_indexes_metadata()?;
 
-        let num_indexes = index_metadatas.len();
+        let num_indexes = indexes_metadata.len();
         self.index_table.reserve(num_indexes);
 
         let mut num_sources = 0;
         let mut num_shards = 0;
 
-        let mut subrequests = Vec::with_capacity(index_metadatas.len());
+        let mut pending_subrequests = Vec::with_capacity(num_indexes.min(LIST_SHARDS_BATCH_SIZE));
 
-        for index_metadata in index_metadatas {
+        for index_metadata in indexes_metadata {
             self.add_index(index_metadata);
         }
 
-        for index_metadata in self.index_table.values() {
+        for (idx, index_metadata) in self.index_table.values().enumerate() {
             for source_config in index_metadata.sources.values() {
                 num_sources += 1;
 
@@ -114,27 +117,30 @@ impl ControlPlaneModel {
                     source_id: source_config.source_id.clone(),
                     shard_state: None,
                 };
-                subrequests.push(request);
+                pending_subrequests.push(request);
             }
-        }
-        if !subrequests.is_empty() {
-            // TODO: Limit the number of subrequests and perform multiple requests if needed.
-            let list_shards_request = metastore::ListShardsRequest { subrequests };
-            let list_shard_response = progress
-                .protect_future(metastore.list_shards(list_shards_request))
-                .await?;
+            if pending_subrequests.len() >= LIST_SHARDS_BATCH_SIZE || idx == num_indexes - 1 {
+                let subrequests = mem::replace(
+                    &mut pending_subrequests,
+                    Vec::with_capacity((num_indexes - idx).min(LIST_SHARDS_BATCH_SIZE)),
+                );
+                let list_shards_request = metastore::ListShardsRequest { subrequests };
+                let list_shards_response = progress
+                    .protect_future(metastore.list_shards(list_shards_request))
+                    .await?;
 
-            for list_shards_subresponse in list_shard_response.subresponses {
-                num_shards += list_shards_subresponse.shards.len();
+                for list_shards_subresponse in list_shards_response.subresponses {
+                    num_shards += list_shards_subresponse.shards.len();
 
-                let ListShardsSubresponse {
-                    index_uid,
-                    source_id,
-                    shards,
-                } = list_shards_subresponse;
-                let index_uid = index_uid.expect("`index_uid` should be a required field");
-                self.shard_table
-                    .insert_shards(&index_uid, &source_id, shards);
+                    let ListShardsSubresponse {
+                        index_uid,
+                        source_id,
+                        shards,
+                    } = list_shards_subresponse;
+                    let index_uid = index_uid.expect("`index_uid` should be a required field");
+                    self.shard_table
+                        .insert_shards(&index_uid, &source_id, shards);
+                }
             }
         }
         info!(

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -116,7 +116,7 @@ async fn start_control_plane(
     metastore.expect_list_indexes_metadata().returning(
         move |_list_indexes_request: quickwit_proto::metastore::ListIndexesMetadataRequest| {
             let indexes_metadata = vec![index_metadata_2.clone(), index_metadata_1.clone()];
-            Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata).unwrap())
+            Ok(ListIndexesMetadataResponse::for_test(indexes_metadata))
         },
     );
     metastore.expect_list_shards().returning(|_| {

--- a/quickwit/quickwit-index-management/src/index.rs
+++ b/quickwit/quickwit-index-management/src/index.rs
@@ -257,7 +257,8 @@ impl IndexService {
         let indexes_metadata = metastore
             .list_indexes_metadata(list_indexes_metadatas_request)
             .await?
-            .deserialize_indexes_metadata()?;
+            .deserialize_indexes_metadata()
+            .await?;
 
         if !ignore_missing && indexes_metadata.len() != index_id_patterns.len() {
             let found_index_ids: HashSet<&str> = indexes_metadata

--- a/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_service.rs
@@ -120,7 +120,8 @@ impl DeleteTaskService {
             .metastore
             .list_indexes_metadata(ListIndexesMetadataRequest::all())
             .await?
-            .deserialize_indexes_metadata()?
+            .deserialize_indexes_metadata()
+            .await?
             .into_iter()
             .map(|index_metadata| {
                 (

--- a/quickwit/quickwit-janitor/src/actors/retention_policy_executor.rs
+++ b/quickwit/quickwit-janitor/src/actors/retention_policy_executor.rs
@@ -80,26 +80,32 @@ impl RetentionPolicyExecutor {
     /// Indexes refresh Loop handler logic.
     /// Should not return an error to prevent the actor from crashing.
     async fn handle_refresh_loop(&mut self, ctx: &ActorContext<Self>) {
-        debug!("retention-policy-refresh-indexes-operation");
+        debug!("loading indexes from the metastore");
         self.counters.num_refresh_passes += 1;
 
-        let index_metadatas = match self
+        let response = match self
             .metastore
             .list_indexes_metadata(ListIndexesMetadataRequest::all())
             .await
-            .and_then(|response| response.deserialize_indexes_metadata())
         {
-            Ok(metadatas) => metadatas,
+            Ok(response) => response,
             Err(error) => {
-                error!(error=?error, "failed to list indexes from the metastore");
+                error!(%error, "failed to list indexes from the metastore");
                 return;
             }
         };
-        debug!(index_ids=%index_metadatas.iter().map(|im| im.index_id()).join(", "), "retention policy refresh");
+        let indexes = match response.deserialize_indexes_metadata().await {
+            Ok(indexes) => indexes,
+            Err(error) => {
+                error!(%error, "failed to deserialize indexes metadata");
+                return;
+            }
+        };
+        info!("loaded {} indexes from the metastore", indexes.len());
 
         let deleted_indexes = compute_deleted_indexes(
             self.index_configs.keys().map(String::as_str),
-            index_metadatas
+            indexes
                 .iter()
                 .map(|index_metadata| index_metadata.index_id()),
         );
@@ -109,8 +115,7 @@ impl RetentionPolicyExecutor {
                 self.index_configs.remove(&index_id);
             }
         }
-
-        for index_metadata in index_metadatas {
+        for index_metadata in indexes {
             let index_uid = index_metadata.index_uid.clone();
             let index_config = index_metadata.into_index_config();
             // We only care about indexes with a retention policy configured.
@@ -365,10 +370,7 @@ mod tests {
                     ("index-2", Some("1 hour")),
                     ("index-3", None),
                 ]);
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(indexes_metadata))
             });
 
         mock_metastore
@@ -381,10 +383,7 @@ mod tests {
                     ("index-2", Some("2 hour")),
                     ("index-3", Some("1 hour")),
                 ]);
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(indexes_metadata))
             });
 
         mock_metastore
@@ -397,10 +396,7 @@ mod tests {
                     ("index-4", Some("1 hour")),
                     ("index-5", None),
                 ]);
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(indexes_metadata))
             });
 
         let retention_policy_executor =
@@ -454,10 +450,7 @@ mod tests {
                     ("index-2", Some("1 hour")),
                     ("index-3", None),
                 ]);
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(indexes_metadata))
             });
 
         mock_metastore

--- a/quickwit/quickwit-metastore/Cargo.toml
+++ b/quickwit/quickwit-metastore/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+bytes = { workspace = true }
 bytesize = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/lazy_file_backed_index.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/lazy_file_backed_index.rs
@@ -50,7 +50,7 @@ impl LazyFileBackedIndex {
         let index_mutex_opt = file_backed_index.map(|index| Arc::new(Mutex::new(index)));
         // If an index is given and a polling interval is given,
         // spawn immediately the polling task.
-        if let Some(index_mutex) = index_mutex_opt.as_ref() {
+        if let Some(index_mutex) = &index_mutex_opt {
             if let Some(polling_interval) = polling_interval_opt {
                 spawn_index_metadata_polling_task(
                     storage.clone(),

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -749,7 +749,8 @@ impl MetastoreService for FileBackedMetastore {
         .into_iter()
         .flatten()
         .collect();
-        let response = ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)?;
+        let response =
+            ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata).await?;
         Ok(response)
     }
 
@@ -1227,6 +1228,7 @@ mod tests {
             .await
             .unwrap()
             .deserialize_indexes_metadata()
+            .await
             .unwrap();
         assert_eq!(indexes_metadata.len(), 1);
 
@@ -1943,6 +1945,7 @@ mod tests {
             .await
             .unwrap()
             .deserialize_indexes_metadata()
+            .await
             .unwrap();
         assert_eq!(indexes_metadata.len(), 1);
 
@@ -1959,6 +1962,7 @@ mod tests {
             .await
             .unwrap()
             .deserialize_indexes_metadata()
+            .await
             .unwrap();
         assert_eq!(indexes_metadata.len(), 2);
 
@@ -1977,6 +1981,7 @@ mod tests {
             .await
             .unwrap()
             .deserialize_indexes_metadata()
+            .await
             .unwrap();
         assert!(indexes_metadata.is_empty());
 

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -357,7 +357,7 @@ impl MetastoreService for PostgresqlMetastore {
         let sql =
             build_index_id_patterns_sql_query(&request.index_id_patterns).map_err(|error| {
                 MetastoreError::Internal {
-                    message: "failed to build `list_indexes_metadatas` SQL query".to_string(),
+                    message: "failed to build `list_indexes_metadata` SQL query".to_string(),
                     cause: error.to_string(),
                 }
             })?;
@@ -368,7 +368,8 @@ impl MetastoreService for PostgresqlMetastore {
             .into_iter()
             .map(|pg_index| pg_index.index_metadata())
             .collect::<MetastoreResult<Vec<IndexMetadata>>>()?;
-        let response = ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)?;
+        let response =
+            ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata).await?;
         Ok(response)
     }
 

--- a/quickwit/quickwit-metastore/src/tests/index.rs
+++ b/quickwit/quickwit-metastore/src/tests/index.rs
@@ -227,6 +227,7 @@ pub async fn test_metastore_list_all_indexes<
         .await
         .unwrap()
         .deserialize_indexes_metadata()
+        .await
         .unwrap()
         .into_iter()
         .filter(|index| index.index_id().starts_with(&index_id_prefix))
@@ -251,6 +252,7 @@ pub async fn test_metastore_list_all_indexes<
         .await
         .unwrap()
         .deserialize_indexes_metadata()
+        .await
         .unwrap()
         .into_iter()
         .filter(|index| index.index_id().starts_with(&index_id_prefix))
@@ -290,6 +292,7 @@ pub async fn test_metastore_list_indexes<MetastoreToTest: MetastoreServiceExt + 
         .await
         .unwrap()
         .deserialize_indexes_metadata()
+        .await
         .unwrap()
         .len();
     assert_eq!(indexes_count, 0);
@@ -325,6 +328,7 @@ pub async fn test_metastore_list_indexes<MetastoreToTest: MetastoreServiceExt + 
         .await
         .unwrap()
         .deserialize_indexes_metadata()
+        .await
         .unwrap()
         .len();
     assert_eq!(indexes_count, 2);

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -73,6 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Metastore service.
     let mut prost_config = prost_build::Config::default();
     prost_config
+        .bytes(["ListIndexesMetadataResponse.indexes_metadata_json_zstd"])
         .extern_path(".quickwit.ingest.ShardId", "crate::types::ShardId")
         .extern_path(".quickwit.common.IndexUid", "crate::types::IndexUid")
         .field_attribute("DeleteQuery.index_uid", "#[serde(alias = \"index_id\")]")

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -208,7 +208,10 @@ message ListIndexesMetadataRequest {
 }
 
 message ListIndexesMetadataResponse {
-  string indexes_metadata_serialized_json = 1;
+  // Deprecated (v0.9.0), use `indexes_metadata_json_zstd` instead.
+  optional string indexes_metadata_json_opt = 1;
+  // A JSON serialized then ZSTD compressed list of `IndexMetadata`: `Vec<IndexMetadata> | JSON | ZSTD`.
+  bytes indexes_metadata_json_zstd = 2;
 }
 
 message DeleteIndexRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -34,8 +34,14 @@ pub struct ListIndexesMetadataRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListIndexesMetadataResponse {
-    #[prost(string, tag = "1")]
-    pub indexes_metadata_serialized_json: ::prost::alloc::string::String,
+    /// Deprecated (v0.9.0), use `indexes_metadata_json_zstd` instead.
+    #[prost(string, optional, tag = "1")]
+    pub indexes_metadata_json_opt: ::core::option::Option<
+        ::prost::alloc::string::String,
+    >,
+    /// A JSON serialized then ZSTD compressed list of `IndexMetadata`: `Vec<IndexMetadata> | JSON | ZSTD`.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub indexes_metadata_json_zstd: ::prost::bytes::Bytes,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -225,10 +225,10 @@ pub async fn resolve_index_patterns(
 
     // Get the index ids from the request
     let indexes_metadata = metastore
-        .clone()
         .list_indexes_metadata(list_indexes_metadata_request)
         .await?
-        .deserialize_indexes_metadata()?;
+        .deserialize_indexes_metadata()
+        .await?;
     check_all_index_metadata_found(&indexes_metadata, index_id_patterns)?;
     Ok(indexes_metadata)
 }

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1021,7 +1021,8 @@ pub async fn root_search(
     let indexes_metadata: Vec<IndexMetadata> = metastore
         .list_indexes_metadata(list_indexes_metadatas_request)
         .await?
-        .deserialize_indexes_metadata()?;
+        .deserialize_indexes_metadata()
+        .await?;
 
     check_all_index_metadata_found(&indexes_metadata[..], &search_request.index_id_patterns[..])?;
 
@@ -2249,10 +2250,9 @@ mod tests {
         mock_metastore
             .expect_list_indexes_metadata()
             .returning(move |_indexes_metadata_request| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         mock_metastore
             .expect_list_splits()
@@ -2347,10 +2347,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore
             .expect_list_splits()
@@ -2416,10 +2415,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![
@@ -2513,10 +2511,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![
@@ -2694,10 +2691,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![
@@ -2869,10 +2865,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![
@@ -2990,10 +2985,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_indexes_metadata_request| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![
@@ -3121,10 +3115,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore
             .expect_list_splits()
@@ -3201,10 +3194,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![MockSplitBuilder::new("split1")
@@ -3264,10 +3256,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![MockSplitBuilder::new("split1")
@@ -3353,10 +3344,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![MockSplitBuilder::new("split1")
@@ -3425,10 +3415,9 @@ mod tests {
         mock_metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         mock_metastore
             .expect_list_splits()
@@ -3511,10 +3500,9 @@ mod tests {
         metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![MockSplitBuilder::new("split1")
@@ -3556,10 +3544,9 @@ mod tests {
         mock_metastore
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata.clone()
-                ])
-                .unwrap())
+                ]))
             });
         mock_metastore
             .expect_list_splits()
@@ -3774,10 +3761,7 @@ mod tests {
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
                 let indexes_metadata = vec![index_metadata.clone(), index_metadata_2.clone()];
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(indexes_metadata))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![
@@ -3958,10 +3942,7 @@ mod tests {
             .expect_list_indexes_metadata()
             .returning(move |_index_ids_query| {
                 let indexes_metadata = vec![index_metadata.clone(), index_metadata_2.clone()];
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata)
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(indexes_metadata))
             });
         metastore.expect_list_splits().returning(move |_filter| {
             let splits = vec![
@@ -4152,12 +4133,11 @@ mod tests {
             move |list_indexes_metadata_request: ListIndexesMetadataRequest| {
                 let index_id_patterns = list_indexes_metadata_request.index_id_patterns;
                 assert_eq!(&index_id_patterns, &["test-index-*".to_string()]);
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     index_metadata_1,
                     index_metadata_2,
                     index_metadata_3,
-                ])
-                .unwrap())
+                ]))
             },
         );
         metastore

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -458,8 +458,9 @@ async fn list_indexes_metadata(
         };
     metastore
         .list_indexes_metadata(list_indexes_metata_request)
+        .await?
+        .deserialize_indexes_metadata()
         .await
-        .and_then(|response| response.deserialize_indexes_metadata())
 }
 
 #[derive(Deserialize, utoipa::IntoParams, utoipa::ToSchema)]
@@ -1249,10 +1250,7 @@ mod tests {
                 );
                 let index_metadata =
                     IndexMetadata::for_test("test-index", "ram:///indexes/test-index");
-                Ok(
-                    ListIndexesMetadataResponse::try_from_indexes_metadata(vec![index_metadata])
-                        .unwrap(),
-                )
+                Ok(ListIndexesMetadataResponse::for_test(vec![index_metadata]))
             });
         let index_service = IndexService::new(
             MetastoreServiceClient::from(mock_metastore),
@@ -1565,6 +1563,7 @@ mod tests {
             .await
             .unwrap()
             .deserialize_indexes_metadata()
+            .await
             .unwrap();
         assert!(indexes.is_empty());
     }

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1166,7 +1166,8 @@ async fn check_cluster_configuration(
     let file_backed_indexes = metastore
         .list_indexes_metadata(ListIndexesMetadataRequest::all())
         .await?
-        .deserialize_indexes_metadata()?
+        .deserialize_indexes_metadata()
+        .await?
         .into_iter()
         .filter(|index_metadata| index_metadata.index_uri().protocol().is_file_storage())
         .collect::<Vec<_>>();
@@ -1216,10 +1217,9 @@ mod tests {
         mock_metastore
             .expect_list_indexes_metadata()
             .return_once(|_| {
-                Ok(ListIndexesMetadataResponse::try_from_indexes_metadata(vec![
+                Ok(ListIndexesMetadataResponse::for_test(vec![
                     IndexMetadata::for_test("test-index", "file:///qwdata/indexes/test-index"),
-                ])
-                .unwrap())
+                ]))
             });
 
         check_cluster_configuration(


### PR DESCRIPTION
Added unit tests.