### PR TITLE
Bump Rust to 1.78

### DIFF
--- a/quickwit/quickwit-actors/src/actor_context.rs
+++ b/quickwit/quickwit-actors/src/actor_context.rs
@@ -241,7 +241,7 @@ impl<A: Actor> ActorContext<A> {
     /// This method hides logic to prevent an actor from being identified
     /// as frozen if the destination actor channel is saturated, and we
     /// are simply experiencing back pressure.
-    pub async fn send_message<DestActor: Actor, M>(
+    pub async fn send_message<DestActor, M>(
         &self,
         mailbox: &Mailbox<DestActor>,
         msg: M,
@@ -260,7 +260,7 @@ impl<A: Actor> ActorContext<A> {
             .await
     }
 
-    pub async fn ask<DestActor: Actor, M, T>(
+    pub async fn ask<DestActor, M, T>(
         &self,
         mailbox: &Mailbox<DestActor>,
         msg: M,
@@ -278,7 +278,7 @@ impl<A: Actor> ActorContext<A> {
 
     /// Similar to `send_message`, except this method
     /// waits asynchronously for the actor reply.
-    pub async fn ask_for_res<DestActor: Actor, M, T, E>(
+    pub async fn ask_for_res<DestActor, M, T, E>(
         &self,
         mailbox: &Mailbox<DestActor>,
         msg: M,

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/search_query_params.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/search_query_params.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -312,14 +313,15 @@ impl FromStr for ExpandWildcards {
         }
     }
 }
-impl ToString for ExpandWildcards {
-    fn to_string(&self) -> String {
-        match &self {
-            Self::Open => "open".to_string(),
-            Self::Closed => "closed".to_string(),
-            Self::Hidden => "hidden".to_string(),
-            Self::None => "none".to_string(),
-            Self::All => "all".to_string(),
+
+impl fmt::Display for ExpandWildcards {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Open => write!(formatter, "open"),
+            Self::Closed => write!(formatter, "closed"),
+            Self::Hidden => write!(formatter, "hidden"),
+            Self::None => write!(formatter, "none"),
+            Self::All => write!(formatter, "all"),
         }
     }
 }
@@ -358,12 +360,13 @@ impl FromStr for SuggestMode {
         }
     }
 }
-impl ToString for SuggestMode {
-    fn to_string(&self) -> String {
-        match &self {
-            Self::Missing => "missing".to_string(),
-            Self::Popular => "popular".to_string(),
-            Self::Always => "always".to_string(),
+
+impl fmt::Display for SuggestMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Missing => write!(formatter, "missing"),
+            Self::Popular => write!(formatter, "popular"),
+            Self::Always => write!(formatter, "always"),
         }
     }
 }

--- a/quickwit/quickwit-serve/src/format.rs
+++ b/quickwit/quickwit-serve/src/format.rs
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt;
+
 use hyper::header::CONTENT_TYPE;
 use quickwit_config::ConfigFormat;
 use serde::{self, Deserialize, Serialize, Serializer};
@@ -55,11 +57,11 @@ impl BodyFormat {
     }
 }
 
-impl ToString for BodyFormat {
-    fn to_string(&self) -> String {
+impl fmt::Display for BodyFormat {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match &self {
-            Self::Json => "json".to_string(),
-            Self::PrettyJson => "pretty_json".to_string(),
+            Self::Json => write!(formatter, "json"),
+            Self::PrettyJson => write!(formatter, "pretty_json"),
         }
     }
 }


### PR DESCRIPTION
### Description
Bump Rust version and fix a few new clippy warnings.

### How was this PR tested?
`make test-all`
