### PR TITLE
remove hits beyond max requested hit

### DIFF
--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -845,14 +845,12 @@ impl Collector for QuickwitCollector {
         // ... and drop the first [..start_offsets) hits.
         // note that self.start_offset is 0 when merging from leaf_search, and is only set when
         // merging from root_search, so as to remove the firsts elements only once.
-        merged_leaf_response
-            .partial_hits
-            .drain(
-                0..self
-                    .start_offset
-                    .min(merged_leaf_response.partial_hits.len()),
-            )
-            .count(); //< we just use count as a way to consume the entire iterator.
+        merged_leaf_response.partial_hits.drain(
+            0..self
+                .start_offset
+                .min(merged_leaf_response.partial_hits.len()),
+        );
+        merged_leaf_response.partial_hits.truncate(self.max_hits);
         Ok(merged_leaf_response)
     }
 }


### PR DESCRIPTION
### Description

due to the 1st case of what's described in https://github.com/quickwit-oss/quickwit/issues/3650 , it can happen that we return up to `start_offset + 2 * max_hits` documents instead of `max_hits`. This happens when a split first fails, and then succeed, but its result is just concatenated instead of doing a proper top-k.
The fix consist in dropping the tail hits at the same time as the hits that should be omitted due to start_offset are removed.

### How was this PR tested?

tested with a modified s3 that errors on a fraction of requests. Without the patch, i often get too many results (and sometime a double error so no response), with the patch, i either get the right number of docs, or said error.