### PR TITLE
Pin remaining Docker container images

### DIFF
--- a/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.4
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.4@sha256:3356619b020614effd22e83cec41236e69f17ce581ffe35e252898b0c693b4e2
 
 ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip"
 

--- a/build/cross-images/aarch64-unknown-linux-musl.dockerfile
+++ b/build/cross-images/aarch64-unknown-linux-musl.dockerfile
@@ -1,4 +1,4 @@
-FROM rustembedded/cross:aarch64-unknown-linux-musl
+FROM rustembedded/cross:aarch64-unknown-linux-musl@sha256:22627e0ba533781062127b13601c37216fdca27123390b07dfabd3f31f3c84a0
 
 
 # The Rust toolchain to use when building our image.  Set by `hooks/build`.

--- a/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4@sha256:7c9067212c2283be2a1d5585af5ecebd4c4a2e18091e2a6aafd23f9b4b81d496
 
 ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip"
 

--- a/build/cross-images/x86_64-unknown-linux-musl.dockerfile
+++ b/build/cross-images/x86_64-unknown-linux-musl.dockerfile
@@ -1,4 +1,4 @@
-FROM quickwit/cross-base:x86_64-unknown-linux-musl
+FROM quickwit/cross-base:x86_64-unknown-linux-musl@sha256:5bcc7843aab64f89bf85c464fa2c5a00ecc634a8b1ac88c84a864f60054450cb
 # See https://github.com/quickwit-inc/rust-musl-builder
 
 RUN echo "Upgrading CMake" && \

--- a/distribution/docker/ubuntu/Dockerfile
+++ b/distribution/docker/ubuntu/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:noble AS builder
+FROM ubuntu:noble@sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252 AS builder
 
 RUN apt-get update && apt-get install -y curl
 RUN curl -L https://install.quickwit.io | sh
 
 
-FROM ubuntu:noble AS quickwit
+FROM ubuntu:noble@sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252 AS quickwit
 
 LABEL org.opencontainers.image.title="Quickwit"
 LABEL maintainer="Quickwit, Inc. <hello@quickwit.io>"


### PR DESCRIPTION
### Description

Pin Docker images by hash to ensure reliable production builds.
Continuation of https://github.com/quickwit-oss/quickwit/pull/5939

### How was this PR tested?

Tested locally by using `docker pull imagename@<hash>`
