### PR TITLE
Balance pipelines when unscaled capacity of individual nodes is exceeded

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic_model.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic_model.rs
@@ -78,6 +78,7 @@ impl Source {
 pub struct SchedulingProblem {
     sources: Vec<Source>,
     indexer_cpu_capacities: Vec<CpuCapacity>,
+    unscaled_cpu_capacities: Vec<CpuCapacity>,
 }
 
 impl SchedulingProblem {
@@ -97,6 +98,7 @@ impl SchedulingProblem {
         // TODO assert for affinity.
         SchedulingProblem {
             sources: Vec::new(),
+            unscaled_cpu_capacities: indexer_cpu_capacities.clone(),
             indexer_cpu_capacities,
         }
     }
@@ -107,6 +109,11 @@ impl SchedulingProblem {
 
     pub fn indexer_cpu_capacity(&self, indexer_ord: IndexerOrd) -> CpuCapacity {
         self.indexer_cpu_capacities[indexer_ord]
+    }
+
+    /// Gets the original cpu capacities before scaling.
+    pub fn unscaled_indexer_cpu_capacities(&self) -> &[CpuCapacity] {
+        &self.unscaled_cpu_capacities
     }
 
     /// Scales the cpu capacity by the given scaling factor.


### PR DESCRIPTION
### Description

Closes https://github.com/quickwit-oss/quickwit/issues/5747

Implementation of proposed solution 2:
> for each source, try to first limit the max number of pipelines that can be assigned to each node according to its unscaled original capacity.

### How was this PR tested?

Added unit test.
