### PR TITLE
Index configuration update

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -14,7 +14,7 @@ In addition to the `index_id`, the index configuration lets you define five item
 - The **search settings**: it defines the default search fields `default_search_fields`, a list of fields that Quickwit will search into if the user query does not explicitly target a field.
 - The **retention policy**: it defines how long Quickwit should keep the indexed data. If not specified, the data is stored forever.
 
-In general, configuration is set at index creation and cannot be modified. Starting Quickwit 0.9, the search setttings and retention policy can be changed using the update endpoint.
+In general, configuration is set at index creation and cannot be modified. Some specific subsets like the search settings and retention policy can be changed using the [update endpoint](../reference/rest-api.md) or the [CLI](../reference/cli.md).
 
 ## Config file format
 

--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -14,7 +14,7 @@ In addition to the `index_id`, the index configuration lets you define five item
 - The **search settings**: it defines the default search fields `default_search_fields`, a list of fields that Quickwit will search into if the user query does not explicitly target a field.
 - The **retention policy**: it defines how long Quickwit should keep the indexed data. If not specified, the data is stored forever.
 
-In general, configuration is set at index creation and cannot be modified. Some specific subsets like the search settings and retention policy can be changed using the [update endpoint](../reference/rest-api.md) or the [CLI](../reference/cli.md).
+Configuration is generally set at index creation and cannot be modified, except for some specific attributes like the search settings and retention policy, which can be changed using the [update endpoint](../reference/rest-api.md) or the [CLI](../reference/cli.md).
 
 ## Config file format
 

--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -12,8 +12,9 @@ In addition to the `index_id`, the index configuration lets you define five item
 - The **doc mapping**: it defines how a document and the fields it contains are stored and indexed for a given index.
 - The **indexing settings**: it defines the timestamp field used for sharding, and some more advanced parameters like the merge policy.
 - The **search settings**: it defines the default search fields `default_search_fields`, a list of fields that Quickwit will search into if the user query does not explicitly target a field.
+- The **retention policy**: it defines how long Quickwit should keep the indexed data. If not specified, the data is stored forever.
 
-Configuration is set at index creation and cannot be modified with the current version of Quickwit.
+In general, configuration is set at index creation and cannot be modified. Starting Quickwit 0.9, the search setttings and retention policy can be changed using the update endpoint.
 
 ## Config file format
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -787,41 +787,6 @@ quickwit tool local-ingest
 | `--overwrite` | Overwrites pre-existing index. |  |
 | `--transform-script` | VRL program to transform docs before ingesting. |  |
 | `--keep-cache` | Does not clear local cache directory upon completion. |  |
-### tool local-search
-
-Searches an index locally.  
-`quickwit tool local-search [args]`
-
-*Synopsis*
-
-```bash
-quickwit tool local-search
-    --index <index>
-    --query <query>
-    [--aggregation <aggregation>]
-    [--max-hits <max-hits>]
-    [--start-offset <start-offset>]
-    [--search-fields <search-fields>]
-    [--snippet-fields <snippet-fields>]
-    [--start-timestamp <start-timestamp>]
-    [--end-timestamp <end-timestamp>]
-    [--sort-by-field <sort-by-field>]
-```
-
-*Options*
-
-| Option | Description | Default |
-|-----------------|-------------|--------:|
-| `--index` | ID of the target index |  |
-| `--query` | Query expressed in natural query language ((barack AND obama) OR "president of united states"). Learn more on https://quickwit.io/docs/reference/search-language. |  |
-| `--aggregation` | JSON serialized aggregation request in tantivy/elasticsearch format. |  |
-| `--max-hits` | Maximum number of hits returned. | `20` |
-| `--start-offset` | Offset in the global result set of the first hit returned. | `0` |
-| `--search-fields` | List of fields that Quickwit will search into if the user query does not explicitly target a field in the query. It overrides the default search fields defined in the index config. Space-separated list, e.g. "field1 field2".  |  |
-| `--snippet-fields` | List of fields that Quickwit will return snippet highlight on. Space-separated list, e.g. "field1 field2".  |  |
-| `--start-timestamp` | Filters out documents before that timestamp (time-series indexes only). |  |
-| `--end-timestamp` | Filters out documents after that timestamp (time-series indexes only). |  |
-| `--sort-by-field` | Sort by field. |  |
 ### tool extract-split
 
 Downloads and extracts a split to a directory.  

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -193,7 +193,7 @@ Updates default search settings.
 ```bash
 quickwit index update search-settings
     --index <index>
-    [--default-search-fields <default-search-fields>]
+    --default-search-fields <default-search-fields>
 ```
 
 *Options*
@@ -201,7 +201,7 @@ quickwit index update search-settings
 | Option | Description |
 |-----------------|-------------|
 | `--index` | ID of the target index |
-| `--default-search-fields` | List of fields that Quickwit will search into if the user query does not explicitly target a field. If not specified, default fields are removed and queries without target field will fail. Space-separated list, e.g. "field1 field2". |
+| `--default-search-fields` | List of fields that Quickwit will search into if the user query does not explicitly target a field. Space-separated list, e.g. "field1 field2". If no value is provided, existing defaults are removed and queries without target field will fail. |
 #### index update retention-policy
 
 Configure or disable the retention policy.  

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -116,7 +116,7 @@ quickwit run
 | Option | Description | Default |
 |-----------------|-------------|--------:|
 | `--config` | Config file location | `config/quickwit.yaml` |
-| `--service` | Services (indexer,searcher,janitor,metastore or control-plane) to run. If unspecified, all the supported services are started. |  |
+| `--service` | Services (`indexer`, `searcher`, `metastore`, `control-plane`, or `janitor`) to run. If unspecified, all the supported services are started. |  |
 
 *Examples*
 
@@ -141,7 +141,7 @@ curl "http://127.0.0.1:7280/api/v1/wikipedia/search?query=barack+obama"
 ```
 
 ## index
-Manages indexes: creates, deletes, ingests, searches, describes...
+Manages indexes: creates, updates, deletes, ingests, searches, describes...
 
 ### index create
 
@@ -180,6 +180,51 @@ quickwit index create --endpoint=http://127.0.0.1:7280 --index-config wikipedia_
 
 ```
 
+### index update
+
+`quickwit index update [args]`
+#### index update search-settings
+
+Updates default search settings.  
+`quickwit index update search-settings [args]`
+
+*Synopsis*
+
+```bash
+quickwit index update search-settings
+    --index <index>
+    [--default-search-fields <default-search-fields>]
+```
+
+*Options*
+
+| Option | Description |
+|-----------------|-------------|
+| `--index` | ID of the target index |
+| `--default-search-fields` | List of fields that Quickwit will search into if the user query does not explicitly target a field. If not specified, default fields are removed and queries without target field will fail. Space-separated list, e.g. "field1 field2". |
+#### index update retention-policy
+
+Configure or disable the retention policy.  
+`quickwit index update retention-policy [args]`
+
+*Synopsis*
+
+```bash
+quickwit index update retention-policy
+    --index <index>
+    [--period <period>]
+    [--schedule <schedule>]
+    [--disable]
+```
+
+*Options*
+
+| Option | Description |
+|-----------------|-------------|
+| `--index` | ID of the target index |
+| `--period` | Duration after which splits are dropped. Expressed in a human-readable way (`1 day`, `2 hours`, `1 week`, ...) |
+| `--schedule` | Frequency at which the retention policy is evaluated and applied. Expressed as a cron expression (0 0 * * * *) or human-readable form (hourly, daily, weekly, ...). |
+| `--disable` | Disable the retention policy. Old indexed data will not be cleaned up anymore. |
 ### index clear
 
 Clears an index: deletes all splits and resets checkpoint.  
@@ -661,8 +706,8 @@ quickwit split list
 | Option | Description |
 |-----------------|-------------|
 | `--index` | Target index ID |
-| `--offset` | Number of splits to skip |
-| `--limit` | Maximum number of splits to retrieve |
+| `--offset` | Number of splits to skip. |
+| `--limit` | Maximum number of splits to retrieve. |
 | `--states` | Selects the splits whose states are included in this comma-separated list of states. Possible values are `staged`, `published`, and `marked`. |
 | `--create-date` | Selects the splits whose creation dates are before this date. |
 | `--start-date` | Selects the splits that contain documents after this date (time-series indexes only). |
@@ -742,6 +787,41 @@ quickwit tool local-ingest
 | `--overwrite` | Overwrites pre-existing index. |  |
 | `--transform-script` | VRL program to transform docs before ingesting. |  |
 | `--keep-cache` | Does not clear local cache directory upon completion. |  |
+### tool local-search
+
+Searches an index locally.  
+`quickwit tool local-search [args]`
+
+*Synopsis*
+
+```bash
+quickwit tool local-search
+    --index <index>
+    --query <query>
+    [--aggregation <aggregation>]
+    [--max-hits <max-hits>]
+    [--start-offset <start-offset>]
+    [--search-fields <search-fields>]
+    [--snippet-fields <snippet-fields>]
+    [--start-timestamp <start-timestamp>]
+    [--end-timestamp <end-timestamp>]
+    [--sort-by-field <sort-by-field>]
+```
+
+*Options*
+
+| Option | Description | Default |
+|-----------------|-------------|--------:|
+| `--index` | ID of the target index |  |
+| `--query` | Query expressed in natural query language ((barack AND obama) OR "president of united states"). Learn more on https://quickwit.io/docs/reference/search-language. |  |
+| `--aggregation` | JSON serialized aggregation request in tantivy/elasticsearch format. |  |
+| `--max-hits` | Maximum number of hits returned. | `20` |
+| `--start-offset` | Offset in the global result set of the first hit returned. | `0` |
+| `--search-fields` | List of fields that Quickwit will search into if the user query does not explicitly target a field in the query. It overrides the default search fields defined in the index config. Space-separated list, e.g. "field1 field2".  |  |
+| `--snippet-fields` | List of fields that Quickwit will return snippet highlight on. Space-separated list, e.g. "field1 field2".  |  |
+| `--start-timestamp` | Filters out documents before that timestamp (time-series indexes only). |  |
+| `--end-timestamp` | Filters out documents after that timestamp (time-series indexes only). |  |
+| `--sort-by-field` | Sort by field. |  |
 ### tool extract-split
 
 Downloads and extracts a split to a directory.  

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -315,7 +315,7 @@ The response is the index metadata of the created index, and the content type is
 PUT api/v1/indexes/<index id>
 ```
 
-Update an index with the updatables parts of the `IndexConfig` payload. Note that this follows the PUT semantics and not PATCH, so all the fields must be specified and Unlike the create endpoint, this API accepts JSON only.
+Update an index with the updatable subset of the `IndexConfig` payload. This endpoint follows PUT semantics (not PATCH), which means that all the updatable fields of the index configuration are replaced by the values specified in this request. In particular, omitting an optional field like retention_policy will delete the associated configuration. Unlike the create endpoint, this API only accepts JSON payloads.
 
 #### PUT payload
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -223,13 +223,13 @@ The response is a JSON object, and the content type is `application/json; charse
 POST api/v1/indexes
 ```
 
-Create an index by posting an `IndexConfig` payload. The API accepts JSON with `content-type: application/json`) and YAML `content-type: application/yaml`.
+Create an index by posting an `IndexConfig` payload. The API accepts JSON with `content-type: application/json` and YAML `content-type: application/yaml`.
 
 #### POST payload
 
-| Variable              | Type               | Description                                                                                                           | Default value                         |
-|-----------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `version`          | `String`           | Config format version, use the same as your Quickwit version. (mandatory)                                             |                                       |
+| Variable            | Type               | Description                                                                                                           | Default value                         |
+|---------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| `version`           | `String`           | Config format version, use the same as your Quickwit version. (mandatory)                                             |                                       |
 | `index_id`          | `String`           | Index ID, see its [validation rules](../configuration/index-config.md#index-id) on identifiers. (mandatory)           |                                       |
 | `index_uri`         | `String`           | Defines where the index files are stored. This parameter expects a [storage URI](../configuration/storage-config.md#storage-uris).           | `{default_index_root_uri}/{index_id}` |
 | `doc_mapping`       | `DocMapping`       | Doc mapping object as specified in the [index config docs](../configuration/index-config.md#doc-mapping) (mandatory)  |                                       |
@@ -301,8 +301,52 @@ curl -XPOST http://0.0.0.0:8080/api/v1/indexes --data @index_config.json -H "Con
 
 The response is the index metadata of the created index, and the content type is `application/json; charset=UTF-8.`
 
-| Field                | Description                               |         Type          |
-|----------------------|-------------------------------------------|:---------------------:|
+| Field                | Description                             |         Type          |
+|----------------------|-----------------------------------------|:---------------------:|
+| `index_config`     | The posted index config.                  |     `IndexConfig`     |
+| `checkpoint`       | Map of checkpoints by source.             |   `IndexCheckpoint`   |
+| `create_timestamp` | Index creation timestamp                  |       `number`        |
+| `sources`          | List of the index sources configurations. | `Array<SourceConfig>` |
+
+
+### Update an index
+
+```
+PUT api/v1/indexes/<index id>
+```
+
+Update an index with the updatables parts of the `IndexConfig` payload. Note that this follows the PUT semantics and not PATCH, so all the fields must be specified and Unlike the create endpoint, this API accepts JSON only.
+
+#### PUT payload
+
+| Variable            | Type               | Description                                                                                                           | Default value                         |
+|---------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| `search_settings`   | `SearchSettings`   | Search settings object as specified in the [index config docs](../configuration/index-config.md#search-settings).     |                                       |
+| `retention`         | `Retention`        | Retention policy object as specified in the [index config docs](../configuration/index-config.md#retention-policy).   |                                       |
+
+
+**Payload Example**
+
+curl -XPUT http://0.0.0.0:8080/api/v1/indexes --data @index_update.json -H "Content-Type: application/json"
+
+```json title="index_update.json
+{
+    "search_settings": {
+        "default_search_fields": ["body"]
+    },
+    "retention": {
+        "period": "3 days",
+        "schedule": "@daily"
+    }
+}
+```
+
+#### Response
+
+The response is the index metadata of the updated index, and the content type is `application/json; charset=UTF-8.`
+
+| Field                | Description                             |         Type          |
+|----------------------|-----------------------------------------|:---------------------:|
 | `index_config`     | The posted index config.                  |     `IndexConfig`     |
 | `checkpoint`       | Map of checkpoints by source.             |   `IndexCheckpoint`   |
 | `create_timestamp` | Index creation timestamp                  |       `number`        |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -309,13 +309,13 @@ The response is the index metadata of the created index, and the content type is
 | `sources`          | List of the index sources configurations. | `Array<SourceConfig>` |
 
 
-### Update an index
+### Update an index (search settings and retention policy only)
 
 ```
 PUT api/v1/indexes/<index id>
 ```
 
-Update an index with the updatable subset of the `IndexConfig` payload. This endpoint follows PUT semantics (not PATCH), which means that all the updatable fields of the index configuration are replaced by the values specified in this request. In particular, omitting an optional field like retention_policy will delete the associated configuration. Unlike the create endpoint, this API only accepts JSON payloads.
+Updates the search settings and retention policy of an index. This endpoint follows PUT semantics (not PATCH), which means that all the updatable fields of the index configuration are replaced by the values specified in this request. In particular, omitting an optional field like retention_policy will delete the associated configuration. Unlike the create endpoint, this API only accepts JSON payloads.
 
 #### PUT payload
 
@@ -337,6 +337,16 @@ curl -XPUT http://0.0.0.0:8080/api/v1/indexes --data @index_update.json -H "Cont
     "retention": {
         "period": "3 days",
         "schedule": "@daily"
+    }
+}
+```
+
+:::warning
+Calling the update endpoint with the following payload will remove the current retention policy.
+```json
+{
+    "search_settings": {
+        "default_search_fields": ["body"]
     }
 }
 ```

--- a/quickwit/quickwit-cli/src/generate_markdown.rs
+++ b/quickwit/quickwit-cli/src/generate_markdown.rs
@@ -197,7 +197,7 @@ fn generate_markdown_from_clap(command: &Command) {
             continue;
         }
 
-        let excluded_doc_commands = ["merge"];
+        let excluded_doc_commands = ["merge", "local-search"];
         for subcommand in command
             .get_subcommands()
             .filter(|subcommand| !excluded_doc_commands.contains(&subcommand.get_name()))

--- a/quickwit/quickwit-cli/src/generate_markdown.rs
+++ b/quickwit/quickwit-cli/src/generate_markdown.rs
@@ -43,11 +43,13 @@ fn markdown_for_subcommand(
     subcommand: &Command,
     command_group: Vec<String>,
     doc_extensions: &toml::Value,
+    level: usize,
 ) {
     let subcommand_name = subcommand.get_name();
 
     let command_name = format!("{} {}", command_group.join(" "), subcommand_name);
-    println!("### {command_name}\n");
+    let header_level = "#".repeat(level);
+    println!("{header_level} {command_name}\n");
 
     let subcommand_ext: Option<&Value> = {
         let mut val_opt: Option<&Value> = doc_extensions.get(command_group[0].to_string());
@@ -201,14 +203,14 @@ fn generate_markdown_from_clap(command: &Command) {
             .filter(|subcommand| !excluded_doc_commands.contains(&subcommand.get_name()))
         {
             let commands = vec![command.get_name().to_string()];
-            markdown_for_subcommand(subcommand, commands, &doc_extensions);
+            markdown_for_subcommand(subcommand, commands, &doc_extensions, 3);
 
             for subsubcommand in subcommand.get_subcommands() {
                 let commands = vec![
                     command.get_name().to_string(),
                     subcommand.get_name().to_string(),
                 ];
-                markdown_for_subcommand(subsubcommand, commands, &doc_extensions);
+                markdown_for_subcommand(subsubcommand, commands, &doc_extensions, 4);
             }
         }
     }

--- a/quickwit/quickwit-cli/src/index/mod.rs
+++ b/quickwit/quickwit-cli/src/index/mod.rs
@@ -154,7 +154,7 @@ pub fn build_index_command() -> Command {
                         .conflicts_with("wait"),
                     Arg::new("commit-timeout")
                         .long("commit-timeout")
-                        .help("Timeout for ingest operations that require waiting for the final commit (`--wait` or `--force`). This is different from the `commit_timeout_secs` indexing setting which sets the maximum time before commiting splits after their creation.")
+                        .help("Timeout for ingest operations that require waiting for the final commit (`--wait` or `--force`). This is different from the `commit_timeout_secs` indexing setting, which sets the maximum time before commiting splits after their creation.")
                         .required(false)
                         .global(true),
                 ])

--- a/quickwit/quickwit-cli/src/index/mod.rs
+++ b/quickwit/quickwit-cli/src/index/mod.rs
@@ -59,7 +59,7 @@ use crate::checklist::GREEN_COLOR;
 use crate::stats::{mean, percentile, std_deviation};
 use crate::{client_args, make_table, prompt_confirmation, ClientArgs, THROUGHPUT_WINDOW_SIZE};
 
-mod update;
+pub mod update;
 
 pub fn build_index_command() -> Command {
     Command::new("index")
@@ -78,7 +78,7 @@ pub fn build_index_command() -> Command {
                 ])
             )
         .subcommand(
-            build_index_update_command()
+            build_index_update_command().display_order(2)
         )
         .subcommand(
             Command::new("clear")
@@ -154,7 +154,7 @@ pub fn build_index_command() -> Command {
                         .conflicts_with("wait"),
                     Arg::new("commit-timeout")
                         .long("commit-timeout")
-                        .help("Duration of the commit timeout operation.")
+                        .help("Timeout for ingest operations that require waiting for the final commit (`--wait` or `--force`). This is different from the `commit_timeout_secs` indexing setting which sets the maximum time before commiting splits after their creation.")
                         .required(false)
                         .global(true),
                 ])
@@ -285,7 +285,7 @@ impl IndexCliCommand {
             "ingest" => Self::parse_ingest_args(submatches),
             "list" => Self::parse_list_args(submatches),
             "search" => Self::parse_search_args(submatches),
-            "update" => Ok(Self::Update(IndexUpdateCliCommand::parse_args(matches)?)),
+            "update" => Ok(Self::Update(IndexUpdateCliCommand::parse_args(submatches)?)),
             _ => bail!("unknown index subcommand `{subcommand}`"),
         }
     }

--- a/quickwit/quickwit-cli/src/index/update.rs
+++ b/quickwit/quickwit-cli/src/index/update.rs
@@ -1,0 +1,261 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::{bail, Context};
+use clap::{arg, ArgMatches, Command};
+use colored::Colorize;
+use quickwit_config::{RetentionPolicy, SearchSettings};
+use quickwit_serve::IndexUpdates;
+use tracing::debug;
+
+use crate::checklist::GREEN_COLOR;
+use crate::ClientArgs;
+
+pub fn build_index_update_command() -> Command {
+    Command::new("update")
+        .display_order(2)
+        .about("Updates an index configuration.")
+        .subcommand(
+            Command::new("search-settings")
+                .about("Updates an default search settings.")
+                .args(&[
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1)
+                        .required(true),
+                    arg!(--"default-search-fields" <FIELD_NAME> "Comma separated list of fields that will be searched by default.")
+                        .display_order(2)
+                        .required(false),
+                ])
+        .subcommand(
+            Command::new("retention-policy")
+                .about("Set or unset a retention policy.")
+                .args(&[
+                    arg!(--index <INDEX> "ID of the target index")
+                        .display_order(1)
+                        .required(true),
+                    arg!(--"retention-policy-period" <RETENTION_PERIOD> "Duration after which splits are dropped.")
+                        .display_order(2)
+                        .required(false),
+                    arg!(--"retention-policy-schedule" <RETENTION_SCHEDULE> "Frequency at which the retention policy is evaluated and applied.")
+                        .display_order(3)
+                        .required(false),
+                    arg!(--"disable-retention-policy" "Disables the retention policy.")
+                        .display_order(4)
+                        .required(false),
+                ])
+        )
+    )
+}
+
+// Structured representation of the retention policy args
+#[derive(Debug, Eq, PartialEq)]
+pub enum RetentionPolicyUpdate {
+    Noop,
+    Update {
+        period: Option<String>,
+        schedule: Option<String>,
+    },
+    Disable,
+}
+
+impl RetentionPolicyUpdate {
+    pub fn apply_update(
+        self,
+        retention_policy_opt: Option<RetentionPolicy>,
+    ) -> anyhow::Result<Option<RetentionPolicy>> {
+        match (self, retention_policy_opt) {
+            (Self::Noop, policy_opt) => Ok(policy_opt),
+            (Self::Update { period: None, .. }, None) => {
+                bail!("`--retention-policy-period` is required when creating a retention policy");
+            }
+            (
+                Self::Update {
+                    period: None,
+                    schedule,
+                },
+                Some(mut policy),
+            ) => {
+                policy.evaluation_schedule = schedule.unwrap_or(policy.evaluation_schedule.clone());
+                Ok(Some(policy))
+            }
+            (
+                Self::Update {
+                    period: Some(period),
+                    schedule,
+                },
+                None,
+            ) => Ok(Some(RetentionPolicy {
+                retention_period: period,
+                evaluation_schedule: schedule.unwrap_or(RetentionPolicy::default_schedule()),
+            })),
+            (
+                Self::Update {
+                    period: Some(period),
+                    schedule,
+                },
+                Some(policy),
+            ) => Ok(Some(RetentionPolicy {
+                retention_period: period,
+                evaluation_schedule: schedule.unwrap_or(policy.evaluation_schedule.clone()),
+            })),
+            (Self::Disable, _) => Ok(None),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct RetentionPolicyArgs {
+    pub client_args: ClientArgs,
+    pub index_id: String,
+    pub retention_policy_update: RetentionPolicyUpdate,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct SearchSettingsArgs {
+    pub client_args: ClientArgs,
+    pub index_id: String,
+    pub default_search_fields: Option<Vec<String>>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum IndexUpdateCliCommand {
+    RetentionPolicy(RetentionPolicyArgs),
+    SearchSettings(SearchSettingsArgs),
+}
+
+impl IndexUpdateCliCommand {
+    pub fn parse_args(mut matches: ArgMatches) -> anyhow::Result<Self> {
+        let (subcommand, submatches) = matches
+            .remove_subcommand()
+            .context("failed to parse index subcommand")?;
+        match subcommand.as_str() {
+            "retention-policy" => Self::parse_update_retention_policy_args(submatches),
+            "search-settings" => Self::parse_update_search_settings_args(submatches),
+            _ => bail!("unknown index update subcommand `{subcommand}`"),
+        }
+    }
+
+    fn parse_update_retention_policy_args(mut matches: ArgMatches) -> anyhow::Result<Self> {
+        let client_args = ClientArgs::parse(&mut matches)?;
+        let index_id = matches
+            .remove_one::<String>("index")
+            .expect("`index` should be a required arg.");
+        let disable_retention_policy = matches.get_flag("disable-retention-policy");
+        let retention_policy_period = matches.remove_one::<String>("retention-policy-period");
+        let retention_policy_schedule = matches.remove_one::<String>("retention-policy-schedule");
+
+        let retention_policy_update = match (
+            disable_retention_policy,
+            retention_policy_period,
+            retention_policy_schedule,
+        ) {
+            (true, Some(_), Some(_)) | (true, None, Some(_)) | (true, Some(_), None) => bail!(
+                "`--retention-policy-period` and `--retention-policy-schedule` cannot be used \
+                 together with `--disable-retention-policy`"
+            ),
+            (true, None, None) => RetentionPolicyUpdate::Disable,
+            (false, None, None) => RetentionPolicyUpdate::Noop,
+            (false, period, schedule) => RetentionPolicyUpdate::Update { period, schedule },
+        };
+
+        Ok(Self::RetentionPolicy(RetentionPolicyArgs {
+            client_args,
+            index_id,
+            retention_policy_update,
+        }))
+    }
+
+    fn parse_update_search_settings_args(mut matches: ArgMatches) -> anyhow::Result<Self> {
+        let client_args = ClientArgs::parse(&mut matches)?;
+        let index_id = matches
+            .remove_one::<String>("index")
+            .expect("`index` should be a required arg.");
+        let default_search_fields = matches
+            .remove_many::<String>("default-search-fields")
+            .map(|values| values.collect());
+        Ok(Self::SearchSettings(SearchSettingsArgs {
+            client_args,
+            index_id,
+            default_search_fields,
+        }))
+    }
+
+    pub async fn execute(self) -> anyhow::Result<()> {
+        match self {
+            Self::RetentionPolicy(args) => update_retention_policy_cli(args).await,
+            Self::SearchSettings(args) => update_search_settings_cli(args).await,
+        }
+    }
+}
+
+pub async fn update_retention_policy_cli(args: RetentionPolicyArgs) -> anyhow::Result<()> {
+    debug!(args=?args, "update-index-retention-policy");
+    println!("❯ Updating index retention policy...");
+    let qw_client = args.client_args.client();
+    let metadata = qw_client.indexes().get(&args.index_id).await?;
+    let new_retention_policy_opt = args
+        .retention_policy_update
+        .apply_update(metadata.index_config.retention_policy_opt)?;
+    if let Some(new_retention_policy) = new_retention_policy_opt.as_ref() {
+        println!(
+            "New retention policy: {}",
+            serde_json::to_string(&new_retention_policy)?
+        );
+    } else {
+        println!("Retention policy disabled.");
+    }
+    qw_client
+        .indexes()
+        .update(
+            &args.index_id,
+            IndexUpdates {
+                retention_policy_opt: new_retention_policy_opt,
+                search_settings: metadata.index_config.search_settings,
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn update_search_settings_cli(args: SearchSettingsArgs) -> anyhow::Result<()> {
+    debug!(args=?args, "update-index-search-settings");
+    println!("❯ Updating index search settings...");
+    let qw_client = args.client_args.client();
+    let metadata = qw_client.indexes().get(&args.index_id).await?;
+    let search_settings = SearchSettings {
+        default_search_fields: args.default_search_fields.unwrap_or(vec![]),
+        ..metadata.index_config.search_settings
+    };
+    println!(
+        "New search settings: {}",
+        serde_json::to_string(&search_settings)?
+    );
+    qw_client
+        .indexes()
+        .update(
+            &args.index_id,
+            IndexUpdates {
+                retention_policy_opt: metadata.index_config.retention_policy_opt,
+                search_settings,
+            },
+        )
+        .await?;
+    println!("{} Index successfully updated.", "✔".color(GREEN_COLOR));
+    Ok(())
+}

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -101,7 +101,6 @@ mod tests {
 
     use bytesize::ByteSize;
     use quickwit_cli::cli::{build_cli, CliCommand};
-    use quickwit_cli::index::update::{IndexUpdateCliCommand, RetentionPolicyArgs};
     use quickwit_cli::index::{
         ClearIndexArgs, CreateIndexArgs, DeleteIndexArgs, DescribeIndexArgs, IndexCliCommand,
         IngestDocsArgs, SearchIndexArgs,
@@ -187,35 +186,6 @@ mod tests {
         assert_eq!(command, expected_cmd);
 
         Ok(())
-    }
-
-    #[test]
-    fn test_cmd_update_subsubcommand() {
-        let app = build_cli().no_binary_name(true);
-        let matches = app
-            .try_get_matches_from([
-                "index",
-                "update",
-                "retention-policy",
-                "--index",
-                "my-index",
-                "--period",
-                "1 day",
-            ])
-            .unwrap();
-        let command = CliCommand::parse_cli_args(matches).unwrap();
-        assert!(matches!(
-            command,
-            CliCommand::Index(IndexCliCommand::Update(
-                IndexUpdateCliCommand::RetentionPolicy(RetentionPolicyArgs {
-                    client_args: _,
-                    index_id,
-                    disable: false,
-                    period: Some(period),
-                    schedule: None,
-                })
-            )) if &index_id == "my-index" &&  &period == "1 day"
-        ));
     }
 
     #[test]

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -101,6 +101,7 @@ mod tests {
 
     use bytesize::ByteSize;
     use quickwit_cli::cli::{build_cli, CliCommand};
+    use quickwit_cli::index::update::{IndexUpdateCliCommand, RetentionPolicyArgs};
     use quickwit_cli::index::{
         ClearIndexArgs, CreateIndexArgs, DeleteIndexArgs, DescribeIndexArgs, IndexCliCommand,
         IngestDocsArgs, SearchIndexArgs,
@@ -186,6 +187,35 @@ mod tests {
         assert_eq!(command, expected_cmd);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_cmd_update_subsubcommand() {
+        let app = build_cli().no_binary_name(true);
+        let matches = app
+            .try_get_matches_from([
+                "index",
+                "update",
+                "retention-policy",
+                "--index",
+                "my-index",
+                "--period",
+                "1 day",
+            ])
+            .unwrap();
+        let command = CliCommand::parse_cli_args(matches).unwrap();
+        assert!(matches!(
+            command,
+            CliCommand::Index(IndexCliCommand::Update(
+                IndexUpdateCliCommand::RetentionPolicy(RetentionPolicyArgs {
+                    client_args: _,
+                    index_id,
+                    disable: false,
+                    period: Some(period),
+                    schedule: None,
+                })
+            )) if &index_id == "my-index" &&  &period == "1 day"
+        ));
     }
 
     #[test]

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -544,10 +544,6 @@ async fn test_cmd_update_index() {
     test_env.start_server().await.unwrap();
     create_logs_index(&test_env).await.unwrap();
 
-    local_ingest_docs(test_env.resource_files["logs"].as_path(), &test_env)
-        .await
-        .unwrap();
-
     // add a policy
     update_retention_policy_cli(RetentionPolicyArgs {
         index_id: index_id.clone(),

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -239,7 +239,7 @@ pub struct RetentionPolicy {
 }
 
 impl RetentionPolicy {
-    fn default_schedule() -> String {
+    pub fn default_schedule() -> String {
         "hourly".to_string()
     }
 

--- a/quickwit/quickwit-integration-tests/src/tests/index_update_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_update_tests.rs
@@ -1,0 +1,146 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use quickwit_config::service::QuickwitService;
+use quickwit_config::SearchSettings;
+use quickwit_rest_client::rest_client::CommitType;
+use quickwit_serve::{IndexUpdates, SearchRequestQueryString};
+use serde_json::json;
+
+use crate::ingest_json;
+use crate::test_utils::{ingest_with_retry, ClusterSandbox};
+
+#[tokio::test]
+async fn test_update_on_multi_nodes_cluster() {
+    quickwit_common::setup_logging_for_tests();
+    let nodes_services = vec![
+        HashSet::from_iter([QuickwitService::Searcher]),
+        HashSet::from_iter([QuickwitService::Metastore]),
+        HashSet::from_iter([QuickwitService::Indexer]),
+        HashSet::from_iter([QuickwitService::ControlPlane]),
+        HashSet::from_iter([QuickwitService::Janitor]),
+    ];
+    let sandbox = ClusterSandbox::start_cluster_nodes(&nodes_services)
+        .await
+        .unwrap();
+    sandbox.wait_for_cluster_num_ready_nodes(5).await.unwrap();
+
+    {
+        // Wait for indexer to fully start.
+        // The starting time is a bit long for a cluster.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let indexing_service_counters = sandbox
+            .indexer_rest_client
+            .node_stats()
+            .indexing()
+            .await
+            .unwrap();
+        assert_eq!(indexing_service_counters.num_running_pipelines, 0);
+    }
+
+    // Create index
+    sandbox
+        .indexer_rest_client
+        .indexes()
+        .create(
+            r#"
+            version: 0.8
+            index_id: my-updatable-index
+            doc_mapping:
+              field_mappings:
+              - name: title
+                type: text
+              - name: body
+                type: text
+            indexing_settings:
+              commit_timeout_secs: 1
+            search_settings:
+              default_search_fields: [title]
+            "#,
+            quickwit_config::ConfigFormat::Yaml,
+            false,
+        )
+        .await
+        .unwrap();
+    assert!(sandbox
+        .indexer_rest_client
+        .node_health()
+        .is_live()
+        .await
+        .unwrap());
+
+    // Wait until indexing pipelines are started.
+    sandbox.wait_for_indexing_pipelines(1).await.unwrap();
+
+    // Check that ingest request send to searcher is forwarded to indexer and thus indexed.
+    ingest_with_retry(
+        &sandbox.searcher_rest_client,
+        "my-updatable-index",
+        ingest_json!({"title": "first", "body": "first record"}),
+        CommitType::Auto,
+    )
+    .await
+    .unwrap();
+    // Wait until split is commited and search.
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    // No hit because default_search_fields covers "title" only
+    let search_response_no_hit = sandbox
+        .searcher_rest_client
+        .search(
+            "my-updatable-index",
+            SearchRequestQueryString {
+                query: "record".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(search_response_no_hit.num_hits, 0);
+    // Update index to also search "body" by default, search should now have 1 hit
+    sandbox
+        .searcher_rest_client
+        .indexes()
+        .update(
+            "my-updatable-index",
+            IndexUpdates {
+                search_settings: SearchSettings {
+                    default_search_fields: vec!["title".to_string(), "body".to_string()],
+                },
+                retention_policy_opt: None,
+            },
+        )
+        .await
+        .unwrap();
+    let search_response_no_hit = sandbox
+        .searcher_rest_client
+        .search(
+            "my-updatable-index",
+            SearchRequestQueryString {
+                query: "record".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(search_response_no_hit.num_hits, 1);
+    sandbox.shutdown().await.unwrap();
+}

--- a/quickwit/quickwit-integration-tests/src/tests/mod.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/mod.rs
@@ -19,3 +19,4 @@
 
 mod basic_tests;
 mod index_tests;
+mod index_update_tests;

--- a/quickwit/quickwit-metastore/src/lib.rs
+++ b/quickwit/quickwit-metastore/src/lib.rs
@@ -52,6 +52,7 @@ pub use metastore::{
     IndexMetadataResponseExt, ListIndexesMetadataResponseExt, ListSplitsQuery,
     ListSplitsRequestExt, ListSplitsResponseExt, MetastoreServiceExt,
     MetastoreServiceStreamSplitsExt, PublishSplitsRequestExt, StageSplitsRequestExt,
+    UpdateIndexRequestExt,
 };
 pub use metastore_factory::{MetastoreFactory, UnsupportedMetastore};
 pub use metastore_resolver::MetastoreResolver;

--- a/quickwit/quickwit-metastore/src/metastore/control_plane_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/control_plane_metastore.rs
@@ -35,7 +35,8 @@ use quickwit_proto::metastore::{
     ListSplitsResponse, ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreResult,
     MetastoreService, MetastoreServiceClient, MetastoreServiceStream, OpenShardsRequest,
     OpenShardsResponse, PublishSplitsRequest, ResetSourceCheckpointRequest, StageSplitsRequest,
-    ToggleSourceRequest, UpdateSplitsDeleteOpstampRequest, UpdateSplitsDeleteOpstampResponse,
+    ToggleSourceRequest, UpdateIndexRequest, UpdateSplitsDeleteOpstampRequest,
+    UpdateSplitsDeleteOpstampResponse,
 };
 
 /// A [`MetastoreService`] implementation that proxies some requests to the control plane so it can
@@ -115,6 +116,14 @@ impl MetastoreService for ControlPlaneMetastore {
     }
 
     // Other metastore API calls.
+
+    async fn update_index(
+        &mut self,
+        request: UpdateIndexRequest,
+    ) -> MetastoreResult<IndexMetadataResponse> {
+        let response = self.metastore.update_index(request).await?;
+        Ok(response)
+    }
 
     async fn index_metadata(
         &mut self,

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -506,7 +506,7 @@ impl FileBackedIndex {
     }
 
     /// Deletes the source. Returns whether a mutation occurred.
-    pub(crate) fn delete_source(&mut self, source_id: &str) -> MetastoreResult<bool> {
+    pub(crate) fn delete_source(&mut self, source_id: &str) -> MetastoreResult<()> {
         self.metadata.delete_source(source_id)
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -213,14 +213,14 @@ impl FileBackedIndex {
         &self.metadata
     }
 
-    /// Replace the search settings in the index config, returning whether a mutation occurred.
+    /// Replaces the search settings in the index config, returning whether a mutation occurred.
     pub fn set_search_settings(&mut self, search_settings: SearchSettings) -> bool {
         let is_mutation = self.metadata.index_config.search_settings != search_settings;
         self.metadata.index_config.search_settings = search_settings;
         is_mutation
     }
 
-    /// Replace the retention policy in the index config, returning whether a mutation occurred.
+    /// Replaces the retention policy in the index config, returning whether a mutation occurred.
     pub fn set_retention_policy(&mut self, retention_policy_opt: Option<RetentionPolicy>) -> bool {
         let is_mutation = self.metadata.index_config.retention_policy_opt != retention_policy_opt;
         self.metadata.index_config.retention_policy_opt = retention_policy_opt;

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -30,7 +30,7 @@ use std::ops::Bound;
 
 use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
-use quickwit_config::{IndexConfig, SourceConfig, INGEST_V2_SOURCE_ID};
+use quickwit_config::{RetentionPolicy, SearchSettings, SourceConfig, INGEST_V2_SOURCE_ID};
 use quickwit_proto::metastore::{
     AcquireShardsRequest, AcquireShardsResponse, DeleteQuery, DeleteShardsRequest, DeleteTask,
     EntityKind, ListShardsSubrequest, ListShardsSubresponse, MetastoreError, MetastoreResult,
@@ -213,9 +213,18 @@ impl FileBackedIndex {
         &self.metadata
     }
 
-    /// Mutable ref to index config.
-    pub fn index_config_mut(&mut self) -> &mut IndexConfig {
-        &mut self.metadata.index_config
+    /// Replace the search settings in the index config, returning whether a mutation occurred.
+    pub fn set_search_settings(&mut self, search_settings: SearchSettings) -> bool {
+        let is_mutation = self.metadata.index_config.search_settings != search_settings;
+        self.metadata.index_config.search_settings = search_settings;
+        is_mutation
+    }
+
+    /// Replace the retention policy in the index config, returning whether a mutation occurred.
+    pub fn set_retention_policy(&mut self, retention_policy_opt: Option<RetentionPolicy>) -> bool {
+        let is_mutation = self.metadata.index_config.retention_policy_opt != retention_policy_opt;
+        self.metadata.index_config.retention_policy_opt = retention_policy_opt;
+        is_mutation
     }
 
     /// Stages a single split.

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -213,6 +213,11 @@ impl FileBackedIndex {
         &self.metadata
     }
 
+    /// Mutable ref to index metadata.
+    pub fn metadata_mut(&mut self) -> &mut IndexMetadata {
+        &mut self.metadata
+    }
+
     /// Stages a single split.
     ///
     /// If a split already exists and is in the [SplitState::Staged] state,

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -30,7 +30,7 @@ use std::ops::Bound;
 
 use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
-use quickwit_config::{SourceConfig, INGEST_V2_SOURCE_ID};
+use quickwit_config::{IndexConfig, SourceConfig, INGEST_V2_SOURCE_ID};
 use quickwit_proto::metastore::{
     AcquireShardsRequest, AcquireShardsResponse, DeleteQuery, DeleteShardsRequest, DeleteTask,
     EntityKind, ListShardsSubrequest, ListShardsSubresponse, MetastoreError, MetastoreResult,
@@ -213,9 +213,9 @@ impl FileBackedIndex {
         &self.metadata
     }
 
-    /// Mutable ref to index metadata.
-    pub fn metadata_mut(&mut self) -> &mut IndexMetadata {
-        &mut self.metadata
+    /// Mutable ref to index config.
+    pub fn index_config_mut(&mut self) -> &mut IndexConfig {
+        &mut self.metadata.index_config
     }
 
     /// Stages a single split.

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -467,12 +467,9 @@ impl MetastoreService for FileBackedMetastore {
 
         let metadata = self
             .mutate(index_uid, |index| {
-                let index_config = index.index_config_mut();
-                if index_config.search_settings != search_settings
-                    || index_config.retention_policy_opt != retention_policy_opt
-                {
-                    index_config.search_settings = search_settings;
-                    index_config.retention_policy_opt = retention_policy_opt;
+                let search_settings_mutated = index.set_search_settings(search_settings);
+                let retention_policy_mutated = index.set_retention_policy(retention_policy_opt);
+                if search_settings_mutated || retention_policy_mutated {
                     Ok(MutationOccurred::Yes(index.metadata().clone()))
                 } else {
                     Ok(MutationOccurred::No(index.metadata().clone()))

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -467,15 +467,15 @@ impl MetastoreService for FileBackedMetastore {
 
         let metadata = self
             .mutate(index_uid, |index| {
-                let metadata = index.metadata_mut();
-                if metadata.index_config.search_settings != search_settings
-                    || metadata.index_config.retention_policy_opt != retention_policy_opt
+                let index_config = index.index_config_mut();
+                if index_config.search_settings != search_settings
+                    || index_config.retention_policy_opt != retention_policy_opt
                 {
-                    metadata.index_config.search_settings = search_settings;
-                    metadata.index_config.retention_policy_opt = retention_policy_opt;
-                    Ok(MutationOccurred::Yes(metadata.clone()))
+                    index_config.search_settings = search_settings;
+                    index_config.retention_policy_opt = retention_policy_opt;
+                    Ok(MutationOccurred::Yes(index.metadata().clone()))
                 } else {
-                    Ok(MutationOccurred::No(metadata.clone()))
+                    Ok(MutationOccurred::No(index.metadata().clone()))
                 }
             })
             .await?;

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -663,9 +663,8 @@ impl MetastoreService for FileBackedMetastore {
         let index_uid = request.index_uid();
 
         self.mutate(index_uid, |index| {
-            index
-                .delete_source(&request.source_id)
-                .map(MutationOccurred::from)
+            index.delete_source(&request.source_id)?;
+            Ok(MutationOccurred::Yes(()))
         })
         .await?;
         Ok(EmptyResponse {})

--- a/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
@@ -126,8 +126,8 @@ impl IndexMetadata {
         Ok(mutation_occurred)
     }
 
-    /// Deletes a source from the index. Returns whether the index was modified (true).
-    pub(crate) fn delete_source(&mut self, source_id: &str) -> MetastoreResult<bool> {
+    /// Deletes a source from the index.
+    pub(crate) fn delete_source(&mut self, source_id: &str) -> MetastoreResult<()> {
         self.sources.remove(source_id).ok_or_else(|| {
             MetastoreError::NotFound(EntityKind::Source {
                 index_id: self.index_id().to_string(),
@@ -135,7 +135,7 @@ impl IndexMetadata {
             })
         })?;
         self.checkpoint.remove_source(source_id);
-        Ok(true)
+        Ok(())
     }
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -31,13 +31,13 @@ use bytes::Bytes;
 use futures::TryStreamExt;
 pub use index_metadata::IndexMetadata;
 use itertools::Itertools;
-use quickwit_config::{IndexConfig, SourceConfig};
+use quickwit_config::{IndexConfig, RetentionPolicy, SearchSettings, SourceConfig};
 use quickwit_doc_mapper::tag_pruning::TagFilterAst;
 use quickwit_proto::metastore::{
     serde_utils, AddSourceRequest, CreateIndexRequest, CreateIndexResponse, DeleteTask,
     IndexMetadataRequest, IndexMetadataResponse, ListIndexesMetadataResponse, ListSplitsRequest,
     ListSplitsResponse, MetastoreError, MetastoreResult, MetastoreService, MetastoreServiceClient,
-    MetastoreServiceStream, PublishSplitsRequest, StageSplitsRequest,
+    MetastoreServiceStream, PublishSplitsRequest, StageSplitsRequest, UpdateIndexRequest,
 };
 use quickwit_proto::types::{IndexUid, SplitId};
 use time::OffsetDateTime;
@@ -176,6 +176,58 @@ pub trait CreateIndexResponseExt {
 impl CreateIndexResponseExt for CreateIndexResponse {
     fn deserialize_index_metadata(&self) -> MetastoreResult<IndexMetadata> {
         serde_utils::from_json_str(&self.index_metadata_json)
+    }
+}
+
+/// Helper trait to build a [`UpdateIndexRequest`] and deserialize its payload.
+pub trait UpdateIndexRequestExt {
+    /// Updates a new [`UpdateIndexRequest`] from an [`IndexConfig`].
+    fn try_from_updates(
+        index_uid: impl Into<IndexUid>,
+        search_settings: &SearchSettings,
+        retention_policy_opt: &Option<RetentionPolicy>,
+    ) -> MetastoreResult<UpdateIndexRequest>;
+
+    /// Deserializes the `index_config_json` field of a [`UpdateIndexRequest`] into an
+    /// [`IndexConfig`].
+    fn deserialize_search_settings(&self) -> MetastoreResult<SearchSettings>;
+
+    /// Deserializes the `source_configs_json` field of a [`UpdateIndexRequest`] into an
+    /// `Vec` of [`SourceConfig`].
+    fn deserialize_retention_policy(&self) -> MetastoreResult<Option<RetentionPolicy>>;
+}
+
+impl UpdateIndexRequestExt for UpdateIndexRequest {
+    fn try_from_updates(
+        index_uid: impl Into<IndexUid>,
+        search_settings: &SearchSettings,
+        retention_policy_opt: &Option<RetentionPolicy>,
+    ) -> MetastoreResult<UpdateIndexRequest> {
+        let search_settings_json = serde_utils::to_json_str(&search_settings)?;
+        let retention_policy_json = if let Some(retention_policy) = &retention_policy_opt {
+            Some(serde_utils::to_json_str(retention_policy)?)
+        } else {
+            None
+        };
+
+        let update_request = UpdateIndexRequest {
+            index_uid: Some(index_uid.into()),
+            search_settings_json,
+            retention_policy_json,
+        };
+        Ok(update_request)
+    }
+
+    fn deserialize_search_settings(&self) -> MetastoreResult<SearchSettings> {
+        serde_utils::from_json_str(&self.search_settings_json)
+    }
+
+    fn deserialize_retention_policy(&self) -> MetastoreResult<Option<RetentionPolicy>> {
+        if let Some(retention_policy_json) = &self.retention_policy_json {
+            serde_utils::from_json_str(retention_policy_json).map(Some)
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -204,11 +204,10 @@ impl UpdateIndexRequestExt for UpdateIndexRequest {
         retention_policy_opt: &Option<RetentionPolicy>,
     ) -> MetastoreResult<UpdateIndexRequest> {
         let search_settings_json = serde_utils::to_json_str(&search_settings)?;
-        let retention_policy_json = if let Some(retention_policy) = &retention_policy_opt {
-            Some(serde_utils::to_json_str(retention_policy)?)
-        } else {
-            None
-        };
+        let retention_policy_json = retention_policy_opt
+            .as_ref()
+            .map(serde_utils::to_json_str)
+            .transpose()?;
 
         let update_request = UpdateIndexRequest {
             index_uid: Some(index_uid.into()),
@@ -223,11 +222,10 @@ impl UpdateIndexRequestExt for UpdateIndexRequest {
     }
 
     fn deserialize_retention_policy(&self) -> MetastoreResult<Option<RetentionPolicy>> {
-        if let Some(retention_policy_json) = &self.retention_policy_json {
-            serde_utils::from_json_str(retention_policy_json).map(Some)
-        } else {
-            Ok(None)
-        }
+        self.retention_policy_json
+            .as_ref()
+            .map(|policy| serde_utils::from_json_str(policy))
+            .transpose()
     }
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -181,19 +181,19 @@ impl CreateIndexResponseExt for CreateIndexResponse {
 
 /// Helper trait to build a [`UpdateIndexRequest`] and deserialize its payload.
 pub trait UpdateIndexRequestExt {
-    /// Updates a new [`UpdateIndexRequest`] from an [`IndexConfig`].
+    /// Creates a new [`UpdateIndexRequest`] from the different updated fields.
     fn try_from_updates(
         index_uid: impl Into<IndexUid>,
         search_settings: &SearchSettings,
         retention_policy_opt: &Option<RetentionPolicy>,
     ) -> MetastoreResult<UpdateIndexRequest>;
 
-    /// Deserializes the `index_config_json` field of a [`UpdateIndexRequest`] into an
-    /// [`IndexConfig`].
+    /// Deserializes the `search_settings_json` field of an [`UpdateIndexRequest`] into a
+    /// [`SearchSettings`] object.
     fn deserialize_search_settings(&self) -> MetastoreResult<SearchSettings>;
 
-    /// Deserializes the `source_configs_json` field of a [`UpdateIndexRequest`] into an
-    /// `Vec` of [`SourceConfig`].
+    /// Deserializes the `retention_policy_json` field of an [`UpdateIndexRequest`] into a
+    /// [`RetentionPolicy`] object.
     fn deserialize_retention_policy(&self) -> MetastoreResult<Option<RetentionPolicy>>;
 }
 

--- a/quickwit/quickwit-metastore/src/tests/mod.rs
+++ b/quickwit/quickwit-metastore/src/tests/mod.rs
@@ -187,6 +187,12 @@ macro_rules! metastore_test_suite {
             }
 
             #[tokio::test]
+            async fn test_metastore_update_index() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_update_index::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
             async fn test_metastore_create_index_with_sources() {
                 let _ = tracing_subscriber::fmt::try_init();
                 $crate::tests::index::test_metastore_create_index_with_sources::<$metastore_type>().await;

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -96,6 +96,9 @@ service MetastoreService {
   // An error will occur if an index that already exists in the storage is specified.
   rpc CreateIndex(CreateIndexRequest) returns (CreateIndexResponse);
 
+  // Update an index.
+  rpc UpdateIndex(UpdateIndexRequest) returns (IndexMetadataResponse);
+
   // Returns the `IndexMetadata` of an index identified by its IndexID or its IndexUID.
   rpc IndexMetadata(IndexMetadataRequest) returns (IndexMetadataResponse);
 
@@ -197,6 +200,12 @@ message CreateIndexRequest {
 message CreateIndexResponse {
   quickwit.common.IndexUid index_uid = 1;
   string index_metadata_json = 2;
+}
+
+message UpdateIndexRequest {
+  quickwit.common.IndexUid index_uid = 1;
+  string search_settings_json = 2;
+  optional string retention_policy_json = 3;
 }
 
 message ListIndexesMetadataRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -23,6 +23,17 @@ pub struct CreateIndexResponse {
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateIndexRequest {
+    #[prost(message, optional, tag = "1")]
+    pub index_uid: ::core::option::Option<crate::types::IndexUid>,
+    #[prost(string, tag = "2")]
+    pub search_settings_json: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "3")]
+    pub retention_policy_json: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListIndexesMetadataRequest {
     /// List of patterns an index should match or not match to get considered
     /// An index must match at least one positive pattern (a pattern not starting
@@ -508,6 +519,11 @@ impl RpcName for CreateIndexRequest {
         "create_index"
     }
 }
+impl RpcName for UpdateIndexRequest {
+    fn rpc_name() -> &'static str {
+        "update_index"
+    }
+}
 impl RpcName for IndexMetadataRequest {
     fn rpc_name() -> &'static str {
         "index_metadata"
@@ -652,6 +668,11 @@ pub trait MetastoreService: std::fmt::Debug + dyn_clone::DynClone + Send + Sync 
         &mut self,
         request: CreateIndexRequest,
     ) -> crate::metastore::MetastoreResult<CreateIndexResponse>;
+    /// Update an index.
+    async fn update_index(
+        &mut self,
+        request: UpdateIndexRequest,
+    ) -> crate::metastore::MetastoreResult<IndexMetadataResponse>;
     /// Returns the `IndexMetadata` of an index identified by its IndexID or its IndexUID.
     async fn index_metadata(
         &mut self,
@@ -892,6 +913,12 @@ impl MetastoreService for MetastoreServiceClient {
     ) -> crate::metastore::MetastoreResult<CreateIndexResponse> {
         self.inner.create_index(request).await
     }
+    async fn update_index(
+        &mut self,
+        request: UpdateIndexRequest,
+    ) -> crate::metastore::MetastoreResult<IndexMetadataResponse> {
+        self.inner.update_index(request).await
+    }
     async fn index_metadata(
         &mut self,
         request: IndexMetadataRequest,
@@ -1069,6 +1096,12 @@ pub mod mock_metastore_service {
             request: super::CreateIndexRequest,
         ) -> crate::metastore::MetastoreResult<super::CreateIndexResponse> {
             self.inner.lock().await.create_index(request).await
+        }
+        async fn update_index(
+            &mut self,
+            request: super::UpdateIndexRequest,
+        ) -> crate::metastore::MetastoreResult<super::IndexMetadataResponse> {
+            self.inner.lock().await.update_index(request).await
         }
         async fn index_metadata(
             &mut self,
@@ -1254,6 +1287,22 @@ impl tower::Service<CreateIndexRequest> for Box<dyn MetastoreService> {
     fn call(&mut self, request: CreateIndexRequest) -> Self::Future {
         let mut svc = self.clone();
         let fut = async move { svc.create_index(request).await };
+        Box::pin(fut)
+    }
+}
+impl tower::Service<UpdateIndexRequest> for Box<dyn MetastoreService> {
+    type Response = IndexMetadataResponse;
+    type Error = crate::metastore::MetastoreError;
+    type Future = BoxFuture<Self::Response, Self::Error>;
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+    fn call(&mut self, request: UpdateIndexRequest) -> Self::Future {
+        let mut svc = self.clone();
+        let fut = async move { svc.update_index(request).await };
         Box::pin(fut)
     }
 }
@@ -1682,6 +1731,11 @@ struct MetastoreServiceTowerServiceStack {
         CreateIndexResponse,
         crate::metastore::MetastoreError,
     >,
+    update_index_svc: quickwit_common::tower::BoxService<
+        UpdateIndexRequest,
+        IndexMetadataResponse,
+        crate::metastore::MetastoreError,
+    >,
     index_metadata_svc: quickwit_common::tower::BoxService<
         IndexMetadataRequest,
         IndexMetadataResponse,
@@ -1818,6 +1872,7 @@ impl Clone for MetastoreServiceTowerServiceStack {
         Self {
             inner: self.inner.clone(),
             create_index_svc: self.create_index_svc.clone(),
+            update_index_svc: self.update_index_svc.clone(),
             index_metadata_svc: self.index_metadata_svc.clone(),
             list_indexes_metadata_svc: self.list_indexes_metadata_svc.clone(),
             delete_index_svc: self.delete_index_svc.clone(),
@@ -1858,6 +1913,12 @@ impl MetastoreService for MetastoreServiceTowerServiceStack {
         request: CreateIndexRequest,
     ) -> crate::metastore::MetastoreResult<CreateIndexResponse> {
         self.create_index_svc.ready().await?.call(request).await
+    }
+    async fn update_index(
+        &mut self,
+        request: UpdateIndexRequest,
+    ) -> crate::metastore::MetastoreResult<IndexMetadataResponse> {
+        self.update_index_svc.ready().await?.call(request).await
     }
     async fn index_metadata(
         &mut self,
@@ -2030,6 +2091,16 @@ type CreateIndexLayer = quickwit_common::tower::BoxLayer<
     >,
     CreateIndexRequest,
     CreateIndexResponse,
+    crate::metastore::MetastoreError,
+>;
+type UpdateIndexLayer = quickwit_common::tower::BoxLayer<
+    quickwit_common::tower::BoxService<
+        UpdateIndexRequest,
+        IndexMetadataResponse,
+        crate::metastore::MetastoreError,
+    >,
+    UpdateIndexRequest,
+    IndexMetadataResponse,
     crate::metastore::MetastoreError,
 >;
 type IndexMetadataLayer = quickwit_common::tower::BoxLayer<
@@ -2295,6 +2366,7 @@ type DeleteIndexTemplatesLayer = quickwit_common::tower::BoxLayer<
 #[derive(Debug, Default)]
 pub struct MetastoreServiceTowerLayerStack {
     create_index_layers: Vec<CreateIndexLayer>,
+    update_index_layers: Vec<UpdateIndexLayer>,
     index_metadata_layers: Vec<IndexMetadataLayer>,
     list_indexes_metadata_layers: Vec<ListIndexesMetadataLayer>,
     delete_index_layers: Vec<DeleteIndexLayer>,
@@ -2350,6 +2422,31 @@ impl MetastoreServiceTowerLayerStack {
                 crate::metastore::MetastoreError,
             >,
         >>::Service as tower::Service<CreateIndexRequest>>::Future: Send + 'static,
+        L: tower::Layer<
+                quickwit_common::tower::BoxService<
+                    UpdateIndexRequest,
+                    IndexMetadataResponse,
+                    crate::metastore::MetastoreError,
+                >,
+            > + Clone + Send + Sync + 'static,
+        <L as tower::Layer<
+            quickwit_common::tower::BoxService<
+                UpdateIndexRequest,
+                IndexMetadataResponse,
+                crate::metastore::MetastoreError,
+            >,
+        >>::Service: tower::Service<
+                UpdateIndexRequest,
+                Response = IndexMetadataResponse,
+                Error = crate::metastore::MetastoreError,
+            > + Clone + Send + Sync + 'static,
+        <<L as tower::Layer<
+            quickwit_common::tower::BoxService<
+                UpdateIndexRequest,
+                IndexMetadataResponse,
+                crate::metastore::MetastoreError,
+            >,
+        >>::Service as tower::Service<UpdateIndexRequest>>::Future: Send + 'static,
         L: tower::Layer<
                 quickwit_common::tower::BoxService<
                     IndexMetadataRequest,
@@ -3019,6 +3116,8 @@ impl MetastoreServiceTowerLayerStack {
     {
         self.create_index_layers
             .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
+        self.update_index_layers
+            .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self.index_metadata_layers
             .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self.list_indexes_metadata_layers
@@ -3090,6 +3189,25 @@ impl MetastoreServiceTowerLayerStack {
         <L::Service as tower::Service<CreateIndexRequest>>::Future: Send + 'static,
     {
         self.create_index_layers.push(quickwit_common::tower::BoxLayer::new(layer));
+        self
+    }
+    pub fn stack_update_index_layer<L>(mut self, layer: L) -> Self
+    where
+        L: tower::Layer<
+                quickwit_common::tower::BoxService<
+                    UpdateIndexRequest,
+                    IndexMetadataResponse,
+                    crate::metastore::MetastoreError,
+                >,
+            > + Send + Sync + 'static,
+        L::Service: tower::Service<
+                UpdateIndexRequest,
+                Response = IndexMetadataResponse,
+                Error = crate::metastore::MetastoreError,
+            > + Clone + Send + Sync + 'static,
+        <L::Service as tower::Service<UpdateIndexRequest>>::Future: Send + 'static,
+    {
+        self.update_index_layers.push(quickwit_common::tower::BoxLayer::new(layer));
         self
     }
     pub fn stack_index_metadata_layer<L>(mut self, layer: L) -> Self
@@ -3671,6 +3789,14 @@ impl MetastoreServiceTowerLayerStack {
                 quickwit_common::tower::BoxService::new(boxed_instance.clone()),
                 |svc, layer| layer.layer(svc),
             );
+        let update_index_svc = self
+            .update_index_layers
+            .into_iter()
+            .rev()
+            .fold(
+                quickwit_common::tower::BoxService::new(boxed_instance.clone()),
+                |svc, layer| layer.layer(svc),
+            );
         let index_metadata_svc = self
             .index_metadata_layers
             .into_iter()
@@ -3882,6 +4008,7 @@ impl MetastoreServiceTowerLayerStack {
         let tower_svc_stack = MetastoreServiceTowerServiceStack {
             inner: boxed_instance.clone(),
             create_index_svc,
+            update_index_svc,
             index_metadata_svc,
             list_indexes_metadata_svc,
             delete_index_svc,
@@ -3989,6 +4116,12 @@ where
             Response = CreateIndexResponse,
             Error = crate::metastore::MetastoreError,
             Future = BoxFuture<CreateIndexResponse, crate::metastore::MetastoreError>,
+        >
+        + tower::Service<
+            UpdateIndexRequest,
+            Response = IndexMetadataResponse,
+            Error = crate::metastore::MetastoreError,
+            Future = BoxFuture<IndexMetadataResponse, crate::metastore::MetastoreError>,
         >
         + tower::Service<
             IndexMetadataRequest,
@@ -4172,6 +4305,12 @@ where
         &mut self,
         request: CreateIndexRequest,
     ) -> crate::metastore::MetastoreResult<CreateIndexResponse> {
+        self.call(request).await
+    }
+    async fn update_index(
+        &mut self,
+        request: UpdateIndexRequest,
+    ) -> crate::metastore::MetastoreResult<IndexMetadataResponse> {
         self.call(request).await
     }
     async fn index_metadata(
@@ -4388,6 +4527,19 @@ where
             .map_err(|status| crate::error::grpc_status_to_service_error(
                 status,
                 CreateIndexRequest::rpc_name(),
+            ))
+    }
+    async fn update_index(
+        &mut self,
+        request: UpdateIndexRequest,
+    ) -> crate::metastore::MetastoreResult<IndexMetadataResponse> {
+        self.inner
+            .update_index(request)
+            .await
+            .map(|response| response.into_inner())
+            .map_err(|status| crate::error::grpc_status_to_service_error(
+                status,
+                UpdateIndexRequest::rpc_name(),
             ))
     }
     async fn index_metadata(
@@ -4774,6 +4926,17 @@ for MetastoreServiceGrpcServerAdapter {
         self.inner
             .clone()
             .create_index(request.into_inner())
+            .await
+            .map(tonic::Response::new)
+            .map_err(crate::error::grpc_error_to_grpc_status)
+    }
+    async fn update_index(
+        &self,
+        request: tonic::Request<UpdateIndexRequest>,
+    ) -> Result<tonic::Response<IndexMetadataResponse>, tonic::Status> {
+        self.inner
+            .clone()
+            .update_index(request.into_inner())
             .await
             .map(tonic::Response::new)
             .map_err(crate::error::grpc_error_to_grpc_status)
@@ -5229,6 +5392,34 @@ pub mod metastore_service_grpc_client {
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new("quickwit.metastore.MetastoreService", "CreateIndex"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Update an index.
+        pub async fn update_index(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateIndexRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::IndexMetadataResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/quickwit.metastore.MetastoreService/UpdateIndex",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("quickwit.metastore.MetastoreService", "UpdateIndex"),
                 );
             self.inner.unary(req, path, codec).await
         }
@@ -6008,6 +6199,14 @@ pub mod metastore_service_grpc_server {
             tonic::Response<super::CreateIndexResponse>,
             tonic::Status,
         >;
+        /// Update an index.
+        async fn update_index(
+            &self,
+            request: tonic::Request<super::UpdateIndexRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::IndexMetadataResponse>,
+            tonic::Status,
+        >;
         /// Returns the `IndexMetadata` of an index identified by its IndexID or its IndexUID.
         async fn index_metadata(
             &self,
@@ -6345,6 +6544,52 @@ pub mod metastore_service_grpc_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = CreateIndexSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/quickwit.metastore.MetastoreService/UpdateIndex" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateIndexSvc<T: MetastoreServiceGrpc>(pub Arc<T>);
+                    impl<
+                        T: MetastoreServiceGrpc,
+                    > tonic::server::UnaryService<super::UpdateIndexRequest>
+                    for UpdateIndexSvc<T> {
+                        type Response = super::IndexMetadataResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpdateIndexRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).update_index(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateIndexSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/quickwit/quickwit-proto/src/getters.rs
+++ b/quickwit/quickwit-proto/src/getters.rs
@@ -68,6 +68,7 @@ generate_getters! {
     ResetSourceCheckpointRequest,
     StageSplitsRequest,
     ToggleSourceRequest,
+    UpdateIndexRequest,
     UpdateSplitsDeleteOpstampRequest
 }
 

--- a/quickwit/quickwit-rest-client/src/rest_client.rs
+++ b/quickwit/quickwit-rest-client/src/rest_client.rs
@@ -26,7 +26,9 @@ use quickwit_indexing::actors::IndexingServiceCounters;
 pub use quickwit_ingest::CommitType;
 use quickwit_metastore::{IndexMetadata, Split, SplitInfo};
 use quickwit_search::SearchResponseRest;
-use quickwit_serve::{ListSplitsQueryParams, ListSplitsResponse, SearchRequestQueryString};
+use quickwit_serve::{
+    IndexUpdates, ListSplitsQueryParams, ListSplitsResponse, SearchRequestQueryString,
+};
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use reqwest::{Client, ClientBuilder, Method, StatusCode, Url};
 use serde::Serialize;
@@ -347,6 +349,21 @@ impl<'a> IndexClient<'a> {
                 Some(body),
                 self.timeout,
             )
+            .await?;
+        let index_metadata = response.deserialize().await?;
+        Ok(index_metadata)
+    }
+
+    pub async fn update(
+        &self,
+        index_id: &str,
+        index_updates: IndexUpdates,
+    ) -> Result<IndexMetadata, Error> {
+        let body = Bytes::from(serde_json::to_string(&index_updates)?);
+        let path = format!("indexes/{index_id}");
+        let response = self
+            .transport
+            .send::<()>(Method::PUT, &path, None, None, Some(body), self.timeout)
             .await?;
         let index_metadata = response.deserialize().await?;
         Ok(index_metadata)

--- a/quickwit/quickwit-serve/src/index_api/mod.rs
+++ b/quickwit/quickwit-serve/src/index_api/mod.rs
@@ -20,5 +20,5 @@
 mod rest_handler;
 
 pub use self::rest_handler::{
-    index_management_handlers, IndexApi, ListSplitsQueryParams, ListSplitsResponse,
+    index_management_handlers, IndexApi, IndexUpdates, ListSplitsQueryParams, ListSplitsResponse,
 };

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -529,7 +529,7 @@ async fn create_index(
 ///
 /// Remove #[serde(deny_unknown_fields)] when adding new fields to allow to ensure forward
 /// compatibility.
-#[derive(Deserialize, Debug, Eq, PartialEq, Default, utoipa::ToSchema)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct IndexUpdates {
     pub search_settings: SearchSettings,
@@ -1791,7 +1791,13 @@ mod tests {
                 .await;
             assert_eq!(resp.status(), 200);
             let resp_json: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
-            let expected_response_json = serde_json::json!({"default_search_fields":["body"]});
+            let expected_response_json = serde_json::json!({
+                "index_config": {
+                    "search_settings": {
+                        "default_search_fields": ["body"]
+                    }
+                }
+            });
             assert_json_include!(actual: resp_json, expected: expected_response_json);
         }
         {
@@ -1804,8 +1810,13 @@ mod tests {
                 .await;
             assert_eq!(resp.status(), 200);
             let resp_json: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
-            let expected_response_json =
-                serde_json::json!({"default_search_fields":["severity_text","body"]});
+            let expected_response_json = serde_json::json!({
+                "index_config": {
+                    "search_settings": {
+                        "default_search_fields": ["severity_text", "body"]
+                    }
+                }
+            });
             assert_json_include!(actual: resp_json, expected: expected_response_json);
         }
     }

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -532,7 +532,6 @@ async fn create_index(
 #[serde(deny_unknown_fields)] // Remove when adding new fields to allow to ensure forward compatibility
 pub struct IndexUpdates {
     pub search_settings: SearchSettings,
-    /// The
     #[serde(rename = "retention_policy")]
     pub retention_policy_opt: Option<RetentionPolicy>,
 }

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -117,7 +117,7 @@ use tracing::{debug, error, info, warn};
 use warp::{Filter, Rejection};
 
 pub use crate::build_info::{BuildInfo, RuntimeInfo};
-pub use crate::index_api::{ListSplitsQueryParams, ListSplitsResponse};
+pub use crate::index_api::{IndexUpdates, ListSplitsQueryParams, ListSplitsResponse};
 pub use crate::metrics::SERVE_METRICS;
 use crate::rate_modulator::RateModulator;
 #[cfg(test)]


### PR DESCRIPTION
### Description

Add an index update endpoint. For this first version, only `search_settings` and `retetention_policy` can be configured.

Notes:
- the janitor has a mechanism to [update the index metadata every hour](https://github.com/quickwit-oss/quickwit/blob/24dc8d5eab5b700a362e5e31f3fcd58e8c395ee0/quickwit/quickwit-janitor/src/actors/retention_policy_executor.rs#L175-L188), so the retention policy update will be taken into account at that moment
- `list_indexes_metadata` calls [are not proxied through the control plane](https://github.com/quickwit-oss/quickwit/blob/24dc8d5eab5b700a362e5e31f3fcd58e8c395ee0/quickwit/quickwit-metastore/src/metastore/control_plane_metastore.rs#L126-L131), so [each `root_search` goes directly to the metastore](https://github.com/quickwit-oss/quickwit/blob/24dc8d5eab5b700a362e5e31f3fcd58e8c395ee0/quickwit/quickwit-search/src/root.rs#L1021-L1025) to get the `search_settings` at each request which means that these changes  are immediately visible by searches

### How was this PR tested?

This PR has a good unit test coverage. The fact that `search_settings` updates are immediately taken into account is covered by an integration test.

I also tested that the openapi spec is correctly rendered by swagger
