### PR TITLE
Fix OTLP timestamps

### DIFF
--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -60,6 +60,8 @@ doc_mapping:
     - name: timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]
+      # should be this but not supported
+      # input_formats: [unix_timestamp_nanos]
       output_format: unix_timestamp_nanos
       indexed: false
       fast: true
@@ -67,6 +69,8 @@ doc_mapping:
     - name: observed_timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]
+      # should be this but not supported
+      # input_formats: [unix_timestamp_nanos]
       output_format: unix_timestamp_nanos
     - name: service_name
       type: text

--- a/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
@@ -109,6 +109,8 @@ doc_mapping:
     - name: span_start_timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]
+      # should be this but not supported
+      # input_formats: [unix_timestamp_nanos]
       output_format: unix_timestamp_nanos
       indexed: false
       fast: true
@@ -116,6 +118,8 @@ doc_mapping:
     - name: span_end_timestamp_nanos
       type: datetime
       input_formats: [unix_timestamp]
+      # should be this but not supported
+      # input_formats: [unix_timestamp_nanos]
       output_format: unix_timestamp_nanos
       indexed: false
       fast: false


### PR DESCRIPTION
### Description

OTLP timestamp are multiplied by 10^9 before being stored, even though they should already be in nano format.

### How was this PR tested?

Describe how you tested this PR.
