### PR TITLE
Add `min_shards` parameter to index config

### DIFF
--- a/quickwit/quickwit-cli/src/source.rs
+++ b/quickwit/quickwit-cli/src/source.rs
@@ -823,7 +823,7 @@ mod tests {
             .collect();
         let sources = vec![SourceConfig {
             source_id: "foo-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::file_from_str("path/to/file").unwrap(),
             transform_config: None,
@@ -884,7 +884,7 @@ mod tests {
         let sources = [
             SourceConfig {
                 source_id: "foo-source".to_string(),
-                num_pipelines: NonZeroUsize::new(1).unwrap(),
+                num_pipelines: NonZeroUsize::MIN,
                 enabled: true,
                 source_params: SourceParams::stdin(),
                 transform_config: None,
@@ -892,7 +892,7 @@ mod tests {
             },
             SourceConfig {
                 source_id: "bar-source".to_string(),
-                num_pipelines: NonZeroUsize::new(1).unwrap(),
+                num_pipelines: NonZeroUsize::MIN,
                 enabled: true,
                 source_params: SourceParams::stdin(),
                 transform_config: None,

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -415,7 +415,7 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
         .map(|vrl_script| TransformConfig::new(vrl_script, None));
     let source_config = SourceConfig {
         source_id: CLI_SOURCE_ID.to_string(),
-        num_pipelines: NonZeroUsize::new(1).expect("1 is always non-zero."),
+        num_pipelines: NonZeroUsize::MIN,
         enabled: true,
         source_params,
         transform_config,
@@ -605,7 +605,7 @@ pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
             index_id: args.index_id,
             source_config: SourceConfig {
                 source_id: args.source_id,
-                num_pipelines: NonZeroUsize::new(1).unwrap(),
+                num_pipelines: NonZeroUsize::MIN,
                 enabled: true,
                 source_params: SourceParams::Vec(VecSourceParams::default()),
                 transform_config: None,

--- a/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.json
+++ b/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.json
@@ -66,6 +66,9 @@
             "heap_size": "3G"
         }
     },
+    "ingest_settings": {
+        "min_shards": 12
+    },
     "search_settings": {
         "default_search_fields": ["severity_text", "body"]
     }

--- a/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.toml
+++ b/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.toml
@@ -34,5 +34,8 @@ maturation_period = "48 hours"
 [indexing_settings.resources]
 heap_size = "3G"
 
+[ingest_settings]
+min_shards = 12
+
 [search_settings]
 default_search_fields = [ "severity_text", "body" ]

--- a/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
+++ b/quickwit/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
@@ -46,5 +46,8 @@ indexing_settings:
   resources:
     heap_size: 3G
 
+ingest_settings:
+  min_shards: 12
+
 search_settings:
   default_search_fields: [severity_text, body]

--- a/quickwit/quickwit-config/src/index_config/serialize.rs
+++ b/quickwit/quickwit-config/src/index_config/serialize.rs
@@ -21,7 +21,7 @@ use quickwit_proto::types::{DocMappingUid, IndexId};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use super::validate_index_config;
+use super::{IngestSettings, validate_index_config};
 use crate::{
     ConfigFormat, DocMapping, IndexConfig, IndexingSettings, RetentionPolicy, SearchSettings,
     validate_identifier,
@@ -185,6 +185,7 @@ impl IndexConfigForSerialization {
             index_uri,
             doc_mapping: self.doc_mapping,
             indexing_settings: self.indexing_settings,
+            ingest_settings: self.ingest_settings,
             search_settings: self.search_settings,
             retention_policy_opt: self.retention_policy_opt,
         };
@@ -231,6 +232,8 @@ pub struct IndexConfigV0_8 {
     #[serde(default)]
     pub indexing_settings: IndexingSettings,
     #[serde(default)]
+    pub ingest_settings: IngestSettings,
+    #[serde(default)]
     pub search_settings: SearchSettings,
     #[serde(rename = "retention")]
     #[serde(default)]
@@ -244,6 +247,7 @@ impl From<IndexConfig> for IndexConfigV0_8 {
             index_uri: Some(index_config.index_uri),
             doc_mapping: index_config.doc_mapping,
             indexing_settings: index_config.indexing_settings,
+            ingest_settings: index_config.ingest_settings,
             search_settings: index_config.search_settings,
             retention_policy_opt: index_config.retention_policy_opt,
         }

--- a/quickwit/quickwit-config/src/index_template/mod.rs
+++ b/quickwit/quickwit-config/src/index_template/mod.rs
@@ -20,7 +20,7 @@ use quickwit_proto::types::{DocMappingUid, IndexId};
 use serde::{Deserialize, Serialize};
 pub use serialize::{IndexTemplateV0_8, VersionedIndexTemplate};
 
-use crate::index_config::validate_index_config;
+use crate::index_config::{IngestSettings, validate_index_config};
 use crate::{
     DocMapping, IndexConfig, IndexingSettings, RetentionPolicy, SearchSettings,
     validate_identifier, validate_index_id_pattern,
@@ -44,6 +44,8 @@ pub struct IndexTemplate {
     pub doc_mapping: DocMapping,
     #[serde(default)]
     pub indexing_settings: IndexingSettings,
+    #[serde(default)]
+    pub ingest_settings: IngestSettings,
     #[serde(default)]
     pub search_settings: SearchSettings,
     #[serde(rename = "retention")]
@@ -72,6 +74,7 @@ impl IndexTemplate {
             index_uri,
             doc_mapping,
             indexing_settings: self.indexing_settings.clone(),
+            ingest_settings: self.ingest_settings.clone(),
             search_settings: self.search_settings.clone(),
             retention_policy_opt: self.retention_policy_opt.clone(),
         };
@@ -128,6 +131,7 @@ impl IndexTemplate {
             description: Some("Test description.".to_string()),
             doc_mapping,
             indexing_settings: IndexingSettings::default(),
+            ingest_settings: IngestSettings::default(),
             search_settings: SearchSettings::default(),
             retention_policy_opt: None,
         }
@@ -168,6 +172,7 @@ impl crate::TestableForRegression for IndexTemplate {
             description: Some("Test description.".to_string()),
             doc_mapping,
             indexing_settings: IndexingSettings::default(),
+            ingest_settings: IngestSettings::default(),
             search_settings: SearchSettings::default(),
             retention_policy_opt: Some(RetentionPolicy {
                 retention_period: "42 days".to_string(),

--- a/quickwit/quickwit-config/src/index_template/serialize.rs
+++ b/quickwit/quickwit-config/src/index_template/serialize.rs
@@ -16,6 +16,7 @@ use quickwit_common::uri::Uri;
 use serde::{Deserialize, Serialize};
 
 use super::{IndexIdPattern, IndexTemplate, IndexTemplateId};
+use crate::index_config::IngestSettings;
 use crate::{DocMapping, IndexingSettings, RetentionPolicy, SearchSettings};
 
 #[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
@@ -49,6 +50,8 @@ pub struct IndexTemplateV0_8 {
     #[serde(default)]
     pub indexing_settings: IndexingSettings,
     #[serde(default)]
+    pub ingest_settings: IngestSettings,
+    #[serde(default)]
     pub search_settings: SearchSettings,
     #[serde(default)]
     pub retention: Option<RetentionPolicy>,
@@ -78,6 +81,7 @@ impl From<IndexTemplateV0_8> for IndexTemplate {
             description: index_template_v0_8.description,
             doc_mapping: index_template_v0_8.doc_mapping,
             indexing_settings: index_template_v0_8.indexing_settings,
+            ingest_settings: index_template_v0_8.ingest_settings,
             search_settings: index_template_v0_8.search_settings,
             retention_policy_opt: index_template_v0_8.retention,
         }
@@ -94,6 +98,7 @@ impl From<IndexTemplate> for IndexTemplateV0_8 {
             description: index_template.description,
             doc_mapping: index_template.doc_mapping,
             indexing_settings: index_template.indexing_settings,
+            ingest_settings: index_template.ingest_settings,
             search_settings: index_template.search_settings,
             retention: index_template.retention_policy_opt,
         }

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -45,8 +45,8 @@ pub use cluster_config::ClusterConfig;
 // See #2048
 use index_config::serialize::{IndexConfigV0_8, VersionedIndexConfig};
 pub use index_config::{
-    IndexConfig, IndexingResources, IndexingSettings, RetentionPolicy, SearchSettings,
-    build_doc_mapper, load_index_config_from_user_config, load_index_config_update,
+    IndexConfig, IndexingResources, IndexingSettings, IngestSettings, RetentionPolicy,
+    SearchSettings, build_doc_mapper, load_index_config_from_user_config, load_index_config_update,
 };
 pub use quickwit_doc_mapper::DocMapping;
 use serde::Serialize;
@@ -98,35 +98,36 @@ pub fn disable_ingest_v1() -> bool {
 
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(
-    IndexingResources,
-    IndexingSettings,
-    SearchSettings,
-    RetentionPolicy,
-    MergePolicyConfig,
+    ConstWriteAmplificationMergePolicyConfig,
     DocMapping,
-    VersionedSourceConfig,
-    SourceConfigV0_7,
-    SourceConfigV0_8,
-    VersionedIndexConfig,
-    IndexConfigV0_8,
-    VersionedIndexTemplate,
-    IndexTemplateV0_8,
-    SourceInputFormat,
-    SourceParams,
     FileSourceMessageType,
     FileSourceNotification,
     FileSourceParamsForSerde,
     FileSourceSqs,
-    PubSubSourceParams,
+    IndexConfigV0_8,
+    IndexingResources,
+    IndexingSettings,
+    IndexTemplateV0_8,
+    IngestSettings,
     KafkaSourceParams,
     KinesisSourceParams,
-    PulsarSourceParams,
+    MergePolicyConfig,
+    PubSubSourceParams,
     PulsarSourceAuth,
+    PulsarSourceParams,
     RegionOrEndpoint,
-    ConstWriteAmplificationMergePolicyConfig,
+    RetentionPolicy,
+    SearchSettings,
+    SourceConfigV0_7,
+    SourceConfigV0_8,
+    SourceInputFormat,
+    SourceParams,
     StableLogMergePolicyConfig,
     TransformConfig,
     VecSourceParams,
+    VersionedIndexConfig,
+    VersionedIndexTemplate,
+    VersionedSourceConfig,
     VoidSourceParams,
 )))]
 /// Schema used for the OpenAPI generation which are apart of this crate.

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -194,8 +194,7 @@ impl IndexerConfig {
     }
 
     pub fn default_merge_concurrency() -> NonZeroUsize {
-        NonZeroUsize::new(quickwit_common::num_cpus() * 2 / 3)
-            .unwrap_or(NonZeroUsize::new(1).unwrap())
+        NonZeroUsize::new(quickwit_common::num_cpus() * 2 / 3).unwrap_or(NonZeroUsize::MIN)
     }
 
     fn default_cpu_capacity() -> CpuCapacity {

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -16,6 +16,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -393,18 +394,24 @@ impl IngestController {
             &local_shards_update.source_uid,
             &local_shards_update.shard_infos,
         );
-        let Some(scaling_mode) = self.scaling_arbiter.should_scale(shard_stats) else {
+        let min_shards = model
+            .index_metadata(&local_shards_update.source_uid.index_uid)
+            .expect("index should exist")
+            .index_config
+            .ingest_settings
+            .min_shards;
+
+        let Some(scaling_mode) = self.scaling_arbiter.should_scale(shard_stats, min_shards) else {
             return Ok(());
         };
-
         match scaling_mode {
-            ScalingMode::Up(shards) => {
+            ScalingMode::Up(num_shards) => {
                 self.try_scale_up_shards(
                     local_shards_update.source_uid,
                     shard_stats,
                     model,
                     progress,
-                    shards,
+                    num_shards,
                 )
                 .await?;
             }
@@ -412,6 +419,7 @@ impl IngestController {
                 self.try_scale_down_shards(
                     local_shards_update.source_uid,
                     shard_stats,
+                    min_shards,
                     model,
                     progress,
                 )
@@ -443,7 +451,7 @@ impl IngestController {
         let mut get_or_create_open_shards_successes = Vec::with_capacity(num_subrequests);
         let mut get_or_create_open_shards_failures = Vec::new();
 
-        let mut num_missing_shards_per_source_uids = HashMap::new();
+        let mut per_source_num_shards_to_open = HashMap::new();
 
         let unavailable_leaders: FnvHashSet<NodeId> = get_open_shards_request
             .unavailable_leaders
@@ -464,19 +472,24 @@ impl IngestController {
                     .index_uid(&get_open_shards_subrequest.index_id)
                     .expect("index should exist")
                     .clone();
+                let min_shards = model
+                    .index_metadata(&index_uid)
+                    .expect("index should exist")
+                    .index_config
+                    .ingest_settings
+                    .min_shards
+                    .get();
                 let source_uid = SourceUid {
                     index_uid,
                     source_id: get_open_shards_subrequest.source_id.clone(),
                 };
-                *num_missing_shards_per_source_uids
-                    .entry(source_uid)
-                    .or_default() += 1;
+                per_source_num_shards_to_open.insert(source_uid, min_shards);
             }
         }
 
         if let Err(metastore_error) = self
             .try_open_shards(
-                num_missing_shards_per_source_uids,
+                per_source_num_shards_to_open,
                 model,
                 &unavailable_leaders,
                 progress,
@@ -743,24 +756,24 @@ impl IngestController {
     /// The number of successfully open shards is returned.
     async fn try_open_shards(
         &mut self,
-        shards_per_source: HashMap<SourceUid, usize>,
+        per_source_num_shards_to_open: HashMap<SourceUid, usize>,
         model: &mut ControlPlaneModel,
         unavailable_leaders: &FnvHashSet<NodeId>,
         progress: &Progress,
     ) -> MetastoreResult<HashMap<SourceUid, usize>> {
-        let num_shards: usize = shards_per_source.values().sum();
+        let total_num_shards_to_open: usize = per_source_num_shards_to_open.values().sum();
 
-        if num_shards == 0 {
+        if total_num_shards_to_open == 0 {
             return Ok(HashMap::new());
         }
         // TODO unavailable leaders
         let Some(leader_follower_pairs) =
-            self.allocate_shards(num_shards, unavailable_leaders, model)
+            self.allocate_shards(total_num_shards_to_open, unavailable_leaders, model)
         else {
             return Ok(HashMap::new());
         };
 
-        let source_uids_with_multiplicity = shards_per_source
+        let source_uids_with_multiplicity = per_source_num_shards_to_open
             .iter()
             .flat_map(|(source_uid, count)| std::iter::repeat_n(source_uid, *count));
 
@@ -854,13 +867,15 @@ impl IngestController {
         &self,
         source_uid: SourceUid,
         shard_stats: ShardStats,
+        min_shards: NonZeroUsize,
         model: &mut ControlPlaneModel,
         progress: &Progress,
     ) -> MetastoreResult<()> {
-        if shard_stats.num_open_shards == 0 {
+        // The scaling arbiter should not suggest scaling down if the number of shards is already
+        // below the minimum, but we're just being defensive here.
+        if shard_stats.num_open_shards <= min_shards.get() {
             return Ok(());
         }
-
         if !model
             .acquire_scaling_permits(&source_uid, ScalingMode::Down)
             .unwrap_or(false)
@@ -2625,12 +2640,19 @@ mod tests {
             num_open_shards: 2,
             ..Default::default()
         };
+        let min_shards = NonZeroUsize::MIN;
         let mut model = ControlPlaneModel::default();
         let progress = Progress::default();
 
         // Test could not find a scale down candidate.
         controller
-            .try_scale_down_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_down_shards(
+                source_uid.clone(),
+                shard_stats,
+                min_shards,
+                &mut model,
+                &progress,
+            )
             .await
             .unwrap();
 
@@ -2646,7 +2668,13 @@ mod tests {
 
         // Test ingester is unavailable.
         controller
-            .try_scale_down_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_down_shards(
+                source_uid.clone(),
+                shard_stats,
+                min_shards,
+                &mut model,
+                &progress,
+            )
             .await
             .unwrap();
 
@@ -2686,14 +2714,26 @@ mod tests {
 
         // Test failed to close shard.
         controller
-            .try_scale_down_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_down_shards(
+                source_uid.clone(),
+                shard_stats,
+                min_shards,
+                &mut model,
+                &progress,
+            )
             .await
             .unwrap();
         assert!(model.all_shards().all(|shard| shard.is_open()));
 
         // Test successfully closed shard.
         controller
-            .try_scale_down_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_down_shards(
+                source_uid.clone(),
+                shard_stats,
+                min_shards,
+                &mut model,
+                &progress,
+            )
             .await
             .unwrap();
         assert!(model.all_shards().all(|shard| shard.is_closed()));
@@ -2710,7 +2750,13 @@ mod tests {
 
         // Test rate limited.
         controller
-            .try_scale_down_shards(source_uid.clone(), shard_stats, &mut model, &progress)
+            .try_scale_down_shards(
+                source_uid.clone(),
+                shard_stats,
+                min_shards,
+                &mut model,
+                &progress,
+            )
             .await
             .unwrap();
         assert!(model.all_shards().any(|shard| shard.is_open()));

--- a/quickwit/quickwit-control-plane/src/ingest/scaling_arbiter.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/scaling_arbiter.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::num::NonZeroUsize;
+
 use crate::model::{ScalingMode, ShardStats};
 
 pub(crate) struct ScalingArbiter {
@@ -66,9 +68,20 @@ impl ScalingArbiter {
     ///
     /// Returns `None` when there are no open shards because in that case routers are expected to
     /// make the [`quickwit_proto::control_plane::GetOrCreateOpenShardsRequest`]
-    pub(crate) fn should_scale(&self, shard_stats: ShardStats) -> Option<ScalingMode> {
-        if shard_stats.num_open_shards == 0 {
+    pub(crate) fn should_scale(
+        &self,
+        shard_stats: ShardStats,
+        min_shards: NonZeroUsize,
+    ) -> Option<ScalingMode> {
+        // If ingest is idle, there is nothing to do. Idle shards are automatically closed by
+        // ingesters (see `quickwit_ingest::ingest_v2::idle::CloseIdleShardsTask`).
+        if shard_stats.num_open_shards == 0 || shard_stats.avg_long_term_ingestion_rate == 0.0 {
             return None;
+        }
+        if shard_stats.num_open_shards < min_shards.get() {
+            let num_shards_to_open = min_shards.get() - shard_stats.num_open_shards;
+            let scaling_mode = ScalingMode::Up(num_shards_to_open);
+            return Some(scaling_mode);
         }
         // Scale up based on the short term metric value while making sure that
         // the long term value doesn't get near the scale down threshold.
@@ -80,29 +93,29 @@ impl ScalingArbiter {
                 self.scale_up_factor_target_shards(shard_stats),
             );
 
-            let target_num_shards = usize::max(1, new_calculated_num_shards);
+            let target_num_shards = usize::max(min_shards.get(), new_calculated_num_shards);
 
             if target_num_shards > shard_stats.num_open_shards {
-                return Some(ScalingMode::Up(
-                    target_num_shards - shard_stats.num_open_shards,
-                ));
+                let num_shards_to_open = target_num_shards - shard_stats.num_open_shards;
+                let scaling_mode = ScalingMode::Up(num_shards_to_open);
+                return Some(scaling_mode);
             }
         }
-
         // On the other hand, scale down only based on the long term metric value to avoid
         // being sensitive to very short drops in ingestion
         if shard_stats.avg_long_term_ingestion_rate <= self.scale_down_shards_threshold_mib_per_sec
-            && shard_stats.num_open_shards > 1
+            && shard_stats.num_open_shards > min_shards.get()
         {
             return Some(ScalingMode::Down);
         }
-
         None
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use super::ScalingArbiter;
     use crate::model::{ScalingMode, ShardStats};
 
@@ -113,59 +126,80 @@ mod tests {
         let scaling_arbiter =
             ScalingArbiter::with_max_shard_ingestion_throughput_mib_per_sec(10.0, 1.01);
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 0,
-                avg_short_term_ingestion_rate: 0.0,
-                avg_long_term_ingestion_rate: 0.0,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 0,
+                    avg_short_term_ingestion_rate: 0.0,
+                    avg_long_term_ingestion_rate: 0.0,
+                },
+                NonZeroUsize::MIN
+            ),
             None,
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 1,
-                avg_short_term_ingestion_rate: 5.0,
-                avg_long_term_ingestion_rate: 6.0,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 1,
+                    avg_short_term_ingestion_rate: 5.0,
+                    avg_long_term_ingestion_rate: 6.0,
+                },
+                NonZeroUsize::MIN
+            ),
             None
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 1,
-                avg_short_term_ingestion_rate: 8.1,
-                avg_long_term_ingestion_rate: 8.1,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 1,
+                    avg_short_term_ingestion_rate: 8.1,
+                    avg_long_term_ingestion_rate: 8.1,
+                },
+                NonZeroUsize::MIN
+            ),
             Some(ScalingMode::Up(1))
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 2,
-                avg_short_term_ingestion_rate: 8.1,
-                avg_long_term_ingestion_rate: 8.1,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 2,
+                    avg_short_term_ingestion_rate: 8.1,
+                    avg_long_term_ingestion_rate: 8.1,
+                },
+                NonZeroUsize::MIN
+            ),
             Some(ScalingMode::Up(1))
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 2,
-                avg_short_term_ingestion_rate: 3.0,
-                avg_long_term_ingestion_rate: 1.5,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 2,
+                    avg_short_term_ingestion_rate: 3.0,
+                    avg_long_term_ingestion_rate: 1.5,
+                },
+                NonZeroUsize::MIN
+            ),
             Some(ScalingMode::Down)
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 1,
-                avg_short_term_ingestion_rate: 3.0,
-                avg_long_term_ingestion_rate: 1.5,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 1,
+                    avg_short_term_ingestion_rate: 3.0,
+                    avg_long_term_ingestion_rate: 1.5,
+                },
+                NonZeroUsize::MIN
+            ),
             None,
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 1,
-                avg_short_term_ingestion_rate: 8.0,
-                avg_long_term_ingestion_rate: 3.0,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 1,
+                    avg_short_term_ingestion_rate: 8.0,
+                    avg_long_term_ingestion_rate: 3.0,
+                },
+                NonZeroUsize::MIN
+            ),
             None,
         );
     }
@@ -176,68 +210,92 @@ mod tests {
         let scaling_arbiter =
             ScalingArbiter::with_max_shard_ingestion_throughput_mib_per_sec(10.0, 2.);
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 0,
-                avg_short_term_ingestion_rate: 0.0,
-                avg_long_term_ingestion_rate: 0.0,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 0,
+                    avg_short_term_ingestion_rate: 0.0,
+                    avg_long_term_ingestion_rate: 0.0,
+                },
+                NonZeroUsize::MIN
+            ),
             None,
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 2,
-                avg_short_term_ingestion_rate: 5.0,
-                avg_long_term_ingestion_rate: 6.0,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 2,
+                    avg_short_term_ingestion_rate: 5.0,
+                    avg_long_term_ingestion_rate: 6.0,
+                },
+                NonZeroUsize::MIN
+            ),
             None
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 1,
-                avg_short_term_ingestion_rate: 8.1,
-                avg_long_term_ingestion_rate: 8.1,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 1,
+                    avg_short_term_ingestion_rate: 8.1,
+                    avg_long_term_ingestion_rate: 8.1,
+                },
+                NonZeroUsize::MIN
+            ),
             Some(ScalingMode::Up(1))
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 2,
-                avg_short_term_ingestion_rate: 8.1,
-                avg_long_term_ingestion_rate: 8.1,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 2,
+                    avg_short_term_ingestion_rate: 8.1,
+                    avg_long_term_ingestion_rate: 8.1,
+                },
+                NonZeroUsize::MIN
+            ),
             Some(ScalingMode::Up(2))
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 2,
-                avg_short_term_ingestion_rate: 3.0,
-                avg_long_term_ingestion_rate: 1.5,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 2,
+                    avg_short_term_ingestion_rate: 3.0,
+                    avg_long_term_ingestion_rate: 1.5,
+                },
+                NonZeroUsize::MIN
+            ),
             Some(ScalingMode::Down)
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 1,
-                avg_short_term_ingestion_rate: 3.0,
-                avg_long_term_ingestion_rate: 1.5,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 1,
+                    avg_short_term_ingestion_rate: 3.0,
+                    avg_long_term_ingestion_rate: 1.5,
+                },
+                NonZeroUsize::MIN
+            ),
             None,
         );
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 1,
-                avg_short_term_ingestion_rate: 8.0,
-                avg_long_term_ingestion_rate: 3.1,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 1,
+                    avg_short_term_ingestion_rate: 8.0,
+                    avg_long_term_ingestion_rate: 3.1,
+                },
+                NonZeroUsize::MIN
+            ),
             None,
         );
         // Scale by just 1 if 2 would bring us too close to the scale down threshold
         assert_eq!(
-            scaling_arbiter.should_scale(ShardStats {
-                num_open_shards: 2,
-                avg_short_term_ingestion_rate: 8.1,
-                avg_long_term_ingestion_rate: 5.,
-            }),
+            scaling_arbiter.should_scale(
+                ShardStats {
+                    num_open_shards: 2,
+                    avg_short_term_ingestion_rate: 8.1,
+                    avg_long_term_ingestion_rate: 5.,
+                },
+                NonZeroUsize::MIN
+            ),
             Some(ScalingMode::Up(1)),
         );
     }
@@ -317,5 +375,46 @@ mod tests {
             scaling_arbiter.scale_up_factor_target_shards(shard_stats),
             8
         );
+    }
+
+    #[test]
+    fn test_scaling_arbiter_idle() {
+        let scaling_arbiter =
+            ScalingArbiter::with_max_shard_ingestion_throughput_mib_per_sec(10.0, 1.5);
+
+        let shard_stats = ShardStats {
+            num_open_shards: 0,
+            avg_short_term_ingestion_rate: 0.0,
+            avg_long_term_ingestion_rate: 0.0,
+        };
+        let min_shards = NonZeroUsize::MIN;
+        let scaling_mode = scaling_arbiter.should_scale(shard_stats, min_shards);
+        assert!(scaling_mode.is_none());
+
+        let shard_stats = ShardStats {
+            num_open_shards: 1,
+            avg_short_term_ingestion_rate: 0.0,
+            avg_long_term_ingestion_rate: 0.0,
+        };
+        let min_shards = NonZeroUsize::new(2).unwrap();
+        let scaling_mode = scaling_arbiter.should_scale(shard_stats, min_shards);
+        assert!(scaling_mode.is_none());
+    }
+
+    #[test]
+    fn test_scaling_arbiter_min_shards() {
+        let scaling_arbiter =
+            ScalingArbiter::with_max_shard_ingestion_throughput_mib_per_sec(10.0, 1.5);
+
+        let shard_stats = ShardStats {
+            num_open_shards: 1,
+            avg_short_term_ingestion_rate: 5.0,
+            avg_long_term_ingestion_rate: 1.0,
+        };
+        let min_shards = NonZeroUsize::new(5).unwrap();
+        let scaling_mode = scaling_arbiter
+            .should_scale(shard_stats, min_shards)
+            .unwrap();
+        assert_eq!(scaling_mode, ScalingMode::Up(4));
     }
 }

--- a/quickwit/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit/quickwit-indexing/src/source/file_source.rs
@@ -232,7 +232,7 @@ mod tests {
         };
         let source_config = SourceConfig {
             source_id: "test-file-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::File(params.clone()),
             transform_config: None,
@@ -284,7 +284,7 @@ mod tests {
         let params = FileSourceParams::Filepath(uri.clone());
         let source_config = SourceConfig {
             source_id: "test-file-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::File(params.clone()),
             transform_config: None,
@@ -348,7 +348,7 @@ mod tests {
         let params = FileSourceParams::Filepath(uri.clone());
         let source_config = SourceConfig {
             source_id: "test-file-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::File(params.clone()),
             transform_config: None,

--- a/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
+++ b/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
@@ -306,7 +306,7 @@ mod gcp_pubsub_emulator_tests {
         let source_id = append_random_suffix("test-gcp-pubsub-source--source");
         SourceConfig {
             source_id,
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::PubSub(PubSubSourceParams {
                 project_id: Some(GCP_TEST_PROJECT.to_string()),

--- a/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest_api_source.rs
@@ -293,7 +293,7 @@ mod tests {
     fn make_source_config() -> SourceConfig {
         SourceConfig {
             source_id: INGEST_API_SOURCE_ID.to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::IngestApi,
             transform_config: None,

--- a/quickwit/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit/quickwit-indexing/src/source/kafka_source.rs
@@ -874,7 +874,7 @@ mod kafka_broker_tests {
         let source_id = append_random_suffix("test-kafka-source--source");
         let source_config = SourceConfig {
             source_id: source_id.clone(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::Kafka(KafkaSourceParams {
                 topic: topic.to_string(),

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -683,7 +683,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "void".to_string(),
-                num_pipelines: NonZeroUsize::new(1).unwrap(),
+                num_pipelines: NonZeroUsize::MIN,
                 enabled: true,
                 source_params: SourceParams::void(),
                 transform_config: None,
@@ -694,7 +694,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "vec".to_string(),
-                num_pipelines: NonZeroUsize::new(1).unwrap(),
+                num_pipelines: NonZeroUsize::MIN,
                 enabled: true,
                 source_params: SourceParams::Vec(VecSourceParams::default()),
                 transform_config: None,
@@ -705,7 +705,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "file".to_string(),
-                num_pipelines: NonZeroUsize::new(1).unwrap(),
+                num_pipelines: NonZeroUsize::MIN,
                 enabled: true,
                 source_params: SourceParams::file_from_str("file-does-not-exist.json").unwrap(),
                 transform_config: None,
@@ -720,7 +720,7 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "file".to_string(),
-                num_pipelines: NonZeroUsize::new(1).unwrap(),
+                num_pipelines: NonZeroUsize::MIN,
                 enabled: true,
                 source_params: SourceParams::file_from_str("data/test_corpus.json").unwrap(),
                 transform_config: None,

--- a/quickwit/quickwit-indexing/src/source/pulsar_source.rs
+++ b/quickwit/quickwit-indexing/src/source/pulsar_source.rs
@@ -493,7 +493,7 @@ mod pulsar_broker_tests {
         let source_id = append_random_suffix("test-pulsar-source--source");
         let source_config = SourceConfig {
             source_id: source_id.clone(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::Pulsar(PulsarSourceParams {
                 topics: topics.into_iter().map(|v| v.as_ref().to_string()).collect(),

--- a/quickwit/quickwit-indexing/src/source/source_factory.rs
+++ b/quickwit/quickwit-indexing/src/source/source_factory.rs
@@ -123,7 +123,7 @@ mod tests {
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_config = SourceConfig {
             source_id: "test-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::void(),
             transform_config: None,

--- a/quickwit/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit/quickwit-indexing/src/source/vec_source.rs
@@ -157,7 +157,7 @@ mod tests {
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_config = SourceConfig {
             source_id: "test-vec-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::Vec(params.clone()),
             transform_config: None,
@@ -205,7 +205,7 @@ mod tests {
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_config = SourceConfig {
             source_id: "test-vec-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::Vec(params.clone()),
             transform_config: None,

--- a/quickwit/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit/quickwit-indexing/src/source/void_source.rs
@@ -79,7 +79,7 @@ mod tests {
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_config = SourceConfig {
             source_id: "test-void-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::void(),
             transform_config: None,
@@ -99,7 +99,7 @@ mod tests {
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_config = SourceConfig {
             source_id: "test-void-source".to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::void(),
             transform_config: None,

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -162,7 +162,7 @@ impl TestSandbox {
         let add_docs_id = self.add_docs_id.fetch_add(1, Ordering::SeqCst);
         let source_config = SourceConfig {
             source_id: INGEST_API_SOURCE_ID.to_string(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::Vec(VecSourceParams {
                 docs,

--- a/quickwit/quickwit-lambda/src/indexer/ingest/helpers.rs
+++ b/quickwit/quickwit-lambda/src/indexer/ingest/helpers.rs
@@ -141,7 +141,7 @@ pub(super) async fn configure_source(
     let source_params = SourceParams::file_from_uri(input_uri);
     Ok(SourceConfig {
         source_id: LAMBDA_SOURCE_ID.to_owned(),
-        num_pipelines: NonZeroUsize::new(1).expect("1 is always non-zero."),
+        num_pipelines: NonZeroUsize::MIN,
         enabled: true,
         source_params,
         transform_config,

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -26,7 +26,7 @@ use std::ops::Bound;
 use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
 use quickwit_config::{
-    DocMapping, IndexingSettings, RetentionPolicy, SearchSettings, SourceConfig,
+    DocMapping, IndexingSettings, IngestSettings, RetentionPolicy, SearchSettings, SourceConfig,
 };
 use quickwit_proto::metastore::{
     AcquireShardsRequest, AcquireShardsResponse, DeleteQuery, DeleteShardsRequest,
@@ -214,24 +214,21 @@ impl FileBackedIndex {
         &self.metadata
     }
 
-    /// Replaces the retention policy in the index config, returning whether a mutation occurred.
-    pub fn set_retention_policy(&mut self, retention_policy_opt: Option<RetentionPolicy>) -> bool {
-        self.metadata.set_retention_policy(retention_policy_opt)
-    }
-
-    /// Replaces the search settings in the index config, returning whether a mutation occurred.
-    pub fn set_search_settings(&mut self, search_settings: SearchSettings) -> bool {
-        self.metadata.set_search_settings(search_settings)
-    }
-
-    /// Replaces the indexing settings in the index config, returning whether a mutation occurred.
-    pub fn set_indexing_settings(&mut self, search_settings: IndexingSettings) -> bool {
-        self.metadata.set_indexing_settings(search_settings)
-    }
-
-    /// Replaces the doc mapping in the index config, returning whether a mutation occurred.
-    pub fn set_doc_mapping(&mut self, doc_mapping: DocMapping) -> bool {
-        self.metadata.set_doc_mapping(doc_mapping)
+    pub fn update_index_config(
+        &mut self,
+        doc_mapping: DocMapping,
+        indexing_settings: IndexingSettings,
+        ingest_settings: IngestSettings,
+        search_settings: SearchSettings,
+        retention_policy_opt: Option<RetentionPolicy>,
+    ) -> bool {
+        self.metadata.update_index_config(
+            doc_mapping,
+            indexing_settings,
+            ingest_settings,
+            search_settings,
+            retention_policy_opt,
+        )
     }
 
     /// Stages a single split.

--- a/quickwit/quickwit-metastore/src/tests/mod.rs
+++ b/quickwit/quickwit-metastore/src/tests/mod.rs
@@ -222,6 +222,13 @@ macro_rules! metastore_test_suite {
 
             #[tokio::test]
             #[serial_test::file_serial]
+            async fn test_metastore_update_ingest_settings() {
+                let _ = tracing_subscriber::fmt::try_init();
+                $crate::tests::index::test_metastore_update_ingest_settings::<$metastore_type>().await;
+            }
+
+            #[tokio::test]
+            #[serial_test::file_serial]
             async fn test_metastore_create_index_enforces_index_id_maximum_length() {
                 let _ = tracing_subscriber::fmt::try_init();
                 $crate::tests::index::test_metastore_create_index_enforces_index_id_maximum_length::<

--- a/quickwit/quickwit-metastore/src/tests/source.rs
+++ b/quickwit/quickwit-metastore/src/tests/source.rs
@@ -53,7 +53,7 @@ pub async fn test_metastore_add_source<MetastoreToTest: MetastoreServiceExt + De
 
     let source = SourceConfig {
         source_id: source_id.to_string(),
-        num_pipelines: NonZeroUsize::new(1).unwrap(),
+        num_pipelines: NonZeroUsize::MIN,
         enabled: true,
         source_params: SourceParams::void(),
         transform_config: None,
@@ -153,7 +153,7 @@ pub async fn test_metastore_update_source<MetastoreToTest: MetastoreServiceExt +
 
     let mut source = SourceConfig {
         source_id: source_id.to_string(),
-        num_pipelines: NonZeroUsize::new(1).unwrap(),
+        num_pipelines: NonZeroUsize::MIN,
         enabled: true,
         source_params: SourceParams::void(),
         transform_config: None,
@@ -258,7 +258,7 @@ pub async fn test_metastore_toggle_source<MetastoreToTest: MetastoreServiceExt +
     let source_id = format!("{index_id}--source");
     let source = SourceConfig {
         source_id: source_id.to_string(),
-        num_pipelines: NonZeroUsize::new(1).unwrap(),
+        num_pipelines: NonZeroUsize::MIN,
         enabled: true,
         source_params: SourceParams::void(),
         transform_config: None,
@@ -324,7 +324,7 @@ pub async fn test_metastore_delete_source<MetastoreToTest: MetastoreServiceExt +
 
     let source = SourceConfig {
         source_id: source_id.to_string(),
-        num_pipelines: NonZeroUsize::new(1).unwrap(),
+        num_pipelines: NonZeroUsize::MIN,
         enabled: true,
         source_params: SourceParams::void(),
         transform_config: None,
@@ -445,7 +445,7 @@ pub async fn test_metastore_reset_checkpoint<
     for (source_id, split_id) in source_ids.iter().zip(split_ids.iter()) {
         let source = SourceConfig {
             source_id: source_id.clone(),
-            num_pipelines: NonZeroUsize::new(1).unwrap(),
+            num_pipelines: NonZeroUsize::MIN,
             enabled: true,
             source_params: SourceParams::void(),
             transform_config: None,

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.7.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.7.expected.json
@@ -99,6 +99,9 @@
           "heap_size": "50.0 MB"
         }
       },
+      "ingest_settings": {
+        "min_shards": 1
+      },
       "search_settings": {
         "default_search_fields": [
           "message"

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.8.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.8.expected.json
@@ -99,6 +99,9 @@
           "heap_size": "50.0 MB"
         }
       },
+      "ingest_settings": {
+        "min_shards": 1
+      },
       "search_settings": {
         "default_search_fields": [
           "message"

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.9.expected.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.9.expected.json
@@ -99,6 +99,9 @@
           "heap_size": "50.0 MB"
         }
       },
+      "ingest_settings": {
+        "min_shards": 12
+      },
       "search_settings": {
         "default_search_fields": [
           "message"

--- a/quickwit/quickwit-metastore/test-data/file-backed-index/v0.9.json
+++ b/quickwit/quickwit-metastore/test-data/file-backed-index/v0.9.json
@@ -99,6 +99,9 @@
           "heap_size": "50.0 MB"
         }
       },
+      "ingest_settings": {
+        "min_shards": 12
+      },
       "search_settings": {
         "default_search_fields": [
           "message"

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.7.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.7.expected.json
@@ -100,6 +100,9 @@
       },
       "split_num_docs_target": 10000001
     },
+    "ingest_settings": {
+      "min_shards": 1
+    },
     "retention": {
       "period": "90 days",
       "schedule": "daily"

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.8.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.8.expected.json
@@ -100,6 +100,9 @@
       },
       "split_num_docs_target": 10000001
     },
+    "ingest_settings": {
+      "min_shards": 1
+    },
     "retention": {
       "period": "90 days",
       "schedule": "daily"

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.9.expected.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.9.expected.json
@@ -104,6 +104,9 @@
       "period": "90 days",
       "schedule": "daily"
     },
+    "ingest_settings": {
+      "min_shards": 12
+    },
     "search_settings": {
       "default_search_fields": [
         "message"

--- a/quickwit/quickwit-metastore/test-data/index-metadata/v0.9.json
+++ b/quickwit/quickwit-metastore/test-data/index-metadata/v0.9.json
@@ -104,6 +104,9 @@
       "period": "90 days",
       "schedule": "daily"
     },
+    "ingest_settings": {
+      "min_shards": 12
+    },
     "search_settings": {
       "default_search_fields": [
         "message"

--- a/quickwit/quickwit-metastore/test-data/manifest/v0.7.expected.json
+++ b/quickwit/quickwit-metastore/test-data/manifest/v0.7.expected.json
@@ -79,6 +79,9 @@
         "period": "42 days",
         "schedule": "daily"
       },
+      "ingest_settings": {
+        "min_shards": 1
+      },
       "search_settings": {
         "default_search_fields": []
       },

--- a/quickwit/quickwit-metastore/test-data/manifest/v0.8.expected.json
+++ b/quickwit/quickwit-metastore/test-data/manifest/v0.8.expected.json
@@ -75,6 +75,9 @@
         "split_num_docs_target": 10000000
       },
       "priority": 100,
+      "ingest_settings": {
+        "min_shards": 1
+      },
       "retention": {
         "period": "42 days",
         "schedule": "daily"

--- a/quickwit/quickwit-metastore/test-data/manifest/v0.9.expected.json
+++ b/quickwit/quickwit-metastore/test-data/manifest/v0.9.expected.json
@@ -74,6 +74,9 @@
         },
         "split_num_docs_target": 10000000
       },
+      "ingest_settings": {
+        "min_shards": 1
+      },
       "priority": 100,
       "retention": {
         "period": "42 days",

--- a/quickwit/quickwit-metastore/test-data/manifest/v0.9.json
+++ b/quickwit/quickwit-metastore/test-data/manifest/v0.9.json
@@ -79,6 +79,9 @@
         "period": "42 days",
         "schedule": "daily"
       },
+      "ingest_settings": {
+        "min_shards": 1
+      },
       "search_settings": {
         "default_search_fields": []
       },

--- a/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/control_plane.proto
@@ -74,6 +74,7 @@ service ControlPlaneService {
 // Shard API
 
 message GetOrCreateOpenShardsRequest {
+  // There should be at most one subrequest per index per request.
   repeated GetOrCreateOpenShardsSubrequest subrequests = 1;
   repeated quickwit.ingest.ShardIds closed_shards = 2;
   // The control plane should return shards that are not present on the supplied leaders.

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -215,10 +215,11 @@ message CreateIndexResponse {
 
 message UpdateIndexRequest {
   quickwit.common.IndexUid index_uid = 1;
-  string search_settings_json = 2;
-  optional string retention_policy_json = 3;
-  string indexing_settings_json = 4;
   string doc_mapping_json = 5;
+  string indexing_settings_json = 4;
+  string ingest_settings_json = 6;
+  string search_settings_json = 2;
+  optional string retention_policy_json_opt = 3;
 }
 
 message ListIndexesMetadataRequest {

--- a/quickwit/quickwit-proto/protos/quickwit/router.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/router.proto
@@ -26,6 +26,7 @@ service IngestRouterService {
 }
 
 message IngestRequestV2 {
+  // There should be at most one subrequest per index per request.
   repeated IngestSubrequest subrequests = 1;
   quickwit.ingest.CommitTypeV2 commit_type = 2;
 }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.control_plane.rs
@@ -2,6 +2,7 @@
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetOrCreateOpenShardsRequest {
+    /// There should be at most one subrequest per index per request.
     #[prost(message, repeated, tag = "1")]
     pub subrequests: ::prost::alloc::vec::Vec<GetOrCreateOpenShardsSubrequest>,
     #[prost(message, repeated, tag = "2")]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.router.rs
@@ -2,6 +2,7 @@
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IngestRequestV2 {
+    /// There should be at most one subrequest per index per request.
     #[prost(message, repeated, tag = "1")]
     pub subrequests: ::prost::alloc::vec::Vec<IngestSubrequest>,
     #[prost(enumeration = "super::CommitTypeV2", tag = "2")]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -23,14 +23,18 @@ pub struct CreateIndexResponse {
 pub struct UpdateIndexRequest {
     #[prost(message, optional, tag = "1")]
     pub index_uid: ::core::option::Option<crate::types::IndexUid>,
+    #[prost(string, tag = "5")]
+    pub doc_mapping_json: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub indexing_settings_json: ::prost::alloc::string::String,
+    #[prost(string, tag = "6")]
+    pub ingest_settings_json: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub search_settings_json: ::prost::alloc::string::String,
     #[prost(string, optional, tag = "3")]
-    pub retention_policy_json: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, tag = "4")]
-    pub indexing_settings_json: ::prost::alloc::string::String,
-    #[prost(string, tag = "5")]
-    pub doc_mapping_json: ::prost::alloc::string::String,
+    pub retention_policy_json_opt: ::core::option::Option<
+        ::prost::alloc::string::String,
+    >,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1763,7 +1763,9 @@ mod tests {
 
     use quickwit_common::ServiceStream;
     use quickwit_common::shared_consts::SCROLL_BATCH_LEN;
-    use quickwit_config::{DocMapping, IndexConfig, IndexingSettings, SearchSettings};
+    use quickwit_config::{
+        DocMapping, IndexConfig, IndexingSettings, IngestSettings, SearchSettings,
+    };
     use quickwit_indexing::MockSplitBuilder;
     use quickwit_metastore::{IndexMetadata, ListSplitsRequestExt, ListSplitsResponseExt};
     use quickwit_proto::metastore::{
@@ -1856,6 +1858,7 @@ mod tests {
         }"#;
         let doc_mapping = serde_json::from_str(doc_mapping_json).unwrap();
         let indexing_settings = IndexingSettings::default();
+        let ingest_settings = IngestSettings::default();
         let search_settings = SearchSettings {
             default_search_fields: vec!["body".to_string()],
         };
@@ -1864,8 +1867,9 @@ mod tests {
             index_uri,
             doc_mapping,
             indexing_settings,
+            ingest_settings,
             search_settings,
-            retention_policy_opt: Default::default(),
+            retention_policy_opt: None,
         })
     }
 
@@ -2027,6 +2031,7 @@ mod tests {
             "store_source": true
         }"#;
         let doc_mapping = serde_json::from_str(doc_mapping_json).unwrap();
+        let ingest_settings = IngestSettings::default();
         let indexing_settings = IndexingSettings::default();
         let search_settings = SearchSettings {
             default_search_fields: vec!["body".to_string()],
@@ -2035,9 +2040,10 @@ mod tests {
             index_id: index_id.to_string(),
             index_uri,
             doc_mapping,
+            ingest_settings,
             indexing_settings,
             search_settings,
-            retention_policy_opt: Default::default(),
+            retention_policy_opt: None,
         })
     }
 

--- a/quickwit/quickwit-serve/src/index_api/index_resource.rs
+++ b/quickwit/quickwit-serve/src/index_api/index_resource.rs
@@ -349,10 +349,11 @@ pub async fn update_index(
 
     let update_request = UpdateIndexRequest::try_from_updates(
         index_uid,
+        &new_index_config.doc_mapping,
+        &new_index_config.indexing_settings,
+        &new_index_config.ingest_settings,
         &new_index_config.search_settings,
         &new_index_config.retention_policy_opt,
-        &new_index_config.indexing_settings,
-        &new_index_config.doc_mapping,
     )?;
     let update_resp = metastore.update_index(update_request).await?;
     Ok(update_resp.deserialize_index_metadata()?)


### PR DESCRIPTION
### Description
Add `min_shards` parameter to index config. When the control place receives an `GetOrCreateOpenShards` request, it opens `min_shards` shards instead of 1. When scaling down, it ensures that we do not scale down below `min_shards`. When scaling up, it ensures that there is at least `min_shards` open if the index is actively receiving data (not idling).

### How was this PR tested?
Added unit tests
