### PR TITLE
fix the PromQL for cache misses

### DIFF
--- a/monitoring/grafana/dashboards/searchers.json
+++ b/monitoring/grafana/dashboards/searchers.json
@@ -606,7 +606,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(quickwit_cache_cache_hits_total{instance=~\"$instance\"}[$__rate_interval])",
+          "expr": "rate(quickwit_cache_cache_misses_total{instance=~\"$instance\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,


### PR DESCRIPTION
I think this was a typo.

Honestly, I'm not sure this is useful to monitor. They are pretty much the same with the rate of total requests.