### PR TITLE
Fix `root_search_requests_total` metric

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast.rs
@@ -124,7 +124,7 @@ enum ShardInfosChange<'a> {
 }
 
 impl LocalShardsSnapshot {
-    pub fn diff<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = ShardInfosChange<'a>> + '_ {
+    pub fn diff<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = ShardInfosChange<'a>> + 'a {
         self.per_source_shard_infos
             .iter()
             .diff_by_key(other.per_source_shard_infos.iter())

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1224,6 +1224,14 @@ pub async fn root_search(
         ["error"]
     };
     SEARCH_METRICS
+        .root_search_requests_total
+        .with_label_values(label_values)
+        .inc();
+    SEARCH_METRICS
+        .root_search_request_duration_seconds
+        .with_label_values(label_values)
+        .observe(elapsed.as_secs_f64());
+    SEARCH_METRICS
         .root_search_targeted_splits
         .with_label_values(label_values)
         .observe(num_splits as f64);


### PR DESCRIPTION
### Description
The `root_search_requests_total` metric is not emitted because the search client is bypassed when searchers are hit directly, which most users do.

I moved the `leaf_search_requests_total` to `SearchServiceImpl` for the metric to appear consistently server-side.

### How was this PR tested?
Ran locally and checked metric in Grafana
