### PR TITLE
Fix `never used` build warning

### DIFF
--- a/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
@@ -149,6 +149,7 @@ impl AzureBlobStorage {
     /// Sets the multipart policy.
     ///
     /// See `MultiPartPolicy`.
+    #[cfg(feature = "integration-testsuite")]
     pub fn set_policy(&mut self, multipart_policy: MultiPartPolicy) {
         self.multipart_policy = multipart_policy;
     }

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -205,6 +205,7 @@ impl S3CompatibleObjectStorage {
     /// Sets the multipart policy.
     ///
     /// See `MultiPartPolicy`.
+    #[cfg(feature = "integration-testsuite")]
     pub fn set_policy(&mut self, multipart_policy: MultiPartPolicy) {
         self.multipart_policy = multipart_policy;
     }

--- a/quickwit/quickwit-storage/src/opendal_storage/base.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/base.rs
@@ -65,6 +65,7 @@ impl OpendalStorage {
         })
     }
 
+    #[cfg(feature = "integration-testsuite")]
     pub fn set_policy(&mut self, multipart_policy: MultiPartPolicy) {
         self.multipart_policy = multipart_policy;
     }


### PR DESCRIPTION
### Description

With some feature combination, we get the following during builds:

```
warning: method `set_policy` is never used
  --> quickwit-storage/src/opendal_storage/base.rs:69:12
   |
53 | impl OpendalStorage {
   | ------------------- method in this implementation
...
69 |     pub fn set_policy(&mut self, multipart_policy: MultiPartPolicy) {
   |            ^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

### How was this PR tested?

Describe how you tested this PR.
