### PR TITLE
Limit to 3 pipelines per node per source

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
@@ -417,17 +417,14 @@ fn place_unassigned_shards_single_source(
     for PlacementCandidate {
         indexer_ord,
         available_capacity,
+        current_num_shards,
         ..
     } in sorted_candidates
     {
-        let current_num_shards_for_indexer_and_source = *solution.indexer_assignments[*indexer_ord]
-            .num_shards_per_source
-            .get(&source.source_ord)
-            .unwrap_or(&0);
         let num_placable_shards_for_available_capacity =
             available_capacity.cpu_millis() / source.load_per_shard;
-        let num_placable_shards_for_limit = limit_num_shards_per_indexer_per_source
-            .saturating_sub(current_num_shards_for_indexer_and_source);
+        let num_placable_shards_for_limit =
+            limit_num_shards_per_indexer_per_source.saturating_sub(*current_num_shards);
         let num_shards_to_place = num_shards
             .min(num_placable_shards_for_available_capacity)
             .min(num_placable_shards_for_limit);

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
@@ -19,6 +19,7 @@ use std::collections::btree_map::Entry;
 use quickwit_proto::indexing::CpuCapacity;
 
 use super::scheduling_logic_model::*;
+use crate::indexing_scheduler::MAX_LOAD_PER_PIPELINE;
 use crate::indexing_scheduler::scheduling::inflate_node_capacities_if_necessary;
 
 // ------------------------------------------------------------------------------------
@@ -288,7 +289,12 @@ fn attempt_place_unassigned_shards(
             })
             .collect();
         placements.sort();
-        place_unassigned_shards_single_source(source, &placements, &mut solution)?;
+        place_unassigned_shards_single_source(
+            source,
+            &placements,
+            problem.num_indexers(),
+            &mut solution,
+        )?;
     }
     assert_place_unassigned_shards_post_condition(problem, &solution);
     Ok(solution)
@@ -323,7 +329,12 @@ fn place_unassigned_shards_with_affinity(
             })
             .collect();
         placements.sort();
-        let _ = place_unassigned_shards_single_source(source, &placements, solution);
+        let _ = place_unassigned_shards_single_source(
+            source,
+            &placements,
+            problem.num_indexers(),
+            solution,
+        );
     }
 }
 
@@ -393,17 +404,33 @@ struct NotEnoughCapacity;
 fn place_unassigned_shards_single_source(
     source: &Source,
     sorted_candidates: &[PlacementCandidate],
+    num_indexers: usize,
     solution: &mut SchedulingSolution,
 ) -> Result<(), NotEnoughCapacity> {
     let mut num_shards = source.num_shards;
+    // To ensure that merges can keep up, we try not to assign more than 3
+    // pipelines per indexer for a source (except if there aren't enough nodes).
+    let target_limit_num_shards_per_indexer_per_source =
+        3 * MAX_LOAD_PER_PIPELINE.cpu_millis() / source.load_per_shard.get();
+    let limit_num_shards_per_indexer_per_source = target_limit_num_shards_per_indexer_per_source
+        .max(num_shards.div_ceil(num_indexers as u32));
     for PlacementCandidate {
         indexer_ord,
         available_capacity,
         ..
     } in sorted_candidates
     {
-        let num_placable_shards = available_capacity.cpu_millis() / source.load_per_shard;
-        let num_shards_to_place = num_placable_shards.min(num_shards);
+        let current_num_shards_for_indexer_and_source = *solution.indexer_assignments[*indexer_ord]
+            .num_shards_per_source
+            .get(&source.source_ord)
+            .unwrap_or(&0);
+        let num_placable_shards_for_available_capacity =
+            available_capacity.cpu_millis() / source.load_per_shard;
+        let num_placable_shards_for_limit = limit_num_shards_per_indexer_per_source
+            .saturating_sub(current_num_shards_for_indexer_and_source);
+        let num_shards_to_place = num_shards
+            .min(num_placable_shards_for_available_capacity)
+            .min(num_placable_shards_for_limit);
         // Update the solution, the shard load, and the number of shards to place.
         solution.indexer_assignments[*indexer_ord]
             .add_shards(source.source_ord, num_shards_to_place);
@@ -628,6 +655,27 @@ mod tests {
         place_unassigned_shards_with_affinity(&problem, &mut solution);
         assert_eq!(solution.indexer_assignments[0].num_shards(1), 4);
         assert_eq!(solution.indexer_assignments[1].num_shards(0), 4);
+    }
+
+    #[test]
+    fn test_placement_limit_with_affinity() {
+        let mut problem =
+            SchedulingProblem::with_indexer_cpu_capacities(vec![mcpu(16_000), mcpu(16_000)]);
+        let max_load_per_pipeline = NonZeroU32::new(MAX_LOAD_PER_PIPELINE.cpu_millis()).unwrap();
+        problem.add_source(4, max_load_per_pipeline);
+        problem.add_source(4, max_load_per_pipeline);
+        problem.inc_affinity(0, 1);
+        problem.inc_affinity(0, 1);
+        problem.inc_affinity(0, 0);
+        problem.inc_affinity(1, 0);
+        let mut solution = problem.new_solution();
+        place_unassigned_shards_with_affinity(&problem, &mut solution);
+        assert_eq!(solution.indexer_assignments[0].num_shards(1), 3);
+        assert_eq!(solution.indexer_assignments[0].num_shards(0), 1);
+        assert_eq!(solution.indexer_assignments[1].num_shards(0), 3);
+        // one shard was not placed because indexer 0 was full and it had no
+        // affinity with indexer 1
+        assert_eq!(solution.indexer_assignments[1].num_shards(1), 0);
     }
 
     #[test]


### PR DESCRIPTION
### Description

Closes https://github.com/quickwit-oss/quickwit/issues/4470
Closes https://github.com/quickwit-oss/quickwit/issues/5747
Closes https://github.com/quickwit-oss/quickwit/issues/4630

This addresses both the limitation that only 1 merge pipelines can run per indexer at any given time and the fact that nodes systematically end up with all pipelines of a source when using Kafka, even if the number of pipelines for that source is rather large.

### How was this PR tested?

Added unit test, should add more
