### PR TITLE
Update token permissions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - "quickwit/**"
       - "!quickwit/quickwit-ui/**"
+
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: 0
   QW_DISABLE_TELEMETRY: 1
@@ -28,6 +32,9 @@ jobs:
     name: Unit tests
     runs-on: "ubuntu-latest"
     timeout-minutes: 40
+    permissions:
+      contents: read
+      actions: write
     services:
       # PostgreSQL service container
       postgres:
@@ -98,6 +105,9 @@ jobs:
     name: Lints
     runs-on: "ubuntu-latest"
     timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
@@ -157,6 +167,9 @@ jobs:
   thirdparty-license:
     name: Check Datadog third-party license file
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,9 @@ on:
       - quickwit/Cargo.lock
       - quickwit/quickwit-*/**
 
+permissions:
+  contents: read
+
 env:
   AWS_REGION: us-east-1
   AWS_ACCESS_KEY_ID: "placeholder"
@@ -28,6 +31,9 @@ jobs:
     name: Coverage
     runs-on: gh-ubuntu-arm64
     timeout-minutes: 40
+    permissions:
+      contents: read
+      actions: write
     # Setting a containing will require to fix the QW_S3_ENDPOINT to http://localstack:4566
     services:
       localstack:

--- a/.github/workflows/publish_cross_images.yml
+++ b/.github/workflows/publish_cross_images.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "build/cross-images/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-cross-images:
     name: Publish cross images

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -12,6 +12,10 @@ on:
       - happy-plazza
       - qw*
       - v*
+
+permissions:
+  contents: read
+
 env:
   REGISTRY_IMAGE: quickwit/quickwit
 
@@ -27,6 +31,9 @@ jobs:
             platform: linux/arm64
             platform_suffix: arm64
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: write
     environment:
       name: production
     steps:
@@ -99,6 +106,9 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: [docker]
+    permissions:
+      contents: read
+      actions: read
     environment: production
     steps:
       - name: Download digests

--- a/.github/workflows/publish_lambda_packages.yml
+++ b/.github/workflows/publish_lambda_packages.yml
@@ -5,10 +5,15 @@ on:
     tags:
       - "aws-lambda-beta-*"
 
+permissions:
+  contents: read
+
 jobs:
   build-lambdas:
     name: Build Quickwit Lambdas
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - name: Install Ubuntu packages

--- a/.github/workflows/publish_nightly_packages.yml
+++ b/.github/workflows/publish_nightly_packages.yml
@@ -5,10 +5,16 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   build-macos-binaries:
     name: Build ${{ matrix.target }}
     runs-on: macos-latest
+    permissions:
+      contents: write
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +33,9 @@ jobs:
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
     name: Build ${{ matrix.target }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/cross-build-binary

--- a/.github/workflows/publish_release_packages.yml
+++ b/.github/workflows/publish_release_packages.yml
@@ -5,10 +5,16 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build-macos-binaries:
     name: Build ${{ matrix.target }}
     runs-on: macos-latest
+    permissions:
+      contents: write
+      actions: write
     strategy:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
@@ -29,6 +35,9 @@ jobs:
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
     name: Build ${{ matrix.target }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v5
       - name: Extract asset version

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -14,10 +14,16 @@ on:
       - "quickwit/quickwit-ui/**"
       - ".github/workflows/ui-ci.yml"
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{ matrix.task.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Description

Update workflows to use less privileged permissions.
- On workflow level set `contents: read`.
- On job level, override `actions: write` and `contents: write` where necessary. The first is required for cache, and the second is required for releases.

### How was this PR tested?

n/a
