### PR TITLE
Add hash index on Posgtres column `shards.index_uid`

### DIFF
--- a/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-shard-index-uid.down.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-shard-index-uid.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS shards_index_uid_idx ON shards USING HASH(index_uid);

--- a/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-shard-index-uid.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/18_create-index-shard-index-uid.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS shards_index_uid_idx;


### PR DESCRIPTION
### Description
Per title. I noticed that the queries `acquire_shards` and `delete_shards` are quite slow on Airmail.

### How was this PR tested?
Ran create/delete index queries against local Postgres db.
