### PR TITLE
use correct precision level for fastfield-based termquery on datetime

### DIFF
--- a/quickwit/quickwit-query/src/query_ast/utils.rs
+++ b/quickwit/quickwit-query/src/query_ast/utils.rs
@@ -141,9 +141,13 @@ fn compute_query_with_field(
             let term = Term::from_field_bool(field, bool_val);
             Ok(make_term_query(term))
         }
-        FieldType::Date(_) => {
+        FieldType::Date(date_options) => {
             let dt = parse_value_from_user_text(value, field_entry.name())?;
-            let term = Term::from_field_date_for_search(field, dt);
+            let term = if date_options.is_indexed() {
+                Term::from_field_date_for_search(field, dt)
+            } else {
+                Term::from_field_date(field, dt.truncate(date_options.get_precision()))
+            };
             Ok(make_term_query(term))
         }
         FieldType::Str(text_options) => {


### PR DESCRIPTION
### Description

when querying indexed timestamps, we truncate dates to the second, as that's how they are stored inside the index, however when querying a non-indexed, fast field, we still do that truncation. This result in queries not matching when they should (or matching when they shouldn't if a doc has a timestamp with no sub-second value, but the query has a sub-second value). This PR make it so when we're about to run a datetime termquery over fastfield, we search for a value with the precision of the fastfield, and not the precision of an sstable

### How was this PR tested?

added unit test