### PR TITLE
lambda: Allow setting postgres as the metastore

### DIFF
--- a/distribution/lambda/README.md
+++ b/distribution/lambda/README.md
@@ -85,7 +85,7 @@ simplify the setup and avoid unstable deployments.
 | Variable | Description | Default |
 |---|---|---|
 | QW_LAMBDA_INDEX_ID | the index this Lambda interacts with (one and only one) | required |
-| QW_LAMBDA_METASTORE_BUCKET | bucket name for metastore files | required |
+| QW_LAMBDA_METASTORE_URI | [Metastore URI](https://quickwit.io/docs/configuration/metastore-config) | required |
 | QW_LAMBDA_INDEX_BUCKET | bucket name for split files | required |
 | QW_LAMBDA_OPENTELEMETRY_URL | HTTP OTEL tracing collector endpoint | none, OTEL disabled |
 | QW_LAMBDA_OPENTELEMETRY_AUTHORIZATION | Authorization header value for HTTP OTEL calls | none, OTEL disabled |
@@ -106,7 +106,6 @@ Indexer only:
 Searcher only:
 | Variable | Description | Default |
 |---|---|---|
-| QW_LAMBDA_SEARCHER_METASTORE_POLLING_INTERVAL_SECONDS | refresh interval of the metastore | 60 |
 | QW_LAMBDA_PARTIAL_REQUEST_CACHE_CAPACITY | `searcher.partial_request_cache_capacity` node config | 64M |
 
 

--- a/distribution/lambda/cdk/stacks/services/indexer_service.py
+++ b/distribution/lambda/cdk/stacks/services/indexer_service.py
@@ -20,6 +20,12 @@ class IndexerService(Construct):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        metastore_uri = environment.get("QW_LAMBDA_METASTORE_URI")
+        if not metastore_uri:
+            # Backwards compatibility.
+            metastore_bucket = environment.get("QW_LAMBDA_METASTORE_BUCKET", store.bucket)
+            metastore_uri = f"s3://${metastore_bucket}/index"
+
         self.lambda_function = aws_lambda.Function(
             self,
             id="Lambda",
@@ -28,7 +34,7 @@ class IndexerService(Construct):
             handler="N/A",
             environment={
                 "QW_LAMBDA_INDEX_BUCKET": store_bucket.bucket_name,
-                "QW_LAMBDA_METASTORE_BUCKET": store_bucket.bucket_name,
+                "QW_LAMBDA_METASTORE_URI": metastore_uri,
                 "QW_LAMBDA_INDEX_ID": index_id,
                 "QW_LAMBDA_INDEX_CONFIG_URI": f"s3://{index_config_bucket}/{index_config_key}",
                 **environment,

--- a/distribution/lambda/cdk/stacks/services/searcher_service.py
+++ b/distribution/lambda/cdk/stacks/services/searcher_service.py
@@ -17,6 +17,13 @@ class SearcherService(Construct):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        metastore_uri = environment.get("QW_LAMBDA_METASTORE_URI")
+        if not metastore_uri:
+            # Backwards compatibility.
+            metastore_bucket = environment.get("QW_LAMBDA_METASTORE_BUCKET", store.bucket)
+            metastore_polling = environment.get("QW_LAMBDA_SEARCHER_METASTORE_POLLING_INTERVAL_SECONDS", 60)
+            metastore_uri = f"s3://${metastore_bucket}/index#polling_interval={metastore_polling}s"
+
         self.lambda_function = aws_lambda.Function(
             self,
             id="Lambda",
@@ -25,7 +32,7 @@ class SearcherService(Construct):
             handler="N/A",
             environment={
                 "QW_LAMBDA_INDEX_BUCKET": store_bucket.bucket_name,
-                "QW_LAMBDA_METASTORE_BUCKET": store_bucket.bucket_name,
+                "QW_LAMBDA_METASTORE_URI": metastore_uri,
                 "QW_LAMBDA_INDEX_ID": index_id,
                 **environment,
             },

--- a/quickwit/quickwit-lambda/src/indexer/environment.rs
+++ b/quickwit/quickwit-lambda/src/indexer/environment.rs
@@ -26,7 +26,7 @@ pub const CONFIGURATION_TEMPLATE: &str = r#"
 version: 0.8
 node_id: lambda-indexer
 cluster_id: lambda-ephemeral
-metastore_uri: s3://${QW_LAMBDA_METASTORE_BUCKET}/index
+metastore_uri: ${QW_LAMBDA_METASTORE_URI}
 default_index_root_uri: s3://${QW_LAMBDA_INDEX_BUCKET}/index
 data_dir: /tmp
 "#;

--- a/quickwit/quickwit-lambda/src/searcher/environment.rs
+++ b/quickwit/quickwit-lambda/src/searcher/environment.rs
@@ -20,7 +20,7 @@
 pub(crate) const CONFIGURATION_TEMPLATE: &str = r#"
 version: 0.8
 node_id: lambda-searcher
-metastore_uri: s3://${QW_LAMBDA_METASTORE_BUCKET}/index#polling_interval=${QW_LAMBDA_SEARCHER_METASTORE_POLLING_INTERVAL_SECONDS:-60}s
+metastore_uri: ${QW_LAMBDA_METASTORE_URI}
 default_index_root_uri: s3://${QW_LAMBDA_INDEX_BUCKET}/index
 data_dir: /tmp
 searcher:


### PR DESCRIPTION
Give the user the full control over the lambda metastore uri.

Backwards compatible.