### PR TITLE
Update indexing settings

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -183,17 +183,12 @@ quickwit index create --endpoint=http://127.0.0.1:7280 --index-config wikipedia_
 ### index update
 
 `quickwit index update [args]`
-#### index update search-settings
-
-Updates default search settings.  
-`quickwit index update search-settings [args]`
 
 *Synopsis*
 
 ```bash
-quickwit index update search-settings
+quickwit index update
     --index <index>
-    --default-search-fields <default-search-fields>
 ```
 
 *Options*
@@ -201,19 +196,33 @@ quickwit index update search-settings
 | Option | Description |
 |-----------------|-------------|
 | `--index` | ID of the target index |
-| `--default-search-fields` | List of fields that Quickwit will search into if the user query does not explicitly target a field. Space-separated list, e.g. "field1 field2". If no value is provided, existing defaults are removed and queries without target field will fail. |
+#### index update search-settings
+
+Updates search settings.  
+`quickwit index update search-settings [args]`
+
+*Synopsis*
+
+```bash
+quickwit index update search-settings
+    --config-file <config-file>
+```
+
+*Options*
+
+| Option | Description |
+|-----------------|-------------|
+| `--config-file` | Location of a json, yaml or toml file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings. |
 #### index update retention-policy
 
-Configure or disable the retention policy.  
+Updates or disables the retention policy.  
 `quickwit index update retention-policy [args]`
 
 *Synopsis*
 
 ```bash
 quickwit index update retention-policy
-    --index <index>
-    [--period <period>]
-    [--schedule <schedule>]
+    [--config-file <config-file>]
     [--disable]
 ```
 
@@ -221,10 +230,25 @@ quickwit index update retention-policy
 
 | Option | Description |
 |-----------------|-------------|
-| `--index` | ID of the target index |
-| `--period` | Duration after which splits are dropped. Expressed in a human-readable way (`1 day`, `2 hours`, `1 week`, ...) |
-| `--schedule` | Frequency at which the retention policy is evaluated and applied. Expressed as a cron expression (0 0 * * * *) or human-readable form (hourly, daily, weekly, ...). |
-| `--disable` | Disable the retention policy. Old indexed data will not be cleaned up anymore. |
+| `--config-file` | Location of a json, yaml or toml file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy. |
+| `--disable` | Disables the retention policy. Old indexed data will not be cleaned up anymore. |
+#### index update indexing-settings
+
+Updates indexing settings.  
+`quickwit index update indexing-settings [args]`
+
+*Synopsis*
+
+```bash
+quickwit index update indexing-settings
+    --config-file <config-file>
+```
+
+*Options*
+
+| Option | Description |
+|-----------------|-------------|
+| `--config-file` | Location of a json, yaml or toml file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings. |
 ### index clear
 
 Clears an index: deletes all splits and resets checkpoint.  
@@ -368,6 +392,7 @@ quickwit index ingest
     [--input-path <input-path>]
     [--batch-size-limit <batch-size-limit>]
     [--wait]
+    [--v2]
     [--force]
     [--commit-timeout <commit-timeout>]
 ```
@@ -380,8 +405,9 @@ quickwit index ingest
 | `--input-path` | Location of the input file. |
 | `--batch-size-limit` | Size limit of each submitted document batch. |
 | `--wait` | Wait for all documents to be commited and available for search before exiting |
+| `--v2` | Ingest v2 (experimental! Do not use me.) |
 | `--force` | Force a commit after the last document is sent, and wait for all documents to be committed and available for search before exiting |
-| `--commit-timeout` | Timeout for ingest operations that require waiting for the final commit (`--wait` or `--force`). This is different from the `commit_timeout_secs` indexing setting which sets the maximum time before commiting splits after their creation. |
+| `--commit-timeout` | Timeout for ingest operations that require waiting for the final commit (`--wait` or `--force`). This is different from the `commit_timeout_secs` indexing setting, which sets the maximum time before commiting splits after their creation. |
 
 *Examples*
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -212,7 +212,7 @@ quickwit index update search-settings
 
 | Option | Description |
 |-----------------|-------------|
-| `--config-file` | Location of a json or yaml file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings. |
+| `--config-file` | Location of a JSON or YAML file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings. |
 #### index update retention-policy
 
 Updates or disables the retention policy.  
@@ -230,8 +230,8 @@ quickwit index update retention-policy
 
 | Option | Description |
 |-----------------|-------------|
-| `--config-file` | Location of a json or yaml file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy. |
-| `--disable` | Disables the retention policy. Old indexed data will not be cleaned up anymore. |
+| `--config-file` | Location of a JSON or YAML file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy. |
+| `--disable` | Disables the retention policy and keeps indexed data forever. |
 #### index update indexing-settings
 
 Updates indexing settings.  
@@ -248,7 +248,7 @@ quickwit index update indexing-settings
 
 | Option | Description |
 |-----------------|-------------|
-| `--config-file` | Location of a json or yaml file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings. |
+| `--config-file` | Location of a JSON or YAML file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings. |
 ### index clear
 
 Clears an index: deletes all splits and resets checkpoint.  

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -212,7 +212,7 @@ quickwit index update search-settings
 
 | Option | Description |
 |-----------------|-------------|
-| `--config-file` | Location of a json, yaml or toml file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings. |
+| `--config-file` | Location of a json or yaml file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings. |
 #### index update retention-policy
 
 Updates or disables the retention policy.  
@@ -230,7 +230,7 @@ quickwit index update retention-policy
 
 | Option | Description |
 |-----------------|-------------|
-| `--config-file` | Location of a json, yaml or toml file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy. |
+| `--config-file` | Location of a json or yaml file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy. |
 | `--disable` | Disables the retention policy. Old indexed data will not be cleaned up anymore. |
 #### index update indexing-settings
 
@@ -248,7 +248,7 @@ quickwit index update indexing-settings
 
 | Option | Description |
 |-----------------|-------------|
-| `--config-file` | Location of a json, yaml or toml file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings. |
+| `--config-file` | Location of a json or yaml file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings. |
 ### index clear
 
 Clears an index: deletes all splits and resets checkpoint.  

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -350,6 +350,7 @@ Calling the update endpoint with the following payload will remove the current r
     }
 }
 ```
+:::
 
 #### Response
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -318,8 +318,8 @@ PUT api/v1/indexes/<index id>/retention-policy
 ```
 
 These endpoints follows PUT semantics (not PATCH), which means that all the fields of the updated configuration are replaced by the values specified in the request. Values that are not specified will be reset to their defaults. The API accepts JSON with `content-type: application/json` and YAML `content-type: application/yaml`.
-- The search settings update is automatically picked up by the janitor service on its next state refresh.
-- The retention policy update is automatically picked up when the next query is executed.
+- The retention policy update is automatically picked up by the janitor service on its next state refresh.
+- The search settings update is automatically picked up by searcher nodes when the next query is executed.
 - The indexing settings update is not automatically picked up by the indexer nodes, they need to be manually restarted.
 
 #### PUT payloads

--- a/quickwit/quickwit-cli/src/index/update.rs
+++ b/quickwit/quickwit-cli/src/index/update.rs
@@ -42,15 +42,17 @@ pub fn build_index_update_command() -> Command {
         .subcommand(
             Command::new("search-settings")
                 .about("Updates search settings.")
+                .long_about("Updates search settings. The update is automatically picked up when the next query is executed.")
                 .args(&[
-                    arg!(--"config-file" <PATH> "Location of a json, yaml or toml file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings.")
+                    arg!(--"config-file" <PATH> "Location of a json or yaml file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings.")
                         .required(true),
                 ]))
         .subcommand(
             Command::new("retention-policy")
                 .about("Updates or disables the retention policy.")
+                .long_about("Updates or disables the retention policy. The update is automatically picked up by the janitor service on its next state refresh.")
                 .args(&[
-                    arg!(--"config-file" <PATH> "Location of a json, yaml or toml file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy.")
+                    arg!(--"config-file" <PATH> "Location of a json or yaml file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy.")
                         .required(false),
                     arg!(--disable "Disables the retention policy. Old indexed data will not be cleaned up anymore.")
                         .required(false),
@@ -59,8 +61,9 @@ pub fn build_index_update_command() -> Command {
         .subcommand(
             Command::new("indexing-settings")
                 .about("Updates indexing settings.")
+                .long_about("Updates indexing settings. The update is not automatically picked up by the indexer nodes, they need to be manually restarted.")
                 .args(&[
-                    arg!(--"config-file" <PATH> "Location of a json, yaml or toml file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings.")
+                    arg!(--"config-file" <PATH> "Location of a json or yaml file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings.")
                         .required(true),
                 ])
 

--- a/quickwit/quickwit-cli/src/index/update.rs
+++ b/quickwit/quickwit-cli/src/index/update.rs
@@ -44,7 +44,7 @@ pub fn build_index_update_command() -> Command {
                 .about("Updates search settings.")
                 .long_about("Updates search settings. The update is automatically picked up when the next query is executed.")
                 .args(&[
-                    arg!(--"config-file" <PATH> "Location of a json or yaml file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings.")
+                    arg!(--"config-file" <PATH> "Location of a JSON or YAML file containing the new search settings. See https://quickwit.io/docs/configuration/index-config#search-settings.")
                         .required(true),
                 ]))
         .subcommand(
@@ -52,9 +52,9 @@ pub fn build_index_update_command() -> Command {
                 .about("Updates or disables the retention policy.")
                 .long_about("Updates or disables the retention policy. The update is automatically picked up by the janitor service on its next state refresh.")
                 .args(&[
-                    arg!(--"config-file" <PATH> "Location of a json or yaml file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy.")
+                    arg!(--"config-file" <PATH> "Location of a JSON or YAML file containing the new retention policy. See https://quickwit.io/docs/configuration/index-config#retention-policy.")
                         .required(false),
-                    arg!(--disable "Disables the retention policy. Old indexed data will not be cleaned up anymore.")
+                    arg!(--disable "Disables the retention policy and keeps indexed data forever.")
                         .required(false),
                 ])
         )
@@ -63,7 +63,7 @@ pub fn build_index_update_command() -> Command {
                 .about("Updates indexing settings.")
                 .long_about("Updates indexing settings. The update is not automatically picked up by the indexer nodes, they need to be manually restarted.")
                 .args(&[
-                    arg!(--"config-file" <PATH> "Location of a json or yaml file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings.")
+                    arg!(--"config-file" <PATH> "Location of a JSON or YAML file containing the new indexing settings. See https://quickwit.io/docs/configuration/index-config#indexing-settings.")
                         .required(true),
                 ])
 
@@ -173,14 +173,14 @@ async fn update_from_file(
     field: UpdateConfigField,
 ) -> anyhow::Result<()> {
     let storage_resolver = StorageResolver::unconfigured();
-    let content = load_file(&storage_resolver, config_file).await?;
+    let config_content = load_file(&storage_resolver, config_file).await?;
     client_args
         .client()
         .indexes()
         .update(
             index_id,
             field,
-            Bytes::from(content.as_slice().to_owned()),
+            Bytes::from(config_content.as_slice().to_owned()),
             ConfigFormat::sniff_from_uri(config_file)?,
         )
         .await?;

--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -231,6 +231,11 @@ pub async fn create_test_env(
     fs::write(&log_docs_path, LOGS_JSON_DOCS)?;
     let wikipedia_docs_path = resources_dir_path.join("wikis.json");
     fs::write(&wikipedia_docs_path, WIKI_JSON_DOCS)?;
+    let retention_policy_update_path = resources_dir_path.join("retention_policy_update.json");
+    fs::write(
+        &retention_policy_update_path,
+        r#"{"period": "1 week", "schedule": "daily"}"#,
+    )?;
 
     let mut resource_files = HashMap::new();
     resource_files.insert("config", node_config_path);
@@ -238,6 +243,7 @@ pub async fn create_test_env(
     resource_files.insert("index_config_without_uri", index_config_without_uri_path);
     resource_files.insert("logs", log_docs_path);
     resource_files.insert("wiki", wikipedia_docs_path);
+    resource_files.insert("retention_policy_update", retention_policy_update_path);
 
     let config_uri =
         Uri::from_str(&format!("file://{}", resource_files["config"].display())).unwrap();

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -519,9 +519,9 @@ impl TestableForRegression for IndexConfig {
     }
 }
 
-/// Represents an update to one of the updatable index configuration field.
+/// Represents an update to one of the updatable index configuration attribute.
 #[derive(Clone, Debug)]
-pub enum IndexUpdate {
+pub enum IndexConfigUpdate {
     SearchSettings(SearchSettings),
     IndexingSettings(IndexingSettings),
     RetentionPolicy(Option<RetentionPolicy>),

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -520,7 +520,8 @@ impl TestableForRegression for IndexConfig {
 }
 
 /// Represents an update to one of the updatable index configuration attribute.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "field", content = "config")]
 pub enum IndexConfigUpdate {
     SearchSettings(SearchSettings),
     IndexingSettings(IndexingSettings),

--- a/quickwit/quickwit-config/src/index_config/mod.rs
+++ b/quickwit/quickwit-config/src/index_config/mod.rs
@@ -519,6 +519,14 @@ impl TestableForRegression for IndexConfig {
     }
 }
 
+/// Represents an update to one of the updatable index configuration field.
+#[derive(Clone, Debug)]
+pub enum IndexUpdate {
+    SearchSettings(SearchSettings),
+    IndexingSettings(IndexingSettings),
+    RetentionPolicy(Option<RetentionPolicy>),
+}
+
 /// Builds and returns the doc mapper associated with index.
 pub fn build_doc_mapper(
     doc_mapping: &DocMapping,

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -46,8 +46,8 @@ pub use cluster_config::ClusterConfig;
 // See #2048
 use index_config::serialize::{IndexConfigV0_8, VersionedIndexConfig};
 pub use index_config::{
-    build_doc_mapper, load_index_config_from_user_config, DocMapping, IndexConfig, IndexUpdate,
-    IndexingResources, IndexingSettings, RetentionPolicy, SearchSettings,
+    build_doc_mapper, load_index_config_from_user_config, DocMapping, IndexConfig,
+    IndexConfigUpdate, IndexingResources, IndexingSettings, RetentionPolicy, SearchSettings,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -211,7 +211,7 @@ impl ConfigFormat {
                     serde_json::from_reader(StripComments::new(payload))?;
                 if let Some(version_value) = json_value.get_mut("version") {
                     if let Some(version_number) = version_value.as_u64() {
-                        warn!(version_value=?version_value, "`version` is supposed to be a string");
+                        warn!(version_value=?version_value, "`version` should be a string, not an integer");
                         *version_value = JsonValue::String(version_number.to_string());
                     }
                 }
@@ -224,7 +224,7 @@ impl ConfigFormat {
                     toml::from_str(payload_str).context("failed to parse TOML file")?;
                 if let Some(version_value) = toml_value.get_mut("version") {
                     if let Some(version_number) = version_value.as_integer() {
-                        warn!(version_value=?version_value, "`version` is supposed to be a string");
+                        warn!(version_value=?version_value, "`version` should be a string, not an integer");
                         *version_value = toml::Value::String(version_number.to_string());
                     }
                 }

--- a/quickwit/quickwit-integration-tests/src/tests/index_update_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/index_update_tests.rs
@@ -20,10 +20,11 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
+use hyper::body::Bytes;
 use quickwit_config::service::QuickwitService;
-use quickwit_config::SearchSettings;
-use quickwit_rest_client::rest_client::CommitType;
-use quickwit_serve::{IndexUpdates, SearchRequestQueryString};
+use quickwit_config::ConfigFormat;
+use quickwit_rest_client::rest_client::{CommitType, UpdateConfigField};
+use quickwit_serve::SearchRequestQueryString;
 use serde_json::json;
 
 use crate::ingest_json;
@@ -121,12 +122,9 @@ async fn test_update_on_multi_nodes_cluster() {
         .indexes()
         .update(
             "my-updatable-index",
-            IndexUpdates {
-                search_settings: SearchSettings {
-                    default_search_fields: vec!["title".to_string(), "body".to_string()],
-                },
-                retention_policy_opt: None,
-            },
+            UpdateConfigField::SearchSettings,
+            Bytes::from(r#"{"default_search_fields":["title", "body"]}"#),
+            ConfigFormat::Json,
         )
         .await
         .unwrap();

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -30,7 +30,9 @@ use std::ops::Bound;
 
 use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
-use quickwit_config::{RetentionPolicy, SearchSettings, SourceConfig, INGEST_V2_SOURCE_ID};
+use quickwit_config::{
+    IndexingSettings, RetentionPolicy, SearchSettings, SourceConfig, INGEST_V2_SOURCE_ID,
+};
 use quickwit_proto::metastore::{
     AcquireShardsRequest, AcquireShardsResponse, DeleteQuery, DeleteShardsRequest, DeleteTask,
     EntityKind, ListShardsSubrequest, ListShardsSubresponse, MetastoreError, MetastoreResult,
@@ -224,6 +226,13 @@ impl FileBackedIndex {
     pub fn set_retention_policy(&mut self, retention_policy_opt: Option<RetentionPolicy>) -> bool {
         let is_mutation = self.metadata.index_config.retention_policy_opt != retention_policy_opt;
         self.metadata.index_config.retention_policy_opt = retention_policy_opt;
+        is_mutation
+    }
+
+    /// Replaces the retention policy in the index config, returning whether a mutation occurred.
+    pub fn set_indexing_settings(&mut self, indexing_settings: IndexingSettings) -> bool {
+        let is_mutation = self.metadata.index_config.indexing_settings != indexing_settings;
+        self.metadata.index_config.indexing_settings = indexing_settings;
         is_mutation
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -41,7 +41,7 @@ use async_trait::async_trait;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use quickwit_common::ServiceStream;
-use quickwit_config::{IndexTemplate, IndexUpdate};
+use quickwit_config::{IndexConfigUpdate, IndexTemplate};
 use quickwit_proto::metastore::{
     serde_utils, AcquireShardsRequest, AcquireShardsResponse, AddSourceRequest, CreateIndexRequest,
     CreateIndexResponse, CreateIndexTemplateRequest, DeleteIndexRequest,
@@ -461,15 +461,15 @@ impl MetastoreService for FileBackedMetastore {
         &mut self,
         request: UpdateIndexRequest,
     ) -> MetastoreResult<IndexMetadataResponse> {
-        let update = request.deserialize_update()?;
+        let update = request.deserialize_index_config_update()?;
         let index_uid = request.index_uid();
 
         let metadata = self
             .mutate(index_uid, |index| {
                 let mutation_occured = match update {
-                    IndexUpdate::SearchSettings(s) => index.set_search_settings(s),
-                    IndexUpdate::RetentionPolicy(s) => index.set_retention_policy(s),
-                    IndexUpdate::IndexingSettings(s) => index.set_indexing_settings(s),
+                    IndexConfigUpdate::SearchSettings(s) => index.set_search_settings(s),
+                    IndexConfigUpdate::RetentionPolicy(s) => index.set_retention_policy(s),
+                    IndexConfigUpdate::IndexingSettings(s) => index.set_indexing_settings(s),
                 };
                 if mutation_occured {
                     Ok(MutationOccurred::Yes(index.metadata().clone()))

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -182,7 +182,7 @@ impl CreateIndexResponseExt for CreateIndexResponse {
 
 /// Helper trait to build a [`UpdateIndexRequest`] and deserialize its payload.
 pub trait UpdateIndexRequestExt {
-    /// Creates a new [`UpdateIndexRequest`] from an `IndexUpdate`.
+    /// Creates a new [`UpdateIndexRequest`] from an [`IndexUpdate`].
     fn try_from_update(
         index_uid: impl Into<IndexUid>,
         update: &IndexUpdate,

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -25,7 +25,7 @@ use quickwit_common::pretty::PrettySample;
 use quickwit_common::uri::Uri;
 use quickwit_common::ServiceStream;
 use quickwit_config::{
-    validate_index_id_pattern, IndexTemplate, IndexTemplateId, IndexUpdate,
+    validate_index_id_pattern, IndexConfigUpdate, IndexTemplate, IndexTemplateId,
     PostgresMetastoreConfig, INGEST_V2_SOURCE_ID,
 };
 use quickwit_proto::ingest::{Shard, ShardState};
@@ -406,24 +406,24 @@ impl MetastoreService for PostgresqlMetastore {
         &mut self,
         request: UpdateIndexRequest,
     ) -> MetastoreResult<IndexMetadataResponse> {
-        let update = request.deserialize_update()?;
+        let update = request.deserialize_index_config_update()?;
         let index_uid: IndexUid = request.index_uid().clone();
         let updated_metadata = run_with_tx!(self.connection_pool, tx, {
             mutate_index_metadata::<MetastoreError, _>(tx, index_uid, |index_metadata| match update
             {
-                IndexUpdate::SearchSettings(s)
+                IndexConfigUpdate::SearchSettings(s)
                     if index_metadata.index_config.search_settings != s =>
                 {
                     index_metadata.index_config.search_settings = s;
                     Ok(MutationOccurred::Yes(()))
                 }
-                IndexUpdate::IndexingSettings(s)
+                IndexConfigUpdate::IndexingSettings(s)
                     if index_metadata.index_config.indexing_settings != s =>
                 {
                     index_metadata.index_config.indexing_settings = s;
                     Ok(MutationOccurred::Yes(()))
                 }
-                IndexUpdate::RetentionPolicy(s)
+                IndexConfigUpdate::RetentionPolicy(s)
                     if index_metadata.index_config.retention_policy_opt != s =>
                 {
                     index_metadata.index_config.retention_policy_opt = s;

--- a/quickwit/quickwit-metastore/src/tests/index.rs
+++ b/quickwit/quickwit-metastore/src/tests/index.rs
@@ -28,8 +28,8 @@
 use quickwit_common::rand::append_random_suffix;
 use quickwit_config::merge_policy_config::{MergePolicyConfig, StableLogMergePolicyConfig};
 use quickwit_config::{
-    IndexConfig, IndexUpdate, IndexingSettings, RetentionPolicy, SearchSettings, SourceConfig,
-    CLI_SOURCE_ID, INGEST_V2_SOURCE_ID,
+    IndexConfig, IndexConfigUpdate, IndexingSettings, RetentionPolicy, SearchSettings,
+    SourceConfig, CLI_SOURCE_ID, INGEST_V2_SOURCE_ID,
 };
 use quickwit_proto::metastore::{
     CreateIndexRequest, DeleteIndexRequest, EntityKind, IndexMetadataRequest,
@@ -119,9 +119,9 @@ pub async fn test_metastore_update_retention_policy<
         new_retention_policy_opt.clone(),
         None,
     ] {
-        let index_update = UpdateIndexRequest::try_from_update(
+        let index_update = UpdateIndexRequest::try_from_index_config_update(
             index_uid.clone(),
-            &IndexUpdate::RetentionPolicy(loop_retention_policy_opt.clone()),
+            &IndexConfigUpdate::RetentionPolicy(loop_retention_policy_opt.clone()),
         )
         .unwrap();
         let response_metadata = metastore
@@ -160,9 +160,9 @@ pub async fn test_metastore_update_search_settings<
         vec!["body".to_owned(), "owner".to_owned()],
         vec![],
     ] {
-        let index_update = UpdateIndexRequest::try_from_update(
+        let index_update = UpdateIndexRequest::try_from_index_config_update(
             index_uid.clone(),
-            &IndexUpdate::SearchSettings(SearchSettings {
+            &IndexConfigUpdate::SearchSettings(SearchSettings {
                 default_search_fields: loop_search_settings.clone(),
             }),
         )
@@ -212,9 +212,9 @@ pub async fn test_metastore_update_indexing_settings<
             ..Default::default()
         }),
     ] {
-        let index_update = UpdateIndexRequest::try_from_update(
+        let index_update = UpdateIndexRequest::try_from_index_config_update(
             index_uid.clone(),
-            &IndexUpdate::IndexingSettings(IndexingSettings {
+            &IndexConfigUpdate::IndexingSettings(IndexingSettings {
                 merge_policy: loop_indexing_settings.clone(),
                 ..Default::default()
             }),

--- a/quickwit/quickwit-metastore/src/tests/index.rs
+++ b/quickwit/quickwit-metastore/src/tests/index.rs
@@ -25,13 +25,12 @@
 //  - list_indexes
 //  - delete_index
 
-use std::collections::BTreeSet;
-
 use quickwit_common::rand::append_random_suffix;
+use quickwit_config::merge_policy_config::{MergePolicyConfig, StableLogMergePolicyConfig};
 use quickwit_config::{
-    IndexConfig, RetentionPolicy, SearchSettings, SourceConfig, CLI_SOURCE_ID, INGEST_V2_SOURCE_ID,
+    IndexConfig, IndexUpdate, IndexingSettings, RetentionPolicy, SearchSettings, SourceConfig,
+    CLI_SOURCE_ID, INGEST_V2_SOURCE_ID,
 };
-use quickwit_doc_mapper::FieldMappingType;
 use quickwit_proto::metastore::{
     CreateIndexRequest, DeleteIndexRequest, EntityKind, IndexMetadataRequest,
     ListIndexesMetadataRequest, MetastoreError, MetastoreService, StageSplitsRequest,
@@ -84,9 +83,9 @@ pub async fn test_metastore_create_index<
     cleanup_index(&mut metastore, index_uid).await;
 }
 
-pub async fn test_metastore_update_index<
+async fn setup_metastore_for_update<
     MetastoreToTest: MetastoreService + MetastoreServiceExt + DefaultForTest,
->() {
+>() -> (MetastoreToTest, IndexUid) {
     let mut metastore = MetastoreToTest::default_for_test().await;
 
     let index_id = append_random_suffix("test-update-index");
@@ -101,51 +100,28 @@ pub async fn test_metastore_update_index<
         .index_uid()
         .clone();
 
-    let index_metadata = metastore
-        .index_metadata(IndexMetadataRequest::for_index_id(index_id.to_string()))
-        .await
-        .unwrap()
-        .deserialize_index_metadata()
-        .unwrap();
+    (metastore, index_uid)
+}
 
-    // use all fields that are currently not set as default
-    let current_defaults = BTreeSet::from_iter(
-        index_metadata
-            .index_config
-            .search_settings
-            .default_search_fields,
-    );
-    let new_search_setting = SearchSettings {
-        default_search_fields: index_metadata
-            .index_config
-            .doc_mapping
-            .field_mappings
-            .iter()
-            .filter(|f| matches!(f.mapping_type, FieldMappingType::Text(..)))
-            .filter(|f| !current_defaults.contains(&f.name))
-            .map(|f| f.name.clone())
-            .collect(),
-    };
-
+pub async fn test_metastore_update_retention_policy<
+    MetastoreToTest: MetastoreService + MetastoreServiceExt + DefaultForTest,
+>() {
+    let (mut metastore, index_uid) = setup_metastore_for_update::<MetastoreToTest>().await;
     let new_retention_policy_opt = Some(RetentionPolicy {
         retention_period: String::from("3 days"),
         evaluation_schedule: String::from("daily"),
     });
-    assert_ne!(
-        index_metadata.index_config.retention_policy_opt, new_retention_policy_opt,
-        "original and updated value are the same, test became inefficient"
-    );
 
-    // run same update twice to check idempotence, then None as a corner case check
+    // set and unset retention policy multiple times
     for loop_retention_policy_opt in [
+        None,
         new_retention_policy_opt.clone(),
         new_retention_policy_opt.clone(),
         None,
     ] {
-        let index_update = UpdateIndexRequest::try_from_updates(
+        let index_update = UpdateIndexRequest::try_from_update(
             index_uid.clone(),
-            &new_search_setting,
-            &loop_retention_policy_opt,
+            &IndexUpdate::RetentionPolicy(loop_retention_policy_opt.clone()),
         )
         .unwrap();
         let response_metadata = metastore
@@ -156,22 +132,117 @@ pub async fn test_metastore_update_index<
             .unwrap();
         assert_eq!(response_metadata.index_uid, index_uid);
         assert_eq!(
-            response_metadata.index_config.search_settings,
-            new_search_setting
-        );
-        assert_eq!(
             response_metadata.index_config.retention_policy_opt,
             loop_retention_policy_opt
         );
         let updated_metadata = metastore
-            .index_metadata(IndexMetadataRequest::for_index_id(index_id.to_string()))
+            .index_metadata(IndexMetadataRequest::for_index_id(
+                index_uid.index_id.to_string(),
+            ))
             .await
             .unwrap()
             .deserialize_index_metadata()
             .unwrap();
         assert_eq!(response_metadata, updated_metadata);
     }
+    cleanup_index(&mut metastore, index_uid).await;
+}
 
+pub async fn test_metastore_update_search_settings<
+    MetastoreToTest: MetastoreService + MetastoreServiceExt + DefaultForTest,
+>() {
+    let (mut metastore, index_uid) = setup_metastore_for_update::<MetastoreToTest>().await;
+
+    for loop_search_settings in [
+        vec![],
+        vec!["body".to_owned()],
+        vec!["body".to_owned()],
+        vec!["body".to_owned(), "owner".to_owned()],
+        vec![],
+    ] {
+        let index_update = UpdateIndexRequest::try_from_update(
+            index_uid.clone(),
+            &IndexUpdate::SearchSettings(SearchSettings {
+                default_search_fields: loop_search_settings.clone(),
+            }),
+        )
+        .unwrap();
+        let response_metadata = metastore
+            .update_index(index_update)
+            .await
+            .unwrap()
+            .deserialize_index_metadata()
+            .unwrap();
+        assert_eq!(
+            response_metadata
+                .index_config
+                .search_settings
+                .default_search_fields,
+            loop_search_settings
+        );
+        let updated_metadata = metastore
+            .index_metadata(IndexMetadataRequest::for_index_id(
+                index_uid.index_id.to_string(),
+            ))
+            .await
+            .unwrap()
+            .deserialize_index_metadata()
+            .unwrap();
+        assert_eq!(
+            updated_metadata
+                .index_config
+                .search_settings
+                .default_search_fields,
+            loop_search_settings
+        );
+    }
+    cleanup_index(&mut metastore, index_uid).await;
+}
+
+pub async fn test_metastore_update_indexing_settings<
+    MetastoreToTest: MetastoreService + MetastoreServiceExt + DefaultForTest,
+>() {
+    let (mut metastore, index_uid) = setup_metastore_for_update::<MetastoreToTest>().await;
+
+    for loop_indexing_settings in [
+        MergePolicyConfig::Nop,
+        MergePolicyConfig::Nop,
+        MergePolicyConfig::StableLog(StableLogMergePolicyConfig {
+            merge_factor: 5,
+            ..Default::default()
+        }),
+    ] {
+        let index_update = UpdateIndexRequest::try_from_update(
+            index_uid.clone(),
+            &IndexUpdate::IndexingSettings(IndexingSettings {
+                merge_policy: loop_indexing_settings.clone(),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        let resp_metadata = metastore
+            .update_index(index_update)
+            .await
+            .unwrap()
+            .deserialize_index_metadata()
+            .unwrap();
+        assert_eq!(
+            resp_metadata.index_config.indexing_settings.merge_policy,
+            loop_indexing_settings
+        );
+        let updated_metadata = metastore
+            .index_metadata(IndexMetadataRequest::for_index_id(
+                index_uid.index_id.to_string(),
+            ))
+            .await
+            .unwrap()
+            .deserialize_index_metadata()
+            .unwrap();
+        assert_eq!(
+            updated_metadata.index_config.indexing_settings.merge_policy,
+            loop_indexing_settings
+        );
+    }
     cleanup_index(&mut metastore, index_uid).await;
 }
 

--- a/quickwit/quickwit-metastore/src/tests/mod.rs
+++ b/quickwit/quickwit-metastore/src/tests/mod.rs
@@ -187,9 +187,21 @@ macro_rules! metastore_test_suite {
             }
 
             #[tokio::test]
-            async fn test_metastore_update_index() {
+            async fn test_metastore_update_retention_policy() {
                 let _ = tracing_subscriber::fmt::try_init();
-                $crate::tests::index::test_metastore_update_index::<$metastore_type>().await;
+                $crate::tests::index::test_metastore_update_retention_policy::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
+            async fn test_metastore_update_search_settings() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_update_search_settings::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
+            async fn test_metastore_update_indexing_settings() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_update_indexing_settings::<$metastore_type>().await;
             }
 
             #[tokio::test]

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -210,8 +210,8 @@ enum UpdatedIndexConfig {
 
 message UpdateIndexRequest {
   quickwit.common.IndexUid index_uid = 1;
-  UpdatedIndexConfig target_config = 2; 
-  optional string config_json = 3;
+  // JSON representation of the updated config field.
+  string updated_config_json = 2;
 }
 
 message ListIndexesMetadataRequest {

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -202,10 +202,16 @@ message CreateIndexResponse {
   string index_metadata_json = 2;
 }
 
+enum UpdatedIndexConfig {
+  SEARCH_SETTINGS = 0;
+  INDEXING_SETTINGS = 1;
+  RETENTION_POLICY = 2;
+}
+
 message UpdateIndexRequest {
   quickwit.common.IndexUid index_uid = 1;
-  string search_settings_json = 2;
-  optional string retention_policy_json = 3;
+  UpdatedIndexConfig target_config = 2; 
+  optional string config_json = 3;
 }
 
 message ListIndexesMetadataRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -26,10 +26,10 @@ pub struct CreateIndexResponse {
 pub struct UpdateIndexRequest {
     #[prost(message, optional, tag = "1")]
     pub index_uid: ::core::option::Option<crate::types::IndexUid>,
-    #[prost(string, tag = "2")]
-    pub search_settings_json: ::prost::alloc::string::String,
+    #[prost(enumeration = "UpdatedIndexConfig", tag = "2")]
+    pub target_config: i32,
     #[prost(string, optional, tag = "3")]
-    pub retention_policy_json: ::core::option::Option<::prost::alloc::string::String>,
+    pub config_json: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -505,6 +505,37 @@ impl SourceType {
             "SOURCE_TYPE_PULSAR" => Some(Self::Pulsar),
             "SOURCE_TYPE_VEC" => Some(Self::Vec),
             "SOURCE_TYPE_VOID" => Some(Self::Void),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum UpdatedIndexConfig {
+    SearchSettings = 0,
+    IndexingSettings = 1,
+    RetentionPolicy = 2,
+}
+impl UpdatedIndexConfig {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            UpdatedIndexConfig::SearchSettings => "SEARCH_SETTINGS",
+            UpdatedIndexConfig::IndexingSettings => "INDEXING_SETTINGS",
+            UpdatedIndexConfig::RetentionPolicy => "RETENTION_POLICY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SEARCH_SETTINGS" => Some(Self::SearchSettings),
+            "INDEXING_SETTINGS" => Some(Self::IndexingSettings),
+            "RETENTION_POLICY" => Some(Self::RetentionPolicy),
             _ => None,
         }
     }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -26,10 +26,9 @@ pub struct CreateIndexResponse {
 pub struct UpdateIndexRequest {
     #[prost(message, optional, tag = "1")]
     pub index_uid: ::core::option::Option<crate::types::IndexUid>,
-    #[prost(enumeration = "UpdatedIndexConfig", tag = "2")]
-    pub target_config: i32,
-    #[prost(string, optional, tag = "3")]
-    pub config_json: ::core::option::Option<::prost::alloc::string::String>,
+    /// JSON representation of the updated config field.
+    #[prost(string, tag = "2")]
+    pub updated_config_json: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-serve/src/index_api/mod.rs
+++ b/quickwit/quickwit-serve/src/index_api/mod.rs
@@ -20,5 +20,5 @@
 mod rest_handler;
 
 pub use self::rest_handler::{
-    index_management_handlers, IndexApi, IndexUpdates, ListSplitsQueryParams, ListSplitsResponse,
+    index_management_handlers, IndexApi, ListSplitsQueryParams, ListSplitsResponse,
 };

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -117,7 +117,7 @@ use tracing::{debug, error, info, warn};
 use warp::{Filter, Rejection};
 
 pub use crate::build_info::{BuildInfo, RuntimeInfo};
-pub use crate::index_api::{IndexUpdates, ListSplitsQueryParams, ListSplitsResponse};
+pub use crate::index_api::{ListSplitsQueryParams, ListSplitsResponse};
 pub use crate::metrics::SERVE_METRICS;
 use crate::rate_modulator::RateModulator;
 #[cfg(test)]


### PR DESCRIPTION
### Description

- Add the indexing settings to the update APIs
- Split the update APIs to one route per updatable field to avoid side effects (e.g not specifying the retention policy drops it)
- Simplify the CLI to be a very basic client for the APIs that read the input body from files

### How was this PR tested?

Unit tests and validated that swagger works fine.
