### PR TITLE
support updating doc mapper through api

### DIFF
--- a/quickwit/quickwit-config/src/index_config/serialize.rs
+++ b/quickwit/quickwit-config/src/index_config/serialize.rs
@@ -98,12 +98,6 @@ pub fn load_index_config_update(
         current_index_config.index_uri,
         new_index_config.index_uri
     );
-    ensure!(
-        current_index_config
-            .doc_mapping
-            .eq_ignore_doc_mapping_uid(&new_index_config.doc_mapping),
-        "`doc_mapping` cannot be updated"
-    );
     Ok(new_index_config)
 }
 
@@ -440,12 +434,12 @@ mod test {
                       tokenizer: default
                       record: position
         "#;
-        let load_error = load_index_config_update(
+        let updated_config = load_index_config_update(
             ConfigFormat::Yaml,
             updated_config_yaml.as_bytes(),
             &original_config,
         )
-        .unwrap_err();
-        assert!(format!("{:?}", load_error).contains("`doc_mapping` cannot be updated"));
+        .unwrap();
+        assert_eq!(updated_config.doc_mapping.field_mappings.len(), 1);
     }
 }

--- a/quickwit/quickwit-doc-mapper/src/default_doc_mapper/tokenizer_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/default_doc_mapper/tokenizer_entry.rs
@@ -26,7 +26,7 @@ use tantivy::tokenizer::{
 };
 
 /// A `TokenizerEntry` defines a custom tokenizer with its name and configuration.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash, utoipa::ToSchema)]
 pub struct TokenizerEntry {
     /// Tokenizer name.
     pub name: String,
@@ -36,7 +36,7 @@ pub struct TokenizerEntry {
 }
 
 /// Tokenizer configuration.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash, utoipa::ToSchema)]
 pub struct TokenizerConfig {
     #[serde(flatten)]
     pub(crate) tokenizer_type: TokenizerType,
@@ -94,7 +94,7 @@ pub fn analyze_text(text: &str, tokenizer: &TokenizerConfig) -> anyhow::Result<V
     Ok(tokens)
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TokenFilterType {
     RemoveLong,
@@ -122,7 +122,7 @@ impl TokenFilterType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TokenizerType {
     #[cfg(any(test, feature = "multilang"))]
@@ -133,7 +133,7 @@ pub enum TokenizerType {
     SourceCode,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct NgramTokenizerOption {
     pub min_gram: usize,
@@ -142,7 +142,7 @@ pub struct NgramTokenizerOption {
     pub prefix_only: bool,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RegexTokenizerOption {
     pub pattern: String,

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -31,7 +31,8 @@ use std::ops::Bound;
 use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
 use quickwit_config::{
-    IndexingSettings, RetentionPolicy, SearchSettings, SourceConfig, INGEST_V2_SOURCE_ID,
+    DocMapping, IndexingSettings, RetentionPolicy, SearchSettings, SourceConfig,
+    INGEST_V2_SOURCE_ID,
 };
 use quickwit_proto::metastore::{
     AcquireShardsRequest, AcquireShardsResponse, DeleteQuery, DeleteShardsRequest,
@@ -229,6 +230,12 @@ impl FileBackedIndex {
     /// Replaces the indexing settings in the index config, returning whether a mutation occurred.
     pub fn set_indexing_settings(&mut self, search_settings: IndexingSettings) -> bool {
         self.metadata.set_indexing_settings(search_settings)
+    }
+
+    /// Replaces the doc mapping in the index config, returning whether a mutation occurred, or
+    /// possibly an error if this change is not allowed
+    pub fn set_doc_mapping(&mut self, doc_mapping: DocMapping) -> MetastoreResult<bool> {
+        self.metadata.set_doc_mapping(doc_mapping)
     }
 
     /// Stages a single split.

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -30,6 +30,7 @@ use quickwit_config::{
     validate_index_id_pattern, IndexTemplate, IndexTemplateId, PostgresMetastoreConfig,
     INGEST_V2_SOURCE_ID,
 };
+use quickwit_doc_mapper::DefaultDocMapperBuilder;
 use quickwit_proto::ingest::{Shard, ShardState};
 use quickwit_proto::metastore::{
     serde_utils, AcquireShardsRequest, AcquireShardsResponse, AddSourceRequest, CreateIndexRequest,
@@ -399,6 +400,19 @@ impl MetastoreService for PostgresqlMetastore {
         let retention_policy_opt = request.deserialize_retention_policy()?;
         let search_settings = request.deserialize_search_settings()?;
         let indexing_settings = request.deserialize_indexing_settings()?;
+        let doc_mapping = request.deserialize_doc_mapping()?;
+
+        // verify the new mapping is coherent
+        let doc_mapper_builder = DefaultDocMapperBuilder {
+            doc_mapping: doc_mapping.clone(),
+            default_search_fields: search_settings.default_search_fields.clone(),
+        };
+        doc_mapper_builder
+            .try_build()
+            .map_err(|e| MetastoreError::InvalidArgument {
+                message: format!("invalid mapping update: {e}"),
+            })?;
+
         let index_uid: IndexUid = request.index_uid().clone();
         let updated_index_metadata = run_with_tx!(self.connection_pool, tx, {
             mutate_index_metadata::<MetastoreError, _>(tx, index_uid, |index_metadata| {
@@ -406,6 +420,7 @@ impl MetastoreService for PostgresqlMetastore {
                     index_metadata.set_retention_policy(retention_policy_opt);
                 mutation_occurred |= index_metadata.set_search_settings(search_settings);
                 mutation_occurred |= index_metadata.set_indexing_settings(indexing_settings);
+                mutation_occurred |= index_metadata.set_doc_mapping(doc_mapping)?;
                 Ok(MutationOccurred::from(mutation_occurred))
             })
             .await

--- a/quickwit/quickwit-metastore/src/tests/index.rs
+++ b/quickwit/quickwit-metastore/src/tests/index.rs
@@ -31,13 +31,14 @@ use quickwit_config::{
     IndexConfig, IndexingSettings, RetentionPolicy, SearchSettings, SourceConfig, CLI_SOURCE_ID,
     INGEST_V2_SOURCE_ID,
 };
+use quickwit_doc_mapper::{Cardinality, FieldMappingEntry, FieldMappingType, QuickwitJsonOptions};
 use quickwit_proto::metastore::{
     CreateIndexRequest, DeleteIndexRequest, EntityKind, IndexMetadataFailure,
     IndexMetadataFailureReason, IndexMetadataRequest, IndexMetadataSubrequest,
     IndexesMetadataRequest, ListIndexesMetadataRequest, MetastoreError, MetastoreService,
     StageSplitsRequest, UpdateIndexRequest,
 };
-use quickwit_proto::types::IndexUid;
+use quickwit_proto::types::{DocMappingUid, IndexUid};
 
 use super::DefaultForTest;
 use crate::tests::cleanup_index;
@@ -126,6 +127,7 @@ pub async fn test_metastore_update_retention_policy<
             &index_config.search_settings,
             &loop_retention_policy_opt,
             &index_config.indexing_settings,
+            &index_config.doc_mapping,
         )
         .unwrap();
         let response_metadata = metastore
@@ -172,6 +174,7 @@ pub async fn test_metastore_update_search_settings<
             },
             &index_config.retention_policy_opt,
             &index_config.indexing_settings,
+            &index_config.doc_mapping,
         )
         .unwrap();
         let response_metadata = metastore
@@ -228,6 +231,7 @@ pub async fn test_metastore_update_indexing_settings<
                 merge_policy: loop_indexing_settings.clone(),
                 ..Default::default()
             },
+            &index_config.doc_mapping,
         )
         .unwrap();
         let resp_metadata = metastore
@@ -252,6 +256,135 @@ pub async fn test_metastore_update_indexing_settings<
             updated_metadata.index_config.indexing_settings.merge_policy,
             loop_indexing_settings
         );
+    }
+    cleanup_index(&mut metastore, index_uid).await;
+}
+
+pub async fn test_metastore_update_doc_mapping<
+    MetastoreToTest: MetastoreService + MetastoreServiceExt + DefaultForTest,
+>() {
+    let (mut metastore, index_uid, index_config) =
+        setup_metastore_for_update::<MetastoreToTest>().await;
+
+    let json_options = QuickwitJsonOptions {
+        description: None,
+        stored: false,
+        indexing_options: None,
+        expand_dots: false,
+        fast: Default::default(),
+    };
+
+    let initial = index_config.doc_mapping.clone();
+    let mut new_field = initial.clone();
+    new_field.field_mappings.push(FieldMappingEntry {
+        name: "new_field".to_string(),
+        mapping_type: FieldMappingType::Json(json_options.clone(), Cardinality::SingleValued),
+    });
+    new_field.doc_mapping_uid = DocMappingUid::random();
+    let mut new_field_stored = initial.clone();
+    new_field_stored.field_mappings.push(FieldMappingEntry {
+        name: "new_field".to_string(),
+        mapping_type: FieldMappingType::Json(
+            QuickwitJsonOptions {
+                stored: true,
+                ..json_options
+            },
+            Cardinality::SingleValued,
+        ),
+    });
+    new_field_stored.doc_mapping_uid = DocMappingUid::random();
+
+    for loop_doc_mapping in [initial.clone(), new_field, new_field_stored, initial] {
+        let index_update = UpdateIndexRequest::try_from_updates(
+            index_uid.clone(),
+            &index_config.search_settings,
+            &index_config.retention_policy_opt,
+            &index_config.indexing_settings,
+            &loop_doc_mapping,
+        )
+        .unwrap();
+        let resp_metadata = metastore
+            .update_index(index_update)
+            .await
+            .unwrap()
+            .deserialize_index_metadata()
+            .unwrap();
+        assert_eq!(resp_metadata.index_config.doc_mapping, loop_doc_mapping);
+        let updated_metadata = metastore
+            .index_metadata(IndexMetadataRequest::for_index_id(
+                index_uid.index_id.to_string(),
+            ))
+            .await
+            .unwrap()
+            .deserialize_index_metadata()
+            .unwrap();
+        assert_eq!(updated_metadata.index_config.doc_mapping, loop_doc_mapping);
+    }
+    cleanup_index(&mut metastore, index_uid).await;
+}
+
+pub async fn test_metastore_update_doc_mapping_fail_case<
+    MetastoreToTest: MetastoreService + MetastoreServiceExt + DefaultForTest,
+>() {
+    let (mut metastore, index_uid, index_config) =
+        setup_metastore_for_update::<MetastoreToTest>().await;
+
+    let initial = index_config.doc_mapping.clone();
+    let json_options = QuickwitJsonOptions {
+        description: None,
+        stored: false,
+        indexing_options: None,
+        expand_dots: false,
+        fast: Default::default(),
+    };
+
+    let mut new_field_same_id = initial.clone();
+    new_field_same_id.field_mappings.push(FieldMappingEntry {
+        name: "new_field".to_string(),
+        mapping_type: FieldMappingType::Json(
+            QuickwitJsonOptions {
+                stored: true,
+                ..json_options
+            },
+            Cardinality::SingleValued,
+        ),
+    });
+
+    let mut timestamp_field_changed = initial.clone();
+    timestamp_field_changed.timestamp_field = None;
+    timestamp_field_changed.doc_mapping_uid = DocMappingUid::random();
+
+    let mut required_field_disappear = initial.clone();
+    required_field_disappear
+        .field_mappings
+        .retain(|field| field.name != "timestamp");
+    required_field_disappear.doc_mapping_uid = DocMappingUid::random();
+
+    for loop_doc_mapping in [
+        new_field_same_id,
+        timestamp_field_changed,
+        required_field_disappear,
+    ] {
+        let index_update = UpdateIndexRequest::try_from_updates(
+            index_uid.clone(),
+            &index_config.search_settings,
+            &index_config.retention_policy_opt,
+            &index_config.indexing_settings,
+            &loop_doc_mapping,
+        )
+        .unwrap();
+        let resp = metastore.update_index(index_update).await;
+        assert!(resp.is_err());
+        // verify nothing was persisted
+        let updated_metadata = metastore
+            .index_metadata(IndexMetadataRequest::for_index_id(
+                index_uid.index_id.to_string(),
+            ))
+            .await
+            .unwrap()
+            .deserialize_index_metadata()
+            .unwrap();
+        assert_eq!(updated_metadata.index_config, index_config);
     }
     cleanup_index(&mut metastore, index_uid).await;
 }

--- a/quickwit/quickwit-metastore/src/tests/mod.rs
+++ b/quickwit/quickwit-metastore/src/tests/mod.rs
@@ -211,6 +211,20 @@ macro_rules! metastore_test_suite {
 
             #[tokio::test]
             #[serial_test::serial]
+            async fn test_metastore_update_doc_mapping() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_update_doc_mapping::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
+            #[serial_test::serial]
+            async fn test_metastore_update_doc_mapping_fail_case() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_update_doc_mapping_fail_case::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
+            #[serial_test::serial]
             async fn test_metastore_update_indexing_settings() {
                 let _ = tracing_subscriber::fmt::try_init();
                 $crate::tests::index::test_metastore_update_indexing_settings::<$metastore_type>().await;

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -216,6 +216,7 @@ message UpdateIndexRequest {
   string search_settings_json = 2;
   optional string retention_policy_json = 3;
   string indexing_settings_json = 4;
+  string doc_mapping_json = 5;
 }
 
 message ListIndexesMetadataRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -32,6 +32,8 @@ pub struct UpdateIndexRequest {
     pub retention_policy_json: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, tag = "4")]
     pub indexing_settings_json: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub doc_mapping_json: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -588,6 +588,7 @@ async fn update_index(
         &new_index_config.search_settings,
         &new_index_config.retention_policy_opt,
         &new_index_config.indexing_settings,
+        &new_index_config.doc_mapping,
     )?;
     let update_resp = metastore.update_index(update_request).await?;
     Ok(update_resp.deserialize_index_metadata()?)


### PR DESCRIPTION
### Description

allow updating the doc-mapper of an index
part of #5084

### How was this PR tested?

updated tests, tested manually on a simple doc-mapper change (changing tokenizer)