### PR TITLE
increase sleep time to make test not/less flaky

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -1032,6 +1032,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::actors::merge_pipeline::SUPERVISE_LOOP_INTERVAL;
 
     async fn spawn_indexing_service_for_test(
         data_dir_path: &Path,
@@ -1605,7 +1606,7 @@ mod tests {
         let observation = indexing_server_handle.process_pending_and_observe().await;
         assert_eq!(observation.num_running_pipelines, 0);
         assert_eq!(observation.num_running_merge_pipelines, 0);
-        universe.sleep(2 * *HEARTBEAT).await;
+        universe.sleep(SUPERVISE_LOOP_INTERVAL).await;
         // Check that the merge pipeline is also shut down as they are no more indexing pipeilne on
         // the index.
         assert!(universe.get_one::<MergePipeline>().is_none());

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -1605,7 +1605,7 @@ mod tests {
         let observation = indexing_server_handle.process_pending_and_observe().await;
         assert_eq!(observation.num_running_pipelines, 0);
         assert_eq!(observation.num_running_merge_pipelines, 0);
-        universe.sleep(*HEARTBEAT).await;
+        universe.sleep(2 * *HEARTBEAT).await;
         // Check that the merge pipeline is also shut down as they are no more indexing pipeilne on
         // the index.
         assert!(universe.get_one::<MergePipeline>().is_none());

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -69,6 +69,8 @@ static SPAWN_PIPELINE_SEMAPHORE: Semaphore = Semaphore::const_new(10);
 #[derive(Debug, Clone, Copy)]
 pub struct FinishPendingMergesAndShutdownPipeline;
 
+pub const SUPERVISE_LOOP_INTERVAL: Duration = Duration::from_secs(1);
+
 struct MergePipelineHandles {
     merge_planner: ActorHandle<MergePlanner>,
     merge_split_downloader: ActorHandle<MergeSplitDownloader>,
@@ -480,7 +482,7 @@ impl Handler<SuperviseLoop> for MergePipeline {
     ) -> Result<(), ActorExitStatus> {
         self.perform_observe().await;
         self.perform_health_check(ctx).await?;
-        ctx.schedule_self_msg(Duration::from_secs(1), supervise_loop_token);
+        ctx.schedule_self_msg(SUPERVISE_LOOP_INTERVAL, supervise_loop_token);
         Ok(())
     }
 }


### PR DESCRIPTION
### Description

increase timeout to make test not flaky (or way less, i wasn't able to make it fail again, but it's possible it would still do, just less often)

### How was this PR tested?

looped `cargo nextest` for a while