### PR TITLE
partially implement _elastic/_cluster/health

### DIFF
--- a/quickwit/quickwit-serve/src/elasticsearch_api/bulk.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/bulk.rs
@@ -172,6 +172,7 @@ mod tests {
     use crate::elasticsearch_api::bulk_v2::ElasticBulkResponse;
     use crate::elasticsearch_api::elastic_api_handlers;
     use crate::elasticsearch_api::model::ElasticsearchError;
+    use crate::elasticsearch_api::tests::mock_cluster;
     use crate::ingest_api::setup_ingest_service;
 
     #[tokio::test]
@@ -184,6 +185,7 @@ mod tests {
         let index_service =
             IndexService::new(metastore_for_test(), StorageResolver::unconfigured());
         let elastic_api_handlers = elastic_api_handlers(
+            mock_cluster().await,
             config,
             search_service,
             ingest_service,
@@ -216,6 +218,7 @@ mod tests {
         let index_service =
             IndexService::new(metastore_for_test(), StorageResolver::unconfigured());
         let elastic_api_handlers = elastic_api_handlers(
+            mock_cluster().await,
             config,
             search_service,
             ingest_service,
@@ -252,6 +255,7 @@ mod tests {
         let index_service =
             IndexService::new(metastore_for_test(), StorageResolver::unconfigured());
         let elastic_api_handlers = elastic_api_handlers(
+            mock_cluster().await,
             config,
             search_service,
             ingest_service,
@@ -285,6 +289,7 @@ mod tests {
         let index_service =
             IndexService::new(metastore_for_test(), StorageResolver::unconfigured());
         let elastic_api_handlers = elastic_api_handlers(
+            mock_cluster().await,
             config,
             search_service,
             ingest_service,
@@ -321,6 +326,7 @@ mod tests {
         let index_service =
             IndexService::new(metastore_for_test(), StorageResolver::unconfigured());
         let elastic_api_handlers = elastic_api_handlers(
+            mock_cluster().await,
             config,
             search_service,
             ingest_service,
@@ -408,6 +414,7 @@ mod tests {
         let index_service =
             IndexService::new(metastore_for_test(), StorageResolver::unconfigured());
         let elastic_api_handlers = elastic_api_handlers(
+            mock_cluster().await,
             config,
             search_service,
             ingest_service,
@@ -493,6 +500,7 @@ mod tests {
         let index_service =
             IndexService::new(metastore_for_test(), StorageResolver::unconfigured());
         let elastic_api_handlers = elastic_api_handlers(
+            mock_cluster().await,
             config,
             search_service,
             ingest_service,

--- a/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
@@ -204,6 +204,12 @@ pub(crate) fn elastic_stats_filter() -> impl Filter<Extract = (), Error = Reject
     warp::path!("_elastic" / "_stats").and(warp::get())
 }
 
+#[utoipa::path(get, tag = "Search", path = "/_cluster/health")]
+pub(crate) fn elastic_cluster_health_filter() -> impl Filter<Extract = (), Error = Rejection> + Clone
+{
+    warp::path!("_elastic" / "_cluster" / "health").and(warp::get())
+}
+
 #[utoipa::path(get, tag = "Search", path = "/_cat/indices/{index}")]
 pub(crate) fn elastic_index_cat_indices_filter(
 ) -> impl Filter<Extract = (Vec<String>, CatIndexQueryParams), Error = Rejection> + Clone {

--- a/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
@@ -28,6 +28,7 @@ use elasticsearch_dsl::{HitsMetadata, ShardStatistics, Source, TotalHits, TotalH
 use futures_util::StreamExt;
 use hyper::StatusCode;
 use itertools::Itertools;
+use quickwit_cluster::Cluster;
 use quickwit_common::truncate_str;
 use quickwit_config::{validate_index_id_pattern, NodeConfig};
 use quickwit_index_management::IndexService;
@@ -43,15 +44,16 @@ use quickwit_query::BooleanOperand;
 use quickwit_search::{list_all_splits, resolve_index_patterns, SearchError, SearchService};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use warp::reply::with_status;
 use warp::{Filter, Rejection};
 
 use super::filter::{
-    elastic_cat_indices_filter, elastic_cluster_info_filter, elastic_delete_index_filter,
-    elastic_field_capabilities_filter, elastic_index_cat_indices_filter,
-    elastic_index_count_filter, elastic_index_field_capabilities_filter,
-    elastic_index_search_filter, elastic_index_stats_filter, elastic_multi_search_filter,
-    elastic_resolve_index_filter, elastic_scroll_filter, elastic_stats_filter,
-    elasticsearch_filter,
+    elastic_cat_indices_filter, elastic_cluster_health_filter, elastic_cluster_info_filter,
+    elastic_delete_index_filter, elastic_field_capabilities_filter,
+    elastic_index_cat_indices_filter, elastic_index_count_filter,
+    elastic_index_field_capabilities_filter, elastic_index_search_filter,
+    elastic_index_stats_filter, elastic_multi_search_filter, elastic_resolve_index_filter,
+    elastic_scroll_filter, elastic_stats_filter, elasticsearch_filter,
 };
 use super::model::{
     build_list_field_request_for_es_api, convert_to_es_field_capabilities_response,
@@ -146,6 +148,57 @@ pub fn es_compat_stats_handler(
         .then(es_compat_stats)
         .map(|result| make_elastic_api_response(result, BodyFormat::default()))
         .recover(recover_fn)
+}
+
+/// Check if the parameter is a known query parameter to reject
+fn is_unsuppported_qp(param: &str) -> bool {
+    ["wait_for_status", "timeout", "level"].contains(&param)
+}
+
+/// GET _elastic/_cluster/health
+pub fn es_compat_cluster_health_handler(
+    cluster: Cluster,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
+    elastic_cluster_health_filter()
+        .and(warp::query::<HashMap<String, String>>())
+        .and(with_arg(cluster))
+        .then(es_compat_cluster_health)
+        .recover(recover_fn)
+}
+
+#[utoipa::path(
+    get,
+    tag = "Node Health",
+    path = "/_elastic/_cluster/health",
+    responses(
+        (status = 200, description = "The cluster is healthy.", body = bool),
+        (status = 503, description = "The cluster is unhealthy.", body = bool),
+    ),
+)]
+/// Get Node Liveliness
+async fn es_compat_cluster_health(
+    query_params: HashMap<String, String>,
+    cluster: Cluster,
+) -> impl warp::Reply {
+    if let Some(invalid_param) = query_params.keys().find(|key| is_unsuppported_qp(key)) {
+        let error_body = warp::reply::json(&json!({
+            "error": "Unsupported parameter.",
+            "param": invalid_param
+        }));
+        return with_status(error_body, StatusCode::BAD_REQUEST);
+    }
+    let is_ready = cluster.is_self_node_ready().await;
+    if is_ready {
+        with_status(
+            warp::reply::json(&json!({"status": "green"})),
+            StatusCode::OK,
+        )
+    } else {
+        with_status(
+            warp::reply::json(&json!({"status": "red"})),
+            StatusCode::SERVICE_UNAVAILABLE,
+        )
+    }
 }
 
 /// GET _elastic/{index}/_stats

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -251,6 +251,7 @@ fn api_v1_routes(
     let api_v1_root_url = warp::path!("api" / "v1" / ..);
     api_v1_root_url.and(
         elastic_api_handlers(
+            quickwit_services.cluster.clone(),
             quickwit_services.node_config.clone(),
             quickwit_services.search_service.clone(),
             quickwit_services.ingest_service.clone(),

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0027-cluster-health.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0027-cluster-health.yaml
@@ -1,0 +1,3 @@
+method: GET
+endpoint: /_cluster/health
+status_code: 200


### PR DESCRIPTION
### Description

implement `_elastic/_cluster/health` endpoint without support for any of its query parameters. 

I reused `cluster.is_self_node_ready()` to determine the health check.

