### PR TITLE
Parallelize S3 delete objects requests

### DIFF
--- a/quickwit/quickwit-storage/src/error.rs
+++ b/quickwit/quickwit-storage/src/error.rs
@@ -193,7 +193,7 @@ impl fmt::Display for BulkDeleteError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "bulk delete error ({} success(es),  {} failure(s), {} unattempted)",
+            "bulk delete error ({} success(es), {} failure(s), {} unattempted)",
             self.successes.len(),
             self.failures.len(),
             self.unattempted.len()


### PR DESCRIPTION
### Description
Parallelize S3 delete objects requests

### How was this PR tested?
Ran `quickwit-storage` test suite locally.
