### PR TITLE
improve ingest lock

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/idle.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/idle.rs
@@ -64,7 +64,7 @@ impl CloseIdleShardsTask {
                 return;
             };
             let Ok(mut state_guard) =
-                with_lock_metrics!(state.lock_partially(), "close_idle_shards", "write").await
+                with_lock_metrics!(state.lock_partially(), "close_idle_shards", "write")
             else {
                 return;
             };

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -292,7 +292,7 @@ impl Ingester {
 
         let mut per_source_shard_ids: HashMap<(IndexUid, SourceId), Vec<ShardId>> = HashMap::new();
 
-        let state_guard = with_lock_metrics!(self.state.lock_fully().await, "reset_shards", "read")
+        let state_guard = with_lock_metrics!(self.state.lock_fully(), "reset_shards", "read")
             .expect("ingester should be ready");
 
         for queue_id in state_guard.mrecordlog.list_queues() {
@@ -325,7 +325,7 @@ impl Ingester {
         match advise_reset_shards_result {
             Ok(Ok(advise_reset_shards_response)) => {
                 let mut state_guard =
-                    with_lock_metrics!(self.state.lock_fully().await, "reset_shards", "write")
+                    with_lock_metrics!(self.state.lock_fully(), "reset_shards", "write")
                         .expect("ingester should be ready");
 
                 state_guard
@@ -458,8 +458,7 @@ impl Ingester {
         let force_commit = commit_type == CommitTypeV2::Force;
         let leader_id: NodeId = persist_request.leader_id.into();
 
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully().await, "persist", "write")?;
+        let mut state_guard = with_lock_metrics!(self.state.lock_fully(), "persist", "write")?;
 
         if state_guard.status() != IngesterStatus::Ready {
             persist_failures.reserve_exact(persist_request.subrequests.len());
@@ -929,8 +928,9 @@ impl Ingester {
         &self,
         init_shards_request: InitShardsRequest,
     ) -> IngestV2Result<InitShardsResponse> {
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully().await, "init_shards", "write")?;
+        let mut state_guard = with_lock_metrics!(self.state.lock_fully(), "init_shards", "write")?;
+        // we do this to allow simultaneous reborrow of multiple fields.
+        let state_guard = &mut *state_guard;
 
         if state_guard.status() != IngesterStatus::Ready {
             return Err(IngestV2Error::Internal("node decommissioned".to_string()));
@@ -984,7 +984,7 @@ impl Ingester {
             )));
         }
         let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully().await, "truncate_shards", "write")?;
+            with_lock_metrics!(self.state.lock_fully(), "truncate_shards", "write")?;
 
         for subrequest in truncate_shards_request.subrequests {
             let queue_id = subrequest.queue_id();
@@ -1011,7 +1011,7 @@ impl Ingester {
         close_shards_request: CloseShardsRequest,
     ) -> IngestV2Result<CloseShardsResponse> {
         let mut state_guard =
-            with_lock_metrics!(self.state.lock_partially().await, "close_shards", "write")?;
+            with_lock_metrics!(self.state.lock_partially(), "close_shards", "write")?;
 
         let mut successes = Vec::with_capacity(close_shards_request.shard_pkeys.len());
 
@@ -1166,7 +1166,7 @@ impl IngesterService for Ingester {
             })
             .collect();
         let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully(), "retain_shards", "write").await?;
+            with_lock_metrics!(self.state.lock_fully(), "retain_shards", "write")?;
         let remove_queue_ids: HashSet<QueueId> = state_guard
             .shards
             .keys()
@@ -1210,8 +1210,7 @@ impl EventSubscriber<ShardPositionsUpdate> for WeakIngesterState {
             warn!("ingester state update failed");
             return;
         };
-        let Ok(mut state_guard) =
-            with_lock_metrics!(state.lock_fully().await, "gc_shards", "write")
+        let Ok(mut state_guard) = with_lock_metrics!(state.lock_fully(), "gc_shards", "write")
         else {
             error!("failed to lock the ingester state");
             return;

--- a/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
@@ -76,7 +76,7 @@ impl Default for IngestResultMetrics {
     }
 }
 
-pub(super) struct IngestV2Metrics {
+pub(crate) struct IngestV2Metrics {
     pub reset_shards_operations_total: IntCounterVec<1>,
     pub open_shards: IntGauge,
     pub closed_shards: IntGauge,
@@ -84,6 +84,7 @@ pub(super) struct IngestV2Metrics {
     pub shard_st_throughput_mib: Histogram,
     pub wal_acquire_lock_requests_in_flight: IntGaugeVec<2>,
     pub wal_acquire_lock_request_duration_secs: HistogramVec<2>,
+    pub wal_hold_lock_duration_secs: HistogramVec<2>,
     pub wal_disk_used_bytes: IntGauge,
     pub wal_memory_used_bytes: IntGauge,
     pub ingest_results: IngestResultMetrics,
@@ -139,6 +140,14 @@ impl Default for IngestV2Metrics {
                 ["operation", "type"],
                 exponential_buckets(0.001, 2.0, 12).unwrap(),
             ),
+            wal_hold_lock_duration_secs: new_histogram_vec(
+                "wal_hold_lock_duration_secs",
+                "Duration for which a lock was held in seconds.",
+                "ingest",
+                &[],
+                ["operation", "type"],
+                exponential_buckets(0.001, 2.0, 12).unwrap(),
+            ),
             wal_disk_used_bytes: new_gauge(
                 "wal_disk_used_bytes",
                 "WAL disk space used in bytes.",
@@ -168,4 +177,4 @@ pub(super) fn report_wal_usage(wal_usage: ResourceUsage) {
         .set(wal_usage.memory_used_bytes as i64);
 }
 
-pub(super) static INGEST_V2_METRICS: Lazy<IngestV2Metrics> = Lazy::new(IngestV2Metrics::default);
+pub(crate) static INGEST_V2_METRICS: Lazy<IngestV2Metrics> = Lazy::new(IngestV2Metrics::default);

--- a/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
@@ -23,7 +23,7 @@ mod doc_mapper;
 mod fetch;
 mod idle;
 mod ingester;
-mod metrics;
+pub(crate) mod metrics;
 mod models;
 mod mrecord;
 mod mrecordlog_utils;

--- a/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
@@ -454,8 +454,7 @@ impl ReplicationTask {
         };
         let queue_id = replica_shard.queue_id();
 
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully(), "init_replica", "write").await?;
+        let mut state_guard = with_lock_metrics!(self.state.lock_fully(), "init_replica", "write")?;
 
         match state_guard.mrecordlog.create_queue(&queue_id).await {
             Ok(_) => {}
@@ -527,8 +526,7 @@ impl ReplicationTask {
         // queue in the WAL and should be deleted.
         let mut shards_to_delete: HashSet<QueueId> = HashSet::new();
 
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully(), "replicate", "write").await?;
+        let mut state_guard = with_lock_metrics!(self.state.lock_fully(), "replicate", "write")?;
 
         if state_guard.status() != IngesterStatus::Ready {
             replicate_failures.reserve_exact(replicate_request.subrequests.len());


### PR DESCRIPTION
- add metric for how long a lock was held
- when a log is held for too long, log which purpose it had
- when waiting for too long, log why we wanted to acquire the lock
- await inside the macro to force awaiting at the right time (currently, we sometime await outside of the macro, meaning we record an instant access to the lock, and then actually proceed to acquire the lock). I'm not a fan of awaiting inside a macro as it's hidden control flow, but i consider it worth the easy-to-miss mistake