### PR TITLE
Add doc section about secured Kafka

### DIFF
--- a/docs/ingest-data/kafka.md
+++ b/docs/ingest-data/kafka.md
@@ -217,6 +217,16 @@ params:
     sasl.password: "your_sasl_password"
 ```
 
+:::note
+
+If you get the following error:
+
+```Client creation error: ssl.ca.location failed: error:05880002:x509 certificate routines::system lib```
+
+It usually means the path to the CA certificate is incorrect. Update the
+`ssl.ca.location` parameter accordingly.
+
+:::
 
 ## Tear down resources (optional)
 

--- a/docs/ingest-data/kafka.md
+++ b/docs/ingest-data/kafka.md
@@ -180,7 +180,7 @@ curl -XPOST -H 'Content-Type: application/json' 'http://localhost:7280/api/v1/gh
 ## Secured Kafka connection (optional)
 
 The Quickwit Kafka source supports SSL and SASL authentication. This is
-particularly useful when consuming an external Kafka service.
+particularly useful when consuming data from an external Kafka service.
 
 ### SSL configuration
 

--- a/docs/ingest-data/kafka.md
+++ b/docs/ingest-data/kafka.md
@@ -192,11 +192,11 @@ num_pipelines: 2
 params:
   topic: gh-archive
   client_params:
-    bootstrap.servers: "your-kafka-broker.com"
-    security.protocol: "SSL"
-    ssl.ca.location: "/path/to/ca.pem"
-    ssl.certificate.location: "/path/to/service.cert"
-    ssl.key.location: "/path/to/service.key"
+    bootstrap.servers: your-kafka-broker.com
+    security.protocol: SSL
+    ssl.ca.location: /path/to/ca.pem
+    ssl.certificate.location: /path/to/service.cert
+    ssl.key.location: /path/to/service.key
 ```
 
 ### SASL configuration

--- a/docs/ingest-data/kafka.md
+++ b/docs/ingest-data/kafka.md
@@ -209,12 +209,12 @@ num_pipelines: 2
 params:
   topic: gh-archive
   client_params:
-    bootstrap.servers: "your-kafka-broker.com"
-    ssl.ca.location: "/path/to/ca.pem"
-    security.protocol: "SASL_SSL"
-    sasl.mechanisms: "SCRAM-SHA-256"
-    sasl.username: "your_sasl_username"
-    sasl.password: "your_sasl_password"
+    bootstrap.servers: your-kafka-broker.com
+    ssl.ca.location: /path/to/ca.pem
+    security.protocol: SASL_SSL
+    sasl.mechanisms: SCRAM-SHA-256
+    sasl.username: your_sasl_username
+    sasl.password: your_sasl_password
 ```
 
 :::note

--- a/docs/ingest-data/kafka.md
+++ b/docs/ingest-data/kafka.md
@@ -176,6 +176,48 @@ curl -XPOST -H 'Content-Type: application/json' 'http://localhost:7280/api/v1/gh
 }'
 ```
 
+
+## Secured Kafka connection (optional)
+
+The Quickwit Kafka source supports SSL and SASL authentication. This is
+particularly useful when consuming an external Kafka service.
+
+### SSL configuration
+
+```yaml
+version: 0.8
+source_id: kafka-source-ssl
+source_type: kafka
+num_pipelines: 2
+params:
+  topic: gh-archive
+  client_params:
+    bootstrap.servers: "your-kafka-broker.com"
+    security.protocol: "SSL"
+    ssl.ca.location: "/path/to/ca.pem"
+    ssl.certificate.location: "/path/to/service.cert"
+    ssl.key.location: "/path/to/service.key"
+```
+
+### SASL configuration
+
+```yaml
+version: 0.8
+source_id: kafka-source-sasl
+source_type: kafka
+num_pipelines: 2
+params:
+  topic: gh-archive
+  client_params:
+    bootstrap.servers: "your-kafka-broker.com"
+    ssl.ca.location: "/path/to/ca.pem"
+    security.protocol: "SASL_SSL"
+    sasl.mechanisms: "SCRAM-SHA-256"
+    sasl.username: "your_sasl_username"
+    sasl.password: "your_sasl_password"
+```
+
+
 ## Tear down resources (optional)
 
 Let's delete the files and resources created for the purpose of this tutorial.


### PR DESCRIPTION
### Description

It is common to used an externally managed Kafka service. In that case authentication is necessary, and it would be good to show that we support it.

### How was this PR tested?

Ran tests using aiven.io and the Quickwit Docker distribution.
