### PR TITLE
fix(jaeger-documentation): update the documentation to work with the …

### DIFF
--- a/docs/distributed-tracing/overview.md
+++ b/docs/distributed-tracing/overview.md
@@ -14,9 +14,11 @@ Moreover, Quickwit supports natively the [OpenTelemetry gRPC and HTTP (protobuf 
 
 ## Plug Quickwit to Jaeger
 
-Quickwit implements a gRPC service compatible with Jaeger UI. All you need is to configure Jaeger with a (span) storage type `grpc-plugin` and you will be able to visualize your traces in Jaeger that are stored in any Quickwit's indexes matching the pattern `otel-traces-v0_*`.
+Quickwit implements a gRPC service compatible with Jaeger UI. All you need is to configure Jaeger with a (span) storage type `grpc`[^1] and you will be able to visualize your traces in Jaeger that are stored in any Quickwit's indexes matching the pattern `otel-traces-v0_*`.
 
 We made a tutorial on [how to plug Quickwit to Jaeger UI](plug-quickwit-to-jaeger.md) that will guide you through the process.
+
+[^1]: It was `grpc-plugin` until the version 1.58 of Jaeger.
 
 ## Send traces to Quickwit
 

--- a/docs/distributed-tracing/plug-quickwit-to-jaeger.md
+++ b/docs/distributed-tracing/plug-quickwit-to-jaeger.md
@@ -32,10 +32,10 @@ We can rely on `host.docker.internal` to get the docker bridge ip address, point
 
 ```bash
 docker run --rm --name jaeger-qw \
-    -e SPAN_STORAGE_TYPE=grpc-plugin \
+    -e SPAN_STORAGE_TYPE=grpc \
     -e GRPC_STORAGE_SERVER=host.docker.internal:7281 \
     -p 16686:16686 \
-    jaegertracing/jaeger-query:latest
+    jaegertracing/jaeger-query:1.60
 ```
 
 ### Linux
@@ -46,10 +46,10 @@ The easiest is probably to use host network mode.
 
 ```bash
 docker run --rm --name jaeger-qw  --network=host \
-    -e SPAN_STORAGE_TYPE=grpc-plugin \
+    -e SPAN_STORAGE_TYPE=grpc \
     -e GRPC_STORAGE_SERVER=127.0.0.1:7281 \
     -p 16686:16686 \
-    jaegertracing/jaeger-query:latest
+    jaegertracing/jaeger-query:1.60
 
 ```
 

--- a/docs/distributed-tracing/send-traces/using-otel-sdk-python.md
+++ b/docs/distributed-tracing/send-traces/using-otel-sdk-python.md
@@ -36,10 +36,10 @@ We can rely on `host.docker.internal` to get the docker bridge ip address, point
 
 ```bash
 docker run --rm --name jaeger-qw \
-    -e SPAN_STORAGE_TYPE=grpc-plugin \
+    -e SPAN_STORAGE_TYPE=grpc \
     -e GRPC_STORAGE_SERVER=host.docker.internal:7281 \
     -p 16686:16686 \
-    jaegertracing/jaeger-query:latest
+    jaegertracing/jaeger-query:1.60
 ```
 
 ### Linux
@@ -50,11 +50,10 @@ The easiest is probably to use host network mode.
 
 ```bash
 docker run --rm --name jaeger-qw --network=host \
-    -e SPAN_STORAGE_TYPE=grpc-plugin \
+    -e SPAN_STORAGE_TYPE=grpc \
     -e GRPC_STORAGE_SERVER=127.0.0.1:7281 \
     -p 16686:16686 \
-    jaegertracing/jaeger-query:latest
-
+    jaegertracing/jaeger-query:1.60
 ```
 
 ## Run a simple Flask app

--- a/docs/get-started/tutorials/tutorial-jaeger.md
+++ b/docs/get-started/tutorials/tutorial-jaeger.md
@@ -27,11 +27,11 @@ services:
     command: ["run"]
 
   jaeger-query:
-    image: jaegertracing/jaeger-query:1.52
+    image: jaegertracing/jaeger-query:1.60
     ports:
       - 16686:16686
     environment:
-      - SPAN_STORAGE_TYPE=grpc-plugin
+      - SPAN_STORAGE_TYPE=grpc
       - GRPC_STORAGE_SERVER=quickwit:7281
       - GRPC_STORAGE_TLS=false
 ```


### PR DESCRIPTION
## Description

Since the version `1.58` of Jaeger, `grpc-plugin` is no longer supported.

This documentation is setting the version `latest` to `1.60` to remain valid and adapt with `grpc` instead.
