### PR TITLE
aws s3 server_side_encryption  configuration when upload object to s3

### DIFF
--- a/quickwit/quickwit-config/src/storage_config.rs
+++ b/quickwit/quickwit-config/src/storage_config.rs
@@ -333,6 +333,8 @@ pub struct S3StorageConfig {
     pub disable_multi_object_delete: bool,
     #[serde(default)]
     pub disable_multipart_upload: bool,
+    #[serde(default)]
+    pub server_side_encryption: Option<String>,
 }
 
 impl S3StorageConfig {
@@ -393,6 +395,7 @@ impl fmt::Debug for S3StorageConfig {
                 "disable_multi_object_delete",
                 &self.disable_multi_object_delete,
             )
+            .field("server_side_encryption", &self.server_side_encryption)
             .finish()
     }
 }


### PR DESCRIPTION
### Description

aws s3 server_side_encryption  configuration when upload object to s3 and config in storage part.

### How was this PR tested?

I builded docker image and installed to EKS with helm chart with config
`storage:
    s3:
      region: ap-southeast-1
      server_side_encryption: Aes256 `

server_side_encryption can be set to Aes256, Awskms or left empty if encryption is not required.
I tried sending logs via Kafka and used the Quickstart document to test if the logs can be written to S3.