### PR TITLE
Add all services to ECS output

### DIFF
--- a/distribution/ecs/quickwit/outputs.tf
+++ b/distribution/ecs/quickwit/outputs.tf
@@ -5,3 +5,15 @@ output "indexer_service_name" {
 output "searcher_service_name" {
   value = "${aws_service_discovery_service.searcher.name}.${aws_service_discovery_private_dns_namespace.quickwit_internal.name}"
 }
+
+output "janitor_service_name" {
+  value = "${aws_service_discovery_service.janitor.name}.${aws_service_discovery_private_dns_namespace.quickwit_internal.name}"
+}
+
+output "control_plane_service_name" {
+  value = "${aws_service_discovery_service.control_plane.name}.${aws_service_discovery_private_dns_namespace.quickwit_internal.name}"
+}
+
+output "metastore_service_name" {
+  value = "${aws_service_discovery_service.metastore.name}.${aws_service_discovery_private_dns_namespace.quickwit_internal.name}"
+}


### PR DESCRIPTION
### Description

It is more consistent to expose all QW services as terraform outputs in the ECS distribution. It can also be usefull for testing the overall cluster readiness.

### How was this PR tested?

Internal CI
