### PR TITLE
fix flaky test

### DIFF
--- a/quickwit/quickwit-index-management/src/garbage_collection.rs
+++ b/quickwit/quickwit-index-management/src/garbage_collection.rs
@@ -183,6 +183,7 @@ async fn delete_splits_marked_for_deletion(
     let mut failed_splits = Vec::new();
 
     'outer: loop {
+        let mut exit = false;
         let query = ListSplitsQuery::try_from_index_uids(index_uids.clone())?
             .with_split_state(SplitState::MarkedForDeletion)
             .with_update_timestamp_lte(updated_before_timestamp)
@@ -248,11 +249,12 @@ async fn delete_splits_marked_for_deletion(
                 Err(delete_splits_error) => {
                     failed_splits.extend(delete_splits_error.storage_failures);
                     failed_splits.extend(delete_splits_error.metastore_failures);
-                    break;
+                    // we don't break so we try other batches, but still leave 'outer after
+                    exit = true;
                 }
             }
         }
-        if num_splits_to_delete < DELETE_SPLITS_BATCH_SIZE {
+        if num_splits_to_delete < DELETE_SPLITS_BATCH_SIZE || exit {
             break;
         }
     }

--- a/quickwit/quickwit-index-management/src/garbage_collection.rs
+++ b/quickwit/quickwit-index-management/src/garbage_collection.rs
@@ -249,12 +249,13 @@ async fn delete_splits_marked_for_deletion(
                 Err(delete_splits_error) => {
                     failed_splits.extend(delete_splits_error.storage_failures);
                     failed_splits.extend(delete_splits_error.metastore_failures);
-                    // we don't break so we try other batches, but still leave 'outer after
                     exit = true;
                 }
             }
         }
         if num_splits_to_delete < DELETE_SPLITS_BATCH_SIZE || exit {
+            // stop the gc if this was the last batch or we encountered an error
+            // (otherwise we might try deleting the same splits in an endless loop)
             break;
         }
     }


### PR DESCRIPTION
fix flakiness in `test_garbage_collect_fails_to_run_delete_on_one_index` introduced in #5380 
the test depends of the order in which we iterate over the map. Fixed by finishing the iteration before aborting the gc run