### PR TITLE
Fix memory consumption/perf bug, group by index id

### DIFF
--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1402,13 +1402,14 @@ fn compute_split_cost(_split_metadata: &SplitMetadata) -> usize {
 pub fn jobs_to_leaf_requests(
     request: &SearchRequest,
     search_indexes_metadatas: &IndexesMetasForLeafSearch,
-    jobs: Vec<SearchJob>,
+    mut jobs: Vec<SearchJob>,
 ) -> crate::Result<Vec<LeafSearchRequest>> {
     let mut search_request_for_leaf = request.clone();
     search_request_for_leaf.start_offset = 0;
     search_request_for_leaf.max_hits += request.start_offset;
     let mut leaf_search_requests = Vec::new();
     // Group jobs by index uid.
+    jobs.sort_by(|job1, job2| job1.index_uid.cmp(&job2.index_uid));
     for (index_uid, job_group) in &jobs.into_iter().group_by(|job| job.index_uid.clone()) {
         let search_index_meta = search_indexes_metadatas.get(&index_uid).ok_or_else(|| {
             SearchError::Internal(format!(


### PR DESCRIPTION
group_by only groups consecutive elements.
the jobs are currently not grouped by index uid, which e.g. causes
1000 indices with 100 splits to emit 100k leaf requests instead of 1000 leaf requests.
This results in memory and performance issues.

The fix reduced query time from 9s to 1.6s and memory from 4.7GB to
780MB

Addresses #4855

