### PR TITLE
Reduce aggregation result footprint

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -7149,6 +7149,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "serde_json_borrow",
  "tantivy",
  "tantivy-fst",
  "thiserror 1.0.69",

--- a/quickwit/quickwit-cli/src/index.rs
+++ b/quickwit/quickwit-cli/src/index.rs
@@ -33,9 +33,8 @@ use quickwit_config::{ConfigFormat, IndexConfig};
 use quickwit_metastore::{IndexMetadata, Split, SplitState};
 use quickwit_proto::search::{CountHits, SortField, SortOrder};
 use quickwit_proto::types::IndexId;
-use quickwit_rest_client::models::IngestSource;
+use quickwit_rest_client::models::{IngestSource, SearchResponseRestClient};
 use quickwit_rest_client::rest_client::{CommitType, IngestEvent};
-use quickwit_search::SearchResponseRest;
 use quickwit_serve::{ListSplitsQueryParams, SearchRequestQueryString, SortBy};
 use quickwit_storage::{load_file, StorageResolver};
 use tabled::settings::object::{FirstRow, Rows, Segment};
@@ -1083,7 +1082,7 @@ fn progress_bar_style() -> ProgressStyle {
     .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
 }
 
-pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchResponseRest> {
+pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchResponseRestClient> {
     let aggs: Option<serde_json::Value> = args
         .aggregation
         .map(|aggs_string| {

--- a/quickwit/quickwit-rest-client/src/models.rs
+++ b/quickwit/quickwit-rest-client/src/models.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 use crate::error::{ApiError, Error, ErrorResponsePayload};
 
@@ -69,6 +71,20 @@ impl ApiResponse {
             Ok(object)
         }
     }
+}
+
+/// A cousin of [`quickwit_search::SearchResponseRest`] that implements [`Deserialize`]
+///
+/// This version of the response is necessary because
+/// `serde_json_borrow::OwnedValue` is not deserializeable.
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct SearchResponseRestClient {
+    pub num_hits: u64,
+    pub hits: Vec<JsonValue>,
+    pub snippets: Option<Vec<JsonValue>>,
+    pub elapsed_time_micros: u64,
+    pub errors: Vec<String>,
+    pub aggregations: Option<JsonValue>,
 }
 
 #[derive(Clone)]

--- a/quickwit/quickwit-rest-client/src/rest_client.rs
+++ b/quickwit/quickwit-rest-client/src/rest_client.rs
@@ -22,7 +22,6 @@ use quickwit_indexing::actors::IndexingServiceCounters;
 pub use quickwit_ingest::CommitType;
 use quickwit_metastore::{IndexMetadata, Split, SplitInfo};
 use quickwit_proto::ingest::Shard;
-use quickwit_search::SearchResponseRest;
 use quickwit_serve::{
     ListSplitsQueryParams, ListSplitsResponse, RestIngestResponse, SearchRequestQueryString,
 };
@@ -32,7 +31,7 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::error::Error;
-use crate::models::{ApiResponse, IngestSource, Timeout};
+use crate::models::{ApiResponse, IngestSource, SearchResponseRestClient, Timeout};
 use crate::BatchLineReader;
 
 pub const DEFAULT_BASE_URL: &str = "http://127.0.0.1:7280";
@@ -210,7 +209,7 @@ impl QuickwitClient {
         &self,
         index_id: &str,
         search_query: SearchRequestQueryString,
-    ) -> Result<SearchResponseRest, Error> {
+    ) -> Result<SearchResponseRestClient, Error> {
         let path = format!("{index_id}/search");
         let bytes = serde_json::to_string(&search_query)
             .unwrap()
@@ -735,7 +734,6 @@ mod test {
     use quickwit_indexing::mock_split;
     use quickwit_ingest::CommitType;
     use quickwit_metastore::IndexMetadata;
-    use quickwit_search::SearchResponseRest;
     use quickwit_serve::{
         ListSplitsQueryParams, ListSplitsResponse, RestIngestResponse, SearchRequestQueryString,
     };
@@ -750,7 +748,7 @@ mod test {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::error::Error;
-    use crate::models::IngestSource;
+    use crate::models::{IngestSource, SearchResponseRestClient};
     use crate::rest_client::QuickwitClientBuilder;
 
     #[tokio::test]
@@ -773,7 +771,7 @@ mod test {
         let search_query_params = SearchRequestQueryString {
             ..Default::default()
         };
-        let expected_search_response = SearchResponseRest {
+        let expected_search_response = SearchResponseRestClient {
             num_hits: 0,
             hits: Vec::new(),
             snippets: None,

--- a/quickwit/quickwit-search/Cargo.toml
+++ b/quickwit/quickwit-search/Cargo.toml
@@ -27,6 +27,7 @@ prost = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_json_borrow = { workspace = true }
 tantivy = { workspace = true }
 tantivy-fst = { workspace = true }
 thiserror = { workspace = true }

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -86,7 +86,9 @@ pub use crate::root::{
     IndexMetasForLeafSearch, SearchJob,
 };
 pub use crate::search_job_placer::{Job, SearchJobPlacer};
-pub use crate::search_response_rest::{SearchPlanResponseRest, SearchResponseRest};
+pub use crate::search_response_rest::{
+    AggregationResults, SearchPlanResponseRest, SearchResponseRest,
+};
 pub use crate::search_stream::root_search_stream;
 pub use crate::service::{MockSearchService, SearchService, SearchServiceImpl};
 

--- a/quickwit/quickwit-search/src/search_response_rest.rs
+++ b/quickwit/quickwit-search/src/search_response_rest.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use std::io;
 
 use quickwit_common::truncate_str;
 use quickwit_proto::search::SearchResponse;
@@ -21,6 +22,21 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::error::SearchError;
+
+/// A lightweight serializable representation of aggregation results.
+///
+/// We use `serde_json_borrow` here to avoid unnecessary
+/// allocations. On large aggregation results with tens of thousands of
+/// entries this has a significant impact compared to `serde_json`.
+#[derive(Serialize, PartialEq, Debug)]
+pub struct AggregationResults(serde_json_borrow::OwnedValue);
+
+impl AggregationResults {
+    /// Parse an aggregation result form a serialized JSON string.
+    pub fn from_json(json_str: &str) -> io::Result<Self> {
+        serde_json_borrow::OwnedValue::from_str(json_str).map(Self)
+    }
+}
 
 /// SearchResponseRest represents the response returned by the REST search API
 /// and is meant to be serialized into JSON.
@@ -39,12 +55,10 @@ pub struct SearchResponseRest {
     pub elapsed_time_micros: u64,
     /// Search errors.
     pub errors: Vec<String>,
-    /// Aggregations. We use `serde_json_borrow` here to avoid unnecessary
-    /// allocations. On large aggregation results with tens of thousands of
-    /// entries this has a significant impact.
+    /// Aggregations.
     #[schema(value_type = Object)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub aggregations: Option<serde_json_borrow::OwnedValue>,
+    pub aggregations: Option<AggregationResults>,
 }
 
 impl TryFrom<SearchResponse> for SearchResponseRest {
@@ -81,7 +95,7 @@ impl TryFrom<SearchResponse> for SearchResponseRest {
         };
 
         let aggregations_opt = if let Some(aggregation_json) = search_response.aggregation {
-            let aggregation = serde_json_borrow::OwnedValue::parse_from(aggregation_json)
+            let aggregation = AggregationResults::from_json(&aggregation_json)
                 .map_err(|err| SearchError::Internal(err.to_string()))?;
             Some(aggregation)
         } else {

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/mod.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/mod.rs
@@ -21,6 +21,7 @@ mod multi_search;
 mod scroll;
 mod search_body;
 mod search_query_params;
+mod search_response;
 mod stats;
 
 pub use bulk_body::BulkAction;
@@ -41,6 +42,7 @@ use quickwit_proto::search::{SortDatetimeFormat, SortOrder};
 pub use scroll::ScrollQueryParams;
 pub use search_body::SearchBody;
 pub use search_query_params::{DeleteQueryParams, SearchQueryParams, SearchQueryParamsCount};
+pub use search_response::ElasticsearchResponse;
 use serde::{Deserialize, Serialize};
 pub use stats::{ElasticsearchStatsResponse, StatsResponseEntry};
 

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/multi_search.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/multi_search.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use elasticsearch_dsl::search::SearchResponse as ElasticsearchResponse;
 use elasticsearch_dsl::ErrorCause;
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -20,6 +19,7 @@ use serde_with::formats::PreferMany;
 use serde_with::{serde_as, OneOrMany};
 
 use super::search_query_params::ExpandWildcards;
+use super::search_response::ElasticsearchResponse;
 use super::ElasticsearchError;
 use crate::simple_list::{from_simple_list, to_simple_list};
 
@@ -100,12 +100,12 @@ pub struct MultiSearchHeader {
     pub routing: Option<Vec<String>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 pub struct MultiSearchResponse {
     pub responses: Vec<MultiSearchSingleResponse>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct MultiSearchSingleResponse {
     #[serde(with = "http_serde::status_code")]
     pub status: StatusCode,

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/search_response.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/search_response.rs
@@ -1,0 +1,78 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use elasticsearch_dsl::{ClusterStatistics, HitsMetadata, ShardStatistics, Suggest};
+use quickwit_search::AggregationResults;
+use serde::Serialize;
+
+type Map<K, V> = std::collections::BTreeMap<K, V>;
+
+/// Search response
+///
+/// This is a fork of [`elasticsearch_dsl::SearchResponse`] with the
+/// `aggregations` field using [`AggregationResults`] instead of
+/// [`serde_json::Value`].
+#[derive(Debug, Default, Serialize, PartialEq)]
+pub struct ElasticsearchResponse {
+    /// The time that it took Elasticsearch to process the query
+    pub took: u32,
+
+    /// The search has been cancelled and results are partial
+    pub timed_out: bool,
+
+    /// Indicates if search has been terminated early
+    #[serde(default)]
+    pub terminated_early: Option<bool>,
+
+    /// Scroll Id
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "_scroll_id")]
+    pub scroll_id: Option<String>,
+
+    /// Dynamically fetched fields
+    #[serde(default)]
+    pub fields: Map<String, serde_json::Value>,
+
+    /// Point in time Id
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pit_id: Option<String>,
+
+    /// Number of reduce phases
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_reduce_phases: Option<u64>,
+
+    /// Maximum document score. [None] when documents are implicitly sorted
+    /// by a field other than `_score`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_score: Option<f32>,
+
+    /// Number of clusters touched with their states
+    #[serde(skip_serializing_if = "Option::is_none", rename = "_clusters")]
+    pub clusters: Option<ClusterStatistics>,
+
+    /// Number of shards touched with their states
+    #[serde(rename = "_shards")]
+    pub shards: ShardStatistics,
+
+    /// Search hits
+    pub hits: HitsMetadata,
+
+    /// Search aggregations
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aggregations: Option<AggregationResults>,
+
+    #[serde(skip_serializing_if = "Map::is_empty", default)]
+    /// Suggest response
+    pub suggest: Map<String, Vec<Suggest>>,
+}


### PR DESCRIPTION
### Description

Profiling showed that parsing the json serialized aggregation string returned by the root searcher into a `serde_json::Value` can take 5x time the memory size of the returned payload. On a loaded system, this can represent a lot of memory that is consumed even if results are served from cache.

By using `serde_json_borrowed::OwnedValue`, we can reduce this tp 3x the size of the returned payload.

### How was this PR tested?

Heaptrack profiling.
