### PR TITLE
Add tonic tls feature

### DIFF
--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-metrics = { workspace = true }
 tokio-stream = { workspace = true }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["tls"] }
 tower = { workspace = true }
 tracing = { workspace = true }
 


### PR DESCRIPTION
### Description

When running 
```sh
cargo bench --package quickwit-actors --bench bench
```
, noticed that the `make_channel` method in the `quickwit-common` crate not work.  
It needs `#[cfg(feature = "tls")]` for `tonic::transport::ClientTlsConfig`.

### How was this PR tested?

cargo bench
