### PR TITLE
Add total size bytes gauge for search after cache

### DIFF
--- a/docs/reference/es_compatible_api.md
+++ b/docs/reference/es_compatible_api.md
@@ -134,7 +134,7 @@ If a parameter appears both as a query string parameter and in the JSON payload,
 | `q`                | `String`      | The search query.                                                                | (Optional)    |
 | `size`             | `Integer`     | Number of hits to return.                                                        | 10            |
 | `sort`             | `String`      | Describes how documents should be ranked. See [Sort order](#sort-order)          | (Optional)    |
-| `scroll`           | `Duration`    | Creates a scroll context for "time to live". See [Scroll](#_scroll--scroll-api). | (Optional)    |
+| `scroll`           | `Duration`    | Creates a scroll context for "time to live". See [Scroll](#_searchscroll--scroll-api). | (Optional)    |
 | `allow_partial_search_results` | `Boolean` | Returns a partial response if some (but not all) of the split searches were unsuccessful. | `true` |
 
 #### Supported Request Body parameters
@@ -279,6 +279,11 @@ First, the client needs to call the `search api` with a `scroll` query parameter
 
 Each subsequent call to the `_search/scroll` endpoint will return a new `scroll_id` pointing to the next page.
 
+:::tip
+
+Using `_search` and then `_search/scroll` is somewhat similar to using `_search` with the `search_after` parameter, except that it creates a lightweight snapshot view of the dataset during the initial call to `_search`. Further calls to `_search/scroll` only return results from that view, thus ensuring more consistent results.
+
+:::
 
 ### `_cat` &nbsp; Cat API
 

--- a/quickwit/quickwit-search/src/cluster_client.rs
+++ b/quickwit/quickwit-search/src/cluster_client.rs
@@ -191,7 +191,7 @@ impl ClusterClient {
         client.leaf_list_terms(request.clone()).await
     }
 
-    /// Attempts to store a given search context within the cluster.
+    /// Attempts to store a given key value pair within the cluster.
     ///
     /// This function may fail silently, if no clients was available.
     pub async fn put_kv(&self, key: &[u8], payload: &[u8], ttl: Duration) {

--- a/quickwit/quickwit-search/src/metrics.rs
+++ b/quickwit/quickwit-search/src/metrics.rs
@@ -34,7 +34,7 @@ pub struct SearchMetrics {
     pub leaf_search_single_split_tasks_pending: IntGauge,
     pub leaf_search_single_split_tasks_ongoing: IntGauge,
     pub leaf_search_single_split_warmup_num_bytes: Histogram,
-    pub search_after_cache_size_bytes: IntGauge,
+    pub searcher_local_kv_store_size_bytes: IntGauge,
 }
 
 impl Default for SearchMetrics {
@@ -147,9 +147,10 @@ impl Default for SearchMetrics {
                 &[],
                 ["affinity"],
             ),
-            search_after_cache_size_bytes: new_gauge(
-                "search_after_cache_size_bytes",
-                "Total size of the search after (and scroll) cache in bytes.",
+            searcher_local_kv_store_size_bytes: new_gauge(
+                "searcher_local_kv_store_size_bytes",
+                "Size of the searcher kv store in bytes. This store is used to cache scroll \
+                 contexts.",
                 "search",
                 &[],
             ),

--- a/quickwit/quickwit-search/src/metrics.rs
+++ b/quickwit/quickwit-search/src/metrics.rs
@@ -17,7 +17,7 @@
 use bytesize::ByteSize;
 use once_cell::sync::Lazy;
 use quickwit_common::metrics::{
-    exponential_buckets, linear_buckets, new_counter, new_counter_vec, new_gauge_vec,
+    exponential_buckets, linear_buckets, new_counter, new_counter_vec, new_gauge, new_gauge_vec,
     new_histogram, new_histogram_vec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
 };
 
@@ -34,6 +34,7 @@ pub struct SearchMetrics {
     pub leaf_search_single_split_tasks_pending: IntGauge,
     pub leaf_search_single_split_tasks_ongoing: IntGauge,
     pub leaf_search_single_split_warmup_num_bytes: Histogram,
+    pub search_after_cache_size_bytes: IntGauge,
 }
 
 impl Default for SearchMetrics {
@@ -145,6 +146,12 @@ impl Default for SearchMetrics {
                 "search",
                 &[],
                 ["affinity"],
+            ),
+            search_after_cache_size_bytes: new_gauge(
+                "search_after_cache_size_bytes",
+                "Total size of the search after (and scroll) cache in bytes.",
+                "search",
+                &[],
             ),
         }
     }

--- a/quickwit/quickwit-search/src/scroll_context.rs
+++ b/quickwit/quickwit-search/src/scroll_context.rs
@@ -38,8 +38,6 @@ use crate::ClusterClient;
 
 /// Maximum number of values in the local search KV store.
 ///
-/// Currently this store is only used for caching scroll contexts.
-///
 /// TODO make configurable.
 ///
 /// Assuming a search context of 1MB, this can
@@ -128,6 +126,13 @@ struct TrackedValue {
     _total_size_metric_guard: GaugeGuard<'static>,
 }
 
+/// In memory key value store with TTL and limited size.
+///
+/// Once the capacity [LOCAL_KV_CACHE_SIZE] is reached, the oldest entries are
+/// removed.
+///
+/// Currently this store is only used for caching scroll contexts. Using it for
+/// other purposes is risky as use cases would compete for its capacity.
 #[derive(Clone)]
 pub(crate) struct MiniKV {
     ttl_with_cache: Arc<RwLock<TtlCache<Vec<u8>, TrackedValue>>>,

--- a/quickwit/quickwit-search/src/scroll_context.rs
+++ b/quickwit/quickwit-search/src/scroll_context.rs
@@ -23,6 +23,7 @@ use anyhow::Context;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use quickwit_common::metrics::GaugeGuard;
+use quickwit_common::shared_consts::SCROLL_BATCH_LEN;
 use quickwit_metastore::SplitMetadata;
 use quickwit_proto::search::{LeafSearchResponse, PartialHit, SearchRequest, SplitSearchError};
 use quickwit_proto::types::IndexUid;
@@ -35,14 +36,13 @@ use crate::root::IndexMetasForLeafSearch;
 use crate::service::SearcherContext;
 use crate::ClusterClient;
 
-/// Maximum capacity of the search after cache.
+/// Maximum number of contexts in the search after cache.
 ///
-/// For the moment this value is hardcoded.
 /// TODO make configurable.
 ///
 /// Assuming a search context of 1MB, this can
 /// amount to up to 1GB.
-const SCROLL_BATCH_LEN: usize = 1_000;
+const SEARCH_AFTER_CACHE_SIZE: usize = 1_000;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct ScrollContext {
@@ -134,7 +134,7 @@ pub(crate) struct MiniKV {
 impl Default for MiniKV {
     fn default() -> MiniKV {
         MiniKV {
-            ttl_with_cache: Arc::new(RwLock::new(TtlCache::new(SCROLL_BATCH_LEN))),
+            ttl_with_cache: Arc::new(RwLock::new(TtlCache::new(SEARCH_AFTER_CACHE_SIZE))),
         }
     }
 }

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -57,7 +57,7 @@ pub struct SearchServiceImpl {
     storage_resolver: StorageResolver,
     cluster_client: ClusterClient,
     searcher_context: Arc<SearcherContext>,
-    search_after_cache: MiniKV,
+    local_kv_store: MiniKV,
 }
 
 /// Trait representing a search service.
@@ -165,7 +165,7 @@ impl SearchServiceImpl {
             storage_resolver,
             cluster_client,
             searcher_context,
-            search_after_cache: MiniKV::default(),
+            local_kv_store: MiniKV::default(),
         }
     }
 }
@@ -322,13 +322,13 @@ impl SearchService for SearchServiceImpl {
 
     async fn put_kv(&self, put_request: PutKvRequest) {
         let ttl = Duration::from_secs(put_request.ttl_secs as u64);
-        self.search_after_cache
+        self.local_kv_store
             .put(put_request.key, put_request.payload, ttl)
             .await;
     }
 
     async fn get_kv(&self, get_request: GetKvRequest) -> Option<Vec<u8>> {
-        let payload: Vec<u8> = self.search_after_cache.get(&get_request.key).await?;
+        let payload: Vec<u8> = self.local_kv_store.get(&get_request.key).await?;
         Some(payload)
     }
 


### PR DESCRIPTION
### Description

The search after cache might get pretty big on a system with many scroll / search after queries. This PR adds a way to track its size.

This is part of the global effort to understand memory consumption on searchers.

### How was this PR tested?

Would add a test if we could merge https://github.com/quickwit-oss/quickwit/pull/5718 first.
