### PR TITLE
feat(es): respect format parameter in range query

### DIFF
--- a/quickwit/quickwit-query/src/elastic_query_dsl/range_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/range_query.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::JsonLiteral;
 
     #[test]
-    fn test_parse_and_convert() {
+    fn test_parse_and_convert() -> anyhow::Result<()> {
         let parser = StrptimeParser::from_str("%Y-%m-%d %H:%M:%S").unwrap();
 
         // valid datetime
@@ -142,5 +142,7 @@ mod tests {
         let input = JsonLiteral::Number(27.into());
         let result = parse_and_convert(input.clone(), &parser)?;
         assert_eq!(result, input);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### Description

Introduce the support for `format` parameter in `RangeQuery`

### How was this PR tested?

```sh
curl -X GET "http://localhost:7280/api/v1/_elastic/stackoverflow-schemaless/_search?pretty" -H 'Content-Type: application/json' -d'
{
  "query": {
    "range": {
      "age": {
        "gte": "2023-01-01",
        "lte": "2023-12-31",
        "boost": 2.0,
        "format": "%Y-%m-%d"
      }
    }
  }
}
```

### Related issue
https://github.com/quickwit-oss/quickwit/issues/5109
