### PR TITLE
add sensitive param to get_from_env_opt

### DIFF
--- a/quickwit/quickwit-cli/src/logger.rs
+++ b/quickwit/quickwit-cli/src/logger.rs
@@ -152,7 +152,7 @@ impl EventFormat<'_> {
     /// Gets the log format from the environment variable `QW_LOG_FORMAT`. Returns a JSON
     /// formatter if the variable is set to `json`, otherwise returns a full formatter.
     fn get_from_env() -> Self {
-        if get_from_env_opt::<String>("QW_LOG_FORMAT")
+        if get_from_env_opt::<String>("QW_LOG_FORMAT", false)
             .map(|log_format| log_format.eq_ignore_ascii_case("json"))
             .unwrap_or(false)
         {

--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -33,7 +33,11 @@ use tracing::error;
 /// QW_RUNTIME_NUM_THREADS environment variable.
 fn get_main_runtime_num_threads() -> usize {
     let default_num_runtime_threads: usize = quickwit_common::num_cpus().div_ceil(3);
-    quickwit_common::get_from_env("QW_TOKIO_RUNTIME_NUM_THREADS", default_num_runtime_threads)
+    quickwit_common::get_from_env(
+        "QW_TOKIO_RUNTIME_NUM_THREADS",
+        default_num_runtime_threads,
+        false,
+    )
 }
 
 fn main() -> anyhow::Result<()> {

--- a/quickwit/quickwit-common/src/cpus.rs
+++ b/quickwit/quickwit-common/src/cpus.rs
@@ -88,7 +88,7 @@ fn parse_cpu_to_mcpu(cpu_string: &str) -> Result<usize, &'static str> {
 //
 // We then get the number of vCPUs by ceiling any non integer value.
 fn get_num_cpus_from_env(env_key: &str) -> Option<usize> {
-    let k8s_cpu_limit_str: String = crate::get_from_env_opt(env_key)?;
+    let k8s_cpu_limit_str: String = crate::get_from_env_opt(env_key, false)?;
     let mcpus = parse_cpu_to_mcpu(&k8s_cpu_limit_str)
         .inspect_err(|err_msg| {
             warn!(

--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -40,6 +40,7 @@ pub fn split_deletion_grace_period() -> Duration {
         let deletion_grace_period_secs: u64 = crate::get_from_env(
             "QW_SPLIT_DELETION_GRACE_PERIOD_SECS",
             DEFAULT_DELETION_GRACE_PERIOD.as_secs(),
+            false,
         );
         let deletion_grace_period_secs_clamped: u64 = deletion_grace_period_secs.clamp(
             MINIMUM_DELETION_GRACE_PERIOD.as_secs(),

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -187,6 +187,7 @@ fn get_default_load_per_shard() -> NonZeroU32 {
         let default_load_per_shard = quickwit_common::get_from_env(
             "QW_DEFAULT_LOAD_PER_SHARD",
             PIPELINE_FULL_CAPACITY.cpu_millis() / 4,
+            false,
         );
         NonZeroU32::new(default_load_per_shard).unwrap()
     })

--- a/quickwit/quickwit-index-management/src/garbage_collection.rs
+++ b/quickwit/quickwit-index-management/src/garbage_collection.rs
@@ -292,14 +292,15 @@ async fn list_splits_metadata(
 fn get_maximum_split_deletion_rate_per_sec() -> Option<usize> {
     static MAX_SPLIT_DELETION_RATE_PER_SEC: OnceLock<Option<usize>> = OnceLock::new();
     *MAX_SPLIT_DELETION_RATE_PER_SEC.get_or_init(|| {
-        quickwit_common::get_from_env_opt::<usize>("QW_MAX_SPLIT_DELETION_RATE_PER_SEC")
+        quickwit_common::get_from_env_opt::<usize>("QW_MAX_SPLIT_DELETION_RATE_PER_SEC", false)
     })
 }
 
 fn get_index_gc_concurrency() -> Option<usize> {
     static INDEX_GC_CONCURRENCY: OnceLock<Option<usize>> = OnceLock::new();
-    *INDEX_GC_CONCURRENCY
-        .get_or_init(|| quickwit_common::get_from_env_opt::<usize>("QW_INDEX_GC_CONCURRENCY"))
+    *INDEX_GC_CONCURRENCY.get_or_init(|| {
+        quickwit_common::get_from_env_opt::<usize>("QW_INDEX_GC_CONCURRENCY", false)
+    })
 }
 
 /// Removes any splits marked for deletion which haven't been

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -101,7 +101,7 @@ const DEFAULT_BATCH_NUM_BYTES: usize = 1024 * 1024; // 1 MiB
 fn get_batch_num_bytes() -> usize {
     static BATCH_NUM_BYTES_CELL: OnceCell<usize> = OnceCell::new();
     *BATCH_NUM_BYTES_CELL.get_or_init(|| {
-        quickwit_common::get_from_env("QW_INGEST_BATCH_NUM_BYTES", DEFAULT_BATCH_NUM_BYTES)
+        quickwit_common::get_from_env("QW_INGEST_BATCH_NUM_BYTES", DEFAULT_BATCH_NUM_BYTES, false)
     })
 }
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -66,6 +66,7 @@ fn ingest_request_timeout() -> Duration {
         let duration_ms = quickwit_common::get_from_env(
             "QW_INGEST_REQUEST_TIMEOUT_MS",
             DEFAULT_INGEST_REQUEST_TIMEOUT.as_millis() as u64,
+            false,
         );
         let minimum_ingest_request_timeout: Duration =
             PERSIST_REQUEST_TIMEOUT * (MAX_PERSIST_ATTEMPTS as u32) + Duration::from_secs(5);

--- a/quickwit/quickwit-search/src/list_fields.rs
+++ b/quickwit/quickwit-search/src/list_fields.rs
@@ -49,7 +49,7 @@ use crate::{
 /// when building the response. This is a workaround until a way is found to
 /// prune the long tail of rare fields.
 static FIELD_LIST_SIZE_LIMIT: LazyLock<usize> =
-    LazyLock::new(|| quickwit_common::get_from_env("QW_FIELD_LIST_SIZE_LIMIT", 100_000));
+    LazyLock::new(|| quickwit_common::get_from_env("QW_FIELD_LIST_SIZE_LIMIT", 100_000, false));
 
 const DYNAMIC_FIELD_PREFIX: &str = "_dynamic.";
 

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -148,6 +148,7 @@ fn get_metastore_client_max_concurrency() -> usize {
     quickwit_common::get_from_env(
         METASTORE_CLIENT_MAX_CONCURRENCY_ENV_KEY,
         DEFAULT_METASTORE_CLIENT_MAX_CONCURRENCY,
+        false,
     )
 }
 

--- a/quickwit/quickwit-serve/src/load_shield.rs
+++ b/quickwit/quickwit-serve/src/load_shield.rs
@@ -38,9 +38,9 @@ impl LoadShield {
         let max_in_flight_env_key = format!("QW_{endpoint_group_uppercase}_MAX_IN_FLIGHT");
         let max_concurrency_env_key = format!("QW_{endpoint_group_uppercase}_MAX_CONCURRENCY");
         let max_in_flight_opt: Option<usize> =
-            quickwit_common::get_from_env_opt(&max_in_flight_env_key);
+            quickwit_common::get_from_env_opt(&max_in_flight_env_key, false);
         let max_concurrency_opt: Option<usize> =
-            quickwit_common::get_from_env_opt(&max_concurrency_env_key);
+            quickwit_common::get_from_env_opt(&max_concurrency_env_key, false);
         let in_flight_semaphore_opt = max_in_flight_opt.map(Semaphore::new);
         let concurrency_semaphore_opt = max_concurrency_opt.map(Semaphore::new);
         let pending_gauge = crate::metrics::SERVE_METRICS

--- a/quickwit/quickwit-serve/src/rest.rs
+++ b/quickwit/quickwit-serve/src/rest.rs
@@ -89,12 +89,12 @@ struct CompressionPredicate {
 
 impl CompressionPredicate {
     fn from_env() -> CompressionPredicate {
-        let minimum_compression_size_opt: Option<u16> = quickwit_common::get_from_env_opt::<usize>(
-            QW_MINIMUM_COMPRESSION_SIZE_KEY,
-        )
-        .map(|minimum_compression_size: usize| {
-            u16::try_from(minimum_compression_size).unwrap_or(u16::MAX)
-        });
+        let minimum_compression_size_opt: Option<u16> =
+            quickwit_common::get_from_env_opt::<usize>(QW_MINIMUM_COMPRESSION_SIZE_KEY, false).map(
+                |minimum_compression_size: usize| {
+                    u16::try_from(minimum_compression_size).unwrap_or(u16::MAX)
+                },
+            );
         let size_above_opt = minimum_compression_size_opt.map(SizeAbove::new);
         CompressionPredicate { size_above_opt }
     }

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -55,7 +55,8 @@ use crate::{
 /// Semaphore to limit the number of concurrent requests to the object store. Some object stores
 /// (R2, SeaweedFs...) return errors when too many concurrent requests are emitted.
 static REQUEST_SEMAPHORE: Lazy<Semaphore> = Lazy::new(|| {
-    let num_permits: usize = quickwit_common::get_from_env("QW_S3_MAX_CONCURRENCY", 10_000usize);
+    let num_permits: usize =
+        quickwit_common::get_from_env("QW_S3_MAX_CONCURRENCY", 10_000usize, false);
     Semaphore::new(num_permits)
 });
 


### PR DESCRIPTION
### Description

- Add sensitive parameter so `get_from_env` functions can be used to get API keys, etc.

### How was this PR tested?

- `make test-all`
