### PR TITLE
Fix Jemalloc not used in release build

### DIFF
--- a/quickwit/quickwit-cli/src/jemalloc.rs
+++ b/quickwit/quickwit-cli/src/jemalloc.rs
@@ -18,11 +18,13 @@ use quickwit_common::metrics::MEMORY_METRICS;
 use tikv_jemallocator::Jemalloc;
 use tracing::error;
 
-#[global_allocator]
 #[cfg(feature = "jemalloc-profiled")]
+#[global_allocator]
 pub static GLOBAL: quickwit_common::jemalloc_profiled::JemallocProfiled =
     quickwit_common::jemalloc_profiled::JemallocProfiled(Jemalloc);
+
 #[cfg(not(feature = "jemalloc-profiled"))]
+#[global_allocator]
 pub static GLOBAL: Jemalloc = Jemalloc;
 
 const JEMALLOC_METRICS_POLLING_INTERVAL: Duration = Duration::from_secs(1);


### PR DESCRIPTION
### Description

This PR merges the hotfix qw-airmail-20250522-hotfix.

Jemalloc was disabled in the release build since https://github.com/quickwit-oss/quickwit/pull/5763

### How was this PR tested?

Checked whether the jemalloc metrics are now ok (if jemalloc is not the global alloc their value max out at ~100KB)
