### PR TITLE
box warp routes

### DIFF
--- a/quickwit/quickwit-codegen/example/src/lib.rs
+++ b/quickwit/quickwit-codegen/example/src/lib.rs
@@ -62,6 +62,7 @@ where S: Service<R>
 }
 
 #[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
 struct CounterLayer {
     counter: Arc<AtomicUsize>,
 }
@@ -77,6 +78,7 @@ impl<S> Layer<S> for CounterLayer {
     }
 }
 
+#[allow(dead_code)]
 fn spawn_ping_response_stream(
     mut request_stream: ServiceStream<PingRequest>,
 ) -> ServiceStream<HelloResult<PingResponse>> {
@@ -114,6 +116,7 @@ fn spawn_ping_response_stream(
 }
 
 #[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
 struct HelloImpl {
     delay: Duration,
 }

--- a/quickwit/quickwit-serve/src/cluster_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/cluster_api/rest_handler.rs
@@ -45,6 +45,7 @@ pub fn cluster_handler(
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
         .recover(recover_fn)
+        .boxed()
 }
 
 #[utoipa::path(

--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -65,6 +65,7 @@ pub fn delete_task_api_handlers(
     get_delete_tasks_handler(metastore.clone())
         .or(post_delete_tasks_handler(metastore.clone()))
         .recover(recover_fn)
+        .boxed()
 }
 
 pub fn get_delete_tasks_handler(

--- a/quickwit/quickwit-serve/src/developer_api/mod.rs
+++ b/quickwit/quickwit-serve/src/developer_api/mod.rs
@@ -46,7 +46,7 @@ pub(crate) fn developer_api_routes(
     warp::path!("api" / "developer" / ..)
         .and(
             debug_handler(cluster.clone())
-                .or(log_level_handler(env_filter_reload_fn.clone()))
+                .or(log_level_handler(env_filter_reload_fn.clone()).boxed())
                 .or(pprof_handlers()),
         )
         .recover(recover_fn)

--- a/quickwit/quickwit-serve/src/elasticsearch_api/bulk.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/bulk.rs
@@ -76,6 +76,7 @@ pub fn es_compat_index_bulk_handler(
         .and(extract_format_from_qs())
         .map(make_elastic_api_response)
         .recover(recover_fn)
+        .boxed()
 }
 
 async fn elastic_ingest_bulk(

--- a/quickwit/quickwit-serve/src/elasticsearch_api/mod.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/mod.rs
@@ -67,6 +67,7 @@ pub fn elastic_api_handlers(
             ingest_service.clone(),
             ingest_router.clone(),
         ))
+        .boxed()
         .or(es_compat_index_bulk_handler(ingest_service, ingest_router))
         .or(es_compat_index_search_handler(search_service.clone()))
         .or(es_compat_index_count_handler(search_service.clone()))
@@ -75,6 +76,7 @@ pub fn elastic_api_handlers(
         .or(es_compat_index_field_capabilities_handler(
             search_service.clone(),
         ))
+        .boxed()
         .or(es_compat_index_stats_handler(metastore.clone()))
         .or(es_compat_delete_index_handler(index_service))
         .or(es_compat_stats_handler(metastore.clone()))
@@ -82,6 +84,7 @@ pub fn elastic_api_handlers(
         .or(es_compat_cat_indices_handler(metastore.clone()))
         .or(es_compat_resolve_index_handler(metastore.clone()))
         .recover(recover_fn)
+        .boxed()
     // Register newly created handlers here.
 }
 

--- a/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
@@ -90,6 +90,7 @@ pub fn es_compat_cluster_info_handler(
                 }))
             },
         )
+        .boxed()
 }
 
 /// GET or POST _elastic/_search
@@ -135,6 +136,7 @@ pub fn es_compat_delete_index_handler(
         .and(with_arg(index_service))
         .then(es_compat_delete_index)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
+        .boxed()
 }
 
 /// GET _elastic/_stats
@@ -146,6 +148,7 @@ pub fn es_compat_stats_handler(
         .then(es_compat_stats)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+        .boxed()
 }
 
 /// GET _elastic/{index}/_stats
@@ -157,6 +160,7 @@ pub fn es_compat_index_stats_handler(
         .then(es_compat_index_stats)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+        .boxed()
 }
 
 /// GET _elastic/_cat/indices
@@ -168,6 +172,7 @@ pub fn es_compat_cat_indices_handler(
         .then(es_compat_cat_indices)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+        .boxed()
 }
 
 /// GET _elastic/_cat/indices/{index}
@@ -179,6 +184,7 @@ pub fn es_compat_index_cat_indices_handler(
         .then(es_compat_index_cat_indices)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+        .boxed()
 }
 
 /// GET  _elastic/_resolve/index/{index}
@@ -189,6 +195,7 @@ pub fn es_compat_resolve_index_handler(
         .and(with_arg(metastore_service))
         .then(es_compat_resolve_index)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
+        .boxed()
 }
 
 /// GET or POST _elastic/{index}/_search
@@ -200,6 +207,7 @@ pub fn es_compat_index_search_handler(
         .then(es_compat_index_search)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+        .boxed()
 }
 
 /// GET or POST _elastic/{index}/_count
@@ -211,6 +219,7 @@ pub fn es_compat_index_count_handler(
         .then(es_compat_index_count)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+        .boxed()
 }
 
 /// POST _elastic/_msearch
@@ -228,6 +237,7 @@ pub fn es_compat_index_multi_search_handler(
             RestApiResponse::new(&result, status_code, BodyFormat::default())
         })
         .recover(recover_fn)
+        .boxed()
 }
 
 /// GET or POST _elastic/_search/scroll
@@ -239,6 +249,7 @@ pub fn es_compat_scroll_handler(
         .then(es_scroll)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+        .boxed()
 }
 
 fn build_request_for_es_api(

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -95,10 +95,12 @@ pub fn index_management_handlers(
         .or(update_index_handler(index_service.metastore()))
         .or(clear_index_handler(index_service.clone()))
         .or(delete_index_handler(index_service.clone()))
+        .boxed()
         // Splits handlers
         .or(list_splits_handler(index_service.metastore()))
         .or(describe_index_handler(index_service.metastore()))
         .or(mark_splits_for_deletion_handler(index_service.metastore()))
+        .boxed()
         // Sources handlers.
         .or(reset_source_checkpoint_handler(index_service.metastore()))
         .or(toggle_source_handler(index_service.metastore()))
@@ -106,11 +108,13 @@ pub fn index_management_handlers(
         .or(get_source_handler(index_service.metastore()))
         .or(delete_source_handler(index_service.metastore()))
         .or(get_source_shards_handler(index_service.metastore()))
+        .boxed()
         // Tokenizer handlers.
         .or(analyze_request_handler())
         // Parse query into query AST handler.
         .or(parse_query_request_handler())
         .recover(recover_fn)
+        .boxed()
 }
 
 fn json_body<T: DeserializeOwned + Send>(
@@ -127,6 +131,7 @@ pub fn get_index_metadata_handler(
         .then(get_index_metadata)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 async fn get_index_metadata(
@@ -163,6 +168,7 @@ fn list_indexes_metadata_handler(
         .then(list_indexes_metadata)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 /// Describes an index with its main information and statistics.
@@ -260,6 +266,7 @@ fn describe_index_handler(
         .then(describe_index)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 /// This struct represents the QueryString passed to
@@ -377,6 +384,7 @@ fn list_splits_handler(
         .then(list_splits)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[derive(Deserialize, utoipa::ToSchema)]
@@ -433,6 +441,7 @@ fn mark_splits_for_deletion_handler(
         .then(mark_splits_for_deletion)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -496,6 +505,7 @@ fn create_index_handler(
         .map(log_failure("failed to create index"))
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -544,6 +554,7 @@ fn update_index_handler(
         .map(log_failure("failed to update index"))
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -606,6 +617,7 @@ fn clear_index_handler(
         .then(clear_index)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -646,6 +658,7 @@ fn delete_index_handler(
         .then(delete_index)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -686,6 +699,7 @@ fn create_source_handler(
         .map(log_failure("failed to create source"))
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -741,6 +755,7 @@ fn get_source_handler(
         .then(get_source)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 async fn get_source(
@@ -774,6 +789,7 @@ fn reset_source_checkpoint_handler(
         .then(reset_source_checkpoint)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -821,6 +837,7 @@ fn toggle_source_handler(
         .then(toggle_source)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[derive(Deserialize, utoipa::ToSchema)]
@@ -880,6 +897,7 @@ fn delete_source_handler(
         .then(delete_source)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[utoipa::path(
@@ -930,6 +948,7 @@ fn get_source_shards_handler(
         .then(get_source_shards)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 async fn get_source_shards(
@@ -982,6 +1001,7 @@ fn analyze_request_handler() -> impl Filter<Extract = (impl warp::Reply,), Error
         .then(analyze_request)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 /// Analyzes text with given tokenizer config and returns the list of tokens.
@@ -1027,6 +1047,7 @@ fn parse_query_request_handler(
         .then(parse_query_request)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 /// Analyzes text with given tokenizer config and returns the list of tokens.

--- a/quickwit/quickwit-serve/src/indexing_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/indexing_api/rest_handler.rs
@@ -62,4 +62,5 @@ pub fn indexing_get_handler(
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
         .recover(recover_fn)
+        .boxed()
 }

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -72,6 +72,7 @@ pub(crate) fn ingest_api_handlers(
     ingest_handler(ingest_service.clone(), config.clone())
         .or(tail_handler(ingest_service))
         .or(ingest_v2_handler(ingest_router, config))
+        .boxed()
 }
 
 fn ingest_filter(
@@ -96,6 +97,7 @@ fn ingest_handler(
         .and(with_arg(ingest_service))
         .then(ingest)
         .map(|result| into_rest_api_response(result, BodyFormat::default()))
+        .boxed()
 }
 
 fn ingest_v2_filter(
@@ -121,6 +123,7 @@ fn ingest_v2_handler(
         .then(ingest_v2)
         .and(with_arg(BodyFormat::default()))
         .map(into_rest_api_response)
+        .boxed()
 }
 
 async fn ingest_v2(
@@ -223,6 +226,7 @@ pub fn tail_handler(
         .then(tail_endpoint)
         .and(extract_format_from_qs())
         .map(into_rest_api_response)
+        .boxed()
 }
 
 fn tail_filter() -> impl Filter<Extract = (String,), Error = Rejection> + Clone {

--- a/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
@@ -68,6 +68,7 @@ pub(crate) fn jaeger_api_handlers(
         .or(jaeger_traces_search_handler(jaeger_service_opt.clone()))
         .or(jaeger_traces_handler(jaeger_service_opt.clone()))
         .recover(recover_fn)
+        .boxed()
 }
 
 fn jaeger_api_path_filter() -> impl Filter<Extract = (Vec<String>,), Error = Rejection> + Clone {

--- a/quickwit/quickwit-serve/src/node_info_handler.rs
+++ b/quickwit/quickwit-serve/src/node_info_handler.rs
@@ -38,6 +38,7 @@ pub fn node_info_handler(
     node_version_handler(build_info, runtime_info)
         .or(node_config_handler(config))
         .recover(recover_fn)
+        .boxed()
 }
 
 #[utoipa::path(get, tag = "Node Info", path = "/version")]

--- a/quickwit/quickwit-serve/src/otlp_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/otlp_api/rest_handler.rs
@@ -56,6 +56,7 @@ pub(crate) fn otlp_ingest_api_handlers(
         .or(otlp_default_traces_handler(otlp_traces_service.clone()).recover(recover_fn))
         .or(otlp_logs_handler(otlp_logs_service).recover(recover_fn))
         .or(otlp_ingest_traces_handler(otlp_traces_service).recover(recover_fn))
+        .boxed()
 }
 
 /// Open Telemetry REST/Protobuf logs ingest endpoint.
@@ -91,6 +92,7 @@ pub(crate) fn otlp_default_logs_handler(
         )
         .and(with_arg(BodyFormat::default()))
         .map(into_rest_api_response)
+        .boxed()
 }
 /// Open Telemetry REST/Protobuf logs ingest endpoint.
 #[utoipa::path(
@@ -116,6 +118,7 @@ pub(crate) fn otlp_logs_handler(
         .then(otlp_ingest_logs)
         .and(with_arg(BodyFormat::default()))
         .map(into_rest_api_response)
+        .boxed()
 }
 
 /// Open Telemetry REST/Protobuf traces ingest endpoint.
@@ -151,6 +154,7 @@ pub(crate) fn otlp_default_traces_handler(
         )
         .and(with_arg(BodyFormat::default()))
         .map(into_rest_api_response)
+        .boxed()
 }
 /// Open Telemetry REST/Protobuf traces ingest endpoint.
 #[utoipa::path(
@@ -176,6 +180,7 @@ pub(crate) fn otlp_ingest_traces_handler(
         .then(otlp_ingest_traces)
         .and(with_arg(BodyFormat::default()))
         .map(into_rest_api_response)
+        .boxed()
 }
 
 #[derive(Debug, Clone, thiserror::Error, Serialize)]

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -145,33 +145,38 @@ pub(crate) async fn start_rest_server(
     let api_doc = warp::path("openapi.json")
         .and(warp::get())
         .map(|| warp::reply::json(&crate::openapi::build_docs()))
-        .recover(recover_fn);
+        .recover(recover_fn)
+        .boxed();
 
     // `/health/*` routes.
     let health_check_routes = health_check_handlers(
         quickwit_services.cluster.clone(),
         quickwit_services.indexing_service_opt.clone(),
         quickwit_services.janitor_service_opt.clone(),
-    );
+    )
+    .boxed();
 
     // `/metrics` route.
     let metrics_routes = warp::path("metrics")
         .and(warp::get())
         .map(metrics_handler)
-        .recover(recover_fn);
+        .recover(recover_fn)
+        .boxed();
 
     // `/api/developer/*` route.
     let developer_routes = developer_api_routes(
         quickwit_services.cluster.clone(),
         quickwit_services.env_filter_reload_fn.clone(),
-    );
+    )
+    .boxed();
     // `/api/v1/*` routes.
     let api_v1_root_route = api_v1_routes(quickwit_services.clone());
 
     let redirect_root_to_ui_route = warp::path::end()
         .and(warp::get())
         .map(|| redirect(http::Uri::from_static("/ui/search")))
-        .recover(recover_fn);
+        .recover(recover_fn)
+        .boxed();
 
     let extra_headers = warp::reply::with::headers(
         quickwit_services
@@ -243,6 +248,7 @@ fn search_routes(
         .or(search_plan_post_handler(search_service.clone()))
         .or(search_stream_handler(search_service))
         .recover(recover_fn)
+        .boxed()
 }
 
 fn api_v1_routes(
@@ -259,37 +265,47 @@ fn api_v1_routes(
             quickwit_services.index_manager.clone(),
         )
         .or(cluster_handler(quickwit_services.cluster.clone()))
+        .boxed()
         .or(node_info_handler(
             BuildInfo::get(),
             RuntimeInfo::get(),
             quickwit_services.node_config.clone(),
         ))
+        .boxed()
         .or(indexing_get_handler(
             quickwit_services.indexing_service_opt.clone(),
         ))
+        .boxed()
         .or(search_routes(quickwit_services.search_service.clone()))
+        .boxed()
         .or(ingest_api_handlers(
             quickwit_services.ingest_router_service.clone(),
             quickwit_services.ingest_service.clone(),
             quickwit_services.node_config.ingest_api_config.clone(),
         ))
+        .boxed()
         .or(otlp_ingest_api_handlers(
             quickwit_services.otlp_logs_service_opt.clone(),
             quickwit_services.otlp_traces_service_opt.clone(),
         ))
+        .boxed()
         .or(index_management_handlers(
             quickwit_services.index_manager.clone(),
             quickwit_services.node_config.clone(),
         ))
+        .boxed()
         .or(delete_task_api_handlers(
             quickwit_services.metastore_client.clone(),
         ))
+        .boxed()
         .or(jaeger_api_handlers(
             quickwit_services.jaeger_service_opt.clone(),
         ))
+        .boxed()
         .or(index_template_api_handlers(
             quickwit_services.metastore_client.clone(),
-        )),
+        ))
+        .boxed(),
     )
 }
 

--- a/quickwit/quickwit-serve/src/template_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/template_api/rest_handler.rs
@@ -57,6 +57,7 @@ pub(crate) fn index_template_api_handlers(
         .or(delete_index_template_handler(metastore.clone()))
         .or(list_index_templates_handler(metastore.clone()))
         .recover(recover_fn)
+        .boxed()
 }
 
 fn create_index_template_handler(

--- a/quickwit/quickwit-serve/src/ui_handler.rs
+++ b/quickwit/quickwit-serve/src/ui_handler.rs
@@ -43,6 +43,7 @@ pub fn ui_handler() -> impl Filter<Extract = (impl warp::Reply,), Error = Reject
         .and(warp::path::tail())
         .and_then(serve_file)
         .recover(recover_fn)
+        .boxed()
 }
 
 async fn serve_file(path: Tail) -> Result<impl warp::Reply, Rejection> {

--- a/quickwit/rust-toolchain.toml
+++ b/quickwit/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78"
+channel = "1.81"
 components = ["cargo", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
box warp routes to avoid super heavy types.
Performance impact should be okay, since these heavy types
are not cache friendly.


This reduces type complexity significantly, but some really long type chains remain.
I've identified two, but they may be more
1. Boxed or chains
2. Response type chains

We can replace the boxed or chains with a Vec, since they all contain the same
box type now. Such a type doesn't seem to exist in warp yet.

`cargo install --path .`
Compile time before
4m49s
Compile time now
4m14s

Tool to list heavy functions:
`
CARGO_PROFILE_RELEASE_LTO=fat cargo llvm-lines --release --bin quickwit > llvm_lines
`
Size down from 32MB to 22MB


update rust tool chain to 1.81 to fix compilation error (https://github.com/servo/rust-url/issues/992)

addresses #5539
