### PR TITLE
Add secondary search queue

### DIFF
--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -283,6 +283,12 @@ pub struct SearcherConfig {
     pub storage_timeout_policy: Option<StorageTimeoutPolicy>,
     pub warmup_memory_budget: ByteSize,
     pub warmup_single_split_initial_allocation: ByteSize,
+
+    pub secondary_max_num_concurrent_split_searches: usize,
+    pub secondary_warmup_memory_budget: ByteSize,
+    pub secondary_targeted_split_count_threshold: Option<usize>,
+    #[serde(default = "SearcherConfig::default_request_timeout_secs")]
+    secondary_request_timeout_secs: NonZeroU64,
 }
 
 /// Configuration controlling how fast a searcher should timeout a `get_slice`
@@ -333,6 +339,11 @@ impl Default for SearcherConfig {
             storage_timeout_policy: None,
             warmup_memory_budget: ByteSize::gb(100),
             warmup_single_split_initial_allocation: ByteSize::gb(1),
+
+            secondary_max_num_concurrent_split_searches: 50,
+            secondary_warmup_memory_budget: ByteSize::gb(50),
+            secondary_targeted_split_count_threshold: None,
+            secondary_request_timeout_secs: Self::default_request_timeout_secs(),
         }
     }
 }
@@ -341,6 +352,9 @@ impl SearcherConfig {
     /// The timeout after which a search should be cancelled
     pub fn request_timeout(&self) -> Duration {
         Duration::from_secs(self.request_timeout_secs.get())
+    }
+    pub fn secondary_request_timeout(&self) -> Duration {
+        Duration::from_secs(self.secondary_request_timeout_secs.get())
     }
     fn default_request_timeout_secs() -> NonZeroU64 {
         NonZeroU64::new(30).unwrap()

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -672,6 +672,13 @@ mod tests {
                 }),
                 warmup_memory_budget: ByteSize::gb(100),
                 warmup_single_split_initial_allocation: ByteSize::gb(1),
+
+                secondary_max_num_concurrent_split_searches: 50,
+                secondary_warmup_memory_budget: ByteSize::gb(50),
+                // Splits per leaf search above which the secondary queue is used. If not set, the
+                // secondary queue is never used.
+                secondary_targeted_split_count_threshold: None,
+                secondary_request_timeout_secs: NonZeroU64::new(30).unwrap(),
             }
         );
         assert_eq!(

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -175,6 +175,7 @@ async fn fetch_docs_in_split(
         split,
         Some(doc_mapper.tokenizer_manager()),
         None,
+        false,
     )
     .await
     .context("open-index-for-split")?;

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -45,7 +45,7 @@ use tokio::task::JoinError;
 use tracing::*;
 
 use crate::collector::{IncrementalCollector, make_collector_for_split, make_merge_collector};
-use crate::metrics::SplitSearchOutcomeCounters;
+use crate::metrics::{SplitSearchOutcomeCounters, queue_label};
 use crate::root::is_metadata_count_request_with_ast;
 use crate::search_permit_provider::{SearchPermit, compute_initial_memory_allocation};
 use crate::service::{SearcherContext, deserialize_doc_mapper};
@@ -92,6 +92,7 @@ pub(crate) async fn open_split_bundle(
     searcher_context: &SearcherContext,
     index_storage: Arc<dyn Storage>,
     split_and_footer_offsets: &SplitIdAndFooterOffsets,
+    split_cache_read_only: bool,
 ) -> anyhow::Result<(FileSlice, BundleStorage)> {
     let split_file = PathBuf::from(format!("{}.split", split_and_footer_offsets.split_id));
     let footer_data = get_split_footer_from_cache_or_fetch(
@@ -105,7 +106,11 @@ pub(crate) async fn open_split_bundle(
     // This is before the bundle storage: at this point, this storage is reading `.split` files.
     let index_storage_with_split_cache =
         if let Some(split_cache) = searcher_context.split_cache_opt.as_ref() {
-            SplitCache::wrap_storage(split_cache.clone(), index_storage.clone())
+            SplitCache::wrap_storage(
+                split_cache.clone(),
+                index_storage.clone(),
+                split_cache_read_only,
+            )
         } else {
             index_storage.clone()
         };
@@ -148,6 +153,7 @@ pub(crate) async fn open_index_with_caches(
     split_and_footer_offsets: &SplitIdAndFooterOffsets,
     tokenizer_manager: Option<&TokenizerManager>,
     ephemeral_unbounded_cache: Option<ByteRangeCache>,
+    split_cache_read_only: bool,
 ) -> anyhow::Result<(Index, HotDirectory)> {
     let index_storage_with_retry_on_timeout =
         configure_storage_retries(searcher_context, index_storage);
@@ -156,6 +162,7 @@ pub(crate) async fn open_index_with_caches(
         searcher_context,
         index_storage_with_retry_on_timeout,
         split_and_footer_offsets,
+        split_cache_read_only,
     )
     .await?;
 
@@ -438,10 +445,10 @@ async fn leaf_search_single_split(
     split: SplitIdAndFooterOffsets,
     aggregations_limits: AggregationLimitsGuard,
     search_permit: &mut SearchPermit,
+    is_broad_search: bool,
 ) -> crate::Result<Option<LeafSearchResponse>> {
     let mut leaf_search_state_guard =
         SplitSearchStateGuard::new(ctx.split_outcome_counters.clone());
-
     rewrite_request(
         &mut search_request,
         &split,
@@ -477,6 +484,8 @@ async fn leaf_search_single_split(
         &split,
         Some(ctx.doc_mapper.tokenizer_manager()),
         Some(byte_range_cache.clone()),
+        // for broad searches, we want to avoid evicting useful cached splits
+        is_broad_search,
     )
     .await?;
 
@@ -1182,6 +1191,7 @@ pub async fn multi_index_leaf_search(
     searcher_context: Arc<SearcherContext>,
     leaf_search_request: LeafSearchRequest,
     storage_resolver: &StorageResolver,
+    is_broad_search: bool,
 ) -> Result<LeafSearchResponse, SearchError> {
     let search_request: Arc<SearchRequest> = leaf_search_request
         .search_request
@@ -1240,6 +1250,7 @@ pub async fn multi_index_leaf_search(
                     leaf_search_request_ref.split_offsets,
                     doc_mapper,
                     aggregation_limits,
+                    is_broad_search,
                 )
                 .await
             }
@@ -1248,11 +1259,13 @@ pub async fn multi_index_leaf_search(
         leaf_request_tasks.push(leaf_request_future);
     }
 
-    let leaf_responses: Vec<crate::Result<LeafSearchResponse>> = tokio::time::timeout(
-        searcher_context.searcher_config.request_timeout(),
-        try_join_all(leaf_request_tasks),
-    )
-    .await??;
+    let timeout = if is_broad_search {
+        searcher_context.searcher_config.secondary_request_timeout()
+    } else {
+        searcher_context.searcher_config.request_timeout()
+    };
+    let leaf_responses: Vec<crate::Result<LeafSearchResponse>> =
+        tokio::time::timeout(timeout, try_join_all(leaf_request_tasks)).await??;
     let merge_collector = make_merge_collector(&search_request, aggregation_limits)?;
     let mut incremental_merge_collector = IncrementalCollector::new(merge_collector);
     for result in leaf_responses {
@@ -1339,6 +1352,7 @@ pub async fn single_doc_mapping_leaf_search(
     splits: Vec<SplitIdAndFooterOffsets>,
     doc_mapper: Arc<DocMapper>,
     aggregations_limits: AggregationLimitsGuard,
+    is_broad_search: bool,
 ) -> Result<LeafSearchResponse, SearchError> {
     let num_docs: u64 = splits.iter().map(|split| split.num_docs).sum();
     let num_splits = splits.len();
@@ -1366,10 +1380,12 @@ pub async fn single_doc_mapping_leaf_search(
                 .warmup_single_split_initial_allocation,
         )
     });
-    let permit_futures = searcher_context
-        .search_permit_provider
-        .get_permits(permit_sizes)
-        .await;
+    let permit_provider = if is_broad_search {
+        &searcher_context.secondary_search_permit_provider
+    } else {
+        &searcher_context.search_permit_provider
+    };
+    let permit_futures = permit_provider.get_permits(permit_sizes).await;
 
     let leaf_search_context = Arc::new(LeafSearchContext {
         searcher_context: searcher_context.clone(),
@@ -1405,6 +1421,7 @@ pub async fn single_doc_mapping_leaf_search(
                     split,
                     leaf_split_search_permit,
                     aggregations_limits.clone(),
+                    is_broad_search,
                 )
                 .in_current_span(),
             ),
@@ -1528,9 +1545,11 @@ async fn leaf_search_single_split_wrapper(
     split: SplitIdAndFooterOffsets,
     mut search_permit: SearchPermit,
     aggregations_limits: AggregationLimitsGuard,
+    is_broad_search: bool,
 ) {
     let timer = crate::SEARCH_METRICS
         .leaf_search_split_duration_secs
+        .with_label_values([queue_label(is_broad_search)])
         .start_timer();
     let leaf_search_single_split_opt_res: crate::Result<Option<LeafSearchResponse>> =
         leaf_search_single_split(
@@ -1540,6 +1559,7 @@ async fn leaf_search_single_split_wrapper(
             split.clone(),
             aggregations_limits,
             &mut search_permit,
+            is_broad_search,
         )
         .await;
 

--- a/quickwit/quickwit-search/src/list_fields.rs
+++ b/quickwit/quickwit-search/src/list_fields.rs
@@ -67,8 +67,13 @@ async fn get_fields_from_split(
     {
         return Ok(list_fields.fields);
     }
-    let (_, split_bundle) =
-        open_split_bundle(searcher_context, index_storage, split_and_footer_offsets).await?;
+    let (_, split_bundle) = open_split_bundle(
+        searcher_context,
+        index_storage,
+        split_and_footer_offsets,
+        false,
+    )
+    .await?;
 
     let serialized_split_fields = split_bundle
         .get_all(Path::new(SPLIT_FIELDS_FILE_NAME))

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -1058,6 +1058,7 @@ async fn test_search_util(test_sandbox: &TestSandbox, query: &str) -> Vec<u32> {
         splits_offsets,
         test_sandbox.doc_mapper(),
         agg_limits,
+        false,
     )
     .await
     .unwrap();

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1026,7 +1026,6 @@ async fn setup_searcher(
     .await?;
     let search_service_clone = search_service.clone();
     let max_message_size = node_config.grpc_config.max_message_size;
-    let request_timeout = node_config.searcher_config.request_timeout();
     let searcher_change_stream = cluster_change_stream.filter_map(move |cluster_change| {
         let search_service_clone = search_service_clone.clone();
         Box::pin(async move {
@@ -1046,7 +1045,8 @@ async fn setup_searcher(
                             SearchServiceClient::from_service(search_service_clone, grpc_addr);
                         Some(Change::Insert(grpc_addr, search_client))
                     } else {
-                        let timeout_channel = Timeout::new(node.channel(), request_timeout);
+                        // Set a very high timeout just to be sure that we cleanup at some point.
+                        let timeout_channel = Timeout::new(node.channel(), Duration::from_mins(30));
                         let search_client = create_search_client_from_channel(
                             grpc_addr,
                             timeout_channel,


### PR DESCRIPTION
### Description

Currently, the search permit provider handles only one query at a time. This is good for the overall query latency when queries are relatively short. It is catastrophic in any concurrent setup where some queries are slow, because all the other queries will be starved from resources until the large query completes.

This PR creates a secondary search permit provider that is independently configured. "Fast" leaf queries are routed to one provider and "slow" ones to the other. Query duration is naively inferred from the number of targetted splits, and the threshold for being routed to one provider or the other can be configured using `SearcherConfig.secondary_targeted_split_count_threshold`.

One limitation of the current implementation of this PR is that for a given root search, various leaf searches might fall on different sides of the threshold. We could fix this by applying the threashold on the root and add the targeted provider in the leaf request.

### How was this PR tested?

We ran this setup on our highly concurrent production environment. It helped stabilize query performance drastically.
