### PR TITLE
Improve shard collocation while limiting to 3 pipelines per node

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/README.md
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/README.md
@@ -15,8 +15,9 @@ We also want to observe some interesting properties such as:
 To simplify the logic and make it easier to test it, we first abstract this in the following
 optimization problem. In Quickwit, we have two types of source:
 
-- The push api source: they have a given (changing) set of shards associated to them.
-  A shard is rate-limited to ensure their throughput is lower than `5MB/s` worth of
+- The push api source: indexes have a given (changing) set of shards associated to them.
+  Shards are stored on indexer nodes and are spread randomly accross them. A shard is
+  rate-limited to ensure their throughput is lower than `5MB/s` worth of
   uncompressed data. This guarantees that a given shard can be indexed by a
   single indexing pipeline.
 

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
@@ -217,14 +217,15 @@ fn assert_enforce_nodes_cpu_capacity_post_condition(
 // We go through the sources in decreasing order of their load,
 // in two passes.
 //
-// In the first pass, we have a look at
-// the nodes with which there is an affinity.
-//
-// If one of them has room for all of the shards, then we assign all
-// of the shards to it.
+// In the first pass, we have a look at the nodes with which there is an
+// affinity.
 //
 // In the second pass, we just put as many shards as possible on the node
 // with the highest available capacity.
+//
+// Each time node is considered for placing shards of a given source, we place
+// as many of them as possible, but without exceeding the current node capacity
+// and the maximum capacity of 3 indexing pipelines.
 //
 // If this algorithm fails to place all remaining shards, we inflate
 // the node capacities by 20% in the scheduling problem and start from the beginning.

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Reverse;
+use std::cmp::{Ordering, Reverse};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 
-use itertools::Itertools;
 use quickwit_proto::indexing::CpuCapacity;
 
 use super::scheduling_logic_model::*;
+use crate::indexing_scheduler::MAX_LOAD_PER_PIPELINE;
 use crate::indexing_scheduler::scheduling::inflate_node_capacities_if_necessary;
 
 // ------------------------------------------------------------------------------------
@@ -229,6 +229,44 @@ fn assert_enforce_nodes_cpu_capacity_post_condition(
 // If this algorithm fails to place all remaining shards, we inflate
 // the node capacities by 20% in the scheduling problem and start from the beginning.
 
+#[derive(Debug, PartialEq, Eq)]
+struct PlacementCandidate {
+    indexer_ord: IndexerOrd,
+    current_num_shards: u32,
+    available_capacity: CpuCapacity,
+    affinity: u32,
+}
+
+impl Ord for PlacementCandidate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Higher affinity is better
+        match self.affinity.cmp(&other.affinity) {
+            Ordering::Equal => {}
+            ordering => return ordering.reverse(),
+        }
+        // If tie, pick the node with shards already assigned first
+        let current_shard_presence = self.current_num_shards.clamp(0, 1);
+        let other_shard_presence = other.current_num_shards.clamp(0, 1);
+        match current_shard_presence.cmp(&other_shard_presence) {
+            Ordering::Equal => {}
+            ordering => return ordering.reverse(),
+        }
+        // If tie, pick the node with the highest available capacity
+        match self.available_capacity.cmp(&other.available_capacity) {
+            Ordering::Equal => {}
+            ordering => return ordering.reverse(),
+        }
+        // Final tie-breaker: indexer ID for deterministic ordering
+        self.indexer_ord.cmp(&other.indexer_ord).reverse()
+    }
+}
+
+impl PartialOrd for PlacementCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 fn attempt_place_unassigned_shards(
     unassigned_shards: &[Source],
     problem: &SchedulingProblem,
@@ -236,12 +274,27 @@ fn attempt_place_unassigned_shards(
 ) -> Result<SchedulingSolution, NotEnoughCapacity> {
     let mut solution = partial_solution.clone();
     for source in unassigned_shards {
-        let indexers_with_most_available_capacity =
-            compute_indexer_available_capacity(problem, &solution)
-                .sorted_by_key(|(indexer_ord, capacity)| Reverse((*capacity, *indexer_ord)));
+        let mut placements: Vec<PlacementCandidate> = solution
+            .indexer_assignments
+            .iter()
+            .map(|indexer_assignment: &IndexerAssignment| {
+                let available_capacity = indexer_assignment.indexer_available_capacity(problem);
+                assert!(available_capacity >= 0i32);
+                let available_capacity = CpuCapacity::from_cpu_millis(available_capacity as u32);
+                let current_num_shards = indexer_assignment.num_shards(source.source_ord);
+                PlacementCandidate {
+                    affinity: 0,
+                    current_num_shards,
+                    available_capacity,
+                    indexer_ord: indexer_assignment.indexer_ord,
+                }
+            })
+            .collect();
+        placements.sort();
         place_unassigned_shards_single_source(
             source,
-            indexers_with_most_available_capacity,
+            &placements,
+            problem.num_indexers(),
             &mut solution,
         )?;
     }
@@ -259,25 +312,29 @@ fn place_unassigned_shards_with_affinity(
         Reverse(load)
     });
     for source in &unassigned_shards {
-        // List of indexer with a non-null affinity and some available capacity, sorted by
-        // (affinity, available capacity) in that order.
-        let indexers_with_affinity_and_available_capacity = source
+        let mut placements: Vec<PlacementCandidate> = source
             .affinities
             .iter()
             .filter(|&(_, &affinity)| affinity != 0u32)
-            .map(|(&indexer_ord, affinity)| {
+            .map(|(&indexer_ord, &affinity)| {
                 let available_capacity =
                     solution.indexer_assignments[indexer_ord].indexer_available_capacity(problem);
-                let capacity = CpuCapacity::from_cpu_millis(available_capacity as u32);
-                (indexer_ord, affinity, capacity)
+                let available_capacity = CpuCapacity::from_cpu_millis(available_capacity as u32);
+                let current_num_shards =
+                    solution.indexer_assignments[indexer_ord].num_shards(source.source_ord);
+                PlacementCandidate {
+                    affinity,
+                    current_num_shards,
+                    available_capacity,
+                    indexer_ord,
+                }
             })
-            .sorted_by_key(|(indexer_ord, affinity, capacity)| {
-                Reverse((*affinity, *capacity, *indexer_ord))
-            })
-            .map(|(indexer_ord, _, capacity)| (indexer_ord, capacity));
+            .collect();
+        placements.sort();
         let _ = place_unassigned_shards_single_source(
             source,
-            indexers_with_affinity_and_available_capacity,
+            &placements,
+            problem.num_indexers(),
             solution,
         );
     }
@@ -350,22 +407,40 @@ struct NotEnoughCapacity;
 /// amongst the node with their given node capacity.
 fn place_unassigned_shards_single_source(
     source: &Source,
-    mut indexer_with_capacities: impl Iterator<Item = (IndexerOrd, CpuCapacity)>,
+    sorted_candidates: &[PlacementCandidate],
+    num_indexers: usize,
     solution: &mut SchedulingSolution,
 ) -> Result<(), NotEnoughCapacity> {
     let mut num_shards = source.num_shards;
-    while num_shards > 0 {
-        let Some((indexer_ord, available_capacity)) = indexer_with_capacities.next() else {
-            return Err(NotEnoughCapacity);
-        };
-        let num_placable_shards = available_capacity.cpu_millis() / source.load_per_shard;
-        let num_shards_to_place = num_placable_shards.min(num_shards);
+    // To ensure that merges can keep up, we try not to assign more than 3
+    // pipelines per indexer for a source (except if there aren't enough nodes).
+    let target_limit_num_shards_per_indexer_per_source =
+        3 * MAX_LOAD_PER_PIPELINE.cpu_millis() / source.load_per_shard.get();
+    let limit_num_shards_per_indexer_per_source = target_limit_num_shards_per_indexer_per_source
+        .max(num_shards.div_ceil(num_indexers as u32));
+    for PlacementCandidate {
+        indexer_ord,
+        available_capacity,
+        current_num_shards,
+        ..
+    } in sorted_candidates
+    {
+        let num_placable_shards_for_available_capacity =
+            available_capacity.cpu_millis() / source.load_per_shard;
+        let num_placable_shards_for_limit =
+            limit_num_shards_per_indexer_per_source.saturating_sub(*current_num_shards);
+        let num_shards_to_place = num_shards
+            .min(num_placable_shards_for_available_capacity)
+            .min(num_placable_shards_for_limit);
         // Update the solution, the shard load, and the number of shards to place.
-        solution.indexer_assignments[indexer_ord]
+        solution.indexer_assignments[*indexer_ord]
             .add_shards(source.source_ord, num_shards_to_place);
         num_shards -= num_shards_to_place;
+        if num_shards == 0 {
+            return Ok(());
+        }
     }
-    Ok(())
+    Err(NotEnoughCapacity)
 }
 
 /// Compute the sources/shards that have not been assigned to any indexer yet.
@@ -394,30 +469,11 @@ fn compute_unassigned_sources(
     unassigned_sources.into_values().collect()
 }
 
-/// Builds a BinaryHeap with the different indexer capacities.
-///
-/// Panics if one of the indexer is over-assigned.
-fn compute_indexer_available_capacity<'a>(
-    problem: &'a SchedulingProblem,
-    solution: &'a SchedulingSolution,
-) -> impl Iterator<Item = (IndexerOrd, CpuCapacity)> + 'a {
-    solution
-        .indexer_assignments
-        .iter()
-        .map(|indexer_assignment| {
-            let available_capacity: i32 = indexer_assignment.indexer_available_capacity(problem);
-            assert!(available_capacity >= 0i32);
-            (
-                indexer_assignment.indexer_ord,
-                CpuCapacity::from_cpu_millis(available_capacity as u32),
-            )
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroU32;
 
+    use itertools::Itertools;
     use proptest::prelude::*;
     use quickwit_proto::indexing::mcpu;
 
@@ -600,6 +656,27 @@ mod tests {
         place_unassigned_shards_with_affinity(&problem, &mut solution);
         assert_eq!(solution.indexer_assignments[0].num_shards(1), 4);
         assert_eq!(solution.indexer_assignments[1].num_shards(0), 4);
+    }
+
+    #[test]
+    fn test_placement_limit_with_affinity() {
+        let mut problem =
+            SchedulingProblem::with_indexer_cpu_capacities(vec![mcpu(16_000), mcpu(16_000)]);
+        let max_load_per_pipeline = NonZeroU32::new(MAX_LOAD_PER_PIPELINE.cpu_millis()).unwrap();
+        problem.add_source(4, max_load_per_pipeline);
+        problem.add_source(4, max_load_per_pipeline);
+        problem.inc_affinity(0, 1);
+        problem.inc_affinity(0, 1);
+        problem.inc_affinity(0, 0);
+        problem.inc_affinity(1, 0);
+        let mut solution = problem.new_solution();
+        place_unassigned_shards_with_affinity(&problem, &mut solution);
+        assert_eq!(solution.indexer_assignments[0].num_shards(1), 3);
+        assert_eq!(solution.indexer_assignments[0].num_shards(0), 1);
+        assert_eq!(solution.indexer_assignments[1].num_shards(0), 3);
+        // one shard was not placed because indexer 0 was full and it had no
+        // affinity with indexer 1
+        assert_eq!(solution.indexer_assignments[1].num_shards(1), 0);
     }
 
     #[test]
@@ -806,5 +883,36 @@ mod tests {
         let solution = solve(problem, previous_solution);
 
         assert_eq!(solution.capacity_scaling_iterations, 1);
+    }
+
+    #[test]
+    fn test_shard_fragmentation_when_iterating() {
+        // Create a problem where affinity constraints cause suboptimal placement
+        // requiring iterative scaling despite initial capacity scaling.
+        let mut problem =
+            SchedulingProblem::with_indexer_cpu_capacities(vec![mcpu(3000), mcpu(3000)]);
+        problem.add_source(1, NonZeroU32::new(1000).unwrap());
+        problem.add_source(1, NonZeroU32::new(1000).unwrap());
+        problem.add_source(1, NonZeroU32::new(1000).unwrap());
+        let empty_solution = problem.new_solution();
+        let first_solution = solve(problem, empty_solution);
+
+        let mut updated_problem =
+            SchedulingProblem::with_indexer_cpu_capacities(vec![mcpu(3000), mcpu(3000)]);
+        updated_problem.add_source(2, NonZeroU32::new(1000).unwrap());
+        updated_problem.add_source(2, NonZeroU32::new(1000).unwrap());
+        updated_problem.add_source(2, NonZeroU32::new(1000).unwrap());
+
+        let second_solution = solve(updated_problem, first_solution);
+
+        for source in 0..2 {
+            let num_shards_per_indexer = second_solution
+                .indexer_assignments
+                .iter()
+                .map(|indexer_assignment| indexer_assignment.num_shards(source))
+                .collect_vec();
+            assert!(num_shards_per_indexer.contains(&2));
+            assert!(num_shards_per_indexer.contains(&0));
+        }
     }
 }


### PR DESCRIPTION
### Description

Closes https://github.com/quickwit-oss/quickwit/issues/4470
Closes https://github.com/quickwit-oss/quickwit/issues/5747
Closes https://github.com/quickwit-oss/quickwit/issues/4630

#### Improve shard collocation

When placing new shards for an existing source, when affinity is not defined (e.g Kafka source), we currently have no affinity for nodes where we have existing indexing pipelines. This can create a fragmented distribution of shards.

This solution is not perfect, ideally we should split the assignation in two steps (just as we do for the shard affinity):
- first assign shards to nodes that already have shards for all the source
- second for sources where we still have shards to assign, assign them to new nodes

#### Limit to 3 pipelines per node

See https://github.com/quickwit-oss/quickwit/pull/5792


### How was this PR tested?

Added unit test
