### PR TITLE
Enable lenient mode for term set query and range query

### DIFF
--- a/docs/reference/es_compatible_api.md
+++ b/docs/reference/es_compatible_api.md
@@ -394,6 +394,7 @@ The following query types are supported.
 | `fields`           | `String[]` (Optional) | Default search target fields.                                                                                               | -             |
 | `default_operator` | `"AND"` or `"OR"`     | In the absence of boolean operator defines whether terms should be combined as a conjunction (`AND`) or disjunction (`OR`). | `OR`          |
 | `boost`            | `Number`              | Multiplier boost for score computation.                                                                                     | 1.0           |
+| `lenient`          | `Boolean`             | [See note](#about-the-lenient-argument).                                                                                    | false         |
 
 
 ### `bool`
@@ -494,7 +495,7 @@ The following query types are supported.
 | `operator`         | `"AND"` or `"OR"` | Defines whether all terms should be present (`AND`) or if at least one term is sufficient to match (`OR`).                     | OR      |
 | `zero_terms_query` | `all` or `none`   | Defines if all (`all`) or no documents (`none`) should be returned if the query does not contain any terms after tokenization. | `none`  |
 | `boost`            | `Number`          | Multiplier boost for score computation                                                                                         | 1.0     |
-
+| `lenient`          | `Boolean`         | [See note](#about-the-lenient-argument).                                                                                       | false   |
 
 
 
@@ -637,8 +638,17 @@ Contrary to ES/Opensearch, in Quickwit, at most 50 terms will be considered when
 }
 ```
 
-#### Supported Multi-match Queries
-| Type            | Description                                                                                 |
+#### Supported parameters
+
+| Variable           | Type                  | Description                                  | Default value |
+| ------------------ | --------------------- | ---------------------------------------------| ------------- |
+| `type`             | `String`              | See supported types below                    | `most_fields` |
+| `fields`           | `String[]` (Optional) | Default search target fields.                | -             |
+| `lenient`          | `Boolean`             | [See note](#about-the-lenient-argument).     | false         |
+
+Supported types:
+
+| `type` value    | Description                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------------- |
 | `most_fields`   | Finds documents matching any field and combines the `_score` from each field (default).  |
 | `phrase`        | Runs a `match_phrase` query on each field.       |
@@ -720,6 +730,12 @@ Query matching only documents containing a non-null value for a given field.
 | -------- | ------ | ------------------------------------------------------- | ------- |
 | `field`  | String | Only documents with a value for field will be returned. | -       |
 
+
+### About the `lenient` argument
+
+Quickwit and Elasticsearch have different interpretations of the `lenient` setting:
+- In Quickwit, lenient mode allows ignoring parts of the query that reference non-existing columns. This is a behavior that Elasticsearch supports by default.
+- In Elasticsearch, lenient mode primarily addresses type errors (such as searching for text in an integer field). Quickwit always supports this behavior, regardless of the `lenient` setting.
 
 ## Search multiple indices
 

--- a/quickwit/quickwit-doc-mapper/src/query_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/query_builder.rs
@@ -702,12 +702,14 @@ mod test {
             phrase: "short".to_string(),
             max_expansions: 50,
             params: params.clone(),
+            lenient: false,
         };
         let long = PhrasePrefixQuery {
             field: "title".to_string(),
             phrase: "not so short".to_string(),
             max_expansions: 50,
             params: params.clone(),
+            lenient: false,
         };
         let mut extractor1 = ExtractPrefixTermRanges::with_schema(&schema, &tokenizer_manager);
         extractor1.visit_phrase_prefix(&short).unwrap();

--- a/quickwit/quickwit-integration-tests/src/tests/update_tests/mod.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/update_tests/mod.rs
@@ -41,7 +41,7 @@ async fn assert_hits_unordered(
         )
         .await;
     if let Ok(expected_hits) = expected_result {
-        let resp = search_res.unwrap_or_else(|_| panic!("query: {}", query));
+        let resp = search_res.unwrap_or_else(|err| panic!("query: {}, error: {}", query, err));
         assert_eq!(resp.errors.len(), 0, "query: {}", query);
         assert_eq!(
             resp.num_hits,

--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -702,6 +702,7 @@ fn build_search_query(
             field: "span_start_timestamp_nanos".to_string(),
             lower_bound: Bound::Unbounded,
             upper_bound: Bound::Unbounded,
+            lenient: false,
         };
 
         if let Some(min_span_start_timestamp_secs) = min_span_start_timestamp_secs_opt {
@@ -731,6 +732,7 @@ fn build_search_query(
             field: "span_duration_millis".to_string(),
             lower_bound: Bound::Unbounded,
             upper_bound: Bound::Unbounded,
+            lenient: false,
         };
 
         if let Some(min_span_duration_millis) = min_span_duration_millis_opt {
@@ -1521,7 +1523,8 @@ mod tests {
                 vec![RangeQuery {
                     field: "span_start_timestamp_nanos".to_string(),
                     lower_bound: Bound::Included("1970-01-01T00:00:03Z".to_string().into()),
-                    upper_bound: Bound::Unbounded
+                    upper_bound: Bound::Unbounded,
+                    lenient: false,
                 }
                 .into()]
             );
@@ -1550,6 +1553,7 @@ mod tests {
                     field: "span_start_timestamp_nanos".to_string(),
                     lower_bound: Bound::Unbounded,
                     upper_bound: Bound::Included("1970-01-01T00:00:33Z".to_string().into()),
+                    lenient: false,
                 }
                 .into()]
             );
@@ -1578,6 +1582,7 @@ mod tests {
                     field: "span_start_timestamp_nanos".to_string(),
                     lower_bound: Bound::Included("1970-01-01T00:00:03Z".to_string().into()),
                     upper_bound: Bound::Included("1970-01-01T00:00:33Z".to_string().into()),
+                    lenient: false,
                 }
                 .into()]
             );
@@ -1605,7 +1610,8 @@ mod tests {
                 vec![RangeQuery {
                     field: "span_duration_millis".to_string(),
                     lower_bound: Bound::Included(7u64.into()),
-                    upper_bound: Bound::Unbounded
+                    upper_bound: Bound::Unbounded,
+                    lenient: false,
                 }
                 .into()]
             );
@@ -1634,6 +1640,7 @@ mod tests {
                     field: "span_duration_millis".to_string(),
                     lower_bound: Bound::Unbounded,
                     upper_bound: Bound::Included(77u64.into()),
+                    lenient: false,
                 }
                 .into()]
             );
@@ -1662,6 +1669,7 @@ mod tests {
                     field: "span_duration_millis".to_string(),
                     lower_bound: Bound::Included(7u64.into()),
                     upper_bound: Bound::Included(77u64.into()),
+                    lenient: false,
                 }
                 .into()]
             );
@@ -1896,12 +1904,14 @@ mod tests {
                         field: "span_start_timestamp_nanos".to_string(),
                         lower_bound: Bound::Included("1970-01-01T00:00:03Z".to_string().into()),
                         upper_bound: Bound::Included("1970-01-01T00:00:33Z".to_string().into()),
+                        lenient: false,
                     }
                     .into(),
                     RangeQuery {
                         field: "span_duration_millis".to_string(),
                         lower_bound: Bound::Included(7u64.into()),
                         upper_bound: Bound::Included(77u64.into()),
+                        lenient: false,
                     }
                     .into(),
                 ]

--- a/quickwit/quickwit-query/src/elastic_query_dsl/match_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/match_query.rs
@@ -19,6 +19,7 @@
 
 use serde::Deserialize;
 
+use super::LeniencyBool;
 use crate::elastic_query_dsl::{
     ConvertibleToQueryAst, ElasticQueryDslInner, StringOrStructForSerialization,
 };
@@ -42,11 +43,8 @@ pub(crate) struct MatchQueryParams {
     pub(crate) operator: BooleanOperand,
     #[serde(default)]
     pub(crate) zero_terms_query: MatchAllOrNone,
-    // Quickwit and Elastic have different notions of lenient. For us, it means it's okay to
-    // disregard part of the query where which uses non-existing collumn (which Elastic does by
-    // default). For Elastic, it covers type errors (searching text in an integer field).
     #[serde(default)]
-    pub(crate) lenient: bool,
+    pub(crate) lenient: LeniencyBool,
 }
 
 impl ConvertibleToQueryAst for MatchQuery {

--- a/quickwit/quickwit-query/src/elastic_query_dsl/mod.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/mod.rs
@@ -50,6 +50,14 @@ use crate::elastic_query_dsl::terms_query::TermsQuery;
 use crate::not_nan_f32::NotNaNf32;
 use crate::query_ast::QueryAst;
 
+/// Quickwit and Elasticsearch have different interpretations of leniency:
+/// - In Quickwit, lenient mode allows ignoring parts of the query that reference non-existing
+///   columns. This is a behavior that Elasticsearch supports by default.
+/// - In Elasticsearch, lenient mode primarily addresses type errors (such as searching for text in
+///   an integer field). Quickwit always supports this behavior, regardless of the `lenient`
+///   setting.
+pub type LeniencyBool = bool;
+
 fn default_max_expansions() -> u32 {
     50
 }

--- a/quickwit/quickwit-query/src/elastic_query_dsl/multi_match.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/multi_match.rs
@@ -21,6 +21,7 @@ use serde::Deserialize;
 use serde_with::formats::PreferMany;
 use serde_with::{serde_as, OneOrMany};
 
+use super::LeniencyBool;
 use crate::elastic_query_dsl::bool_query::BoolQuery;
 use crate::elastic_query_dsl::match_bool_prefix::MatchBoolPrefixQuery;
 use crate::elastic_query_dsl::match_phrase_query::{MatchPhraseQuery, MatchPhraseQueryParams};
@@ -48,11 +49,8 @@ struct MultiMatchQueryForDeserialization {
     #[serde_as(deserialize_as = "OneOrMany<_, PreferMany>")]
     #[serde(default)]
     fields: Vec<String>,
-    // Quickwit and Elastic have different notions of lenient. For us, it means it's okay to
-    // disregard part of the query where which uses non-existing collumn (which Elastic does by
-    // default). For Elastic, it covers type errors (searching text in an integer field).
     #[serde(default)]
-    lenient: bool,
+    lenient: LeniencyBool,
 }
 
 fn deserialize_match_query_for_one_field(

--- a/quickwit/quickwit-query/src/elastic_query_dsl/phrase_prefix_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/phrase_prefix_query.rs
@@ -67,6 +67,7 @@ impl ConvertibleToQueryAst for MatchPhrasePrefixQuery {
             phrase: query,
             params: analyzer,
             max_expansions,
+            lenient: false,
         };
         Ok(phrase_prefix_query_ast.into())
     }

--- a/quickwit/quickwit-query/src/elastic_query_dsl/query_string_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/query_string_query.rs
@@ -19,6 +19,7 @@
 
 use serde::Deserialize;
 
+use super::LeniencyBool;
 use crate::elastic_query_dsl::ConvertibleToQueryAst;
 use crate::not_nan_f32::NotNaNf32;
 use crate::query_ast::UserInputQuery;
@@ -40,11 +41,8 @@ pub(crate) struct QueryStringQuery {
     default_operator: BooleanOperand,
     #[serde(default)]
     boost: Option<NotNaNf32>,
-    // Regardless of this option Quickwit behaves in elasticsearch definition of
-    // lenient. We include this property here just to accept user queries containing
-    // this option.
     #[serde(default)]
-    lenient: bool,
+    lenient: LeniencyBool,
 }
 
 impl ConvertibleToQueryAst for QueryStringQuery {

--- a/quickwit/quickwit-query/src/query_ast/full_text_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/full_text_query.rs
@@ -227,6 +227,7 @@ pub struct FullTextQuery {
     pub field: String,
     pub text: String,
     pub params: FullTextParams,
+    /// Support missing fields
     pub lenient: bool,
 }
 

--- a/quickwit/quickwit-query/src/query_ast/phrase_prefix_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/phrase_prefix_query.rs
@@ -38,6 +38,7 @@ pub struct PhrasePrefixQuery {
     pub phrase: String,
     pub max_expansions: u32,
     pub params: FullTextParams,
+    /// Support missing fields
     pub lenient: bool,
 }
 

--- a/quickwit/quickwit-query/src/query_ast/phrase_prefix_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/phrase_prefix_query.rs
@@ -122,7 +122,7 @@ impl BuildTantivyAst for PhrasePrefixQuery {
         let (_, terms) = match self.get_terms(schema, tokenizer_manager) {
             Ok(res) => res,
             Err(InvalidQuery::FieldDoesNotExist { .. }) if self.lenient => {
-                return Ok(crate::MatchAllOrNone::MatchNone.into())
+                return Ok(TantivyQueryAst::match_none())
             }
             Err(e) => return Err(e),
         };

--- a/quickwit/quickwit-query/src/query_ast/term_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/term_query.rs
@@ -41,16 +41,6 @@ impl From<TermQuery> for QueryAst {
     }
 }
 
-impl TermQuery {
-    #[cfg(test)]
-    pub fn from_field_value(field: impl ToString, value: impl ToString) -> Self {
-        Self {
-            field: field.to_string(),
-            value: value.to_string(),
-        }
-    }
-}
-
 impl BuildTantivyAst for TermQuery {
     fn build_tantivy_ast_impl(
         &self,

--- a/quickwit/quickwit-query/src/query_ast/term_set_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/term_set_query.rs
@@ -34,6 +34,7 @@ use crate::InvalidQuery;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct TermSetQuery {
     pub terms_per_field: HashMap<String, BTreeSet<String>>,
+    pub lenient: bool,
 }
 
 impl TermSetQuery {
@@ -56,8 +57,13 @@ impl TermSetQuery {
                     field: full_path.to_string(),
                     value: value.to_string(),
                 };
-                let ast =
-                    term_query.build_tantivy_ast_call(schema, tokenizer_manager, &[], false)?;
+                let ast = term_query.build_tantivy_ast_call(
+                    schema,
+                    tokenizer_manager,
+                    &[],
+                    // disable term query validation when doing a lenient set query
+                    !self.lenient,
+                )?;
                 let tantivy_query: Box<dyn crate::TantivyQuery> = ast.simplify().into();
                 tantivy_query.query_terms(&mut |term, _| {
                     terms.insert(term.clone());
@@ -76,9 +82,13 @@ impl BuildTantivyAst for TermSetQuery {
         _search_fields: &[String],
         _with_validation: bool,
     ) -> Result<TantivyQueryAst, InvalidQuery> {
-        let terms_it = self.make_term_iterator(schema, tokenizer_manager)?;
-        let term_set_query = tantivy::query::TermSetQuery::new(terms_it);
-        Ok(term_set_query.into())
+        let terms = self.make_term_iterator(schema, tokenizer_manager)?;
+        if terms.is_empty() {
+            Ok(TantivyQueryAst::match_none())
+        } else {
+            let term_set_query = tantivy::query::TermSetQuery::new(terms);
+            Ok(term_set_query.into())
+        }
     }
 }
 

--- a/quickwit/quickwit-query/src/query_ast/user_input_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/user_input_query.rs
@@ -273,12 +273,14 @@ fn convert_user_input_literal(
                     phrase: phrase.clone(),
                     params: full_text_params.clone(),
                     max_expansions: DEFAULT_PHRASE_QUERY_MAX_EXPANSION,
+                    lenient,
                 }
                 .into()
             } else if wildcard {
                 query_ast::WildcardQuery {
                     field: field_name,
                     value: phrase.clone(),
+                    lenient,
                 }
                 .into()
             } else {

--- a/quickwit/quickwit-query/src/query_ast/user_input_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/user_input_query.rs
@@ -162,6 +162,7 @@ fn convert_user_input_ast_to_query_ast(
                     field,
                     lower_bound: convert_bound(lower),
                     upper_bound: convert_bound(upper),
+                    lenient,
                 };
                 Ok(range_query.into())
             }
@@ -179,7 +180,10 @@ fn convert_user_input_ast_to_query_ast(
                 for field in field_names {
                     terms_per_field.insert(field.to_string(), terms.clone());
                 }
-                let term_set_query = query_ast::TermSetQuery { terms_per_field };
+                let term_set_query = query_ast::TermSetQuery {
+                    terms_per_field,
+                    lenient,
+                };
                 Ok(term_set_query.into())
             }
             UserInputLeaf::Exists { field } => Ok(FieldPresenceQuery { field }.into()),

--- a/quickwit/quickwit-query/src/query_ast/user_input_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/user_input_query.rs
@@ -49,6 +49,7 @@ pub struct UserInputQuery {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_fields: Option<Vec<String>>,
     pub default_operator: BooleanOperand,
+    /// Support missing fields
     pub lenient: bool,
 }
 

--- a/quickwit/quickwit-query/src/query_ast/wildcard_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/wildcard_query.rs
@@ -69,7 +69,7 @@ fn unescape_with_final_wildcard(phrase: &str) -> anyhow::Result<String> {
         .scan(State::Normal, |state, c| {
             if *saw_wildcard {
                 return Some(Some(Err(anyhow!(
-                    "Wildcard iquery contains wildcard in non final position"
+                    "Wildcard query contains wildcard in non final position"
                 ))));
             }
             match state {
@@ -185,7 +185,7 @@ impl BuildTantivyAst for WildcardQuery {
         let (_, term) = match self.extract_prefix_term(schema, tokenizer_manager) {
             Ok(res) => res,
             Err(InvalidQuery::FieldDoesNotExist { .. }) if self.lenient => {
-                return Ok(crate::MatchAllOrNone::MatchNone.into())
+                return Ok(TantivyQueryAst::match_none())
             }
             Err(e) => return Err(e),
         };

--- a/quickwit/quickwit-query/src/query_ast/wildcard_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/wildcard_query.rs
@@ -34,22 +34,13 @@ use crate::{find_field_or_hit_dynamic, InvalidQuery};
 pub struct WildcardQuery {
     pub field: String,
     pub value: String,
+    /// Support missing fields
     pub lenient: bool,
 }
 
 impl From<WildcardQuery> for QueryAst {
     fn from(wildcard_query: WildcardQuery) -> Self {
         Self::Wildcard(wildcard_query)
-    }
-}
-
-impl WildcardQuery {
-    #[cfg(test)]
-    pub fn from_field_value(field: impl ToString, value: impl ToString) -> Self {
-        Self {
-            field: field.to_string(),
-            value: value.to_string(),
-        }
     }
 }
 
@@ -218,6 +209,7 @@ mod tests {
         let query = WildcardQuery {
             field: "my_field".to_string(),
             value: "MyString Wh1ch a nOrMal Tokenizer would cut*".to_string(),
+            lenient: false,
         };
         let tokenizer_manager = create_default_quickwit_tokenizer_manager();
         for tokenizer in ["raw", "whitespace"] {

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -677,6 +677,7 @@ fn remove_redundant_timestamp_range(
             upper_bound: map_bound(final_end_timestamp, |bound| {
                 bound.into_timestamp_nanos().into()
             }),
+            lenient: false,
         };
         new_ast = if let QueryAst::Bool(mut bool_query) = new_ast {
             if bool_query.must.is_empty()
@@ -1477,6 +1478,7 @@ mod tests {
                 lower_bound: Bound::Included(time1.into()),
                 // *1000 has no impact, we detect timestamp in ms instead of s
                 upper_bound: Bound::Included((time4 * 1000).into()),
+                lenient: false,
             }))
             .unwrap(),
             ..SearchRequest::default()
@@ -1488,6 +1490,7 @@ mod tests {
                 field: timestamp_field.to_string(),
                 lower_bound: Bound::Included(time1.into()),
                 upper_bound: Bound::Included(time3.into()),
+                lenient: false,
             }))
             .unwrap(),
             ..SearchRequest::default()
@@ -1507,12 +1510,14 @@ mod tests {
             field: timestamp_field.to_string(),
             lower_bound: Bound::Unbounded,
             upper_bound: Bound::Excluded((time3 * S_TO_NS).into()),
+            lenient: false,
         };
         let search_request = SearchRequest {
             query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
                 field: timestamp_field.to_string(),
                 lower_bound: Bound::Included(time1.into()),
                 upper_bound: Bound::Excluded(time3.into()),
+                lenient: false,
             }))
             .unwrap(),
             ..SearchRequest::default()
@@ -1539,12 +1544,14 @@ mod tests {
             field: timestamp_field.to_string(),
             lower_bound: Bound::Excluded((time2 * S_TO_NS).into()),
             upper_bound: Bound::Unbounded,
+            lenient: false,
         };
         let search_request = SearchRequest {
             query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
                 field: timestamp_field.to_string(),
                 lower_bound: Bound::Excluded(time2.into()),
                 upper_bound: Bound::Included(time3.into()),
+                lenient: false,
             }))
             .unwrap(),
             ..SearchRequest::default()
@@ -1566,12 +1573,14 @@ mod tests {
             field: timestamp_field.to_string(),
             lower_bound: Bound::Unbounded,
             upper_bound: Bound::Excluded((time2 * S_TO_NS).into()),
+            lenient: false,
         };
         let search_request = SearchRequest {
             query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
                 field: timestamp_field.to_string(),
                 lower_bound: Bound::Included(time1.into()),
                 upper_bound: Bound::Included(time3.into()),
+                lenient: false,
             }))
             .unwrap(),
             start_timestamp: Some(time1),
@@ -1584,12 +1593,14 @@ mod tests {
             field: timestamp_field.to_string(),
             lower_bound: Bound::Unbounded,
             upper_bound: Bound::Included((time2 * S_TO_NS).into()),
+            lenient: false,
         };
         let search_request = SearchRequest {
             query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
                 field: timestamp_field.to_string(),
                 lower_bound: Bound::Included(time1.into()),
                 upper_bound: Bound::Included(time2.into()),
+                lenient: false,
             }))
             .unwrap(),
             start_timestamp: Some(time1),
@@ -1602,6 +1613,7 @@ mod tests {
             field: timestamp_field.to_string(),
             lower_bound: Bound::Included((time3 * S_TO_NS).into()),
             upper_bound: Bound::Unbounded,
+            lenient: false,
         };
 
         let search_request = SearchRequest {
@@ -1609,6 +1621,7 @@ mod tests {
                 field: timestamp_field.to_string(),
                 lower_bound: Bound::Included(time2.into()),
                 upper_bound: Bound::Included(time4.into()),
+                lenient: false,
             }))
             .unwrap(),
             start_timestamp: Some(time3),
@@ -1622,6 +1635,7 @@ mod tests {
                 field: timestamp_field.to_string(),
                 lower_bound: Bound::Included(time3.into()),
                 upper_bound: Bound::Included(time4.into()),
+                lenient: false,
             }))
             .unwrap(),
             start_timestamp: Some(time2),
@@ -1685,6 +1699,7 @@ mod tests {
                     field: "timestamp".to_string(),
                     lower_bound: Bound::Included(1_700_002_000_000_000_000u64.into()),
                     upper_bound: Bound::Unbounded,
+                    lenient: false,
                 }
                 .into()],
                 ..BoolQuery::default()

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -4056,6 +4056,7 @@ mod tests {
             field: timestamp_field.to_string(),
             lower_bound: Bound::Included(JsonLiteral::String("2021-04-13T22:45:41Z".to_owned())),
             upper_bound: Bound::Excluded(JsonLiteral::String("2021-05-06T06:51:19Z".to_owned())),
+            lenient: false,
         }
         .into();
 
@@ -4114,6 +4115,7 @@ mod tests {
             field: timestamp_field.to_string(),
             lower_bound: Bound::Excluded(JsonLiteral::String("2021-04-13T22:45:41Z".to_owned())),
             upper_bound: Bound::Included(JsonLiteral::String("2021-05-06T06:51:19Z".to_owned())),
+            lenient: false,
         }
         .into();
         timestamp_range_extractor.start_timestamp = None;
@@ -4126,6 +4128,7 @@ mod tests {
             field: "other_field".to_string(),
             lower_bound: Bound::Included(JsonLiteral::String("2021-04-13T22:45:41Z".to_owned())),
             upper_bound: Bound::Excluded(JsonLiteral::String("2021-05-06T06:51:19Z".to_owned())),
+            lenient: false,
         }
         .into();
         timestamp_range_extractor.start_timestamp = None;
@@ -4142,6 +4145,7 @@ mod tests {
             upper_bound: Bound::Excluded(JsonLiteral::String(
                 "2021-05-06T06:51:19.001Z".to_owned(),
             )),
+            lenient: false,
         }
         .into();
 

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0005-query_string_query.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0005-query_string_query.yaml
@@ -226,12 +226,24 @@ json:
   query:
     query_string:
       query: "true"
-      fields: ["public", "public.inner"]
+      fields: ["public", "public.notdefined", "notdefined"]
       lenient: true
 expected:
   hits:
     total:
       value: 100
+---
+# trailing wildcard
+json:
+  query:
+    query_string:
+      query: "jour*"
+      fields: ["payload.description", "payload.notdefined", "notdefined"]
+      lenient: true
+expected:
+  hits:
+    total:
+      value: 3
 ---
 # elasticsearch accepts this query
 engines:
@@ -240,5 +252,5 @@ json:
   query:
     query_string:
       query: "true"
-      fields: ["public", "public.inner"]
+      fields: ["public", "public.notdefined"]
 status_code: 400


### PR DESCRIPTION
### Description

This change is a follow up to https://github.com/quickwit-oss/quickwit/pull/5575 if we wanted to make it possible to have the same level of leniency as ES.

It makes range queries and term set queries potentially lenient.

### How was this PR tested?

Describe how you tested this PR.
