### PR TITLE
Increase replication request timeout for unit tests

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
@@ -50,7 +50,7 @@ pub(super) const SYN_REPLICATION_STREAM_CAPACITY: usize = 5;
 
 /// Duration after which replication requests time out with [`ReplicationError::Timeout`].
 const REPLICATION_REQUEST_TIMEOUT: Duration = if cfg!(any(test, feature = "testsuite")) {
-    Duration::from_millis(10)
+    Duration::from_millis(50)
 } else {
     Duration::from_secs(3)
 };


### PR DESCRIPTION
### Description
Fixes flaky tests on macOS.

### How was this PR tested?
Ran `cargo test --manifest-path quickwit/Cargo.toml -p quickwit-ingest --lib -- test_ingester_persist_replicate` multiple times
