### PR TITLE
shorten delete_splits_marked_for_deletion log

### DIFF
--- a/quickwit/quickwit-index-management/src/garbage_collection.rs
+++ b/quickwit/quickwit-index-management/src/garbage_collection.rs
@@ -166,7 +166,7 @@ pub async fn run_garbage_collect(
     )
     .await
 }
-#[instrument(skip(storages, metastore, progress_opt))]
+#[instrument(skip(index_uids, storages, metastore, progress_opt), fields(num_index=%index_uids.len()))]
 /// Removes any splits marked for deletion which haven't been
 /// updated after `updated_before_timestamp` in batches of 1000 splits.
 ///

--- a/quickwit/quickwit-index-management/src/garbage_collection.rs
+++ b/quickwit/quickwit-index-management/src/garbage_collection.rs
@@ -166,7 +166,7 @@ pub async fn run_garbage_collect(
     )
     .await
 }
-#[instrument(skip(index_uids, storages, metastore, progress_opt), fields(num_index=%index_uids.len()))]
+#[instrument(skip(index_uids, storages, metastore, progress_opt), fields(num_indexes=%index_uids.len()))]
 /// Removes any splits marked for deletion which haven't been
 /// updated after `updated_before_timestamp` in batches of 1000 splits.
 ///


### PR DESCRIPTION
### Description

make `delete_splits_marked_for_deletion` shorter. Before it used to show only a single index id, but with gc batching, it can now show thousands at once when that function returns an error.