### PR TITLE
Upgrade actions/upload-artifact to match actions/download-artifact

### DIFF
--- a/.github/actions/cargo-build-macos-binary/action.yml
+++ b/.github/actions/cargo-build-macos-binary/action.yml
@@ -54,7 +54,7 @@ runs:
           BINARY_VERSION=${{ inputs.version }} ARCHIVE_NAME=${{ env.ASSET_FULL_NAME }}
       shell: bash
     - name: Save binary archive for three days
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: ${{ env.ASSET_FULL_NAME }}.tar.gz
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -51,7 +51,7 @@ runs:
           BINARY_VERSION=${{ inputs.version }} ARCHIVE_NAME=${{ env.ASSET_FULL_NAME }}
       shell: bash
     - name: Save binary archive for three days
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: ${{ env.ASSET_FULL_NAME }}.tar.gz
         path: ./${{ env.ASSET_FULL_NAME }}.tar.gz

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           pattern: digest-*
           path: /tmp/digests
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -79,7 +79,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: digest
           path: /tmp/digests/*

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: digest
+          name: digest-${{ matrix.platform }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -93,7 +93,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4.1.8
         with:
-          name: digest
+          pattern: digest-*
           path: /tmp/digests
 
       - name: Set up Docker Buildx

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -22,8 +22,10 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux/amd64
+            platform_suffix: amd64
           - os: gh-ubuntu-arm64
             platform: linux/arm64
+            platform_suffix: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -81,7 +83,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: digest-${{ matrix.platform }}
+          name: digest-${{ matrix.platform_suffix }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
### Description

Looks like the bump from actions/download-artifact 3 to 4 broke the docker CI (https://github.com/quickwit-oss/quickwit/actions/workflows/publish_docker_images.yml). This is an expected breaking change (https://github.com/actions/download-artifact?tab=readme-ov-file#breaking-changes))

### How was this PR tested?

Describe how you tested this PR.
