### PR TITLE
External Postgres metastore for ECS distrib

### DIFF
--- a/distribution/ecs/README.md
+++ b/distribution/ecs/README.md
@@ -33,7 +33,7 @@ Metastore database backups are disabled as restoring one would lead to
 inconsistencies with the index store on S3. To ensure high availability, you
 should enable `rds_config.multi_az` instead. To use your own Postgres database
 instead of creating a new RDS instance, configure the
-`external_postgres_uri_parameter_arn` variable (e.g
+`external_postgres_uri_ssm_parameter_arn` variable (e.g
 `postgres://user:password@domain:port/db`).
 
 Using NAT Gateways for the image registry is quite costly (approx. $0.05/hour/AZ). If

--- a/distribution/ecs/README.md
+++ b/distribution/ecs/README.md
@@ -31,8 +31,10 @@ file.
 
 Metastore database backups are disabled as restoring one would lead to
 inconsistencies with the index store on S3. To ensure high availability, you
-should enable `rds_config.multi_az` instead. The module currently doesn't allow
-using an externally provided metastore.
+should enable `rds_config.multi_az` instead. To use your own Postgres database
+instead of creating a new RDS instance, configure the
+`external_postgres_uri_parameter_arn` variable (e.g
+`postgres://user:password@domain:port/db`).
 
 Using NAT Gateways for the image registry is quite costly (approx. $0.05/hour/AZ). If
 you are not already using NAT Gateways in the AZs where Quickwit will be

--- a/distribution/ecs/example/terraform.tf
+++ b/distribution/ecs/example/terraform.tf
@@ -71,7 +71,7 @@ module "quickwit" {
   #   multi_az       = false
   # }
 
-  # external_postgres_uri_parameter_arn = aws_ssm_parameter.postgres_uri.arn
+  # external_postgres_uri_ssm_parameter_arn = aws_ssm_parameter.postgres_uri.arn
 
   ## Example logging configuration 
   # sidecar_container_definitions  = {

--- a/distribution/ecs/example/terraform.tf
+++ b/distribution/ecs/example/terraform.tf
@@ -40,6 +40,7 @@ module "quickwit" {
   #   desired_count = 1
   #   memory        = 2048
   #   cpu           = 1024
+  #   storage       = 21
   # }
 
   # quickwit_metastore = {
@@ -52,6 +53,7 @@ module "quickwit" {
   #   desired_count = 1
   #   memory        = 2048
   #   cpu           = 1024
+  #   storage       = 21
   # }
 
   # quickwit_control_plane = {
@@ -70,7 +72,6 @@ module "quickwit" {
   # }
 
   # external_postgres_uri_parameter_arn = aws_ssm_parameter.postgres_uri.arn
-  external_postgres_uri_parameter_arn = "yolo"
 
   ## Example logging configuration 
   # sidecar_container_definitions  = {

--- a/distribution/ecs/example/terraform.tf
+++ b/distribution/ecs/example/terraform.tf
@@ -69,6 +69,9 @@ module "quickwit" {
   #   multi_az       = false
   # }
 
+  # external_postgres_uri_parameter_arn = aws_ssm_parameter.postgres_uri.arn
+  external_postgres_uri_parameter_arn = "yolo"
+
   ## Example logging configuration 
   # sidecar_container_definitions  = {
   #   my_sidecar_container = see http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html

--- a/distribution/ecs/quickwit/configs.tf
+++ b/distribution/ecs/quickwit/configs.tf
@@ -12,6 +12,9 @@ locals {
   s3_id     = var.module_id == "" ? random_id.module.hex : "${var.module_id}-${random_id.module.hex}"
 
   quickwit_index_s3_prefix = var.quickwit_index_s3_prefix == "" ? aws_s3_bucket.index[0].id : var.quickwit_index_s3_prefix
+
+  use_external_rds           = var.external_postgres_uri_parameter_arn != ""
+  postgres_uri_parameter_arn = var.external_postgres_uri_parameter_arn != "" ? var.external_postgres_uri_parameter_arn : aws_ssm_parameter.postgres_credential[0].arn
 }
 
 resource "random_id" "module" {

--- a/distribution/ecs/quickwit/configs.tf
+++ b/distribution/ecs/quickwit/configs.tf
@@ -13,8 +13,8 @@ locals {
 
   quickwit_index_s3_prefix = var.quickwit_index_s3_prefix == "" ? aws_s3_bucket.index[0].id : var.quickwit_index_s3_prefix
 
-  use_external_rds           = var.external_postgres_uri_parameter_arn != ""
-  postgres_uri_parameter_arn = var.external_postgres_uri_parameter_arn != "" ? var.external_postgres_uri_parameter_arn : aws_ssm_parameter.postgres_credential[0].arn
+  use_external_rds           = var.external_postgres_uri_ssm_parameter_arn != ""
+  postgres_uri_parameter_arn = var.external_postgres_uri_ssm_parameter_arn != "" ? var.external_postgres_uri_ssm_parameter_arn : aws_ssm_parameter.postgres_credential[0].arn
 }
 
 resource "random_id" "module" {

--- a/distribution/ecs/quickwit/iam.tf
+++ b/distribution/ecs/quickwit/iam.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "quickwit_task_permission" {
 }
 
 resource "aws_iam_policy" "quickwit_task_permission" {
-  name = "quickwit-task-execution-policy-${local.module_id}"
+  name = "quickwit-task-policy-${local.module_id}"
   path = "/"
 
   policy = data.aws_iam_policy_document.quickwit_task_permission.json

--- a/distribution/ecs/quickwit/iam.tf
+++ b/distribution/ecs/quickwit/iam.tf
@@ -13,20 +13,54 @@ data "aws_iam_policy_document" "quickwit_task_permission" {
       "arn:aws:s3:::${local.quickwit_index_s3_prefix}*",
     ]
   }
+}
 
+resource "aws_iam_policy" "quickwit_task_permission" {
+  name = "quickwit-task-execution-policy-${local.module_id}"
+  path = "/"
+
+  policy = data.aws_iam_policy_document.quickwit_task_permission.json
+}
+
+data "aws_iam_policy_document" "quickwit_task_execution_permission" {
   statement {
     actions = [
-      "ecs:Describe*",
-      "ecs:List*"
+      "logs:PutLogEvents",
+      "logs:CreateLogStream"
     ]
 
     resources = ["*"]
   }
+  statement {
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CreateRepository",
+      "ecr:BatchImportUpstreamImage"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = ["ssm:GetParameters"]
+
+    resources = [local.postgres_uri_parameter_arn]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+
+    resources = ["arn:aws:secretsmanager:*:*:secret:*"]
+  }
+
 }
 
-resource "aws_iam_policy" "quickwit" {
-  name = "quickwit-task-policy-${local.module_id}"
+resource "aws_iam_policy" "quickwit_task_execution_permission" {
+  name = "quickwit-task-execution-policy-${local.module_id}"
   path = "/"
 
-  policy = data.aws_iam_policy_document.quickwit_task_permission.json
+  policy = data.aws_iam_policy_document.quickwit_task_execution_permission.json
 }

--- a/distribution/ecs/quickwit/quickwit-control-plane.tf
+++ b/distribution/ecs/quickwit/quickwit-control-plane.tf
@@ -3,7 +3,7 @@ module "quickwit_control_plane" {
   service_name                   = "control_plane"
   service_discovery_registry_arn = aws_service_discovery_service.control_plane.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = aws_ssm_parameter.postgres_credential.arn
+  postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit.arn
   module_id                      = local.module_id

--- a/distribution/ecs/quickwit/quickwit-control-plane.tf
+++ b/distribution/ecs/quickwit/quickwit-control-plane.tf
@@ -5,7 +5,8 @@ module "quickwit_control_plane" {
   cluster_arn                    = module.ecs_cluster.arn
   postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
-  s3_access_policy_arn           = aws_iam_policy.quickwit.arn
+  s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
+  task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn
   module_id                      = local.module_id
   quickwit_cluster_member_sg_id  = aws_security_group.quickwit_cluster_member_sg.id
 

--- a/distribution/ecs/quickwit/quickwit-indexer.tf
+++ b/distribution/ecs/quickwit/quickwit-indexer.tf
@@ -3,7 +3,7 @@ module "quickwit_indexer" {
   service_name                   = "indexer"
   service_discovery_registry_arn = aws_service_discovery_service.indexer.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = aws_ssm_parameter.postgres_credential.arn
+  postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit.arn
   module_id                      = local.module_id

--- a/distribution/ecs/quickwit/quickwit-indexer.tf
+++ b/distribution/ecs/quickwit/quickwit-indexer.tf
@@ -5,7 +5,8 @@ module "quickwit_indexer" {
   cluster_arn                    = module.ecs_cluster.arn
   postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
-  s3_access_policy_arn           = aws_iam_policy.quickwit.arn
+  s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
+  task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn
   module_id                      = local.module_id
   quickwit_cluster_member_sg_id  = aws_security_group.quickwit_cluster_member_sg.id
 

--- a/distribution/ecs/quickwit/quickwit-janitor.tf
+++ b/distribution/ecs/quickwit/quickwit-janitor.tf
@@ -3,7 +3,7 @@ module "quickwit_janitor" {
   service_name                   = "janitor"
   service_discovery_registry_arn = aws_service_discovery_service.janitor.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = aws_ssm_parameter.postgres_credential.arn
+  postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit.arn
   module_id                      = local.module_id

--- a/distribution/ecs/quickwit/quickwit-janitor.tf
+++ b/distribution/ecs/quickwit/quickwit-janitor.tf
@@ -5,7 +5,8 @@ module "quickwit_janitor" {
   cluster_arn                    = module.ecs_cluster.arn
   postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
-  s3_access_policy_arn           = aws_iam_policy.quickwit.arn
+  s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
+  task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn
   module_id                      = local.module_id
   quickwit_cluster_member_sg_id  = aws_security_group.quickwit_cluster_member_sg.id
 

--- a/distribution/ecs/quickwit/quickwit-metastore.tf
+++ b/distribution/ecs/quickwit/quickwit-metastore.tf
@@ -5,7 +5,8 @@ module "quickwit_metastore" {
   cluster_arn                    = module.ecs_cluster.arn
   postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
-  s3_access_policy_arn           = aws_iam_policy.quickwit.arn
+  s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
+  task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn
   module_id                      = local.module_id
   quickwit_cluster_member_sg_id  = aws_security_group.quickwit_cluster_member_sg.id
 

--- a/distribution/ecs/quickwit/quickwit-metastore.tf
+++ b/distribution/ecs/quickwit/quickwit-metastore.tf
@@ -3,7 +3,7 @@ module "quickwit_metastore" {
   service_name                   = "metastore"
   service_discovery_registry_arn = aws_service_discovery_service.metastore.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = aws_ssm_parameter.postgres_credential.arn
+  postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit.arn
   module_id                      = local.module_id

--- a/distribution/ecs/quickwit/quickwit-searcher.tf
+++ b/distribution/ecs/quickwit/quickwit-searcher.tf
@@ -5,7 +5,8 @@ module "quickwit_searcher" {
   cluster_arn                    = module.ecs_cluster.arn
   postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
-  s3_access_policy_arn           = aws_iam_policy.quickwit.arn
+  s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
+  task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn
   module_id                      = local.module_id
   quickwit_cluster_member_sg_id  = aws_security_group.quickwit_cluster_member_sg.id
 

--- a/distribution/ecs/quickwit/quickwit-searcher.tf
+++ b/distribution/ecs/quickwit/quickwit-searcher.tf
@@ -3,7 +3,7 @@ module "quickwit_searcher" {
   service_name                   = "searcher"
   service_discovery_registry_arn = aws_service_discovery_service.searcher.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = aws_ssm_parameter.postgres_credential.arn
+  postgres_credential_arn        = local.postgres_uri_parameter_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit.arn
   module_id                      = local.module_id

--- a/distribution/ecs/quickwit/rds.tf
+++ b/distribution/ecs/quickwit/rds.tf
@@ -24,13 +24,12 @@ module "quickwit_db" {
   username = "quickwit"
   password = random_password.quickwit_db[0].result
 
-  port                                 = "5432"
-  publicly_accessible                  = false
-  manage_master_user_password          = true
-  manage_master_user_password_rotation = false
-  iam_database_authentication_enabled  = true
-  vpc_security_group_ids               = [aws_security_group.quickwit_db[0].id]
-  db_subnet_group_name                 = aws_db_subnet_group.quickwit[0].name
+  port                                = "5432"
+  publicly_accessible                 = false
+  manage_master_user_password         = false
+  iam_database_authentication_enabled = true
+  vpc_security_group_ids              = [aws_security_group.quickwit_db[0].id]
+  db_subnet_group_name                = aws_db_subnet_group.quickwit[0].name
 
   maintenance_window = "Mon:00:00-Mon:03:00"
 

--- a/distribution/ecs/quickwit/service/ecs.tf
+++ b/distribution/ecs/quickwit/service/ecs.tf
@@ -128,4 +128,9 @@ module "quickwit_service" {
   tasks_iam_role_policies = {
     s3_access = var.s3_access_policy_arn
   }
+
+  task_exec_iam_role_policies = {
+    policy = var.task_execution_policy_arn
+  }
+
 }

--- a/distribution/ecs/quickwit/service/ecs.tf
+++ b/distribution/ecs/quickwit/service/ecs.tf
@@ -8,7 +8,7 @@ module "quickwit_service" {
   cpu    = var.service_config.cpu
   memory = var.service_config.memory
   ephemeral_storage = {
-    size_in_gib = var.service_config.storage
+    size_in_gib = var.service_config.ephemeral_storage_gib
   }
 
   container_definitions = merge(var.sidecar_container_definitions, {

--- a/distribution/ecs/quickwit/service/ecs.tf
+++ b/distribution/ecs/quickwit/service/ecs.tf
@@ -7,6 +7,9 @@ module "quickwit_service" {
 
   cpu    = var.service_config.cpu
   memory = var.service_config.memory
+  ephemeral_storage = {
+    size_in_gib = var.service_config.storage
+  }
 
   container_definitions = merge(var.sidecar_container_definitions, {
     quickwit = {

--- a/distribution/ecs/quickwit/service/variables.tf
+++ b/distribution/ecs/quickwit/service/variables.tf
@@ -52,6 +52,8 @@ variable "quickwit_peer_list" {
 
 variable "s3_access_policy_arn" {}
 
+variable "task_execution_policy_arn" {}
+
 variable "quickwit_cpu_architecture" {}
 
 variable "module_id" {}

--- a/distribution/ecs/quickwit/service/variables.tf
+++ b/distribution/ecs/quickwit/service/variables.tf
@@ -41,6 +41,7 @@ variable "service_config" {
     desired_count = optional(number, 1)
     memory        = number
     cpu           = number
+    storage       = optional(number, 21)
   })
 }
 

--- a/distribution/ecs/quickwit/service/variables.tf
+++ b/distribution/ecs/quickwit/service/variables.tf
@@ -38,10 +38,10 @@ variable "quickwit_image" {}
 
 variable "service_config" {
   type = object({
-    desired_count = optional(number, 1)
-    memory        = number
-    cpu           = number
-    storage       = optional(number, 21)
+    desired_count         = optional(number, 1)
+    memory                = number
+    cpu                   = number
+    ephemeral_storage_gib = optional(number, 21)
   })
 }
 

--- a/distribution/ecs/quickwit/variables.tf
+++ b/distribution/ecs/quickwit/variables.tf
@@ -127,3 +127,8 @@ variable "rds_config" {
   })
   default = {}
 }
+
+variable "external_postgres_uri_parameter_arn" {
+  description = "ARN of the SSM parameter containing the URI of a Postgres instance (postgres://{user}:{password}@{address}:{port}/{db_instance_name}). The Postgres instance should allow indbound connections from the subnets specified in `variable.subnet_ids`. If provided, the internal RDS will not be created and `var.rds_config` is ignored."
+  default     = ""
+}

--- a/distribution/ecs/quickwit/variables.tf
+++ b/distribution/ecs/quickwit/variables.tf
@@ -75,6 +75,7 @@ variable "quickwit_indexer" {
     desired_count = optional(number, 1)
     memory        = optional(number, 4096)
     cpu           = optional(number, 1024)
+    storage       = optional(number, 21)
   })
   default = {}
 }
@@ -95,6 +96,7 @@ variable "quickwit_searcher" {
     desired_count = optional(number, 1)
     memory        = optional(number, 2048)
     cpu           = optional(number, 1024)
+    storage       = optional(number, 21)
   })
   default = {}
 }

--- a/distribution/ecs/quickwit/variables.tf
+++ b/distribution/ecs/quickwit/variables.tf
@@ -72,10 +72,10 @@ variable "log_configuration" {
 variable "quickwit_indexer" {
   description = "Indexer service sizing configurations"
   type = object({
-    desired_count = optional(number, 1)
-    memory        = optional(number, 4096)
-    cpu           = optional(number, 1024)
-    storage       = optional(number, 21)
+    desired_count         = optional(number, 1)
+    memory                = optional(number, 4096)
+    cpu                   = optional(number, 1024)
+    ephemeral_storage_gib = optional(number, 21)
   })
   default = {}
 }
@@ -93,10 +93,10 @@ variable "quickwit_metastore" {
 variable "quickwit_searcher" {
   description = "Searcher service sizing configurations"
   type = object({
-    desired_count = optional(number, 1)
-    memory        = optional(number, 2048)
-    cpu           = optional(number, 1024)
-    storage       = optional(number, 21)
+    desired_count         = optional(number, 1)
+    memory                = optional(number, 2048)
+    cpu                   = optional(number, 1024)
+    ephemeral_storage_gib = optional(number, 21)
   })
   default = {}
 }
@@ -130,7 +130,7 @@ variable "rds_config" {
   default = {}
 }
 
-variable "external_postgres_uri_parameter_arn" {
+variable "external_postgres_uri_ssm_parameter_arn" {
   description = "ARN of the SSM parameter containing the URI of a Postgres instance (postgres://{user}:{password}@{address}:{port}/{db_instance_name}). The Postgres instance should allow indbound connections from the subnets specified in `variable.subnet_ids`. If provided, the internal RDS will not be created and `var.rds_config` is ignored."
   default     = ""
 }


### PR DESCRIPTION
### Description

Add the possibility to use an external postgres for the metastore.

Also used the opportunity to add:
- extra ECR policies to enable using pul through cache
- configurable storage size

### How was this PR tested?

Tested in internal CI
