### PR TITLE
Use content_length_limit for ES bulk limit

### DIFF
--- a/quickwit/quickwit-serve/src/elasticsearch_api/bulk.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/bulk.rs
@@ -20,6 +20,7 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
+use bytesize::ByteSize;
 use hyper::StatusCode;
 use quickwit_config::{disable_ingest_v1, enable_ingest_v2};
 use quickwit_ingest::{
@@ -42,8 +43,9 @@ use crate::{with_arg, Body};
 pub fn es_compat_bulk_handler(
     ingest_service: IngestServiceClient,
     ingest_router: IngestRouterServiceClient,
+    content_length_limit: ByteSize,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    elastic_bulk_filter()
+    elastic_bulk_filter(content_length_limit)
         .and(with_arg(ingest_service))
         .and(with_arg(ingest_router))
         .then(|body, bulk_options, ingest_service, ingest_router| {
@@ -58,8 +60,9 @@ pub fn es_compat_bulk_handler(
 pub fn es_compat_index_bulk_handler(
     ingest_service: IngestServiceClient,
     ingest_router: IngestRouterServiceClient,
+    content_length_limit: ByteSize,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    elastic_index_bulk_filter()
+    elastic_index_bulk_filter(content_length_limit)
         .and(with_arg(ingest_service))
         .and(with_arg(ingest_router))
         .then(

--- a/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
@@ -35,7 +35,6 @@ use crate::search_api::{extract_index_id_patterns, extract_index_id_patterns_def
 use crate::Body;
 
 const BODY_LENGTH_LIMIT: ByteSize = ByteSize::mib(1);
-const CONTENT_LENGTH_LIMIT: ByteSize = ByteSize::mib(10);
 
 // TODO: Make all elastic endpoint models `utoipa` compatible
 // and register them here.
@@ -72,11 +71,12 @@ pub(crate) fn elasticsearch_filter(
     )
 )]
 pub(crate) fn elastic_bulk_filter(
+    content_length_limit: ByteSize,
 ) -> impl Filter<Extract = (Body, ElasticBulkOptions), Error = Rejection> + Clone {
     warp::path!("_elastic" / "_bulk")
         .and(warp::post().or(warp::put()).unify())
         .and(warp::body::content_length_limit(
-            CONTENT_LENGTH_LIMIT.as_u64(),
+            content_length_limit.as_u64(),
         ))
         .and(get_body_bytes())
         .and(serde_qs::warp::query(serde_qs::Config::default()))
@@ -95,11 +95,12 @@ pub(crate) fn elastic_bulk_filter(
     )
 )]
 pub(crate) fn elastic_index_bulk_filter(
+    content_length_limit: ByteSize,
 ) -> impl Filter<Extract = (String, Body, ElasticBulkOptions), Error = Rejection> + Clone {
     warp::path!("_elastic" / String / "_bulk")
         .and(warp::post().or(warp::put()).unify())
         .and(warp::body::content_length_limit(
-            CONTENT_LENGTH_LIMIT.as_u64(),
+            content_length_limit.as_u64(),
         ))
         .and(get_body_bytes())
         .and(serde_qs::warp::query::<ElasticBulkOptions>(

--- a/quickwit/quickwit-serve/src/elasticsearch_api/mod.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/mod.rs
@@ -61,14 +61,20 @@ pub fn elastic_api_handlers(
     metastore: MetastoreServiceClient,
     index_service: IndexService,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
+    let ingest_content_length_limit = node_config.ingest_api_config.content_length_limit;
     es_compat_cluster_info_handler(node_config, BuildInfo::get())
         .or(es_compat_search_handler(search_service.clone()))
         .or(es_compat_bulk_handler(
             ingest_service.clone(),
             ingest_router.clone(),
+            ingest_content_length_limit,
         ))
         .boxed()
-        .or(es_compat_index_bulk_handler(ingest_service, ingest_router))
+        .or(es_compat_index_bulk_handler(
+            ingest_service,
+            ingest_router,
+            ingest_content_length_limit,
+        ))
         .or(es_compat_index_search_handler(search_service.clone()))
         .or(es_compat_index_count_handler(search_service.clone()))
         .or(es_compat_scroll_handler(search_service.clone()))


### PR DESCRIPTION
### Description

ES bulk API had a harcoded content length limit.

### How was this PR tested?
N/A
