### PR TITLE
Make the split deletion grace period configurable.

### DIFF
--- a/quickwit/quickwit-janitor/src/actors/garbage_collector.rs
+++ b/quickwit/quickwit-janitor/src/actors/garbage_collector.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::{stream, StreamExt};
 use quickwit_actors::{Actor, ActorContext, Handler};
-use quickwit_common::shared_consts::DELETION_GRACE_PERIOD;
+use quickwit_common::shared_consts::split_deletion_grace_period;
 use quickwit_index_management::run_garbage_collect;
 use quickwit_metastore::ListIndexesMetadataResponseExt;
 use quickwit_proto::metastore::{
@@ -124,7 +124,7 @@ impl GarbageCollector {
                 storage,
                 metastore,
                 STAGED_GRACE_PERIOD,
-                DELETION_GRACE_PERIOD,
+                split_deletion_grace_period(),
                 false,
                 Some(ctx.progress()),
             ).await;
@@ -216,7 +216,7 @@ mod tests {
     use std::sync::Arc;
 
     use quickwit_actors::Universe;
-    use quickwit_common::shared_consts::DELETION_GRACE_PERIOD;
+    use quickwit_common::shared_consts::split_deletion_grace_period;
     use quickwit_common::ServiceStream;
     use quickwit_metastore::{
         IndexMetadata, ListSplitsRequestExt, ListSplitsResponseExt, Split, SplitMetadata,
@@ -281,7 +281,7 @@ mod tests {
                     SplitState::MarkedForDeletion => {
                         let expected_deletion_timestamp = OffsetDateTime::now_utc()
                             .unix_timestamp()
-                            - DELETION_GRACE_PERIOD.as_secs() as i64;
+                            - split_deletion_grace_period().as_secs() as i64;
                         assert_eq!(
                             query.update_timestamp.end,
                             Bound::Included(expected_deletion_timestamp),
@@ -336,7 +336,7 @@ mod tests {
             Arc::new(mock_storage),
             MetastoreServiceClient::from_mock(mock_metastore),
             STAGED_GRACE_PERIOD,
-            DELETION_GRACE_PERIOD,
+            split_deletion_grace_period(),
             false,
             None,
         )

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -67,18 +67,14 @@ use crate::{
 fn max_scroll_ttl() -> Duration {
     static MAX_SCROLL_TTL_LOCK: OnceLock<Duration> = OnceLock::new();
     *MAX_SCROLL_TTL_LOCK.get_or_init(|| {
-        let split_deletion_grace_period_secs =
-            shared_consts::split_deletion_grace_period().as_secs();
+        let split_deletion_grace_period = shared_consts::split_deletion_grace_period();
         assert!(
-            split_deletion_grace_period_secs
-                >= shared_consts::MINIMUM_DELETION_GRACE_PERIOD.as_secs(),
-            "The split deletion grace period is too short ({}s). This should not happen.",
-            split_deletion_grace_period_secs
+            split_deletion_grace_period
+                >= shared_consts::MINIMUM_DELETION_GRACE_PERIOD,
+            "The split deletion grace period is too short ({split_deletion_grace_period:?}). This should not happen."
         );
         // We remove an extra margin of 2minutes from the split deletion grace period.
-        Duration::from_secs(
-            quickwit_common::shared_consts::split_deletion_grace_period().as_secs() - 60 * 2,
-        )
+        split_deletion_grace_period - Duration::from_secs(60 * 2)
     })
 }
 


### PR DESCRIPTION
... with the environment variable QW_SPLIT_DELETION_GRACE_PERIOD_SECS.

The default is sensible for most case, but for project airmail, we need to be able to recover from a metastore backup that could be several hours old.
