### PR TITLE
Enable ingest v1 by default.

### DIFF
--- a/docs/ingest-data/ingest-api.md
+++ b/docs/ingest-data/ingest-api.md
@@ -78,11 +78,11 @@ This concludes the tutorial. You can now move on to the [next tutorial](/docs/in
 
 In 0.9, Quickwit introduced a new version of the ingest API that enables distributing the indexing in the cluster regardless of the node that received the ingest request. This new ingestion service is often referred to as "Ingest V2" compared to the legacy ingestion (V1). In upcoming versions the new ingest API will also be capable of replicating the write ahead log in order to achieve higher durability.
 
-By default, both ingestion services are enabled and ingest V2 is used. You can toggle this behavior with the following environment variables:
+By default, ingest V1 is enabled and used. You can enable ingest V2 with the following environment variables:
 
 | Variable              | Description   | Default value |
 | --------------------- | --------------|-------------- |
-| `QW_ENABLE_INGEST_V2` | Start the V2 ingest service and use it by default. | true | 
+| `QW_ENABLE_INGEST_V2` | Start the V2 ingest service and use it by default. | false | 
 | `QW_DISABLE_INGEST_V1`| V1 ingest will be used by the APIs only if V2 is disabled. Running V1 along V2 is necessary to migrate to V2 without loosing existing unindexed V1 logs. | false |
 
 :::note

--- a/docs/internals/ingest-v2.md
+++ b/docs/internals/ingest-v2.md
@@ -1,6 +1,6 @@
 # Ingest V2
 
-Ingest V2 is the latest ingestion API that is designed to be more efficient and scalable for thousands of indexes than the previous version. It is the default since 0.9.
+Ingest V2 is the latest ingestion API that is designed to be more efficient and scalable for thousands of indexes than the previous version. It is currently disabled by default and can be enabled via the `QW_ENABLE_INGEST_V2` environment variable.
 
 ## Architecture
 

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -85,7 +85,7 @@ pub use crate::storage_config::{
 /// Returns true if the ingest API v2 is enabled.
 pub fn enable_ingest_v2() -> bool {
     static ENABLE_INGEST_V2: Lazy<bool> =
-        Lazy::new(|| get_bool_from_env("QW_ENABLE_INGEST_V2", true));
+        Lazy::new(|| get_bool_from_env("QW_ENABLE_INGEST_V2", false));
     *ENABLE_INGEST_V2
 }
 


### PR DESCRIPTION
In order to release a 0.9 version, we should use the ingest v1 by default.