### PR TITLE
make some s3 error retryable

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5651,6 +5651,7 @@ name = "quickwit-aws"
 version = "0.8.0"
 dependencies = [
  "aws-config",
+ "aws-runtime",
  "aws-sdk-kinesis",
  "aws-sdk-s3",
  "aws-sdk-sqs",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -277,6 +277,7 @@ zstd = "0.13.0"
 
 aws-config = "1.5.4"
 aws-credential-types = { version = "1.2", features = ["hardcoded-credentials"] }
+aws-runtime = "1.3.1"
 aws-sdk-kinesis = "1.37"
 aws-sdk-s3 = "1.42"
 aws-sdk-sqs = "1.36"

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 
 [dependencies]
 aws-config = { workspace = true }
+aws-runtime = { workspace = true }
 aws-sdk-kinesis = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true }
 aws-sdk-sqs = { workspace = true, optional = true }

--- a/quickwit/quickwit-aws/src/error.rs
+++ b/quickwit/quickwit-aws/src/error.rs
@@ -19,6 +19,7 @@
 
 #![allow(clippy::match_like_matches_macro)]
 
+use aws_runtime::retries::classifiers::{THROTTLING_ERRORS, TRANSIENT_ERRORS};
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadError;
 use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadError;
@@ -47,57 +48,65 @@ where E: AwsRetryable
     }
 }
 
+fn is_retryable(meta: &aws_sdk_s3::error::ErrorMetadata) -> bool {
+    if let Some(code) = meta.code() {
+        THROTTLING_ERRORS.contains(&code) || TRANSIENT_ERRORS.contains(&code)
+    } else {
+        false
+    }
+}
+
 impl AwsRetryable for GetObjectError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for DeleteObjectError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for DeleteObjectsError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for UploadPartError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for CompleteMultipartUploadError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for AbortMultipartUploadError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for CreateMultipartUploadError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for PutObjectError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 
 impl AwsRetryable for HeadObjectError {
     fn is_retryable(&self) -> bool {
-        false
+        is_retryable(self.meta())
     }
 }
 


### PR DESCRIPTION
### Description

mark some S3 errors as retry-able. The code in qw-storage already uses `aws_retry()` on write requests. The actual error we get from GCS is `SlowDown`, but aws sdk contains a list of errors, so we that instead of hard-coding a single value;
improvement for #5211

### How was this PR tested?

added unit test to Storage::put for retry.