### PR TITLE
Add timeout to metastore GRPC client

### DIFF
--- a/quickwit/quickwit-codegen/example/src/error.rs
+++ b/quickwit/quickwit-codegen/example/src/error.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 
 use quickwit_actors::AskError;
+use quickwit_common::tower::TimeoutExceeded;
 use quickwit_proto::error::GrpcServiceError;
 pub use quickwit_proto::error::{grpc_error_to_grpc_status, grpc_status_to_service_error};
 use quickwit_proto::{ServiceError, ServiceErrorCode};
@@ -70,5 +71,11 @@ where E: fmt::Debug
 {
     fn from(error: AskError<E>) -> Self {
         HelloError::Internal(format!("{error:?}"))
+    }
+}
+
+impl From<TimeoutExceeded> for HelloError {
+    fn from(_: TimeoutExceeded) -> Self {
+        HelloError::Timeout("client".to_string())
     }
 }

--- a/quickwit/quickwit-codegen/example/src/lib.rs
+++ b/quickwit/quickwit-codegen/example/src/lib.rs
@@ -162,7 +162,7 @@ mod tests {
 
     use bytesize::ByteSize;
     use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Universe};
-    use quickwit_common::tower::{BalanceChannel, Change};
+    use quickwit_common::tower::{BalanceChannel, Change, TimeoutLayer};
     use tokio::sync::mpsc::error::TrySendError;
     use tokio_stream::StreamExt;
     use tonic::transport::{Endpoint, Server};
@@ -766,5 +766,63 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(error, HelloError::Timeout(_)));
+    }
+
+    #[tokio::test]
+    async fn test_balanced_channel_timeout() {
+        let addr_str = "127.0.0.1:11112";
+        let addr: SocketAddr = addr_str.parse().unwrap();
+        // We want to abruptly stop a server without even sending the connection
+        // RST packet. Simply dropping the tonic Server is not enough, so we
+        // spawn a thread and freeze it with thread::park().
+        std::thread::spawn(move || {
+            let server_fut = async {
+                let hello = HelloImpl {
+                    // delay the response so that the server freezes in the middle of the request
+                    delay: Duration::from_millis(1000),
+                };
+                let grpc_server_adapter = HelloGrpcServerAdapter::new(hello);
+                let grpc_server = HelloGrpcServer::new(grpc_server_adapter);
+                tokio::select! {
+                    // wait just enough to let the client perform its request
+                    _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+                    _ = Server::builder().add_service(grpc_server).serve(addr) => {}
+                };
+                std::thread::park();
+                println!("Thread unparked, unexpected");
+            };
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(server_fut);
+        });
+
+        // create a client that will try to connect to the server
+        let (balance_channel, balance_channel_tx) = BalanceChannel::new();
+        let channel = Endpoint::from_str(&format!("http://{addr_str}"))
+            .unwrap()
+            .connect_lazy();
+        balance_channel_tx
+            .send(Change::Insert(addr, channel))
+            .unwrap();
+
+        let grpc_client = HelloClient::tower()
+            // this test fails if we comment out the TimeoutLayer
+            .stack_layer(TimeoutLayer::new(Duration::from_secs(3)))
+            .build_from_balance_channel(balance_channel, ByteSize::mib(1));
+
+        let response_fut = async move {
+            grpc_client
+                .hello(HelloRequest {
+                    name: "World".to_string(),
+                })
+                .await
+        };
+        let response_fut = tokio::time::timeout(Duration::from_secs(5), response_fut);
+        response_fut
+            .await
+            .unwrap()
+            .expect_err("should have timed out at the client level");
     }
 }

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -631,10 +631,6 @@ impl IndexingService {
         let pipeline_diff = self.compute_pipeline_diff(tasks);
 
         if !pipeline_diff.pipelines_to_shutdown.is_empty() {
-            info!(
-                pipeline_uids=?pipeline_diff.pipelines_to_shutdown,
-                "shutdown indexing pipelines"
-            );
             self.shutdown_pipelines(&pipeline_diff.pipelines_to_shutdown)
                 .await;
         }
@@ -753,6 +749,10 @@ impl IndexingService {
 
     /// Shuts down the pipelines with supplied ids and performs necessary cleanup.
     async fn shutdown_pipelines(&mut self, pipelines_to_shutdown: &[PipelineUid]) {
+        info!(
+            pipeline_uids=?pipelines_to_shutdown,
+            "shutdown indexing pipelines"
+        );
         let should_gc_ingest_api_queues = pipelines_to_shutdown
             .iter()
             .flat_map(|pipeline_uid| self.indexing_pipelines.get(pipeline_uid))

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -631,6 +631,10 @@ impl IndexingService {
         let pipeline_diff = self.compute_pipeline_diff(tasks);
 
         if !pipeline_diff.pipelines_to_shutdown.is_empty() {
+            info!(
+                pipeline_uids=?pipeline_diff.pipelines_to_shutdown,
+                "shutdown indexing pipelines"
+            );
             self.shutdown_pipelines(&pipeline_diff.pipelines_to_shutdown)
                 .await;
         }

--- a/quickwit/quickwit-proto/src/metastore/mod.rs
+++ b/quickwit/quickwit-proto/src/metastore/mod.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use quickwit_common::rate_limited_error;
 use quickwit_common::retry::Retryable;
-use quickwit_common::tower::MakeLoadShedError;
+use quickwit_common::tower::{MakeLoadShedError, TimeoutExceeded};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{IndexId, IndexUid, QueueId, SourceId, SplitId};
@@ -184,6 +184,12 @@ impl From<sqlx::Error> for MetastoreError {
         MetastoreError::Db {
             message: error.to_string(),
         }
+    }
+}
+
+impl From<TimeoutExceeded> for MetastoreError {
+    fn from(_: TimeoutExceeded) -> Self {
+        MetastoreError::Timeout("client".to_string())
     }
 }
 


### PR DESCRIPTION
### Description

On Airmail, a large Quickwit deployment, we observe that loosing the metastore connectivity, even temporarily, triggers indexer pods restarts. The IndexingService not responding to liveness check because the actor is hanging on metastore requests.

Adding a timeout to metastore requests:
- creates more explicit error messages in cases where the IndexingService does fail because of metastore timeouts
- gives the indexer a chance to recover thanks to the metastore client retries

### How was this PR tested?

Unit test on the example GRPC stack.
