### PR TITLE
Fix bulk api response order

### DIFF
--- a/quickwit/rest-api-tests/README.md
+++ b/quickwit/rest-api-tests/README.md
@@ -34,7 +34,7 @@ running in DEBUG mode is fine.
 ```
 
 When targeting elasticsearch, the script expects elastic to be running on
-`http://localhost:9200`.
+`http://localhost:9200` (see [compose script](./docker-compose.yaml)).
 
 In both cases, the test will take care of setting up, ingesting and tearing down the
 indexes involved.

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0006-partial-index-not-found.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0006-partial-index-not-found.yaml
@@ -1,7 +1,9 @@
 ndjson:
-  - index: { "_index": "test-index-not-found", "_id": "1" }
-  - message: Hello, World!"
   - index: { "_index": "test-index-not-found" }
+  - message: Hello, World!"
+  - index: { "_index": "test-index" }
+  - message: Hola, Mundo!
+  - index: { "_index": "test-index-pattern-777" }
   - message: Hola, Mundo!
 status_code: 200
 expected:
@@ -9,7 +11,6 @@ expected:
   items:
     - index:
         _index: test-index-not-found
-        _id: "1"
         status: 404
         error:
           index: test-index-not-found
@@ -17,12 +18,8 @@ expected:
           reason:
             $expect: val.startswith('no such index [test-index-not-found]')
     - index:
-        _index: test-index-not-found
-        _id: null
-        status: 404
-        error:
-          index: test-index-not-found
-          type: index_not_found_exception
-          reason:
-            $expect: val.startswith('no such index [test-index-not-found]')
-
+        _index: test-index
+        status: 201
+    - index:
+        _index: test-index-pattern-777
+        status: 201

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.elasticsearch.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.elasticsearch.yaml
@@ -3,6 +3,10 @@ method: DELETE
 endpoint: test-index
 status_code: null
 ---
+method: DELETE
+endpoint: test-index-pattern-777
+status_code: null
+---
 method: PUT
 endpoint: test-index
 json: {
@@ -19,3 +23,10 @@ json: {
     }
   }
 }
+---
+# Only create indexes automatically for specific pattern
+method: PUT
+endpoint: _cluster/settings
+json:
+  transient:
+    action.auto_create_index: "test-index-pattern-*"

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_setup.quickwit.yaml
@@ -6,6 +6,11 @@ status_code: null
 ---
 method: DELETE
 api_root: http://localhost:7280/api/v1/
+endpoint: indexes/test-index-pattern-777
+status_code: null
+---
+method: DELETE
+api_root: http://localhost:7280/api/v1/
 endpoint: templates/test-index-template
 status_code: null
 ---
@@ -31,7 +36,7 @@ json:
   version: "0.8"
   template_id: test-index-template
   index_id_patterns:
-    - test-index-happy-path*
+    - test-index-pattern-*
   doc_mapping:
     mode: dynamic
   indexing_settings:

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_teardown.elasticsearch.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/_teardown.elasticsearch.yaml
@@ -1,0 +1,10 @@
+# Reconfigure with the default settings
+method: PUT
+endpoint: _cluster/settings
+json:
+  transient:
+    action.auto_create_index: "true"
+---
+method: DELETE
+endpoint: test-index*
+status_code: null

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_ctx.elasticsearch.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_ctx.elasticsearch.yaml
@@ -1,1 +1,0 @@
-api_root: http://localhost:9200

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_ctx.quickwit.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_ctx.quickwit.yaml
@@ -1,3 +1,0 @@
-api_root: http://localhost:7280/api/v1/_elastic
-params:
-  enable_ingest_v2: 'true'

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_ctx.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_ctx.yaml
@@ -1,2 +1,0 @@
-method: [POST]
-endpoint: "_bulk"

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_setup.elasticsearch.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_setup.elasticsearch.yaml
@@ -1,6 +1,0 @@
-# Disable automatic creation of indexes.
-method: PUT
-endpoint: _cluster/settings
-json:
-  transient:
-    action.auto_create_index: "false"

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_teardown.elasticsearch.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/index_not_found/_teardown.elasticsearch.yaml
@@ -1,6 +1,0 @@
-# Enable automatic creation of indexes.
-method: PUT
-endpoint: _cluster/settings
-json:
-  transient:
-    action.auto_create_index: "true"


### PR DESCRIPTION
### Description

The bulk API should have its responses in the same order as the submitted actions (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-api-response-body)

### How was this PR tested?

Describe how you tested this PR.
