### PR TITLE
Fix delete task not respecting default fields

### DIFF
--- a/quickwit/quickwit-serve/src/delete_task_api/handler.rs
+++ b/quickwit/quickwit-serve/src/delete_task_api/handler.rs
@@ -45,6 +45,7 @@ pub struct DeleteQueryRequest {
     /// Query text. The query language is that of tantivy.
     pub query: String,
     // Fields to search on
+    #[serde(rename(deserialize = "search_field"))]
     #[serde(default)]
     pub search_fields: Option<Vec<String>>,
     /// If set, restrict delete to documents with a `timestamp >= start_timestamp`.
@@ -232,7 +233,7 @@ mod tests {
             .path("/test-delete-task-rest/delete-tasks")
             .method("POST")
             .json(&true)
-            .body(r#"{"query": "myterm", "start_timestamp": 1, "end_timestamp": 10, "search_fields": ["body"]}"#)
+            .body(r#"{"query": "myterm", "start_timestamp": 1, "end_timestamp": 10, "search_field": ["body"]}"#)
             .reply(&delete_query_api_handlers)
             .await;
         assert_eq!(resp.status(), 200);


### PR DESCRIPTION
### Description

This seems to have been broken in https://github.com/quickwit-oss/quickwit/pull/3148

According to the docs, delete tasks should support default fields https://github.com/quickwit-oss/quickwit/blob/722cb877a611972f29167b11191aa0f6acb9c213/docs/reference/rest-api.md#L759

### How was this PR tested?

Unit tests.
