### PR TITLE
memoize s3 client

### DIFF
--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -127,7 +127,7 @@ fn get_region(s3_storage_config: &S3StorageConfig) -> Option<Region> {
     })
 }
 
-pub(crate) async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
+pub async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
     let aws_config = get_aws_config().await;
     let credentials_provider =
         get_credentials_provider(s3_storage_config).or(aws_config.credentials_provider());
@@ -155,28 +155,6 @@ pub(crate) async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3C
 }
 
 impl S3CompatibleObjectStorage {
-    /// Creates an object storage given a region, a bucket name and an S3 client.
-    pub async fn new(
-        s3_storage_config: &S3StorageConfig,
-        uri: Uri,
-        bucket: String,
-        s3_client: S3Client,
-    ) -> Result<Self, StorageResolverError> {
-        let retry_params = RetryParams::aggressive();
-        let disable_multi_object_delete = s3_storage_config.disable_multi_object_delete;
-        let disable_multipart_upload = s3_storage_config.disable_multipart_upload;
-        Ok(Self {
-            s3_client,
-            uri,
-            bucket,
-            prefix: PathBuf::new(),
-            multipart_policy: MultiPartPolicy::default(),
-            retry_params,
-            disable_multi_object_delete,
-            disable_multipart_upload,
-        })
-    }
-
     /// Creates an object storage given a region and an uri.
     pub async fn from_uri(
         s3_storage_config: &S3StorageConfig,
@@ -196,8 +174,19 @@ impl S3CompatibleObjectStorage {
             let message = format!("failed to extract bucket name from S3 URI: {uri}");
             StorageResolverError::InvalidUri(message)
         })?;
-        let storage = Self::new(s3_storage_config, uri.clone(), bucket, s3_client).await?;
-        Ok(storage.with_prefix(prefix))
+        let retry_params = RetryParams::aggressive();
+        let disable_multi_object_delete = s3_storage_config.disable_multi_object_delete;
+        let disable_multipart_upload = s3_storage_config.disable_multipart_upload;
+        Ok(Self {
+            s3_client,
+            uri: uri.clone(),
+            bucket,
+            prefix,
+            multipart_policy: MultiPartPolicy::default(),
+            retry_params,
+            disable_multi_object_delete,
+            disable_multipart_upload,
+        })
     }
 
     /// Sets a specific for all buckets.

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -127,7 +127,7 @@ fn get_region(s3_storage_config: &S3StorageConfig) -> Option<Region> {
     })
 }
 
-async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
+pub(crate) async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
     let aws_config = get_aws_config().await;
     let credentials_provider =
         get_credentials_provider(s3_storage_config).or(aws_config.credentials_provider());
@@ -155,13 +155,13 @@ async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
 }
 
 impl S3CompatibleObjectStorage {
-    /// Creates an object storage given a region and a bucket name.
+    /// Creates an object storage given a region, a bucket name and an S3 client.
     pub async fn new(
         s3_storage_config: &S3StorageConfig,
         uri: Uri,
         bucket: String,
+        s3_client: S3Client,
     ) -> Result<Self, StorageResolverError> {
-        let s3_client = create_s3_client(s3_storage_config).await;
         let retry_params = RetryParams::aggressive();
         let disable_multi_object_delete = s3_storage_config.disable_multi_object_delete;
         let disable_multipart_upload = s3_storage_config.disable_multipart_upload;
@@ -182,11 +182,21 @@ impl S3CompatibleObjectStorage {
         s3_storage_config: &S3StorageConfig,
         uri: &Uri,
     ) -> Result<Self, StorageResolverError> {
+        let s3_client = create_s3_client(s3_storage_config).await;
+        Self::from_uri_and_client(s3_storage_config, uri, s3_client).await
+    }
+
+    /// Creates an object storage given a region, an uri and an S3 client.
+    pub async fn from_uri_and_client(
+        s3_storage_config: &S3StorageConfig,
+        uri: &Uri,
+        s3_client: S3Client,
+    ) -> Result<Self, StorageResolverError> {
         let (bucket, prefix) = parse_s3_uri(uri).ok_or_else(|| {
             let message = format!("failed to extract bucket name from S3 URI: {uri}");
             StorageResolverError::InvalidUri(message)
         })?;
-        let storage = Self::new(s3_storage_config, uri.clone(), bucket).await?;
+        let storage = Self::new(s3_storage_config, uri.clone(), bucket, s3_client).await?;
         Ok(storage.with_prefix(prefix))
     }
 

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage_resolver.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage_resolver.rs
@@ -33,7 +33,8 @@ use crate::{
 /// S3 compatible object storage resolver.
 pub struct S3CompatibleObjectStorageFactory {
     storage_config: S3StorageConfig,
-    // we cache the S3Client so we don't rebuild one every time we need to connect to S3.
+    // we cache the S3Client so we don't rebuild one every time we build a new Storage (for
+    // every search query).
     // We don't build it in advance because we don't know if this factory is one that will
     // end up being used, or if something like azure, gcs, or even local files, will be used
     // instead.


### PR DESCRIPTION
### Description

memoize s3 client, keeping them until they seem unused. I don't think we ever use more than a single S3StorageConfig, so we could store a single value, but a map we gc seems less confusing if we start having multiple config at once
fix #4933 
fix #5236

### How was this PR tested?

ran a cluster and looked at searcher logs. Didn't look at janitor logs, though there is no reason for it to behave differently