### PR TITLE
send extended_bounds in ms

### DIFF
--- a/quickwit/quickwit-ui/src/services/client.ts
+++ b/quickwit/quickwit-ui/src/services/client.ts
@@ -156,9 +156,10 @@ export class Client {
       const interval = histogram.interval
       let extended_bounds;
       if (request.startTimestamp && request.endTimestamp) {
+	// extended_bounds are ms
         extended_bounds = {
-          min: request.startTimestamp,
-          max: request.endTimestamp,
+          min: request.startTimestamp * 1000,
+          max: request.endTimestamp * 1000,
         };
       } else {
         extended_bounds = undefined;


### PR DESCRIPTION
### Description

send extended_bounds as ms from quickwit ui, otherwise we get graphs starting in 1970

### How was this PR tested?

tested manually by using the histogram aggregation ui while setting time bounds