### PR TITLE
fix failing tests after rustc and serde update

### DIFF
--- a/quickwit/quickwit-common/src/rendezvous_hasher.rs
+++ b/quickwit/quickwit-common/src/rendezvous_hasher.rs
@@ -64,7 +64,7 @@ mod tests {
         let mut socket_set3 = vec![socket1, socket4];
         sort_by_rendez_vous_hash(&mut socket_set3, "key");
 
-        assert_eq!(socket_set1, &[socket1, socket2, socket3, socket4]);
+        assert_eq!(socket_set1, &[socket1, socket3, socket2, socket4]);
         assert_eq!(socket_set2, &[socket1, socket2, socket4]);
         assert_eq!(socket_set3, &[socket1, socket4]);
     }

--- a/quickwit/quickwit-search/src/cluster_client.rs
+++ b/quickwit/quickwit-search/src/cluster_client.rs
@@ -746,30 +746,30 @@ mod tests {
     #[tokio::test]
     async fn test_put_kv_happy_path() {
         // 3 servers 1, 2, 3
-        // Targeted key has affinity [2, 3, 1].
+        // Targeted key has affinity [3, 2, 1].
         //
         // Put on 2 and 3 is successful
-        // Get succeeds on 2.
+        // Get succeeds on 3.
         let mock_search_service_1 = MockSearchService::new();
         let mut mock_search_service_2 = MockSearchService::new();
-        mock_search_service_2.expect_put_kv().once().returning(
+        // Due to the buffered call it is possible for the
+        // put request to 2 to be emitted too.
+        mock_search_service_2
+            .expect_put_kv()
+            .returning(|_put_req: quickwit_proto::search::PutKvRequest| {});
+        let mut mock_search_service_3 = MockSearchService::new();
+        mock_search_service_3.expect_put_kv().once().returning(
             |put_req: quickwit_proto::search::PutKvRequest| {
                 assert_eq!(put_req.key, b"my_key");
                 assert_eq!(put_req.payload, b"my_payload");
             },
         );
-        mock_search_service_2.expect_get_kv().once().returning(
+        mock_search_service_3.expect_get_kv().once().returning(
             |get_req: quickwit_proto::search::GetKvRequest| {
                 assert_eq!(get_req.key, b"my_key");
                 Some(b"my_payload".to_vec())
             },
         );
-        let mut mock_search_service_3 = MockSearchService::new();
-        // Due to the buffered call it is possible for the
-        // put request to 3 to be emitted too.
-        mock_search_service_3
-            .expect_put_kv()
-            .returning(|_put_req: quickwit_proto::search::PutKvRequest| {});
         let searcher_pool = searcher_pool_for_test([
             ("127.0.0.1:1001", mock_search_service_1),
             ("127.0.0.1:1002", mock_search_service_2),
@@ -791,11 +791,11 @@ mod tests {
     #[tokio::test]
     async fn test_put_kv_failing_get() {
         // 3 servers 1, 2, 3
-        // Targeted key has affinity [2, 3, 1].
+        // Targeted key has affinity [3, 2, 1].
         //
         // Put on 2 and 3 is successful
-        // Get fails on 2.
-        // Get succeeds on 3.
+        // Get fails on 3.
+        // Get succeeds on 2.
         let mock_search_service_1 = MockSearchService::new();
         let mut mock_search_service_2 = MockSearchService::new();
         mock_search_service_2.expect_put_kv().once().returning(
@@ -807,7 +807,7 @@ mod tests {
         mock_search_service_2.expect_get_kv().once().returning(
             |get_req: quickwit_proto::search::GetKvRequest| {
                 assert_eq!(get_req.key, b"my_key");
-                None
+                Some(b"my_payload".to_vec())
             },
         );
         let mut mock_search_service_3 = MockSearchService::new();
@@ -820,7 +820,7 @@ mod tests {
         mock_search_service_3.expect_get_kv().once().returning(
             |get_req: quickwit_proto::search::GetKvRequest| {
                 assert_eq!(get_req.key, b"my_key");
-                Some(b"my_payload".to_vec())
+                None
             },
         );
         let searcher_pool = searcher_pool_for_test([

--- a/quickwit/quickwit-search/src/search_job_placer.rs
+++ b/quickwit/quickwit-search/src/search_job_placer.rs
@@ -427,21 +427,22 @@ mod tests {
 
             let expected_searcher_addr_1: SocketAddr = ([127, 0, 0, 1], 1001).into();
             let expected_searcher_addr_2: SocketAddr = ([127, 0, 0, 1], 1002).into();
+            // on a small number of splits, we may be unbalanced
             let expected_assigned_jobs = vec![
                 (
                     expected_searcher_addr_1,
                     vec![
-                        SearchJob::for_test("split5", 5),
-                        SearchJob::for_test("split4", 4),
                         SearchJob::for_test("split3", 3),
+                        SearchJob::for_test("split2", 2),
+                        SearchJob::for_test("split1", 1),
                     ],
                 ),
                 (
                     expected_searcher_addr_2,
                     vec![
                         SearchJob::for_test("split6", 6),
-                        SearchJob::for_test("split2", 2),
-                        SearchJob::for_test("split1", 1),
+                        SearchJob::for_test("split5", 5),
+                        SearchJob::for_test("split4", 4),
                     ],
                 ),
             ];

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/bulk_query_params.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/bulk_query_params.rs
@@ -114,7 +114,7 @@ mod tests {
             serde_qs::from_str::<ElasticBulkOptions>("refresh=wait")
                 .unwrap_err()
                 .to_string(),
-            "unknown variant `wait`, expected one of `false`, `true`, `wait_for`"
+            "unknown variant `wait`, expected one of `false`, ``, `true`, `wait_for`"
         );
     }
 }


### PR DESCRIPTION
### Description

fix https://github.com/quickwit-oss/quickwit/issues/5563
Hash for IpAddr changed with 1.82, update tests relying on the order of Hash (consistent hashing stuff) to take that into account
serde error message changed slightly, fix that too

### How was this PR tested?

`cargo nextest run`