### PR TITLE
Validate doc mapping update

### DIFF
--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -47,6 +47,7 @@ use index_config::serialize::{IndexConfigV0_8, VersionedIndexConfig};
 pub use index_config::{
     IndexConfig, IndexingResources, IndexingSettings, IngestSettings, RetentionPolicy,
     SearchSettings, build_doc_mapper, load_index_config_from_user_config, load_index_config_update,
+    prepare_doc_mapping_update,
 };
 pub use quickwit_doc_mapper::DocMapping;
 use serde::Serialize;

--- a/quickwit/quickwit-doc-mapper/src/doc_mapping.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapping.rs
@@ -166,20 +166,6 @@ impl DocMapping {
     pub fn default_max_num_partitions() -> NonZeroU32 {
         NonZeroU32::new(200).unwrap()
     }
-
-    /// Returns whether the `other` doc mapping is equal to `self` leaving their respective doc
-    /// mapping UIDs out of the comparison.
-    pub fn eq_ignore_doc_mapping_uid(&self, other: &Self) -> bool {
-        let doc_mapping_uid = DocMappingUid::default();
-
-        let mut left = self.clone();
-        left.doc_mapping_uid = doc_mapping_uid;
-
-        let mut right = other.clone();
-        right.doc_mapping_uid = doc_mapping_uid;
-
-        left == right
-    }
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -221,7 +221,7 @@ impl FileBackedIndex {
         ingest_settings: IngestSettings,
         search_settings: SearchSettings,
         retention_policy_opt: Option<RetentionPolicy>,
-    ) -> bool {
+    ) -> MetastoreResult<bool> {
         self.metadata.update_index_config(
             doc_mapping,
             indexing_settings,

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -575,7 +575,7 @@ impl MetastoreService for FileBackedMetastore {
                     ingest_settings,
                     search_settings,
                     retention_policy_opt,
-                );
+                )?;
                 let index_metadata = index.metadata().clone();
 
                 if mutation_occurred {

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -431,7 +431,7 @@ impl MetastoreService for PostgresqlMetastore {
                     ingest_settings,
                     search_settings,
                     retention_policy_opt,
-                );
+                )?;
                 Ok(MutationOccurred::from(mutation_occurred))
             })
             .await


### PR DESCRIPTION
### Description
This PR ensures that the doc mapping is validated at the metastore API level when an index config is updated.

### How was this PR tested?
- Add unit tests
- Ran config and metastore test suites locally:
```sh
c t --manifest-path quickwit/Cargo.toml -p quickwit-config
QW_TEST_DATABASE_URL=postgres://quickwit-dev:quickwit-dev@localhost:5432/quickwit-metastore-dev c t --manifest-path quickwit/Cargo.toml -p quickwit-metastore --all-features
```
