### PR TITLE
Issue/5008 cp metastore shard list divergence

### DIFF
--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -777,6 +777,8 @@ impl Handler<GetOrCreateOpenShardsRequest> for ControlPlane {
         request: GetOrCreateOpenShardsRequest,
         ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
+        // TODO This seems incorrect... Index creation could yield a metastore error... In that
+        // case, we end up with an inconsistent state.
         if let Err(control_plane_error) = self
             .auto_create_indexes(&request.subrequests, ctx.progress())
             .await


### PR DESCRIPTION
Draft because:
- it needs unit testing
- it needs discussion

The current situation is definitely not good but:
- will ingesters react on uninitialized shard as if they were closed

Other solution to consider:
- initialize BEFORE updating the metastore & model.
I actually like this solution, as on the delete path we also have a state where the shard is on the ingester and not in the metastore/control plane model. It respects the idea that a shard is on

ingester > (metastore = controlplane model)

Other solutions to NOT consider:
- I don't think there is a sound path where not requiring initialization is a possibility. 
We would risk that a late message ingest message could create a shard that does not exist.
