### PR TITLE
Remove deduplication of logs and traces by service name and timestamp

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
@@ -174,6 +174,14 @@ impl JsonDocBatchV2Builder {
             doc_lengths: self.doc_lengths,
         }
     }
+
+    pub fn with_num_docs(num_docs: usize) -> Self {
+        Self {
+            doc_uids: Vec::with_capacity(num_docs),
+            doc_lengths: Vec::with_capacity(num_docs),
+            ..Default::default()
+        }
+    }
 }
 
 /// Helper struct to build an [`IngestRequestV2`].


### PR DESCRIPTION
### Description
Remove deduplication of logs and traces by service name and timestamp, which causes the issue reported in #5852. I chose to remove the sorting logic entirely. It's unclear if we get any performance from this, especially after merges occur. I was certainly guilty of premature optimization when I wrote this garbage :/

