### PR TITLE
Retry 503 in CLI

### DIFF
--- a/docs/internals/ingest-v2.md
+++ b/docs/internals/ingest-v2.md
@@ -4,7 +4,11 @@ Ingest V2 is the latest ingestion API that is designed to be more efficient and 
 
 ## Architecture
 
-Just like ingest V1, the new ingest uses [`mrecordlog`](https://github.com/quickwit-oss/mrecordlog) to persist ingested documents that are waiting to be indexed. But unlike V1, which always persists the documents locally on the node that receives them, ingest V2 can dynamically distribute them into WAL units called _shards_. The assigned shard can be local or on another indexer. The control plane is in charge of distributing the shards to balance the indexing work as well as possible across all indexer nodes. The progress within each shard is not tracked as an index metadata checkpoint anymore but in a dedicated metastore `shards` table.
+Just like ingest V1, the new ingest uses [`mrecordlog`](https://github.com/quickwit-oss/mrecordlog) to persist ingested documents that are waiting to be indexed. But unlike V1, which always persists the documents locally on the node that receives them, ingest V2 can dynamically distribute them into WAL units called _shards_. Here are a few key behaviors of this new mechanism:
+- When an indexer receives a document for ingestion, the assigned shard can be local or on another indexer.
+- The control plane is in charge of distributing the shards to balance the indexing work as well as possible across all indexer nodes.
+- Each shard has a throughput limit (5MB). If the ingest rate on an index is becoming greater than the cumulated throughput of all its shards, the control plane schedules the creation of new shards. Note that when the cumulated throughput is exceeded on an index, the ingest API returns "service unavailable" errors until the new shards are effectively created.
+- The progress within each shard is tracked in a dedicated metastore `shards` table (instead of the index metadata checkpoint like for other sources).
 
 In the future, the shard based ingest will also be capable of writing a replica for each shard, thus ensuring a high durability of the documents that are waiting to be indexed (durability of the indexed documents is guarantied by the object store).
 
@@ -33,3 +37,6 @@ See [full configuration example](https://github.com/quickwit-oss/quickwit/blob/m
   - `ingest_api.replication_factor`, not working yet
 - ingest V1 always writes to the WAL of the node receiving the request, V2 potentially forwards it to another node, dynamically assigned by the control plane to distribute the indexing work more evenly.
 - ingest V2 parses and validates input documents synchronously. Schema and JSON formatting errors are returned in the ingest response (for ingest V1 those errors were available in the server logs only).
+- ingest V2 returns transient errors when the ingestion rate is too fast
+  - 429 too many requests
+  - 503 no shards available: the cumulated shard throughput is reached and new shards are about to be created

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -1077,6 +1077,17 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
             println!("└ document: {}", failure.document);
         }
     }
+    if response.num_service_unavailable > 0 || response.num_too_many_requests > 0 {
+        println!("Retried request counts:");
+        println!(
+            "  503 (service unavailable) = {}",
+            response.num_service_unavailable
+        );
+        println!(
+            "  429 (too many requests)   = {}",
+            response.num_too_many_requests
+        );
+    }
     Ok(())
 }
 

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -39,14 +39,12 @@ use quickwit_proto::jaeger::storage::v1::span_reader_plugin_client::SpanReaderPl
 use quickwit_proto::opentelemetry::proto::collector::logs::v1::logs_service_client::LogsServiceClient;
 use quickwit_proto::opentelemetry::proto::collector::trace::v1::trace_service_client::TraceServiceClient;
 use quickwit_proto::types::NodeId;
-use quickwit_rest_client::models::IngestSource;
+use quickwit_rest_client::models::{CumulatedIngestResponse, IngestSource};
 use quickwit_rest_client::rest_client::{
     CommitType, QuickwitClient, QuickwitClientBuilder, DEFAULT_BASE_URL,
 };
 use quickwit_serve::tcp_listener::for_tests::TestTcpListenerResolver;
-use quickwit_serve::{
-    serve_quickwit, ListSplitsQueryParams, RestIngestResponse, SearchRequestQueryString,
-};
+use quickwit_serve::{serve_quickwit, ListSplitsQueryParams, SearchRequestQueryString};
 use quickwit_storage::StorageResolver;
 use reqwest::Url;
 use serde_json::Value;
@@ -248,7 +246,7 @@ pub(crate) async fn ingest(
     index_id: &str,
     ingest_source: IngestSource,
     commit_type: CommitType,
-) -> anyhow::Result<RestIngestResponse> {
+) -> anyhow::Result<CumulatedIngestResponse> {
     let resp = client
         .ingest(index_id, ingest_source, None, None, commit_type)
         .await?;

--- a/quickwit/quickwit-rest-client/src/models.rs
+++ b/quickwit/quickwit-rest-client/src/models.rs
@@ -20,6 +20,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use quickwit_serve::{RestIngestResponse, RestParseFailure};
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 
@@ -83,6 +84,45 @@ pub enum IngestSource {
     Stdin,
 }
 
+#[derive(Debug, PartialEq, Default)]
+pub struct CumulatedIngestResponse {
+    pub num_docs_for_processing: u64,
+    pub num_ingested_docs: Option<u64>,
+    pub num_rejected_docs: Option<u64>,
+    pub parse_failures: Option<Vec<RestParseFailure>>,
+    pub num_too_many_requests: u64,
+    pub num_service_unavailable: u64,
+}
+
+impl CumulatedIngestResponse {
+    /// Aggregates ingest counts and errors.
+    pub fn merge(self, other: RestIngestResponse) -> Self {
+        Self {
+            num_docs_for_processing: self.num_docs_for_processing + other.num_docs_for_processing,
+            num_ingested_docs: apply_op(self.num_ingested_docs, other.num_ingested_docs, |a, b| {
+                a + b
+            }),
+            num_rejected_docs: apply_op(self.num_rejected_docs, other.num_rejected_docs, |a, b| {
+                a + b
+            }),
+            parse_failures: apply_op(self.parse_failures, other.parse_failures, |a, b| {
+                a.into_iter().chain(b).collect()
+            }),
+            num_too_many_requests: self.num_too_many_requests,
+            num_service_unavailable: self.num_service_unavailable,
+        }
+    }
+}
+
+fn apply_op<T>(a: Option<T>, b: Option<T>, f: impl Fn(T, T) -> T) -> Option<T> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(f(a, b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
 /// A structure that represent a timeout. Unlike Duration it can also represent an infinite or no
 /// timeout value.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
@@ -136,5 +176,57 @@ impl Timeout {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use quickwit_proto::ingest::ParseFailureReason;
+
+    use super::*;
+
+    #[test]
+    fn test_merge_responses() {
+        let mut merged_response = CumulatedIngestResponse::default();
+        let response1 = RestIngestResponse {
+            num_docs_for_processing: 10,
+            num_ingested_docs: Some(5),
+            num_rejected_docs: Some(2),
+            parse_failures: Some(vec![RestParseFailure {
+                message: "error1".to_string(),
+                document: "doc1".to_string(),
+                reason: ParseFailureReason::InvalidJson,
+            }]),
+        };
+        let response2 = RestIngestResponse {
+            num_docs_for_processing: 15,
+            num_ingested_docs: Some(10),
+            num_rejected_docs: Some(3),
+            parse_failures: Some(vec![RestParseFailure {
+                message: "error2".to_string(),
+                document: "doc2".to_string(),
+                reason: ParseFailureReason::InvalidJson,
+            }]),
+        };
+        merged_response = merged_response.merge(response1);
+        merged_response = merged_response.merge(response2);
+        assert_eq!(merged_response.num_docs_for_processing, 25);
+        assert_eq!(merged_response.num_ingested_docs.unwrap(), 15);
+        assert_eq!(merged_response.num_rejected_docs.unwrap(), 5);
+        assert_eq!(
+            merged_response.parse_failures.unwrap(),
+            vec![
+                RestParseFailure {
+                    message: "error1".to_string(),
+                    document: "doc1".to_string(),
+                    reason: ParseFailureReason::InvalidJson,
+                },
+                RestParseFailure {
+                    message: "error2".to_string(),
+                    document: "doc2".to_string(),
+                    reason: ParseFailureReason::InvalidJson,
+                }
+            ]
+        );
     }
 }

--- a/quickwit/quickwit-rest-client/src/rest_client.rs
+++ b/quickwit/quickwit-rest-client/src/rest_client.rs
@@ -28,16 +28,14 @@ pub use quickwit_ingest::CommitType;
 use quickwit_metastore::{IndexMetadata, Split, SplitInfo};
 use quickwit_proto::ingest::Shard;
 use quickwit_search::SearchResponseRest;
-use quickwit_serve::{
-    ListSplitsQueryParams, ListSplitsResponse, RestIngestResponse, SearchRequestQueryString,
-};
+use quickwit_serve::{ListSplitsQueryParams, ListSplitsResponse, SearchRequestQueryString};
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use reqwest::{Client, ClientBuilder, Method, StatusCode, Url};
 use serde::Serialize;
 use serde_json::json;
 
 use crate::error::Error;
-use crate::models::{ApiResponse, IngestSource, Timeout};
+use crate::models::{ApiResponse, CumulatedIngestResponse, IngestSource, Timeout};
 use crate::BatchLineReader;
 
 pub const DEFAULT_BASE_URL: &str = "http://127.0.0.1:7280";
@@ -268,7 +266,7 @@ impl QuickwitClient {
         batch_size_limit_opt: Option<usize>,
         mut on_ingest_event: Option<&mut (dyn FnMut(IngestEvent) + Sync)>,
         last_block_commit: CommitType,
-    ) -> Result<RestIngestResponse, Error> {
+    ) -> Result<CumulatedIngestResponse, Error> {
         let ingest_path = format!("{index_id}/ingest");
         let mut query_params = HashMap::new();
         // TODO(#5604)
@@ -288,7 +286,7 @@ impl QuickwitClient {
                 BatchLineReader::from_string(ingest_payload, batch_size_limit)
             }
         };
-        let mut cumulated_resp = RestIngestResponse::default();
+        let mut cumulated_resp = CumulatedIngestResponse::default();
         while let Some(batch) = batch_reader.next_batch().await? {
             loop {
                 let timeout = if !batch_reader.has_next() && last_block_commit != CommitType::Auto {
@@ -317,15 +315,19 @@ impl QuickwitClient {
                     )
                     .await?;
                 if response.status_code() == StatusCode::TOO_MANY_REQUESTS {
-                    if let Some(event_fn) = &mut on_ingest_event {
-                        event_fn(IngestEvent::Sleep)
-                    }
-                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    cumulated_resp.num_too_many_requests += 1;
+                } else if response.status_code() == StatusCode::SERVICE_UNAVAILABLE {
+                    // usually returned when the throughput of all shards is saturated
+                    cumulated_resp.num_service_unavailable += 1;
                 } else {
                     let current_parsed_resp = response.deserialize().await?;
                     cumulated_resp = cumulated_resp.merge(current_parsed_resp);
                     break;
                 }
+                if let Some(event_fn) = &mut on_ingest_event {
+                    event_fn(IngestEvent::Sleep)
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
             }
             if let Some(event_fn) = &mut on_ingest_event {
                 event_fn(IngestEvent::IngestedDocBatch(batch.len()))
@@ -731,7 +733,7 @@ mod test {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::error::Error;
-    use crate::models::IngestSource;
+    use crate::models::{CumulatedIngestResponse, IngestSource};
     use crate::rest_client::QuickwitClientBuilder;
 
     #[tokio::test]
@@ -828,7 +830,16 @@ mod test {
             .ingest("my-index", ingest_source, None, None, CommitType::Auto)
             .await
             .unwrap();
-        assert_eq!(actual_response, mock_response);
+        assert_eq!(
+            actual_response,
+            CumulatedIngestResponse {
+                num_docs_for_processing: 2,
+                num_ingested_docs: Some(2),
+                num_rejected_docs: Some(0),
+                parse_failures: Some(Vec::new()),
+                ..Default::default()
+            }
+        );
     }
 
     #[tokio::test]
@@ -863,7 +874,16 @@ mod test {
             .ingest("my-index", ingest_source, None, None, CommitType::Force)
             .await
             .unwrap();
-        assert_eq!(actual_response, mock_response);
+        assert_eq!(
+            actual_response,
+            CumulatedIngestResponse {
+                num_docs_for_processing: 2,
+                num_ingested_docs: Some(2),
+                num_rejected_docs: Some(0),
+                parse_failures: Some(Vec::new()),
+                ..Default::default()
+            }
+        );
     }
 
     #[tokio::test]
@@ -898,7 +918,16 @@ mod test {
             .ingest("my-index", ingest_source, None, None, CommitType::WaitFor)
             .await
             .unwrap();
-        assert_eq!(actual_response, mock_response);
+        assert_eq!(
+            actual_response,
+            CumulatedIngestResponse {
+                num_docs_for_processing: 2,
+                num_ingested_docs: Some(2),
+                num_rejected_docs: Some(0),
+                parse_failures: Some(Vec::new()),
+                ..Default::default()
+            }
+        );
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-serve/src/ingest_api/response.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/response.rs
@@ -103,32 +103,8 @@ impl RestIngestResponse {
         }
         Ok(resp)
     }
-
-    /// Aggregates ingest counts and errors.
-    pub fn merge(self, other: Self) -> Self {
-        Self {
-            num_docs_for_processing: self.num_docs_for_processing + other.num_docs_for_processing,
-            num_ingested_docs: apply_op(self.num_ingested_docs, other.num_ingested_docs, |a, b| {
-                a + b
-            }),
-            num_rejected_docs: apply_op(self.num_rejected_docs, other.num_rejected_docs, |a, b| {
-                a + b
-            }),
-            parse_failures: apply_op(self.parse_failures, other.parse_failures, |a, b| {
-                a.into_iter().chain(b).collect()
-            }),
-        }
-    }
 }
 
-fn apply_op<T>(a: Option<T>, b: Option<T>, f: impl Fn(T, T) -> T) -> Option<T> {
-    match (a, b) {
-        (Some(a), Some(b)) => Some(f(a, b)),
-        (Some(a), None) => Some(a),
-        (None, Some(b)) => Some(b),
-        (None, None) => None,
-    }
-}
 #[cfg(test)]
 mod tests {
     use quickwit_proto::ingest::router::{IngestFailure, IngestFailureReason, IngestSuccess};
@@ -208,48 +184,5 @@ mod tests {
         };
         let result = RestIngestResponse::from_ingest_v2(failure_resp, None, 10);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_merge_responses() {
-        let response1 = RestIngestResponse {
-            num_docs_for_processing: 10,
-            num_ingested_docs: Some(5),
-            num_rejected_docs: Some(2),
-            parse_failures: Some(vec![RestParseFailure {
-                message: "error1".to_string(),
-                document: "doc1".to_string(),
-                reason: ParseFailureReason::InvalidJson,
-            }]),
-        };
-        let response2 = RestIngestResponse {
-            num_docs_for_processing: 15,
-            num_ingested_docs: Some(10),
-            num_rejected_docs: Some(3),
-            parse_failures: Some(vec![RestParseFailure {
-                message: "error2".to_string(),
-                document: "doc2".to_string(),
-                reason: ParseFailureReason::InvalidJson,
-            }]),
-        };
-        let merged_response = response1.merge(response2);
-        assert_eq!(merged_response.num_docs_for_processing, 25);
-        assert_eq!(merged_response.num_ingested_docs.unwrap(), 15);
-        assert_eq!(merged_response.num_rejected_docs.unwrap(), 5);
-        assert_eq!(
-            merged_response.parse_failures.unwrap(),
-            vec![
-                RestParseFailure {
-                    message: "error1".to_string(),
-                    document: "doc1".to_string(),
-                    reason: ParseFailureReason::InvalidJson,
-                },
-                RestParseFailure {
-                    message: "error2".to_string(),
-                    document: "doc2".to_string(),
-                    reason: ParseFailureReason::InvalidJson,
-                }
-            ]
-        );
     }
 }


### PR DESCRIPTION
### Description

When ingesting the hdfs dataset the ingest CLI fails with 503. This PR adds a retry when that happens to make the CLI more robust (and make the hdfs tutorial work :-) )

### How was this PR tested?

Manual test with the gzipped hdfs dataset + integration test
