### PR TITLE
Create hash index on `delete_tasks.index_uid`

### DIFF
--- a/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-delete-tasks-index-uid.down.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-delete-tasks-index-uid.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS delete_tasks_index_uid_idx;

--- a/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-delete-tasks-index-uid.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-delete-tasks-index-uid.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS delete_tasks_index_uid_idx ON delete_tasks USING HASH(index_uid);

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -134,10 +134,7 @@ where E: sqlx::Executor<'a, Database = Postgres> {
     )
     .bind(index_id)
     .fetch_optional(executor)
-    .await
-    .map_err(|error| MetastoreError::Db {
-        message: error.to_string(),
-    })?;
+    .await?;
     Ok(index_opt)
 }
 
@@ -159,10 +156,7 @@ where
     )
     .bind(index_uid.to_string())
     .fetch_optional(executor)
-    .await
-    .map_err(|error| MetastoreError::Db {
-        message: error.to_string(),
-    })?;
+    .await?;
     Ok(index_opt)
 }
 
@@ -1033,10 +1027,7 @@ impl MetastoreService for PostgresqlMetastore {
         )
         .bind(request.index_uid().to_string())
         .fetch_one(&self.connection_pool)
-        .await
-        .map_err(|error| MetastoreError::Db {
-            message: error.to_string(),
-        })?;
+        .await?;
 
         Ok(LastDeleteOpstampResponse::new(max_opstamp as u64))
     }


### PR DESCRIPTION
### Description
That query is very slow on Airmail but not at all on Cicada.

@trinity-1686a, what are your thoughts?  Should we make (`index_uid`, opstamp`) the primary key of this table instead? The b-tree could help select both the index UID and max opstamp.

### How was this PR tested?
Ran migrations.
