### PR TITLE
batch delete from gc

### DIFF
--- a/quickwit/quickwit-index-management/src/garbage_collection.rs
+++ b/quickwit/quickwit-index-management/src/garbage_collection.rs
@@ -22,17 +22,18 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use futures::{Future, StreamExt};
 use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
-use quickwit_common::{Progress, ServiceStream};
+use quickwit_common::Progress;
 use quickwit_metastore::{
     ListSplitsQuery, ListSplitsRequestExt, MetastoreServiceStreamSplitsExt, SplitInfo,
     SplitMetadata, SplitState,
 };
 use quickwit_proto::metastore::{
-    DeleteSplitsRequest, ListSplitsRequest, ListSplitsResponse, MarkSplitsForDeletionRequest,
-    MetastoreError, MetastoreResult, MetastoreService, MetastoreServiceClient,
+    DeleteSplitsRequest, ListSplitsRequest, MarkSplitsForDeletionRequest, MetastoreError,
+    MetastoreService, MetastoreServiceClient,
 };
 use quickwit_proto::types::{IndexUid, SplitId};
 use quickwit_storage::{BulkDeleteError, Storage};
@@ -94,23 +95,23 @@ pub async fn run_garbage_collect(
     dry_run: bool,
     progress_opt: Option<&Progress>,
 ) -> anyhow::Result<SplitRemovalInfo> {
-
-
-
     let grace_period_timestamp =
         OffsetDateTime::now_utc().unix_timestamp() - staged_grace_period.as_secs() as i64;
 
     let index_uids: Vec<IndexUid> = indexes.keys().cloned().collect();
 
-    let Some(list_splits_query_for_index_uids) = ListSplitsQuery::try_from_index_uids(index_uids.clone()) else {
-        return Ok(SplitRemovalInfo::default())
+    let Some(list_splits_query_for_index_uids) =
+        ListSplitsQuery::try_from_index_uids(index_uids.clone())
+    else {
+        return Ok(SplitRemovalInfo::default());
     };
     let list_splits_query = list_splits_query_for_index_uids
         .clone()
         .with_split_state(SplitState::Staged)
         .with_update_timestamp_lte(grace_period_timestamp);
 
-    let list_deletable_staged_request = ListSplitsRequest::try_from_list_splits_query(&list_splits_query)?;
+    let list_deletable_staged_request =
+        ListSplitsRequest::try_from_list_splits_query(&list_splits_query)?;
     let deletable_staged_splits: Vec<SplitMetadata> = protect_future(
         progress_opt,
         metastore.list_splits(list_deletable_staged_request),
@@ -120,8 +121,8 @@ pub async fn run_garbage_collect(
     .await?;
 
     if dry_run {
-        let marked_for_deletion_query = list_splits_query_for_index_uids
-            .with_split_state(SplitState::MarkedForDeletion);
+        let marked_for_deletion_query =
+            list_splits_query_for_index_uids.with_split_state(SplitState::MarkedForDeletion);
         let marked_for_deletion_request =
             ListSplitsRequest::try_from_list_splits_query(&marked_for_deletion_query)?;
         let mut splits_marked_for_deletion: Vec<SplitMetadata> = protect_future(
@@ -241,18 +242,20 @@ async fn delete_splits(
     }
 }
 
-use anyhow::Context;
-
 /// Fetch the list metadata from the metastore and returns them as a Vec.
-async fn list_splits_metadata(metastore: &MetastoreServiceClient, query: &ListSplitsQuery) -> anyhow::Result<Vec<SplitMetadata>> {
-    let list_splits_request = ListSplitsRequest::try_from_list_splits_query(&query)
+async fn list_splits_metadata(
+    metastore: &MetastoreServiceClient,
+    query: &ListSplitsQuery,
+) -> anyhow::Result<Vec<SplitMetadata>> {
+    let list_splits_request = ListSplitsRequest::try_from_list_splits_query(query)
         .context("failed to build list splits request")?;
-    let metastore = metastore.clone();
-    let splits_to_delete_stream =
-        metastore
-            .list_splits(list_splits_request).await
-            .context("failed to fetch stream splits")?;
-    let splits = splits_to_delete_stream.collect_splits_metadata().await
+    let splits_to_delete_stream = metastore
+        .list_splits(list_splits_request)
+        .await
+        .context("failed to fetch stream splits")?;
+    let splits = splits_to_delete_stream
+        .collect_splits_metadata()
+        .await
         .context("failed to collect splits")?;
     Ok(splits)
 }
@@ -284,7 +287,12 @@ async fn delete_splits_marked_for_deletion_several_indexes(
         .sort_by_index_uid();
 
     loop {
-        let splits_metadata_to_delete: Vec<SplitMetadata> = match protect_future(progress_opt, list_splits_metadata(&metastore, &list_splits_query)).await {
+        let splits_metadata_to_delete: Vec<SplitMetadata> = match protect_future(
+            progress_opt,
+            list_splits_metadata(&metastore, &list_splits_query),
+        )
+        .await
+        {
             Ok(splits) => splits,
             Err(list_splits_err) => {
                 error!(error=?list_splits_err, "failed to list splits");

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -631,7 +631,14 @@ pub struct ListSplitsQuery {
 
     /// Sorts the splits by staleness, i.e. by delete opstamp and publish timestamp in ascending
     /// order.
-    pub sort_by_staleness: bool,
+    pub sort_by: SortBy,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum SortBy {
+    None,
+    Staleness,
+    IndexUid,
 }
 
 #[allow(unused_attributes)]
@@ -650,7 +657,7 @@ impl ListSplitsQuery {
             update_timestamp: Default::default(),
             create_timestamp: Default::default(),
             mature: Bound::Unbounded,
-            sort_by_staleness: false,
+            sort_by: SortBy::None,
         }
     }
 
@@ -675,7 +682,7 @@ impl ListSplitsQuery {
             update_timestamp: Default::default(),
             create_timestamp: Default::default(),
             mature: Bound::Unbounded,
-            sort_by_staleness: false,
+            sort_by: SortBy::None,
         })
     }
 
@@ -842,7 +849,13 @@ impl ListSplitsQuery {
     /// Sorts the splits by staleness, i.e. by delete opstamp and publish timestamp in ascending
     /// order.
     pub fn sort_by_staleness(mut self) -> Self {
-        self.sort_by_staleness = true;
+        self.sort_by = SortBy::Staleness;
+        self
+    }
+
+    /// Sorts the splits by index_uid.
+    pub fn sort_by_index_uid(mut self) -> Self {
+        self.sort_by = SortBy::IndexUid;
         self
     }
 }

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -662,15 +662,12 @@ impl ListSplitsQuery {
     }
 
     /// Creates a new [`ListSplitsQuery`] from a non-empty list of index UIDs.
-    /// Returns an error if the list is empty.
-    pub fn try_from_index_uids(index_uids: Vec<IndexUid>) -> MetastoreResult<Self> {
+    /// Returns None if the list is empty.
+    pub fn try_from_index_uids(index_uids: Vec<IndexUid>) -> Option<Self> {
         if index_uids.is_empty() {
-            return Err(MetastoreError::Internal {
-                message: "ListSplitQuery should define at least one index uid".to_string(),
-                cause: "".to_string(),
-            });
+            return None;
         }
-        Ok(Self {
+        Some(Self {
             index_uids,
             node_id: None,
             limit: None,

--- a/quickwit/quickwit-metastore/src/metastore/postgres/model.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/model.rs
@@ -30,6 +30,16 @@ use tracing::error;
 
 use crate::{IndexMetadata, Split, SplitMetadata, SplitState};
 
+#[derive(Iden, Clone, Copy)]
+#[allow(dead_code)]
+pub enum Indexes {
+    Table,
+    IndexUid,
+    IndexId,
+    IndexMetadataJson,
+    CreateTimestamp,
+}
+
 /// A model structure for handling index metadata in a database.
 #[derive(sqlx::FromRow)]
 pub(super) struct PgIndex {

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -193,8 +193,10 @@ pub async fn list_relevant_splits(
     tags_filter_opt: Option<TagFilterAst>,
     metastore: &mut MetastoreServiceClient,
 ) -> crate::Result<Vec<SplitMetadata>> {
-    let mut query =
-        ListSplitsQuery::try_from_index_uids(index_uids)?.with_split_state(SplitState::Published);
+    let Some(mut query) = ListSplitsQuery::try_from_index_uids(index_uids) else {
+        return Ok(Vec::new());
+    };
+    query = query.with_split_state(SplitState::Published);
 
     if let Some(start_ts) = start_timestamp {
         query = query.with_time_range_start_gte(start_ts);

--- a/quickwit/quickwit-search/src/list_terms.rs
+++ b/quickwit/quickwit-search/src/list_terms.rs
@@ -90,8 +90,11 @@ pub async fn root_list_terms(
         .iter()
         .map(|index_metadata| index_metadata.index_uid.clone())
         .collect();
-    let mut query = quickwit_metastore::ListSplitsQuery::try_from_index_uids(index_uids)?
-        .with_split_state(quickwit_metastore::SplitState::Published);
+
+    let Some(mut query) = quickwit_metastore::ListSplitsQuery::try_from_index_uids(index_uids) else {
+        return Ok(ListTermsResponse::default());
+    };
+    query = query.with_split_state(quickwit_metastore::SplitState::Published);
 
     if let Some(start_ts) = list_terms_request.start_timestamp {
         query = query.with_time_range_start_gte(start_ts);

--- a/quickwit/quickwit-search/src/list_terms.rs
+++ b/quickwit/quickwit-search/src/list_terms.rs
@@ -91,7 +91,8 @@ pub async fn root_list_terms(
         .map(|index_metadata| index_metadata.index_uid.clone())
         .collect();
 
-    let Some(mut query) = quickwit_metastore::ListSplitsQuery::try_from_index_uids(index_uids) else {
+    let Some(mut query) = quickwit_metastore::ListSplitsQuery::try_from_index_uids(index_uids)
+    else {
         return Ok(ListTermsResponse::default());
     };
     query = query.with_split_state(quickwit_metastore::SplitState::Published);


### PR DESCRIPTION
### Description

follow up to #5380
if a cluster generate less than 1k split per 10 minutes, everything was fine, but in case it would generate more than that, we have a slow down for 2 reasons:
- we no longer run 10 tasks in parallel
- we may get a batch of 1k splits from many different indexes, and get a 2nd batch from the same set of indexes, meaning more than one delete per index, despite having few splits to delete for each indexes. This can in theory cause us to do up to n_index time more delete calls to the metastore than necessary (caped to 1k)

Changes made:
- we run up to 10 deletion from storage + metastore concurrently
- we retrieve splits sorted by index_uid from metastore, so we don't do many delete per index
- we query for 10k splits instead of 1k: before we would query for 10 * 1k, but as this is now batched, we can increase this number to keep a similar effect to before

### How was this PR tested?

tested on a small cluster to not be utterly broken, for perf improvement, we'll need a way bigger cluster
