### PR TITLE
rename index-id to hopefully fix coverage

### DIFF
--- a/quickwit/quickwit-integration-tests/src/tests/update_tests/doc_mapping_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/update_tests/doc_mapping_tests.rs
@@ -278,7 +278,7 @@ async fn test_update_doc_mapping_json_to_object() {
 
 #[tokio::test]
 async fn test_update_doc_mapping_object_to_json() {
-    let index_id = "update-json-to-object";
+    let index_id = "update-object-to-json";
     let original_doc_mappings = json!({
         "field_mappings": [
             {


### PR DESCRIPTION
two test had the same index-id, which is my best guess as to why CI is currently red on main