### PR TITLE
Support secret manager for the URI

### DIFF
--- a/distribution/ecs/README.md
+++ b/distribution/ecs/README.md
@@ -33,8 +33,8 @@ Metastore database backups are disabled as restoring one would lead to
 inconsistencies with the index store on S3. To ensure high availability, you
 should enable `rds_config.multi_az` instead. To use your own Postgres database
 instead of creating a new RDS instance, configure the
-`external_postgres_uri_ssm_parameter_arn` variable (e.g
-`postgres://user:password@domain:port/db`).
+`external_postgres_uri_secret_arn` variable (e.g ARN of an SSM parameter with
+the value `postgres://user:password@domain:port/db`).
 
 Using NAT Gateways for the image registry is quite costly (approx. $0.05/hour/AZ). If
 you are not already using NAT Gateways in the AZs where Quickwit will be

--- a/distribution/ecs/example/terraform.tf
+++ b/distribution/ecs/example/terraform.tf
@@ -72,7 +72,7 @@ module "quickwit" {
   #   multi_az       = false
   # }
 
-  # external_postgres_uri_ssm_parameter_arn = aws_ssm_parameter.postgres_uri.arn
+  # external_postgres_uri_secret_arn = aws_ssm_parameter.postgres_uri.arn
 
   ## Example logging configuration 
   # sidecar_container_definitions  = {

--- a/distribution/ecs/quickwit/configs.tf
+++ b/distribution/ecs/quickwit/configs.tf
@@ -13,8 +13,8 @@ locals {
 
   quickwit_index_s3_prefix = var.quickwit_index_s3_prefix == "" ? aws_s3_bucket.index[0].id : var.quickwit_index_s3_prefix
 
-  use_external_rds           = var.external_postgres_uri_ssm_parameter_arn != ""
-  postgres_uri_parameter_arn = var.external_postgres_uri_ssm_parameter_arn != "" ? var.external_postgres_uri_ssm_parameter_arn : aws_ssm_parameter.postgres_credential[0].arn
+  use_external_rds        = var.external_postgres_uri_secret_arn != ""
+  postgres_uri_secret_arn = var.external_postgres_uri_secret_arn != "" ? var.external_postgres_uri_secret_arn : aws_ssm_parameter.postgres_credential[0].arn
 }
 
 resource "random_id" "module" {

--- a/distribution/ecs/quickwit/iam.tf
+++ b/distribution/ecs/quickwit/iam.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "quickwit_task_execution_permission" {
   statement {
     actions = ["ssm:GetParameters"]
 
-    resources = [local.postgres_uri_parameter_arn]
+    resources = [local.postgres_uri_secret_arn]
   }
 
   statement {

--- a/distribution/ecs/quickwit/quickwit-control-plane.tf
+++ b/distribution/ecs/quickwit/quickwit-control-plane.tf
@@ -3,7 +3,7 @@ module "quickwit_control_plane" {
   service_name                   = "control_plane"
   service_discovery_registry_arn = aws_service_discovery_service.control_plane.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = local.postgres_uri_parameter_arn
+  postgres_uri_secret_arn        = local.postgres_uri_secret_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
   task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn

--- a/distribution/ecs/quickwit/quickwit-indexer.tf
+++ b/distribution/ecs/quickwit/quickwit-indexer.tf
@@ -3,7 +3,7 @@ module "quickwit_indexer" {
   service_name                   = "indexer"
   service_discovery_registry_arn = aws_service_discovery_service.indexer.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = local.postgres_uri_parameter_arn
+  postgres_uri_secret_arn        = local.postgres_uri_secret_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
   task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn

--- a/distribution/ecs/quickwit/quickwit-janitor.tf
+++ b/distribution/ecs/quickwit/quickwit-janitor.tf
@@ -3,7 +3,7 @@ module "quickwit_janitor" {
   service_name                   = "janitor"
   service_discovery_registry_arn = aws_service_discovery_service.janitor.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = local.postgres_uri_parameter_arn
+  postgres_uri_secret_arn        = local.postgres_uri_secret_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
   task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn

--- a/distribution/ecs/quickwit/quickwit-metastore.tf
+++ b/distribution/ecs/quickwit/quickwit-metastore.tf
@@ -3,7 +3,7 @@ module "quickwit_metastore" {
   service_name                   = "metastore"
   service_discovery_registry_arn = aws_service_discovery_service.metastore.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = local.postgres_uri_parameter_arn
+  postgres_uri_secret_arn        = local.postgres_uri_secret_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
   task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn

--- a/distribution/ecs/quickwit/quickwit-searcher.tf
+++ b/distribution/ecs/quickwit/quickwit-searcher.tf
@@ -3,7 +3,7 @@ module "quickwit_searcher" {
   service_name                   = "searcher"
   service_discovery_registry_arn = aws_service_discovery_service.searcher.arn
   cluster_arn                    = module.ecs_cluster.arn
-  postgres_credential_arn        = local.postgres_uri_parameter_arn
+  postgres_uri_secret_arn        = local.postgres_uri_secret_arn
   quickwit_peer_list             = local.quickwit_peer_list
   s3_access_policy_arn           = aws_iam_policy.quickwit_task_permission.arn
   task_execution_policy_arn      = aws_iam_policy.quickwit_task_execution_permission.arn

--- a/distribution/ecs/quickwit/service/ecs.tf
+++ b/distribution/ecs/quickwit/service/ecs.tf
@@ -27,7 +27,7 @@ module "quickwit_service" {
       secrets = [
         {
           name      = "QW_METASTORE_URI"
-          valueFrom = var.postgres_credential_arn
+          valueFrom = var.postgres_uri_secret_arn
         }
       ]
 
@@ -117,10 +117,6 @@ module "quickwit_service" {
     {
       name = "quickwit-keys"
     }
-  ]
-
-  task_exec_ssm_param_arns = [
-    var.postgres_credential_arn
   ]
 
   tasks_iam_role_policies = local.tasks_iam_role_policies

--- a/distribution/ecs/quickwit/service/variables.tf
+++ b/distribution/ecs/quickwit/service/variables.tf
@@ -32,7 +32,9 @@ variable "subnet_ids" {
   type = list(string)
 }
 
-variable "postgres_credential_arn" {}
+variable "postgres_uri_secret_arn" {
+  description = "ARN of the SSM parameter or Secret Manager secret containing the URI of a Postgres instance"
+}
 
 variable "quickwit_image" {}
 

--- a/distribution/ecs/quickwit/variables.tf
+++ b/distribution/ecs/quickwit/variables.tf
@@ -131,7 +131,7 @@ variable "rds_config" {
   default = {}
 }
 
-variable "external_postgres_uri_ssm_parameter_arn" {
-  description = "ARN of the SSM parameter containing the URI of a Postgres instance (postgres://{user}:{password}@{address}:{port}/{db_instance_name}). The Postgres instance should allow indbound connections from the subnets specified in `variable.subnet_ids`. If provided, the internal RDS will not be created and `var.rds_config` is ignored."
+variable "external_postgres_uri_secret_arn" {
+  description = "ARN of the SSM parameter or Secret Manager secret containing the URI of a Postgres instance (postgres://{user}:{password}@{address}:{port}/{db_instance_name}). The Postgres instance should allow indbound connections from the subnets specified in `variable.subnet_ids`. If provided, the internal RDS will not be created and `var.rds_config` is ignored."
   default     = ""
 }


### PR DESCRIPTION
### Description

Currently, when using an external Postgres as metastore backend, we only support SSM. This small change leverages the fact that ECS supports both SSM and Secret Manager to inject secrets as environment variables.

### How was this PR tested?

Internal CI
