### PR TITLE
Fix Typos in Documentation and Comments

### DIFF
--- a/docs/reference/updating-mapper.md
+++ b/docs/reference/updating-mapper.md
@@ -44,7 +44,7 @@ Conversion from a type to itself is omitted. Conversions that never succeed and 
 | date | text | convert to rfc3339 textual representation |
 | ip | text | convert to IPv6 representation. For IPv4, convert to IPv4-mapped IPv6 address (`::ffff:1.2.3.4`) |
 | bool | text | convert to "true" or false" |
-| u64/i64/f64 | bool | convert 0/0.0 to false and 1/1.0 to true, otherise omit |
+| u64/i64/f64 | bool | convert 0/0.0 to false and 1/1.0 to true, otherwise omit |
 | text | bool | convert if "true" or "false" (lowercase), otherwise omit |
 | text | ip | convert if valid IPv4 or IPv6, otherwise omit |
 | text | f64 | convert if valid floating point number, otherwise omit |

--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn test_get_from_env() {
         // SAFETY: this test may not be entirely sound if not run with nextest or --test-threads=1
-        // as this is only a test, and it would be extremly inconvenient to run it in a different
+        // as this is only a test, and it would be extremely inconvenient to run it in a different
         // way, we are keeping it that way
 
         const TEST_KEY: &str = "TEST_KEY";


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the documentation and code comments. Specifically, it changes "otherise" to "otherwise" in the documentation and "extremly" to "extremely" in a code comment. These changes improve clarity and maintain consistency in the codebase. No functional code changes are included.