### PR TITLE
Fix stdin source registration for local-ingest tool. Fixes #5772.

### DIFF
--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -115,6 +115,7 @@ pub use vec_source::{VecSource, VecSourceFactory};
 pub use void_source::{VoidSource, VoidSourceFactory};
 
 use self::doc_file_reader::dir_and_filename;
+use self::stdin_source::StdinSourceFactory;
 use crate::actors::DocProcessor;
 use crate::models::RawDocBatch;
 use crate::source::ingest::IngestSourceFactory;
@@ -415,6 +416,7 @@ pub fn quickwit_supported_sources() -> &'static SourceLoader {
         source_factory.add_source(SourceType::Kinesis, KinesisSourceFactory);
         #[cfg(feature = "pulsar")]
         source_factory.add_source(SourceType::Pulsar, PulsarSourceFactory);
+        source_factory.add_source(SourceType::Stdin, StdinSourceFactory);
         source_factory.add_source(SourceType::Vec, VecSourceFactory);
         source_factory.add_source(SourceType::Void, VoidSourceFactory);
         source_factory

--- a/quickwit/quickwit-indexing/src/source/stdin_source.rs
+++ b/quickwit/quickwit-indexing/src/source/stdin_source.rs
@@ -108,10 +108,10 @@ impl Source for StdinSource {
     }
 }
 
-pub struct FileSourceFactory;
+pub struct StdinSourceFactory;
 
 #[async_trait]
-impl TypedSourceFactory for FileSourceFactory {
+impl TypedSourceFactory for StdinSourceFactory {
     type Source = StdinSource;
     type Params = ();
 


### PR DESCRIPTION
### Description

Fixes #5772.

### How was this PR tested?

Tested the local ingest on the otel-logs-v0_9 index with the following json

```json

{"timestamp_nanos":1640995200000000000,"observed_timestamp_nanos":1640995200000000000,"service_name":"my-service","severity_text":"INFO","severity_number":9,"body":{"message":"User logged in successfully"},"attributes":{"user_id":"12345","endpoint":"/login"},"resource_attributes":{"host.name":"server-01","service.version":"1.0.0"}}

```
