### PR TITLE
Downgrade actions/download-artifact from 4.1.8 to 4.1.7

### DIFF
--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -91,7 +91,7 @@ jobs:
     needs: [docker]
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.1.7
         with:
           name: digest
           path: /tmp/digests


### PR DESCRIPTION
### Description

Looks like the bump from 4.1.7 to 4.1.8 (https://github.com/quickwit-oss/quickwit/pull/5410) broke the docker CI (https://github.com/quickwit-oss/quickwit/actions/workflows/publish_docker_images.yml). I didn't investigate why.

### How was this PR tested?

Test now passes.