### PR TITLE
Added an environment to control ingest v2 fetch batch len.

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -75,8 +75,6 @@ impl fmt::Debug for FetchStreamTask {
 }
 
 impl FetchStreamTask {
-    pub const DEFAULT_BATCH_NUM_BYTES: usize = 1024 * 1024; // 1 MiB
-
     pub fn spawn(
         open_fetch_stream_request: OpenFetchStreamRequest,
         mrecordlog: Arc<RwLock<Option<MultiRecordLogAsync>>>,


### PR DESCRIPTION
It is controlled by `QW_INGEST_BATCH_NUM_BYTES`.
The default is unchanged (1MiB), and the value is cached.
