### PR TITLE
Validate documents 

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -6049,6 +6049,7 @@ dependencies = [
  "quickwit-codegen",
  "quickwit-common",
  "quickwit-config",
+ "quickwit-doc-mapper",
  "quickwit-proto",
  "rand 0.8.5",
  "rand_distr",

--- a/quickwit/quickwit-codegen/example/Cargo.toml
+++ b/quickwit/quickwit-codegen/example/Cargo.toml
@@ -27,7 +27,7 @@ utoipa = { workspace = true }
 
 quickwit-actors = { workspace = true }
 quickwit-common = { workspace = true }
-quickwit-proto ={ workspace = true }
+quickwit-proto = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -2401,7 +2401,6 @@ mod tests {
         control_plane_mailbox.ask(callback).await.unwrap();
 
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
-        println!("{:?}", control_plane_debug_info);
         let shard =
             &control_plane_debug_info["shard_table"]["test-index:00000000000000000000000000"][0];
         assert_eq!(shard["shard_id"], "00000000000000000000");

--- a/quickwit/quickwit-indexing/src/actors/doc_processor.rs
+++ b/quickwit/quickwit-indexing/src/actors/doc_processor.rs
@@ -324,7 +324,7 @@ pub struct DocProcessorCounters {
     /// - number of docs that could not be parsed.
     /// - number of docs that were not valid json.
     /// - number of docs that could not be transformed.
-    /// - number of docs for which the doc mapper returnd an error.
+    /// - number of docs for which the doc mapper returned an error.
     /// - number of valid docs.
     pub valid: DocProcessorCounter,
     pub doc_mapper_errors: DocProcessorCounter,

--- a/quickwit/quickwit-ingest/Cargo.toml
+++ b/quickwit/quickwit-ingest/Cargo.toml
@@ -38,6 +38,7 @@ quickwit-actors = { workspace = true }
 quickwit-cluster = { workspace = true }
 quickwit-common = { workspace = true }
 quickwit-config = { workspace = true }
+quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }
 quickwit-proto = { workspace = true }
 
 [dev-dependencies]

--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast.rs
@@ -484,6 +484,7 @@ mod tests {
             ShardState::Open,
             Position::Beginning,
             Position::Beginning,
+            None,
             Instant::now(),
         );
         state_guard.shards.insert(queue_id_00.clone(), shard_00);
@@ -493,6 +494,7 @@ mod tests {
             ShardState::Open,
             Position::Beginning,
             Position::Beginning,
+            None,
             Instant::now(),
         );
         shard_01.is_advertisable = true;

--- a/quickwit/quickwit-ingest/src/ingest_v2/doc_mapper.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/doc_mapper.rs
@@ -1,0 +1,243 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+
+use quickwit_common::thread_pool::run_cpu_intensive;
+use quickwit_config::{build_doc_mapper, DocMapping, SearchSettings};
+use quickwit_doc_mapper::DocMapper;
+use quickwit_proto::ingest::{
+    DocBatchV2, IngestV2Error, IngestV2Result, ParseFailure, ParseFailureReason,
+};
+use quickwit_proto::types::DocMappingUid;
+use serde_json::Value as JsonValue;
+use tracing::info;
+
+/// Attempts to get the doc mapper identified by the given doc mapping UID `doc_mapping_uid` from
+/// the `doc_mappers` cache. If it is not found, it is built from the specified JSON doc mapping
+/// `doc_mapping_json` and inserted into the cache before being returned.
+pub(super) fn get_or_try_build_doc_mapper(
+    doc_mappers: &mut HashMap<DocMappingUid, Weak<dyn DocMapper>>,
+    doc_mapping_uid: DocMappingUid,
+    doc_mapping_json: &str,
+) -> IngestV2Result<Arc<dyn DocMapper>> {
+    if let Entry::Occupied(occupied) = doc_mappers.entry(doc_mapping_uid) {
+        if let Some(doc_mapper) = occupied.get().upgrade() {
+            return Ok(doc_mapper);
+        }
+        occupied.remove();
+    }
+    let doc_mapper = try_build_doc_mapper(doc_mapping_json)?;
+
+    if doc_mapper.doc_mapping_uid() != doc_mapping_uid {
+        let message = format!(
+            "doc mapping UID mismatch: expected `{doc_mapping_uid}`, got `{}`",
+            doc_mapper.doc_mapping_uid()
+        );
+        return Err(IngestV2Error::Internal(message));
+    }
+    doc_mappers.insert(doc_mapping_uid, Arc::downgrade(&doc_mapper));
+    info!("inserted doc mapper `{doc_mapping_uid}` into cache`");
+
+    Ok(doc_mapper)
+}
+
+/// Attempts to build a doc mapper from the specified JSON doc mapping `doc_mapping_json`.
+pub(super) fn try_build_doc_mapper(doc_mapping_json: &str) -> IngestV2Result<Arc<dyn DocMapper>> {
+    let doc_mapping: DocMapping = serde_json::from_str(doc_mapping_json).map_err(|error| {
+        IngestV2Error::Internal(format!("failed to parse doc mapping: {error}"))
+    })?;
+    let search_settings = SearchSettings::default();
+    let doc_mapper = build_doc_mapper(&doc_mapping, &search_settings)
+        .map_err(|error| IngestV2Error::Internal(format!("failed to build doc mapper: {error}")))?;
+    Ok(doc_mapper)
+}
+
+/// Parses the JSON documents contained in the batch and applies the doc mapper. Returns the
+/// original batch and a list of parse failures.
+pub(super) async fn validate_doc_batch(
+    doc_batch: DocBatchV2,
+    doc_mapper: Arc<dyn DocMapper>,
+) -> IngestV2Result<(DocBatchV2, Vec<ParseFailure>)> {
+    let validate_doc_batch_fn = move || {
+        let mut parse_failures: Vec<ParseFailure> = Vec::new();
+
+        for (doc_uid, doc) in doc_batch.docs() {
+            let Ok(json_doc) = serde_json::from_slice::<JsonValue>(&doc) else {
+                let parse_failure = ParseFailure {
+                    doc_uid: Some(doc_uid),
+                    reason: ParseFailureReason::InvalidJson as i32,
+                    message: "failed to parse JSON document".to_string(),
+                };
+                parse_failures.push(parse_failure);
+                continue;
+            };
+            let JsonValue::Object(json_obj) = json_doc else {
+                let parse_failure = ParseFailure {
+                    doc_uid: Some(doc_uid),
+                    reason: ParseFailureReason::InvalidJson as i32,
+                    message: "JSON document is not an object".to_string(),
+                };
+                parse_failures.push(parse_failure);
+                continue;
+            };
+            if let Err(error) = doc_mapper.doc_from_json_obj(json_obj, doc.len() as u64) {
+                let parse_failure = ParseFailure {
+                    doc_uid: Some(doc_uid),
+                    reason: ParseFailureReason::InvalidSchema as i32,
+                    message: error.to_string(),
+                };
+                parse_failures.push(parse_failure);
+            }
+        }
+        (doc_batch, parse_failures)
+    };
+    run_cpu_intensive(validate_doc_batch_fn)
+        .await
+        .map_err(|error| {
+            let message = format!("failed to validate documents: {error}");
+            IngestV2Error::Internal(message)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use quickwit_proto::types::DocUid;
+
+    use super::*;
+
+    #[test]
+    fn test_get_or_try_build_doc_mapper() {
+        let mut doc_mappers: HashMap<DocMappingUid, Weak<dyn DocMapper>> = HashMap::new();
+
+        let doc_mapping_uid = DocMappingUid::random();
+        let doc_mapping_json = r#"{
+            "field_mappings": [{
+                "name": "message",
+                "type": "text"
+            }]
+        }"#;
+        let error =
+            get_or_try_build_doc_mapper(&mut doc_mappers, doc_mapping_uid, doc_mapping_json)
+                .unwrap_err();
+        assert!(
+            matches!(error, IngestV2Error::Internal(message) if message.contains("doc mapping UID mismatch"))
+        );
+
+        let doc_mapping_json = format!(
+            r#"{{
+                "doc_mapping_uid": "{doc_mapping_uid}",
+                "field_mappings": [{{
+                        "name": "message",
+                        "type": "text"
+                }}]
+            }}"#
+        );
+        let doc_mapper =
+            get_or_try_build_doc_mapper(&mut doc_mappers, doc_mapping_uid, &doc_mapping_json)
+                .unwrap();
+        assert_eq!(doc_mappers.len(), 1);
+        assert_eq!(doc_mapper.doc_mapping_uid(), doc_mapping_uid);
+        assert_eq!(Arc::strong_count(&doc_mapper), 1);
+
+        drop(doc_mapper);
+        assert!(doc_mappers
+            .get(&doc_mapping_uid)
+            .unwrap()
+            .upgrade()
+            .is_none());
+
+        let error = get_or_try_build_doc_mapper(&mut doc_mappers, doc_mapping_uid, "").unwrap_err();
+        assert!(
+            matches!(error, IngestV2Error::Internal(message) if message.contains("parse doc mapping"))
+        );
+        assert_eq!(doc_mappers.len(), 0);
+    }
+
+    #[test]
+    fn test_try_build_doc_mapper() {
+        let error = try_build_doc_mapper("").unwrap_err();
+        assert!(
+            matches!(error, IngestV2Error::Internal(message) if message.contains("parse doc mapping"))
+        );
+
+        let error = try_build_doc_mapper(r#"{"timestamp_field": ".timestamp"}"#).unwrap_err();
+        assert!(
+            matches!(error, IngestV2Error::Internal(message) if message.contains("build doc mapper"))
+        );
+
+        let doc_mapping_json = r#"{
+            "mode": "strict",
+            "field_mappings": [{
+                "name": "message",
+                "type": "text"
+        }]}"#;
+        let doc_mapper = try_build_doc_mapper(doc_mapping_json).unwrap();
+        let schema = doc_mapper.schema();
+        assert_eq!(schema.num_fields(), 2);
+
+        let contains_message_field = schema
+            .fields()
+            .map(|(_field, entry)| entry.name())
+            .any(|field_name| field_name == "message");
+        assert!(contains_message_field);
+    }
+
+    #[tokio::test]
+    async fn test_validate_doc_batch() {
+        let doc_mapping_json = r#"{
+            "mode": "strict",
+            "field_mappings": [
+                {
+                    "name": "doc",
+                    "type": "text"
+                }
+            ]
+        }"#;
+        let doc_mapper = try_build_doc_mapper(doc_mapping_json).unwrap();
+        let doc_batch = DocBatchV2::default();
+
+        let (_, parse_failures) = validate_doc_batch(doc_batch, doc_mapper.clone())
+            .await
+            .unwrap();
+        assert_eq!(parse_failures.len(), 0);
+
+        let doc_batch =
+            DocBatchV2::for_test(["", "[]", r#"{"foo": "bar"}"#, r#"{"doc": "test-doc-000"}"#]);
+        let (_, parse_failures) = validate_doc_batch(doc_batch, doc_mapper).await.unwrap();
+        assert_eq!(parse_failures.len(), 3);
+
+        let parse_failure_0 = &parse_failures[0];
+        assert_eq!(parse_failure_0.doc_uid(), DocUid::for_test(0));
+        assert_eq!(parse_failure_0.reason(), ParseFailureReason::InvalidJson);
+        assert!(parse_failure_0.message.contains("parse JSON document"));
+
+        let parse_failure_1 = &parse_failures[1];
+        assert_eq!(parse_failure_1.doc_uid(), DocUid::for_test(1));
+        assert_eq!(parse_failure_1.reason(), ParseFailureReason::InvalidJson);
+        assert!(parse_failure_1.message.contains("not an object"));
+
+        let parse_failure_2 = &parse_failures[2];
+        assert_eq!(parse_failure_2.doc_uid(), DocUid::for_test(2));
+        assert_eq!(parse_failure_2.reason(), ParseFailureReason::InvalidSchema);
+        assert!(parse_failure_2.message.contains("not declared"));
+    }
+}

--- a/quickwit/quickwit-ingest/src/ingest_v2/idle.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/idle.rs
@@ -105,6 +105,7 @@ mod tests {
             ShardState::Open,
             Position::Beginning,
             Position::Beginning,
+            None,
             now - idle_shard_timeout,
         );
         let queue_id_01 = queue_id(&index_uid, "test-source", &ShardId::from(1));
@@ -114,6 +115,7 @@ mod tests {
             ShardState::Open,
             Position::Beginning,
             Position::Beginning,
+            None,
             now - idle_shard_timeout / 2,
         );
         let queue_id_02 = queue_id(&index_uid, "test-source", &ShardId::from(2));

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -17,13 +17,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use quickwit_doc_mapper::DocMapper;
 use quickwit_proto::ingest::ShardState;
 use quickwit_proto::types::{NodeId, Position};
 use tokio::sync::watch;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub(super) enum IngesterShardType {
     /// A primary shard hosted on a leader and replicated on a follower.
     Primary { follower_id: NodeId },
@@ -51,6 +53,8 @@ pub(super) struct IngesterShard {
     /// was successfully opened before advertising it. Currently, this confirmation comes in the
     /// form of `PersistRequest` or `FetchRequest`.
     pub is_advertisable: bool,
+    /// Document mapper for the shard. Replica shards and closed solo shards do not have one.
+    pub doc_mapper_opt: Option<Arc<dyn DocMapper>>,
     pub shard_status_tx: watch::Sender<ShardStatus>,
     pub shard_status_rx: watch::Receiver<ShardStatus>,
     /// Instant at which the shard was last written to.
@@ -63,6 +67,7 @@ impl IngesterShard {
         shard_state: ShardState,
         replication_position_inclusive: Position,
         truncation_position_inclusive: Position,
+        doc_mapper: Arc<dyn DocMapper>,
         now: Instant,
     ) -> Self {
         let shard_status = (shard_state, replication_position_inclusive.clone());
@@ -73,6 +78,7 @@ impl IngesterShard {
             replication_position_inclusive,
             truncation_position_inclusive,
             is_advertisable: false,
+            doc_mapper_opt: Some(doc_mapper),
             shard_status_tx,
             shard_status_rx,
             last_write_instant: now,
@@ -96,6 +102,7 @@ impl IngesterShard {
             // This is irrelevant for replica shards since they are not advertised via gossip
             // anyway.
             is_advertisable: false,
+            doc_mapper_opt: None,
             shard_status_tx,
             shard_status_rx,
             last_write_instant: now,
@@ -106,6 +113,7 @@ impl IngesterShard {
         shard_state: ShardState,
         replication_position_inclusive: Position,
         truncation_position_inclusive: Position,
+        doc_mapper_opt: Option<Arc<dyn DocMapper>>,
         now: Instant,
     ) -> Self {
         let shard_status = (shard_state, replication_position_inclusive.clone());
@@ -116,6 +124,7 @@ impl IngesterShard {
             replication_position_inclusive,
             truncation_position_inclusive,
             is_advertisable: false,
+            doc_mapper_opt,
             shard_status_tx,
             shard_status_rx,
             last_write_instant: now,
@@ -124,7 +133,7 @@ impl IngesterShard {
 
     pub fn follower_id_opt(&self) -> Option<&NodeId> {
         match &self.shard_type {
-            IngesterShardType::Primary { follower_id } => Some(follower_id),
+            IngesterShardType::Primary { follower_id, .. } => Some(follower_id),
             IngesterShardType::Replica { .. } => None,
             IngesterShardType::Solo => None,
         }
@@ -182,6 +191,8 @@ impl IngesterShard {
 
 #[cfg(test)]
 mod tests {
+    use quickwit_config::{build_doc_mapper, DocMapping, SearchSettings};
+
     use super::*;
 
     impl IngesterShard {
@@ -231,16 +242,21 @@ mod tests {
 
     #[test]
     fn test_new_primary_shard() {
+        let doc_mapping: DocMapping = serde_json::from_str("{}").unwrap();
+        let search_settings = SearchSettings::default();
+        let doc_mapper = build_doc_mapper(&doc_mapping, &search_settings).unwrap();
+
         let primary_shard = IngesterShard::new_primary(
             "test-follower".into(),
             ShardState::Closed,
             Position::offset(42u64),
             Position::Beginning,
+            doc_mapper,
             Instant::now(),
         );
         assert!(matches!(
             &primary_shard.shard_type,
-            IngesterShardType::Primary { follower_id } if *follower_id == "test-follower"
+            IngesterShardType::Primary { follower_id, .. } if *follower_id == "test-follower"
         ));
         assert!(!primary_shard.is_replica());
         assert_eq!(primary_shard.shard_state, ShardState::Closed);
@@ -287,9 +303,10 @@ mod tests {
             ShardState::Closed,
             Position::offset(42u64),
             Position::Beginning,
+            None,
             Instant::now(),
         );
-        assert_eq!(solo_shard.shard_type, IngesterShardType::Solo);
+        solo_shard.assert_is_solo();
         assert!(!solo_shard.is_replica());
         assert_eq!(solo_shard.shard_state, ShardState::Closed);
         assert_eq!(

--- a/quickwit/quickwit-ingest/src/ingest_v2/mrecordlog_utils.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mrecordlog_utils.rs
@@ -52,8 +52,8 @@ pub(super) async fn append_non_empty_doc_batch(
 ) -> Result<Position, AppendDocBatchError> {
     let append_result = if force_commit {
         let encoded_mrecords = doc_batch
-            .docs()
-            .map(|doc| MRecord::Doc(doc).encode())
+            .into_docs()
+            .map(|(_doc_uid, doc)| MRecord::Doc(doc).encode())
             .chain(once(MRecord::Commit.encode()));
 
         #[cfg(feature = "failpoints")]
@@ -66,7 +66,9 @@ pub(super) async fn append_non_empty_doc_batch(
             .append_records(queue_id, None, encoded_mrecords)
             .await
     } else {
-        let encoded_mrecords = doc_batch.docs().map(|doc| MRecord::Doc(doc).encode());
+        let encoded_mrecords = doc_batch
+            .into_docs()
+            .map(|(_doc_uid, doc)| MRecord::Doc(doc).encode());
 
         #[cfg(feature = "failpoints")]
         fail_point!("ingester:append_records", |_| {

--- a/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
@@ -1239,18 +1239,18 @@ mod tests {
 
         state_guard
             .mrecordlog
-            .assert_records_eq(&queue_id_01, .., &[(0, "\0\0test-doc-foo")]);
+            .assert_records_eq(&queue_id_01, .., &[(0, [0, 0], "test-doc-foo")]);
 
         state_guard.mrecordlog.assert_records_eq(
             &queue_id_02,
             ..,
-            &[(0, "\0\0test-doc-bar"), (1, "\0\0test-doc-baz")],
+            &[(0, [0, 0], "test-doc-bar"), (1, [0, 0], "test-doc-baz")],
         );
 
         state_guard.mrecordlog.assert_records_eq(
             &queue_id_11,
             ..,
-            &[(0, "\0\0test-doc-qux"), (1, "\0\0test-doc-tux")],
+            &[(0, [0, 0], "test-doc-qux"), (1, [0, 0], "test-doc-tux")],
         );
         drop(state_guard);
 
@@ -1296,7 +1296,7 @@ mod tests {
         state_guard.mrecordlog.assert_records_eq(
             &queue_id_01,
             ..,
-            &[(0, "\0\0test-doc-foo"), (1, "\0\0test-doc-moo")],
+            &[(0, [0, 0], "test-doc-foo"), (1, [0, 0], "test-doc-moo")],
         );
     }
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
@@ -234,7 +234,7 @@ impl RoutingTableEntry {
             target_shards.sort_unstable_by(|left, right| left.shard_id.cmp(&right.shard_id));
 
             info!(
-                index_id=%self.index_uid.index_id,
+                index_uid=%self.index_uid,
                 source_id=%self.source_id,
                 "inserted {num_inserted_shards} shards into routing table"
             );

--- a/quickwit/quickwit-metastore/src/lib.rs
+++ b/quickwit/quickwit-metastore/src/lib.rs
@@ -63,12 +63,12 @@ pub(crate) use split_metadata_version::{SplitMetadataV0_8, VersionedSplitMetadat
 
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(
+    IndexMetadataV0_8,
     Split,
+    SplitMetadataV0_8,
     SplitState,
     VersionedIndexMetadata,
-    IndexMetadataV0_8,
     VersionedSplitMetadata,
-    SplitMetadataV0_8,
 )))]
 /// Schema used for the OpenAPI generation which are apart of this crate.
 pub struct MetastoreApiSchemas;

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -102,8 +102,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .extern_path(".quickwit.common.IndexUid", "crate::types::IndexUid")
         .extern_path(".quickwit.ingest.ShardId", "crate::types::ShardId")
-        .field_attribute("DeleteQuery.index_uid", "#[serde(alias = \"index_id\")]")
         .field_attribute("DeleteQuery.index_uid", "#[schema(value_type = String)]")
+        .field_attribute("DeleteQuery.index_uid", "#[serde(alias = \"index_id\")]")
         .field_attribute("DeleteQuery.query_ast", "#[serde(alias = \"query\")]")
         .field_attribute(
             "DeleteQuery.start_timestamp",
@@ -138,6 +138,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ".quickwit.common.DocMappingUid",
             "crate::types::DocMappingUid",
         )
+        .extern_path(".quickwit.common.DocUid", "crate::types::DocUid")
         .extern_path(".quickwit.common.IndexUid", "crate::types::IndexUid")
         .extern_path(".quickwit.ingest.Position", "crate::types::Position")
         .extern_path(".quickwit.ingest.ShardId", "crate::types::ShardId")

--- a/quickwit/quickwit-proto/protos/quickwit/common.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/common.proto
@@ -30,11 +30,21 @@ message DocMappingUid {
   bytes doc_mapping_uid = 1;
 }
 
+// The corresponding Rust struct [`crate::types::DocUid`] is defined manually and
+// externally provided during code generation (see `build.rs`).
+//
+// Modify at your own risk.
+message DocUid {
+  // ULID encoded as a sequence of 16 bytes (big-endian u128).
+  bytes doc_uid = 1;
+}
+
 // The corresponding Rust struct [`crate::types::IndexUid`] is defined manually and
 // externally provided during code generation (see `build.rs`).
 //
 // Modify at your own risk.
 message IndexUid {
   string index_id = 1;
+  // ULID encoded as a sequence of 16 bytes (big-endian u128).
   bytes incarnation_id = 2;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/ingest.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingest.proto
@@ -56,6 +56,7 @@ enum CommitTypeV2 {
 message DocBatchV2 {
   bytes doc_buffer = 1;
   repeated uint32 doc_lengths = 2;
+  repeated quickwit.common.DocUid doc_uids = 3;
 }
 
 message MRecordBatch {
@@ -115,4 +116,16 @@ message ShardIdPositions {
 message ShardIdPosition {
   ShardId shard_id = 1;
   Position publish_position_inclusive = 2;
+}
+
+enum ParseFailureReason {
+  PARSE_FAILURE_REASON_UNSPECIFIED = 0;
+  PARSE_FAILURE_REASON_INVALID_JSON = 1;
+  PARSE_FAILURE_REASON_INVALID_SCHEMA = 2;
+}
+
+message ParseFailure {
+  quickwit.common.DocUid doc_uid = 1;
+  ParseFailureReason reason = 2;
+  string message = 3;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -94,6 +94,8 @@ message PersistSuccess {
   string source_id = 3;
   quickwit.ingest.ShardId shard_id = 4;
   quickwit.ingest.Position replication_position_inclusive = 5;
+  uint32 num_persisted_docs = 6;
+  repeated quickwit.ingest.ParseFailure parse_failures = 7;
 }
 
 enum PersistFailureReason {
@@ -256,6 +258,7 @@ message InitShardsRequest {
 message InitShardSubrequest {
   uint32 subrequest_id = 1;
   quickwit.ingest.Shard shard = 2;
+  string doc_mapping_json = 3;
 }
 
 message InitShardsResponse {

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -348,13 +348,12 @@ message DeleteTask {
 message DeleteQuery {
   reserved 4, 5;
 
-  // Index ID.
+  // Index UID.
   quickwit.common.IndexUid index_uid = 1;
   // If set, restrict search to documents with a `timestamp >= start_timestamp`.
   optional int64 start_timestamp = 2;
   // If set, restrict search to documents with a `timestamp < end_timestamp``.
   optional int64 end_timestamp = 3;
-  // Query text. The query language is that of tantivy.
   // Query AST serialized in JSON
   string query_ast = 6;
 }

--- a/quickwit/quickwit-proto/protos/quickwit/router.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/router.proto
@@ -57,6 +57,8 @@ message IngestSuccess {
   quickwit.ingest.ShardId shard_id = 4;
   // Replication position inclusive.
   quickwit.ingest.Position replication_position_inclusive = 5;
+  uint32 num_ingested_docs = 6;
+  repeated quickwit.ingest.ParseFailure parse_failures = 7;
 }
 
 enum IngestFailureReason {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.common.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.common.rs
@@ -1,12 +1,12 @@
-/// The corresponding Rust struct \[`crate::types::DocMappingUid`\] is defined manually and
+/// The corresponding Rust struct \[`crate::types::DocUid`\] is defined manually and
 /// externally provided during code generation (see `build.rs`).
 ///
 /// Modify at your own risk.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DocMappingUid {
+pub struct DocUid {
     /// ULID encoded as a sequence of 16 bytes (big-endian u128).
     #[prost(bytes = "vec", tag = "1")]
-    pub doc_mapping_uid: ::prost::alloc::vec::Vec<u8>,
+    pub doc_uid: ::prost::alloc::vec::Vec<u8>,
 }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -71,6 +71,10 @@ pub struct PersistSuccess {
     pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "5")]
     pub replication_position_inclusive: ::core::option::Option<crate::types::Position>,
+    #[prost(uint32, tag = "6")]
+    pub num_persisted_docs: u32,
+    #[prost(message, repeated, tag = "7")]
+    pub parse_failures: ::prost::alloc::vec::Vec<super::ParseFailure>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -354,6 +358,8 @@ pub struct InitShardSubrequest {
     pub subrequest_id: u32,
     #[prost(message, optional, tag = "2")]
     pub shard: ::core::option::Option<super::Shard>,
+    #[prost(string, tag = "3")]
+    pub doc_mapping_json: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
@@ -47,6 +47,10 @@ pub struct IngestSuccess {
     /// Replication position inclusive.
     #[prost(message, optional, tag = "5")]
     pub replication_position_inclusive: ::core::option::Option<crate::types::Position>,
+    #[prost(uint32, tag = "6")]
+    pub num_ingested_docs: u32,
+    #[prost(message, repeated, tag = "7")]
+    pub parse_failures: ::prost::alloc::vec::Vec<super::ParseFailure>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
@@ -18,6 +18,8 @@ pub struct DocBatchV2 {
     pub doc_buffer: ::prost::bytes::Bytes,
     #[prost(uint32, repeated, tag = "2")]
     pub doc_lengths: ::prost::alloc::vec::Vec<u32>,
+    #[prost(message, repeated, tag = "3")]
+    pub doc_uids: ::prost::alloc::vec::Vec<crate::types::DocUid>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -99,6 +101,17 @@ pub struct ShardIdPosition {
     pub publish_position_inclusive: ::core::option::Option<crate::types::Position>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ParseFailure {
+    #[prost(message, optional, tag = "1")]
+    pub doc_uid: ::core::option::Option<crate::types::DocUid>,
+    #[prost(enumeration = "ParseFailureReason", tag = "2")]
+    pub reason: i32,
+    #[prost(string, tag = "3")]
+    pub message: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -166,6 +179,37 @@ impl ShardState {
             "SHARD_STATE_OPEN" => Some(Self::Open),
             "SHARD_STATE_UNAVAILABLE" => Some(Self::Unavailable),
             "SHARD_STATE_CLOSED" => Some(Self::Closed),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ParseFailureReason {
+    Unspecified = 0,
+    InvalidJson = 1,
+    InvalidSchema = 2,
+}
+impl ParseFailureReason {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ParseFailureReason::Unspecified => "PARSE_FAILURE_REASON_UNSPECIFIED",
+            ParseFailureReason::InvalidJson => "PARSE_FAILURE_REASON_INVALID_JSON",
+            ParseFailureReason::InvalidSchema => "PARSE_FAILURE_REASON_INVALID_SCHEMA",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PARSE_FAILURE_REASON_UNSPECIFIED" => Some(Self::Unspecified),
+            "PARSE_FAILURE_REASON_INVALID_JSON" => Some(Self::InvalidJson),
+            "PARSE_FAILURE_REASON_INVALID_SCHEMA" => Some(Self::InvalidSchema),
             _ => None,
         }
     }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -237,10 +237,10 @@ pub struct DeleteTask {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteQuery {
-    /// Index ID.
+    /// Index UID.
     #[prost(message, optional, tag = "1")]
-    #[serde(alias = "index_id")]
     #[schema(value_type = String)]
+    #[serde(alias = "index_id")]
     pub index_uid: ::core::option::Option<crate::types::IndexUid>,
     /// If set, restrict search to documents with a `timestamp >= start_timestamp`.
     #[prost(int64, optional, tag = "2")]
@@ -250,7 +250,6 @@ pub struct DeleteQuery {
     #[prost(int64, optional, tag = "3")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_timestamp: ::core::option::Option<i64>,
-    /// Query text. The query language is that of tantivy.
     /// Query AST serialized in JSON
     #[prost(string, tag = "6")]
     #[serde(alias = "query")]

--- a/quickwit/quickwit-proto/src/getters.rs
+++ b/quickwit/quickwit-proto/src/getters.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use crate::control_plane::*;
 use crate::indexing::*;
 use crate::ingest::ingester::*;
@@ -63,6 +82,13 @@ generate_copy_getters!(
     OpenShardSubrequest,
     Shard
 );
+
+// [`DocUid`] getters
+generate_copy_getters! {
+    impl fn doc_uid() -> DocUid {} for
+
+    ParseFailure
+}
 
 // [`IndexUid`] getters
 generate_getters! {

--- a/quickwit/quickwit-proto/src/types/doc_uid.rs
+++ b/quickwit/quickwit-proto/src/types/doc_uid.rs
@@ -19,65 +19,64 @@
 
 use std::borrow::Cow;
 use std::fmt;
-use std::str::FromStr;
 
-use anyhow::Context;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub use ulid::Ulid;
 
 use super::ULID_SIZE;
 
-/// Unique identifier for a document mapping.
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, Ord, PartialOrd, utoipa::ToSchema)]
-pub struct DocMappingUid(Ulid);
+/// A doc UID identifies a document across segments, splits, and indexes.
+#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct DocUid(Ulid);
 
-impl fmt::Debug for DocMappingUid {
+impl fmt::Debug for DocUid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "DocMapping({})", self.0)
+        write!(f, "Doc({})", self.0)
     }
 }
 
-impl fmt::Display for DocMappingUid {
+impl fmt::Display for DocUid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl From<Ulid> for DocMappingUid {
+impl From<Ulid> for DocUid {
     fn from(ulid: Ulid) -> Self {
         Self(ulid)
     }
 }
 
-impl DocMappingUid {
-    /// Creates a new random doc mapping UID.
+impl DocUid {
+    /// Creates a new random doc UID.
     pub fn random() -> Self {
         Self(Ulid::new())
     }
 
     #[cfg(any(test, feature = "testsuite"))]
-    pub fn for_test(ulid_u128: u128) -> DocMappingUid {
+    pub fn for_test(ulid_u128: u128) -> DocUid {
         Self(Ulid::from(ulid_u128))
     }
 }
 
-impl<'de> Deserialize<'de> for DocMappingUid {
+impl<'de> Deserialize<'de> for DocUid {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
-        let doc_mapping_uid_str: Cow<'de, str> = Cow::deserialize(deserializer)?;
-        doc_mapping_uid_str.parse().map_err(D::Error::custom)
+        let doc_uid_str: Cow<'de, str> = Cow::deserialize(deserializer)?;
+        let doc_uid = Ulid::from_string(&doc_uid_str).map_err(D::Error::custom)?;
+        Ok(Self(doc_uid))
     }
 }
 
-impl Serialize for DocMappingUid {
+impl Serialize for DocUid {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where S: Serializer {
         serializer.collect_str(&self.0)
     }
 }
 
-impl prost::Message for DocMappingUid {
+impl prost::Message for DocUid {
     fn encode_raw<B>(&self, buf: &mut B)
     where B: prost::bytes::BufMut {
         // TODO: when `bytes::encode` supports `&[u8]`, we can remove this allocation.
@@ -94,7 +93,7 @@ impl prost::Message for DocMappingUid {
     where
         B: prost::bytes::Buf,
     {
-        const STRUCT_NAME: &str = "DocMappingUid";
+        const STRUCT_NAME: &str = "DocUid";
 
         match tag {
             1u32 => {
@@ -102,14 +101,14 @@ impl prost::Message for DocMappingUid {
 
                 prost::encoding::bytes::merge(wire_type, &mut buffer, buf, ctx).map_err(
                     |mut error| {
-                        error.push(STRUCT_NAME, "doc_mapping_uid");
+                        error.push(STRUCT_NAME, "doc_uid");
                         error
                     },
                 )?;
                 let ulid_bytes: [u8; ULID_SIZE] =
                     buffer.try_into().map_err(|buffer: Vec<u8>| {
                         prost::DecodeError::new(format!(
-                            "invalid length for field `doc_mapping_uid`, expected 16 bytes, got {}",
+                            "invalid length for field `doc_uid`, expected 16 bytes, got {}",
                             buffer.len()
                         ))
                     })?;
@@ -132,36 +131,29 @@ impl prost::Message for DocMappingUid {
     }
 }
 
-impl FromStr for DocMappingUid {
-    type Err = anyhow::Error;
+/// Generates monotonically increasing doc UIDs. It is not `Clone` nor `Copy` on purpose.
+#[derive(Debug)]
+pub struct DocUidGenerator {
+    next_ulid: Ulid,
+}
 
-    fn from_str(doc_mapping_uid_str: &str) -> Result<Self, Self::Err> {
-        Ulid::from_string(doc_mapping_uid_str)
-            .map(Self)
-            .with_context(|| format!("failed to parse doc mapping UID `{doc_mapping_uid_str}`"))
+impl Default for DocUidGenerator {
+    fn default() -> Self {
+        Self {
+            next_ulid: Ulid::new(),
+        }
     }
 }
 
-#[cfg(feature = "postgres")]
-impl TryFrom<String> for DocMappingUid {
-    type Error = anyhow::Error;
-
-    fn try_from(doc_mapping_uid_str: String) -> Result<Self, Self::Error> {
-        doc_mapping_uid_str.parse()
-    }
-}
-
-#[cfg(feature = "postgres")]
-impl sqlx::Type<sqlx::Postgres> for DocMappingUid {
-    fn type_info() -> sqlx::postgres::PgTypeInfo {
-        sqlx::postgres::PgTypeInfo::with_name("VARCHAR(26)")
-    }
-}
-
-#[cfg(feature = "postgres")]
-impl sqlx::Encode<'_, sqlx::Postgres> for DocMappingUid {
-    fn encode_by_ref(&self, buf: &mut sqlx::postgres::PgArgumentBuffer) -> sqlx::encode::IsNull {
-        sqlx::Encode::<sqlx::Postgres>::encode(&self.0.to_string(), buf)
+impl DocUidGenerator {
+    /// Generates a new doc UID.
+    #[allow(clippy::unwrap_or_default)]
+    pub fn next_doc_uid(&mut self) -> DocUid {
+        let doc_uid = DocUid(self.next_ulid);
+        // Clippy insists on using `unwrap_or_default`, but that's really not what we want here:
+        // https://github.com/rust-lang/rust-clippy/issues/11631
+        self.next_ulid = self.next_ulid.increment().unwrap_or_else(Ulid::new);
+        doc_uid
     }
 }
 
@@ -173,29 +165,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_doc_mapping_uid_json_serde_roundtrip() {
-        let doc_mapping_uid = DocMappingUid::default();
-        let serialized = serde_json::to_string(&doc_mapping_uid).unwrap();
+    fn test_doc_uid_json_serde_roundtrip() {
+        let doc_uid = DocUid::default();
+        let serialized = serde_json::to_string(&doc_uid).unwrap();
         assert_eq!(serialized, r#""00000000000000000000000000""#);
 
-        let deserialized: DocMappingUid = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, doc_mapping_uid);
+        let deserialized: DocUid = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, doc_uid);
     }
 
     #[test]
-    fn test_doc_mapping_uid_prost_serde_roundtrip() {
-        let doc_mapping_uid = DocMappingUid::random();
+    fn test_doc_uid_prost_serde_roundtrip() {
+        let doc_uid = DocUid::random();
 
-        let encoded = doc_mapping_uid.encode_to_vec();
-        assert_eq!(
-            DocMappingUid::decode(Bytes::from(encoded)).unwrap(),
-            doc_mapping_uid
-        );
+        let encoded = doc_uid.encode_to_vec();
+        assert_eq!(DocUid::decode(Bytes::from(encoded)).unwrap(), doc_uid);
 
-        let encoded = doc_mapping_uid.encode_length_delimited_to_vec();
+        let encoded = doc_uid.encode_length_delimited_to_vec();
         assert_eq!(
-            DocMappingUid::decode_length_delimited(Bytes::from(encoded)).unwrap(),
-            doc_mapping_uid
+            DocUid::decode_length_delimited(Bytes::from(encoded)).unwrap(),
+            doc_uid
         );
+    }
+
+    #[test]
+    fn test_doc_uid_generator() {
+        let mut generator = DocUidGenerator::default();
+        let doc_uids: Vec<DocUid> = (0..10_000).map(|_| generator.next_doc_uid()).collect();
+        assert!(doc_uids.windows(2).all(|window| window[0] < window[1]));
     }
 }

--- a/quickwit/quickwit-proto/src/types/index_uid.rs
+++ b/quickwit/quickwit-proto/src/types/index_uid.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 pub use ulid::Ulid;
 
-use crate::types::pipeline_uid::ULID_SIZE;
+use super::ULID_SIZE;
 use crate::types::IndexId;
 
 /// Index identifiers that uniquely identify not only the index, but also

--- a/quickwit/quickwit-proto/src/types/mod.rs
+++ b/quickwit/quickwit-proto/src/types/mod.rs
@@ -29,16 +29,21 @@ use tracing::warn;
 pub use ulid::Ulid;
 
 mod doc_mapping_uid;
+mod doc_uid;
 mod index_uid;
 mod pipeline_uid;
 mod position;
 mod shard_id;
 
 pub use doc_mapping_uid::DocMappingUid;
+pub use doc_uid::{DocUid, DocUidGenerator};
 pub use index_uid::IndexUid;
 pub use pipeline_uid::PipelineUid;
 pub use position::Position;
 pub use shard_id::ShardId;
+
+/// The size of an ULID in bytes. Use `ULID_LEN` for the length of Base32 encoded ULID strings.
+pub(crate) const ULID_SIZE: usize = 16;
 
 pub type IndexId = String;
 

--- a/quickwit/quickwit-proto/src/types/pipeline_uid.rs
+++ b/quickwit/quickwit-proto/src/types/pipeline_uid.rs
@@ -17,17 +17,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
+use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
-/// The size of a ULID in bytes.
-pub(crate) const ULID_SIZE: usize = 16;
+use super::ULID_SIZE;
 
-/// A pipeline uid identify an indexing pipeline and an indexing task.
+/// A pipeline UID identifies an indexing pipeline and an indexing task.
 #[derive(Clone, Copy, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PipelineUid(Ulid);
 
@@ -44,7 +45,7 @@ impl Display for PipelineUid {
 }
 
 impl PipelineUid {
-    /// Creates a new random pipeline uid.
+    /// Creates a new random pipeline UID.
     pub fn random() -> Self {
         Self(Ulid::new())
     }
@@ -73,9 +74,8 @@ impl Serialize for PipelineUid {
 
 impl<'de> Deserialize<'de> for PipelineUid {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let ulid_str = String::deserialize(deserializer)?;
-        let ulid = Ulid::from_string(&ulid_str)
-            .map_err(|error| serde::de::Error::custom(error.to_string()))?;
+        let ulid_str: Cow<'de, str> = Cow::deserialize(deserializer)?;
+        let ulid = Ulid::from_string(&ulid_str).map_err(D::Error::custom)?;
         Ok(Self(ulid))
     }
 }

--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -38,7 +38,7 @@ use crate::with_arg;
 #[derive(utoipa::OpenApi)]
 #[openapi(
     paths(get_delete_tasks, post_delete_request),
-    components(schemas(DeleteQueryRequest, DeleteTask, DeleteQuery,))
+    components(schemas(DeleteQueryRequest, DeleteTask, DeleteQuery))
 )]
 pub struct DeleteTaskApi;
 

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/mod.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/mod.rs
@@ -34,7 +34,7 @@ pub use cat_indices::{
     CatIndexQueryParams, ElasticsearchCatIndexResponse, ElasticsearchResolveIndexEntryResponse,
     ElasticsearchResolveIndexResponse,
 };
-pub use error::{ElasticsearchError, ErrorCauseException};
+pub use error::{ElasticException, ElasticsearchError};
 pub use field_capability::{
     build_list_field_request_for_es_api, convert_to_es_field_capabilities_response,
     FieldCapabilityQueryParams, FieldCapabilityRequestBody, FieldCapabilityResponse,

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -27,7 +27,7 @@ use quickwit_proto::ingest::router::{
     IngestFailureReason, IngestRequestV2, IngestResponseV2, IngestRouterService,
     IngestRouterServiceClient, IngestSubrequest,
 };
-use quickwit_proto::types::IndexId;
+use quickwit_proto::types::{DocUidGenerator, IndexId};
 use serde::Deserialize;
 use warp::{Filter, Rejection};
 
@@ -122,9 +122,10 @@ async fn ingest_v2(
     ingest_router: IngestRouterServiceClient,
 ) -> Result<IngestResponse, IngestServiceError> {
     let mut doc_batch_builder = DocBatchV2Builder::default();
+    let mut doc_uid_generator = DocUidGenerator::default();
 
     for doc in lines(&body.content) {
-        doc_batch_builder.add_doc(doc);
+        doc_batch_builder.add_doc(doc_uid_generator.next_doc_uid(), doc);
     }
     let doc_batch_opt = doc_batch_builder.build();
 

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0001-happy-path.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0001-happy-path.yaml
@@ -1,16 +1,16 @@
 ndjson:
-  - index: { "_index": "test-index-happy-path", "_id": "1" }
+  - index: { "_index": "test-index", "_id": "1" }
   - message: Hello, World!
-  - index: { "_index": "test-index-happy-path" }
+  - index: { "_index": "test-index" }
   - message: Hola, Mundo!
 status_code: 200
 expected:
   errors: false
   items:
     - index:
-        _index: test-index-happy-path
+        _index: test-index
         _id: "1"
         status: 201
     - index:
-        _index: test-index-happy-path
+        _index: test-index
         status: 201

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0004-put-request.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0004-put-request.yaml
@@ -1,4 +1,11 @@
 method: PUT
 ndjson:
-  - index: { "_index": "test-index", "_id": "1" }
+  - index: { "_index": "test-index" }
   - message: Hello, World!
+status_code: 200
+expected:
+  errors: false
+  items:
+    - index:
+        _index: test-index
+        status: 201

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0004-validation-failed-no-requests-added.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0004-validation-failed-no-requests-added.yaml
@@ -1,8 +1,0 @@
-ndjson:
-  - index: { "_index": "test-index", "_id": "2" }
-status_code: 400
-expected:
-  status: 400
-  error:
-    type: action_request_validation_exception
-    reason: "Validation Failed: 1: no requests added;"

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0005-document-parsing-exception.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0005-document-parsing-exception.yaml
@@ -1,0 +1,16 @@
+ndjson:
+  - index: { "_index": "test-index", "_id": "5" }
+  - message: Hello, World!
+    timestamp: timestamp
+status_code: 200
+expected:
+  errors: true
+  items:
+    - index:
+        _index: test-index
+        _id: "5"
+        status: 400
+        error:
+          type: document_parsing_exception
+          reason:
+            $expect: "'timestamp' in val"

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.elasticsearch.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.elasticsearch.yaml
@@ -11,6 +11,10 @@ json: {
       "message": {
         "type": "text",
         "store": true
+      },
+      "timestamp": {
+        "type": "integer",
+        "store": true
       }
     }
   }

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.quickwit.yaml
@@ -14,6 +14,8 @@ json:
     field_mappings:
         - name: message
           type: text
+        - name: timestamp
+          type: datetime
 sleep_after: 3
 ---
 # Create index template

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_teardown.elasticsearch.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_teardown.elasticsearch.yaml
@@ -1,3 +1,0 @@
-method: DELETE
-endpoint: test-index
----


### PR DESCRIPTION
### Description
Parse and validate documents before persisting them into WAL. Returns parse failures to clients.

### How was this PR tested?
Added unit tests.
