### PR TITLE
Update dashboard and docs for split_search_outcome metric

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -68,9 +68,9 @@ Examples of operation names: `create_index`, `index_metadata`, `delete_index`, `
 
 | Namespace | Metric Name | Description | Type |
 | --------- | ----------- | ----------- | ---- |
-| `quickwit_search` | `leaf_searches_splits_total` | Number of leaf searches (count of splits) started | `counter` |
+| `quickwit_search` | `split_search_outcome` | Count of split search outcomes by category | `counter` |
 | `quickwit_search` | `leaf_search_split_duration_secs` | Number of seconds required to run a leaf search over a single split. The timer starts after the semaphore is obtained | `histogram` |
-| `quickwit_search` | `active_search_threads_count` | Number of threads in use in the CPU thread pool | `gauge` |
+| `quickwit_search` | `leaf_list_terms_splits_total` | Number of list terms splits total | `counter` |
 
 ## Storage Metrics
 

--- a/monitoring/grafana/dashboards/searchers.json
+++ b/monitoring/grafana/dashboards/searchers.json
@@ -108,17 +108,17 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "quickwit_search_leaf_searches_splits_total{instance=~\"$instance\"}",
+          "expr": "quickwit_search_split_search_outcome{instance=~\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{instance}} {{category}}",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
-      "title": "Leaf search splits",
+      "title": "Split search outcome",
       "type": "timeseries"
     },
     {
@@ -857,7 +857,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(quickwit_search_leaf_searches_splits_total,instance)",
+        "definition": "label_values(quickwit_search_split_search_outcome,instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -865,7 +865,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(quickwit_search_leaf_searches_splits_total,instance)",
+          "query": "label_values(quickwit_search_split_search_outcome,instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
### Description

Replace deprecated leaf_searches_splits_total metric with the new split_search_outcome metric introduced in #6001. Also added leaf_list_terms_splits_total to docs.

### How was this PR tested?

N/A