### PR TITLE
Limit warmup memory usage

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3502,12 +3502,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3502,23 +3502,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -226,11 +226,7 @@ pub struct SearcherConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_timeout_policy: Option<StorageTimeoutPolicy>,
-
-    // TODO validate that `warmup_memory_budget` is greater than `warmup_single_split_initial_allocation`
-    // TODO set serde default
     pub warmup_memory_budget: ByteSize,
-    // TODO set serde default
     pub warmup_single_split_initial_allocation: ByteSize,
 }
 
@@ -280,9 +276,7 @@ impl Default for SearcherConfig {
             split_cache: None,
             request_timeout_secs: Self::default_request_timeout_secs(),
             storage_timeout_policy: None,
-            // TODO change this to the method used for serde default.
             warmup_memory_budget: ByteSize::gb(1),
-            // TODO change this to the method used for serde default.
             warmup_single_split_initial_allocation: ByteSize::mb(50),
         }
     }
@@ -316,6 +310,14 @@ impl SearcherConfig {
                      split_cache.max_file_descriptors ({})",
                     self.max_num_concurrent_split_streams,
                     split_cache_limits.max_file_descriptors
+                );
+            }
+            if self.warmup_single_split_initial_allocation > self.warmup_memory_budget {
+                anyhow::bail!(
+                    "warmup_single_split_initial_allocation ({}) must be lower or equal to \
+                     warmup_memory_budget ({})",
+                    self.warmup_single_split_initial_allocation,
+                    self.warmup_memory_budget
                 );
             }
         }

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -226,6 +226,12 @@ pub struct SearcherConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_timeout_policy: Option<StorageTimeoutPolicy>,
+
+    // TODO validate that `warmup_memory_budget` is greater than `warmup_single_split_initial_allocation`
+    // TODO set serde default
+    pub warmup_memory_budget: ByteSize,
+    // TODO set serde default
+    pub warmup_single_split_initial_allocation: ByteSize,
 }
 
 /// Configuration controlling how fast a searcher should timeout a `get_slice`
@@ -263,7 +269,7 @@ impl StorageTimeoutPolicy {
 
 impl Default for SearcherConfig {
     fn default() -> Self {
-        Self {
+        SearcherConfig {
             fast_field_cache_capacity: ByteSize::gb(1),
             split_footer_cache_capacity: ByteSize::mb(500),
             partial_request_cache_capacity: ByteSize::mb(64),
@@ -274,6 +280,10 @@ impl Default for SearcherConfig {
             split_cache: None,
             request_timeout_secs: Self::default_request_timeout_secs(),
             storage_timeout_policy: None,
+            // TODO change this to the method used for serde default.
+            warmup_memory_budget: ByteSize::gb(1),
+            // TODO change this to the method used for serde default.
+            warmup_single_split_initial_allocation: ByteSize::mb(50),
         }
     }
 }

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -616,7 +616,9 @@ mod tests {
                     min_throughtput_bytes_per_secs: 100_000,
                     timeout_millis: 2_000,
                     max_num_retries: 2
-                })
+                }),
+                warmup_memory_budget: ByteSize::gb(1),
+                warmup_single_split_initial_allocation: ByteSize::mb(50),
             }
         );
         assert_eq!(

--- a/quickwit/quickwit-directories/src/lib.rs
+++ b/quickwit/quickwit-directories/src/lib.rs
@@ -37,7 +37,7 @@ mod storage_directory;
 mod union_directory;
 
 pub use self::bundle_directory::{get_hotcache_from_split, read_split_footer, BundleDirectory};
-pub use self::caching_directory::CachingDirectory;
+pub use self::caching_directory::{CachingDirectory, DirectoryCache};
 pub use self::debug_proxy_directory::{DebugProxyDirectory, ReadOperation};
 pub use self::hot_directory::{write_hotcache, HotDirectory};
 pub use self::storage_directory::StorageDirectory;

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -347,6 +347,14 @@ message LeafSearchRequest {
   repeated string index_uris = 9;
 }
 
+message ResourceStats {
+    uint64 short_lived_cache_num_bytes = 1;
+    uint64 split_num_docs = 2;
+    uint64 warmup_microsecs = 3;
+    uint64 cpu_thread_pool_wait_microsecs = 4;
+    uint64 cpu_microsecs = 5;
+}
+
 /// LeafRequestRef references data in LeafSearchRequest to deduplicate data.
 message LeafRequestRef {
   // The ordinal of the doc_mapper in `LeafSearchRequest.doc_mappers`
@@ -479,6 +487,8 @@ message LeafSearchResponse {
 
   // postcard serialized intermediate aggregation_result.
   optional bytes intermediate_aggregation_result = 6;
+
+  ResourceStats resource_stats = 8;
 }
 
 message SnippetRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -286,6 +286,21 @@ pub struct LeafSearchRequest {
     #[prost(string, repeated, tag = "9")]
     pub index_uris: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResourceStats {
+    #[prost(uint64, tag = "1")]
+    pub short_lived_cache_num_bytes: u64,
+    #[prost(uint64, tag = "2")]
+    pub split_num_docs: u64,
+    #[prost(uint64, tag = "3")]
+    pub warmup_microsecs: u64,
+    #[prost(uint64, tag = "4")]
+    pub cpu_thread_pool_wait_microsecs: u64,
+    #[prost(uint64, tag = "5")]
+    pub cpu_microsecs: u64,
+}
 /// / LeafRequestRef references data in LeafSearchRequest to deduplicate data.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -457,6 +472,8 @@ pub struct LeafSearchResponse {
     pub intermediate_aggregation_result: ::core::option::Option<
         ::prost::alloc::vec::Vec<u8>,
     >,
+    #[prost(message, optional, tag = "8")]
+    pub resource_stats: ::core::option::Option<ResourceStats>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/quickwit/quickwit-search/src/cluster_client.rs
+++ b/quickwit/quickwit-search/src/cluster_client.rs
@@ -322,7 +322,7 @@ fn merge_original_with_retry_leaf_search_response(
         retry_response.resource_stats.as_ref(),
     ]
     .into_iter()
-    .flat_map(|el_opt| el_opt);
+    .flatten();
     let resource_stats = merge_resource_stats_it(&mut stats);
     Ok(LeafSearchResponse {
         intermediate_aggregation_result,

--- a/quickwit/quickwit-search/src/cluster_client.rs
+++ b/quickwit/quickwit-search/src/cluster_client.rs
@@ -317,13 +317,10 @@ fn merge_original_with_retry_leaf_search_response(
         (Some(left), None) => Some(left),
         (None, None) => None,
     };
-    let mut stats = [
-        original_response.resource_stats.as_ref(),
-        retry_response.resource_stats.as_ref(),
-    ]
-    .into_iter()
-    .flatten();
-    let resource_stats = merge_resource_stats_it(&mut stats);
+    let resource_stats = merge_resource_stats_it([
+        &original_response.resource_stats,
+        &retry_response.resource_stats,
+    ]);
     Ok(LeafSearchResponse {
         intermediate_aggregation_result,
         num_hits: original_response.num_hits + retry_response.num_hits,

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -1806,7 +1806,8 @@ mod tests {
                 failed_splits: Vec::new(),
                 num_attempted_splits: 3,
                 num_successful_splits: 3,
-                intermediate_aggregation_result: None
+                intermediate_aggregation_result: None,
+                resource_stats: None,
             }
         );
 
@@ -1845,6 +1846,7 @@ mod tests {
                     num_attempted_splits: 3,
                     num_successful_splits: 3,
                     intermediate_aggregation_result: None,
+                    resource_stats: None,
                 },
                 LeafSearchResponse {
                     num_hits: 10,
@@ -1863,6 +1865,7 @@ mod tests {
                     num_attempted_splits: 2,
                     num_successful_splits: 1,
                     intermediate_aggregation_result: None,
+                    resource_stats: None,
                 },
             ],
         );
@@ -1894,7 +1897,8 @@ mod tests {
                 }],
                 num_attempted_splits: 5,
                 num_successful_splits: 4,
-                intermediate_aggregation_result: None
+                intermediate_aggregation_result: None,
+                resource_stats: None,
             }
         );
 
@@ -1934,6 +1938,7 @@ mod tests {
                     num_attempted_splits: 3,
                     num_successful_splits: 3,
                     intermediate_aggregation_result: None,
+                    resource_stats: None,
                 },
                 LeafSearchResponse {
                     num_hits: 10,
@@ -1952,6 +1957,7 @@ mod tests {
                     num_attempted_splits: 2,
                     num_successful_splits: 1,
                     intermediate_aggregation_result: None,
+                    resource_stats: None,
                 },
             ],
         );
@@ -1983,7 +1989,8 @@ mod tests {
                 }],
                 num_attempted_splits: 5,
                 num_successful_splits: 4,
-                intermediate_aggregation_result: None
+                intermediate_aggregation_result: None,
+                resource_stats: None,
             }
         );
         // TODO would be nice to test aggregation too.

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -174,7 +174,7 @@ async fn fetch_docs_in_split(
     global_doc_addrs.sort_by_key(|doc| doc.doc_addr);
     // Opens the index without the ephemeral unbounded cache, this cache is indeed not useful
     // when fetching docs as we will fetch them only once.
-    let mut index = open_index_with_caches(
+    let mut index = open_index_with_caches::<()>(
         &searcher_context,
         index_storage,
         split,

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -27,7 +27,7 @@ use quickwit_doc_mapper::DocMapper;
 use quickwit_proto::search::{
     FetchDocsResponse, PartialHit, SnippetRequest, SplitIdAndFooterOffsets,
 };
-use quickwit_storage::Storage;
+use quickwit_storage::{ByteRangeCache, Storage};
 use tantivy::query::Query;
 use tantivy::schema::document::CompactDocValue;
 use tantivy::schema::{Document as DocumentTrait, Field, TantivyDocument, Value};
@@ -174,12 +174,12 @@ async fn fetch_docs_in_split(
     global_doc_addrs.sort_by_key(|doc| doc.doc_addr);
     // Opens the index without the ephemeral unbounded cache, this cache is indeed not useful
     // when fetching docs as we will fetch them only once.
-    let mut index = open_index_with_caches::<()>(
+    let mut index = open_index_with_caches(
         &searcher_context,
         index_storage,
         split,
         Some(doc_mapper.tokenizer_manager()),
-        None,
+        Option::<Arc<ByteRangeCache>>::None,
     )
     .await
     .context("open-index-for-split")?;

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -179,7 +179,7 @@ async fn fetch_docs_in_split(
         index_storage,
         split,
         Some(doc_mapper.tokenizer_manager()),
-        false,
+        None,
     )
     .await
     .context("open-index-for-split")?;

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -30,8 +30,8 @@ use quickwit_common::pretty::PrettySample;
 use quickwit_directories::{CachingDirectory, DirectoryCache, HotDirectory, StorageDirectory};
 use quickwit_doc_mapper::{DocMapper, TermRange, WarmupInfo};
 use quickwit_proto::search::{
-    CountHits, LeafSearchRequest, LeafSearchResponse, PartialHit, SearchRequest, SortOrder,
-    SortValue, SplitIdAndFooterOffsets, SplitSearchError,
+    CountHits, LeafSearchRequest, LeafSearchResponse, PartialHit, ResourceStats, SearchRequest,
+    SortOrder, SortValue, SplitIdAndFooterOffsets, SplitSearchError,
 };
 use quickwit_query::query_ast::{BoolQuery, QueryAst, QueryAstTransformer, RangeQuery, TermQuery};
 use quickwit_query::tokenizers::TokenizerManager;
@@ -468,7 +468,7 @@ async fn leaf_search_single_split(
                     } else {
                         searcher.search(&query, &collector)?
                     };
-                leaf_search_response.resource_stats = Some(quickwit_proto::search::ResourceStats {
+                leaf_search_response.resource_stats = Some(ResourceStats {
                     cpu_microsecs: cpu_start.elapsed().as_micros() as u64,
                     short_lived_cache_num_bytes,
                     split_num_docs,

--- a/quickwit/quickwit-search/src/leaf_cache.rs
+++ b/quickwit/quickwit-search/src/leaf_cache.rs
@@ -252,6 +252,7 @@ mod tests {
                 sort_value2: None,
                 split_id: "split_1".to_string(),
             }],
+            resource_stats: None,
         };
 
         assert!(cache.get(split_1.clone(), query_1.clone()).is_none());
@@ -342,6 +343,7 @@ mod tests {
                 sort_value2: None,
                 split_id: "split_1".to_string(),
             }],
+            resource_stats: None,
         };
 
         // for split_1, 1 and 1bis cover different timestamp ranges

--- a/quickwit/quickwit-search/src/leaf_cache.rs
+++ b/quickwit/quickwit-search/src/leaf_cache.rs
@@ -192,7 +192,8 @@ impl std::ops::RangeBounds<i64> for Range {
 #[cfg(test)]
 mod tests {
     use quickwit_proto::search::{
-        LeafSearchResponse, PartialHit, SearchRequest, SortValue, SplitIdAndFooterOffsets,
+        LeafSearchResponse, PartialHit, ResourceStats, SearchRequest, SortValue,
+        SplitIdAndFooterOffsets,
     };
 
     use super::LeafSearchCache;
@@ -343,7 +344,7 @@ mod tests {
                 sort_value2: None,
                 split_id: "split_1".to_string(),
             }],
-            resource_stats: None,
+            resource_stats: Some(ResourceStats::default()),
         };
 
         // for split_1, 1 and 1bis cover different timestamp ranges

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -42,6 +42,7 @@ mod search_response_rest;
 mod search_stream;
 mod service;
 pub(crate) mod top_k_collector;
+mod tracked_cache;
 
 mod metrics;
 mod search_permit_provider;

--- a/quickwit/quickwit-search/src/list_terms.rs
+++ b/quickwit/quickwit-search/src/list_terms.rs
@@ -33,7 +33,7 @@ use quickwit_proto::search::{
     SplitIdAndFooterOffsets, SplitSearchError,
 };
 use quickwit_proto::types::IndexUid;
-use quickwit_storage::Storage;
+use quickwit_storage::{ByteRangeCache, Storage};
 use tantivy::schema::{Field, FieldType};
 use tantivy::{ReloadPolicy, Term};
 use tracing::{debug, error, info, instrument};
@@ -216,7 +216,10 @@ async fn leaf_list_terms_single_split(
     storage: Arc<dyn Storage>,
     split: SplitIdAndFooterOffsets,
 ) -> crate::Result<LeafListTermsResponse> {
-    let index = open_index_with_caches(searcher_context, storage, &split, None, true).await?;
+    let cache =
+        ByteRangeCache::with_infinite_capacity(&quickwit_storage::STORAGE_METRICS.shortlived_cache);
+    let index =
+        open_index_with_caches(searcher_context, storage, &split, None, Some(cache)).await?;
     let split_schema = index.schema();
     let reader = index
         .reader_builder()

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -694,7 +694,8 @@ pub fn get_count_from_metadata(split_metadatas: &[SplitMetadata]) -> Vec<LeafSea
 /// This function only considers the memory usage associated to the input data
 /// and does not take in account aggregations (intermediary or not) results for instance.
 ///
-/// Since its point is to log memory intensive queries, it focuses on the metric of the number of bytes per document.
+/// Since its point is to log memory intensive queries, it focuses on the metric of the number of
+/// bytes per document.
 ///
 /// The threshold is computed dynamically using gradient descent.
 fn is_top_1pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
@@ -705,10 +706,11 @@ fn is_top_1pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
     // We multiply those figure by 1_000 for accuracy.
     const PERCENTILE: u64 = 95;
     const PRIOR_NUM_BYTES_PER_DOC: u64 = 3 * 1_000;
-    static NUM_BYTES_PER_DOC_95_PERCENTILE_ESTIMATOR: AtomicU64 = AtomicU64::new(PRIOR_NUM_BYTES_PER_DOC);
+    static NUM_BYTES_PER_DOC_95_PERCENTILE_ESTIMATOR: AtomicU64 =
+        AtomicU64::new(PRIOR_NUM_BYTES_PER_DOC);
     let num_bits_per_docs = num_bytes * 1_000 / split_num_docs;
     let current_estimator = NUM_BYTES_PER_DOC_95_PERCENTILE_ESTIMATOR.load(Ordering::Relaxed);
-    let is_memory_intensive =  num_bits_per_docs > current_estimator;
+    let is_memory_intensive = num_bits_per_docs > current_estimator;
     let new_estimator: u64 = if is_memory_intensive {
         current_estimator.saturating_add(PRIOR_NUM_BYTES_PER_DOC * PERCENTILE / 100)
     } else {
@@ -781,7 +783,10 @@ pub(crate) async fn search_partial_hits_phase(
     );
 
     if let Some(resource_stats) = &leaf_search_response.resource_stats {
-        if is_top_1pct_memory_intensive(resource_stats.short_lived_cache_num_bytes, resource_stats.split_num_docs) {
+        if is_top_1pct_memory_intensive(
+            resource_stats.short_lived_cache_num_bytes,
+            resource_stats.split_num_docs,
+        ) {
             // We log at most 5 times per minute.
             quickwit_common::rate_limited_info!(limit_per_min=5, split_num_docs=resource_stats.split_num_docs, %search_request.query_ast, short_lived_cached_num_bytes=resource_stats.short_lived_cache_num_bytes, query=%search_request.query_ast, "memory intensive query");
         }

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -698,7 +698,7 @@ pub fn get_count_from_metadata(split_metadatas: &[SplitMetadata]) -> Vec<LeafSea
 /// bytes per document.
 ///
 /// The threshold is computed dynamically using gradient descent.
-fn is_top_1pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
+fn is_top_5pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
     // It is not worth considering small splits for this.
     if split_num_docs < 100_000 {
         return false;
@@ -783,7 +783,7 @@ pub(crate) async fn search_partial_hits_phase(
     );
 
     if let Some(resource_stats) = &leaf_search_response.resource_stats {
-        if is_top_1pct_memory_intensive(
+        if is_top_5pct_memory_intensive(
             resource_stats.short_lived_cache_num_bytes,
             resource_stats.split_num_docs,
         ) {

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -49,7 +50,7 @@ use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResult
 use tantivy::collector::Collector;
 use tantivy::schema::{Field, FieldEntry, FieldType, Schema};
 use tantivy::TantivyError;
-use tracing::{debug, info, info_span, instrument};
+use tracing::{debug, info_span, instrument};
 
 use crate::cluster_client::ClusterClient;
 use crate::collector::{make_merge_collector, QuickwitAggregations};
@@ -683,8 +684,42 @@ pub fn get_count_from_metadata(split_metadatas: &[SplitMetadata]) -> Vec<LeafSea
             num_attempted_splits: 1,
             num_successful_splits: 1,
             intermediate_aggregation_result: None,
+            resource_stats: None,
         })
         .collect()
+}
+
+/// Returns true if the query is particularly memory intensive.
+///
+/// This function only considers the memory usage associated to the input data
+/// and does not take in account aggregations (intermediary or not) results for instance.
+///
+/// Since its point is to log memory intensive queries, it focuses on the metric of the number of bytes per document.
+///
+/// The threshold is computed dynamically using gradient descent.
+fn is_top_1pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
+    // It is not worth considering small splits for this.
+    if split_num_docs < 100_000 {
+        return false;
+    }
+    // We multiply those figure by 1_000 for accuracy.
+    const PERCENTILE: u64 = 95;
+    const PRIOR_NUM_BYTES_PER_DOC: u64 = 3 * 1_000;
+    static NUM_BYTES_PER_DOC_95_PERCENTILE_ESTIMATOR: AtomicU64 = AtomicU64::new(PRIOR_NUM_BYTES_PER_DOC);
+    let num_bits_per_docs = num_bytes * 1_000 / split_num_docs;
+    let current_estimator = NUM_BYTES_PER_DOC_95_PERCENTILE_ESTIMATOR.load(Ordering::Relaxed);
+    let is_memory_intensive =  num_bits_per_docs > current_estimator;
+    let new_estimator: u64 = if is_memory_intensive {
+        current_estimator.saturating_add(PRIOR_NUM_BYTES_PER_DOC * PERCENTILE / 100)
+    } else {
+        current_estimator.saturating_sub(PRIOR_NUM_BYTES_PER_DOC * (100 - PERCENTILE) / 100)
+    };
+    // We do not use fetch_add / fetch_sub directly as they wrap around.
+    // Concurrency could lead to different results here, but really we don't care.
+    //
+    // This is just ignoring some gradient updates.
+    NUM_BYTES_PER_DOC_95_PERCENTILE_ESTIMATOR.store(new_estimator, Ordering::Relaxed);
+    is_memory_intensive
 }
 
 /// If this method fails for some splits, a partial search response is returned, with the list of
@@ -744,9 +779,18 @@ pub(crate) async fn search_partial_hits_phase(
         has_intermediate_aggregation_result = leaf_search_response.intermediate_aggregation_result.is_some(),
         "Merged leaf search response."
     );
+
+    if let Some(resource_stats) = &leaf_search_response.resource_stats {
+        if is_top_1pct_memory_intensive(resource_stats.short_lived_cache_num_bytes, resource_stats.split_num_docs) {
+            // We log at most 5 times per minute.
+            quickwit_common::rate_limited_info!(limit_per_min=5, split_num_docs=resource_stats.split_num_docs, %search_request.query_ast, short_lived_cached_num_bytes=resource_stats.short_lived_cache_num_bytes, query=%search_request.query_ast, "memory intensive query");
+        }
+    }
+
     if !leaf_search_response.failed_splits.is_empty() {
         quickwit_common::rate_limited_error!(limit_per_min=6, failed_splits = ?leaf_search_response.failed_splits, "leaf search response contains at least one failed split");
     }
+
     Ok(leaf_search_response)
 }
 
@@ -1107,14 +1151,13 @@ async fn refine_and_list_matches(
 /// 2. Merges the search results.
 /// 3. Sends fetch docs requests to multiple leaf nodes.
 /// 4. Builds the response with docs and returns.
-#[instrument(skip_all)]
+#[instrument(skip_all, fields(request_id))]
 pub async fn root_search(
     searcher_context: &SearcherContext,
     mut search_request: SearchRequest,
     mut metastore: MetastoreServiceClient,
     cluster_client: &ClusterClient,
 ) -> crate::Result<SearchResponse> {
-    info!(searcher_context = ?searcher_context, search_request = ?search_request);
     let start_instant = tokio::time::Instant::now();
     let list_indexes_metadatas_request = ListIndexesMetadataRequest {
         index_id_patterns: search_request.index_id_patterns.clone(),
@@ -1169,9 +1212,12 @@ pub async fn root_search(
     )
     .await;
 
+    let elapsed = start_instant.elapsed();
+
     if let Ok(search_response) = &mut search_response_result {
-        search_response.elapsed_time_micros = start_instant.elapsed().as_micros() as u64;
+        search_response.elapsed_time_micros = elapsed.as_micros() as u64;
     }
+
     let label_values = if search_response_result.is_ok() {
         ["success"]
     } else {

--- a/quickwit/quickwit-search/src/search_permit_provider.rs
+++ b/quickwit/quickwit-search/src/search_permit_provider.rs
@@ -209,6 +209,7 @@ impl SearchPermit {
         }
         let memory_delta = new_memory_usage as i64 - self.memory_allocation as i64;
         self.warmup_permit_held = false;
+        self.memory_allocation = new_memory_usage;
         self.send_if_still_running(SearchPermitMessage::WarmupCompleted { memory_delta });
     }
 

--- a/quickwit/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit/quickwit-search/src/search_stream/leaf.rs
@@ -29,7 +29,7 @@ use quickwit_proto::search::{
     LeafSearchStreamResponse, OutputFormat, SearchRequest, SearchStreamRequest,
     SplitIdAndFooterOffsets,
 };
-use quickwit_storage::Storage;
+use quickwit_storage::{ByteRangeCache, Storage};
 use tantivy::columnar::{DynamicColumn, HasAssociatedColumnType};
 use tantivy::fastfield::Column;
 use tantivy::query::Query;
@@ -127,12 +127,15 @@ async fn leaf_search_stream_single_split(
         &split,
     );
 
+    let cache =
+        ByteRangeCache::with_infinite_capacity(&quickwit_storage::STORAGE_METRICS.shortlived_cache);
+
     let index = open_index_with_caches(
         &searcher_context,
         storage,
         &split,
         Some(doc_mapper.tokenizer_manager()),
-        true,
+        Some(cache),
     )
     .await?;
     let split_schema = index.schema();

--- a/quickwit/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit/quickwit-search/src/search_stream/leaf.rs
@@ -127,8 +127,11 @@ async fn leaf_search_stream_single_split(
         &split,
     );
 
-    let cache =
-        ByteRangeCache::with_infinite_capacity(&quickwit_storage::STORAGE_METRICS.shortlived_cache);
+    let cache = ByteRangeCache::with_infinite_capacity(
+        &quickwit_storage::STORAGE_METRICS.shortlived_cache,
+        // should we not track the memory with a SearcherPermit?
+        (),
+    );
 
     let index = open_index_with_caches(
         &searcher_context,

--- a/quickwit/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit/quickwit-search/src/search_stream/leaf.rs
@@ -129,7 +129,7 @@ async fn leaf_search_stream_single_split(
 
     let cache =
         ByteRangeCache::with_infinite_capacity(&quickwit_storage::STORAGE_METRICS.shortlived_cache);
-    // TODO should create a SearchPermit we wrap with TrackedByteRangeCache here?
+    // TODO should create a SearchPermit and wrap ByteRangeCache with TrackedByteRangeCache here?
     let index = open_index_with_caches(
         &searcher_context,
         storage,

--- a/quickwit/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit/quickwit-search/src/search_stream/leaf.rs
@@ -127,18 +127,15 @@ async fn leaf_search_stream_single_split(
         &split,
     );
 
-    let cache = ByteRangeCache::with_infinite_capacity(
-        &quickwit_storage::STORAGE_METRICS.shortlived_cache,
-        // should we not track the memory with a SearcherPermit?
-        (),
-    );
-
+    let cache =
+        ByteRangeCache::with_infinite_capacity(&quickwit_storage::STORAGE_METRICS.shortlived_cache);
+    // TODO should create a SearchPermit we wrap with TrackedByteRangeCache here?
     let index = open_index_with_caches(
         &searcher_context,
         storage,
         &split,
         Some(doc_mapper.tokenizer_manager()),
-        Some(cache),
+        Some(Arc::new(cache)),
     )
     .await?;
     let split_schema = index.schema();

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -489,7 +489,7 @@ impl SearcherContext {
             &quickwit_storage::STORAGE_METRICS.split_footer_cache,
         );
         let leaf_search_split_semaphore =
-            SearchPermitProvider::new(searcher_config.max_num_concurrent_split_searches);
+            SearchPermitProvider::new(searcher_config.max_num_concurrent_split_searches, searcher_config.warmup_memory_budget, searcher_config.warmup_single_split_initial_allocation);
         let split_stream_semaphore =
             Semaphore::new(searcher_config.max_num_concurrent_split_streams);
         let fast_field_cache_capacity = searcher_config.fast_field_cache_capacity.as_u64() as usize;

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -488,8 +488,11 @@ impl SearcherContext {
             capacity_in_bytes,
             &quickwit_storage::STORAGE_METRICS.split_footer_cache,
         );
-        let leaf_search_split_semaphore =
-            SearchPermitProvider::new(searcher_config.max_num_concurrent_split_searches, searcher_config.warmup_memory_budget, searcher_config.warmup_single_split_initial_allocation);
+        let leaf_search_split_semaphore = SearchPermitProvider::new(
+            searcher_config.max_num_concurrent_split_searches,
+            searcher_config.warmup_memory_budget,
+            searcher_config.warmup_single_split_initial_allocation,
+        );
         let split_stream_semaphore =
             Semaphore::new(searcher_config.max_num_concurrent_split_streams);
         let fast_field_cache_capacity = searcher_config.fast_field_cache_capacity.as_u64() as usize;

--- a/quickwit/quickwit-search/src/tracked_cache.rs
+++ b/quickwit/quickwit-search/src/tracked_cache.rs
@@ -19,6 +19,7 @@
 
 use std::sync::{Arc, Mutex};
 
+use bytesize::ByteSize;
 use quickwit_directories::DirectoryCache;
 use quickwit_storage::ByteRangeCache;
 
@@ -50,7 +51,7 @@ impl TrackedByteRangeCache {
             .search_permit
             .lock()
             .unwrap()
-            .warmup_completed(self.get_num_bytes());
+            .warmup_completed(ByteSize(self.get_num_bytes()));
     }
 
     pub fn get_num_bytes(&self) -> u64 {

--- a/quickwit/quickwit-search/src/tracked_cache.rs
+++ b/quickwit/quickwit-search/src/tracked_cache.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2024 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::{Arc, Mutex};
+
+use quickwit_directories::DirectoryCache;
+use quickwit_storage::ByteRangeCache;
+
+use crate::search_permit_provider::SearchPermit;
+
+/// A [`ByteRangeCache`] tied to a [`SearchPermit`].
+#[derive(Clone)]
+pub struct TrackedByteRangeCache {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    cache: ByteRangeCache,
+    search_permit: Mutex<SearchPermit>,
+}
+
+impl TrackedByteRangeCache {
+    pub fn new(cache: ByteRangeCache, search_permit: SearchPermit) -> TrackedByteRangeCache {
+        TrackedByteRangeCache {
+            inner: Arc::new(Inner {
+                cache,
+                search_permit: Mutex::new(search_permit),
+            }),
+        }
+    }
+
+    pub fn warmup_completed(&self) {
+        self.inner
+            .search_permit
+            .lock()
+            .unwrap()
+            .warmup_completed(self.get_num_bytes());
+    }
+
+    pub fn get_num_bytes(&self) -> u64 {
+        self.inner.cache.get_num_bytes()
+    }
+}
+
+impl DirectoryCache for TrackedByteRangeCache {
+    fn get_slice(
+        &self,
+        path: &std::path::Path,
+        byte_range: std::ops::Range<usize>,
+    ) -> Option<quickwit_storage::OwnedBytes> {
+        self.inner.cache.get_slice(path, byte_range)
+    }
+    fn put_slice(
+        &self,
+        path: std::path::PathBuf,
+        byte_range: std::ops::Range<usize>,
+        bytes: quickwit_storage::OwnedBytes,
+    ) {
+        self.inner.cache.put_slice(path, byte_range, bytes)
+    }
+}

--- a/quickwit/quickwit-storage/src/cache/byte_range_cache.rs
+++ b/quickwit/quickwit-storage/src/cache/byte_range_cache.rs
@@ -21,7 +21,8 @@ use std::borrow::{Borrow, Cow};
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use tantivy::directory::OwnedBytes;
 
@@ -344,31 +345,54 @@ impl<T: 'static + ToOwned + ?Sized> Drop for NeedMutByteRangeCache<T> {
 /// cached data, the changes may or may not get recorded.
 ///
 /// At the moment this is hardly a cache as it features no eviction policy.
+#[derive(Clone)]
 pub struct ByteRangeCache {
-    inner: Mutex<NeedMutByteRangeCache<Path>>,
+    inner_arc: Arc<Inner>,
+}
+
+struct Inner {
+    num_stored_bytes: AtomicU64,
+    need_mut_byte_range_cache: Mutex<NeedMutByteRangeCache<Path>>,
 }
 
 impl ByteRangeCache {
     /// Creates a slice cache that never removes any entry.
     pub fn with_infinite_capacity(cache_counters: &'static CacheMetrics) -> Self {
+        let need_mut_byte_range_cache =
+            NeedMutByteRangeCache::with_infinite_capacity(cache_counters);
+        let inner = Inner {
+            num_stored_bytes: AtomicU64::default(),
+            need_mut_byte_range_cache: Mutex::new(need_mut_byte_range_cache),
+        };
         ByteRangeCache {
-            inner: Mutex::new(NeedMutByteRangeCache::with_infinite_capacity(
-                cache_counters,
-            )),
+            inner_arc: Arc::new(inner),
         }
+    }
+
+    /// Overall amount of bytes stored in the cache.
+    pub fn get_num_bytes(&self) -> u64 {
+        self.inner_arc.num_stored_bytes.load(Ordering::Relaxed)
     }
 
     /// If available, returns the cached view of the slice.
     pub fn get_slice(&self, path: &Path, byte_range: Range<usize>) -> Option<OwnedBytes> {
-        self.inner.lock().unwrap().get_slice(path, byte_range)
+        self.inner_arc
+            .need_mut_byte_range_cache
+            .lock()
+            .unwrap()
+            .get_slice(path, byte_range)
     }
 
     /// Put the given amount of data in the cache.
     pub fn put_slice(&self, path: PathBuf, byte_range: Range<usize>, bytes: OwnedBytes) {
-        self.inner
-            .lock()
-            .unwrap()
-            .put_slice(path, byte_range, bytes)
+        let mut need_mut_byte_range_cache_locked =
+            self.inner_arc.need_mut_byte_range_cache.lock().unwrap();
+        need_mut_byte_range_cache_locked.put_slice(path, byte_range, bytes);
+        let num_bytes = need_mut_byte_range_cache_locked.num_bytes;
+        drop(need_mut_byte_range_cache_locked);
+        self.inner_arc
+            .num_stored_bytes
+            .store(num_bytes as u64, Ordering::Relaxed);
     }
 }
 
@@ -446,13 +470,13 @@ mod tests {
                             .sum();
                         // in some case we have ranges touching each other, count_items count them
                         // as only one, but cache count them as 2.
-                        assert!(cache.inner.lock().unwrap().num_items >= expected_item_count as u64);
+                        assert!(cache.inner_arc.need_mut_byte_range_cache.lock().unwrap().num_items >= expected_item_count as u64);
 
                         let expected_byte_count = state.values()
                             .flatten()
                             .filter(|stored| **stored)
                             .count();
-                        assert_eq!(cache.inner.lock().unwrap().num_bytes, expected_byte_count as u64);
+                        assert_eq!(cache.inner_arc.need_mut_byte_range_cache.lock().unwrap().num_bytes, expected_byte_count as u64);
                     }
                     Operation::Get {
                         range,
@@ -519,7 +543,7 @@ mod tests {
         );
 
         {
-            let mutable_cache = cache.inner.lock().unwrap();
+            let mutable_cache = cache.inner_arc.need_mut_byte_range_cache.lock().unwrap();
             assert_eq!(mutable_cache.cache.len(), 4);
             assert_eq!(mutable_cache.num_items, 4);
             assert_eq!(mutable_cache.cache_counters.in_cache_count.get(), 4);
@@ -531,7 +555,7 @@ mod tests {
 
         {
             // now they should've been merged, except the last one
-            let mutable_cache = cache.inner.lock().unwrap();
+            let mutable_cache = cache.inner_arc.need_mut_byte_range_cache.lock().unwrap();
             assert_eq!(mutable_cache.cache.len(), 2);
             assert_eq!(mutable_cache.num_items, 2);
             assert_eq!(mutable_cache.cache_counters.in_cache_count.get(), 2);

--- a/quickwit/quickwit-storage/src/cache/byte_range_cache.rs
+++ b/quickwit/quickwit-storage/src/cache/byte_range_cache.rs
@@ -21,7 +21,6 @@ use std::borrow::{Borrow, Cow};
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tantivy::directory::OwnedBytes;
@@ -345,54 +344,69 @@ impl<T: 'static + ToOwned + ?Sized> Drop for NeedMutByteRangeCache<T> {
 /// cached data, the changes may or may not get recorded.
 ///
 /// At the moment this is hardly a cache as it features no eviction policy.
-#[derive(Clone)]
-pub struct ByteRangeCache {
-    inner_arc: Arc<Inner>,
+pub struct ByteRangeCache<T = ()> {
+    inner_arc: Arc<Mutex<Inner<T>>>,
 }
 
-struct Inner {
-    num_stored_bytes: AtomicU64,
-    need_mut_byte_range_cache: Mutex<NeedMutByteRangeCache<Path>>,
+struct Inner<T> {
+    need_mut_byte_range_cache: NeedMutByteRangeCache<Path>,
+    tracker: T,
 }
 
-impl ByteRangeCache {
+impl<T> Clone for ByteRangeCache<T> {
+    fn clone(&self) -> Self {
+        ByteRangeCache {
+            inner_arc: self.inner_arc.clone(),
+        }
+    }
+}
+
+impl<T> ByteRangeCache<T> {
     /// Creates a slice cache that never removes any entry.
-    pub fn with_infinite_capacity(cache_counters: &'static CacheMetrics) -> Self {
+    pub fn with_infinite_capacity(cache_counters: &'static CacheMetrics, tracker: T) -> Self {
         let need_mut_byte_range_cache =
             NeedMutByteRangeCache::with_infinite_capacity(cache_counters);
         let inner = Inner {
-            num_stored_bytes: AtomicU64::default(),
-            need_mut_byte_range_cache: Mutex::new(need_mut_byte_range_cache),
+            need_mut_byte_range_cache,
+            tracker,
         };
         ByteRangeCache {
-            inner_arc: Arc::new(inner),
+            inner_arc: Arc::new(Mutex::new(inner)),
         }
     }
 
     /// Overall amount of bytes stored in the cache.
     pub fn get_num_bytes(&self) -> u64 {
-        self.inner_arc.num_stored_bytes.load(Ordering::Relaxed)
+        self.inner_arc
+            .lock()
+            .unwrap()
+            .need_mut_byte_range_cache
+            .num_bytes
     }
 
     /// If available, returns the cached view of the slice.
     pub fn get_slice(&self, path: &Path, byte_range: Range<usize>) -> Option<OwnedBytes> {
         self.inner_arc
-            .need_mut_byte_range_cache
             .lock()
             .unwrap()
+            .need_mut_byte_range_cache
             .get_slice(path, byte_range)
     }
 
     /// Put the given amount of data in the cache.
     pub fn put_slice(&self, path: PathBuf, byte_range: Range<usize>, bytes: OwnedBytes) {
-        let mut need_mut_byte_range_cache_locked =
-            self.inner_arc.need_mut_byte_range_cache.lock().unwrap();
-        need_mut_byte_range_cache_locked.put_slice(path, byte_range, bytes);
-        let num_bytes = need_mut_byte_range_cache_locked.num_bytes;
-        drop(need_mut_byte_range_cache_locked);
-        self.inner_arc
-            .num_stored_bytes
-            .store(num_bytes as u64, Ordering::Relaxed);
+        let mut inner = self.inner_arc.lock().unwrap();
+        inner
+            .need_mut_byte_range_cache
+            .put_slice(path, byte_range, bytes);
+    }
+
+    /// Apply the provided action on the tracker.
+    ///
+    /// The action should not block for long.
+    pub fn track(&self, action: impl FnOnce(&mut T)) {
+        let mut inner = self.inner_arc.lock().unwrap();
+        action(&mut inner.tracker);
     }
 }
 
@@ -449,7 +463,7 @@ mod tests {
             state.insert("path1", vec![false; 12]);
             state.insert("path2", vec![false; 12]);
 
-            let cache = ByteRangeCache::with_infinite_capacity(&CACHE_METRICS_FOR_TESTS);
+            let cache = ByteRangeCache::with_infinite_capacity(&CACHE_METRICS_FOR_TESTS, ());
 
             for op in ops {
                 match op {
@@ -470,13 +484,13 @@ mod tests {
                             .sum();
                         // in some case we have ranges touching each other, count_items count them
                         // as only one, but cache count them as 2.
-                        assert!(cache.inner_arc.need_mut_byte_range_cache.lock().unwrap().num_items >= expected_item_count as u64);
+                        assert!(cache.inner_arc.lock().unwrap().need_mut_byte_range_cache.num_items >= expected_item_count as u64);
 
                         let expected_byte_count = state.values()
                             .flatten()
                             .filter(|stored| **stored)
                             .count();
-                        assert_eq!(cache.inner_arc.need_mut_byte_range_cache.lock().unwrap().num_bytes, expected_byte_count as u64);
+                        assert_eq!(cache.inner_arc.lock().unwrap().need_mut_byte_range_cache.num_bytes, expected_byte_count as u64);
                     }
                     Operation::Get {
                         range,
@@ -517,7 +531,7 @@ mod tests {
         static METRICS: Lazy<CacheMetrics> =
             Lazy::new(|| CacheMetrics::for_component("byterange_cache_test"));
 
-        let cache = ByteRangeCache::with_infinite_capacity(&METRICS);
+        let cache = ByteRangeCache::with_infinite_capacity(&METRICS, ());
 
         let key: std::path::PathBuf = "key".into();
 
@@ -543,7 +557,7 @@ mod tests {
         );
 
         {
-            let mutable_cache = cache.inner_arc.need_mut_byte_range_cache.lock().unwrap();
+            let mutable_cache = &cache.inner_arc.lock().unwrap().need_mut_byte_range_cache;
             assert_eq!(mutable_cache.cache.len(), 4);
             assert_eq!(mutable_cache.num_items, 4);
             assert_eq!(mutable_cache.cache_counters.in_cache_count.get(), 4);
@@ -555,7 +569,7 @@ mod tests {
 
         {
             // now they should've been merged, except the last one
-            let mutable_cache = cache.inner_arc.need_mut_byte_range_cache.lock().unwrap();
+            let mutable_cache = &cache.inner_arc.lock().unwrap().need_mut_byte_range_cache;
             assert_eq!(mutable_cache.cache.len(), 2);
             assert_eq!(mutable_cache.num_items, 2);
             assert_eq!(mutable_cache.cache_counters.in_cache_count.get(), 2);

--- a/quickwit/quickwit-storage/src/cache/byte_range_cache.rs
+++ b/quickwit/quickwit-storage/src/cache/byte_range_cache.rs
@@ -377,8 +377,7 @@ impl ByteRangeCache {
         need_mut_byte_range_cache_locked.put_slice(path, byte_range, bytes);
         let num_bytes = need_mut_byte_range_cache_locked.num_bytes;
         drop(need_mut_byte_range_cache_locked);
-        self.num_stored_bytes
-            .store(num_bytes as u64, Ordering::Relaxed);
+        self.num_stored_bytes.store(num_bytes, Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
We also measure the amount of memory taken by a split search, and log this.
