### PR TITLE
Improve search split cache docs

### DIFF
--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -208,16 +208,16 @@ This section contains the configuration options for a Searcher.
 | `partial_request_cache_capacity` | Partial request in memory cache capacity on a Searcher. Cache intermediate state for a request, possibly making subsequent requests faster. It can be disabled by setting the size to `0`. | `64M` |
 | `max_num_concurrent_split_searches` | Maximum number of concurrent split search requests running on a Searcher. | `100` |
 | `max_num_concurrent_split_streams` | Maximum number of concurrent split stream requests running on a Searcher. | `100` |
-| `split_cache` | Searcher split cache configuration options defined in the section below. | |
+| `split_cache` | Searcher split cache configuration options defined in the section below. | _disabled_ |
 
 
 ### Searcher split cache configuration
 
-This section contains the configuration options for the searcher split cache.
+This section contains the configuration options for the on disk searcher split cache.
 
 | Property | Description | Default value |
 | --- | --- | --- |
-| `max_num_bytes` | Maximum size in bytes allowed in the split cache. | `1G` |
+| `max_num_bytes` | Maximum disk size in bytes allowed in the split cache. Can be exceeded by the size of one split. | |
 | `max_num_splits` | Maximum number of splits allowed in the split cache.   | `10000` |
 | `num_concurrent_downloads` | Maximum number of concurrent download of splits. | `1` |
 

--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -208,7 +208,7 @@ This section contains the configuration options for a Searcher.
 | `partial_request_cache_capacity` | Partial request in memory cache capacity on a Searcher. Cache intermediate state for a request, possibly making subsequent requests faster. It can be disabled by setting the size to `0`. | `64M` |
 | `max_num_concurrent_split_searches` | Maximum number of concurrent split search requests running on a Searcher. | `100` |
 | `max_num_concurrent_split_streams` | Maximum number of concurrent split stream requests running on a Searcher. | `100` |
-| `split_cache` | Searcher split cache configuration options defined in the section below. | _disabled_ |
+| `split_cache` | Searcher split cache configuration options defined in the section below. Cache disabled if unspecified. | |
 
 
 ### Searcher split cache configuration

--- a/quickwit/quickwit-storage/src/split_cache/split_table.rs
+++ b/quickwit/quickwit-storage/src/split_cache/split_table.rs
@@ -100,7 +100,8 @@ pub struct SplitInfo {
 /// - downloading_splits
 /// - candidate_splits.
 ///
-/// It is possible for the split table to exceed its limits, by at most one split.
+/// It is possible for the split table size in bytes to exceed its limits, by at
+/// most one split.
 pub struct SplitTable {
     on_disk_splits: BTreeSet<SplitKey>,
     downloading_splits: BTreeSet<SplitKey>,
@@ -360,7 +361,7 @@ impl SplitTable {
             return false;
         }
         if self.on_disk_splits.len() + self.downloading_splits.len()
-            > self.limits.max_num_splits.get() as usize
+            >= self.limits.max_num_splits.get() as usize
         {
             return true;
         }
@@ -608,7 +609,7 @@ mod tests {
             splits_to_delete,
             split_to_download,
         } = split_table.find_download_opportunity().unwrap();
-        assert_eq!(&splits_to_delete[..], &[splits[0].0][..]);
+        assert_eq!(&splits_to_delete[..], &[splits[0].0, splits[1].0]);
         assert_eq!(split_to_download.split_ulid, new_ulid);
     }
 


### PR DESCRIPTION
### Description

Improve the search split cache UX by:
- being strict on the number of split in the cache instead of letting it exceed the configured limit by one
- making the docs a bit more explicit

### How was this PR tested?

Describe how you tested this PR.
