### PR TITLE
fix jaeger http endpoint

### DIFF
--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -330,7 +330,10 @@ impl JaegerService {
                 default_operator: BooleanOperand::And,
                 lenient: true,
             };
-            query.must.push(is_root.into());
+            let mut new_query = BoolQuery::default();
+            new_query.must.push(query.into());
+            new_query.must.push(is_root.into());
+            query = new_query;
         }
 
         let query_ast: QueryAst = query.into();


### PR DESCRIPTION
### Description

fix a bug with jaeger search api returning all root span instead of matching ones.
The query was modified to be `Must(is_root) Should(TraceId1) Should(TraceId2)...`, which sounds like it limits more than just Shoulds would, but actually it means the Should only count for scoring (which we are not doing). What we ought to do is `Must(is_root) Must(Should(TraceId1) Should(TraceId2)...)` (must be root, and must match one of the trace id)