### PR TITLE
Fix Typos in Comments and Documentation

### DIFF
--- a/quickwit/quickwit-config/src/source_config/mod.rs
+++ b/quickwit/quickwit-config/src/source_config/mod.rs
@@ -498,7 +498,7 @@ impl KinesisSourceParams {
     fn validate_update(&self, other: &Self) -> anyhow::Result<()> {
         // Changing the stream would likely mess up the checkpoints because the
         // Kinesis shard IDs are used as metastore checkpoint PartitionId, and
-        // there uniqueness is only guarantied within a stream.
+        // there uniqueness is only guaranteed within a stream.
         ensure!(
             self.stream_name == other.stream_name,
             "Kinesis stream_name cannot be updated"

--- a/quickwit/quickwit-query/src/aggregations.rs
+++ b/quickwit/quickwit-query/src/aggregations.rs
@@ -30,7 +30,7 @@ use tantivy::aggregation::metric::{
 // hopefully all From in this module are no-ops, otherwise, this is a very sad situation
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-/// The final aggegation result.
+/// The final aggregation result.
 pub struct AggregationResults(pub Vec<(String, AggregationResult)>);
 
 impl From<TantivyAggregationResults> for AggregationResults {


### PR DESCRIPTION
### Description

This pull request corrects minor typographical errors in comments and documentation to improve code clarity and maintain professionalism. 
