### PR TITLE
Handle nested OTLP values in attributes and log bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Ubuntu packages
-        run: sudo apt-get -y install protobuf-compiler python3 python3-pip
+        run: sudo apt-get -y install protobuf-compiler python3
       - uses: dorny/paths-filter@v3
         id: modified
         with:
@@ -86,11 +86,12 @@ jobs:
         run: cargo build --features=postgres --bin quickwit
         working-directory: ./quickwit
       - name: Install python packages
-        run: sudo pip3 install pyaml requests
         if: always() && steps.modified.outputs.rust_src == 'true'
-      - name: run REST API tests
+        run: python3 -m venv venv && source venv/bin/activate && pip install pyaml requests
+        working-directory: ./quickwit/rest-api-tests
+      - name: Run REST API tests
         if: always() && steps.modified.outputs.rust_src == 'true'
-        run: python3 ./run_tests.py --binary ../target/debug/quickwit
+        run: source venv/bin/activate && python3 ./run_tests.py --binary ../target/debug/quickwit
         working-directory: ./quickwit/rest-api-tests
 
   lints:

--- a/quickwit/quickwit-opentelemetry/Cargo.toml
+++ b/quickwit/quickwit-opentelemetry/Cargo.toml
@@ -32,6 +32,7 @@ quickwit-proto = { workspace = true }
 [dev-dependencies]
 quickwit-common = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
+quickwit-proto = { workspace = true, features = ["testsuite"] }
 
 [features]
 testsuite = []


### PR DESCRIPTION
### Description
Attributes are not supposed to carry nested values, but bodies can. Since we use the same function to convert OTLP values to JSON values, we should handle them in `oltp_value_to_json_value`. Closes #5458.

### How was this PR tested?
Updated unit tests.
