### PR TITLE
Exit when chitchat server fails

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
 [[package]]
 name = "chitchat"
 version = "0.9.0"
+source = "git+https://github.com/quickwit-oss/chitchat.git?rev=58880f0#58880f069fc2c7ace55eaa66551e930673e42869"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1640,7 +1640,6 @@ dependencies = [
 [[package]]
 name = "chitchat"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/chitchat.git?rev=13968f0#13968f0d2153cbc0873c3c8e4cb8f6db4d156dbc"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "chitchat"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/chitchat.git?rev=58880f0#58880f069fc2c7ace55eaa66551e930673e42869"
+source = "git+https://github.com/quickwit-oss/chitchat.git?rev=d3113d9#d3113d9efdaa8403fdaf7b87be4b8d1b7bc29880"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "chitchat"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/chitchat.git?rev=d3113d9#d3113d9efdaa8403fdaf7b87be4b8d1b7bc29880"
+source = "git+https://github.com/quickwit-oss/chitchat.git?rev=bd54c81#bd54c810700814f83599a31a7e29f2a5eb8324b3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -91,7 +91,7 @@ binggan = { version = "0.14" }
 bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "1.3", features = ["serde"] }
 bytestring = "1.4"
-chitchat = { git = "https://github.com/quickwit-oss/chitchat.git", rev = "13968f0" }
+chitchat = { git = "https://github.com/quickwit-oss/chitchat.git", rev = "58880f0" }
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -91,7 +91,7 @@ binggan = { version = "0.14" }
 bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "1.3", features = ["serde"] }
 bytestring = "1.4"
-chitchat = { git = "https://github.com/quickwit-oss/chitchat.git", rev = "d3113d9" }
+chitchat = { git = "https://github.com/quickwit-oss/chitchat.git", rev = "bd54c81" }
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -91,7 +91,7 @@ binggan = { version = "0.14" }
 bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "1.3", features = ["serde"] }
 bytestring = "1.4"
-chitchat = { git = "https://github.com/quickwit-oss/chitchat.git", rev = "58880f0" }
+chitchat = { git = "https://github.com/quickwit-oss/chitchat.git", rev = "d3113d9" }
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -385,7 +385,7 @@ impl Cluster {
         info!(
             cluster_id=%self.cluster_id,
             node_id=%self.self_chitchat_id.node_id,
-            "Leaving the cluster."
+            "leaving the cluster"
         );
         self.set_self_node_readiness(false).await;
         tokio::time::sleep(self.gossip_interval * 2).await;
@@ -898,6 +898,7 @@ mod tests {
             .unwrap();
 
         node_1.leave().await;
+        drop(node_1);
 
         let cluster_changes: Vec<ClusterChange> = node_1_change_stream.collect().await;
         assert_eq!(cluster_changes.len(), 6);

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -440,7 +440,7 @@ impl Cluster {
 
     pub async fn chitchat_server_termination_watcher(
         &self,
-    ) -> impl Future<Output = anyhow::Result<()>> {
+    ) -> impl Future<Output = anyhow::Result<()>> + use<> {
         self.inner
             .read()
             .await

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -387,7 +387,7 @@ async fn test_scheduler_scheduling_multiple_indexers() {
     assert_eq!(scheduler_state.num_schedule_indexing_plan, 1);
 
     // Shutdown cluster and wait until the new scheduling.
-    cluster_indexer_2.shutdown().await;
+    cluster_indexer_2.leave().await;
 
     cluster
         .wait_for_ready_members(

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -395,7 +395,12 @@ fn start_shard_positions_service(
     });
 }
 
-async fn shutdown_handler(
+/// Waits for the shutdown signal and notifies all other services when it
+/// occurs.
+///
+/// Usually called when receiving a SIGTERM signal, e.g. k8s trying to
+/// decomission a pod.
+async fn shutdown_signal_handler(
     shutdown_signal: BoxFutureInfaillible<()>,
     universe: Universe,
     ingester_opt: Option<Ingester>,
@@ -797,7 +802,7 @@ pub async fn serve_quickwit(
         "node_readiness_reporting",
     );
 
-    let shutdown_handle = tokio::spawn(shutdown_handler(
+    let shutdown_handle = tokio::spawn(shutdown_signal_handler(
         shutdown_signal,
         universe,
         ingester_opt,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -395,6 +395,36 @@ fn start_shard_positions_service(
     });
 }
 
+async fn shutdown_handler(
+    shutdown_signal: BoxFutureInfaillible<()>,
+    universe: Universe,
+    ingester_opt: Option<Ingester>,
+    grpc_shutdown_trigger_tx: oneshot::Sender<()>,
+    rest_shutdown_trigger_tx: oneshot::Sender<()>,
+    cluster: Cluster,
+) -> HashMap<String, ActorExitStatus> {
+    shutdown_signal.await;
+    // We must decommission the ingester first before terminating the indexing pipelines that
+    // may consume from it. We also need to keep the gRPC server running while doing so.
+    if let Some(ingester) = ingester_opt {
+        if let Err(error) = wait_for_ingester_decommission(ingester).await {
+            error!("failed to decommission ingester gracefully: {:?}", error);
+        }
+    }
+    let actor_exit_statuses = universe.quit().await;
+
+    if grpc_shutdown_trigger_tx.send(()).is_err() {
+        debug!("gRPC server shutdown signal receiver was dropped");
+    }
+    if rest_shutdown_trigger_tx.send(()).is_err() {
+        debug!("REST server shutdown signal receiver was dropped");
+    }
+    if let Err(err) = cluster.initiate_shutdown().await {
+        debug!("{err}");
+    }
+    actor_exit_statuses
+}
+
 pub async fn serve_quickwit(
     node_config: NodeConfig,
     runtimes_config: RuntimesConfig,
@@ -757,7 +787,7 @@ pub async fn serve_quickwit(
     // Thus readiness task is started once gRPC and REST servers are started.
     spawn_named_task(
         node_readiness_reporting_task(
-            cluster,
+            cluster.clone(),
             metastore_through_control_plane,
             ingester_opt.clone(),
             grpc_readiness_signal_rx,
@@ -767,26 +797,14 @@ pub async fn serve_quickwit(
         "node_readiness_reporting",
     );
 
-    let shutdown_handle = tokio::spawn(async move {
-        shutdown_signal.await;
-
-        // We must decommission the ingester first before terminating the indexing pipelines that
-        // may consume from it. We also need to keep the gRPC server running while doing so.
-        if let Some(ingester) = ingester_opt {
-            if let Err(error) = wait_for_ingester_decommission(ingester).await {
-                error!("failed to decommission ingester gracefully: {:?}", error);
-            }
-        }
-        let actor_exit_statuses = universe.quit().await;
-
-        if grpc_shutdown_trigger_tx.send(()).is_err() {
-            debug!("gRPC server shutdown signal receiver was dropped");
-        }
-        if rest_shutdown_trigger_tx.send(()).is_err() {
-            debug!("REST server shutdown signal receiver was dropped");
-        }
-        actor_exit_statuses
-    });
+    let shutdown_handle = tokio::spawn(shutdown_handler(
+        shutdown_signal,
+        universe,
+        ingester_opt,
+        grpc_shutdown_trigger_tx,
+        rest_shutdown_trigger_tx,
+        cluster.clone(),
+    ));
     let grpc_join_handle = async move {
         spawn_named_task(grpc_server, "grpc_server")
             .await
@@ -801,7 +819,9 @@ pub async fn serve_quickwit(
             .context("REST server failed")
     };
 
-    if let Err(err) = tokio::try_join!(grpc_join_handle, rest_join_handle) {
+    let chitchat_server_handle = cluster.chitchat_server_termination_watcher().await;
+
+    if let Err(err) = tokio::try_join!(grpc_join_handle, rest_join_handle, chitchat_server_handle) {
         error!("server failed: {err:?}");
     }
 


### PR DESCRIPTION
### Description

Closes https://github.com/quickwit-oss/quickwit/issues/5787

Currently, Quickwit node would keep running if chitchat server stops (panic or error). This PR adds a watcher for this and stops the nodes if something goes wrong in chitchat.

This PR depends on https://github.com/quickwit-oss/chitchat/pull/162

### How was this PR tested?

Describe how you tested this PR.
