### PR TITLE
Add time_series_dimension property into _field_caps API method

### DIFF
--- a/quickwit/quickwit-serve/src/elasticsearch_api/mod.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/mod.rs
@@ -68,6 +68,7 @@ pub fn elastic_api_handlers(
         .or(es_compat_index_multi_search_handler(search_service.clone()))
         .or(es_compat_index_field_capabilities_handler(
             search_service.clone(),
+            metastore.clone(),
         ))
         .or(es_compat_bulk_handler(
             ingest_service.clone(),


### PR DESCRIPTION
### Description

`time_series_dimension` determine whether field will be used by Opensearch Dashboards to build histogram or not.

Fixing issue: https://github.com/quickwit-oss/quickwit/issues/5003

### How was this PR tested?

Added test to cover my change.
