### PR TITLE
Invalid index_id with ingest v2 returns 429 

### DIFF
--- a/quickwit/quickwit-serve/src/elasticsearch_api/bulk_v2.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/bulk_v2.rs
@@ -123,7 +123,7 @@ pub(crate) async fn elastic_bulk_ingest_v2(
                 )
             })?;
 
-        // Validate index id early because propagating back the right error (400)
+        // Validate index ID early because propagating back the right error (400)
         // from deeper ingest layers is harder
         if validate_identifier("", &index_id).is_err() {
             let invalid_item = make_invalid_index_id_item(index_id.clone(), meta.es_doc_id);

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -215,11 +215,11 @@ async fn ingest_v2(
         None
     };
 
-    // Validate index id early because propagating back the right error (400)
+    // Validate index ID early because propagating back the right error (400)
     // from deeper ingest layers is harder
     if validate_identifier("", &index_id).is_err() {
         return Err(IngestServiceError::BadRequest(
-            "invalid index_id".to_string(),
+            "invalid index ID".to_string(),
         ));
     }
 

--- a/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/ingest_api/rest_handler.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bytes::{Buf, Bytes};
-use quickwit_config::{IngestApiConfig, INGEST_V2_SOURCE_ID};
+use quickwit_config::{validate_identifier, IngestApiConfig, INGEST_V2_SOURCE_ID};
 use quickwit_ingest::{
     CommitType, DocBatchBuilder, DocBatchV2Builder, FetchResponse, IngestRequest, IngestService,
     IngestServiceClient, IngestServiceError, TailRequest,
@@ -214,6 +214,14 @@ async fn ingest_v2(
     } else {
         None
     };
+
+    // Validate index id early because propagating back the right error (400)
+    // from deeper ingest layers is harder
+    if validate_identifier("", &index_id).is_err() {
+        return Err(IngestServiceError::BadRequest(
+            "invalid index_id".to_string(),
+        ));
+    }
 
     let subrequest = IngestSubrequest {
         subrequest_id: 0,

--- a/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0007-illegal-index-name.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/bulk/0007-illegal-index-name.yaml
@@ -1,0 +1,20 @@
+ndjson:
+  - index: { "_index": "test-index" }
+  - message: Hola, Mundo!
+  - index: { "_index": "test-index-pattern-11" }
+  - message: Hola, Mundo!
+  - index: { "_index": "test-index-pattern-&1" }
+  - message: Hola, Mundo!
+status_code: 200
+expected:
+  errors: true
+  items:
+    - index:
+        _index: test-index
+        status: 201
+    - index:
+        _index: test-index-pattern-11
+        status: 201
+    - index:
+        _index: test-index-pattern-&1
+        status: 400


### PR DESCRIPTION
### Description of the issue

When using index templates, specifying and index name that matches the pattern but has illegal characters results in a 429 response code instead of a 400.

Description of the problem:
- the index_id validity is not validated until the metastore is called
- calling `GetOrCreateOpenShards` with an invalid index_id on the metastore fails with MetastoreError::JsonDeserializeError
- a failure to call the metastore is logged but not repported to the ingest workbench
- because the router is not populated, the workbench fails with "shard not found errors" for the failing index but also other targetted indexes batched with it

### Proposed solution

The index id is now validated in `quickwit-serve`, before calling the ingest router (ES bulk and native APIs)

### How was this PR tested?

Added unit and integration (python) tests
