### PR TITLE
Add ES API compatible date time parsers

### DIFF
--- a/quickwit/quickwit-datetime/src/date_time_format.rs
+++ b/quickwit/quickwit-datetime/src/date_time_format.rs
@@ -162,6 +162,8 @@ pub enum DateTimeInputFormat {
     Rfc3339,
     Strptime(StrptimeParser),
     Timestamp,
+    ESStrictDateOptionalTime,
+    ESStrictDateTimeNoMillis,
 }
 
 impl DateTimeInputFormat {
@@ -172,6 +174,8 @@ impl DateTimeInputFormat {
             DateTimeInputFormat::Rfc3339 => "rfc3339",
             DateTimeInputFormat::Strptime(parser) => parser.borrow_strptime_format(),
             DateTimeInputFormat::Timestamp => "unix_timestamp",
+            DateTimeInputFormat::ESStrictDateOptionalTime => "strict_date_optional_time",
+            DateTimeInputFormat::ESStrictDateTimeNoMillis => "strict_date_time_no_millis",
         }
     }
 }
@@ -191,6 +195,8 @@ impl FromStr for DateTimeInputFormat {
             "rfc2822" => DateTimeInputFormat::Rfc2822,
             "rfc3339" => DateTimeInputFormat::Rfc3339,
             "unix_timestamp" => DateTimeInputFormat::Timestamp,
+            "strict_date_optional_time" => DateTimeInputFormat::ESStrictDateOptionalTime,
+            "strict_date_time_no_millis" => DateTimeInputFormat::ESStrictDateTimeNoMillis,
             _ => {
                 if !is_strftime_formatting(date_time_format_str) {
                     return Err(format!(


### PR DESCRIPTION
### Description

ES uses [own names][1] for date formats. I implemented the ones that I was able to find in OSD.

Test cases taken from [doc][1] and [OS test][2].

This PR is fixing [issue](https://github.com/quickwit-oss/quickwit/issues/5460) and restore compatibility with OSD.

[1]: https://opensearch.org/docs/latest/field-types/supported-field-types/date/
[2]: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java

### How was this PR tested?

Added unit tests to cover new parsers.
