### PR TITLE
use serde_json_borrow to parse JSON

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4343,14 +4343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oneshot"
-version = "0.1.6"
-source = "git+https://github.com/fulmicoton/oneshot.git?rev=c10a3ba#c10a3ba32adc189acf68acd579ba9755075ecb4d"
-dependencies = [
- "loom",
-]
-
-[[package]]
 name = "onig"
 version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4675,7 +4667,6 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5884,7 +5875,7 @@ dependencies = [
  "libz-sys",
  "mockall",
  "once_cell",
- "oneshot 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oneshot",
  "openssl",
  "proptest",
  "prost",
@@ -8008,8 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.23.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
+version = "0.22.0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8033,7 +8023,7 @@ dependencies = [
  "measure_time",
  "memmap2",
  "once_cell",
- "oneshot 0.1.6 (git+https://github.com/fulmicoton/oneshot.git?rev=c10a3ba)",
+ "oneshot",
  "rayon",
  "regex",
  "rust-stemmers",
@@ -8061,7 +8051,6 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "bitpacking",
 ]
@@ -8069,7 +8058,6 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8084,7 +8072,6 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8107,7 +8094,6 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "nom",
 ]
@@ -8115,7 +8101,6 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -8126,7 +8111,6 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -8136,7 +8120,6 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=5b7cca1#5b7cca13e5136c7e3b86f645be38b08bed2d6f78"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3308,6 +3308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,6 +4352,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oneshot"
+version = "0.1.6"
+source = "git+https://github.com/fulmicoton/oneshot.git?rev=c10a3ba#c10a3ba32adc189acf68acd579ba9755075ecb4d"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "onig"
 version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,6 +4684,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5821,6 +5839,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_json_borrow",
  "serde_yaml",
  "siphasher",
  "tantivy",
@@ -5875,7 +5894,7 @@ dependencies = [
  "libz-sys",
  "mockall",
  "once_cell",
- "oneshot",
+ "oneshot 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
  "proptest",
  "prost",
@@ -5899,6 +5918,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_json_borrow",
  "tantivy",
  "tempfile",
  "thiserror",
@@ -7253,6 +7273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_borrow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256097ff1654ce1975402cb5a2bfa2cad3cc3199e1d704bf303b386fc971f3c"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7999,7 +8029,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.22.0"
+version = "0.23.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8015,7 +8046,7 @@ dependencies = [
  "fs4",
  "futures-util",
  "htmlescape",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "levenshtein_automata",
  "log",
  "lru",
@@ -8023,7 +8054,7 @@ dependencies = [
  "measure_time",
  "memmap2",
  "once_cell",
- "oneshot",
+ "oneshot 0.1.6 (git+https://github.com/fulmicoton/oneshot.git?rev=c10a3ba)",
  "rayon",
  "regex",
  "rust-stemmers",
@@ -8051,6 +8082,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "bitpacking",
 ]
@@ -8058,10 +8090,11 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "downcast-rs",
  "fastdivide",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "serde",
  "tantivy-bitpacker",
  "tantivy-common",
@@ -8072,6 +8105,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8094,6 +8128,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "nom",
 ]
@@ -8101,6 +8136,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -8111,6 +8147,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -8120,6 +8157,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=2e3641c#2e3641c2ae970e8b78c256da2dac19b12d566139"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -210,6 +210,7 @@ sea-query-binder = { version = "0.5", features = [
 # ^1.0.184 due to serde-rs/serde#2538
 serde = { version = "1.0.184", features = ["derive", "rc"] }
 serde_json = "1.0"
+serde_json_borrow = { version = "0.5" }
 serde_qs = { version = "0.12", features = ["warp"] }
 serde_with = "3.8.0"
 serde_yaml = "0.9"
@@ -318,7 +319,7 @@ quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry = { path = "quickwit-telemetry" }
 
-tantivy = { path = "../../../tantivy/compact_doc", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "2e3641c", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",
@@ -346,5 +347,5 @@ sasl2-sys = { git = "https://github.com/quickwit-oss/rust-sasl/", rev = "daca921
 debug = false
 
 [profile.release]
-debug = true
+#debug = true
 lto = "thin"

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -318,7 +318,7 @@ quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry = { path = "quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "5b7cca1", default-features = false, features = [
+tantivy = { path = "../../../tantivy/compact_doc", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",
@@ -346,4 +346,5 @@ sasl2-sys = { git = "https://github.com/quickwit-oss/rust-sasl/", rev = "daca921
 debug = false
 
 [profile.release]
+debug = true
 lto = "thin"

--- a/quickwit/quickwit-doc-mapper/Cargo.toml
+++ b/quickwit/quickwit-doc-mapper/Cargo.toml
@@ -23,7 +23,9 @@ once_cell = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_json_borrow = { workspace = true }
 siphasher = { workspace = true }
+time = { workspace = true }
 tantivy = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/quickwit/quickwit-doc-mapper/benches/routing_expression_bench.rs
+++ b/quickwit/quickwit-doc-mapper/benches/routing_expression_bench.rs
@@ -19,7 +19,6 @@
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use quickwit_doc_mapper::{DocMapper, RoutingExpr};
-use serde_json::Value as JsonValue;
 
 const JSON_TEST_DATA: &str = include_str!("data/simple-routing-expression-bench.json");
 
@@ -48,7 +47,7 @@ pub fn simple_routing_expression_benchmark(c: &mut Criterion) {
     let doc_mapper: Box<dyn DocMapper> = serde_json::from_str(DOC_MAPPER_CONF).unwrap();
     let lines: Vec<&str> = JSON_TEST_DATA.lines().map(|line| line.trim()).collect();
 
-    let json_lines: Vec<serde_json::Map<String, JsonValue>> = lines
+    let json_lines: Vec<serde_json_borrow::Value> = lines
         .iter()
         .map(|line| serde_json::from_str(line).unwrap())
         .collect();

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/default_mapper.rs
@@ -35,7 +35,9 @@ use tantivy::schema::document::{
 use tantivy::schema::{
     Field, FieldType, OwnedValue as TantivyValue, Schema, Value, INDEXED, STORED,
 };
-use tantivy::TantivyDocument as Document;
+use tantivy::{DateTime, TantivyDocument as Document};
+use time::format_description::well_known::Rfc3339;
+use time::{OffsetDateTime, UtcOffset};
 
 use super::field_mapping_entry::RAW_TOKENIZER_NAME;
 use super::DefaultDocMapperBuilder;
@@ -461,8 +463,8 @@ fn tantivy_value_to_json(val: TantivyValue) -> JsonValue {
 }
 
 #[inline]
-fn populate_field_presence_for_json_value<'a>(
-    json_value: CompactDocValue<'a>,
+fn populate_field_presence_for_json_value(
+    json_value: CompactDocValue,
     path_hasher: &PathHasher,
     is_expand_dots_enabled: bool,
     output: &mut FnvHashSet<u64>,
@@ -560,6 +562,91 @@ impl<T, I: Iterator<Item = T>, U: Clone> Iterator for ZipCloneable<T, I, U> {
     }
 }
 
+#[derive(Debug, Clone)]
+/// This wrapper is there to implement the `Value` trait for `serde_json_borrow::Value`.
+/// We could move this to tantivy
+pub struct BorrowJson<'a>(&'a serde_json_borrow::Value<'a>);
+pub fn can_be_rfc3339_date_time(text: &str) -> bool {
+    if let Some(&first_byte) = text.as_bytes().first() {
+        if first_byte.is_ascii_digit() {
+            return true;
+        }
+    }
+
+    false
+}
+
+impl<'a> Value<'a> for BorrowJson<'a> {
+    type ArrayIter = JsonArrayIter<'a>;
+    type ObjectIter = JsonObjectIter<'a>;
+
+    #[inline]
+    fn as_value(&self) -> ReferenceValue<'a, Self> {
+        match self.0 {
+            serde_json_borrow::Value::Null => ReferenceValueLeaf::Null.into(),
+            serde_json_borrow::Value::Bool(value) => ReferenceValueLeaf::Bool(*value).into(),
+            serde_json_borrow::Value::Number(number) => {
+                if let Some(val) = number.as_i64() {
+                    ReferenceValueLeaf::I64(val).into()
+                } else if let Some(val) = number.as_u64() {
+                    ReferenceValueLeaf::U64(val).into()
+                } else if let Some(val) = number.as_f64() {
+                    ReferenceValueLeaf::F64(val).into()
+                } else {
+                    panic!("Unsupported serde_json_borrow number");
+                }
+            }
+            serde_json_borrow::Value::Str(text) => {
+                if can_be_rfc3339_date_time(text) {
+                    match OffsetDateTime::parse(text, &Rfc3339) {
+                        Ok(dt) => {
+                            let dt_utc = dt.to_offset(UtcOffset::UTC);
+                            ReferenceValueLeaf::Date(DateTime::from_utc(dt_utc)).into()
+                        }
+                        Err(_) => ReferenceValueLeaf::Str(text).into(),
+                    }
+                } else {
+                    ReferenceValueLeaf::Str(text).into()
+                }
+            }
+            serde_json_borrow::Value::Array(elements) => ReferenceValue::Array(JsonArrayIter {
+                iter: elements.iter(),
+            }),
+            serde_json_borrow::Value::Object(object) => ReferenceValue::Object(JsonObjectIter {
+                iter: object.as_vec().iter(),
+            }),
+        }
+    }
+}
+
+/// A wrapper struct for an interator producing [Value]s.
+pub struct JsonArrayIter<'a> {
+    iter: std::slice::Iter<'a, serde_json_borrow::Value<'a>>,
+}
+
+impl<'a> Iterator for JsonArrayIter<'a> {
+    type Item = BorrowJson<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.iter.next()?;
+        Some(BorrowJson(value))
+    }
+}
+
+/// A wrapper struct for an interator producing [Value]s.
+pub struct JsonObjectIter<'a> {
+    iter: std::slice::Iter<'a, (std::borrow::Cow<'a, str>, serde_json_borrow::Value<'a>)>,
+}
+
+impl<'a> Iterator for JsonObjectIter<'a> {
+    type Item = (&'a str, BorrowJson<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (key, value) = self.iter.next()?;
+        Some((key.as_ref(), BorrowJson(value)))
+    }
+}
+
 #[typetag::serde(name = "default")]
 impl DocMapper for DefaultDocMapper {
     fn doc_from_json_obj(
@@ -567,20 +654,20 @@ impl DocMapper for DefaultDocMapper {
         json_obj: JsonObject,
         document_len: u64,
     ) -> Result<(Partition, Document), DocParsingError> {
-        let partition: Partition = self.partition_key.eval_hash(&json_obj);
+        let partition: Partition = self.partition_key.eval_hash(json_obj.get_value());
 
-        let mut dynamic_json_obj = serde_json::Map::default();
+        let mut dynamic_json_obj = serde_json_borrow::Map::default();
         let mut field_path = Vec::new();
-        let mut document = Document::with_capacity(document_len as usize * 2);
+        // CompactDoc in tantivy is typically similar in size as the serialized JSON
+        let mut document = Document::with_capacity(document_len as usize * 3 / 2);
 
-        let json_obj = JsonValue::Object(json_obj);
         if let Some(source_field) = self.source_field {
-            document.add_field_value(source_field, &json_obj);
+            document.add_field_value(source_field, BorrowJson(&json_obj));
         }
 
         let mode = self.mode.mode_type();
         self.field_mappings.doc_from_json(
-            json_obj,
+            json_obj.get_value(),
             mode,
             &mut document,
             &mut field_path,
@@ -590,9 +677,11 @@ impl DocMapper for DefaultDocMapper {
         if let Some(dynamic_field) = self.dynamic_field {
             if !dynamic_json_obj.is_empty() {
                 if !self.concatenate_dynamic_fields.is_empty() {
-                    let json_obj_values =
-                        JsonValueIterator::new(serde_json::Value::Object(dynamic_json_obj.clone()))
-                            .flat_map(map_primitive_json_to_tantivy);
+                    // TODO: work on serde_json_borrow::Value
+                    let json_obj_values = JsonValueIterator::new(serde_json::Value::Object(
+                        serde_json::Map::from(dynamic_json_obj.clone()),
+                    ))
+                    .flat_map(map_primitive_json_to_tantivy);
 
                     for value in json_obj_values {
                         for (concatenate_dynamic_field, value) in
@@ -602,7 +691,10 @@ impl DocMapper for DefaultDocMapper {
                         }
                     }
                 }
-                document.add_field_value(dynamic_field, &JsonValue::Object(dynamic_json_obj));
+                document.add_field_value(
+                    dynamic_field,
+                    BorrowJson(&serde_json_borrow::Value::Object(dynamic_json_obj)),
+                );
             }
         }
 
@@ -625,7 +717,7 @@ impl DocMapper for DefaultDocMapper {
                 }
                 let mut path_hasher: PathHasher = PathHasher::default();
                 path_hasher.append(&field.field_id().to_le_bytes()[..]);
-                if let ReferenceValue::Object(json_obj) = value {
+                if let ReferenceValue::Object(json_obj) = value.as_value() {
                     let is_expand_dots_enabled: bool =
                         if let FieldType::JsonObject(json_options) = field_entry.field_type() {
                             json_options.is_expand_dots_enabled()
@@ -719,10 +811,10 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    use itertools::Itertools;
     use quickwit_common::PathHasher;
     use quickwit_query::query_ast::query_ast_from_user_text;
     use serde_json::{self, json, Value as JsonValue};
+    use serde_json_borrow::OwnedValue;
     use tantivy::schema::{FieldType, IndexRecordOption, OwnedValue as TantivyValue, Type, Value};
 
     use super::DefaultDocMapper;
@@ -733,8 +825,8 @@ mod tests {
         DYNAMIC_FIELD_NAME, FIELD_PRESENCE_FIELD_NAME, SOURCE_FIELD_NAME,
     };
 
-    fn example_json_doc_value() -> JsonValue {
-        serde_json::json!({
+    fn example_json_doc_value() -> OwnedValue {
+        let val = serde_json::json!({
             "timestamp": 1586960586i64,
             "body": "20200415T072306-0700 INFO This is a great log",
             "response_date2": "2021-12-19T16:39:57+00:00",
@@ -749,7 +841,8 @@ mod tests {
                 "server.status": ["200", "201"],
                 "server.payload": ["YQ==", "Yg=="]
             }
-        })
+        });
+        OwnedValue::from_string(serde_json::to_string(&val).unwrap()).unwrap()
     }
 
     const EXPECTED_JSON_PATHS_AND_VALUES: &str = r#"{
@@ -783,11 +876,9 @@ mod tests {
 
     #[test]
     fn test_parsing_document() {
-        let json_doc = example_json_doc_value();
+        let json_doc: OwnedValue = example_json_doc_value();
         let doc_mapper = crate::default_doc_mapper_for_test();
-        let (_, document) = doc_mapper
-            .doc_from_json_obj(json_doc.as_object().unwrap().clone(), 0)
-            .unwrap();
+        let (_, document) = doc_mapper.doc_from_json_obj(json_doc.clone(), 0).unwrap();
         let schema = doc_mapper.schema();
         // 9 property entry + 1 field "_source" + 2 fields values for "tags" field
         // + 2 values inf "server.status" field + 2 values in "server.payload" field
@@ -796,33 +887,26 @@ mod tests {
         let expected_json_paths_and_values: HashMap<String, JsonValue> =
             serde_json::from_str(EXPECTED_JSON_PATHS_AND_VALUES).unwrap();
         let mut field_presences: HashSet<u64> = HashSet::new();
-        for field_value in document.field_values() {
-            let field_name = schema.get_field_name(field_value.field());
+        for (field, value) in document.field_values() {
+            let field_name = schema.get_field_name(field);
             if field_name == SOURCE_FIELD_NAME {
-                // some part of aws-sdk enables `preserve_order` on serde_json.
-                // to get "normal" equality, we are forced to recreate the json object
-                // with sorted keys.
-                let sorted_json_values = json_doc
-                    .as_object()
-                    .unwrap()
-                    .clone()
-                    .into_iter()
-                    .sorted_by(|k1, k2| k1.0.cmp(&k2.0))
-                    .collect::<serde_json::Map<_, _>>();
                 assert_eq!(
-                    tantivy::schema::OwnedValue::from(field_value.value().as_value()),
-                    tantivy::schema::OwnedValue::from(sorted_json_values)
+                    tantivy::schema::OwnedValue::from(value),
+                    tantivy::schema::OwnedValue::from(serde_json::Value::from(
+                        json_doc.get_value()
+                    ))
                 );
             } else if field_name == DYNAMIC_FIELD_NAME {
                 assert_eq!(
-                    serde_json::to_string(&field_value.value()).unwrap(),
+                    serde_json::to_string(&tantivy::schema::OwnedValue::from(value)).unwrap(),
                     r#"{"response_date2":"2021-12-19T16:39:57Z"}"#
                 );
             } else if field_name == FIELD_PRESENCE_FIELD_NAME {
-                let field_presence_u64 = field_value.value().as_u64().unwrap();
+                let field_presence_u64 = value.as_u64().unwrap();
                 field_presences.insert(field_presence_u64);
             } else {
-                let value = serde_json::to_string(field_value.value()).unwrap();
+                let value =
+                    serde_json::to_string(&tantivy::schema::OwnedValue::from(value)).unwrap();
                 let is_value_in_expected_values = expected_json_paths_and_values
                     .get(field_name)
                     .unwrap()
@@ -1270,12 +1354,15 @@ mod tests {
         let builder = serde_json::from_str::<DefaultDocMapperBuilder>(doc_mapper).unwrap();
         let doc_mapper = builder.try_build().unwrap();
         let schema = doc_mapper.schema();
-        let json_doc_value: JsonValue = serde_json::json!({
+        let json_doc_value = serde_json_borrow::OwnedValue::from_str(
+            r#"{
             "city": "tokio",
             "image": "YWJj"
-        });
+        }"#,
+        )
+        .unwrap();
         let (_, document) = doc_mapper
-            .doc_from_json_obj(json_doc_value.as_object().unwrap().clone(), 0)
+            .doc_from_json_obj(json_doc_value.clone(), 0)
             .unwrap();
 
         // 2 properties, + 1 value for "_source" + 2 for field presence.
@@ -1288,18 +1375,21 @@ mod tests {
         )
         .unwrap();
         let mut field_presences: HashSet<u64> = HashSet::default();
-        document.field_values().iter().for_each(|field_value| {
-            let field_name = schema.get_field_name(field_value.field());
+        document.field_values().for_each(|(field, value)| {
+            let field_name = schema.get_field_name(field);
             if field_name == SOURCE_FIELD_NAME {
                 assert_eq!(
-                    tantivy::schema::OwnedValue::from(field_value.value().as_value()),
-                    tantivy::schema::OwnedValue::from(json_doc_value.as_object().unwrap().clone())
+                    tantivy::schema::OwnedValue::from(value),
+                    tantivy::schema::OwnedValue::from(serde_json::Value::from(
+                        json_doc_value.get_value()
+                    ))
                 );
             } else if field_name == FIELD_PRESENCE_FIELD_NAME {
-                let field_value_hash = field_value.value().as_u64().unwrap();
+                let field_value_hash = value.as_u64().unwrap();
                 field_presences.insert(field_value_hash);
             } else {
-                let value = serde_json::to_string(field_value.value()).unwrap();
+                let value =
+                    serde_json::to_string(&tantivy::schema::OwnedValue::from(value)).unwrap();
                 let is_value_in_expected_values = expected_json_paths_and_values
                     .get(field_name)
                     .unwrap()
@@ -1605,10 +1695,10 @@ mod tests {
         let schema = default_doc_mapper.schema();
         let field = schema.get_field(field).unwrap();
         let (_, doc) = default_doc_mapper.doc_from_json_str(document_json).unwrap();
-        let vals: Vec<&TantivyValue> = doc.get_all(field).collect();
+        let vals: Vec<_> = doc.get_all(field).collect();
         assert_eq!(vals.len(), expected.len());
         for (val, exp) in vals.into_iter().zip(expected.iter()) {
-            assert_eq!(val, exp);
+            assert_eq!(&TantivyValue::from(val), exp);
         }
     }
 

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -37,6 +37,7 @@ quickwit-query = { workspace = true }
 rdkafka = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_json_borrow = { workspace = true }
 tantivy = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -36,7 +36,7 @@ use quickwit_opentelemetry::otlp::{
 use quickwit_proto::types::{IndexId, SourceId};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
-use tantivy::schema::{Field, Value};
+use tantivy::schema::Field;
 use tantivy::{DateTime, TantivyDocument};
 use thiserror::Error;
 use tokio::runtime::Handle;

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -1337,7 +1337,7 @@ mod tests {
         fn doc_to_json(
             &self,
             _named_doc: std::collections::BTreeMap<String, Vec<tantivy::schema::OwnedValue>>,
-        ) -> anyhow::Result<quickwit_doc_mapper::JsonObject> {
+        ) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {
             unimplemented!()
         }
         fn schema(&self) -> tantivy::schema::Schema {

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -185,10 +185,10 @@ async fn fetch_docs_in_split(
     .context("open-index-for-split")?;
     // we add an executor here, we could add it in open_index_with_caches, though we should verify
     // the side-effect before
-    //let tantivy_executor = crate::search_thread_pool()
-        //.get_underlying_rayon_thread_pool()
-        //.into();
-    //index.set_executor(tantivy_executor);
+    let tantivy_executor = crate::search_thread_pool()
+        .get_underlying_rayon_thread_pool()
+        .into();
+    index.set_executor(tantivy_executor);
     let index_reader = index
         .reader_builder()
         // the docs are presorted so a cache size of NUM_CONCURRENT_REQUESTS is fine

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -29,7 +29,8 @@ use quickwit_proto::search::{
 };
 use quickwit_storage::Storage;
 use tantivy::query::Query;
-use tantivy::schema::{Document as DocumentTrait, Field, OwnedValue, TantivyDocument, Value};
+use tantivy::schema::document::CompactDocValue;
+use tantivy::schema::{Document as DocumentTrait, Field, TantivyDocument, Value};
 use tantivy::snippet::SnippetGenerator;
 use tantivy::{ReloadPolicy, Score, Searcher, Term};
 use tracing::{error, Instrument};
@@ -184,10 +185,10 @@ async fn fetch_docs_in_split(
     .context("open-index-for-split")?;
     // we add an executor here, we could add it in open_index_with_caches, though we should verify
     // the side-effect before
-    let tantivy_executor = crate::search_thread_pool()
-        .get_underlying_rayon_thread_pool()
-        .into();
-    index.set_executor(tantivy_executor);
+    //let tantivy_executor = crate::search_thread_pool()
+        //.get_underlying_rayon_thread_pool()
+        //.into();
+    //index.set_executor(tantivy_executor);
     let index_reader = index
         .reader_builder()
         // the docs are presorted so a cache size of NUM_CONCURRENT_REQUESTS is fine
@@ -274,7 +275,7 @@ impl FieldsSnippetGenerator {
     fn snippets_from_field_values(
         &self,
         field_name: &str,
-        field_values: Vec<&OwnedValue>,
+        field_values: Vec<CompactDocValue<'_>>,
     ) -> Option<Vec<String>> {
         if let Some(snippet_generator) = self.field_generators.get(field_name) {
             let values = field_values


### PR DESCRIPTION
- **update tantivy**
- **use serde_json_borrow instead of serde_json::Value**


```
➜  quickwit-indices cat mezmo/mezmo-use-stage-2023-01-20-ndjson/lines.njson | quickwit tool local-ingest --index mezmo
serde_json_borrow + CompactDoc
 Num docs   46475 Parse errs     0 PublSplits   0 Input size    56MB Thrghput 28.42MB/s Time 00:00:02
 Num docs   94511 Parse errs     0 PublSplits   0 Input size   115MB Thrghput 38.54MB/s Time 00:00:03
 Num docs  138769 Parse errs     0 PublSplits   0 Input size   170MB Thrghput 42.67MB/s Time 00:00:04
 Num docs  184161 Parse errs     0 PublSplits   0 Input size   225MB Thrghput 45.15MB/s Time 00:00:05
 Num docs  227811 Parse errs     0 PublSplits   0 Input size   280MB Thrghput 56.02MB/s Time 00:00:06
 Num docs  273217 Parse errs     0 PublSplits   0 Input size   337MB Thrghput 55.50MB/s Time 00:00:07
 Num docs  320748 Parse errs     0 PublSplits   0 Input size   395MB Thrghput 56.17MB/s Time 00:00:08
 Num docs  366026 Parse errs     0 PublSplits   0 Input size   451MB Thrghput 56.45MB/s Time 00:00:09
 Num docs  410292 Parse errs     0 PublSplits   0 Input size   506MB Thrghput 56.45MB/s Time 00:00:10
 Num docs  456037 Parse errs     0 PublSplits   0 Input size   562MB Thrghput 56.26MB/s Time 00:00:11
 Num docs  501879 Parse errs     0 PublSplits   0 Input size   619MB Thrghput 56.09MB/s Time 00:00:12
 Num docs  549379 Parse errs     0 PublSplits   0 Input size   677MB Thrghput 56.47MB/s Time 00:00:13
 Num docs  594425 Parse errs     0 PublSplits   0 Input size   732MB Thrghput 56.45MB/s Time 00:00:14
 Num docs  638732 Parse errs     0 PublSplits   0 Input size   788MB Thrghput 56.38MB/s Time 00:00:15
```

```
➜  quickwit-indices cat mezmo/mezmo-use-stage-2023-01-20-ndjson/lines.njson | quickwit tool local-ingest --index mezmo
MAIN_BRUNCH
 Num docs   39859 Parse errs     0 PublSplits   0 Input size    48MB Thrghput 48.31MB/s Time 00:00:01
 Num docs   39859 Parse errs     0 PublSplits   0 Input size    48MB Thrghput 24.17MB/s Time 00:00:02
 Num docs   77716 Parse errs     0 PublSplits   0 Input size    95MB Thrghput 31.78MB/s Time 00:00:03
 Num docs  117262 Parse errs     0 PublSplits   0 Input size   144MB Thrghput 36.13MB/s Time 00:00:04
 Num docs  156652 Parse errs     0 PublSplits   0 Input size   192MB Thrghput 36.12MB/s Time 00:00:05
 Num docs  197282 Parse errs     0 PublSplits   0 Input size   242MB Thrghput 48.50MB/s Time 00:00:06
 Num docs  237082 Parse errs     0 PublSplits   0 Input size   291MB Thrghput 49.13MB/s Time 00:00:07
 Num docs  276808 Parse errs     0 PublSplits   0 Input size   341MB Thrghput 49.24MB/s Time 00:00:08
 Num docs  314865 Parse errs     0 PublSplits   0 Input size   388MB Thrghput 48.82MB/s Time 00:00:09
 Num docs  353884 Parse errs     0 PublSplits   0 Input size   437MB Thrghput 48.72MB/s Time 00:00:10
 Num docs  393704 Parse errs     0 PublSplits   0 Input size   485MB Thrghput 48.51MB/s Time 00:00:11
 Num docs  432803 Parse errs     0 PublSplits   0 Input size   534MB Thrghput 48.19MB/s Time 00:00:12
 Num docs  473526 Parse errs     0 PublSplits   0 Input size   583MB Thrghput 48.94MB/s Time 00:00:13
 Num docs  512875 Parse errs     0 PublSplits   0 Input size   633MB Thrghput 49.05MB/s Time 00:00:14
 Num docs  553857 Parse errs     0 PublSplits   0 Input size   682MB Thrghput 49.26MB/s Time 00:00:15
```
