### PR TITLE
Fix order mismatch in elastic compatible `msearch` api

### DIFF
--- a/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
@@ -890,7 +890,7 @@ async fn es_compat_index_multi_search(
     let max_concurrent_searches =
         multi_search_params.max_concurrent_searches.unwrap_or(10) as usize;
     let search_responses = futures::stream::iter(futures)
-        .buffer_unordered(max_concurrent_searches)
+        .buffered(max_concurrent_searches)
         .collect::<Vec<_>>()
         .await;
     let responses = search_responses


### PR DESCRIPTION
### Description

`buffer_unordered` will collect records in the order in which they complete. But we need to return data in the same order as user requested otherwise user can't match response with requests.

Fixes issue: https://github.com/quickwit-oss/quickwit/issues/5731

### How was this PR tested?

Manually using Grafana plugin
