### PR TITLE
Minor refactoring in the rate limiter.

### DIFF
--- a/quickwit/quickwit-ingest/Cargo.toml
+++ b/quickwit/quickwit-ingest/Cargo.toml
@@ -48,6 +48,7 @@ mockall = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"]}
 
 quickwit-actors = { workspace = true, features = ["testsuite"] }
 quickwit-cluster = { workspace = true, features = ["testsuite"] }


### PR DESCRIPTION
The point is to be able to remove the needless private function, and test public functions.
