### PR TITLE
add node_id to emited spans

### DIFF
--- a/quickwit/quickwit-cli/src/cli.rs
+++ b/quickwit/quickwit-cli/src/cli.rs
@@ -14,6 +14,7 @@
 
 use anyhow::{Context, bail};
 use clap::{Arg, ArgAction, ArgMatches, Command, arg};
+use quickwit_common::uri::Uri;
 use quickwit_serve::EnvFilterReloadFn;
 use tracing::Level;
 
@@ -93,6 +94,16 @@ impl CliCommand {
             CliCommand::Source(subcommand) => subcommand.execute().await,
             CliCommand::Split(subcommand) => subcommand.execute().await,
             CliCommand::Tool(subcommand) => subcommand.execute().await,
+        }
+    }
+
+    pub fn config_uri(&self) -> Option<&Uri> {
+        match self {
+            CliCommand::Run(run) => Some(&run.config_uri),
+            CliCommand::Index(_) => None,
+            CliCommand::Source(_) => None,
+            CliCommand::Split(_) => None,
+            CliCommand::Tool(tools) => tools.config_uri(),
         }
     }
 }

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -221,7 +221,7 @@ pub fn start_actor_runtimes(
 }
 
 /// Loads a node config located at `config_uri` with the default storage configuration.
-async fn load_node_config(config_uri: &Uri) -> anyhow::Result<NodeConfig> {
+pub async fn load_node_config(config_uri: &Uri) -> anyhow::Result<NodeConfig> {
     let config_content = load_file(&StorageResolver::unconfigured(), config_uri)
         .await
         .context("failed to load node config")?;

--- a/quickwit/quickwit-cli/src/logger.rs
+++ b/quickwit/quickwit-cli/src/logger.rs
@@ -56,6 +56,7 @@ pub fn setup_logging_and_tracing(
     level: Level,
     ansi_colors: bool,
     build_info: &BuildInfo,
+    node_name: String,
 ) -> anyhow::Result<EnvFilterReloadFn> {
     #[cfg(feature = "tokio-console")]
     {
@@ -112,6 +113,7 @@ pub fn setup_logging_and_tracing(
             .with_resource(Resource::new([
                 KeyValue::new("service.name", "quickwit"),
                 KeyValue::new("service.version", build_info.version.clone()),
+                KeyValue::new("service.node", node_name),
             ]))
             .build();
         let tracer = provider.tracer("quickwit");

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -394,6 +394,16 @@ impl ToolCliCommand {
             Self::ExtractSplit(args) => extract_split_cli(args).await,
         }
     }
+
+    pub fn config_uri(&self) -> Option<&Uri> {
+        match self {
+            Self::GarbageCollect(args) => Some(&args.config_uri),
+            Self::LocalIngest(args) => Some(&args.config_uri),
+            Self::LocalSearch(args) => Some(&args.config_uri),
+            Self::Merge(args) => Some(&args.config_uri),
+            Self::ExtractSplit(args) => Some(&args.config_uri),
+        }
+    }
 }
 
 pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<()> {


### PR DESCRIPTION
### Description

add the node_id to emitted spans, making traces easier to interpret

### How was this PR tested?

spin a one node cluster, make it trace to itself, and verify the new field is shown in jaeger