### PR TITLE
Publish docker image only in "production" environment.

### DIFF
--- a/.github/workflows/publish_cross_images.yml
+++ b/.github/workflows/publish_cross_images.yml
@@ -12,6 +12,8 @@ jobs:
   build-cross-images:
     name: Publish cross images
     runs-on: ubuntu-latest
+    environment:
+        name: production
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -27,6 +27,8 @@ jobs:
             platform: linux/arm64
             platform_suffix: arm64
     runs-on: ${{ matrix.os }}
+    environment:
+      name: production
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The point of this environment is that it now hosts the github secrets that are required to push to github.
That environment is configured to require a CR from a short list of 6 major contributors.
The goal here is to prevent a malicious contributor with write access to access the docker api token secrets.