### PR TITLE
fix(metastore): add index to support index name wildcard expansion

### DIFF
--- a/quickwit/quickwit-metastore/migrations/postgresql/23_change-indexes-unique-index.down.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/23_change-indexes-unique-index.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS indexes_index_id_unique;
+ALTER TABLE indexes ADD CONSTRAINT indexes_index_id_unique UNIQUE (index_id);

--- a/quickwit/quickwit-metastore/migrations/postgresql/23_change-indexes-unique-index.up.sql
+++ b/quickwit/quickwit-metastore/migrations/postgresql/23_change-indexes-unique-index.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE indexes DROP CONSTRAINT IF EXISTS indexes_index_id_unique;
+
+CREATE UNIQUE INDEX IF NOT EXISTS indexes_index_id_unique
+  ON indexes USING btree ("index_id" varchar_pattern_ops);


### PR DESCRIPTION
### Description
The sql that is generated to expand an index name (index_id) into all of the matching index names uses the LIKE clause to do partial text matches. However, the only index on the index_id column utilizes the default btree configuration which can only do exact value comparisons. In environments with a large search volume over many thousands of indexes, this can be a bottle neck as the query will always do an full table scan. This drops and recreates the unique index on index_id to include the `varchar_pattern_ops` which allows for wildcard matching on a varchar column using the LIKE operator

Fixes: #5437

### How was this PR tested?
* Quickwit release binary built
* Docker docker compose started
* started quickwit metastore `quickwit run --service metastore
* Verify the unique index of the same name created with the `varchar_pattern_ops` operator class exists on `index_id`
* Insert a number of records into the table, and confirm a `LIKE` clause w/ a terminal wildcard produces an index scan.


```txl
\d+ indexes
                                                                   Table "public.indexes"
       Column        |            Type             | Collation | Nullable |                 Default                  | Storage  | Stats target | Description 
---------------------+-----------------------------+-----------+----------+------------------------------------------+----------+--------------+-------------
 index_uid           | character varying(282)      |           | not null |                                          | extended |              | 
 index_metadata_json | text                        |           | not null |                                          | extended |              | 
 create_timestamp    | timestamp without time zone |           | not null | timezone('UTC'::text, CURRENT_TIMESTAMP) | plain    |              | 
 index_id            | character varying(255)      |           | not null | ''::character varying                    | extended |              | 
Indexes:
    "indexes_pkey" PRIMARY KEY, btree (index_uid)
    "indexes_index_id_unique" UNIQUE, btree (index_id varchar_pattern_ops)
Referenced by:
    TABLE "delete_tasks" CONSTRAINT "delete_tasks_index_uid_fkey" FOREIGN KEY (index_uid) REFERENCES indexes(index_uid) ON DELETE CASCADE
    TABLE "shards" CONSTRAINT "shards_index_uid_fkey" FOREIGN KEY (index_uid) REFERENCES indexes(index_uid) ON DELETE CASCADE
    TABLE "splits" CONSTRAINT "splits_index_uid_fkey" FOREIGN KEY (index_uid) REFERENCES indexes(index_uid) ON DELETE CASCADE
```

```txl
EXPLAIN(ANALYZE, BUFFERS, COSTS, TIMING) SELECT * FROM indexes WHERE (index_id LIKE 'logline.d1f92cd2db.2024-08-18%');

                                                                   QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using indexes_index_id_unique_bis on indexes  (cost=0.41..8.43 rows=3 width=1945) (actual time=0.012..0.012 rows=1 loops=1)
   Index Cond: (((index_id)::text ~>=~ 'logline.d1f92cd2db.2024-08-18'::text) AND ((index_id)::text ~<~ 'logline.d1f92cd2db.2024-08-19'::text))
   Filter: ((index_id)::text ~~ 'logline.d1f92cd2db.2024-08-18%'::text)
   Buffers: shared hit=4
 Planning:
   Buffers: shared hit=41
 Planning Time: 0.214 ms
 Execution Time: 0.025 ms
```
