### PR TITLE
change dashboards 's timezone to null

### DIFF
--- a/monitoring/grafana/dashboards/indexers.json
+++ b/monitoring/grafana/dashboards/indexers.json
@@ -1242,7 +1242,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "utc",
+  "timezone": "browser",
   "title": "Quickwit Indexers",
   "uid": "quickwit-indexers",
   "version": 2,

--- a/monitoring/grafana/dashboards/indexers.json
+++ b/monitoring/grafana/dashboards/indexers.json
@@ -1242,7 +1242,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "",
   "title": "Quickwit Indexers",
   "uid": "quickwit-indexers",
   "version": 2,

--- a/monitoring/grafana/dashboards/ingesters.json
+++ b/monitoring/grafana/dashboards/ingesters.json
@@ -637,7 +637,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "",
   "title": "Quickwit Ingesters",
   "uid": "DjSPsTvSz",
   "version": 1,

--- a/monitoring/grafana/dashboards/ingesters.json
+++ b/monitoring/grafana/dashboards/ingesters.json
@@ -637,7 +637,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "utc",
+  "timezone": "browser",
   "title": "Quickwit Ingesters",
   "uid": "DjSPsTvSz",
   "version": 1,

--- a/monitoring/grafana/dashboards/metastore.json
+++ b/monitoring/grafana/dashboards/metastore.json
@@ -384,7 +384,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "",
   "title": "Quickwit Metastore",
   "uid": "quickwit-metastore",
   "version": 1,

--- a/monitoring/grafana/dashboards/metastore.json
+++ b/monitoring/grafana/dashboards/metastore.json
@@ -384,7 +384,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "utc",
+  "timezone": "browser",
   "title": "Quickwit Metastore",
   "uid": "quickwit-metastore",
   "version": 1,

--- a/monitoring/grafana/dashboards/searchers.json
+++ b/monitoring/grafana/dashboards/searchers.json
@@ -1204,7 +1204,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "utc",
+  "timezone": "browser",
   "title": "Quickwit Searchers",
   "uid": "quickwit-searchers",
   "version": 1,

--- a/monitoring/grafana/dashboards/searchers.json
+++ b/monitoring/grafana/dashboards/searchers.json
@@ -1204,7 +1204,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "",
   "title": "Quickwit Searchers",
   "uid": "quickwit-searchers",
   "version": 1,


### PR DESCRIPTION
### Description

Change Grafana dashboard timezone to browser from utc, users can see dashboard with the local time.
