### PR TITLE
Fix: Remove  / when calling search endpoint

### DIFF
--- a/quickwit/quickwit-ui/src/services/client.test.ts
+++ b/quickwit/quickwit-ui/src/services/client.test.ts
@@ -21,24 +21,35 @@ import { SearchRequest } from '../utils/models';
 import { Client } from './client';
 
 describe('Client unit test', () => {
-    it('Should build search URL', () => {
+    it('Should construct correct search URL', async () => {
+        // Mocking the fetch function to simulate network requests
+        const mockFetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+        (global as any).fetch = mockFetch; // eslint-disable-line @typescript-eslint/no-explicit-any
+
         const searchRequest: SearchRequest = {
-          indexId: 'my-new-fresh-index-id',
-          query: 'severity_error:ERROR',
-          startTimestamp: 100,
-          endTimestamp: 200,
-          maxHits: 20,
-          sortByField: {
-            field_name: 'timestamp',
-            order: 'Desc',
-          },
-          aggregation: false,
-          aggregationConfig: {
-            metric: null,
-            term: null,
-            histogram: null,
-          },
+            indexId: 'my-new-fresh-index-id',
+            query: 'severity_error:ERROR',
+            startTimestamp: 100,
+            endTimestamp: 200,
+            maxHits: 20,
+            sortByField: {
+              field_name: 'timestamp',
+              order: 'Desc',
+            },
+            aggregation: false,
+            aggregationConfig: {
+              metric: null,
+              term: null,
+              histogram: null,
+            },
         };
-        expect(new Client().buildSearchBody(searchRequest, null)).toBe('{"query":"severity_error:ERROR","max_hits":20,"start_timestamp":100,"end_timestamp":200,"sort_by_field":"+timestamp"}');
+
+        const client = new Client();
+        expect(client.buildSearchBody(searchRequest, null)).toBe('{"query":"severity_error:ERROR","max_hits":20,"start_timestamp":100,"end_timestamp":200,"sort_by_field":"+timestamp"}');
+
+        await client.search(searchRequest, null);
+        const expectedUrl = `${client.apiRoot()}my-new-fresh-index-id/search`;
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
     });
 });

--- a/quickwit/quickwit-ui/src/services/client.ts
+++ b/quickwit/quickwit-ui/src/services/client.ts
@@ -40,7 +40,7 @@ export class Client {
     if (request.indexId === null || request.indexId === undefined) {
       throw Error("Search request must have and index id.")
     }
-    const url = `${this.apiRoot()}/${request.indexId}/search`;
+    const url = `${this.apiRoot()}${request.indexId}/search`;
     const body = this.buildSearchBody(request, timestamp_field);
     return this.fetch(url, this.defaultGetRequestParams(), body);
   }


### PR DESCRIPTION
Fixes #5186

There was an unnecessary / in the URL.
Additionally, some browsers still successfully made the call.