### PR TITLE
Replace FileSourceParams path with URI

### DIFF
--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -744,7 +744,7 @@ mod tests {
             source_id: "foo-source".to_string(),
             num_pipelines: NonZeroUsize::new(1).unwrap(),
             enabled: true,
-            source_params: SourceParams::file("path/to/file"),
+            source_params: SourceParams::file_from_str("path/to/file").unwrap(),
             transform_config: None,
             input_format: SourceInputFormat::Json,
         }];

--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -753,9 +753,10 @@ mod tests {
             source_type: "file".to_string(),
             enabled: "true".to_string(),
         }];
+        let expected_uri = Uri::from_str("path/to/file").unwrap();
         let expected_params = vec![ParamsRow {
             key: "filepath".to_string(),
-            value: JsonValue::String("path/to/file".to_string()),
+            value: JsonValue::String(expected_uri.to_string()),
         }];
         let expected_checkpoint = vec![
             CheckpointRow {

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -173,7 +173,7 @@ pub fn build_tool_command() -> Command {
 pub struct LocalIngestDocsArgs {
     pub config_uri: Uri,
     pub index_id: IndexId,
-    pub input_path_opt: Option<PathBuf>,
+    pub input_path_opt: Option<Uri>,
     pub input_format: SourceInputFormat,
     pub overwrite: bool,
     pub vrl_script: Option<String>,
@@ -251,9 +251,7 @@ impl ToolCliCommand {
             .remove_one::<String>("index")
             .expect("`index` should be a required arg.");
         let input_path_opt = if let Some(input_path) = matches.remove_one::<String>("input-path") {
-            Uri::from_str(&input_path)?
-                .filepath()
-                .map(|path| path.to_path_buf())
+            Some(Uri::from_str(&input_path)?)
         } else {
             None
         };
@@ -410,8 +408,8 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
         get_resolvers(&config.storage_configs, &config.metastore_configs);
     let mut metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
 
-    let source_params = if let Some(filepath) = args.input_path_opt.as_ref() {
-        SourceParams::file(filepath)
+    let source_params = if let Some(uri) = args.input_path_opt.as_ref() {
+        SourceParams::file_from_uri(uri.clone())
     } else {
         SourceParams::stdin()
     };

--- a/quickwit/quickwit-cli/tests/cli.rs
+++ b/quickwit/quickwit-cli/tests/cli.rs
@@ -22,11 +22,10 @@
 mod helpers;
 
 use std::path::Path;
-use std::str::FromStr;
 
 use anyhow::Result;
 use clap::error::ErrorKind;
-use helpers::{TestEnv, TestStorageType};
+use helpers::{uri_from_path, TestEnv, TestStorageType};
 use quickwit_cli::checklist::ChecklistError;
 use quickwit_cli::cli::build_cli;
 use quickwit_cli::index::{
@@ -258,15 +257,17 @@ async fn test_ingest_docs_cli() {
 
     // Ensure cache directory is empty.
     let cache_directory_path = get_cache_directory_path(&test_env.data_dir_path);
-    let data_dir_uri = Uri::from_str(test_env.data_dir_path.to_str().unwrap()).unwrap();
-
     assert!(cache_directory_path.read_dir().unwrap().next().is_none());
+
+    let does_not_exit_uri = uri_from_path(&test_env.data_dir_path)
+        .join("file-does-not-exist.json")
+        .unwrap();
 
     // Ingest a non-existing file should fail.
     let args = LocalIngestDocsArgs {
         config_uri: test_env.resource_files.config,
         index_id: test_env.index_id,
-        input_path_opt: Some(data_dir_uri.join("file-does-not-exist.json").unwrap()),
+        input_path_opt: Some(does_not_exit_uri),
         input_format: SourceInputFormat::Json,
         overwrite: false,
         clear_cache: true,

--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -18,7 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -191,8 +191,8 @@ pub enum TestStorageType {
     LocalFileSystem,
 }
 
-fn uri_from_path(path: PathBuf) -> Uri {
-    Uri::from_str(&format!("file://{}", path.display())).unwrap()
+pub fn uri_from_path(path: &Path) -> Uri {
+    Uri::from_str(path.to_str().unwrap()).unwrap()
 }
 
 /// Creates all necessary artifacts in a test environment.
@@ -264,12 +264,12 @@ pub async fn create_test_env(
         .context("failed to parse cluster endpoint")?;
 
     let resource_files = TestResourceFiles {
-        config: uri_from_path(node_config_path),
-        index_config: uri_from_path(index_config_path),
-        index_config_without_uri: uri_from_path(index_config_without_uri_path),
-        index_config_with_retention: uri_from_path(index_config_with_retention_path),
-        log_docs: uri_from_path(log_docs_path),
-        wikipedia_docs: uri_from_path(wikipedia_docs_path),
+        config: uri_from_path(&node_config_path),
+        index_config: uri_from_path(&index_config_path),
+        index_config_without_uri: uri_from_path(&index_config_without_uri_path),
+        index_config_with_retention: uri_from_path(&index_config_with_retention_path),
+        log_docs: uri_from_path(&log_docs_path),
+        wikipedia_docs: uri_from_path(&wikipedia_docs_path),
     };
 
     Ok(TestEnv {

--- a/quickwit/quickwit-common/src/fs.rs
+++ b/quickwit/quickwit-common/src/fs.rs
@@ -34,7 +34,7 @@ pub async fn empty_dir<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Helper function to get the cache path.
+/// Helper function to get the indexer split cache path.
 pub fn get_cache_directory_path(data_dir_path: &Path) -> PathBuf {
     data_dir_path.join("indexer-split-cache").join("splits")
 }

--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -20,10 +20,8 @@
 pub(crate) mod serialize;
 
 use std::num::NonZeroUsize;
-use std::path::Path;
 use std::str::FromStr;
 
-use anyhow::Context;
 use bytes::Bytes;
 use quickwit_common::is_false;
 use quickwit_common::uri::Uri;
@@ -239,14 +237,6 @@ impl SourceParams {
 
     pub fn file_from_str<P: AsRef<str>>(filepath: P) -> anyhow::Result<Self> {
         FileSourceParams::from_str(filepath.as_ref()).map(Self::File)
-    }
-
-    pub fn file_from_path<P: AsRef<Path>>(filepath: P) -> anyhow::Result<Self> {
-        let path_str = filepath
-            .as_ref()
-            .to_str()
-            .context("failed to convert path to string")?;
-        Self::file_from_str(path_str)
     }
 
     pub fn stdin() -> Self {

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -639,7 +639,7 @@ mod tests {
             source_id: "test-source".to_string(),
             num_pipelines: NonZeroUsize::MIN,
             enabled: true,
-            source_params: SourceParams::file(PathBuf::from(test_file)),
+            source_params: SourceParams::file_from_str(test_file).unwrap(),
             transform_config: None,
             input_format: SourceInputFormat::Json,
         };
@@ -758,7 +758,7 @@ mod tests {
             source_id: "test-source".to_string(),
             num_pipelines: NonZeroUsize::MIN,
             enabled: true,
-            source_params: SourceParams::file(PathBuf::from(test_file)),
+            source_params: SourceParams::file_from_str(test_file).unwrap(),
             transform_config: None,
             input_format: SourceInputFormat::Json,
         };
@@ -965,7 +965,7 @@ mod tests {
             source_id: "test-source".to_string(),
             num_pipelines: NonZeroUsize::MIN,
             enabled: true,
-            source_params: SourceParams::file(PathBuf::from(test_file)),
+            source_params: SourceParams::file_from_str(test_file).unwrap(),
             transform_config: None,
             input_format: SourceInputFormat::Json,
         };

--- a/quickwit/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit/quickwit-indexing/src/source/file_source.rs
@@ -160,7 +160,6 @@ mod tests {
     use std::str::FromStr;
 
     use quickwit_actors::{Command, Universe};
-    use quickwit_common::uri::Uri;
     use quickwit_config::{SourceConfig, SourceInputFormat, SourceParams};
     use quickwit_metastore::checkpoint::{PartitionId, SourceCheckpointDelta};
     use quickwit_proto::types::{IndexUid, Position};
@@ -236,7 +235,7 @@ mod tests {
         let temp_file = generate_dummy_doc_file(gzip, 20_000).await;
         let filepath = temp_file.path().to_str().unwrap();
         let params = FileSourceParams::from_str(filepath).unwrap();
-
+        let uri = params.filepath.as_ref().unwrap().clone();
         let source_config = SourceConfig {
             source_id: "test-file-source".to_string(),
             num_pipelines: NonZeroUsize::new(1).unwrap(),
@@ -270,7 +269,6 @@ mod tests {
         let batch1 = indexer_msgs[0].downcast_ref::<RawDocBatch>().unwrap();
         let batch2 = indexer_msgs[1].downcast_ref::<RawDocBatch>().unwrap();
         let command = indexer_msgs[2].downcast_ref::<Command>().unwrap();
-        let uri = Uri::from_str(filepath).unwrap();
         assert_eq!(
             format!("{:?}", &batch1.checkpoint_delta),
             format!(
@@ -309,6 +307,7 @@ mod tests {
         let temp_file = generate_index_doc_file(gzip, 100).await;
         let temp_file_path = temp_file.path().to_str().unwrap();
         let params = FileSourceParams::from_str(temp_file_path).unwrap();
+        let uri = params.filepath.as_ref().unwrap();
         let source_config = SourceConfig {
             source_id: "test-file-source".to_string(),
             num_pipelines: NonZeroUsize::new(1).unwrap(),
@@ -317,7 +316,7 @@ mod tests {
             transform_config: None,
             input_format: SourceInputFormat::Json,
         };
-        let partition_id = PartitionId::from(temp_file_path);
+        let partition_id = PartitionId::from(uri.as_str());
         let source_checkpoint_delta = SourceCheckpointDelta::from_partition_delta(
             partition_id,
             Position::Beginning,

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -677,7 +677,7 @@ mod tests {
                 source_id: "file".to_string(),
                 num_pipelines: NonZeroUsize::new(1).unwrap(),
                 enabled: true,
-                source_params: SourceParams::file("file-does-not-exist.json"),
+                source_params: SourceParams::file_from_str("file-does-not-exist.json").unwrap(),
                 transform_config: None,
                 input_format: SourceInputFormat::Json,
             };
@@ -692,7 +692,7 @@ mod tests {
                 source_id: "file".to_string(),
                 num_pipelines: NonZeroUsize::new(1).unwrap(),
                 enabled: true,
-                source_params: SourceParams::file("data/test_corpus.json"),
+                source_params: SourceParams::file_from_str("data/test_corpus.json").unwrap(),
                 transform_config: None,
                 input_format: SourceInputFormat::Json,
             };

--- a/quickwit/quickwit-lambda/src/indexer/handler.rs
+++ b/quickwit/quickwit-lambda/src/indexer/handler.rs
@@ -34,7 +34,7 @@ async fn indexer_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
     let payload = serde_json::from_value::<IndexerEvent>(event.payload)?;
 
     let ingest_res = ingest(IngestArgs {
-        input_path: payload.uri(),
+        input_path: payload.uri()?,
         input_format: quickwit_config::SourceInputFormat::Json,
         overwrite: false,
         vrl_script: None,

--- a/quickwit/quickwit-lambda/src/indexer/ingest/helpers.rs
+++ b/quickwit/quickwit-lambda/src/indexer/ingest/helpers.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{bail, Context};
 use chitchat::transport::ChannelTransport;
@@ -138,12 +138,12 @@ pub(super) async fn send_telemetry() {
 
 /// Convert the incomming file path to a source config
 pub(super) async fn configure_source(
-    input_path: PathBuf,
+    input_uri: Uri,
     input_format: SourceInputFormat,
     vrl_script: Option<String>,
 ) -> anyhow::Result<SourceConfig> {
     let transform_config = vrl_script.map(|vrl_script| TransformConfig::new(vrl_script, None));
-    let source_params = SourceParams::file(input_path.clone());
+    let source_params = SourceParams::file_from_uri(input_uri);
     Ok(SourceConfig {
         source_id: LAMBDA_SOURCE_ID.to_owned(),
         num_pipelines: NonZeroUsize::new(1).expect("1 is always non-zero."),

--- a/quickwit/quickwit-lambda/src/indexer/ingest/mod.rs
+++ b/quickwit/quickwit-lambda/src/indexer/ingest/mod.rs
@@ -20,7 +20,6 @@
 mod helpers;
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 
 use anyhow::bail;
 use helpers::{
@@ -31,6 +30,7 @@ use quickwit_actors::Universe;
 use quickwit_cli::start_actor_runtimes;
 use quickwit_cli::tool::start_statistics_reporting_loop;
 use quickwit_common::runtimes::RuntimesConfig;
+use quickwit_common::uri::Uri;
 use quickwit_config::service::QuickwitService;
 use quickwit_config::SourceInputFormat;
 use quickwit_index_management::clear_cache_directory;
@@ -43,7 +43,7 @@ use crate::utils::load_node_config;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct IngestArgs {
-    pub input_path: PathBuf,
+    pub input_path: Uri,
     pub input_format: SourceInputFormat,
     pub overwrite: bool,
     pub vrl_script: Option<String>,


### PR DESCRIPTION
### Description

The `FileSourceParams` curently contains a path that is converted forth and back to a URI. This PR straitens up things to avoid these conversions.

### How was this PR tested?

Describe how you tested this PR.
