### PR TITLE
Pin pipenv and it's deps by hash in workflows. See #5937

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install python packages
         if: always() && steps.modified.outputs.rust_src == 'true'
         run: |
-          pip install --user pipenv==2025.0.4
+          pip install --user --require-hashes -r ${{ github.workspace }}/.github/workflows/requirements.txt
           pipenv install --deploy --ignore-pipfile
         working-directory: ./quickwit/rest-api-tests
       - name: Run REST API tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Install python packages
         run: |
-          pip install --user pipenv==2025.0.4
+          pip install --user --require-hashes -r ${{ github.workspace }}/.github/workflows/requirements.txt
           pipenv install --deploy --ignore-pipfile
         working-directory: ./quickwit/quickwit-cli/tests
 

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,0 +1,22 @@
+# contains pinned dependencies for installing pipenv to ensure repeatable builds in CI/CD workflows
+certifi==2025.10.5 \
+    --hash=sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de \
+    --hash=sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43
+distlib==0.4.0 \
+    --hash=sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16 \
+    --hash=sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d
+filelock==3.20.0 \
+    --hash=sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2 \
+    --hash=sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4
+packaging==25.0 \
+    --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
+    --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
+pipenv==2025.0.4 \
+    --hash=sha256:36fc2a7841ccdb2f58a9f787b296c2e15dea3b5b79b84d4071812f28b7e8d7a2 \
+    --hash=sha256:e1fbe4cfd25ab179f123d1fbb1fa1cdc0b3ffcdb1f21c775dcaa12ccc356f2bb
+platformdirs==4.5.0 \
+    --hash=sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312 \
+    --hash=sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3
+virtualenv==20.35.4 \
+    --hash=sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c \
+    --hash=sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b


### PR DESCRIPTION
### Description

Pinned pipenv and its dependencies by hash to make scorecard check pass while waiting for a reply regarding best practices https://github.com/ossf/scorecard/discussions/4834

### How was this PR tested?

n/a
