### PR TITLE
Increase target shard usage

### DIFF
--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -73,7 +73,7 @@ pub const DEFAULT_SHARD_THROUGHPUT_LIMIT: ByteSize = ByteSize::mib(5);
 pub const DEFAULT_SHARD_BURST_LIMIT: ByteSize = ByteSize::mib(50);
 
 /// A compromise between "exponential" scale up and moderate shard count increase.
-pub const DEFAULT_SHARD_SCALE_UP_FACTOR: f32 = 1.5;
+pub const DEFAULT_SHARD_SCALE_UP_FACTOR: f32 = 1.1;
 
 // (Just a reexport).
 pub use bytesize::MIB;


### PR DESCRIPTION
### Description

Currently the target shard usage before scaling down the number of shards is 20%. This is quite low which results in a high number of shards.

### How was this PR tested?

Added unit tests.
