### PR TITLE
Add GET api/v1/indexes to Lambda searcher

### DIFF
--- a/distribution/lambda/cdk/cli.py
+++ b/distribution/lambda/cdk/cli.py
@@ -460,3 +460,4 @@ def test_mock_data_endpoints():
         expected_status=400,
     )
     req("GET", f"/api/v1/_elastic/_search?q=animal", expected_status=501)
+    req("GET", f"/api/v1/indexes/{mock_sales_index_id}")

--- a/quickwit/quickwit-lambda/src/searcher/api.rs
+++ b/quickwit/quickwit-lambda/src/searcher/api.rs
@@ -88,12 +88,22 @@ fn es_compat_api(
         .or(es_compat_cat_indices_handler(metastore.clone()))
 }
 
+fn index_api(
+    metastore: MetastoreServiceClient,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
+    get_index_metadata_handler(metastore)
+}
+
 fn v1_searcher_api(
     search_service: Arc<dyn SearchService>,
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     warp::path!("api" / "v1" / ..)
-        .and(native_api(search_service.clone()).or(es_compat_api(search_service, metastore)))
+        .and(
+            native_api(search_service.clone())
+                .or(es_compat_api(search_service, metastore.clone()))
+                .or(index_api(metastore)),
+        )
         .with(warp::filters::compression::gzip())
         .recover(|rejection| {
             error!(?rejection, "request rejected");

--- a/quickwit/quickwit-serve/src/index_api/mod.rs
+++ b/quickwit/quickwit-serve/src/index_api/mod.rs
@@ -20,5 +20,6 @@
 mod rest_handler;
 
 pub use self::rest_handler::{
-    index_management_handlers, IndexApi, IndexUpdates, ListSplitsQueryParams, ListSplitsResponse,
+    get_index_metadata_handler, index_management_handlers, IndexApi, IndexUpdates,
+    ListSplitsQueryParams, ListSplitsResponse,
 };

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -114,7 +114,7 @@ fn json_body<T: DeserializeOwned + Send>(
     warp::body::content_length_limit(1024 * 1024).and(warp::body::json())
 }
 
-fn get_index_metadata_handler(
+pub fn get_index_metadata_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     warp::path!("indexes" / String)

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1248,6 +1248,7 @@ pub mod lambda_search_api {
         es_compat_index_stats_handler, es_compat_scroll_handler, es_compat_search_handler,
         es_compat_stats_handler,
     };
+    pub use crate::index_api::get_index_metadata_handler;
     pub use crate::rest::recover_fn;
     pub use crate::search_api::{search_get_handler, search_post_handler};
 }


### PR DESCRIPTION
### Description

Closes #5039.
Add `GET /api/v1/indexes` endpoint to Lambda Searcher to use quickwit Lambda as Grafana datasource.

### How was this PR tested?

1. Locally running Lambda searcher by using cargo lambda.
```
export AWS_ACCESS_KEY_ID="****"
export AWS_SECRET_ACCESS_KEY="****"
export AWS_SESSION_TOKEN="****"
export AWS_REGION="us-east-1"
export AWS_LAMBDA_HTTP_IGNORE_STAGE_IN_PATH="true"
export QW_LAMBDA_INDEX_BUCKET="quickwitlambdastack-quickwitindexstore****"
export QW_LAMBDA_INDEX_ID="hdfs-logs"
export QW_LAMBDA_METASTORE_BUCKET="quickwitlambdastack-quickwitindexstore****"
export RUST_LOG="quickwit=info"
cargo lambda watch
```

2. Setup Grafana (https://quickwit.io/docs/get-started/tutorials/trace-analytics-with-grafana)
	- url: `http://host.docker.internal:9000/lambda-url/searcher/api/v1`
	- Index ID: `hdfs-logs`

![Screenshot 2024-06-03 at 20 29 44](https://github.com/quickwit-oss/quickwit/assets/6882610/de109fe1-7ed3-44e9-94b6-cee0f99c5dca)

3. Explorer quickwit data
![Screenshot 2024-06-03 at 20 32 25](https://github.com/quickwit-oss/quickwit/assets/6882610/acbd7ecb-1791-4130-be18-1daeea234dc4)


