### PR TITLE
Fix krb5 transitive dependency cross build

### DIFF
--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -43,10 +43,6 @@ runs:
         QW_COMMIT_DATE: ${{ env.QW_COMMIT_DATE }}
         QW_COMMIT_HASH: ${{ env.QW_COMMIT_HASH }}
         QW_COMMIT_TAGS: ${{ env.QW_COMMIT_TAGS }}
-        # Fix build for transitive dependency rdkafka -> rdkafka-sys -> sasl2-sys -> krb5-src
-        KRB5_CV_ATTR_CONSTRUCTOR_DESTRUCTOR: yes
-        AC_CV_FUNC_REGCOMP: yes
-        AC_CV_PRINTF_POSITIONAL: yes
       working-directory: ./quickwit
     - name: Bundle archive
       run: |

--- a/.github/actions/cross-build-binary/action.yml
+++ b/.github/actions/cross-build-binary/action.yml
@@ -43,7 +43,10 @@ runs:
         QW_COMMIT_DATE: ${{ env.QW_COMMIT_DATE }}
         QW_COMMIT_HASH: ${{ env.QW_COMMIT_HASH }}
         QW_COMMIT_TAGS: ${{ env.QW_COMMIT_TAGS }}
-
+        # Fix build for transitive dependency rdkafka -> rdkafka-sys -> sasl2-sys -> krb5-src
+        KRB5_CV_ATTR_CONSTRUCTOR_DESTRUCTOR: yes
+        AC_CV_FUNC_REGCOMP: yes
+        AC_CV_PRINTF_POSITIONAL: yes
       working-directory: ./quickwit
     - name: Bundle archive
       run: |

--- a/quickwit/Cross.toml
+++ b/quickwit/Cross.toml
@@ -17,7 +17,11 @@ image = "quickwit/cross:aarch64-unknown-linux-gnu"
 [target.aarch64-unknown-linux-gnu.env]
 # Fix build for transitive dependency rdkafka -> rdkafka-sys -> sasl2-sys -> krb5-src
 # Introduced by https://github.com/MaterializeInc/rust-krb5-src/pull/27
-passthrough = ["KRB5_CV_ATTR_CONSTRUCTOR_DESTRUCTOR=yes", "AC_CV_FUNC_REGCOMP=yes", "AC_CV_PRINTF_POSITIONAL=yes"]
+passthrough = [
+    "krb5_cv_attr_constructor_destructor=yes",
+    "ac_cv_func_regcomp=yes",
+    "ac_cv_printf_positional=yes",
+]
 
 [target.aarch64-unknown-linux-musl]
 image = "quickwit/cross:aarch64-unknown-linux-musl"

--- a/quickwit/Cross.toml
+++ b/quickwit/Cross.toml
@@ -10,7 +10,6 @@ image = "quickwit/cross:x86_64-unknown-linux-gnu"
 
 [target.x86_64-unknown-linux-musl]
 image = "quickwit/cross:x86_64-unknown-linux-musl"
-RUSTFLAGS="LIB_LDFLAGS=-L/usr/lib/x86_64-linux-gnu CFLAGS=-I/usr/local/musl/include CC=musl-gcc"
 
 [target.aarch64-unknown-linux-gnu]
 image = "quickwit/cross:aarch64-unknown-linux-gnu"
@@ -22,4 +21,3 @@ passthrough = ["KRB5_CV_ATTR_CONSTRUCTOR_DESTRUCTOR=yes", "AC_CV_FUNC_REGCOMP=ye
 
 [target.aarch64-unknown-linux-musl]
 image = "quickwit/cross:aarch64-unknown-linux-musl"
-linker = "aarch64-linux-musl-gcc"

--- a/quickwit/Cross.toml
+++ b/quickwit/Cross.toml
@@ -18,3 +18,7 @@ image = "quickwit/cross:aarch64-unknown-linux-gnu"
 [target.aarch64-unknown-linux-musl]
 image = "quickwit/cross:aarch64-unknown-linux-musl"
 linker = "aarch64-linux-musl-gcc"
+
+[target.aarch64-unknown-linux-musl.env]
+# Fix build for transitive dependency rdkafka -> rdkafka-sys -> sasl2-sys -> krb5-src
+passthrough = ["KRB5_CV_ATTR_CONSTRUCTOR_DESTRUCTOR=yes", "AC_CV_FUNC_REGCOMP=yes", "AC_CV_PRINTF_POSITIONAL=yes"]

--- a/quickwit/Cross.toml
+++ b/quickwit/Cross.toml
@@ -15,10 +15,11 @@ RUSTFLAGS="LIB_LDFLAGS=-L/usr/lib/x86_64-linux-gnu CFLAGS=-I/usr/local/musl/incl
 [target.aarch64-unknown-linux-gnu]
 image = "quickwit/cross:aarch64-unknown-linux-gnu"
 
+[target.aarch64-unknown-linux-gnu.env]
+# Fix build for transitive dependency rdkafka -> rdkafka-sys -> sasl2-sys -> krb5-src
+# Introduced by https://github.com/MaterializeInc/rust-krb5-src/pull/27
+passthrough = ["KRB5_CV_ATTR_CONSTRUCTOR_DESTRUCTOR=yes", "AC_CV_FUNC_REGCOMP=yes", "AC_CV_PRINTF_POSITIONAL=yes"]
+
 [target.aarch64-unknown-linux-musl]
 image = "quickwit/cross:aarch64-unknown-linux-musl"
 linker = "aarch64-linux-musl-gcc"
-
-[target.aarch64-unknown-linux-musl.env]
-# Fix build for transitive dependency rdkafka -> rdkafka-sys -> sasl2-sys -> krb5-src
-passthrough = ["KRB5_CV_ATTR_CONSTRUCTOR_DESTRUCTOR=yes", "AC_CV_FUNC_REGCOMP=yes", "AC_CV_PRINTF_POSITIONAL=yes"]


### PR DESCRIPTION
### Description

Current nightly builds are failing on ARM because of the transitive dep krb5-sys (imported by rdkafka SASL)

The issue started after https://github.com/quickwit-oss/quickwit/pull/5486 which upgraded the krb5-sys, in which https://github.com/MaterializeInc/rust-krb5-src/pull/27 somehow broke the cross build instead of fixing it.

### How was this PR tested?

Describe how you tested this PR.
