### PR TITLE
Solving warn `received an empty publish shard positions update`.

### DIFF
--- a/quickwit/quickwit-metastore/src/tests/shard.rs
+++ b/quickwit/quickwit-metastore/src/tests/shard.rs
@@ -248,7 +248,12 @@ pub async fn test_metastore_acquire_shards<
     let acquire_shards_request = AcquireShardsRequest {
         index_uid: test_index.index_uid.clone().into(),
         source_id: test_index.source_id.clone(),
-        shard_ids: vec![ShardId::from(1), ShardId::from(2), ShardId::from(3)],
+        shard_ids: vec![
+            ShardId::from(1),
+            ShardId::from(2),
+            ShardId::from(3),
+            ShardId::from(666),
+        ], // shard 666 does not exist
         publish_token: "test-publish-token-foo".to_string(),
     };
     let acquire_shards_response = metastore

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -161,6 +161,12 @@ service MetastoreService {
   // Acquires a set of shards for indexing. This RPC locks the shards for publishing thanks to a publish token and only
   // the last indexer that has acquired the shards is allowed to publish. The response returns for each subrequest the
   // list of acquired shards along with the positions to index from.
+  //
+  // If a requested shard is missing, this method does not return an error. It should simply return the list of
+  // shards that were actually acquired.
+  //
+  // For this reason, AcquireShards.acquire_shards may return less subresponse than there was in the request.
+  // Also they may be returned in any order.
   rpc AcquireShards(AcquireShardsRequest) returns (AcquireShardsResponse);
 
   // Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
@@ -387,6 +393,7 @@ message AcquireShardsRequest {
 }
 
 message AcquireShardsResponse {
+  // List of acquired shards, in no specific order.
   repeated quickwit.ingest.Shard acquired_shards = 3;
 }
 

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -328,6 +328,7 @@ pub struct AcquireShardsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AcquireShardsResponse {
+    /// List of acquired shards, in no specific order.
     #[prost(message, repeated, tag = "3")]
     pub acquired_shards: ::prost::alloc::vec::Vec<super::ingest::Shard>,
 }
@@ -771,6 +772,12 @@ pub trait MetastoreService: std::fmt::Debug + dyn_clone::DynClone + Send + Sync 
     /// Acquires a set of shards for indexing. This RPC locks the shards for publishing thanks to a publish token and only
     /// the last indexer that has acquired the shards is allowed to publish. The response returns for each subrequest the
     /// list of acquired shards along with the positions to index from.
+    ///
+    /// If a requested shard is missing, this method does not return an error. It should simply return the list of
+    /// shards that were actually acquired.
+    ///
+    /// For this reason, AcquireShards.acquire_shards may return less subresponse than there was in the request.
+    /// Also they may be returned in any order.
     async fn acquire_shards(
         &mut self,
         request: AcquireShardsRequest,
@@ -5944,6 +5951,12 @@ pub mod metastore_service_grpc_client {
         /// Acquires a set of shards for indexing. This RPC locks the shards for publishing thanks to a publish token and only
         /// the last indexer that has acquired the shards is allowed to publish. The response returns for each subrequest the
         /// list of acquired shards along with the positions to index from.
+        ///
+        /// If a requested shard is missing, this method does not return an error. It should simply return the list of
+        /// shards that were actually acquired.
+        ///
+        /// For this reason, AcquireShards.acquire_shards may return less subresponse than there was in the request.
+        /// Also they may be returned in any order.
         pub async fn acquire_shards(
             &mut self,
             request: impl tonic::IntoRequest<super::AcquireShardsRequest>,
@@ -6332,6 +6345,12 @@ pub mod metastore_service_grpc_server {
         /// Acquires a set of shards for indexing. This RPC locks the shards for publishing thanks to a publish token and only
         /// the last indexer that has acquired the shards is allowed to publish. The response returns for each subrequest the
         /// list of acquired shards along with the positions to index from.
+        ///
+        /// If a requested shard is missing, this method does not return an error. It should simply return the list of
+        /// shards that were actually acquired.
+        ///
+        /// For this reason, AcquireShards.acquire_shards may return less subresponse than there was in the request.
+        /// Also they may be returned in any order.
         async fn acquire_shards(
             &self,
             request: tonic::Request<super::AcquireShardsRequest>,


### PR DESCRIPTION
This should remove all warn logging `received an empty publish shard positions update`. We also start logging an info showing highlighting the race condition that was causing this warning log.

Closes #4888
