### PR TITLE
fix: Use appropriate Term method for date search

### DIFF
--- a/quickwit/quickwit-query/src/query_ast/utils.rs
+++ b/quickwit/quickwit-query/src/query_ast/utils.rs
@@ -143,7 +143,7 @@ fn compute_query_with_field(
         }
         FieldType::Date(_) => {
             let dt = parse_value_from_user_text(value, field_entry.name())?;
-            let term = Term::from_field_date(field, dt);
+            let term = Term::from_field_date_for_search(field, dt);
             Ok(make_term_query(term))
         }
         FieldType::Str(text_options) => {


### PR DESCRIPTION
### Description

Tantivy's PR https://github.com/quickwit-oss/tantivy/pull/2456 removed date truncation to the second in method `from_field_date` and introduced a new method `from_field_date_for_search` for this purpose.

> Fixes date truncation issue in Term, where DateTime was truncated to seconds precision unconditionally, but we only want to apply that truncation on the inverted index.

It seems that the method used by Quickwit to generate the Term struct during searches was never updated.

### How was this PR tested?

Added a unit test