### PR TITLE
Pin `aws-sdk-s3` dep to 1.62

### DIFF
--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -281,7 +281,7 @@ aws-config = "1.5.4"
 aws-credential-types = { version = "1.2", features = ["hardcoded-credentials"] }
 aws-runtime = "1.3.1"
 aws-sdk-kinesis = "1.37"
-aws-sdk-s3 = "1.42"
+aws-sdk-s3 = "=1.62"
 aws-sdk-sqs = "1.36"
 aws-smithy-async = "1.2"
 aws-smithy-runtime = "1.6.2"


### PR DESCRIPTION
### Description
Effectively disabling the computation of a checksum for request bodies and preventing the following error:
```
storage error(kind=Internal, source=dispatch failure: other: RequestChecksumInterceptor modify_before_retry_loop interceptor encountered an error: error during request construction: Only request bodies with a known size can be checksum validated
```

This is a temporary fix. See #5649.