### PR TITLE
add test for term agg number serialization

### DIFF
--- a/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
@@ -375,4 +375,21 @@ expected:
   aggregations:
     response_stats:
       sum_of_squares: 55300.0
-
+# Test term aggs number precision
+method: [GET]
+engines:
+  - quickwit
+endpoint: _elastic/aggregations/_search
+json:
+  query: { match_all: {} }
+  size: 0
+  aggs:
+    names: 
+      terms: 
+        field: "high_prec_test"
+expected:
+  aggregations:
+    names:
+      buckets:
+      - doc_count: 1 
+        key: 1769070189829214200

--- a/quickwit/rest-api-tests/scenarii/aggregations/0002-doc-len.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/0002-doc-len.yaml
@@ -12,7 +12,7 @@ json:
 expected:
   aggregations:
     doc_len:
-      value: 913.0
+      value: 952.0
 ---
 # Test doc len isn't shown when querying documents
 method: [GET]

--- a/quickwit/rest-api-tests/scenarii/aggregations/_setup.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/_setup.quickwit.yaml
@@ -25,6 +25,9 @@ json:
           - rfc3339
         fast_precision: seconds
         fast: true
+      - name: high_prec_test
+        type: u64
+        fast: true
     store_document_size: true
 ---
 # Create empty index
@@ -64,7 +67,7 @@ endpoint: aggregations/ingest
 params:
   commit: force
 ndjson:
-  - {"name": "Fritz", "response": 30, "id": 0}
+  - {"name": "Fritz", "high_prec_test": 1769070189829214200, "response": 30, "id": 0}
   - {"name": "Fritz", "response": 30, "id": 0}
   - {"name": "Holger", "response": 30, "id": 4, "date": "2015-02-06T00:00:00Z", "host": "192.168.0.10"}
   - {"name": "Werner", "response": 20, "id": 5, "date": "2015-01-02T00:00:00Z", "host": "192.168.0.10"}


### PR DESCRIPTION
Add a test to make sure large u64 are serialized correctly without truncation

closes https://github.com/quickwit-oss/quickwit/issues/5254