### PR TITLE
Add pull through cache to ECS distrib

### DIFF
--- a/distribution/ecs/README.md
+++ b/distribution/ecs/README.md
@@ -69,7 +69,7 @@ We provide an example of self contained deployment with an ad-hoc VPC.
 
 ### Deploy the Quickwit module and connect through a bastion
 
-To make it easy to access your the Quickwit cluster, the example stack includes
+To make it easy to access your Quickwit cluster, the example stack includes
 a bastion instance. Access is secured using an SSH key pair that you need to
 provide (e.g generated with `ssh-keygen -t ed25519`).
 

--- a/distribution/ecs/README.md
+++ b/distribution/ecs/README.md
@@ -67,11 +67,13 @@ We provide an example of self contained deployment with an ad-hoc VPC.
 > This stack costs ~$150/month to run (Fargate tasks, NAT Gateways
 > and RDS)
 
-To make it easy to access your the Quickwit cluster, this stack includes a
-bastion instance. Access is secured using an SSH key pair that you need to
+### Deploy the Quickwit module and connect through a bastion
+
+To make it easy to access your the Quickwit cluster, the example stack includes
+a bastion instance. Access is secured using an SSH key pair that you need to
 provide (e.g generated with `ssh-keygen -t ed25519`).
 
-In the `./example` directory create a `terraform.tfvars` file with the public
+In the `./example` directory, create a `terraform.tfvars` file with the public
 key of your RSA key pair:
 
 ```terraform
@@ -119,3 +121,18 @@ curl -X POST \
 
 If your SSH tunnel to the searcher is still running, you should be able to see
 the ingested data in the UI.
+
+### Setup an ECR repository to avoid throttling from Docker Hub
+
+By default, the example stack uses Docker Hub to pull the Quickwit image. This
+is convenient but it quickly runs into rate limiting. To avoid this, in the
+`terraform.tfvars` file, set the `dockerhub_pull_through_creds_secret_arn` to a
+AWS Secret with the following content:
+
+```json
+{"username":"...","accessToken":"..."}
+```
+
+This will:
+- provision an ECR repository and a pull through cache rule
+- configure the Quickwit module to use that repository

--- a/distribution/ecs/example/image.tf
+++ b/distribution/ecs/example/image.tf
@@ -1,0 +1,33 @@
+variable "dockerhub_pull_through_creds_secret_arn" {
+  description = "If left empty, image is pulled directly from Docker Hub, which might be throttled."
+  default     = ""
+}
+
+locals {
+  ecr_repository_prefix = "quickwit-ecs-example"
+}
+
+# This repo is populated by the pull through cache below
+resource "aws_ecr_repository" "quickwit" {
+  count                = var.dockerhub_pull_through_creds_secret_arn == "" ? 0 : 1
+  name                 = "${local.ecr_repository_prefix}/quickwit/quickwit"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_pull_through_cache_rule" "docker_hub" {
+  count                 = var.dockerhub_pull_through_creds_secret_arn == "" ? 0 : 1
+  ecr_repository_prefix = local.ecr_repository_prefix
+  upstream_registry_url = "registry-1.docker.io"
+  credential_arn        = var.dockerhub_pull_through_creds_secret_arn
+}
+
+
+locals {
+  ecr_domain     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com"
+  image_prefix   = var.dockerhub_pull_through_creds_secret_arn == "" ? "" : "${local.ecr_domain}/${local.ecr_repository_prefix}/"
+  quickwit_image = "${local.image_prefix}quickwit/quickwit"
+}

--- a/distribution/ecs/example/terraform.tf
+++ b/distribution/ecs/example/terraform.tf
@@ -17,11 +17,9 @@ provider "aws" {
   }
 }
 
-# resource "aws_ecr_repository" "quickwit" {
-#   name                 = "quickwit"
-#   force_delete         = true
-#   image_tag_mutability = "MUTABLE"
-# }
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
 
 module "quickwit" {
   source                       = "../quickwit"
@@ -31,9 +29,12 @@ module "quickwit" {
 
   ## Optional configurations:
 
+  # - ECR if you provide the `dockerhub_pull_through_creds_secret_arn` variable
+  # - Docker Hub otherwise (subject to throttling)
+  quickwit_image = "${local.quickwit_image}:latest"
+
   # quickwit_index_s3_prefix  = "my-bucket/my-prefix"
   # quickwit_domain           = "quickwit"
-  # quickwit_image = aws_ecr_repository.quickwit.repository_url
   # quickwit_cpu_architecture = "ARM64"
 
   # quickwit_indexer = {

--- a/distribution/ecs/example/vpc.tf
+++ b/distribution/ecs/example/vpc.tf
@@ -5,7 +5,7 @@ module "vpc" {
   name = "quickwit-ecs"
   cidr = "10.0.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b"]
+  azs             = ["${data.aws_region.current.name}a", "${data.aws_region.current.name}b"]
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
 

--- a/distribution/ecs/quickwit/service/config.tf
+++ b/distribution/ecs/quickwit/service/config.tf
@@ -3,6 +3,10 @@ locals {
 
   quickwit_common_environment = [
     {
+      name  = "QW_ENABLED_SERVICES"
+      value = var.service_name
+    },
+    {
       name  = "QW_PEER_SEEDS"
       value = join(",", var.quickwit_peer_list)
     },

--- a/distribution/ecs/quickwit/service/ecs.tf
+++ b/distribution/ecs/quickwit/service/ecs.tf
@@ -22,12 +22,7 @@ module "quickwit_service" {
 
       command = ["run"]
 
-      environment = concat(local.quickwit_common_environment, [
-        {
-          name  = "QW_ENABLED_SERVICES"
-          value = var.service_name
-        }
-      ])
+      environment = local.quickwit_common_environment
 
       secrets = [
         {


### PR DESCRIPTION
### Description

When pulling directly from Docker Hub, we often run into throttling and the deployment fails silently. Adding the option to use a pull through cache makes it a lot easier to test the ECS distribution.

### How was this PR tested?

Describe how you tested this PR.
