### PR TITLE
Removing invalid docs from persistence.

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_api_service.rs
+++ b/quickwit/quickwit-ingest/src/ingest_api_service.rs
@@ -206,10 +206,10 @@ impl IngestApiService {
 
             num_docs += batch_num_docs;
             INGEST_METRICS
-                .ingested_num_bytes
+                .ingested_docs_bytes_valid
                 .inc_by(batch_num_bytes as u64);
             INGEST_METRICS
-                .ingested_num_docs
+                .ingested_docs_valid
                 .inc_by(batch_num_docs as u64);
         }
         // TODO we could fsync here and disable autosync to have better i/o perfs.


### PR DESCRIPTION

    Removing invalid docs from persistence.

    This PR filters out invalid docs from batches before persisting the
    batch.
    That way, they won't be persisted in the mrecordlog and the
    indexing pipeline will not have to parse them again (and log an error).

    This PR also improves a little bit on the metric for ingested docs.
    The num_docs and bytes metric now have a validity `label`, and the
    point at which they are measured is documented in the metric description.

    Closes #5205

