### PR TITLE
add gzip to commands needed for install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,7 @@ install_from_archive() {
     need_cmd mv
     need_cmd rm
     need_cmd tar
+    need_cmd gzip
     need_cmd chmod
     need_cmd grep
     need_cmd head


### PR DESCRIPTION
### Description

when installing on amazonlinux via `install.quickwit.io`, i got the following error:
```
tar (child): gzip: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```
we don't invoke gzip directly, but tar needs it to open a tar.gz.

For some reason `bc` is reported as missing, but the installation still continue and succeed
