### PR TITLE
fix ci after rustup breaking change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y
       - name: Setup stable Rust Toolchain
         if: steps.modified.outputs.rust_src == 'true'
-        run: rustup show
+        run: rustup show active-toolchain || rustup toolchain install
         working-directory: ./quickwit
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
@@ -120,7 +120,7 @@ jobs:
         run: rustup toolchain install nightly
       - name: Setup stable Rust Toolchain
         if: steps.modified.outputs.rust_src == 'true'
-        run: rustup show
+        run: rustup show active-toolchain || rustup toolchain install
         working-directory: ./quickwit
       - name: Setup cache
         if: steps.modified.outputs.rust_src == 'true'

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -25,7 +25,7 @@ jobs:
           - name: Cypress run
             command: |
               sudo apt-get -y install protobuf-compiler
-              rustup show
+              rustup show active-toolchain || rustup toolchain install
               CI=false yarn --cwd quickwit-ui build
               RUSTFLAGS="--cfg tokio_unstable" cargo build --features=postgres
               mkdir qwdata


### PR DESCRIPTION
rustup no longer install toolchains on it's own based on `rust-toolchain.toml`, update ci to reflect that

see also https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html