### PR TITLE
Cleanup integration tests

### DIFF
--- a/quickwit/quickwit-integration-tests/resources/tests/documents_to_ingest.json
+++ b/quickwit/quickwit-integration-tests/resources/tests/documents_to_ingest.json
@@ -1,3 +1,0 @@
-{"body":"foo"}
-{"body":"bar"}
-{"body":"baz"}

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -266,33 +266,15 @@ macro_rules! ingest_json {
     };
 }
 
-pub(crate) async fn ingest_with_retry(
+pub(crate) async fn ingest(
     client: &QuickwitClient,
     index_id: &str,
     ingest_source: IngestSource,
     commit_type: CommitType,
 ) -> anyhow::Result<()> {
-    wait_until_predicate(
-        || {
-            let commit_type_clone = commit_type;
-            let ingest_source_clone = ingest_source.clone();
-            async move {
-                // Index one record.
-                if let Err(err) = client
-                    .ingest(index_id, ingest_source_clone, None, None, commit_type_clone)
-                    .await
-                {
-                    debug!(index=%index_id, err=%err, "failed to ingest");
-                    false
-                } else {
-                    true
-                }
-            }
-        },
-        Duration::from_secs(10),
-        Duration::from_millis(100),
-    )
-    .await?;
+    client
+        .ingest(index_id, ingest_source, None, None, commit_type)
+        .await?;
     Ok(())
 }
 

--- a/quickwit/quickwit-integration-tests/src/test_utils/mod.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/mod.rs
@@ -20,4 +20,4 @@
 mod cluster_sandbox;
 mod shutdown;
 
-pub(crate) use cluster_sandbox::{ingest_with_retry, ClusterSandbox, ClusterSandboxBuilder};
+pub(crate) use cluster_sandbox::{ingest, ClusterSandbox, ClusterSandboxBuilder};

--- a/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
@@ -27,7 +27,7 @@ use quickwit_rest_client::models::IngestSource;
 use quickwit_rest_client::rest_client::CommitType;
 use quickwit_serve::SearchRequestQueryString;
 
-use crate::test_utils::{ingest_with_retry, ClusterSandboxBuilder};
+use crate::test_utils::{ingest, ClusterSandboxBuilder};
 
 fn get_ndjson_filepath(ndjson_dataset_filename: &str) -> String {
     format!(
@@ -190,7 +190,7 @@ async fn test_multi_nodes_cluster() {
     // Check that ingest request send to searcher is forwarded to indexer and thus indexed.
     let ndjson_filepath = get_ndjson_filepath("documents_to_ingest.json");
     let ingest_source = IngestSource::File(PathBuf::from_str(&ndjson_filepath).unwrap());
-    ingest_with_retry(
+    ingest(
         &sandbox.searcher_rest_client,
         "my-new-multi-node-index",
         ingest_source,

--- a/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/basic_tests.rs
@@ -17,25 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
-use std::str::FromStr;
 use std::time::Duration;
 
 use hyper::{Body, Method, Request, StatusCode};
 use quickwit_config::service::QuickwitService;
-use quickwit_rest_client::models::IngestSource;
-use quickwit_rest_client::rest_client::CommitType;
 use quickwit_serve::SearchRequestQueryString;
 
-use crate::test_utils::{ingest, ClusterSandboxBuilder};
-
-fn get_ndjson_filepath(ndjson_dataset_filename: &str) -> String {
-    format!(
-        "{}/resources/tests/{}",
-        env!("CARGO_MANIFEST_DIR"),
-        ndjson_dataset_filename
-    )
-}
+use crate::test_utils::ClusterSandboxBuilder;
 
 #[tokio::test]
 async fn test_ui_redirect_on_get() {
@@ -130,20 +118,6 @@ async fn test_multi_nodes_cluster() {
         .build_and_start()
         .await;
 
-    {
-        // Wait for indexer to fully start.
-        // The starting time is a bit long for a cluster.
-        tokio::time::sleep(Duration::from_secs(3)).await;
-        let indexing_service_counters = sandbox
-            .indexer_rest_client
-            .node_stats()
-            .indexing()
-            .await
-            .unwrap();
-        assert_eq!(indexing_service_counters.num_running_pipelines, 0);
-    }
-
-    // Create index
     sandbox
         .indexer_rest_client
         .indexes()
@@ -163,6 +137,7 @@ async fn test_multi_nodes_cluster() {
         )
         .await
         .unwrap();
+
     assert!(sandbox
         .indexer_rest_client
         .node_health()
@@ -170,10 +145,10 @@ async fn test_multi_nodes_cluster() {
         .await
         .unwrap());
 
-    // Wait until indexing pipelines are started.
+    // Assert that at least 1 indexing pipelines is successfully started
     sandbox.wait_for_indexing_pipelines(1).await.unwrap();
 
-    // Check search is working.
+    // Check that search is working
     let search_response_empty = sandbox
         .searcher_rest_client
         .search(
@@ -187,30 +162,5 @@ async fn test_multi_nodes_cluster() {
         .unwrap();
     assert_eq!(search_response_empty.num_hits, 0);
 
-    // Check that ingest request send to searcher is forwarded to indexer and thus indexed.
-    let ndjson_filepath = get_ndjson_filepath("documents_to_ingest.json");
-    let ingest_source = IngestSource::File(PathBuf::from_str(&ndjson_filepath).unwrap());
-    ingest(
-        &sandbox.searcher_rest_client,
-        "my-new-multi-node-index",
-        ingest_source,
-        CommitType::Auto,
-    )
-    .await
-    .unwrap();
-    // Wait until split is committed and search.
-    tokio::time::sleep(Duration::from_secs(4)).await;
-    let search_response_one_hit = sandbox
-        .searcher_rest_client
-        .search(
-            "my-new-multi-node-index",
-            SearchRequestQueryString {
-                query: "body:bar".to_string(),
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-    assert_eq!(search_response_one_hit.num_hits, 1);
     sandbox.shutdown().await.unwrap();
 }

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
@@ -740,11 +740,10 @@ async fn test_shutdown_control_plane_first() {
         .await
         .unwrap();
 
-    // The indexer should fail to shutdown because it cannot commit the
-    // shard EOF
-    if let Ok(Ok(_)) = tokio::time::timeout(Duration::from_secs(5), sandbox.shutdown()).await {
-        panic!("Expected timeout or error on shutdown");
-    }
+    // The indexer hangs on shutdown because it cannot commit the shard EOF
+    tokio::time::timeout(Duration::from_secs(5), sandbox.shutdown())
+        .await
+        .unwrap_err();
 }
 
 #[tokio::test]

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
@@ -36,10 +36,11 @@ fn initialize_tests() {
     std::env::set_var("QW_ENABLE_INGEST_V2", "true");
 }
 
-// TODO: The control plane schedules the old pipeline and this test fails (not
-// always). It might be because the reschedule takes too long to happen
-// or another bug.
+// TODO: This test is flaky. Sometimes the control plane schedules the old
+// pipeline and this test fails (not always). It might be because the reschedule
+// takes too long to happen or another bug.
 #[tokio::test]
+#[ignore]
 async fn test_ingest_recreated_index() {
     initialize_tests();
     let mut sandbox = ClusterSandboxBuilder::build_and_start_standalone().await;
@@ -311,6 +312,14 @@ async fn test_commit_force() {
     .unwrap();
 
     sandbox.assert_hit_count(index_id, "body:force", 1).await;
+
+    // Delete the index to avoid waiting for the commit timeout on shutdown #5068
+    sandbox
+        .indexer_rest_client
+        .indexes()
+        .delete(index_id, false)
+        .await
+        .unwrap();
 
     sandbox.shutdown().await.unwrap();
 }

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
@@ -36,9 +36,7 @@ fn initialize_tests() {
     std::env::set_var("QW_ENABLE_INGEST_V2", "true");
 }
 
-// TODO: This test is flaky. Sometimes the control plane schedules the old
-// pipeline and this test fails (not always). It might be because the reschedule
-// takes too long to happen or another bug.
+/// Ingesting on a freshly re-created index sometimes fails, see #5430
 #[tokio::test]
 #[ignore]
 async fn test_ingest_recreated_index() {

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_tests.rs
@@ -29,7 +29,7 @@ use quickwit_serve::ListSplitsQueryParams;
 use serde_json::json;
 
 use crate::ingest_json;
-use crate::test_utils::{ingest_with_retry, ClusterSandboxBuilder};
+use crate::test_utils::{ingest, ClusterSandboxBuilder};
 
 fn initialize_tests() {
     quickwit_common::setup_logging_for_tests();
@@ -69,7 +69,7 @@ async fn test_single_node_multi_splits() {
         .unwrap();
 
     // Index one record.
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "first record"}),
@@ -106,7 +106,7 @@ async fn test_single_node_multi_splits() {
     );
 
     // Index multiple records in different splits.
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "second record"}),
@@ -120,7 +120,7 @@ async fn test_single_node_multi_splits() {
         .await
         .unwrap();
 
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "third record"}),
@@ -134,7 +134,7 @@ async fn test_single_node_multi_splits() {
         .await
         .unwrap();
 
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "fourth record"}),
@@ -242,7 +242,7 @@ async fn test_ingest_v2_happy_path() {
         .await
         .unwrap();
 
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "doc1"}),
@@ -300,7 +300,7 @@ async fn test_commit_force() {
     // the commit isn't forced
     tokio::time::timeout(
         Duration::from_secs(20),
-        ingest_with_retry(
+        ingest(
             &sandbox.indexer_rest_client,
             index_id,
             ingest_json!({"body": "force"}),
@@ -488,7 +488,7 @@ async fn test_very_large_index_name() {
         .unwrap();
 
     // Test force commit
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "not too long"}),
@@ -576,7 +576,7 @@ async fn test_shutdown_single_node() {
         .unwrap();
 
     // Ensure that the index is ready to accept records.
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "one"}),
@@ -644,7 +644,7 @@ async fn test_shutdown_control_plane_first() {
         .await
         .unwrap();
 
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "one"}),
@@ -711,7 +711,7 @@ async fn test_shutdown_indexer_first() {
         .await
         .unwrap();
 
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         index_id,
         ingest_json!({"body": "one"}),

--- a/quickwit/quickwit-integration-tests/src/tests/otlp_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/otlp_tests.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use futures_util::StreamExt;
 use quickwit_config::service::QuickwitService;
@@ -131,7 +131,7 @@ async fn test_ingest_traces_with_otlp_grpc_api() {
     }
 
     sandbox
-        .shutdown_services(&HashSet::from_iter([QuickwitService::Indexer]))
+        .shutdown_services([QuickwitService::Indexer])
         .await
         .unwrap();
     sandbox.shutdown().await.unwrap();
@@ -205,7 +205,7 @@ async fn test_ingest_logs_with_otlp_grpc_api() {
     }
 
     sandbox
-        .shutdown_services(&HashSet::from_iter([QuickwitService::Indexer]))
+        .shutdown_services([QuickwitService::Indexer])
         .await
         .unwrap();
     sandbox.shutdown().await.unwrap();
@@ -240,7 +240,7 @@ async fn test_jaeger_api() {
         .unwrap();
 
     sandbox
-        .shutdown_services(&HashSet::from_iter([QuickwitService::Indexer]))
+        .shutdown_services([QuickwitService::Indexer])
         .await
         .unwrap();
 

--- a/quickwit/quickwit-integration-tests/src/tests/update_tests/search_settings_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/update_tests/search_settings_tests.rs
@@ -25,7 +25,7 @@ use serde_json::json;
 
 use super::assert_hits_unordered;
 use crate::ingest_json;
-use crate::test_utils::{ingest_with_retry, ClusterSandboxBuilder};
+use crate::test_utils::{ingest, ClusterSandboxBuilder};
 
 #[tokio::test]
 async fn test_update_search_settings_on_multi_nodes_cluster() {
@@ -86,7 +86,7 @@ async fn test_update_search_settings_on_multi_nodes_cluster() {
     // Wait until indexing pipelines are started
     sandbox.wait_for_indexing_pipelines(1).await.unwrap();
 
-    ingest_with_retry(
+    ingest(
         &sandbox.indexer_rest_client,
         "my-updatable-index",
         ingest_json!({"title": "first", "body": "first record"}),


### PR DESCRIPTION
### Description

Uncomment some tests and remove some outdated workarounds in the integration tests:
- ingest retries do not seem to be required anymore
- isolated the failing test when ingesting data on a re-created index (and annotate it with #[ignore])
- grouped all the ingest tests into a single module (`ingest_tests`)
- better wording and small helper improvements

### How was this PR tested?

Describe how you tested this PR.
