### PR TITLE
Trigger early commit when shutting down ingest V2

### DIFF
--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -34,6 +34,7 @@ pub mod pubsub;
 pub mod rand;
 pub mod rate_limited_tracing;
 pub mod rate_limiter;
+pub mod ref_tracker;
 pub mod rendezvous_hasher;
 pub mod retry;
 pub mod runtimes;

--- a/quickwit/quickwit-common/src/ref_tracker.rs
+++ b/quickwit/quickwit-common/src/ref_tracker.rs
@@ -1,0 +1,125 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::LinkedList;
+use std::sync::Weak;
+
+pub trait Container<T> {
+    fn contains(&self, other: &T) -> bool;
+}
+
+/// Data structure for checking if a given value is still present in a set of
+/// weakly referenced containers (e.g arrays).
+///
+/// Each time a lookup is performed, all inactive references are removed.
+/// Lookups are O(number of referenced containers).
+pub struct RefTracker<C, T> {
+    refs: LinkedList<Weak<C>>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<C, T> Default for RefTracker<C, T> {
+    fn default() -> Self {
+        RefTracker {
+            refs: LinkedList::new(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<C: Container<T>, T> RefTracker<C, T> {
+    pub fn add(&mut self, weak: Weak<C>) {
+        self.refs.push_back(weak);
+    }
+
+    pub fn contains(&mut self, value: &T) -> bool {
+        // TODO replace impl with `LinkedList::retain` when stabilized
+        let mut new_refs = LinkedList::new();
+        let mut value_found = false;
+        while let Some(weak) = self.refs.pop_front() {
+            if let Some(ingester_ids) = weak.upgrade() {
+                if !value_found && ingester_ids.contains(value) {
+                    value_found = true;
+                }
+                new_refs.push_back(weak);
+            }
+        }
+        self.refs = new_refs;
+        value_found
+    }
+}
+
+impl<T: PartialEq> Container<T> for Vec<T> {
+    fn contains(&self, other: &T) -> bool {
+        self[..].contains(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn test_add_and_contains() {
+        let mut ref_tracker = RefTracker::default();
+        let container = Arc::new(vec![1, 2, 3]);
+        let weak_container = Arc::downgrade(&container);
+
+        ref_tracker.add(weak_container);
+        assert!(ref_tracker.contains(&2));
+        assert!(!ref_tracker.contains(&4));
+    }
+
+    #[test]
+    fn test_contains_with_dropped_reference() {
+        let mut ref_tracker = RefTracker::default();
+        let container = Arc::new(vec![1, 2, 3]);
+        let weak_container = Arc::downgrade(&container);
+
+        ref_tracker.add(weak_container);
+        drop(container);
+
+        assert!(!ref_tracker.contains(&2));
+        assert!(ref_tracker.refs.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_references() {
+        let mut ref_tracker = RefTracker::default();
+        let container1 = Arc::new(vec![1, 2, 3]);
+        let container2 = Arc::new(vec![4, 5, 6]);
+        let weak_container1 = Arc::downgrade(&container1);
+        let weak_container2 = Arc::downgrade(&container2);
+
+        ref_tracker.add(weak_container1);
+        ref_tracker.add(weak_container2);
+
+        assert!(ref_tracker.contains(&2));
+        assert!(ref_tracker.contains(&5));
+        assert!(!ref_tracker.contains(&7));
+    }
+
+    #[test]
+    fn test_empty_tracker() {
+        let mut ref_tracker: RefTracker<Vec<_>, i32> = RefTracker::default();
+        assert!(!ref_tracker.contains(&1));
+    }
+}

--- a/quickwit/quickwit-indexing/src/source/ingest/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest/mod.rs
@@ -506,6 +506,9 @@ impl Source for IngestSource {
                 num_millis=%now.elapsed().as_millis(),
                 "Sending doc batch to indexer."
             );
+            if !self.fetch_stream.has_active_shard_subscriptions() {
+                batch_builder.force_commit();
+            }
             let message = batch_builder.build();
             ctx.send_message(doc_processor_mailbox, message).await?;
         }

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -294,6 +294,14 @@ impl MultiFetchStream {
         self.fetch_message_tx.clone()
     }
 
+    pub fn has_active_shard_subscriptions(&self) -> bool {
+        tracing::info!(
+            tx_count = self.fetch_message_tx.strong_count(),
+            "has_active_shard_subscriptions"
+        );
+        self.fetch_message_tx.strong_count() > 1
+    }
+
     /// Subscribes to a shard and fails over to the replica if an error occurs.
     #[allow(clippy::too_many_arguments)]
     pub async fn subscribe(
@@ -1864,8 +1872,9 @@ pub(super) mod tests {
         let client_id = "test-client".to_string();
         let ingester_pool = IngesterPool::default();
         let retry_params = RetryParams::for_test();
-        let _multi_fetch_stream =
+        let multi_fetch_stream =
             MultiFetchStream::new(self_node_id, client_id, ingester_pool, retry_params);
+        assert!(!multi_fetch_stream.has_active_shard_subscriptions())
         // TODO: Backport from original branch.
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -913,6 +913,7 @@ impl Ingester {
             mrecordlog,
             shard_status_rx,
             get_batch_num_bytes(),
+            self.state.status_rx.clone(),
         );
         Ok(service_stream)
     }

--- a/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
@@ -54,7 +54,7 @@ use serde::Serialize;
 use tracing::{error, info};
 use workbench::pending_subrequests;
 
-pub use self::fetch::{FetchStreamError, MultiFetchStream};
+pub use self::fetch::{FetchStreamError, MultiFetchMessage, MultiFetchStream};
 pub use self::ingester::{wait_for_ingester_decommission, wait_for_ingester_status, Ingester};
 use self::mrecord::MRECORD_HEADER_LEN;
 pub use self::mrecord::{decoded_mrecords, MRecord};

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use futures_util::FutureExt;
@@ -602,7 +603,6 @@ async fn test_shutdown_single_node() {
 
     sandbox.enable_ingest_v2();
 
-    // Create index
     sandbox
         .indexer_rest_client
         .indexes()
@@ -625,28 +625,87 @@ async fn test_shutdown_single_node() {
         .await
         .unwrap();
 
-    // Ensure that the index is ready to accept records.
-    ingest_with_retry(
-        &sandbox.indexer_rest_client,
-        index_id,
-        ingest_json!({"body": "one"}),
-        CommitType::Force,
-    )
-    .await
-    .unwrap();
-
-    // Test force commit
     sandbox
         .indexer_rest_client
         .ingest(
             index_id,
-            ingest_json!({"body": "two"}),
+            ingest_json!({"body": "commit me before shutdown"}),
             None,
             None,
-            CommitType::Force,
+            CommitType::Auto,
         )
         .await
         .unwrap();
+
+    // assert that we don't wait the commit timeout (60s)
+    tokio::time::timeout(std::time::Duration::from_secs(10), sandbox.shutdown())
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_shutdown_indexer_first() {
+    initialize_tests();
+    let mut sandbox = ClusterSandboxBuilder::default()
+        .add_node([QuickwitService::Indexer])
+        .add_node([
+            QuickwitService::ControlPlane,
+            QuickwitService::Searcher,
+            QuickwitService::Metastore,
+            QuickwitService::Janitor,
+        ])
+        .build_and_start()
+        .await;
+    let index_id = "test_shutdown_separate_indexer";
+
+    sandbox.enable_ingest_v2();
+
+    sandbox
+        .indexer_rest_client
+        .indexes()
+        .create(
+            format!(
+                r#"
+            version: 0.8
+            index_id: {index_id}
+            doc_mapping:
+              field_mappings:
+              - name: body
+                type: text
+            indexing_settings:
+              commit_timeout_secs: 60
+            "#
+            ),
+            ConfigFormat::Yaml,
+            false,
+        )
+        .await
+        .unwrap();
+
+    sandbox
+        .indexer_rest_client
+        .ingest(
+            index_id,
+            ingest_json!({"body": "commit me before shutdown"}),
+            None,
+            None,
+            CommitType::Auto,
+        )
+        .await
+        .unwrap();
+
+    // assert that we don't wait the commit timeout (60s)
+    tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        sandbox.shutdown_services(&HashSet::from_iter([QuickwitService::Indexer])),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // still, the doc should be committed during the graceful shutdown
+    sandbox.assert_hit_count(index_id, "body:before", 1).await;
 
     tokio::time::timeout(std::time::Duration::from_secs(10), sandbox.shutdown())
         .await
@@ -654,12 +713,10 @@ async fn test_shutdown_single_node() {
         .unwrap();
 }
 
-/// When the control plane is on a different node, it might be shutdown
-/// before the ingest pipeline is scheduled on the indexer.
 #[tokio::test]
-async fn test_shutdown_control_plane_early_shutdown() {
+async fn test_shutdown_metastore_first() {
     initialize_tests();
-    let sandbox = ClusterSandboxBuilder::default()
+    let mut sandbox = ClusterSandboxBuilder::default()
         .add_node([QuickwitService::Indexer])
         .add_node([
             QuickwitService::ControlPlane,
@@ -672,6 +729,8 @@ async fn test_shutdown_control_plane_early_shutdown() {
     let index_id = "test_shutdown_separate_indexer";
 
     // TODO: make this test work with ingest v2 (#5068)
+    // When the control plane/metastore are shutdown before the indexer, the
+    // indexer shutdown should not hang indefinitely
     // sandbox.enable_ingest_v2();
 
     // Create index
@@ -707,69 +766,18 @@ async fn test_shutdown_control_plane_early_shutdown() {
     .await
     .unwrap();
 
-    tokio::time::timeout(std::time::Duration::from_secs(10), sandbox.shutdown())
-        .await
-        .unwrap()
-        .unwrap();
-}
-
-/// When the control plane/metastore are shutdown before the indexer, the
-/// indexer shutdown should not hang indefinitely
-#[tokio::test]
-async fn test_shutdown_separate_indexer() {
-    initialize_tests();
-    let sandbox = ClusterSandboxBuilder::default()
-        .add_node([QuickwitService::Indexer])
-        .add_node([
+    tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        sandbox.shutdown_services(&HashSet::from_iter([
             QuickwitService::ControlPlane,
             QuickwitService::Searcher,
             QuickwitService::Metastore,
             QuickwitService::Janitor,
-        ])
-        .build_and_start()
-        .await;
-    let index_id = "test_shutdown_separate_indexer";
-
-    // TODO: make this test work with ingest v2 (#5068)
-    // sandbox.enable_ingest_v2();
-
-    // Create index
-    sandbox
-        .indexer_rest_client
-        .indexes()
-        .create(
-            format!(
-                r#"
-            version: 0.8
-            index_id: {index_id}
-            doc_mapping:
-              field_mappings:
-              - name: body
-                type: text
-            indexing_settings:
-              commit_timeout_secs: 1
-            "#
-            ),
-            ConfigFormat::Yaml,
-            false,
-        )
-        .await
-        .unwrap();
-
-    // Ensure that the index is ready to accept records.
-    ingest_with_retry(
-        &sandbox.indexer_rest_client,
-        index_id,
-        ingest_json!({"body": "one"}),
-        CommitType::Force,
+        ])),
     )
     .await
+    .unwrap()
     .unwrap();
-
-    sandbox
-        .wait_for_splits(index_id, Some(vec![SplitState::Published]), 1)
-        .await
-        .unwrap();
 
     tokio::time::timeout(std::time::Duration::from_secs(10), sandbox.shutdown())
         .await

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
@@ -616,7 +616,7 @@ async fn test_shutdown_single_node() {
               - name: body
                 type: text
             indexing_settings:
-              commit_timeout_secs: 1
+              commit_timeout_secs: 60
             "#
             ),
             ConfigFormat::Yaml,

--- a/quickwit/quickwit-proto/protos/quickwit/ingester.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingester.proto
@@ -249,6 +249,7 @@ message FetchEof {
   string source_id = 2;
   quickwit.ingest.ShardId shard_id = 3;
   quickwit.ingest.Position eof_position = 4;
+  bool is_decommissioning = 5;
 }
 
 message InitShardsRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.ingester.rs
@@ -342,6 +342,8 @@ pub struct FetchEof {
     pub shard_id: ::core::option::Option<crate::types::ShardId>,
     #[prost(message, optional, tag = "4")]
     pub eof_position: ::core::option::Option<crate::types::Position>,
+    #[prost(bool, tag = "5")]
+    pub is_decommissioning: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
### Description

Currently the shutdown waits for the shards to be indexed without triggering an early commit, so the shutdown can take as long as the longest commit timeout.

### How was this PR tested?

Integ tests
