### PR TITLE
Show queues_dir_path on failed create

### DIFF
--- a/quickwit/quickwit-ingest/src/queue.rs
+++ b/quickwit/quickwit-ingest/src/queue.rs
@@ -41,7 +41,15 @@ pub struct Queues {
 
 impl Queues {
     pub async fn open(queues_dir_path: &Path) -> crate::Result<Queues> {
-        tokio::fs::create_dir_all(queues_dir_path).await.unwrap();
+        tokio::fs::create_dir_all(queues_dir_path)
+            .await
+            .map_err(|error| {
+                IngestServiceError::IoError(format!(
+                    "failed to create WAL directory `{}`: {}",
+                    queues_dir_path.display(),
+                    error
+                ))
+            })?;
         let record_log = MultiRecordLogAsync::open(queues_dir_path).await?;
         Ok(Queues { record_log })
     }


### PR DESCRIPTION
### Description

I needed to look at the code to work out that I had bad permissions on `qwdata`.

### How was this PR tested?

Before,

````
thread 'main' panicked at /projects/quickwit/quickwit/quickwit-ingest/src/queue.rs:44:58:
called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
````


After,

```
✘ command failed: failed to start ingest v1 service

Caused by:
    0: failed to open the ingest API record log located at `/noperm/qwdata/queues`
    1: io error failed to create WAL directory `/noperm/qwdata/queues`: Permission denied (os error 13)
```