### PR TITLE
Use `unresolvable.wikipedia.org` in `test_peer_socket_addrs`

### DIFF
--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -879,7 +879,7 @@ mod tests {
                     ..Default::default()
                 },
                 peer_seeds: ConfigValue::for_test(List(vec![
-                    "unresolvable-host".to_string(),
+                    "unresolvable.example.com".to_string(),
                     "localhost".to_string(),
                     "localhost:1337".to_string(),
                     "127.0.0.1".to_string(),


### PR DESCRIPTION
### Description
`unresolvable-host` resolves to `unresolvable-host` in some environments.

### How was this PR tested?
`c t -p quickwit-config`
