### PR TITLE
configure stalled stream protection

### DIFF
--- a/quickwit/quickwit-aws/src/lib.rs
+++ b/quickwit/quickwit-aws/src/lib.rs
@@ -20,6 +20,7 @@
 use std::time::Duration;
 
 use aws_config::retry::RetryConfig;
+use aws_config::stalled_stream_protection::StalledStreamProtectionConfig;
 use aws_config::BehaviorVersion;
 pub use aws_smithy_async::rt::sleep::TokioSleep;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
@@ -63,6 +64,7 @@ pub async fn get_aws_config() -> &'static aws_config::SdkConfig {
                 .build(https_connector);
 
             aws_config::defaults(BehaviorVersion::v2024_03_28())
+                .stalled_stream_protection(StalledStreamProtectionConfig::enabled().build())
                 .http_client(hyper_client)
                 // Currently handle this ourselves so probably best for now to leave it as is.
                 .retry_config(RetryConfig::disabled())

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -144,6 +144,7 @@ async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
     s3_config.set_http_client(aws_config.http_client());
     s3_config.set_retry_config(aws_config.retry_config().cloned());
     s3_config.set_sleep_impl(aws_config.sleep_impl());
+    s3_config.set_stalled_stream_protection(aws_config.stalled_stream_protection());
     s3_config.set_timeout_config(aws_config.timeout_config().cloned());
 
     if let Some(endpoint) = s3_storage_config.endpoint() {


### PR DESCRIPTION
### Description

may fix #5294
configure `StalledStreamProtectionConfig`. For some reason, when unconfigured, the default grace period is 5s, but when configured, the default is 20s.
If this doesn't fix #5294, we can do
```rs
StalledStreamProtectionConfig::enabled()
    .upload_enabled(false)
    .build()
``` 
to restore pre march behaviour. I believe it would be best to keep this enabled if possible, as it allows earlier detection of dead connections.

### How was this PR tested?

verified from aws debug logs that it picks the correct timeout
