### PR TITLE
Fix indexing split store config docs

### DIFF
--- a/docs/configuration/node-config.md
+++ b/docs/configuration/node-config.md
@@ -153,8 +153,8 @@ This section contains the configuration options for an indexer. The split store 
 
 | Property | Description | Default value |
 | --- | --- | --- |
-| `split_store_max_num_bytes` | Maximum size in bytes allowed in the split store for each index-source pair. | `100G` |
-| `split_store_max_num_splits` | Maximum number of files allowed in the split store for each index-source pair. | `1000` |
+| `split_store_max_num_bytes` | Maximum size in bytes allowed in the split store. | `100G` |
+| `split_store_max_num_splits` | Maximum number of files allowed in the split store. | `1000` |
 | `max_concurrent_split_uploads` | Maximum number of concurrent split uploads allowed on the node. | `12` |
 | `merge_concurrency` | Maximum number of merge operations that can be executed on the node at one point in time. | `(2 x num threads available) / 3` |
 | `enable_otlp_endpoint` | If true, enables the OpenTelemetry exporter endpoint to ingest logs and traces via the OpenTelemetry Protocol (OTLP). | `false` |


### PR DESCRIPTION
### Description

It seems from the code that the split store quota on the indexer side is global. This is also what is suggested in the docs [here](https://github.com/quickwit-oss/quickwit/blob/8ee25c972013e1f5f3acbb2c2cef23036cd5a6e9/docs/operating/data-directory.md#L51). 

### How was this PR tested?

NA
