### PR TITLE
rewrite agg extended bounds

### DIFF
--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -638,7 +638,7 @@ impl SegmentCollector for QuickwitSegmentCollector {
 }
 
 /// Available aggregation types.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(untagged)]
 pub enum QuickwitAggregations {
     /// Aggregation used by the Jaeger service to find trace IDs that match a

--- a/quickwit/quickwit-search/src/find_trace_ids_collector.rs
+++ b/quickwit/quickwit-search/src/find_trace_ids_collector.rs
@@ -111,7 +111,7 @@ impl Eq for TraceIdTermOrd {}
 /// Finds the most recent trace ids among a set of matching spans. Multiple spans belonging to the
 /// same trace can be found in the document set. As a result, this problem is akin to finding the
 /// top k elements with duplicates
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FindTraceIdsCollector {
     /// The number of traces to select.
     pub num_traces: usize,

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -438,13 +438,10 @@ fn rewrite_aggregation(search_request: &mut SearchRequest) {
             }
         });
         if modified_something {
-            if let Ok(serialized_aggregation) = serde_json::to_string(&aggregations) {
-                // it's fine to put a (Tantivy)Aggregations and not a QuickwitAggregations because
-                // the former is an serde-untagged variant of the later
-                search_request.aggregation_request = Some(serialized_aggregation);
-            } else {
-                warn!("we failed to reserialize aggregation, this shouldn't happen");
-            }
+            // it's fine to put a (Tantivy)Aggregations and not a QuickwitAggregations because
+            // the former is an serde-untagged variant of the later
+            search_request.aggregation_request =
+                Some(serde_json::to_string(&aggregations).expect("serializing should never fail"));
         }
     }
 }

--- a/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
@@ -6,8 +6,8 @@ endpoint: _elastic/aggregations/_search
 json:
   query: { match_all: {} }
   aggs:
-    date_histo: 
-      date_histogram: 
+    date_histo:
+      date_histogram:
         field: "date"
         fixed_interval: "30d"
         offset: "-4d"
@@ -17,7 +17,7 @@ expected:
       buckets:
         -  { "doc_count": 5, "key": 1420070400000.0, "key_as_string": "2015-01-01T00:00:00Z" }
         -  { "doc_count": 2, "key": 1422662400000.0, "key_as_string": "2015-01-31T00:00:00Z" }
---- 
+---
 # Test date histogram with extended bounds
 method: [GET]
 engines:
@@ -26,8 +26,8 @@ endpoint: _elastic/aggregations/_search
 json:
   query: { match_all: {} }
   aggs:
-    date_histo: 
-      date_histogram: 
+    date_histo:
+      date_histogram:
         field: "date"
         fixed_interval: "30d"
         offset: "-4d"
@@ -41,7 +41,7 @@ expected:
         -  { "doc_count": 5, "key": 1420070400000.0, "key_as_string": "2015-01-01T00:00:00Z" }
         -  { "doc_count": 2, "key": 1422662400000.0, "key_as_string": "2015-01-31T00:00:00Z" }
         -  { "doc_count": 0, "key": 1425254400000.0, "key_as_string": "2015-03-02T00:00:00Z" }
---- 
+---
 # Test date histogram aggregation and sub-aggregation 
 method: [GET]
 engines:

--- a/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
@@ -18,6 +18,30 @@ expected:
         -  { "doc_count": 5, "key": 1420070400000.0, "key_as_string": "2015-01-01T00:00:00Z" }
         -  { "doc_count": 2, "key": 1422662400000.0, "key_as_string": "2015-01-31T00:00:00Z" }
 --- 
+# Test date histogram with extended bounds
+method: [GET]
+engines:
+  - quickwit
+endpoint: _elastic/aggregations/_search
+json:
+  query: { match_all: {} }
+  aggs:
+    date_histo: 
+      date_histogram: 
+        field: "date"
+        fixed_interval: "30d"
+        offset: "-4d"
+        extended_bounds:
+          min: 1420070400000
+          max: 1425254400000
+expected:
+  aggregations:
+    date_histo:
+      buckets:
+        -  { "doc_count": 5, "key": 1420070400000.0, "key_as_string": "2015-01-01T00:00:00Z" }
+        -  { "doc_count": 2, "key": 1422662400000.0, "key_as_string": "2015-01-31T00:00:00Z" }
+        -  { "doc_count": 0, "key": 1425254400000.0, "key_as_string": "2015-03-02T00:00:00Z" }
+--- 
 # Test date histogram aggregation and sub-aggregation 
 method: [GET]
 engines:


### PR DESCRIPTION
### Description

fix #4926
remove extended bounds from histogram aggregations at the leaf_search_single_split level.
This should make it possible for the partial request cache to hit on dashboards using that feature, such as grafana.
cc @PSeitz 

### How was this PR tested?

added integration test to verify the behavior doesn't change
added unit test to verify we rewrite the bounds at both top and leaf level
manually tested a few (manually wrote) aggregation and verify cache metrics record hits when expected.