### PR TITLE
Remove newline in a table cell (`index-config.md`)

### DIFF
--- a/docs/configuration/index-config.md
+++ b/docs/configuration/index-config.md
@@ -676,8 +676,7 @@ This section describes search settings for a given index.
 
 | Variable      | Description   | Default value |
 | ------------- | ------------- | ------------- |
-| `default_search_fields`      | Default list of fields that will be used for search. The field names in this list may be declared
-explicitly in the schema, or may refer to a field captured by the dynamic mode.   | `None` |
+| `default_search_fields` | Default list of fields that will be used for search. The field names in this list may be declared explicitly in the schema, or may refer to a field captured by the dynamic mode. | `None` |
 
 ## Retention policy
 


### PR DESCRIPTION
### Description

There is a broken table in [the docs](https://quickwit.io/docs/configuration/index-config#search-settings):

![image](https://github.com/quickwit-oss/quickwit/assets/68805512/90d0281c-f650-46d5-8c30-5e961ddb5e12)

I removed the linebreak in the description row.

### How was this PR tested?

Didn't test because couldn't find out how you build the docs 🙁, but the markdown looks ok now:

![image](https://github.com/quickwit-oss/quickwit/assets/68805512/563adb6f-3b11-443e-a566-edb3aad60690)
