### PR TITLE
Error when updating nested dynamic mapping to primitive explicit

### DIFF
--- a/quickwit/quickwit-integration-tests/src/tests/update_tests/doc_mapping_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/update_tests/doc_mapping_tests.rs
@@ -546,6 +546,38 @@ async fn test_update_doc_mapping_dynamic_to_strict() {
 }
 
 #[tokio::test]
+async fn test_update_doc_mapping_dynamic_to_strict_with_nested() {
+    let index_id = "update_dynamic_to_strict_with_nested";
+    let original_doc_mappings = json!({
+        "mode": "dynamic",
+        "field_mappings": [],
+    });
+    let ingest_before_update = &[json!({"body": {"inner_body": "hello"}})];
+    let updated_doc_mappings = json!({
+        "mode": "dynamic",
+        "field_mappings": [
+            {
+                "name": "body",
+                "type": "text",
+            }
+        ],
+    });
+    let ingest_after_update = &[json!({"body": "world"})];
+    validate_search_across_doc_mapping_updates(
+        index_id,
+        original_doc_mappings,
+        ingest_before_update,
+        updated_doc_mappings,
+        ingest_after_update,
+        &[(
+            "body.inner_body:hello",
+            Ok(&[json!({"body": {"inner_body": "hello"}})]),
+        )],
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_update_doc_mapping_add_field_on_strict() {
     let index_id = "update-add-field-on-strict";
     let original_doc_mappings = json!({

--- a/quickwit/quickwit-integration-tests/src/tests/update_tests/mod.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/update_tests/mod.rs
@@ -41,7 +41,7 @@ async fn assert_hits_unordered(
         )
         .await;
     if let Ok(expected_hits) = expected_result {
-        let resp = search_res.unwrap_or_else(|_| panic!("query: {}", query));
+        let resp = search_res.unwrap_or_else(|err| panic!("query: {}, error: {}", query, err));
         assert_eq!(resp.errors.len(), 0, "query: {}", query);
         assert_eq!(
             resp.num_hits,


### PR DESCRIPTION
### Description

Fix `invalid query: field does not exist: xxxx` when a field that used to be created dynamically and with nested fields is added to the doc mapping with a primitive type.

### How was this PR tested?

Describe how you tested this PR.
