### PR TITLE
Return 429 on ES API when no shards available

### DIFF
--- a/quickwit/quickwit-serve/src/elasticsearch_api/bulk_v2.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/bulk_v2.rs
@@ -273,6 +273,11 @@ fn make_elastic_bulk_response_v2(
                 format!("shard rate limiting [{}]", failure.index_id),
                 StatusCode::TOO_MANY_REQUESTS,
             ),
+            IngestFailureReason::NoShardsAvailable => (
+                ElasticException::RateLimited,
+                format!("no shards available [{}]", failure.index_id),
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
             reason => {
                 let pretty_reason = reason
                     .as_str_name()


### PR DESCRIPTION
### Description

Closes https://github.com/quickwit-oss/quickwit/issues/5565

### How was this PR tested?

N/A
