### PR TITLE
Fix possible source types in docs

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -547,7 +547,7 @@ Create source by posting a source config JSON payload.
 |-------------------|----------|------------------------------------------------------------------------------------------------------|---------------|
 | `version**       | `String` | Config format version, put your current Quickwit version. (mandatory)                                |               |
 | `source_id`     | `String` | Source ID. See ID [validation rules](../configuration/source-config.md)(mandatory)                   |               |
-| `source_type`   | `String` | Source type: `kafka`, `kinesis`, `file`. (mandatory)                                                 |               |
+| `source_type`   | `String` | Source type: `kafka`, `kinesis` or `pulsar` (mandatory)                                              |               |
 | `num_pipelines` | `usize`  | Number of running indexing pipelines per node for this source.                                       | 1             |
 | `params`        | `object` | Source parameters as defined in [source config docs](../configuration/source-config.md). (mandatory) |               |
 


### PR DESCRIPTION
### Description

Creating a file source of the API does not make much sense and is in contradiction with the source description which states that the source is used by the CLI only.

On the other hand, there is a tutorial to ingest data from pulsar so it should also be listed in the supported source type list.

### How was this PR tested?

Describe how you tested this PR.
