### PR TITLE
Add in flight get slice metric

### DIFF
--- a/quickwit/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit/quickwit-storage/src/local_file_storage.rs
@@ -28,6 +28,7 @@ use quickwit_config::StorageBackend;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tracing::warn;
 
+use crate::metrics::object_storage_get_slice_in_flight_guards;
 use crate::storage::SendableAsync;
 use crate::{
     BulkDeleteError, DebouncedStorage, DeleteFailure, OwnedBytes, Storage, StorageError,
@@ -214,6 +215,7 @@ impl Storage for LocalFileStorage {
             // step, as there would be if using tokio async File.
             let mut file = std::fs::File::open(full_path)?;
             file.seek(SeekFrom::Start(range.start as u64))?;
+            let _in_flight_guards = object_storage_get_slice_in_flight_guards(range.len());
             let mut content_bytes: Vec<u8> = Vec::with_capacity(range.len());
             #[allow(clippy::uninit_vec)]
             unsafe {

--- a/quickwit/quickwit-storage/src/metrics.rs
+++ b/quickwit/quickwit-storage/src/metrics.rs
@@ -16,7 +16,7 @@
 
 use once_cell::sync::Lazy;
 use quickwit_common::metrics::{
-    new_counter, new_counter_vec, new_gauge, new_histogram_vec, Histogram, IntCounter,
+    new_counter, new_counter_vec, new_gauge, new_histogram_vec, GaugeGuard, Histogram, IntCounter,
     IntCounterVec, IntGauge,
 };
 
@@ -32,6 +32,8 @@ pub struct StorageMetrics {
     pub get_slice_timeout_all_timeouts: IntCounter,
     pub object_storage_get_total: IntCounter,
     pub object_storage_get_errors_total: IntCounterVec<1>,
+    pub object_storage_get_slice_in_flight_count: IntGauge,
+    pub object_storage_get_slice_in_flight_num_bytes: IntGauge,
     pub object_storage_put_total: IntCounter,
     pub object_storage_put_parts: IntCounter,
     pub object_storage_download_num_bytes: IntCounter,
@@ -97,7 +99,8 @@ impl Default for StorageMetrics {
             get_slice_timeout_all_timeouts,
             object_storage_get_total: new_counter(
                 "object_storage_gets_total",
-                "Number of objects fetched.",
+                "Number of objects fetched. Might be lower than get_slice_timeout_outcome if \
+                 queries are debounced.",
                 "storage",
                 &[],
             ),
@@ -107,6 +110,19 @@ impl Default for StorageMetrics {
                 "storage",
                 &[],
                 ["code"],
+            ),
+            object_storage_get_slice_in_flight_count: new_gauge(
+                "object_storage_get_slice_in_flight_count",
+                "Number of GetObject for which the memory was allocated but the download is still \
+                 in progress.",
+                "storage",
+                &[],
+            ),
+            object_storage_get_slice_in_flight_num_bytes: new_gauge(
+                "object_storage_get_slice_in_flight_num_bytes",
+                "Memory allocated for GetObject requests that are still in progress.",
+                "storage",
+                &[],
             ),
             object_storage_put_total: new_counter(
                 "object_storage_puts_total",
@@ -212,3 +228,16 @@ pub static STORAGE_METRICS: Lazy<StorageMetrics> = Lazy::new(StorageMetrics::def
 #[cfg(test)]
 pub static CACHE_METRICS_FOR_TESTS: Lazy<CacheMetrics> =
     Lazy::new(|| CacheMetrics::for_component("fortest"));
+
+pub fn object_storage_get_slice_in_flight_guards(
+    get_request_size: usize,
+) -> (GaugeGuard<'static>, GaugeGuard<'static>) {
+    let mut bytes_guard = GaugeGuard::from_gauge(
+        &crate::STORAGE_METRICS.object_storage_get_slice_in_flight_num_bytes,
+    );
+    bytes_guard.add(get_request_size as i64);
+    let mut count_guard =
+        GaugeGuard::from_gauge(&crate::STORAGE_METRICS.object_storage_get_slice_in_flight_count);
+    count_guard.add(1);
+    (bytes_guard, count_guard)
+}

--- a/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
@@ -44,6 +44,7 @@ use tokio_util::io::StreamReader;
 use tracing::{instrument, warn};
 
 use crate::debouncer::DebouncedStorage;
+use crate::metrics::object_storage_get_slice_in_flight_guards;
 use crate::storage::SendableAsync;
 use crate::{
     BulkDeleteError, DeleteFailure, MultiPartPolicy, PutPayload, Storage, StorageError,
@@ -194,18 +195,21 @@ impl AzureBlobStorage {
     ) -> StorageResult<Vec<u8>> {
         let name = self.blob_name(path);
         let capacity = range_opt.as_ref().map(Range::len).unwrap_or(0);
-
         retry(&self.retry_params, || async {
-            let mut response_stream = if let Some(range) = range_opt.as_ref() {
-                self.container_client
+            let (mut response_stream, _in_flight_guards) = if let Some(range) = range_opt.as_ref() {
+                let stream = self
+                    .container_client
                     .blob_client(&name)
                     .get()
                     .range(range.clone())
-                    .into_stream()
+                    .into_stream();
+                // only record ranged get request as being in flight
+                let in_flight_guards = object_storage_get_slice_in_flight_guards(capacity);
+                (stream, Some(in_flight_guards))
             } else {
-                self.container_client.blob_client(&name).get().into_stream()
+                let stream = self.container_client.blob_client(&name).get().into_stream();
+                (stream, None)
             };
-
             let mut buf: Vec<u8> = Vec::with_capacity(capacity);
             download_all(&mut response_stream, &mut buf).await?;
 


### PR DESCRIPTION
### Description

This PR adds 2 new metrics to track how many get_slice requests are being executed and how much data has been allocated for them. This memory is currently not tracked in anywhere, and it might take up significant space if downloading many large object slices in parallel.

### How was this PR tested?

Describe how you tested this PR.
