### PR TITLE
docs(dist/k8s): fix link to helm doc

### DIFF
--- a/distribution/kubernetes/README.md
+++ b/distribution/kubernetes/README.md
@@ -1,3 +1,3 @@
 # Quickwit on Kubernetes
 
-To deploy Quickwit on Kubernetes, use the official Quickwit Helm chart available at [helm.quickwit.io](https://helm.quickwit.io/) and refer to our [documentation](https://quickwit.io/docs/deployment/kubernetes) for more information.
+To deploy Quickwit on Kubernetes, use the official Quickwit Helm chart available at [helm.quickwit.io](https://helm.quickwit.io/) and refer to our [documentation](https://quickwit.io/docs/deployment/kubernetes/helm) for more information.


### PR DESCRIPTION
### Description

Fix Helm documentation link from distribution/kubernetes README.

### How was this PR tested?

N/A
