### PR TITLE
update tantivy

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -4739,7 +4739,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "bitpacking",
 ]
@@ -8226,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8241,7 +8241,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8264,7 +8264,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "nom",
 ]
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -8283,7 +8283,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -8293,7 +8293,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=13e9885#13e9885dfda8cebf4bfef72f53bf811da8549445"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=3d1c4b3#3d1c4b313a63a854214eea669a865837e146ee17"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -325,7 +325,7 @@ quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry = { path = "quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "13e9885", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "3d1c4b3", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",

--- a/quickwit/quickwit-query/src/query_ast/utils.rs
+++ b/quickwit/quickwit-query/src/query_ast/utils.rs
@@ -181,7 +181,7 @@ fn compute_tantivy_ast_query_for_json(
 ) -> Result<TantivyQueryAst, InvalidQuery> {
     let mut bool_query = TantivyBoolQuery::default();
     let term = Term::from_field_json_path(field, json_path, json_options.is_expand_dots_enabled());
-    if let Some(term) = convert_to_fast_value_and_append_to_json_term(term, text) {
+    if let Some(term) = convert_to_fast_value_and_append_to_json_term(term, text, true) {
         bool_query
             .should
             .push(TantivyTermQuery::new(term, IndexRecordOption::Basic).into());


### PR DESCRIPTION
uses the new range query API and JSON query impl in tantivy
includes the new term aggregation key type Key::I64 and Key::U64 used in tantivy (prerequisite for https://github.com/quickwit-oss/quickwit/issues/5254)

`range_query_numeric` benchmark may be be improved, since we don't do a boolean query over all numeric types anymore.
Update: `range_query_numeric` is unaffected

Follow-Ups: 
* Add a test for https://github.com/quickwit-oss/quickwit/issues/5254
* Enable range queries on string