### PR TITLE
Fix unlikely provider panic when requesting search permit

### DIFF
--- a/quickwit/quickwit-search/src/search_permit_provider.rs
+++ b/quickwit/quickwit-search/src/search_permit_provider.rs
@@ -163,10 +163,10 @@ impl SearchPermitActor {
                     permits.push(SearchPermitFuture(rx));
                 }
                 self.assign_available_permits();
-                permit_sender
-                    .send(permits)
-                    // This is a request response pattern, so we can safely ignore the error.
-                    .expect("Receiver lives longer than sender");
+                // The receiver could be dropped in the (unlikely) situation
+                // where the future requesting these permits is cancelled before
+                // this message is processed.
+                let _ = permit_sender.send(permits);
             }
             SearchPermitMessage::UpdateMemory { memory_delta } => {
                 if self.total_memory_allocated as i64 + memory_delta < 0 {


### PR DESCRIPTION
### Description

Fix an unlikely but critical panic in the search permit provider.

### How was this PR tested?

Describe how you tested this PR.
