### PR TITLE
Update tantivy version

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3085,12 +3085,12 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs4"
-version = "0.8.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5727,8 +5727,8 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "ownedbytes"
-version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.9.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -9738,8 +9738,8 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tantivy"
-version = "0.23.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.25.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -9793,16 +9793,16 @@ dependencies = [
 
 [[package]]
 name = "tantivy-bitpacker"
-version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.8.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "bitpacking",
 ]
 
 [[package]]
 name = "tantivy-columnar"
-version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.5.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -9816,8 +9816,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-common"
-version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.9.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -9839,29 +9839,30 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.22.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.24.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "nom",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "tantivy-sstable"
-version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.5.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
  "tantivy-bitpacker",
  "tantivy-common",
  "tantivy-fst",
- "zstd 0.13.3",
 ]
 
 [[package]]
 name = "tantivy-stacker"
-version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.5.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -9870,8 +9871,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-tokenizer-api"
-version = "0.3.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=80f5f1e#80f5f1ecd4d5d30069b44e5acd3801f610d36056"
+version = "0.5.0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=b621e4da#b621e4dabeef8bfbf4687de0730a47ae0905d40a"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -347,7 +347,7 @@ quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry = { path = "quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "80f5f1e", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "b621e4da", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",

--- a/quickwit/quickwit-proto/src/search/mod.rs
+++ b/quickwit/quickwit-proto/src/search/mod.rs
@@ -227,7 +227,7 @@ impl PartialHit {
 /// Serializes the Split fields.
 ///
 /// `fields_metadata` has to be sorted.
-pub fn serialize_split_fields(list_fields: ListFields) -> Vec<u8> {
+pub fn serialize_split_fields(list_fields: &ListFields) -> Vec<u8> {
     let payload = list_fields.encode_to_vec();
     let compression_level = 3;
     let payload_compressed = zstd::stream::encode_all(&mut &payload[..], compression_level)

--- a/quickwit/quickwit-search/src/list_fields.rs
+++ b/quickwit/quickwit-search/src/list_fields.rs
@@ -70,15 +70,15 @@ pub async fn get_fields_from_split(
         Ordering::Equal => left.field_type.cmp(&right.field_type),
         other => other,
     });
+    let list_fields = ListFields {
+        fields: list_fields,
+    };
     // Put result into cache
-    searcher_context.list_fields_cache.put(
-        split_and_footer_offsets.clone(),
-        ListFields {
-            fields: list_fields.clone(),
-        },
-    );
+    searcher_context
+        .list_fields_cache
+        .put(split_and_footer_offsets.clone(), &list_fields);
 
-    Ok(Box::new(list_fields.into_iter()))
+    Ok(Box::new(list_fields.fields.into_iter()))
 }
 
 /// `current_group` needs to contain at least one element.

--- a/quickwit/quickwit-search/src/list_fields_cache.rs
+++ b/quickwit/quickwit-search/src/list_fields_cache.rs
@@ -41,9 +41,8 @@ impl ListFieldsCache {
         deserialize_split_fields(encoded_result).ok()
     }
 
-    pub fn put(&self, split_info: SplitIdAndFooterOffsets, list_fields: ListFields) {
+    pub fn put(&self, split_info: SplitIdAndFooterOffsets, list_fields: &ListFields) {
         let key = CacheKey::from_split_meta(split_info);
-
         let encoded_result = serialize_split_fields(list_fields);
         self.content.put(key, OwnedBytes::new(encoded_result));
     }
@@ -110,7 +109,7 @@ mod tests {
             fields: vec![result.clone()],
         };
 
-        cache.put(split_1.clone(), list_fields.clone());
+        cache.put(split_1.clone(), &list_fields);
         assert_eq!(cache.get(split_1.clone()).unwrap(), list_fields);
         assert!(cache.get(split_2).is_none());
     }


### PR DESCRIPTION
In https://github.com/quickwit-oss/tantivy/pull/2679 we modified the prototype of the function that expose fields information.

The new method expose the size used per field for each tantivy datastructure.

This PR updates quickwit to:
- compile
- limit the number of fields exported in the packager to the 1k most prominent fields.

This is also a preliminary solution to address
https://github.com/quickwit-oss/quickwit/issues/5832
