### PR TITLE
Faster shard scaling

### DIFF
--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -67,9 +67,9 @@ pub const INGESTER_PRIMARY_SHARDS_PREFIX: &str = "ingester.primary_shards:";
 pub const SPLIT_FIELDS_FILE_NAME: &str = "split_fields";
 
 /// More or less the indexing throughput of a core
-/// i.e PIPELINE_THROUGHPUT / PIPELINE_FULL_CAPACITY
+/// i.e. PIPELINE_THROUGHPUT / PIPELINE_FULL_CAPACITY
 pub const DEFAULT_SHARD_THROUGHPUT_LIMIT: ByteSize = ByteSize::mib(5);
-/// Large enough to absorb small bursts but should remain defensive against unbalanced shards
+/// Large enough to absorb small bursts but should remain defensive against unbalanced shards.
 pub const DEFAULT_SHARD_BURST_LIMIT: ByteSize = ByteSize::mib(50);
 
 /// A compromise between "exponential" scale up and moderate shard count increase.

--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -69,8 +69,14 @@ pub const SPLIT_FIELDS_FILE_NAME: &str = "split_fields";
 /// More or less the indexing throughput of a core
 /// i.e PIPELINE_THROUGHPUT / PIPELINE_FULL_CAPACITY
 pub const DEFAULT_SHARD_THROUGHPUT_LIMIT: ByteSize = ByteSize::mib(5);
-///
+/// Large enough to absorb small bursts but should remain defensive against unbalanced shards
 pub const DEFAULT_SHARD_BURST_LIMIT: ByteSize = ByteSize::mib(50);
+
+/// Maximum factor that avoids oscillating between scale up and scale down
+pub const MAX_SHARD_SCALE_UP_FACTOR: f32 = 2.0;
+/// A high value to allow quick scale up by default
+pub const DEFAULT_SHARD_SCALE_UP_FACTOR: f32 = 1.5;
+const _: () = assert!(DEFAULT_SHARD_SCALE_UP_FACTOR < MAX_SHARD_SCALE_UP_FACTOR);
 
 // (Just a reexport).
 pub use bytesize::MIB;

--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -66,7 +66,11 @@ pub const INGESTER_PRIMARY_SHARDS_PREFIX: &str = "ingester.primary_shards:";
 /// File name for the encoded list of fields in the split
 pub const SPLIT_FIELDS_FILE_NAME: &str = "split_fields";
 
+/// More or less the indexing throughput of a core
+/// i.e PIPELINE_THROUGHPUT / PIPELINE_FULL_CAPACITY
 pub const DEFAULT_SHARD_THROUGHPUT_LIMIT: ByteSize = ByteSize::mib(5);
+///
+pub const DEFAULT_SHARD_BURST_LIMIT: ByteSize = ByteSize::mib(50);
 
 // (Just a reexport).
 pub use bytesize::MIB;

--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -72,11 +72,8 @@ pub const DEFAULT_SHARD_THROUGHPUT_LIMIT: ByteSize = ByteSize::mib(5);
 /// Large enough to absorb small bursts but should remain defensive against unbalanced shards
 pub const DEFAULT_SHARD_BURST_LIMIT: ByteSize = ByteSize::mib(50);
 
-/// Maximum factor that avoids oscillating between scale up and scale down
-pub const MAX_SHARD_SCALE_UP_FACTOR: f32 = 2.0;
-/// A high value to allow quick scale up by default
+/// A compromise between "exponential" scale up and moderate shard count increase.
 pub const DEFAULT_SHARD_SCALE_UP_FACTOR: f32 = 1.5;
-const _: () = assert!(DEFAULT_SHARD_SCALE_UP_FACTOR < MAX_SHARD_SCALE_UP_FACTOR);
 
 // (Just a reexport).
 pub use bytesize::MIB;

--- a/quickwit/quickwit-config/src/cluster_config/mod.rs
+++ b/quickwit/quickwit-config/src/cluster_config/mod.rs
@@ -24,6 +24,7 @@ pub struct ClusterConfig {
     pub default_index_root_uri: Uri,
     pub replication_factor: usize,
     pub shard_throughput_limit: ByteSize,
+    pub shard_scaling_factor: f32,
 }
 
 impl ClusterConfig {
@@ -35,6 +36,7 @@ impl ClusterConfig {
             default_index_root_uri: Uri::for_test("ram:///indexes"),
             replication_factor: 1,
             shard_throughput_limit: quickwit_common::shared_consts::DEFAULT_SHARD_THROUGHPUT_LIMIT,
+            shard_scaling_factor: 1.01,
         }
     }
 }

--- a/quickwit/quickwit-config/src/cluster_config/mod.rs
+++ b/quickwit/quickwit-config/src/cluster_config/mod.rs
@@ -24,7 +24,7 @@ pub struct ClusterConfig {
     pub default_index_root_uri: Uri,
     pub replication_factor: usize,
     pub shard_throughput_limit: ByteSize,
-    pub shard_scaling_factor: f32,
+    pub shard_scale_up_factor: f32,
 }
 
 impl ClusterConfig {
@@ -36,7 +36,7 @@ impl ClusterConfig {
             default_index_root_uri: Uri::for_test("ram:///indexes"),
             replication_factor: 1,
             shard_throughput_limit: quickwit_common::shared_consts::DEFAULT_SHARD_THROUGHPUT_LIMIT,
-            shard_scaling_factor: 1.01,
+            shard_scale_up_factor: 1.01,
         }
     }
 }

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -167,7 +167,7 @@ impl ControlPlane {
                     ingester_pool.clone(),
                     replication_factor,
                     shard_throughput_limit_mib,
-                    cluster_config.shard_scaling_factor,
+                    cluster_config.shard_scale_up_factor,
                 );
 
                 let readiness_tx = readiness_tx.clone();

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -167,6 +167,7 @@ impl ControlPlane {
                     ingester_pool.clone(),
                     replication_factor,
                     shard_throughput_limit_mib,
+                    cluster_config.shard_scaling_factor,
                 );
 
                 let readiness_tx = readiness_tx.clone();

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -285,6 +285,7 @@ impl IngestController {
         ingester_pool: IngesterPool,
         replication_factor: usize,
         max_shard_ingestion_throughput_mib_per_sec: f32,
+        shard_scaling_factor: f32,
     ) -> Self {
         IngestController {
             metastore,
@@ -294,6 +295,7 @@ impl IngestController {
             stats: IngestControllerStats::default(),
             scaling_arbiter: ScalingArbiter::with_max_shard_ingestion_throughput_mib_per_sec(
                 max_shard_ingestion_throughput_mib_per_sec,
+                shard_scaling_factor,
             ),
         }
     }
@@ -396,12 +398,13 @@ impl IngestController {
         };
 
         match scaling_mode {
-            ScalingMode::Up => {
+            ScalingMode::Up(shards) => {
                 self.try_scale_up_shards(
                     local_shards_update.source_uid,
                     shard_stats,
                     model,
                     progress,
+                    shards,
                 )
                 .await?;
             }
@@ -670,18 +673,19 @@ impl IngestController {
         shard_stats: ShardStats,
         model: &mut ControlPlaneModel,
         progress: &Progress,
+        shards_to_create: usize,
     ) -> MetastoreResult<()> {
         if !model
-            .acquire_scaling_permits(&source_uid, ScalingMode::Up)
+            .acquire_scaling_permits(&source_uid, ScalingMode::Up(shards_to_create))
             .unwrap_or(false)
         {
             return Ok(());
         }
-        let new_num_open_shards = shard_stats.num_open_shards + 1;
-        let new_shard_source_uids: HashMap<SourceUid, usize> =
-            HashMap::from_iter([(source_uid.clone(), 1)]);
+        let new_num_open_shards = shard_stats.num_open_shards + shards_to_create;
+        let new_shards_per_source: HashMap<SourceUid, usize> =
+            HashMap::from_iter([(source_uid.clone(), shards_to_create)]);
         let successful_source_uids_res = self
-            .try_open_shards(new_shard_source_uids, model, &Default::default(), progress)
+            .try_open_shards(new_shards_per_source, model, &Default::default(), progress)
             .await;
 
         match successful_source_uids_res {
@@ -691,7 +695,7 @@ impl IngestController {
                 if successful_source_uids.is_empty() {
                     // We did not manage to create the shard.
                     // We can release our permit.
-                    model.release_scaling_permits(&source_uid, ScalingMode::Up);
+                    model.release_scaling_permits(&source_uid, ScalingMode::Up(shards_to_create));
                     warn!(
                         index_uid=%source_uid.index_uid,
                         source_id=%source_uid.source_id,
@@ -715,7 +719,7 @@ impl IngestController {
                     source_id=%source_uid.source_id,
                     "scaling up number of shards to {new_num_open_shards} failed: {metastore_error:?}"
                 );
-                model.release_scaling_permits(&source_uid, ScalingMode::Up);
+                model.release_scaling_permits(&source_uid, ScalingMode::Up(shards_to_create));
                 Err(metastore_error)
             }
         }
@@ -739,12 +743,12 @@ impl IngestController {
     /// The number of successfully open shards is returned.
     async fn try_open_shards(
         &mut self,
-        source_uids: HashMap<SourceUid, usize>,
+        shards_per_source: HashMap<SourceUid, usize>,
         model: &mut ControlPlaneModel,
         unavailable_leaders: &FnvHashSet<NodeId>,
         progress: &Progress,
     ) -> MetastoreResult<HashMap<SourceUid, usize>> {
-        let num_shards: usize = source_uids.values().sum();
+        let num_shards: usize = shards_per_source.values().sum();
 
         if num_shards == 0 {
             return Ok(HashMap::new());
@@ -756,7 +760,7 @@ impl IngestController {
             return Ok(HashMap::new());
         };
 
-        let source_uids_with_multiplicity = source_uids
+        let source_uids_with_multiplicity = shards_per_source
             .iter()
             .flat_map(|(source_uid, count)| std::iter::repeat(source_uid).take(*count));
 
@@ -1347,6 +1351,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let mut model = ControlPlaneModel::default();
@@ -1532,6 +1537,7 @@ mod tests {
             ingester_pool,
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let mut model = ControlPlaneModel::default();
@@ -1574,6 +1580,7 @@ mod tests {
             ingester_pool,
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
         let mut model = ControlPlaneModel::default();
 
@@ -1624,6 +1631,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let mut model = ControlPlaneModel::default();
@@ -1806,6 +1814,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let ingester_id_0 = NodeId::from("test-ingester-0");
@@ -2029,6 +2038,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -2166,6 +2176,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -2363,6 +2374,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -2487,6 +2499,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -2510,9 +2523,9 @@ mod tests {
 
         let progress = Progress::default();
 
-        // Test could not find leader.
+        // Test could not find leader because no ingester in pool
         controller
-            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress, 1)
             .await
             .unwrap();
 
@@ -2564,21 +2577,21 @@ mod tests {
 
         // Test failed to open shards.
         controller
-            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress, 1)
             .await
             .unwrap();
         assert_eq!(model.all_shards().count(), 0);
 
         // Test failed to init shards.
         controller
-            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress, 1)
             .await
             .unwrap_err();
         assert_eq!(model.all_shards().count(), 0);
 
         // Test successfully opened shard.
         controller
-            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_up_shards(source_uid.clone(), shard_stats, &mut model, &progress, 1)
             .await
             .unwrap();
         assert_eq!(
@@ -2598,6 +2611,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -2824,6 +2838,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -2907,6 +2922,7 @@ mod tests {
             ingester_pool,
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let mut model = ControlPlaneModel::default();
@@ -2982,6 +2998,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let closed_shards = controller.close_shards(Vec::new()).await;
@@ -3138,6 +3155,7 @@ mod tests {
             ingester_pool.clone(),
             replication_factor,
             TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
         );
 
         let mut model = ControlPlaneModel::default();

--- a/quickwit/quickwit-control-plane/src/ingest/scaling_arbiter.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/scaling_arbiter.rs
@@ -30,14 +30,14 @@ pub(crate) struct ScalingArbiter {
     // after scaling up, and double check that it is above the long term threshold.
     scale_up_shards_short_term_threshold_mib_per_sec: f32,
     scale_up_shards_long_term_threshold_mib_per_sec: f32,
-    // The max increase factor of the number of shards in one scaling operation
-    shard_scaling_factor: f32,
+    // The max increase factor of the number of shards in one scale up operation
+    shard_scale_up_factor: f32,
 }
 
 impl ScalingArbiter {
     pub fn with_max_shard_ingestion_throughput_mib_per_sec(
         max_shard_throughput_mib_per_sec: f32,
-        shard_scaling_factor: f32,
+        shard_scale_up_factor: f32,
     ) -> ScalingArbiter {
         ScalingArbiter {
             scale_up_shards_short_term_threshold_mib_per_sec: max_shard_throughput_mib_per_sec
@@ -45,7 +45,7 @@ impl ScalingArbiter {
             scale_up_shards_long_term_threshold_mib_per_sec: max_shard_throughput_mib_per_sec
                 * 0.3f32,
             scale_down_shards_threshold_mib_per_sec: max_shard_throughput_mib_per_sec * 0.2f32,
-            shard_scaling_factor,
+            shard_scale_up_factor,
         }
     }
 
@@ -65,7 +65,7 @@ impl ScalingArbiter {
 
             // compute the next number of shards we should have according the scaling factor
             let target_number_shards =
-                (shard_stats.num_open_shards as f32 * self.shard_scaling_factor).ceil() as usize;
+                (shard_stats.num_open_shards as f32 * self.shard_scale_up_factor).ceil() as usize;
 
             let new_number_shards = max_number_shards.min(target_number_shards);
 

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -25,7 +25,7 @@ use quickwit_proto::ingest::{Shard, ShardState};
 use quickwit_proto::types::{IndexUid, NodeId, ShardId, SourceId, SourceUid};
 use tracing::{error, info, warn};
 
-/// Limits the number of shards that can be opened for scaling up a source to 5 per minute.
+/// Limits the number of scale up operations that can happen to a source to 5 per minute.
 const SCALING_UP_RATE_LIMITER_SETTINGS: RateLimiterSettings = RateLimiterSettings {
     burst_limit: 5,
     rate_limit: ConstantRate::new(5, Duration::from_secs(60)),

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -574,7 +574,9 @@ impl ShardTable {
 #[derive(Clone, Copy, Default)]
 pub(crate) struct ShardStats {
     pub num_open_shards: usize,
+    /// Average short-term ingestion rate (MiB/s) per open shard
     pub avg_short_term_ingestion_rate: f32,
+    /// Average long-term ingestion rate (MiB/s) per open shard
     pub avg_long_term_ingestion_rate: f32,
 }
 

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1058,7 +1058,7 @@ async fn setup_control_plane(
         default_index_root_uri,
         replication_factor,
         shard_throughput_limit: ingest_api_config.shard_throughput_limit,
-        shard_scaling_factor: ingest_api_config.shard_scale_up_factor,
+        shard_scale_up_factor: ingest_api_config.shard_scale_up_factor,
     };
     let (control_plane_mailbox, _control_plane_handle, mut readiness_rx) = ControlPlane::spawn(
         universe,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1058,6 +1058,7 @@ async fn setup_control_plane(
         default_index_root_uri,
         replication_factor,
         shard_throughput_limit: ingest_api_config.shard_throughput_limit,
+        shard_scaling_factor: ingest_api_config.shard_scale_up_factor,
     };
     let (control_plane_mailbox, _control_plane_handle, mut readiness_rx) = ControlPlane::spawn(
         universe,


### PR DESCRIPTION
### Description

Indexers return a lot of 429 when ingest rates fluctuate, even if the overall indexing capacity (~5MB/core) is note reached. This PR makes some small parameter adjustments to decrease the overall error rates on typical workloads. It will be the topic for another issue/PR to introduce the structual changes that are necessary to improve the routing strategy.

- Customizable shard burst limit with default increased to 50MB: helps absorbing the load until the next scale up
- Shard scaling factor: helps keeping up with load fluctuations on workloads with high number of shards (e.g having +20MB/s on an index where the average ingest rate is 100MB/s is more likely than +20MB/s on an index where the average rate is 1MB/s)

Related to https://github.com/quickwit-oss/quickwit/issues/5270

### How was this PR tested?

Adhoc python load testing framework: https://github.com/rdettai/qw-ingest-tests
