### PR TITLE
Revert "Fix default dynamic mapping config (#5653)"

### DIFF
--- a/quickwit/quickwit-config/src/index_config/serialize.rs
+++ b/quickwit/quickwit-config/src/index_config/serialize.rs
@@ -349,45 +349,6 @@ mod test {
     }
 
     #[test]
-    fn test_default_dynamic_mapping_matches_docs() {
-        let minimal_config_yaml = r#"
-            version: 0.8
-            index_id: hdfs-logs
-            doc_mapping:
-              doc_mapping_uid: 00000000000000000000000000
-        "#;
-        let docs_config_yaml = r#"
-            version: 0.8
-            index_id: hdfs-logs
-            doc_mapping:
-                doc_mapping_uid: 00000000000000000000000000
-                mode: dynamic
-                dynamic_mapping:
-                    indexed: true
-                    stored: true
-                    tokenizer: default
-                    record: basic
-                    expand_dots: true
-                    fast: true
-        "#;
-        {
-            let minimal_index_config: IndexConfig = load_index_config_from_user_config(
-                ConfigFormat::Yaml,
-                minimal_config_yaml.as_bytes(),
-                &Uri::for_test("s3://mybucket"),
-            )
-            .unwrap();
-            let docs_index_config: IndexConfig = load_index_config_from_user_config(
-                ConfigFormat::Yaml,
-                docs_config_yaml.as_bytes(),
-                &Uri::for_test("s3://mybucket"),
-            )
-            .unwrap();
-            assert_eq!(minimal_index_config, docs_index_config);
-        }
-    }
-
-    #[test]
     fn test_update_index_root_uri() {
         let original_config_yaml = r#"
             version: 0.8

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_entry.rs
@@ -409,14 +409,6 @@ impl TextIndexingOptions {
             fieldnorms: false,
         }
     }
-
-    fn default_dynamic() -> Self {
-        TextIndexingOptions {
-            tokenizer: QuickwitTextTokenizer::default(),
-            record: IndexRecordOption::Basic,
-            fieldnorms: false,
-        }
-    }
 }
 
 impl Default for TextIndexingOptions {
@@ -619,11 +611,8 @@ impl QuickwitJsonOptions {
     /// Build a default QuickwitJsonOptions for dynamic fields.
     pub fn default_dynamic() -> Self {
         QuickwitJsonOptions {
-            description: None,
-            indexing_options: Some(TextIndexingOptions::default_dynamic()),
-            stored: true,
-            expand_dots: true,
             fast: FastFieldOptions::default_enabled(),
+            ..Default::default()
         }
     }
 }

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/mod.rs
@@ -266,7 +266,7 @@ mod tests {
             tantivy_schema.get_field_entry(dynamic_field).field_type()
         {
             let text_opt = json_options.get_text_indexing_options().unwrap();
-            assert_eq!(text_opt.tokenizer(), "default");
+            assert_eq!(text_opt.tokenizer(), "raw");
         } else {
             panic!("dynamic field should be of JSON type");
         }


### PR DESCRIPTION
### Description

Revert https://github.com/quickwit-oss/quickwit/pull/5653 to avoid regressions.

We will then still need to fix the fact that CI didn't catch this (https://github.com/quickwit-oss/quickwit/issues/5681) and the fact that the docs are not aligned with the behavior (https://github.com/quickwit-oss/quickwit/issues/5682)

Note: if we decide to update the docs, don't forget to also update the tutorial https://github.com/quickwit-oss/quickwit/issues/5571

### How was this PR tested?

Describe how you tested this PR.
