### PR TITLE
Use nextest in Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ You will be notified by email from the CI system if any issues are discovered, b
 2. Install node@20 and `npm install -g yarn`
 3. Install awslocal https://github.com/localstack/awscli-local
 4. Install protoc https://grpc.io/docs/protoc-installation/ (you may need to install the latest binaries rather than your distro's flavor)
+5. Install nextest https://nexte.st/docs/installation/pre-built-binaries/
 
 ### GitHub Codespaces
 

--- a/quickwit/Makefile
+++ b/quickwit/Makefile
@@ -30,11 +30,11 @@ test-all:
 	QW_S3_FORCE_PATH_STYLE_ACCESS=1 \
 	QW_TEST_DATABASE_URL=postgres://quickwit-dev:quickwit-dev@localhost:5432/quickwit-metastore-dev \
 	RUST_MIN_STACK=67108864 \
-	cargo test --all-features
-	cargo test --test failpoints --features fail/failpoints
+	cargo nextest run --all-features
+	cargo nextest run --test failpoints --features fail/failpoints
 
 test-failpoints:
-	cargo test --test failpoints --features fail/failpoints
+	cargo nextest run --test failpoints --features fail/failpoints
 
 # TODO: to be replaced by https://github.com/quickwit-oss/quickwit/issues/237
 TARGET ?= x86_64-unknown-linux-gnu

--- a/quickwit/Makefile
+++ b/quickwit/Makefile
@@ -30,7 +30,7 @@ test-all:
 	QW_S3_FORCE_PATH_STYLE_ACCESS=1 \
 	QW_TEST_DATABASE_URL=postgres://quickwit-dev:quickwit-dev@localhost:5432/quickwit-metastore-dev \
 	RUST_MIN_STACK=67108864 \
-	cargo nextest run --all-features
+	cargo nextest run --all-features --retries 1
 	cargo nextest run --test failpoints --features fail/failpoints
 
 test-failpoints:


### PR DESCRIPTION
### Description

We use nextest in the CI to stabilize tests. This PR changes the Makefile to also use nextest.

### How was this PR tested?

Ran `make test-all`
