### PR TITLE
Batch `index_metadata` calls in indexing service

### DIFF
--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -418,15 +418,11 @@ impl Cluster {
     /// - value: Number of indexing tasks in the group.
     /// Keys present in chitchat state but not in the given `indexing_tasks` are marked for
     /// deletion.
-    pub async fn update_self_node_indexing_tasks(
-        &self,
-        indexing_tasks: &[IndexingTask],
-    ) -> anyhow::Result<()> {
+    pub async fn update_self_node_indexing_tasks(&self, indexing_tasks: &[IndexingTask]) {
         let chitchat = self.chitchat().await;
         let mut chitchat_guard = chitchat.lock().await;
         let node_state = chitchat_guard.self_node_state();
         set_indexing_tasks_in_node_state(indexing_tasks, node_state);
-        Ok(())
     }
 
     pub async fn chitchat(&self) -> Arc<Mutex<Chitchat>> {
@@ -961,8 +957,7 @@ mod tests {
             .await;
         cluster2
             .update_self_node_indexing_tasks(&[indexing_task1.clone(), indexing_task2.clone()])
-            .await
-            .unwrap();
+            .await;
         cluster1
             .wait_for_ready_members(|members| members.len() == 2, Duration::from_secs(30))
             .await
@@ -1042,8 +1037,7 @@ mod tests {
             .collect_vec();
         cluster1
             .update_self_node_indexing_tasks(&indexing_tasks)
-            .await
-            .unwrap();
+            .await;
         for cluster in [&cluster2, &cluster3] {
             let cluster_clone = cluster.clone();
             let indexing_tasks_clone = indexing_tasks.clone();
@@ -1063,7 +1057,7 @@ mod tests {
         }
 
         // Mark tasks for deletion.
-        cluster1.update_self_node_indexing_tasks(&[]).await.unwrap();
+        cluster1.update_self_node_indexing_tasks(&[]).await;
         for cluster in [&cluster2, &cluster3] {
             let cluster_clone = cluster.clone();
             wait_until_predicate(
@@ -1084,8 +1078,7 @@ mod tests {
         // Re-add tasks.
         cluster1
             .update_self_node_indexing_tasks(&indexing_tasks)
-            .await
-            .unwrap();
+            .await;
         for cluster in [&cluster2, &cluster3] {
             let cluster_clone = cluster.clone();
             let indexing_tasks_clone = indexing_tasks.clone();

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -48,8 +48,8 @@ use quickwit_proto::indexing::ShardPositionsUpdate;
 use quickwit_proto::metastore::{
     serde_utils, AddSourceRequest, CreateIndexRequest, CreateIndexResponse, DeleteIndexRequest,
     DeleteShardsRequest, DeleteSourceRequest, EmptyResponse, FindIndexTemplateMatchesRequest,
-    IndexTemplateMatch, MetastoreError, MetastoreResult, MetastoreService, MetastoreServiceClient,
-    ToggleSourceRequest,
+    IndexMetadataResponse, IndexTemplateMatch, MetastoreError, MetastoreResult, MetastoreService,
+    MetastoreServiceClient, ToggleSourceRequest, UpdateIndexRequest,
 };
 use quickwit_proto::types::{IndexUid, NodeId, ShardId, SourceUid};
 use serde::Serialize;
@@ -570,8 +570,36 @@ impl DeferableReplyHandler<CreateIndexRequest> for ControlPlane {
         } else {
             reply(Ok(response));
         }
-
         Ok(())
+    }
+}
+
+// This handler is a metastore call proxied through the control plane: we must first forward the
+// request to the metastore, and then act on the event.
+#[async_trait]
+impl Handler<UpdateIndexRequest> for ControlPlane {
+    type Reply = ControlPlaneResult<IndexMetadataResponse>;
+
+    async fn handle(
+        &mut self,
+        request: UpdateIndexRequest,
+        ctx: &ActorContext<Self>,
+    ) -> Result<Self::Reply, ActorExitStatus> {
+        let index_uid: IndexUid = request.index_uid().clone();
+        debug!(%index_uid, "updating index");
+
+        let response = match ctx
+            .protect_future(self.metastore.update_index(request))
+            .await
+        {
+            Ok(response) => response,
+            Err(metastore_error) => {
+                return convert_metastore_error(metastore_error);
+            }
+        };
+        // TODO: Handle doc mapping and/or indexing settings update here.
+        info!(%index_uid, "updated index");
+        Ok(Ok(response))
     }
 }
 
@@ -681,9 +709,9 @@ impl Handler<ToggleSourceRequest> for ControlPlane {
         };
         info!(%index_uid, source_id, enabled=enable, "toggled source");
 
-        let mutation_occured = self.model.toggle_source(&index_uid, &source_id, enable)?;
+        let mutation_occurred = self.model.toggle_source(&index_uid, &source_id, enable)?;
 
-        if mutation_occured {
+        if mutation_occurred {
             let _rebuild_plan_waiter = self.rebuild_plan_debounced(ctx);
         }
         Ok(Ok(EmptyResponse {}))
@@ -1020,9 +1048,10 @@ mod tests {
     };
     use quickwit_proto::ingest::{Shard, ShardPKey, ShardState};
     use quickwit_proto::metastore::{
-        EntityKind, FindIndexTemplateMatchesResponse, ListIndexesMetadataRequest,
-        ListIndexesMetadataResponse, ListShardsRequest, ListShardsResponse, ListShardsSubresponse,
-        MetastoreError, MockMetastoreService, OpenShardSubresponse, OpenShardsResponse, SourceType,
+        DeleteShardsResponse, EntityKind, FindIndexTemplateMatchesResponse,
+        ListIndexesMetadataRequest, ListIndexesMetadataResponse, ListShardsRequest,
+        ListShardsResponse, ListShardsSubresponse, MetastoreError, MockMetastoreService,
+        OpenShardSubresponse, OpenShardsResponse, SourceType,
     };
     use quickwit_proto::types::Position;
     use tokio::sync::Mutex;
@@ -1556,7 +1585,14 @@ mod tests {
                 assert_eq!(delete_shards_request.source_id, INGEST_V2_SOURCE_ID);
                 assert_eq!(delete_shards_request.shard_ids, [ShardId::from(17)]);
                 assert!(!delete_shards_request.force);
-                Ok(EmptyResponse {})
+
+                let response = DeleteShardsResponse {
+                    index_uid: delete_shards_request.index_uid,
+                    source_id: delete_shards_request.source_id,
+                    successes: delete_shards_request.shard_ids,
+                    failures: Vec::new(),
+                };
+                Ok(response)
             },
         );
 
@@ -1776,7 +1812,14 @@ mod tests {
                 assert_eq!(delete_shards_request.source_id, INGEST_V2_SOURCE_ID);
                 assert_eq!(delete_shards_request.shard_ids, [ShardId::from(17)]);
                 assert!(!delete_shards_request.force);
-                Ok(EmptyResponse {})
+
+                let response = DeleteShardsResponse {
+                    index_uid: delete_shards_request.index_uid,
+                    source_id: delete_shards_request.source_id,
+                    successes: delete_shards_request.shard_ids,
+                    failures: Vec::new(),
+                };
+                Ok(response)
             },
         );
 

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -221,8 +221,7 @@ async fn test_scheduler_scheduling_and_control_loop_apply_plan_again() {
     // `ApplyIndexingPlanRequest`.
     cluster
         .update_self_node_indexing_tasks(&indexing_tasks)
-        .await
-        .unwrap();
+        .await;
     let scheduler_state = control_plane_mailbox
         .ask(Observe)
         .await
@@ -237,8 +236,7 @@ async fn test_scheduler_scheduling_and_control_loop_apply_plan_again() {
     // receive a new `ApplyIndexingPlanRequest`.
     cluster
         .update_self_node_indexing_tasks(&[indexing_tasks[0].clone()])
-        .await
-        .unwrap();
+        .await;
     tokio::time::sleep(MIN_DURATION_BETWEEN_SCHEDULING.mul_f32(1.2)).await;
     let scheduler_state = control_plane_mailbox
         .ask(Observe)
@@ -377,12 +375,10 @@ async fn test_scheduler_scheduling_multiple_indexers() {
     assert_eq!(indexing_service_inbox_messages_2.len(), 1);
     cluster_indexer_1
         .update_self_node_indexing_tasks(&indexing_service_inbox_messages_1[0].indexing_tasks)
-        .await
-        .unwrap();
+        .await;
     cluster_indexer_2
         .update_self_node_indexing_tasks(&indexing_service_inbox_messages_2[0].indexing_tasks)
-        .await
-        .unwrap();
+        .await;
 
     // Wait 2 CONTROL_PLAN_LOOP_INTERVAL again and check the scheduler will not apply the plan
     // several times.

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -24,8 +24,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use fnv::FnvHashSet;
-use futures::future::try_join_all;
 use itertools::Itertools;
 use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorHandle, ActorState, Handler, Healthz, Mailbox,
@@ -43,15 +41,19 @@ use quickwit_ingest::{
     DropQueueRequest, GetPartitionId, IngestApiService, IngesterPool, ListQueuesRequest,
     QUEUES_DIR_NAME,
 };
-use quickwit_metastore::{IndexMetadata, IndexMetadataResponseExt, ListIndexesMetadataResponseExt};
+use quickwit_metastore::{
+    IndexMetadata, IndexMetadataResponseExt, IndexesMetadataResponseExt,
+    ListIndexesMetadataResponseExt,
+};
 use quickwit_proto::indexing::{
     ApplyIndexingPlanRequest, ApplyIndexingPlanResponse, IndexingError, IndexingPipelineId,
     IndexingTask, PipelineMetrics,
 };
 use quickwit_proto::metastore::{
-    IndexMetadataRequest, ListIndexesMetadataRequest, MetastoreService, MetastoreServiceClient,
+    IndexMetadataRequest, IndexMetadataSubrequest, IndexesMetadataRequest,
+    ListIndexesMetadataRequest, MetastoreService, MetastoreServiceClient,
 };
-use quickwit_proto::types::{IndexId, IndexUid, PipelineUid};
+use quickwit_proto::types::{IndexId, IndexUid, PipelineUid, ShardId};
 use quickwit_storage::StorageResolver;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
@@ -199,15 +201,15 @@ impl IndexingService {
         })
     }
 
-    async fn detach_pipeline(
+    async fn detach_indexing_pipeline(
         &mut self,
-        pipeline_uid: PipelineUid,
+        pipeline_uid: &PipelineUid,
     ) -> Result<ActorHandle<IndexingPipeline>, IndexingError> {
         let pipeline_handle = self
             .indexing_pipelines
-            .remove(&pipeline_uid)
+            .remove(pipeline_uid)
             .ok_or_else(|| {
-                let message = format!("indexing pipeline `{pipeline_uid}` not found");
+                let message = format!("could not find indexing pipeline `{pipeline_uid}`");
                 IndexingError::Internal(message)
             })?;
         self.counters.num_running_pipelines -= 1;
@@ -222,7 +224,7 @@ impl IndexingService {
             .merge_pipeline_handles
             .remove(pipeline_id)
             .ok_or_else(|| {
-                let message = format!("merge pipeline `{pipeline_id}` not found");
+                let message = format!("could not find merge pipeline `{pipeline_id}`");
                 IndexingError::Internal(message)
             })?;
         self.counters.num_running_merge_pipelines -= 1;
@@ -231,13 +233,13 @@ impl IndexingService {
 
     async fn observe_pipeline(
         &mut self,
-        pipeline_uid: PipelineUid,
+        pipeline_uid: &PipelineUid,
     ) -> Result<Observation<IndexingStatistics>, IndexingError> {
         let pipeline_handle = &self
             .indexing_pipelines
-            .get(&pipeline_uid)
+            .get(pipeline_uid)
             .ok_or_else(|| {
-                let message = format!("indexing pipeline `{pipeline_uid}` not found");
+                let message = format!("could not find indexing pipeline `{pipeline_uid}`");
                 IndexingError::Internal(message)
             })?
             .handle;
@@ -366,18 +368,46 @@ impl IndexingService {
     }
 
     async fn index_metadata(
-        &self,
+        &mut self,
         ctx: &ActorContext<Self>,
         index_id: &str,
     ) -> Result<IndexMetadata, IndexingError> {
-        let _protect_guard = ctx.protect_zone();
+        let _protected_zone_guard = ctx.protect_zone();
         let index_metadata_response = self
             .metastore
-            .clone()
             .index_metadata(IndexMetadataRequest::for_index_id(index_id.to_string()))
             .await?;
         let index_metadata = index_metadata_response.deserialize_index_metadata()?;
         Ok(index_metadata)
+    }
+
+    async fn indexes_metadata(
+        &mut self,
+        ctx: &ActorContext<Self>,
+        indexing_pipeline_ids: &[IndexingPipelineId],
+    ) -> Result<Vec<IndexMetadata>, IndexingError> {
+        let index_metadata_subrequests: Vec<IndexMetadataSubrequest> = indexing_pipeline_ids
+            .iter()
+            // Remove duplicate subrequests
+            .unique_by(|pipeline_id| &pipeline_id.index_uid)
+            .map(|pipeline_id| IndexMetadataSubrequest {
+                index_id: None,
+                index_uid: Some(pipeline_id.index_uid.clone()),
+            })
+            .collect();
+        let indexes_metadata_request = IndexesMetadataRequest {
+            subrequests: index_metadata_subrequests,
+        };
+        let _protected_zone_guard = ctx.protect_zone();
+
+        let indexes_metadata_response = self
+            .metastore
+            .indexes_metadata(indexes_metadata_request)
+            .await?;
+        let indexes_metadata = indexes_metadata_response
+            .deserialize_indexes_metadata()
+            .await?;
+        Ok(indexes_metadata)
     }
 
     async fn handle_supervise(&mut self) -> Result<(), ActorExitStatus> {
@@ -399,7 +429,7 @@ impl IndexingService {
                         // and are themselves in charge of supervising the pipeline actors.
                         error!(
                             pipeline_uid=%pipeline_uid,
-                            "Indexing pipeline exited with failure. This should never happen."
+                            "indexing pipeline exited with failure: this should never happen, please report"
                         );
                         self.counters.num_failed_pipelines += 1;
                         self.counters.num_running_pipelines -= 1;
@@ -407,27 +437,32 @@ impl IndexingService {
                     }
                 }
             });
-        // Evict and kill merge pipelines that are not needed.
-        let needed_merge_pipeline_ids: HashSet<MergePipelineId> = self
+        let merge_pipelines_to_retain: HashSet<MergePipelineId> = self
             .indexing_pipelines
             .values()
             .map(|pipeline_handle| MergePipelineId::from(&pipeline_handle.indexing_pipeline_id))
             .collect();
-        let current_merge_pipeline_ids: HashSet<MergePipelineId> =
-            self.merge_pipeline_handles.keys().cloned().collect();
-        for merge_pipeline_id_to_shut_down in
-            current_merge_pipeline_ids.difference(&needed_merge_pipeline_ids)
-        {
+
+        let merge_pipelines_to_shutdown: Vec<MergePipelineId> = self
+            .merge_pipeline_handles
+            .keys()
+            .filter(|running_merge_pipeline_id| {
+                !merge_pipelines_to_retain.contains(running_merge_pipeline_id)
+            })
+            .cloned()
+            .collect();
+
+        for merge_pipeline_to_shutdown in merge_pipelines_to_shutdown {
             if let Some((_, merge_pipeline_handle)) = self
                 .merge_pipeline_handles
-                .remove_entry(merge_pipeline_id_to_shut_down)
+                .remove_entry(&merge_pipeline_to_shutdown)
             {
                 // We kill the merge pipeline to avoid waiting a merge operation to finish as it can
                 // be long.
                 info!(
-                    index_id=%merge_pipeline_id_to_shut_down.index_uid.index_id,
-                    source_id=%merge_pipeline_id_to_shut_down.source_id,
-                    "No more indexing pipeline on this index and source, killing merge pipeline."
+                    index_uid=%merge_pipeline_to_shutdown.index_uid,
+                    source_id=%merge_pipeline_to_shutdown.source_id,
+                    "no more indexing pipeline on this index and source, killing merge pipeline"
                 );
                 merge_pipeline_handle.handle.kill().await;
             }
@@ -438,8 +473,7 @@ impl IndexingService {
                 merge_pipeline_mailbox_handle.handle.state().is_running()
             });
         self.counters.num_running_merge_pipelines = self.merge_pipeline_handles.len();
-        self.update_cluster_running_indexing_tasks_in_chitchat()
-            .await;
+        self.update_chitchat_running_plan().await;
 
         let pipeline_metrics: HashMap<&IndexingPipelineId, PipelineMetrics> = self
             .indexing_pipelines
@@ -480,48 +514,6 @@ impl IndexingService {
         Ok(merge_planner_mailbox)
     }
 
-    async fn find_and_shutdown_decommissioned_pipelines(&mut self, tasks: &[IndexingTask]) {
-        let pipeline_uids_in_plan: FnvHashSet<PipelineUid> = tasks
-            .iter()
-            .map(|indexing_task| indexing_task.pipeline_uid())
-            .collect();
-
-        let pipeline_uids_to_remove: Vec<PipelineUid> = self
-            .indexing_pipelines
-            .keys()
-            .cloned()
-            .filter(|pipeline_uid| !pipeline_uids_in_plan.contains(pipeline_uid))
-            .collect::<Vec<_>>();
-
-        // Shut down currently running pipelines that are missing in the new plan.
-        self.shutdown_pipelines(&pipeline_uids_to_remove).await;
-    }
-
-    async fn find_and_spawn_new_pipelines(
-        &mut self,
-        tasks: &[IndexingTask],
-        ctx: &ActorContext<Self>,
-    ) -> Result<Vec<IndexingPipelineId>, IndexingError> {
-        let pipeline_ids_to_add: Vec<IndexingPipelineId> = tasks
-            .iter()
-            .filter(|indexing_task| {
-                let pipeline_uid = indexing_task.pipeline_uid();
-                !self.indexing_pipelines.contains_key(&pipeline_uid)
-            })
-            .flat_map(|indexing_task| {
-                let pipeline_uid = indexing_task.pipeline_uid();
-                let index_uid = indexing_task.index_uid().clone();
-                Some(IndexingPipelineId {
-                    node_id: self.node_id.clone(),
-                    index_uid,
-                    source_id: indexing_task.source_id.clone(),
-                    pipeline_uid,
-                })
-            })
-            .collect();
-        self.spawn_pipelines(&pipeline_ids_to_add, ctx).await
-    }
-
     /// For all Ingest V2 pipelines, assigns the set of shards they should be working on.
     /// This is done regardless of whether there has been a change in their shard list
     /// or not.
@@ -542,7 +534,7 @@ impl IndexingService {
             let message = AssignShards(assignment);
 
             if let Err(error) = pipeline_handle.mailbox.send_message(message).await {
-                error!(error=%error, "failed to assign shards to indexing pipeline");
+                error!(%error, "failed to assign shards to indexing pipeline");
             }
         }
     }
@@ -550,106 +542,141 @@ impl IndexingService {
     /// Applies the indexing plan by:
     /// - Stopping the running pipelines not present in the provided plan.
     /// - Starting the pipelines that are not running.
-    /// Note: the indexing is a list of `IndexingTask` and has no ordinal
-    /// like a pipeline. We assign an ordinal for each `IndexingTask` from
-    /// [0, n) with n the number of indexing tasks given a (index_id, source_id).
     async fn apply_indexing_plan(
         &mut self,
         tasks: &[IndexingTask],
         ctx: &ActorContext<Self>,
     ) -> Result<(), IndexingError> {
-        self.find_and_shutdown_decommissioned_pipelines(tasks).await;
-        let failed_spawning_pipeline_ids = self.find_and_spawn_new_pipelines(tasks, ctx).await?;
+        let pipeline_diff = self.compute_pipeline_diff(tasks);
+
+        if !pipeline_diff.pipelines_to_shutdown.is_empty() {
+            self.shutdown_pipelines(&pipeline_diff.pipelines_to_shutdown)
+                .await;
+        }
+        let mut spawn_pipeline_failures: Vec<IndexingPipelineId> = Vec::new();
+
+        if !pipeline_diff.pipelines_to_spawn.is_empty() {
+            spawn_pipeline_failures = self
+                .spawn_pipelines(&pipeline_diff.pipelines_to_spawn, ctx)
+                .await?;
+        }
         self.assign_shards_to_pipelines(tasks).await;
-        self.update_cluster_running_indexing_tasks_in_chitchat()
-            .await;
-        if !failed_spawning_pipeline_ids.is_empty() {
+        self.update_chitchat_running_plan().await;
+
+        if !spawn_pipeline_failures.is_empty() {
             let message = format!(
                 "failed to spawn indexing pipelines: {:?}",
-                failed_spawning_pipeline_ids
+                spawn_pipeline_failures
             );
             return Err(IndexingError::Internal(message));
         }
         Ok(())
     }
 
+    /// Identifies the pipelines to spawn and shutdown by comparing the scheduled plan with the
+    /// current running plan.
+    fn compute_pipeline_diff(&self, tasks: &[IndexingTask]) -> IndexingPipelineDiff {
+        let mut pipelines_to_spawn: Vec<IndexingPipelineId> = Vec::new();
+        let mut scheduled_pipeline_uids: HashSet<PipelineUid> = HashSet::with_capacity(tasks.len());
+
+        for task in tasks {
+            let pipeline_uid = task.pipeline_uid();
+
+            if !self.indexing_pipelines.contains_key(&pipeline_uid) {
+                let pipeline_id = IndexingPipelineId {
+                    node_id: self.node_id.clone(),
+                    index_uid: task.index_uid().clone(),
+                    source_id: task.source_id.clone(),
+                    pipeline_uid,
+                };
+                pipelines_to_spawn.push(pipeline_id);
+            }
+            scheduled_pipeline_uids.insert(pipeline_uid);
+        }
+        let pipelines_to_shutdown: Vec<PipelineUid> = self
+            .indexing_pipelines
+            .keys()
+            .filter(|pipeline_uid| !scheduled_pipeline_uids.contains(pipeline_uid))
+            .copied()
+            .collect();
+
+        IndexingPipelineDiff {
+            pipelines_to_shutdown,
+            pipelines_to_spawn,
+        }
+    }
+
     /// Spawns the pipelines with supplied ids and returns a list of failed pipelines.
     async fn spawn_pipelines(
         &mut self,
-        added_pipeline_ids: &[IndexingPipelineId],
+        pipelines_to_spawn: &[IndexingPipelineId],
         ctx: &ActorContext<Self>,
     ) -> Result<Vec<IndexingPipelineId>, IndexingError> {
-        // We fetch the new indexes metadata.
-        let indexes_metadata_futures = added_pipeline_ids
-            .iter()
-            // No need to emit two request for the same `index_uid`
-            .unique_by(|pipeline_id| pipeline_id.index_uid.clone())
-            .map(|pipeline_id| self.index_metadata(ctx, &pipeline_id.index_uid.index_id));
-        let indexes_metadata = try_join_all(indexes_metadata_futures).await?;
-        let indexes_metadata_by_index_id: HashMap<IndexUid, IndexMetadata> = indexes_metadata
+        let indexes_metadata = self.indexes_metadata(ctx, pipelines_to_spawn).await?;
+
+        let per_index_uid_indexes_metadata: HashMap<IndexUid, IndexMetadata> = indexes_metadata
             .into_iter()
             .map(|index_metadata| (index_metadata.index_uid.clone(), index_metadata))
             .collect();
 
-        let mut failed_spawning_pipeline_ids: Vec<IndexingPipelineId> = Vec::new();
+        let mut spawn_pipeline_failures: Vec<IndexingPipelineId> = Vec::new();
 
-        // Add new pipelines.
-        for new_pipeline_id in added_pipeline_ids {
+        for pipeline_to_spawn in pipelines_to_spawn {
             if let Some(index_metadata) =
-                indexes_metadata_by_index_id.get(&new_pipeline_id.index_uid)
+                per_index_uid_indexes_metadata.get(&pipeline_to_spawn.index_uid)
             {
-                if let Some(source_config) = index_metadata.sources.get(&new_pipeline_id.source_id)
+                if let Some(source_config) =
+                    index_metadata.sources.get(&pipeline_to_spawn.source_id)
                 {
                     if let Err(error) = self
                         .spawn_pipeline_inner(
                             ctx,
-                            new_pipeline_id.clone(),
+                            pipeline_to_spawn.clone(),
                             index_metadata.index_config.clone(),
                             source_config.clone(),
                         )
                         .await
                     {
-                        error!(pipeline_id=?new_pipeline_id, err=?error, "failed to spawn pipeline");
-                        failed_spawning_pipeline_ids.push(new_pipeline_id.clone());
+                        error!(pipeline_id=?pipeline_to_spawn, %error, "failed to spawn pipeline");
+                        spawn_pipeline_failures.push(pipeline_to_spawn.clone());
                     }
                 } else {
-                    error!(pipeline_id=?new_pipeline_id, "failed to spawn pipeline: source does not exist");
-                    failed_spawning_pipeline_ids.push(new_pipeline_id.clone());
+                    error!(pipeline_id=?pipeline_to_spawn, "failed to spawn pipeline: source not found");
+                    spawn_pipeline_failures.push(pipeline_to_spawn.clone());
                 }
             } else {
                 error!(
-                    "Failed to spawn pipeline: index {} no longer exists.",
-                    &new_pipeline_id.index_uid.to_string()
+                    "failed to spawn pipeline: index `{}` no longer exists",
+                    pipeline_to_spawn.index_uid
                 );
-                failed_spawning_pipeline_ids.push(new_pipeline_id.clone());
+                spawn_pipeline_failures.push(pipeline_to_spawn.clone());
             }
         }
-
-        Ok(failed_spawning_pipeline_ids)
+        Ok(spawn_pipeline_failures)
     }
 
     /// Shuts down the pipelines with supplied ids and performs necessary cleanup.
-    async fn shutdown_pipelines(&mut self, pipeline_uids: &[PipelineUid]) {
-        let should_gc_ingest_api_queues = pipeline_uids
+    async fn shutdown_pipelines(&mut self, pipelines_to_shutdown: &[PipelineUid]) {
+        let should_gc_ingest_api_queues = pipelines_to_shutdown
             .iter()
             .flat_map(|pipeline_uid| self.indexing_pipelines.get(pipeline_uid))
             .any(|pipeline_handle| {
                 pipeline_handle.indexing_pipeline_id.source_id == INGEST_API_SOURCE_ID
             });
 
-        for &pipeline_uid_to_remove in pipeline_uids {
-            match self.detach_pipeline(pipeline_uid_to_remove).await {
+        for pipeline_to_shutdown in pipelines_to_shutdown {
+            match self.detach_indexing_pipeline(pipeline_to_shutdown).await {
                 Ok(pipeline_handle) => {
-                    // Killing the pipeline ensure that all pipeline actors will stop.
+                    // Killing the pipeline ensures that all the pipeline actors will stop.
                     pipeline_handle.kill().await;
                 }
                 Err(error) => {
                     // Just log the detach error, it can only come from a missing pipeline in the
                     // `indexing_pipeline_handles`.
                     error!(
-                        pipeline_id=?pipeline_uid_to_remove,
-                        err=?error,
-                        "Detach error.",
+                        pipeline_uid=%pipeline_to_shutdown,
+                        ?error,
+                        "failed to detach indexing pipeline",
                     );
                 }
             }
@@ -660,42 +687,42 @@ impl IndexingService {
         if should_gc_ingest_api_queues {
             if let Err(error) = self.run_ingest_api_queues_gc().await {
                 warn!(
-                    err=?error,
-                    "Ingest API queues garbage collect error.",
+                    %error,
+                    "failed to garbage collect ingest API queues",
                 );
             }
         }
     }
 
-    async fn update_cluster_running_indexing_tasks_in_chitchat(&self) {
+    /// Broadcasts the current running plan via chitchat.
+    async fn update_chitchat_running_plan(&self) {
         let mut indexing_tasks: Vec<IndexingTask> = self
             .indexing_pipelines
             .values()
-            .map(|handle| IndexingTask {
-                index_uid: Some(handle.indexing_pipeline_id.index_uid.clone()),
-                source_id: handle.indexing_pipeline_id.source_id.clone(),
-                pipeline_uid: Some(handle.indexing_pipeline_id.pipeline_uid),
-                shard_ids: handle
+            .map(|pipeline_handle| {
+                let shard_ids: Vec<ShardId> = pipeline_handle
                     .handle
                     .last_observation()
                     .shard_ids
                     .iter()
                     .cloned()
-                    .collect(),
+                    .collect();
+
+                IndexingTask {
+                    index_uid: Some(pipeline_handle.indexing_pipeline_id.index_uid.clone()),
+                    source_id: pipeline_handle.indexing_pipeline_id.source_id.clone(),
+                    pipeline_uid: Some(pipeline_handle.indexing_pipeline_id.pipeline_uid),
+                    shard_ids,
+                }
             })
             .collect();
+
+        // TODO: Does anybody why we sort the indexing tasks by pipeline_uid here?
         indexing_tasks.sort_unstable_by_key(|task| task.pipeline_uid);
 
-        if let Err(error) = self
-            .cluster
+        self.cluster
             .update_self_node_indexing_tasks(&indexing_tasks)
-            .await
-        {
-            error!(
-                "Error when updating the cluster state with indexing running tasks: {}",
-                error
-            );
-        }
+            .await;
     }
 
     /// Garbage collects ingest API queues of deleted indexes.
@@ -763,7 +790,8 @@ impl Handler<ObservePipeline> for IndexingService {
         msg: ObservePipeline,
         _ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        let observation = self.observe_pipeline(msg.pipeline_id.pipeline_uid).await;
+        let pipeline_uid = msg.pipeline_id.pipeline_uid;
+        let observation = self.observe_pipeline(&pipeline_uid).await;
         Ok(observation)
     }
 }
@@ -777,7 +805,9 @@ impl Handler<DetachIndexingPipeline> for IndexingService {
         msg: DetachIndexingPipeline,
         _ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        Ok(self.detach_pipeline(msg.pipeline_id.pipeline_uid).await)
+        let pipeline_uid = msg.pipeline_id.pipeline_uid;
+        let detach_pipeline_result = self.detach_indexing_pipeline(&pipeline_uid).await;
+        Ok(detach_pipeline_result)
     }
 }
 
@@ -873,6 +903,11 @@ impl Handler<Healthz> for IndexingService {
         // In the future, check metrics such as available disk space.
         Ok(true)
     }
+}
+
+struct IndexingPipelineDiff {
+    pipelines_to_shutdown: Vec<PipelineUid>,
+    pipelines_to_spawn: Vec<IndexingPipelineId>,
 }
 
 #[cfg(test)]
@@ -1325,7 +1360,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_indexing_service_shut_down_merge_pipeline_when_no_indexing_pipeline() {
+    async fn test_indexing_service_shutdown_merge_pipeline_when_no_indexing_pipeline() {
         quickwit_common::setup_logging_for_tests();
         let transport = ChannelTransport::default();
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
@@ -1457,7 +1492,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_indexing_service_does_not_shut_down_pipelines_on_indexing_pipeline_freeze() {
+    async fn test_indexing_service_does_not_shutdown_pipelines_on_indexing_pipeline_freeze() {
         quickwit_common::setup_logging_for_tests();
         let transport = ChannelTransport::default();
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)

--- a/quickwit/quickwit-metastore/src/lib.rs
+++ b/quickwit/quickwit-metastore/src/lib.rs
@@ -49,8 +49,8 @@ pub(crate) use metastore::index_metadata::serialize::{IndexMetadataV0_8, Version
 pub use metastore::postgres::PostgresqlMetastore;
 pub use metastore::{
     file_backed, AddSourceRequestExt, CreateIndexRequestExt, CreateIndexResponseExt, IndexMetadata,
-    IndexMetadataResponseExt, ListIndexesMetadataResponseExt, ListSplitsQuery,
-    ListSplitsRequestExt, ListSplitsResponseExt, MetastoreServiceExt,
+    IndexMetadataResponseExt, IndexesMetadataResponseExt, ListIndexesMetadataResponseExt,
+    ListSplitsQuery, ListSplitsRequestExt, ListSplitsResponseExt, MetastoreServiceExt,
     MetastoreServiceStreamSplitsExt, PublishSplitsRequestExt, StageSplitsRequestExt,
     UpdateIndexRequestExt,
 };

--- a/quickwit/quickwit-metastore/src/metastore/control_plane_metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/control_plane_metastore.rs
@@ -25,18 +25,18 @@ use quickwit_proto::control_plane::{ControlPlaneService, ControlPlaneServiceClie
 use quickwit_proto::metastore::{
     AcquireShardsRequest, AcquireShardsResponse, AddSourceRequest, CreateIndexRequest,
     CreateIndexResponse, CreateIndexTemplateRequest, DeleteIndexRequest,
-    DeleteIndexTemplatesRequest, DeleteQuery, DeleteShardsRequest, DeleteSourceRequest,
-    DeleteSplitsRequest, DeleteTask, EmptyResponse, FindIndexTemplateMatchesRequest,
-    FindIndexTemplateMatchesResponse, GetIndexTemplateRequest, GetIndexTemplateResponse,
-    IndexMetadataRequest, IndexMetadataResponse, LastDeleteOpstampRequest,
-    LastDeleteOpstampResponse, ListDeleteTasksRequest, ListDeleteTasksResponse,
-    ListIndexTemplatesRequest, ListIndexTemplatesResponse, ListIndexesMetadataRequest,
-    ListIndexesMetadataResponse, ListShardsRequest, ListShardsResponse, ListSplitsRequest,
-    ListSplitsResponse, ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreResult,
-    MetastoreService, MetastoreServiceClient, MetastoreServiceStream, OpenShardsRequest,
-    OpenShardsResponse, PublishSplitsRequest, ResetSourceCheckpointRequest, StageSplitsRequest,
-    ToggleSourceRequest, UpdateIndexRequest, UpdateSplitsDeleteOpstampRequest,
-    UpdateSplitsDeleteOpstampResponse,
+    DeleteIndexTemplatesRequest, DeleteQuery, DeleteShardsRequest, DeleteShardsResponse,
+    DeleteSourceRequest, DeleteSplitsRequest, DeleteTask, EmptyResponse,
+    FindIndexTemplateMatchesRequest, FindIndexTemplateMatchesResponse, GetIndexTemplateRequest,
+    GetIndexTemplateResponse, IndexMetadataRequest, IndexMetadataResponse, IndexesMetadataRequest,
+    IndexesMetadataResponse, LastDeleteOpstampRequest, LastDeleteOpstampResponse,
+    ListDeleteTasksRequest, ListDeleteTasksResponse, ListIndexTemplatesRequest,
+    ListIndexTemplatesResponse, ListIndexesMetadataRequest, ListIndexesMetadataResponse,
+    ListShardsRequest, ListShardsResponse, ListSplitsRequest, ListSplitsResponse,
+    ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreResult, MetastoreService,
+    MetastoreServiceClient, MetastoreServiceStream, OpenShardsRequest, OpenShardsResponse,
+    PublishSplitsRequest, ResetSourceCheckpointRequest, StageSplitsRequest, ToggleSourceRequest,
+    UpdateIndexRequest, UpdateSplitsDeleteOpstampRequest, UpdateSplitsDeleteOpstampResponse,
 };
 
 /// A [`MetastoreService`] implementation that proxies some requests to the control plane so it can
@@ -86,6 +86,19 @@ impl MetastoreService for ControlPlaneMetastore {
         Ok(response)
     }
 
+    // Technically, proxying this call via the control plane is not necessary at the moment because
+    // it does not modify attributes the control plane cares about (retention policy, search
+    // settings). However, it would be easy to forget to do so when we add the ability to update the
+    // doc mapping or merge policy of an index, so we've already set up the proxy here since calling
+    // `update_index` is very infrequent anyway.
+    async fn update_index(
+        &mut self,
+        request: UpdateIndexRequest,
+    ) -> MetastoreResult<IndexMetadataResponse> {
+        let response = self.control_plane.update_index(request).await?;
+        Ok(response)
+    }
+
     async fn delete_index(
         &mut self,
         request: DeleteIndexRequest,
@@ -117,19 +130,18 @@ impl MetastoreService for ControlPlaneMetastore {
 
     // Other metastore API calls.
 
-    async fn update_index(
-        &mut self,
-        request: UpdateIndexRequest,
-    ) -> MetastoreResult<IndexMetadataResponse> {
-        let response = self.metastore.update_index(request).await?;
-        Ok(response)
-    }
-
     async fn index_metadata(
         &mut self,
         request: IndexMetadataRequest,
     ) -> MetastoreResult<IndexMetadataResponse> {
         self.metastore.index_metadata(request).await
+    }
+
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> MetastoreResult<IndexesMetadataResponse> {
+        self.metastore.indexes_metadata(request).await
     }
 
     async fn list_indexes_metadata(
@@ -244,7 +256,7 @@ impl MetastoreService for ControlPlaneMetastore {
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> MetastoreResult<EmptyResponse> {
+    ) -> MetastoreResult<DeleteShardsResponse> {
         self.metastore.delete_shards(request).await
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -39,23 +39,27 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::future::try_join_all;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use itertools::Itertools;
 use quickwit_common::ServiceStream;
 use quickwit_config::IndexTemplate;
 use quickwit_proto::metastore::{
     serde_utils, AcquireShardsRequest, AcquireShardsResponse, AddSourceRequest, CreateIndexRequest,
     CreateIndexResponse, CreateIndexTemplateRequest, DeleteIndexRequest,
-    DeleteIndexTemplatesRequest, DeleteQuery, DeleteShardsRequest, DeleteSourceRequest,
-    DeleteSplitsRequest, DeleteTask, EmptyResponse, EntityKind, FindIndexTemplateMatchesRequest,
-    FindIndexTemplateMatchesResponse, GetIndexTemplateRequest, GetIndexTemplateResponse,
-    IndexMetadataRequest, IndexMetadataResponse, IndexTemplateMatch, LastDeleteOpstampRequest,
-    LastDeleteOpstampResponse, ListDeleteTasksRequest, ListDeleteTasksResponse,
-    ListIndexTemplatesRequest, ListIndexTemplatesResponse, ListIndexesMetadataRequest,
-    ListIndexesMetadataResponse, ListShardsRequest, ListShardsResponse, ListSplitsRequest,
-    ListSplitsResponse, ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreError,
-    MetastoreResult, MetastoreService, MetastoreServiceStream, OpenShardSubrequest,
-    OpenShardsRequest, OpenShardsResponse, PublishSplitsRequest, ResetSourceCheckpointRequest,
-    StageSplitsRequest, ToggleSourceRequest, UpdateIndexRequest, UpdateSplitsDeleteOpstampRequest,
+    DeleteIndexTemplatesRequest, DeleteQuery, DeleteShardsRequest, DeleteShardsResponse,
+    DeleteSourceRequest, DeleteSplitsRequest, DeleteTask, EmptyResponse, EntityKind,
+    FindIndexTemplateMatchesRequest, FindIndexTemplateMatchesResponse, GetIndexTemplateRequest,
+    GetIndexTemplateResponse, IndexMetadataFailure, IndexMetadataFailureReason,
+    IndexMetadataRequest, IndexMetadataResponse, IndexTemplateMatch, IndexesMetadataRequest,
+    IndexesMetadataResponse, LastDeleteOpstampRequest, LastDeleteOpstampResponse,
+    ListDeleteTasksRequest, ListDeleteTasksResponse, ListIndexTemplatesRequest,
+    ListIndexTemplatesResponse, ListIndexesMetadataRequest, ListIndexesMetadataResponse,
+    ListShardsRequest, ListShardsResponse, ListSplitsRequest, ListSplitsResponse,
+    ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreError, MetastoreResult,
+    MetastoreService, MetastoreServiceStream, OpenShardSubrequest, OpenShardsRequest,
+    OpenShardsResponse, PublishSplitsRequest, ResetSourceCheckpointRequest, StageSplitsRequest,
+    ToggleSourceRequest, UpdateIndexRequest, UpdateSplitsDeleteOpstampRequest,
     UpdateSplitsDeleteOpstampResponse,
 };
 use quickwit_proto::types::{IndexId, IndexUid};
@@ -72,8 +76,8 @@ use self::state::MetastoreState;
 use self::store_operations::{delete_index, index_exists, load_index, put_index};
 use super::{
     AddSourceRequestExt, CreateIndexRequestExt, IndexMetadataResponseExt,
-    ListIndexesMetadataResponseExt, ListSplitsRequestExt, ListSplitsResponseExt,
-    PublishSplitsRequestExt, StageSplitsRequestExt, UpdateIndexRequestExt,
+    IndexesMetadataResponseExt, ListIndexesMetadataResponseExt, ListSplitsRequestExt,
+    ListSplitsResponseExt, PublishSplitsRequestExt, StageSplitsRequestExt, UpdateIndexRequestExt,
     STREAM_SPLITS_CHUNK_SIZE,
 };
 use crate::checkpoint::IndexCheckpointDelta;
@@ -335,9 +339,46 @@ impl FileBackedMetastore {
         Ok(index_mutex)
     }
 
+    async fn index_metadata_inner(
+        &mut self,
+        index_id_opt: Option<IndexId>,
+        index_uid_opt: Option<IndexUid>,
+    ) -> Result<IndexMetadata, (MetastoreError, Option<IndexId>, Option<IndexUid>)> {
+        let index_id = if let Some(index_id) = &index_id_opt {
+            index_id
+        } else if let Some(index_uid) = &index_uid_opt {
+            &index_uid.index_id
+        } else {
+            let message = "invalid request: neither `index_id` nor `index_uid` is set".to_string();
+            let metastore_error = MetastoreError::Internal {
+                message,
+                cause: "".to_string(),
+            };
+            return Err((metastore_error, index_id_opt, index_uid_opt));
+        };
+        let index_metadata = match self
+            .read_any(index_id, |index| Ok(index.metadata().clone()))
+            .await
+        {
+            Ok(index_metadata) => index_metadata,
+            Err(metastore_error) => {
+                return Err((metastore_error, index_id_opt, index_uid_opt));
+            }
+        };
+        if let Some(index_uid) = &index_uid_opt {
+            if index_metadata.index_uid != *index_uid {
+                let metastore_error = MetastoreError::NotFound(EntityKind::Index {
+                    index_id: index_id.to_string(),
+                });
+                return Err((metastore_error, index_id_opt, index_uid_opt));
+            }
+        }
+        Ok(index_metadata)
+    }
+
     /// Returns the list of splits for the given request.
     /// No error is returned if any of the requested `index_uid` does not exist.
-    async fn inner_list_splits(&self, request: ListSplitsRequest) -> MetastoreResult<Vec<Split>> {
+    async fn list_splits_inner(&self, request: ListSplitsRequest) -> MetastoreResult<Vec<Split>> {
         let list_splits_query = request.deserialize_list_splits_query()?;
         let mut all_splits = Vec::new();
         for index_uid in &list_splits_query.index_uids {
@@ -461,22 +502,25 @@ impl MetastoreService for FileBackedMetastore {
         &mut self,
         request: UpdateIndexRequest,
     ) -> MetastoreResult<IndexMetadataResponse> {
-        let search_settings = request.deserialize_search_settings()?;
         let retention_policy_opt = request.deserialize_retention_policy()?;
+        let search_settings = request.deserialize_search_settings()?;
         let index_uid = request.index_uid();
 
-        let metadata = self
+        let index_metadata = self
             .mutate(index_uid, |index| {
-                let search_settings_mutated = index.set_search_settings(search_settings);
-                let retention_policy_mutated = index.set_retention_policy(retention_policy_opt);
-                if search_settings_mutated || retention_policy_mutated {
-                    Ok(MutationOccurred::Yes(index.metadata().clone()))
+                let mut mutation_occurred = index.set_retention_policy(retention_policy_opt);
+                mutation_occurred |= index.set_search_settings(search_settings);
+
+                let index_metadata = index.metadata().clone();
+
+                if mutation_occurred {
+                    Ok(MutationOccurred::Yes(index_metadata))
                 } else {
-                    Ok(MutationOccurred::No(index.metadata().clone()))
+                    Ok(MutationOccurred::No(index_metadata))
                 }
             })
             .await?;
-        IndexMetadataResponse::try_from_index_metadata(&metadata)
+        IndexMetadataResponse::try_from_index_metadata(&index_metadata)
     }
 
     async fn delete_index(
@@ -694,7 +738,7 @@ impl MetastoreService for FileBackedMetastore {
         &mut self,
         request: ListSplitsRequest,
     ) -> MetastoreResult<MetastoreServiceStream<ListSplitsResponse>> {
-        let splits = self.inner_list_splits(request).await?;
+        let splits = self.list_splits_inner(request).await?;
         let splits_responses: Vec<MetastoreResult<ListSplitsResponse>> = splits
             .chunks(STREAM_SPLITS_CHUNK_SIZE)
             .map(|chunk| ListSplitsResponse::try_from_splits(chunk.to_vec()))
@@ -715,7 +759,7 @@ impl MetastoreService for FileBackedMetastore {
             .with_limit(request.num_splits as usize);
         let list_splits_request =
             ListSplitsRequest::try_from_list_splits_query(&list_splits_query)?;
-        let splits = self.inner_list_splits(list_splits_request).await?;
+        let splits = self.list_splits_inner(list_splits_request).await?;
         ListSplitsResponse::try_from_splits(splits)
     }
 
@@ -723,18 +767,57 @@ impl MetastoreService for FileBackedMetastore {
         &mut self,
         request: IndexMetadataRequest,
     ) -> MetastoreResult<IndexMetadataResponse> {
-        let index_id = request.get_index_id()?;
         let index_metadata = self
-            .read_any(&index_id, |index| Ok(index.metadata().clone()))
-            .await?;
-        if let Some(index_uid) = &request.index_uid {
-            if index_metadata.index_uid != *index_uid {
-                return Err(MetastoreError::NotFound(EntityKind::Index {
-                    index_id: index_id.to_string(),
-                }));
+            .index_metadata_inner(request.index_id, request.index_uid)
+            .await
+            .map_err(|(metastore_error, _index_id_opt, _index_uid_opt)| metastore_error)?;
+        let response = IndexMetadataResponse::try_from_index_metadata(&index_metadata)?;
+        Ok(response)
+    }
+
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> MetastoreResult<IndexesMetadataResponse> {
+        let mut indexes_metadata: Vec<IndexMetadata> =
+            Vec::with_capacity(request.subrequests.len());
+        let mut failures: Vec<IndexMetadataFailure> = Vec::new();
+
+        let mut index_metadata_futures = FuturesUnordered::new();
+
+        for subrequest in request.subrequests {
+            let mut metastore = self.clone();
+            let index_metadata_future = async move {
+                metastore
+                    .index_metadata_inner(subrequest.index_id, subrequest.index_uid)
+                    .await
+            };
+            index_metadata_futures.push(index_metadata_future);
+        }
+        while let Some(index_metadata_result) = index_metadata_futures.next().await {
+            match index_metadata_result {
+                Ok(index_metadata) => indexes_metadata.push(index_metadata),
+                Err((MetastoreError::NotFound(_), index_id, index_uid)) => {
+                    let failure = IndexMetadataFailure {
+                        index_id,
+                        index_uid,
+                        reason: IndexMetadataFailureReason::NotFound as i32,
+                    };
+                    failures.push(failure)
+                }
+                // All other errors are considered internal errors.
+                Err((_metastore_error, index_id, index_uid)) => {
+                    let failure = IndexMetadataFailure {
+                        index_id,
+                        index_uid,
+                        reason: IndexMetadataFailureReason::Internal as i32,
+                    };
+                    failures.push(failure)
+                }
             }
         }
-        let response = IndexMetadataResponse::try_from_index_metadata(&index_metadata)?;
+        let response =
+            IndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata, failures).await?;
         Ok(response)
     }
 
@@ -815,11 +898,12 @@ impl MetastoreService for FileBackedMetastore {
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> MetastoreResult<EmptyResponse> {
+    ) -> MetastoreResult<DeleteShardsResponse> {
         let index_uid = request.index_uid().clone();
-        self.mutate(&index_uid, |index| index.delete_shards(request))
+        let response = self
+            .mutate(&index_uid, |index| index.delete_shards(request))
             .await?;
-        Ok(EmptyResponse {})
+        Ok(response)
     }
 
     async fn list_shards(

--- a/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/index_metadata/mod.rs
@@ -23,7 +23,9 @@ use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 
 use quickwit_common::uri::Uri;
-use quickwit_config::{IndexConfig, SourceConfig, TestableForRegression};
+use quickwit_config::{
+    IndexConfig, RetentionPolicy, SearchSettings, SourceConfig, TestableForRegression,
+};
 use quickwit_proto::metastore::{EntityKind, MetastoreError, MetastoreResult};
 use quickwit_proto::types::{IndexUid, Position, SourceId};
 use serde::{Deserialize, Serialize};
@@ -97,6 +99,26 @@ impl IndexMetadata {
     /// Accessor to the index config's index uri for convenience.
     pub fn index_uri(&self) -> &Uri {
         &self.index_config().index_uri
+    }
+
+    /// Replaces or removes the current retention policy, returning whether a mutation occurred.
+    pub fn set_retention_policy(&mut self, retention_policy_opt: Option<RetentionPolicy>) -> bool {
+        if self.index_config.retention_policy_opt != retention_policy_opt {
+            self.index_config.retention_policy_opt = retention_policy_opt;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Replaces or removes the current search settings, returning whether a mutation occurred.
+    pub fn set_search_settings(&mut self, search_settings: SearchSettings) -> bool {
+        if self.index_config.search_settings != search_settings {
+            self.index_config.search_settings = search_settings;
+            true
+        } else {
+            false
+        }
     }
 
     /// Adds a source to the index. Returns an error if the source already exists.

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -21,6 +21,7 @@ use std::fmt::{self, Write};
 
 use async_trait::async_trait;
 use futures::StreamExt;
+use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
 use quickwit_common::uri::Uri;
 use quickwit_common::ServiceStream;
@@ -32,20 +33,22 @@ use quickwit_proto::ingest::{Shard, ShardState};
 use quickwit_proto::metastore::{
     serde_utils, AcquireShardsRequest, AcquireShardsResponse, AddSourceRequest, CreateIndexRequest,
     CreateIndexResponse, CreateIndexTemplateRequest, DeleteIndexRequest,
-    DeleteIndexTemplatesRequest, DeleteQuery, DeleteShardsRequest, DeleteSourceRequest,
-    DeleteSplitsRequest, DeleteTask, EmptyResponse, EntityKind, FindIndexTemplateMatchesRequest,
-    FindIndexTemplateMatchesResponse, GetIndexTemplateRequest, GetIndexTemplateResponse,
-    IndexMetadataRequest, IndexMetadataResponse, IndexTemplateMatch, LastDeleteOpstampRequest,
-    LastDeleteOpstampResponse, ListDeleteTasksRequest, ListDeleteTasksResponse,
-    ListIndexTemplatesRequest, ListIndexTemplatesResponse, ListIndexesMetadataRequest,
-    ListIndexesMetadataResponse, ListShardsRequest, ListShardsResponse, ListShardsSubresponse,
-    ListSplitsRequest, ListSplitsResponse, ListStaleSplitsRequest, MarkSplitsForDeletionRequest,
-    MetastoreError, MetastoreResult, MetastoreService, MetastoreServiceStream, OpenShardSubrequest,
+    DeleteIndexTemplatesRequest, DeleteQuery, DeleteShardsRequest, DeleteShardsResponse,
+    DeleteSourceRequest, DeleteSplitsRequest, DeleteTask, EmptyResponse, EntityKind,
+    FindIndexTemplateMatchesRequest, FindIndexTemplateMatchesResponse, GetIndexTemplateRequest,
+    GetIndexTemplateResponse, IndexMetadataFailure, IndexMetadataFailureReason,
+    IndexMetadataRequest, IndexMetadataResponse, IndexTemplateMatch, IndexesMetadataRequest,
+    IndexesMetadataResponse, LastDeleteOpstampRequest, LastDeleteOpstampResponse,
+    ListDeleteTasksRequest, ListDeleteTasksResponse, ListIndexTemplatesRequest,
+    ListIndexTemplatesResponse, ListIndexesMetadataRequest, ListIndexesMetadataResponse,
+    ListShardsRequest, ListShardsResponse, ListShardsSubresponse, ListSplitsRequest,
+    ListSplitsResponse, ListStaleSplitsRequest, MarkSplitsForDeletionRequest, MetastoreError,
+    MetastoreResult, MetastoreService, MetastoreServiceStream, OpenShardSubrequest,
     OpenShardSubresponse, OpenShardsRequest, OpenShardsResponse, PublishSplitsRequest,
     ResetSourceCheckpointRequest, StageSplitsRequest, ToggleSourceRequest, UpdateIndexRequest,
     UpdateSplitsDeleteOpstampRequest, UpdateSplitsDeleteOpstampResponse,
 };
-use quickwit_proto::types::{IndexId, IndexUid, Position, PublishToken, SourceId};
+use quickwit_proto::types::{IndexId, IndexUid, Position, PublishToken, ShardId, SourceId};
 use sea_query::{Asterisk, PostgresQueryBuilder, Query};
 use sea_query_binder::SqlxBinder;
 use sqlx::{Acquire, Executor, Postgres, Transaction};
@@ -62,7 +65,9 @@ use crate::checkpoint::{
 };
 use crate::file_backed::MutationOccurred;
 use crate::metastore::postgres::utils::split_maturity_timestamp;
-use crate::metastore::{PublishSplitsRequestExt, STREAM_SPLITS_CHUNK_SIZE};
+use crate::metastore::{
+    IndexesMetadataResponseExt, PublishSplitsRequestExt, STREAM_SPLITS_CHUNK_SIZE,
+};
 use crate::{
     AddSourceRequestExt, CreateIndexRequestExt, IndexMetadata, IndexMetadataResponseExt,
     ListIndexesMetadataResponseExt, ListSplitsRequestExt, ListSplitsResponseExt,
@@ -155,7 +160,7 @@ where
         FOR UPDATE
         "#,
     )
-    .bind(index_uid.to_string())
+    .bind(&index_uid)
     .fetch_optional(executor)
     .await?;
     Ok(index_opt)
@@ -201,7 +206,7 @@ async fn try_apply_delta_v2(
         FOR UPDATE
         "#,
     )
-    .bind(index_uid.to_string())
+    .bind(index_uid)
     .bind(source_id)
     .bind(shard_ids)
     .fetch_all(tx.as_mut())
@@ -255,7 +260,7 @@ async fn try_apply_delta_v2(
                 AND shards.shard_id = new_positions.shard_id
             "#,
     )
-    .bind(index_uid.to_string())
+    .bind(index_uid)
     .bind(source_id)
     .bind(shard_ids)
     .bind(new_positions)
@@ -279,10 +284,10 @@ macro_rules! run_with_tx {
         let op_fut = move || async move { $x };
         let op_result: MetastoreResult<_> = op_fut().await;
         if op_result.is_ok() {
-            debug!("commit");
+            debug!("committing transaction");
             tx.commit().await?;
         } else {
-            warn!("rollback");
+            warn!("rolling transaction back");
             tx.rollback().await?;
         }
         op_result
@@ -324,7 +329,7 @@ where
         "#,
     )
     .bind(index_metadata_json)
-    .bind(index_uid.to_string())
+    .bind(&index_uid)
     .execute(tx.as_mut())
     .await?;
     if update_index_res.rows_affected() == 0 {
@@ -346,29 +351,12 @@ impl MetastoreService for PostgresqlMetastore {
         vec![self.uri.clone()]
     }
 
-    #[instrument(skip(self))]
-    async fn list_indexes_metadata(
-        &mut self,
-        request: ListIndexesMetadataRequest,
-    ) -> MetastoreResult<ListIndexesMetadataResponse> {
-        let sql =
-            build_index_id_patterns_sql_query(&request.index_id_patterns).map_err(|error| {
-                MetastoreError::Internal {
-                    message: "failed to build `list_indexes_metadata` SQL query".to_string(),
-                    cause: error.to_string(),
-                }
-            })?;
-        let pg_indexes = sqlx::query_as::<_, PgIndex>(&sql)
-            .fetch_all(&self.connection_pool)
-            .await?;
-        let indexes_metadata = pg_indexes
-            .into_iter()
-            .map(|pg_index| pg_index.index_metadata())
-            .collect::<MetastoreResult<Vec<IndexMetadata>>>()?;
-        let response =
-            ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata).await?;
-        Ok(response)
-    }
+    // Index API:
+    // - `create_index`
+    // - `update_index`
+    // - `index_metadata`
+    // - `indexes_metadata`
+    // - `list_indexes_metadata`
 
     #[instrument(skip(self))]
     async fn create_index(
@@ -409,21 +397,139 @@ impl MetastoreService for PostgresqlMetastore {
         let retention_policy_opt = request.deserialize_retention_policy()?;
         let search_settings = request.deserialize_search_settings()?;
         let index_uid: IndexUid = request.index_uid().clone();
-        let updated_metadata = run_with_tx!(self.connection_pool, tx, {
+        let updated_index_metadata = run_with_tx!(self.connection_pool, tx, {
             mutate_index_metadata::<MetastoreError, _>(tx, index_uid, |index_metadata| {
-                if index_metadata.index_config.search_settings != search_settings
-                    || index_metadata.index_config.retention_policy_opt != retention_policy_opt
-                {
-                    index_metadata.index_config.search_settings = search_settings;
-                    index_metadata.index_config.retention_policy_opt = retention_policy_opt;
-                    Ok(MutationOccurred::Yes(()))
-                } else {
-                    Ok(MutationOccurred::No(()))
-                }
+                let mut mutation_occurred =
+                    index_metadata.set_retention_policy(retention_policy_opt);
+                mutation_occurred |= index_metadata.set_search_settings(search_settings);
+                Ok(MutationOccurred::from(mutation_occurred))
             })
             .await
         })?;
-        IndexMetadataResponse::try_from_index_metadata(&updated_metadata)
+        IndexMetadataResponse::try_from_index_metadata(&updated_index_metadata)
+    }
+
+    #[instrument(skip(self))]
+    async fn index_metadata(
+        &mut self,
+        request: IndexMetadataRequest,
+    ) -> MetastoreResult<IndexMetadataResponse> {
+        let response = if let Some(index_uid) = &request.index_uid {
+            index_opt_for_uid(&self.connection_pool, index_uid.clone()).await?
+        } else if let Some(index_id) = &request.index_id {
+            index_opt(&self.connection_pool, index_id).await?
+        } else {
+            let message = "invalid request: neither `index_id` nor `index_uid` is set".to_string();
+            return Err(MetastoreError::Internal {
+                message,
+                cause: "".to_string(),
+            });
+        };
+        let index_metadata = response
+            .ok_or(MetastoreError::NotFound(EntityKind::Index {
+                index_id: request.index_id.expect("`index_id` should be set"),
+            }))?
+            .index_metadata()?;
+        let response = IndexMetadataResponse::try_from_index_metadata(&index_metadata)?;
+        Ok(response)
+    }
+
+    #[instrument(skip(self))]
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> MetastoreResult<IndexesMetadataResponse> {
+        const INDEXES_METADATA_QUERY: &str = include_str!("queries/indexes_metadata.sql");
+
+        let num_subrequests = request.subrequests.len();
+
+        if num_subrequests == 0 {
+            return Ok(Default::default());
+        }
+        let mut index_ids: Vec<IndexId> = Vec::new();
+        let mut index_uids: Vec<IndexUid> = Vec::with_capacity(num_subrequests);
+        let mut failures: Vec<IndexMetadataFailure> = Vec::new();
+
+        for subrequest in request.subrequests {
+            if let Some(index_id) = subrequest.index_id {
+                index_ids.push(index_id);
+            } else if let Some(index_uid) = subrequest.index_uid {
+                index_uids.push(index_uid);
+            } else {
+                let failure = IndexMetadataFailure {
+                    index_id: subrequest.index_id,
+                    index_uid: subrequest.index_uid,
+                    reason: IndexMetadataFailureReason::Internal as i32,
+                };
+                failures.push(failure);
+            }
+        }
+        let pg_indexes: Vec<PgIndex> = sqlx::query_as::<_, PgIndex>(INDEXES_METADATA_QUERY)
+            .bind(&index_ids)
+            .bind(&index_uids)
+            .fetch_all(&self.connection_pool)
+            .await?;
+
+        let indexes_metadata: Vec<IndexMetadata> = pg_indexes
+            .iter()
+            .map(|pg_index| pg_index.index_metadata())
+            .collect::<MetastoreResult<_>>()?;
+
+        if pg_indexes.len() + failures.len() < num_subrequests {
+            for index_id in index_ids {
+                if pg_indexes
+                    .iter()
+                    .all(|pg_index| pg_index.index_id != index_id)
+                {
+                    let failure = IndexMetadataFailure {
+                        index_id: Some(index_id),
+                        index_uid: None,
+                        reason: IndexMetadataFailureReason::NotFound as i32,
+                    };
+                    failures.push(failure);
+                }
+            }
+            for index_uid in index_uids {
+                if pg_indexes
+                    .iter()
+                    .all(|pg_index| pg_index.index_uid != index_uid)
+                {
+                    let failure = IndexMetadataFailure {
+                        index_id: None,
+                        index_uid: Some(index_uid),
+                        reason: IndexMetadataFailureReason::NotFound as i32,
+                    };
+                    failures.push(failure);
+                }
+            }
+        }
+        let response =
+            IndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata, failures).await?;
+        Ok(response)
+    }
+
+    #[instrument(skip(self))]
+    async fn list_indexes_metadata(
+        &mut self,
+        request: ListIndexesMetadataRequest,
+    ) -> MetastoreResult<ListIndexesMetadataResponse> {
+        let sql =
+            build_index_id_patterns_sql_query(&request.index_id_patterns).map_err(|error| {
+                MetastoreError::Internal {
+                    message: "failed to build `list_indexes_metadata` SQL query".to_string(),
+                    cause: error.to_string(),
+                }
+            })?;
+        let pg_indexes = sqlx::query_as::<_, PgIndex>(&sql)
+            .fetch_all(&self.connection_pool)
+            .await?;
+        let indexes_metadata: Vec<IndexMetadata> = pg_indexes
+            .into_iter()
+            .map(|pg_index| pg_index.index_metadata())
+            .collect::<MetastoreResult<_>>()?;
+        let response =
+            ListIndexesMetadataResponse::try_from_indexes_metadata(indexes_metadata).await?;
+        Ok(response)
     }
 
     #[instrument(skip_all, fields(index_id=%request.index_uid()))]
@@ -433,7 +539,7 @@ impl MetastoreService for PostgresqlMetastore {
     ) -> MetastoreResult<EmptyResponse> {
         let index_uid: IndexUid = request.index_uid().clone();
         let delete_result = sqlx::query("DELETE FROM indexes WHERE index_uid = $1")
-            .bind(index_uid.to_string())
+            .bind(&index_uid)
             .execute(&self.connection_pool)
             .await?;
         // FIXME: This is not idempotent.
@@ -526,7 +632,7 @@ impl MetastoreService for PostgresqlMetastore {
                 .bind(delete_opstamps)
                 .bind(maturity_timestamps)
                 .bind(SplitState::Staged.as_str())
-                .bind(index_uid.to_string())
+                .bind(&index_uid)
                 .fetch_all(tx.as_mut())
                 .await
                 .map_err(|sqlx_error| convert_sqlx_err(&index_uid.index_id, sqlx_error))?;
@@ -682,7 +788,7 @@ impl MetastoreService for PostgresqlMetastore {
                 not_marked_split_ids,
             ): (i64, i64, Vec<String>, Vec<String>, Vec<String>) =
                 sqlx::query_as(PUBLISH_SPLITS_QUERY)
-                    .bind(index_uid.to_string())
+                    .bind(&index_uid)
                     .bind(index_metadata_json)
                     .bind(staged_split_ids)
                     .bind(replaced_split_ids)
@@ -812,7 +918,7 @@ impl MetastoreService for PostgresqlMetastore {
         "#;
         let (num_found_splits, num_marked_splits, not_found_split_ids): (i64, i64, Vec<String>) =
             sqlx::query_as(MARK_SPLITS_FOR_DELETION_QUERY)
-                .bind(index_uid.to_string())
+                .bind(&index_uid)
                 .bind(split_ids.clone())
                 .fetch_one(&self.connection_pool)
                 .await
@@ -895,7 +1001,7 @@ impl MetastoreService for PostgresqlMetastore {
             Vec<String>,
             Vec<String>,
         ) = sqlx::query_as(DELETE_SPLITS_QUERY)
-            .bind(index_uid.to_string())
+            .bind(&index_uid)
             .bind(split_ids)
             .fetch_one(&self.connection_pool)
             .await
@@ -931,32 +1037,6 @@ impl MetastoreService for PostgresqlMetastore {
             );
         }
         Ok(EmptyResponse {})
-    }
-
-    #[instrument(skip(self))]
-    async fn index_metadata(
-        &mut self,
-        request: IndexMetadataRequest,
-    ) -> MetastoreResult<IndexMetadataResponse> {
-        let response = if let Some(index_uid) = &request.index_uid {
-            index_opt_for_uid(&self.connection_pool, index_uid.clone()).await?
-        } else if let Some(index_id) = &request.index_id {
-            index_opt(&self.connection_pool, index_id).await?
-        } else {
-            return Err(MetastoreError::Internal {
-                message: "either `index_id` or `index_uid` must be set".to_string(),
-                cause: "missing index identifier".to_string(),
-            });
-        };
-        let index_metadata = response
-            .ok_or({
-                MetastoreError::NotFound(EntityKind::Index {
-                    index_id: request.get_index_id().expect("index_id is set").to_string(),
-                })
-            })?
-            .index_metadata()?;
-        let response = IndexMetadataResponse::try_from_index_metadata(&index_metadata)?;
-        Ok(response)
     }
 
     #[instrument(skip(self))]
@@ -1015,7 +1095,7 @@ impl MetastoreService for PostgresqlMetastore {
                         AND source_id = $2
                 "#,
             )
-            .bind(index_uid.to_string())
+            .bind(&index_uid)
             .bind(source_id)
             .execute(tx.as_mut())
             .await?;
@@ -1057,7 +1137,7 @@ impl MetastoreService for PostgresqlMetastore {
             WHERE index_uid = $1
         "#,
         )
-        .bind(request.index_uid().to_string())
+        .bind(request.index_uid())
         .fetch_one(&self.connection_pool)
         .await
         .map_err(|error| MetastoreError::Db {
@@ -1126,7 +1206,7 @@ impl MetastoreService for PostgresqlMetastore {
         "#,
         )
         .bind(request.delete_opstamp as i64)
-        .bind(index_uid.to_string())
+        .bind(&index_uid)
         .bind(split_ids)
         .execute(&self.connection_pool)
         .await?;
@@ -1159,7 +1239,7 @@ impl MetastoreService for PostgresqlMetastore {
                     AND opstamp > $2
                 "#,
         )
-        .bind(index_uid.to_string())
+        .bind(&index_uid)
         .bind(request.opstamp_start as i64)
         .fetch_all(&self.connection_pool)
         .await?;
@@ -1192,7 +1272,7 @@ impl MetastoreService for PostgresqlMetastore {
                 LIMIT $4
             "#,
         )
-        .bind(index_uid.to_string())
+        .bind(&index_uid)
         .bind(request.delete_opstamp as i64)
         .bind(SplitState::Published.as_str())
         .bind(request.num_splits as i64)
@@ -1207,6 +1287,7 @@ impl MetastoreService for PostgresqlMetastore {
         Ok(response)
     }
 
+    // TODO: Issue a single SQL query.
     async fn open_shards(
         &mut self,
         request: OpenShardsRequest,
@@ -1233,16 +1314,11 @@ impl MetastoreService for PostgresqlMetastore {
         if request.shard_ids.is_empty() {
             return Ok(Default::default());
         }
-        let shard_ids: Vec<&str> = request
-            .shard_ids
-            .iter()
-            .map(|shard_id| shard_id.as_str())
-            .collect();
         let pg_shards: Vec<PgShard> = sqlx::query_as(ACQUIRE_SHARDS_QUERY)
-            .bind(request.index_uid().to_string())
+            .bind(request.index_uid())
             .bind(&request.source_id)
-            .bind(&shard_ids)
-            .bind(request.publish_token)
+            .bind(&request.shard_ids)
+            .bind(&request.publish_token)
             .fetch_all(&self.connection_pool)
             .await?;
         let acquired_shards = pg_shards
@@ -1253,6 +1329,7 @@ impl MetastoreService for PostgresqlMetastore {
         Ok(response)
     }
 
+    // TODO: Issue a single SQL query.
     async fn list_shards(
         &mut self,
         request: ListShardsRequest,
@@ -1292,34 +1369,73 @@ impl MetastoreService for PostgresqlMetastore {
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> MetastoreResult<EmptyResponse> {
+    ) -> MetastoreResult<DeleteShardsResponse> {
         const DELETE_SHARDS_QUERY: &str = include_str!("queries/shards/delete.sql");
+
+        const FIND_NOT_DELETABLE_SHARDS_QUERY: &str =
+            include_str!("queries/shards/find_not_deletable.sql");
 
         if request.shard_ids.is_empty() {
             return Ok(Default::default());
         }
-        let shard_ids: Vec<&str> = request
-            .shard_ids
-            .iter()
-            .map(|shard_id| shard_id.as_str())
-            .collect();
-        let pg_shards: Vec<PgShard> = sqlx::query_as(DELETE_SHARDS_QUERY)
-            .bind(request.index_uid().to_string())
+        let query_result = sqlx::query(DELETE_SHARDS_QUERY)
+            .bind(request.index_uid())
             .bind(&request.source_id)
-            .bind(&shard_ids)
+            .bind(&request.shard_ids)
             .bind(request.force)
+            .execute(&self.connection_pool)
+            .await?;
+
+        // Happy path: all shards were deleted.
+        if request.force || query_result.rows_affected() == request.shard_ids.len() as u64 {
+            let response = DeleteShardsResponse {
+                index_uid: request.index_uid,
+                source_id: request.source_id,
+                successes: request.shard_ids,
+                failures: Vec::new(),
+            };
+            return Ok(response);
+        }
+        // Unhappy path: some shards were not deleted because they do not exist or are not fully
+        // indexed.
+        let not_deletable_pg_shards: Vec<PgShard> = sqlx::query_as(FIND_NOT_DELETABLE_SHARDS_QUERY)
+            .bind(request.index_uid())
+            .bind(&request.source_id)
+            .bind(&request.shard_ids)
             .fetch_all(&self.connection_pool)
             .await?;
-        if !request.force
-            && pg_shards.into_iter().any(|pg_shard| {
-                let position: Position = pg_shard.publish_position_inclusive.into();
-                position.is_eof()
-            })
-        {
-            let message = "failed to delete shard ``: shard is not fully indexed".to_string();
-            return Err(MetastoreError::InvalidArgument { message });
+
+        if not_deletable_pg_shards.is_empty() {
+            let response = DeleteShardsResponse {
+                index_uid: request.index_uid,
+                source_id: request.source_id,
+                successes: request.shard_ids,
+                failures: Vec::new(),
+            };
+            return Ok(response);
         }
-        Ok(EmptyResponse {})
+        let failures: Vec<ShardId> = not_deletable_pg_shards
+            .into_iter()
+            .map(|pg_shard| pg_shard.shard_id)
+            .collect();
+        warn!(
+            index_uid=%request.index_uid(),
+            source_id=%request.source_id,
+            "failed to delete shards `{}`: shards are not fully indexed",
+            failures.iter().join(", ")
+        );
+        let successes: Vec<ShardId> = request
+            .shard_ids
+            .into_iter()
+            .filter(|shard_id| !failures.contains(shard_id))
+            .collect();
+        let response = DeleteShardsResponse {
+            index_uid: request.index_uid,
+            source_id: request.source_id,
+            successes,
+            failures,
+        };
+        Ok(response)
     }
 
     // Index Template API
@@ -1634,7 +1750,7 @@ mod tests {
 
             for shard in shards {
                 sqlx::query(INSERT_SHARD_QUERY)
-                    .bind(index_uid.to_string())
+                    .bind(index_uid)
                     .bind(source_id)
                     .bind(shard.shard_id().as_str())
                     .bind(shard.shard_state().as_json_str_name())
@@ -1658,7 +1774,7 @@ mod tests {
                     AND source_id = $2
                 "#,
             )
-            .bind(index_uid.to_string())
+            .bind(index_uid)
             .bind(source_id.as_str())
             .fetch_all(&self.connection_pool)
             .await

--- a/quickwit/quickwit-metastore/src/metastore/postgres/queries/indexes_metadata.sql
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/queries/indexes_metadata.sql
@@ -1,0 +1,7 @@
+SELECT
+    *
+FROM
+    indexes
+WHERE
+    index_id = ANY ($1)
+    OR index_uid = ANY ($2)

--- a/quickwit/quickwit-metastore/src/metastore/postgres/queries/shards/delete.sql
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/queries/shards/delete.sql
@@ -2,5 +2,5 @@ DELETE FROM shards
 WHERE index_uid = $1
     AND source_id = $2
     AND shard_id = ANY ($3)
-    AND ($4 = TRUE
+    AND ($4
         OR publish_position_inclusive LIKE '~%')

--- a/quickwit/quickwit-metastore/src/metastore/postgres/queries/shards/find_not_deletable.sql
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/queries/shards/find_not_deletable.sql
@@ -1,0 +1,9 @@
+SELECT
+    *
+FROM
+    shards
+WHERE
+    index_uid = $1
+    AND source_id = $2
+    AND shard_id = ANY ($3)
+    AND publish_position_inclusive NOT LIKE '~%'

--- a/quickwit/quickwit-metastore/src/tests/mod.rs
+++ b/quickwit/quickwit-metastore/src/tests/mod.rs
@@ -175,8 +175,10 @@ macro_rules! metastore_test_suite {
             // Index API tests
             //
             //  - create_index
+            //  - update_index
             //  - index_exists
             //  - index_metadata
+            //  - indexes_metadata
             //  - list_indexes
             //  - delete_index
 
@@ -187,15 +189,15 @@ macro_rules! metastore_test_suite {
             }
 
             #[tokio::test]
-            async fn test_metastore_update_index() {
-                let _ = tracing_subscriber::fmt::try_init();
-                $crate::tests::index::test_metastore_update_index::<$metastore_type>().await;
-            }
-
-            #[tokio::test]
             async fn test_metastore_create_index_with_sources() {
                 let _ = tracing_subscriber::fmt::try_init();
                 $crate::tests::index::test_metastore_create_index_with_sources::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
+            async fn test_metastore_update_index() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_update_index::<$metastore_type>().await;
             }
 
             #[tokio::test]
@@ -217,6 +219,12 @@ macro_rules! metastore_test_suite {
             async fn test_metastore_index_metadata() {
                 let _ = tracing_subscriber::fmt::try_init();
                 $crate::tests::index::test_metastore_index_metadata::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
+            async fn test_metastore_indexes_metadata() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_indexes_metadata::<$metastore_type>().await;
             }
 
             #[tokio::test]

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -87,7 +87,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Metastore service.
     let mut prost_config = prost_build::Config::default();
     prost_config
-        .bytes(["ListIndexesMetadataResponse.indexes_metadata_json_zstd"])
+        .bytes([
+            "IndexesMetadataResponse.indexes_metadata_json_zstd",
+            "ListIndexesMetadataResponse.indexes_metadata_json_zstd",
+        ])
         .extern_path(".quickwit.ingest.ShardId", "crate::types::ShardId")
         .extern_path(".quickwit.common.IndexUid", "crate::types::IndexUid")
         .field_attribute("DeleteQuery.index_uid", "#[serde(alias = \"index_id\")]")

--- a/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
@@ -32,6 +32,7 @@ service ControlPlaneService {
 
   // The following RPCs are forwarded and handled by the metastore:
   // - `create_index`
+  // - `update_index`
   // - `delete_index`
   // - `add_source`
   // - `toggle_source`
@@ -41,6 +42,9 @@ service ControlPlaneService {
 
   // Creates a new index.
   rpc CreateIndex(quickwit.metastore.CreateIndexRequest) returns (quickwit.metastore.CreateIndexResponse);
+
+  // Updates an index.
+  rpc UpdateIndex(quickwit.metastore.UpdateIndexRequest) returns (quickwit.metastore.IndexMetadataResponse);
 
   // Deletes an index.
   rpc DeleteIndex(quickwit.metastore.DeleteIndexRequest) returns (quickwit.metastore.EmptyResponse);

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -102,6 +102,9 @@ service MetastoreService {
   // Returns the `IndexMetadata` of an index identified by its IndexID or its IndexUID.
   rpc IndexMetadata(IndexMetadataRequest) returns (IndexMetadataResponse);
 
+  // Fetches the metadata of a list of indexes identified by their Index IDs or UIDs.
+  rpc IndexesMetadata(IndexesMetadataRequest) returns (IndexesMetadataResponse);
+
   // Gets an indexes metadatas.
   rpc ListIndexesMetadata(ListIndexesMetadataRequest) returns (ListIndexesMetadataResponse);
 
@@ -163,9 +166,9 @@ service MetastoreService {
   // list of acquired shards along with the positions to index from.
   rpc AcquireShards(AcquireShardsRequest) returns (AcquireShardsResponse);
 
-  // Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+  // Deletes a set of shards. This RPC deletes the shards from the metastore.
   // If the shard did not exist to begin with, the operation is successful and does not return any error.
-  rpc DeleteShards(DeleteShardsRequest) returns (EmptyResponse);
+  rpc DeleteShards(DeleteShardsRequest) returns (DeleteShardsResponse);
 
   rpc ListShards(ListShardsRequest) returns (ListShardsResponse);
 
@@ -220,6 +223,7 @@ message ListIndexesMetadataResponse {
   // Deprecated (v0.9.0), use `indexes_metadata_json_zstd` instead.
   optional string indexes_metadata_json_opt = 1;
   // A JSON serialized then ZSTD compressed list of `IndexMetadata`: `Vec<IndexMetadata> | JSON | ZSTD`.
+  // We don't use `repeated` here to increase the compression rate and ratio.
   bytes indexes_metadata_json_zstd = 2;
 }
 
@@ -238,6 +242,34 @@ message IndexMetadataRequest {
 
 message IndexMetadataResponse {
   string index_metadata_serialized_json = 1;
+}
+
+message IndexesMetadataRequest {
+  repeated IndexMetadataSubrequest subrequests = 1;
+}
+
+message IndexMetadataSubrequest {
+  optional string index_id = 1;
+  optional quickwit.common.IndexUid index_uid = 2;
+}
+
+message IndexesMetadataResponse {
+  // A JSON serialized then ZSTD compressed list of `IndexMetadata`: `Vec<IndexMetadata> | JSON | ZSTD`.
+  // We don't use `repeated` here to increase the compression rate and ratio.
+  bytes indexes_metadata_json_zstd = 1;
+  repeated IndexMetadataFailure failures = 2;
+}
+
+message IndexMetadataFailure {
+  optional string index_id = 1;
+  optional quickwit.common.IndexUid index_uid = 2;
+  IndexMetadataFailureReason reason = 3;
+}
+
+enum IndexMetadataFailureReason {
+  INDEX_METADATA_FAILURE_REASON_UNSPECIFIED = 0;
+  INDEX_METADATA_FAILURE_REASON_NOT_FOUND = 1;
+  INDEX_METADATA_FAILURE_REASON_INTERNAL = 2;
 }
 
 message ListSplitsRequest {
@@ -396,6 +428,16 @@ message DeleteShardsRequest {
   repeated quickwit.ingest.ShardId shard_ids = 3;
   // If false, only shards at EOF positions will be deleted.
   bool force = 4;
+}
+
+message DeleteShardsResponse {
+  quickwit.common.IndexUid index_uid = 1;
+  string source_id = 2;
+  // List of shard IDs that were successfully deleted.
+  repeated quickwit.ingest.ShardId successes = 3;
+  // List of shard IDs that could not be deleted because `force` was set to `false` in the request,
+  // and the shards are not at EOF, i.e., not fully indexed.
+  repeated quickwit.ingest.ShardId failures = 4;
 }
 
 message ListShardsRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -51,6 +51,7 @@ pub struct ListIndexesMetadataResponse {
         ::prost::alloc::string::String,
     >,
     /// A JSON serialized then ZSTD compressed list of `IndexMetadata`: `Vec<IndexMetadata> | JSON | ZSTD`.
+    /// We don't use `repeated` here to increase the compression rate and ratio.
     #[prost(bytes = "bytes", tag = "2")]
     pub indexes_metadata_json_zstd: ::prost::bytes::Bytes,
 }
@@ -80,6 +81,44 @@ pub struct IndexMetadataRequest {
 pub struct IndexMetadataResponse {
     #[prost(string, tag = "1")]
     pub index_metadata_serialized_json: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IndexesMetadataRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub subrequests: ::prost::alloc::vec::Vec<IndexMetadataSubrequest>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IndexMetadataSubrequest {
+    #[prost(string, optional, tag = "1")]
+    pub index_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "2")]
+    pub index_uid: ::core::option::Option<crate::types::IndexUid>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IndexesMetadataResponse {
+    /// A JSON serialized then ZSTD compressed list of `IndexMetadata`: `Vec<IndexMetadata> | JSON | ZSTD`.
+    /// We don't use `repeated` here to increase the compression rate and ratio.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub indexes_metadata_json_zstd: ::prost::bytes::Bytes,
+    #[prost(message, repeated, tag = "2")]
+    pub failures: ::prost::alloc::vec::Vec<IndexMetadataFailure>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IndexMetadataFailure {
+    #[prost(string, optional, tag = "1")]
+    pub index_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "2")]
+    pub index_uid: ::core::option::Option<crate::types::IndexUid>,
+    #[prost(enumeration = "IndexMetadataFailureReason", tag = "3")]
+    pub reason: i32,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -348,6 +387,22 @@ pub struct DeleteShardsRequest {
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteShardsResponse {
+    #[prost(message, optional, tag = "1")]
+    pub index_uid: ::core::option::Option<crate::types::IndexUid>,
+    #[prost(string, tag = "2")]
+    pub source_id: ::prost::alloc::string::String,
+    /// List of shard IDs that were successfully deleted.
+    #[prost(message, repeated, tag = "3")]
+    pub successes: ::prost::alloc::vec::Vec<crate::types::ShardId>,
+    /// List of shard IDs that could not be deleted because `force` was set to `false` in the request,
+    /// and the shards are not at EOF, i.e., not fully indexed.
+    #[prost(message, repeated, tag = "4")]
+    pub failures: ::prost::alloc::vec::Vec<crate::types::ShardId>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListShardsRequest {
     #[prost(message, repeated, tag = "1")]
     pub subrequests: ::prost::alloc::vec::Vec<ListShardsSubrequest>,
@@ -509,6 +564,43 @@ impl SourceType {
         }
     }
 }
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum IndexMetadataFailureReason {
+    Unspecified = 0,
+    NotFound = 1,
+    Internal = 2,
+}
+impl IndexMetadataFailureReason {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            IndexMetadataFailureReason::Unspecified => {
+                "INDEX_METADATA_FAILURE_REASON_UNSPECIFIED"
+            }
+            IndexMetadataFailureReason::NotFound => {
+                "INDEX_METADATA_FAILURE_REASON_NOT_FOUND"
+            }
+            IndexMetadataFailureReason::Internal => {
+                "INDEX_METADATA_FAILURE_REASON_INTERNAL"
+            }
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "INDEX_METADATA_FAILURE_REASON_UNSPECIFIED" => Some(Self::Unspecified),
+            "INDEX_METADATA_FAILURE_REASON_NOT_FOUND" => Some(Self::NotFound),
+            "INDEX_METADATA_FAILURE_REASON_INTERNAL" => Some(Self::Internal),
+            _ => None,
+        }
+    }
+}
 /// BEGIN quickwit-codegen
 #[allow(unused_imports)]
 use std::str::FromStr;
@@ -527,6 +619,11 @@ impl RpcName for UpdateIndexRequest {
 impl RpcName for IndexMetadataRequest {
     fn rpc_name() -> &'static str {
         "index_metadata"
+    }
+}
+impl RpcName for IndexesMetadataRequest {
+    fn rpc_name() -> &'static str {
+        "indexes_metadata"
     }
 }
 impl RpcName for ListIndexesMetadataRequest {
@@ -678,6 +775,11 @@ pub trait MetastoreService: std::fmt::Debug + dyn_clone::DynClone + Send + Sync 
         &mut self,
         request: IndexMetadataRequest,
     ) -> crate::metastore::MetastoreResult<IndexMetadataResponse>;
+    /// Fetches the metadata of a list of indexes identified by their Index IDs or UIDs.
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> crate::metastore::MetastoreResult<IndexesMetadataResponse>;
     /// Gets an indexes metadatas.
     async fn list_indexes_metadata(
         &mut self,
@@ -775,12 +877,12 @@ pub trait MetastoreService: std::fmt::Debug + dyn_clone::DynClone + Send + Sync 
         &mut self,
         request: AcquireShardsRequest,
     ) -> crate::metastore::MetastoreResult<AcquireShardsResponse>;
-    /// Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+    /// Deletes a set of shards. This RPC deletes the shards from the metastore.
     /// If the shard did not exist to begin with, the operation is successful and does not return any error.
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> crate::metastore::MetastoreResult<EmptyResponse>;
+    ) -> crate::metastore::MetastoreResult<DeleteShardsResponse>;
     async fn list_shards(
         &mut self,
         request: ListShardsRequest,
@@ -925,6 +1027,12 @@ impl MetastoreService for MetastoreServiceClient {
     ) -> crate::metastore::MetastoreResult<IndexMetadataResponse> {
         self.inner.index_metadata(request).await
     }
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> crate::metastore::MetastoreResult<IndexesMetadataResponse> {
+        self.inner.indexes_metadata(request).await
+    }
     async fn list_indexes_metadata(
         &mut self,
         request: ListIndexesMetadataRequest,
@@ -1036,7 +1144,7 @@ impl MetastoreService for MetastoreServiceClient {
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> crate::metastore::MetastoreResult<EmptyResponse> {
+    ) -> crate::metastore::MetastoreResult<DeleteShardsResponse> {
         self.inner.delete_shards(request).await
     }
     async fn list_shards(
@@ -1108,6 +1216,12 @@ pub mod mock_metastore_service {
             request: super::IndexMetadataRequest,
         ) -> crate::metastore::MetastoreResult<super::IndexMetadataResponse> {
             self.inner.lock().await.index_metadata(request).await
+        }
+        async fn indexes_metadata(
+            &mut self,
+            request: super::IndexesMetadataRequest,
+        ) -> crate::metastore::MetastoreResult<super::IndexesMetadataResponse> {
+            self.inner.lock().await.indexes_metadata(request).await
         }
         async fn list_indexes_metadata(
             &mut self,
@@ -1224,7 +1338,7 @@ pub mod mock_metastore_service {
         async fn delete_shards(
             &mut self,
             request: super::DeleteShardsRequest,
-        ) -> crate::metastore::MetastoreResult<super::EmptyResponse> {
+        ) -> crate::metastore::MetastoreResult<super::DeleteShardsResponse> {
             self.inner.lock().await.delete_shards(request).await
         }
         async fn list_shards(
@@ -1319,6 +1433,22 @@ impl tower::Service<IndexMetadataRequest> for Box<dyn MetastoreService> {
     fn call(&mut self, request: IndexMetadataRequest) -> Self::Future {
         let mut svc = self.clone();
         let fut = async move { svc.index_metadata(request).await };
+        Box::pin(fut)
+    }
+}
+impl tower::Service<IndexesMetadataRequest> for Box<dyn MetastoreService> {
+    type Response = IndexesMetadataResponse;
+    type Error = crate::metastore::MetastoreError;
+    type Future = BoxFuture<Self::Response, Self::Error>;
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+    fn call(&mut self, request: IndexesMetadataRequest) -> Self::Future {
+        let mut svc = self.clone();
+        let fut = async move { svc.indexes_metadata(request).await };
         Box::pin(fut)
     }
 }
@@ -1611,7 +1741,7 @@ impl tower::Service<AcquireShardsRequest> for Box<dyn MetastoreService> {
     }
 }
 impl tower::Service<DeleteShardsRequest> for Box<dyn MetastoreService> {
-    type Response = EmptyResponse;
+    type Response = DeleteShardsResponse;
     type Error = crate::metastore::MetastoreError;
     type Future = BoxFuture<Self::Response, Self::Error>;
     fn poll_ready(
@@ -1741,6 +1871,11 @@ struct MetastoreServiceTowerServiceStack {
         IndexMetadataResponse,
         crate::metastore::MetastoreError,
     >,
+    indexes_metadata_svc: quickwit_common::tower::BoxService<
+        IndexesMetadataRequest,
+        IndexesMetadataResponse,
+        crate::metastore::MetastoreError,
+    >,
     list_indexes_metadata_svc: quickwit_common::tower::BoxService<
         ListIndexesMetadataRequest,
         ListIndexesMetadataResponse,
@@ -1833,7 +1968,7 @@ struct MetastoreServiceTowerServiceStack {
     >,
     delete_shards_svc: quickwit_common::tower::BoxService<
         DeleteShardsRequest,
-        EmptyResponse,
+        DeleteShardsResponse,
         crate::metastore::MetastoreError,
     >,
     list_shards_svc: quickwit_common::tower::BoxService<
@@ -1874,6 +2009,7 @@ impl Clone for MetastoreServiceTowerServiceStack {
             create_index_svc: self.create_index_svc.clone(),
             update_index_svc: self.update_index_svc.clone(),
             index_metadata_svc: self.index_metadata_svc.clone(),
+            indexes_metadata_svc: self.indexes_metadata_svc.clone(),
             list_indexes_metadata_svc: self.list_indexes_metadata_svc.clone(),
             delete_index_svc: self.delete_index_svc.clone(),
             list_splits_svc: self.list_splits_svc.clone(),
@@ -1925,6 +2061,12 @@ impl MetastoreService for MetastoreServiceTowerServiceStack {
         request: IndexMetadataRequest,
     ) -> crate::metastore::MetastoreResult<IndexMetadataResponse> {
         self.index_metadata_svc.ready().await?.call(request).await
+    }
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> crate::metastore::MetastoreResult<IndexesMetadataResponse> {
+        self.indexes_metadata_svc.ready().await?.call(request).await
     }
     async fn list_indexes_metadata(
         &mut self,
@@ -2037,7 +2179,7 @@ impl MetastoreService for MetastoreServiceTowerServiceStack {
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> crate::metastore::MetastoreResult<EmptyResponse> {
+    ) -> crate::metastore::MetastoreResult<DeleteShardsResponse> {
         self.delete_shards_svc.ready().await?.call(request).await
     }
     async fn list_shards(
@@ -2111,6 +2253,16 @@ type IndexMetadataLayer = quickwit_common::tower::BoxLayer<
     >,
     IndexMetadataRequest,
     IndexMetadataResponse,
+    crate::metastore::MetastoreError,
+>;
+type IndexesMetadataLayer = quickwit_common::tower::BoxLayer<
+    quickwit_common::tower::BoxService<
+        IndexesMetadataRequest,
+        IndexesMetadataResponse,
+        crate::metastore::MetastoreError,
+    >,
+    IndexesMetadataRequest,
+    IndexesMetadataResponse,
     crate::metastore::MetastoreError,
 >;
 type ListIndexesMetadataLayer = quickwit_common::tower::BoxLayer<
@@ -2296,11 +2448,11 @@ type AcquireShardsLayer = quickwit_common::tower::BoxLayer<
 type DeleteShardsLayer = quickwit_common::tower::BoxLayer<
     quickwit_common::tower::BoxService<
         DeleteShardsRequest,
-        EmptyResponse,
+        DeleteShardsResponse,
         crate::metastore::MetastoreError,
     >,
     DeleteShardsRequest,
-    EmptyResponse,
+    DeleteShardsResponse,
     crate::metastore::MetastoreError,
 >;
 type ListShardsLayer = quickwit_common::tower::BoxLayer<
@@ -2368,6 +2520,7 @@ pub struct MetastoreServiceTowerLayerStack {
     create_index_layers: Vec<CreateIndexLayer>,
     update_index_layers: Vec<UpdateIndexLayer>,
     index_metadata_layers: Vec<IndexMetadataLayer>,
+    indexes_metadata_layers: Vec<IndexesMetadataLayer>,
     list_indexes_metadata_layers: Vec<ListIndexesMetadataLayer>,
     delete_index_layers: Vec<DeleteIndexLayer>,
     list_splits_layers: Vec<ListSplitsLayer>,
@@ -2472,6 +2625,31 @@ impl MetastoreServiceTowerLayerStack {
                 crate::metastore::MetastoreError,
             >,
         >>::Service as tower::Service<IndexMetadataRequest>>::Future: Send + 'static,
+        L: tower::Layer<
+                quickwit_common::tower::BoxService<
+                    IndexesMetadataRequest,
+                    IndexesMetadataResponse,
+                    crate::metastore::MetastoreError,
+                >,
+            > + Clone + Send + Sync + 'static,
+        <L as tower::Layer<
+            quickwit_common::tower::BoxService<
+                IndexesMetadataRequest,
+                IndexesMetadataResponse,
+                crate::metastore::MetastoreError,
+            >,
+        >>::Service: tower::Service<
+                IndexesMetadataRequest,
+                Response = IndexesMetadataResponse,
+                Error = crate::metastore::MetastoreError,
+            > + Clone + Send + Sync + 'static,
+        <<L as tower::Layer<
+            quickwit_common::tower::BoxService<
+                IndexesMetadataRequest,
+                IndexesMetadataResponse,
+                crate::metastore::MetastoreError,
+            >,
+        >>::Service as tower::Service<IndexesMetadataRequest>>::Future: Send + 'static,
         L: tower::Layer<
                 quickwit_common::tower::BoxService<
                     ListIndexesMetadataRequest,
@@ -2933,25 +3111,25 @@ impl MetastoreServiceTowerLayerStack {
         L: tower::Layer<
                 quickwit_common::tower::BoxService<
                     DeleteShardsRequest,
-                    EmptyResponse,
+                    DeleteShardsResponse,
                     crate::metastore::MetastoreError,
                 >,
             > + Clone + Send + Sync + 'static,
         <L as tower::Layer<
             quickwit_common::tower::BoxService<
                 DeleteShardsRequest,
-                EmptyResponse,
+                DeleteShardsResponse,
                 crate::metastore::MetastoreError,
             >,
         >>::Service: tower::Service<
                 DeleteShardsRequest,
-                Response = EmptyResponse,
+                Response = DeleteShardsResponse,
                 Error = crate::metastore::MetastoreError,
             > + Clone + Send + Sync + 'static,
         <<L as tower::Layer<
             quickwit_common::tower::BoxService<
                 DeleteShardsRequest,
-                EmptyResponse,
+                DeleteShardsResponse,
                 crate::metastore::MetastoreError,
             >,
         >>::Service as tower::Service<DeleteShardsRequest>>::Future: Send + 'static,
@@ -3120,6 +3298,8 @@ impl MetastoreServiceTowerLayerStack {
             .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self.index_metadata_layers
             .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
+        self.indexes_metadata_layers
+            .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self.list_indexes_metadata_layers
             .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self.delete_index_layers
@@ -3227,6 +3407,25 @@ impl MetastoreServiceTowerLayerStack {
         <L::Service as tower::Service<IndexMetadataRequest>>::Future: Send + 'static,
     {
         self.index_metadata_layers.push(quickwit_common::tower::BoxLayer::new(layer));
+        self
+    }
+    pub fn stack_indexes_metadata_layer<L>(mut self, layer: L) -> Self
+    where
+        L: tower::Layer<
+                quickwit_common::tower::BoxService<
+                    IndexesMetadataRequest,
+                    IndexesMetadataResponse,
+                    crate::metastore::MetastoreError,
+                >,
+            > + Send + Sync + 'static,
+        L::Service: tower::Service<
+                IndexesMetadataRequest,
+                Response = IndexesMetadataResponse,
+                Error = crate::metastore::MetastoreError,
+            > + Clone + Send + Sync + 'static,
+        <L::Service as tower::Service<IndexesMetadataRequest>>::Future: Send + 'static,
+    {
+        self.indexes_metadata_layers.push(quickwit_common::tower::BoxLayer::new(layer));
         self
     }
     pub fn stack_list_indexes_metadata_layer<L>(mut self, layer: L) -> Self
@@ -3590,13 +3789,13 @@ impl MetastoreServiceTowerLayerStack {
         L: tower::Layer<
                 quickwit_common::tower::BoxService<
                     DeleteShardsRequest,
-                    EmptyResponse,
+                    DeleteShardsResponse,
                     crate::metastore::MetastoreError,
                 >,
             > + Send + Sync + 'static,
         L::Service: tower::Service<
                 DeleteShardsRequest,
-                Response = EmptyResponse,
+                Response = DeleteShardsResponse,
                 Error = crate::metastore::MetastoreError,
             > + Clone + Send + Sync + 'static,
         <L::Service as tower::Service<DeleteShardsRequest>>::Future: Send + 'static,
@@ -3799,6 +3998,14 @@ impl MetastoreServiceTowerLayerStack {
             );
         let index_metadata_svc = self
             .index_metadata_layers
+            .into_iter()
+            .rev()
+            .fold(
+                quickwit_common::tower::BoxService::new(boxed_instance.clone()),
+                |svc, layer| layer.layer(svc),
+            );
+        let indexes_metadata_svc = self
+            .indexes_metadata_layers
             .into_iter()
             .rev()
             .fold(
@@ -4010,6 +4217,7 @@ impl MetastoreServiceTowerLayerStack {
             create_index_svc,
             update_index_svc,
             index_metadata_svc,
+            indexes_metadata_svc,
             list_indexes_metadata_svc,
             delete_index_svc,
             list_splits_svc,
@@ -4128,6 +4336,12 @@ where
             Response = IndexMetadataResponse,
             Error = crate::metastore::MetastoreError,
             Future = BoxFuture<IndexMetadataResponse, crate::metastore::MetastoreError>,
+        >
+        + tower::Service<
+            IndexesMetadataRequest,
+            Response = IndexesMetadataResponse,
+            Error = crate::metastore::MetastoreError,
+            Future = BoxFuture<IndexesMetadataResponse, crate::metastore::MetastoreError>,
         >
         + tower::Service<
             ListIndexesMetadataRequest,
@@ -4251,9 +4465,9 @@ where
         >
         + tower::Service<
             DeleteShardsRequest,
-            Response = EmptyResponse,
+            Response = DeleteShardsResponse,
             Error = crate::metastore::MetastoreError,
-            Future = BoxFuture<EmptyResponse, crate::metastore::MetastoreError>,
+            Future = BoxFuture<DeleteShardsResponse, crate::metastore::MetastoreError>,
         >
         + tower::Service<
             ListShardsRequest,
@@ -4317,6 +4531,12 @@ where
         &mut self,
         request: IndexMetadataRequest,
     ) -> crate::metastore::MetastoreResult<IndexMetadataResponse> {
+        self.call(request).await
+    }
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> crate::metastore::MetastoreResult<IndexesMetadataResponse> {
         self.call(request).await
     }
     async fn list_indexes_metadata(
@@ -4430,7 +4650,7 @@ where
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> crate::metastore::MetastoreResult<EmptyResponse> {
+    ) -> crate::metastore::MetastoreResult<DeleteShardsResponse> {
         self.call(request).await
     }
     async fn list_shards(
@@ -4553,6 +4773,19 @@ where
             .map_err(|status| crate::error::grpc_status_to_service_error(
                 status,
                 IndexMetadataRequest::rpc_name(),
+            ))
+    }
+    async fn indexes_metadata(
+        &mut self,
+        request: IndexesMetadataRequest,
+    ) -> crate::metastore::MetastoreResult<IndexesMetadataResponse> {
+        self.inner
+            .indexes_metadata(request)
+            .await
+            .map(|response| response.into_inner())
+            .map_err(|status| crate::error::grpc_status_to_service_error(
+                status,
+                IndexesMetadataRequest::rpc_name(),
             ))
     }
     async fn list_indexes_metadata(
@@ -4800,7 +5033,7 @@ where
     async fn delete_shards(
         &mut self,
         request: DeleteShardsRequest,
-    ) -> crate::metastore::MetastoreResult<EmptyResponse> {
+    ) -> crate::metastore::MetastoreResult<DeleteShardsResponse> {
         self.inner
             .delete_shards(request)
             .await
@@ -4948,6 +5181,17 @@ for MetastoreServiceGrpcServerAdapter {
         self.inner
             .clone()
             .index_metadata(request.into_inner())
+            .await
+            .map(tonic::Response::new)
+            .map_err(crate::error::grpc_error_to_grpc_status)
+    }
+    async fn indexes_metadata(
+        &self,
+        request: tonic::Request<IndexesMetadataRequest>,
+    ) -> Result<tonic::Response<IndexesMetadataResponse>, tonic::Status> {
+        self.inner
+            .clone()
+            .indexes_metadata(request.into_inner())
             .await
             .map(tonic::Response::new)
             .map_err(crate::error::grpc_error_to_grpc_status)
@@ -5158,7 +5402,7 @@ for MetastoreServiceGrpcServerAdapter {
     async fn delete_shards(
         &self,
         request: tonic::Request<DeleteShardsRequest>,
-    ) -> Result<tonic::Response<EmptyResponse>, tonic::Status> {
+    ) -> Result<tonic::Response<DeleteShardsResponse>, tonic::Status> {
         self.inner
             .clone()
             .delete_shards(request.into_inner())
@@ -5450,6 +5694,37 @@ pub mod metastore_service_grpc_client {
                     GrpcMethod::new(
                         "quickwit.metastore.MetastoreService",
                         "IndexMetadata",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Fetches the metadata of a list of indexes identified by their Index IDs or UIDs.
+        pub async fn indexes_metadata(
+            &mut self,
+            request: impl tonic::IntoRequest<super::IndexesMetadataRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::IndexesMetadataResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/quickwit.metastore.MetastoreService/IndexesMetadata",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "quickwit.metastore.MetastoreService",
+                        "IndexesMetadata",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -5974,12 +6249,15 @@ pub mod metastore_service_grpc_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+        /// Deletes a set of shards. This RPC deletes the shards from the metastore.
         /// If the shard did not exist to begin with, the operation is successful and does not return any error.
         pub async fn delete_shards(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteShardsRequest>,
-        ) -> std::result::Result<tonic::Response<super::EmptyResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteShardsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -6215,6 +6493,14 @@ pub mod metastore_service_grpc_server {
             tonic::Response<super::IndexMetadataResponse>,
             tonic::Status,
         >;
+        /// Fetches the metadata of a list of indexes identified by their Index IDs or UIDs.
+        async fn indexes_metadata(
+            &self,
+            request: tonic::Request<super::IndexesMetadataRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::IndexesMetadataResponse>,
+            tonic::Status,
+        >;
         /// Gets an indexes metadatas.
         async fn list_indexes_metadata(
             &self,
@@ -6339,12 +6625,15 @@ pub mod metastore_service_grpc_server {
             tonic::Response<super::AcquireShardsResponse>,
             tonic::Status,
         >;
-        /// Deletes a set of shards. This RPC deletes the shards from the metastore and the storage.
+        /// Deletes a set of shards. This RPC deletes the shards from the metastore.
         /// If the shard did not exist to begin with, the operation is successful and does not return any error.
         async fn delete_shards(
             &self,
             request: tonic::Request<super::DeleteShardsRequest>,
-        ) -> std::result::Result<tonic::Response<super::EmptyResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteShardsResponse>,
+            tonic::Status,
+        >;
         async fn list_shards(
             &self,
             request: tonic::Request<super::ListShardsRequest>,
@@ -6636,6 +6925,52 @@ pub mod metastore_service_grpc_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = IndexMetadataSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/quickwit.metastore.MetastoreService/IndexesMetadata" => {
+                    #[allow(non_camel_case_types)]
+                    struct IndexesMetadataSvc<T: MetastoreServiceGrpc>(pub Arc<T>);
+                    impl<
+                        T: MetastoreServiceGrpc,
+                    > tonic::server::UnaryService<super::IndexesMetadataRequest>
+                    for IndexesMetadataSvc<T> {
+                        type Response = super::IndexesMetadataResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::IndexesMetadataRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).indexes_metadata(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = IndexesMetadataSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -7486,7 +7821,7 @@ pub mod metastore_service_grpc_server {
                         T: MetastoreServiceGrpc,
                     > tonic::server::UnaryService<super::DeleteShardsRequest>
                     for DeleteShardsSvc<T> {
-                        type Response = super::EmptyResponse;
+                        type Response = super::DeleteShardsResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,

--- a/quickwit/quickwit-proto/src/getters.rs
+++ b/quickwit/quickwit-proto/src/getters.rs
@@ -55,6 +55,7 @@ generate_getters! {
     DeleteIndexRequest,
     DeleteQuery,
     DeleteShardsRequest,
+    DeleteShardsResponse,
     DeleteSourceRequest,
     DeleteSplitsRequest,
     LastDeleteOpstampRequest,

--- a/quickwit/quickwit-proto/src/metastore/mod.rs
+++ b/quickwit/quickwit-proto/src/metastore/mod.rs
@@ -275,21 +275,6 @@ impl IndexMetadataRequest {
             index_id: None,
         }
     }
-
-    /// Returns the index id either from the `index_id` or the `index_uid`.
-    /// If none of them is set, an error is returned.
-    pub fn get_index_id(&self) -> MetastoreResult<IndexId> {
-        if let Some(index_id) = &self.index_id {
-            Ok(index_id.to_string())
-        } else if let Some(index_uid) = &self.index_uid {
-            Ok(index_uid.index_id.to_string())
-        } else {
-            Err(MetastoreError::Internal {
-                message: "index_id or index_uid must be set".to_string(),
-                cause: "".to_string(),
-            })
-        }
-    }
 }
 
 impl MarkSplitsForDeletionRequest {

--- a/quickwit/quickwit-proto/src/types/index_uid.rs
+++ b/quickwit/quickwit-proto/src/types/index_uid.rs
@@ -203,6 +203,29 @@ impl TryFrom<String> for IndexUid {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl sqlx::Type<sqlx::Postgres> for IndexUid {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("VARCHAR")
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Encode<'_, sqlx::Postgres> for IndexUid {
+    fn encode_by_ref(&self, buf: &mut sqlx::postgres::PgArgumentBuffer) -> sqlx::encode::IsNull {
+        let _ = sqlx::Encode::<sqlx::Postgres>::encode(&self.index_id, buf);
+        let _ = sqlx::Encode::<sqlx::Postgres>::encode(":", buf);
+        sqlx::Encode::<sqlx::Postgres>::encode(&self.incarnation_id.to_string(), buf)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::postgres::PgHasArrayType for IndexUid {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("VARCHAR[]")
+    }
+}
+
 impl PartialEq<(&'static str, u128)> for IndexUid {
     fn eq(&self, (index_id, incarnation_id): &(&str, u128)) -> bool {
         self.index_id == *index_id && self.incarnation_id == Ulid::from(*incarnation_id)

--- a/quickwit/quickwit-proto/src/types/shard_id.rs
+++ b/quickwit/quickwit-proto/src/types/shard_id.rs
@@ -139,6 +139,27 @@ impl PartialEq<ShardId> for &ShardId {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl sqlx::Type<sqlx::Postgres> for ShardId {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("VARCHAR")
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Encode<'_, sqlx::Postgres> for ShardId {
+    fn encode_by_ref(&self, buf: &mut sqlx::postgres::PgArgumentBuffer) -> sqlx::encode::IsNull {
+        sqlx::Encode::<sqlx::Postgres>::encode(self.as_str(), buf)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::postgres::PgHasArrayType for ShardId {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("VARCHAR[]")
+    }
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
### Description
Add a batch `indexes_metadata` API to the metastore and use it in the indexing service when spawning new indexing pipelines upon applying a new indexing plan.

### How was this PR tested?
Added unit test
