### PR TITLE
limit search thread pool size

### DIFF
--- a/quickwit/quickwit-config/src/storage_config.rs
+++ b/quickwit/quickwit-config/src/storage_config.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::ops::Deref;
+use std::sync::OnceLock;
 use std::{env, fmt};
 
 use anyhow::ensure;
@@ -370,11 +371,14 @@ impl S3StorageConfig {
     }
 
     pub fn force_path_style_access(&self) -> Option<bool> {
-        let force_path_style_access = get_bool_from_env(
-            "QW_S3_FORCE_PATH_STYLE_ACCESS",
-            self.force_path_style_access,
-        );
-        Some(force_path_style_access)
+        static FORCE_PATH_STYLE: OnceLock<Option<bool>> = OnceLock::new();
+        *FORCE_PATH_STYLE.get_or_init(|| {
+            let force_path_style_access = get_bool_from_env(
+                "QW_S3_FORCE_PATH_STYLE_ACCESS",
+                self.force_path_style_access,
+            );
+            Some(force_path_style_access)
+        })
     }
 }
 

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -259,7 +259,7 @@ pub struct SplitSearchError {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafSearchRequest {
     /// Search request. This is a perfect copy of the original search request,
-    /// that was sent to root apart from the start_offset & max_hits params.
+    /// that was sent to root apart from the start_offset, max_hits params and index_id_patterns.
     #[prost(message, optional, tag = "1")]
     pub search_request: ::core::option::Option<SearchRequest>,
     /// List of leaf requests, one per index.

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -97,7 +97,8 @@ pub type SearcherPool = Pool<SocketAddr, SearchServiceClient>;
 
 fn search_thread_pool() -> &'static ThreadPool {
     static SEARCH_THREAD_POOL: OnceLock<ThreadPool> = OnceLock::new();
-    SEARCH_THREAD_POOL.get_or_init(|| ThreadPool::new("search", None))
+    let search_thread_pool_size = quickwit_common::get_from_env_opt("QW_SEARCH_THREAD_POOL_SIZE");
+    SEARCH_THREAD_POOL.get_or_init(|| ThreadPool::new("search", search_thread_pool_size))
 }
 
 /// GlobalDocAddress serves as a hit address.

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -97,8 +97,11 @@ pub type SearcherPool = Pool<SocketAddr, SearchServiceClient>;
 
 fn search_thread_pool() -> &'static ThreadPool {
     static SEARCH_THREAD_POOL: OnceLock<ThreadPool> = OnceLock::new();
-    let search_thread_pool_size = quickwit_common::get_from_env_opt("QW_SEARCH_THREAD_POOL_SIZE");
-    SEARCH_THREAD_POOL.get_or_init(|| ThreadPool::new("search", search_thread_pool_size))
+    SEARCH_THREAD_POOL.get_or_init(|| {
+        let search_thread_pool_size =
+            quickwit_common::get_from_env_opt("QW_SEARCH_THREAD_POOL_SIZE");
+        ThreadPool::new("search", search_thread_pool_size)
+    })
 }
 
 /// GlobalDocAddress serves as a hit address.

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1568,6 +1568,7 @@ pub fn jobs_to_leaf_request(
     let mut search_request_for_leaf = request.clone();
     search_request_for_leaf.start_offset = 0;
     search_request_for_leaf.max_hits += request.start_offset;
+    search_request_for_leaf.index_id_patterns = Vec::new();
 
     let mut leaf_search_request = LeafSearchRequest {
         search_request: Some(search_request_for_leaf),
@@ -1580,6 +1581,12 @@ pub fn jobs_to_leaf_request(
     // Group jobs by index uid, as the split offsets are relative to the index.
     group_jobs_by_index_id(jobs, |job_group| {
         let index_uid = &job_group[0].index_uid;
+        leaf_search_request
+            .search_request
+            .as_mut()
+            .unwrap()
+            .index_id_patterns
+            .push(index_uid.index_id.to_string());
         let search_index_meta = search_indexes_metadatas.get(index_uid).ok_or_else(|| {
             SearchError::Internal(format!(
                 "received job for an unknown index {index_uid}. it should never happen"


### PR DESCRIPTION
Don't take all threads for search, reserve one thread for incoming requests. Otherwise there may not be enough CPU left to answer health checks
This behavior can be overruled by manually setting the search thread pool size via `QW_SEARCH_THREAD_POOL_SIZE`.

improve logging:
log actual indices that are being queried on leaf nodes instead of the patterns from the user request
reduce env var spam

Related to https://github.com/quickwit-oss/quickwit/issues/5305