### PR TITLE
add debug endpoint to get mrecordlog summary

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mrecordlog"
 version = "0.4.0"
-source = "git+https://github.com/quickwit-oss/mrecordlog?rev=8a77dd2#8a77dd20d4a6a56b94f0ceb17082d57bd65d81b6"
+source = "git+https://github.com/quickwit-oss/mrecordlog?rev=25bd600#25bd600942862761036fe567b458bf652cce72a8"
 dependencies = [
  "bytes",
  "crc32fast",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mrecordlog"
 version = "0.4.0"
-source = "git+https://github.com/quickwit-oss/mrecordlog?rev=187486f#187486fcde8dcfc4d570af4af19be852ab325cde"
+source = "git+https://github.com/quickwit-oss/mrecordlog?rev=8a77dd2#8a77dd20d4a6a56b94f0ceb17082d57bd65d81b6"
 dependencies = [
  "bytes",
  "crc32fast",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -154,7 +154,7 @@ matches = "0.1.9"
 md5 = "0.7"
 mime_guess = "2.0.4"
 mockall = "0.11"
-mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "8a77dd2" }
+mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "25bd600" }
 new_string_template = "1.4.0"
 nom = "7.1.3"
 num_cpus = "1"

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -154,7 +154,7 @@ matches = "0.1.9"
 md5 = "0.7"
 mime_guess = "2.0.4"
 mockall = "0.11"
-mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "187486f" }
+mrecordlog = { git = "https://github.com/quickwit-oss/mrecordlog", rev = "8a77dd2" }
 new_string_template = "1.4.0"
 nom = "7.1.3"
 num_cpus = "1"

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -138,7 +138,11 @@ impl IngesterState {
         info!("opening WAL located at `{}`", wal_dir_path.display());
         let open_result = MultiRecordLogAsync::open_with_prefs(
             wal_dir_path,
-            mrecordlog::SyncPolicy::OnDelay(Duration::from_secs(5)),
+            mrecordlog::PersistPolicy::OnDelay {
+                interval: Duration::from_secs(5),
+                // TODO maybe we want to fsync too?
+                action: mrecordlog::PersistAction::Flush,
+            },
         )
         .await;
 

--- a/quickwit/quickwit-ingest/src/mrecordlog_async.rs
+++ b/quickwit/quickwit-ingest/src/mrecordlog_async.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 
 use bytes::Buf;
 use mrecordlog::error::*;
-use mrecordlog::{MultiRecordLog, Record, ResourceUsage, SyncPolicy};
+use mrecordlog::{MultiRecordLog, Record, ResourceUsage, PersistPolicy, PersistAction};
 use tokio::task::JoinError;
 use tracing::error;
 
@@ -50,16 +50,16 @@ impl MultiRecordLogAsync {
     }
 
     pub async fn open(directory_path: &Path) -> Result<Self, ReadRecordError> {
-        Self::open_with_prefs(directory_path, SyncPolicy::OnAppend).await
+        Self::open_with_prefs(directory_path, PersistPolicy::Always(PersistAction::Flush)).await
     }
 
     pub async fn open_with_prefs(
         directory_path: &Path,
-        sync_policy: SyncPolicy,
+        persist_policy: PersistPolicy,
     ) -> Result<Self, ReadRecordError> {
         let directory_path = directory_path.to_path_buf();
         let mrecordlog = tokio::task::spawn(async move {
-            MultiRecordLog::open_with_prefs(&directory_path, sync_policy)
+            MultiRecordLog::open_with_prefs(&directory_path, persist_policy)
         })
         .await
         .map_err(|join_err| {

--- a/quickwit/quickwit-ingest/src/mrecordlog_async.rs
+++ b/quickwit/quickwit-ingest/src/mrecordlog_async.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 
 use bytes::Buf;
 use mrecordlog::error::*;
-use mrecordlog::{MultiRecordLog, Record, ResourceUsage, PersistPolicy, PersistAction};
+use mrecordlog::{MultiRecordLog, PersistAction, PersistPolicy, Record, ResourceUsage};
 use tokio::task::JoinError;
 use tracing::error;
 
@@ -187,5 +187,9 @@ impl MultiRecordLogAsync {
 
     pub fn resource_usage(&self) -> ResourceUsage {
         self.mrecordlog_ref().resource_usage()
+    }
+
+    pub fn summary(&self) -> mrecordlog::QueuesSummary {
+        self.mrecordlog_ref().summary()
     }
 }

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -53,6 +53,9 @@ service IngesterService {
 
   // Decommissions the ingester.
   rpc Decommission(DecommissionRequest) returns (DecommissionResponse);
+
+  // Get mrecordlog summary
+  rpc MrecordlogSummary(MrecordlogSummaryRequest) returns (MrecordlogSummaryResponse);
 }
 
 message RetainShardsForSource {
@@ -266,6 +269,20 @@ message DecommissionRequest {
 }
 
 message DecommissionResponse {
+}
+
+message MrecordlogSummaryRequest {
+}
+
+message MrecordlogSummaryResponse {
+  repeated MrecordlogQueueSummary queues = 1;
+}
+
+message MrecordlogQueueSummary {
+  string id = 1;
+  uint64 start = 2;
+  optional uint64 end = 3;
+  optional uint64 file_number = 4;
 }
 
 message OpenObservationStreamRequest {

--- a/quickwit/quickwit-serve/src/debugging_api.rs
+++ b/quickwit/quickwit-serve/src/debugging_api.rs
@@ -17,12 +17,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
+
 use quickwit_proto::control_plane::{
     ControlPlaneService, ControlPlaneServiceClient, GetDebugStateRequest,
 };
+use warp::{Filter, Rejection};
+
+use crate::{with_arg, QuickwitServices};
 
 #[derive(utoipa::OpenApi)]
-#[openapi(paths(debugging_handler))]
+#[openapi(paths(control_plane_debugging_handler))]
 /// Endpoints which are weirdly tied to another crate with no
 /// other bits of information attached.
 ///
@@ -30,10 +35,20 @@ use quickwit_proto::control_plane::{
 /// Then it should have it's own specific API group.
 pub struct DebugApi;
 
+pub(crate) fn debugging_routes(
+    quickwit_services: Arc<QuickwitServices>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
+    let debugging_routes = warp::path!("api" / "debugging" / ..);
+
+    debugging_routes.and(control_plane_debugging_handler(
+        quickwit_services.control_plane_service.clone(),
+    ))
+}
+
 #[utoipa::path(
     get,
-    tag = "Get debug information for node",
-    path = "/",
+    tag = "Get debug informations about the control plane from the node viewpoint",
+    path = "/shard",
     responses(
         (status = 200, description = "Successfully fetched debugging info.", body = GetDebugStateRequestResponse),
     ),
@@ -42,16 +57,23 @@ pub struct DebugApi;
 ///
 /// The format is not guaranteed to ever be stable, and is meant to provide some introspection to
 /// help with debugging.
-pub async fn debugging_handler(
-    mut control_plane_service_client: ControlPlaneServiceClient,
-) -> impl warp::Reply {
-    let debug_info = control_plane_service_client
-        .get_debug_state(GetDebugStateRequest {})
-        .await;
-    crate::rest_api_response::RestApiResponse::new(
-        &debug_info,
-        // TODO error code on error
-        hyper::StatusCode::OK,
-        crate::format::BodyFormat::PrettyJson,
-    )
+pub fn control_plane_debugging_handler(
+    control_plane_service_client: ControlPlaneServiceClient,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
+    warp::path("shard")
+        .and(warp::path::end())
+        .and(with_arg(control_plane_service_client.clone()))
+        .then(
+            |mut control_plane_service_client: ControlPlaneServiceClient| async move {
+                let debug_info = control_plane_service_client
+                    .get_debug_state(GetDebugStateRequest {})
+                    .await;
+                crate::rest_api_response::RestApiResponse::new(
+                    &debug_info,
+                    // TODO error code on error
+                    hyper::StatusCode::OK,
+                    crate::format::BodyFormat::PrettyJson,
+                )
+            },
+        )
 }

--- a/quickwit/quickwit-serve/src/openapi.rs
+++ b/quickwit/quickwit-serve/src/openapi.rs
@@ -85,7 +85,7 @@ pub fn build_docs() -> utoipa::openapi::OpenApi {
     // Routing
     docs_base.merge_components_and_paths(HealthCheckApi::openapi().with_path_prefix("/health"));
     docs_base.merge_components_and_paths(MetricsApi::openapi().with_path_prefix("/metrics"));
-    docs_base.merge_components_and_paths(DebugApi::openapi().with_path_prefix("/debugging"));
+    docs_base.merge_components_and_paths(DebugApi::openapi().with_path_prefix("/api/debugging"));
     docs_base.merge_components_and_paths(ClusterApi::openapi().with_path_prefix("/api/v1"));
     docs_base.merge_components_and_paths(DeleteTaskApi::openapi().with_path_prefix("/api/v1"));
     docs_base.merge_components_and_paths(IndexApi::openapi().with_path_prefix("/api/v1"));

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -32,7 +32,7 @@ use tracing::{error, info};
 use warp::{redirect, Filter, Rejection, Reply};
 
 use crate::cluster_api::cluster_handler;
-use crate::debugging_api::debugging_handler;
+use crate::debugging_api::debugging_routes;
 use crate::decompression::{CorruptedData, UnsupportedEncoding};
 use crate::delete_task_api::delete_task_api_handlers;
 use crate::elasticsearch_api::elastic_api_handlers;
@@ -90,11 +90,8 @@ pub(crate) async fn start_rest_server(
     // `/metrics` route.
     let metrics_routes = warp::path("metrics").and(warp::get()).map(metrics_handler);
 
-    // `/debugging` route.
-    let control_plane_service = quickwit_services.control_plane_service.clone();
-    let debugging_routes = warp::path("debugging")
-        .and(warp::get())
-        .then(move || debugging_handler(control_plane_service.clone()));
+    // `/api/debugging/*` route.
+    let debugging_routes = debugging_routes(quickwit_services.clone());
 
     // `/api/v1/*` routes.
     let api_v1_root_route = api_v1_routes(quickwit_services.clone());


### PR DESCRIPTION
### Description

update mrecordlog
move debugging endpoints to their own prefix, and add debug endpoint to get mrecordlog state summary
fix #4800 

### How was this PR tested?

tested manually on an indexer and a non-indexer node