### PR TITLE
[ui] Prevent the search result date to overflow

### DIFF
--- a/quickwit/quickwit-ui/src/components/SearchResult/Row.tsx
+++ b/quickwit/quickwit-ui/src/components/SearchResult/Row.tsx
@@ -83,7 +83,14 @@ function DisplayTimestampValue(row: RawDoc, timestampField: Field | null) {
   }
   return (
     <TableCell sx={{ verticalAlign: "top", padding: "4px" }}>
-      <Box sx={{ maxHeight: "115px", width: "90px", display: "inline-block" }}>
+      <Box
+        sx={{
+          maxHeight: "115px",
+          width: "90px",
+          display: "inline-block",
+          wordBreak: "break-word",
+        }}
+      >
         {formatDateTime(
           field_value,
           timestampField.field_mapping.output_format,


### PR DESCRIPTION
### Description

Allows the date column content to break instead of overflowing. Keeps the 90px width.

| before | after |
|---|---|
| <img width="480" height="436" alt="image" src="https://github.com/user-attachments/assets/6ccd071d-778f-40f4-81c0-a7fc04147118" /> | <img width="480" height="436" alt="image" src="https://github.com/user-attachments/assets/fd15e0c0-175c-4ff3-9a55-cef179c5c61e" /> |



### How was this PR tested?

minor UI fix, tested locally
