### PR TITLE
Fix azure multipart upload data corruption

### DIFF
--- a/quickwit/quickwit-storage/tests/azure_storage.rs
+++ b/quickwit/quickwit-storage/tests/azure_storage.rs
@@ -45,7 +45,7 @@ async fn azure_storage_test_suite() -> anyhow::Result<()> {
 
     object_storage.set_policy(MultiPartPolicy {
         // On azure, block size is limited between 64KB and 100MB.
-        target_part_num_bytes: 5 * 1_024 * 1_024, // 5MB
+        target_part_num_bytes: 2 * 1_024 * 1_024, // 2MB
         max_num_parts: 10_000,
         multipart_threshold_num_bytes: 10_000_000,
         max_object_num_bytes: 5_000_000_000_000,


### PR DESCRIPTION
### Description

Blocks were added to BlockList in completion order rather than sequential order, causing data corruption. Zero pad block IDs and sort before committing to ensure correct blob reconstruction.

Also improve the existing test that was only checking file, the test would fail on main if integrity check was turned on.

### How was this PR tested?

This PR passes the unit test, also has been runnin in for last two days in production without data corruption, prior to this PR - split was getting corrupted every 45 minutes.

