### PR TITLE
add api endpoint to get query ast

### DIFF
--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -76,6 +76,9 @@ service SearchService {
   rpc ListFields(ListFieldsRequest) returns (ListFieldsResponse);
 
   rpc LeafListFields(LeafListFieldsRequest) returns (ListFieldsResponse);
+
+  // Describe how a search would be processed.
+  rpc SearchPlan(SearchRequest) returns (SearchPlanResponse);
 }
 
 /// Scroll Request
@@ -296,6 +299,10 @@ message SearchResponse {
 
   // Scroll Id (only set if scroll_secs was set in the request)
   optional string scroll_id = 6;
+}
+
+message SearchPlanResponse {
+  string result = 1;
 }
 
 message SplitSearchError {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -234,6 +234,13 @@ pub struct SearchResponse {
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SearchPlanResponse {
+    #[prost(string, tag = "1")]
+    pub result: ::prost::alloc::string::String,
+}
+#[derive(Serialize, Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SplitSearchError {
     /// The searcherror that occurred formatted as string.
     #[prost(string, tag = "1")]
@@ -1201,6 +1208,32 @@ pub mod search_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// Describe how a search would be processed.
+        pub async fn search_plan(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SearchRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SearchPlanResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/quickwit.search.SearchService/SearchPlan",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("quickwit.search.SearchService", "SearchPlan"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -1320,6 +1353,14 @@ pub mod search_service_server {
             request: tonic::Request<super::LeafListFieldsRequest>,
         ) -> std::result::Result<
             tonic::Response<super::ListFieldsResponse>,
+            tonic::Status,
+        >;
+        /// Describe how a search would be processed.
+        async fn search_plan(
+            &self,
+            request: tonic::Request<super::SearchRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SearchPlanResponse>,
             tonic::Status,
         >;
     }
@@ -1925,6 +1966,50 @@ pub mod search_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = LeafListFieldsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/quickwit.search.SearchService/SearchPlan" => {
+                    #[allow(non_camel_case_types)]
+                    struct SearchPlanSvc<T: SearchService>(pub Arc<T>);
+                    impl<
+                        T: SearchService,
+                    > tonic::server::UnaryService<super::SearchRequest>
+                    for SearchPlanSvc<T> {
+                        type Response = super::SearchPlanResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SearchRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).search_plan(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SearchPlanSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -84,11 +84,11 @@ pub use crate::cluster_client::ClusterClient;
 pub use crate::error::{parse_grpc_error, SearchError};
 use crate::fetch_docs::fetch_docs;
 pub use crate::root::{
-    check_all_index_metadata_found, jobs_to_leaf_request, root_search, IndexMetasForLeafSearch,
-    SearchJob,
+    check_all_index_metadata_found, jobs_to_leaf_request, root_search, search_plan,
+    IndexMetasForLeafSearch, SearchJob,
 };
 pub use crate::search_job_placer::{Job, SearchJobPlacer};
-pub use crate::search_response_rest::SearchResponseRest;
+pub use crate::search_response_rest::{SearchPlanResponseRest, SearchResponseRest};
 pub use crate::search_stream::root_search_stream;
 pub use crate::service::{MockSearchService, SearchService, SearchServiceImpl};
 

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1190,12 +1190,12 @@ pub async fn search_plan(
         + warmup_info
             .terms_grouped_by_field
             .values()
-            .map(|terms| terms.len())
+            .map(|terms: &HashMap<tantivy::Term, bool>| terms.len())
             .sum::<usize>();
     let position_query_count = warmup_info
         .terms_grouped_by_field
         .values()
-        .map(|terms| {
+        .map(|terms: &HashMap<tantivy::Term, bool>| {
             terms
                 .values()
                 .filter(|load_position| **load_position)

--- a/quickwit/quickwit-search/src/search_response_rest.rs
+++ b/quickwit/quickwit-search/src/search_response_rest.rs
@@ -119,7 +119,9 @@ pub struct SearchPlanResponseRest {
     pub storage_requests: StorageRequestCount,
 }
 
-/// Number of expected storage requests, per request kind
+/// Number of expected storage requests, per request kind.
+///
+/// These figures do not take in account whether the data is already cached or not.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct StorageRequestCount {
     /// Number of split footer downloaded, always 1

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -48,7 +48,10 @@ use crate::metrics_api::metrics_handler;
 use crate::node_info_handler::node_info_handler;
 use crate::otlp_api::otlp_ingest_api_handlers;
 use crate::rest_api_response::{RestApiError, RestApiResponse};
-use crate::search_api::{search_get_handler, search_post_handler, search_stream_handler};
+use crate::search_api::{
+    search_get_handler, search_plan_get_handler, search_plan_post_handler, search_post_handler,
+    search_stream_handler,
+};
 use crate::template_api::index_template_api_handlers;
 use crate::ui_handler::ui_handler;
 use crate::{BodyFormat, BuildInfo, QuickwitServices, RuntimeInfo};
@@ -234,6 +237,8 @@ fn search_routes(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
     search_get_handler(search_service.clone())
         .or(search_post_handler(search_service.clone()))
+        .or(search_plan_get_handler(search_service.clone()))
+        .or(search_plan_post_handler(search_service.clone()))
         .or(search_stream_handler(search_service))
         .recover(recover_fn)
 }

--- a/quickwit/quickwit-serve/src/search_api/grpc_adapter.rs
+++ b/quickwit/quickwit-serve/src/search_api/grpc_adapter.rs
@@ -183,4 +183,15 @@ impl grpc::SearchService for GrpcSearchAdapter {
         let resp = self.0.leaf_list_fields(request.into_inner()).await;
         convert_to_grpc_result(resp)
     }
+
+    #[instrument(skip(self, request))]
+    async fn search_plan(
+        &self,
+        request: tonic::Request<quickwit_proto::search::SearchRequest>,
+    ) -> Result<tonic::Response<quickwit_proto::search::SearchPlanResponse>, tonic::Status> {
+        set_parent_span_from_request_metadata(request.metadata());
+        let search_request = request.into_inner();
+        let search_result = self.0.search_plan(search_request).await;
+        convert_to_grpc_result(search_result)
+    }
 }

--- a/quickwit/quickwit-serve/src/search_api/mod.rs
+++ b/quickwit/quickwit-serve/src/search_api/mod.rs
@@ -23,8 +23,9 @@ mod rest_handler;
 pub use self::grpc_adapter::GrpcSearchAdapter;
 pub(crate) use self::rest_handler::{extract_index_id_patterns, extract_index_id_patterns_default};
 pub use self::rest_handler::{
-    search_get_handler, search_post_handler, search_request_from_api_request,
-    search_stream_handler, SearchApi, SearchRequestQueryString, SortBy,
+    search_get_handler, search_plan_get_handler, search_plan_post_handler, search_post_handler,
+    search_request_from_api_request, search_stream_handler, SearchApi, SearchRequestQueryString,
+    SortBy,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

fix #5190
add api endpoint to get the quickwit and tantivy ast for a query, as well as what splits would be hit (taking into account time range and tags), and how many/what kind of storage request are to be expected for each split

### How was this PR tested?

tested manually plus added basic unit test