### PR TITLE
fix gcs tests

### DIFF
--- a/quickwit/quickwit-storage/src/lib.rs
+++ b/quickwit/quickwit-storage/src/lib.rs
@@ -174,7 +174,6 @@ pub(crate) mod test_suite {
             .get_slice(Path::new("missingfile"), 0..3)
             .await
             .map_err(|err| err.kind());
-
         assert!(matches!(err, Err(StorageErrorKind::NotFound)));
         Ok(())
     }

--- a/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
@@ -57,7 +57,6 @@ pub mod test_config_helpers {
 
     /// URL of the local GCP emulator.
     pub const LOCAL_GCP_EMULATOR_ENDPOINT: &str = "http://127.0.0.1:4443";
-    
     /// Creates a storage connecting to a local emulated google cloud storage.
     pub fn new_emulated_google_cloud_storage(
         uri: &Uri,

--- a/quickwit/quickwit-storage/tests/google_cloud_storage.rs
+++ b/quickwit/quickwit-storage/tests/google_cloud_storage.rs
@@ -28,12 +28,11 @@ mod gcp_storage_test_suite {
         LOCAL_GCP_EMULATOR_ENDPOINT, new_emulated_google_cloud_storage,
     };
 
-    pub async fn sign_gcs_request(req: &mut reqwest::Request) -> anyhow::Result<()> {
+    pub fn sign_gcs_request(req: &mut reqwest::Request) {
         req.headers_mut().insert(
             reqwest::header::AUTHORIZATION,
-            reqwest::header::HeaderValue::from_str("Bearer dummy")?,
+            reqwest::header::HeaderValue::from_str("Bearer dummy").unwrap(),
         );
-        Ok(())
     }
 
     async fn create_gcs_bucket(bucket_name: &str) -> anyhow::Result<()> {
@@ -47,7 +46,7 @@ mod gcp_storage_test_suite {
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .build()?;
 
-        sign_gcs_request(&mut request).await?;
+        sign_gcs_request(&mut request);
 
         let response = client.execute(request).await?;
 


### PR DESCRIPTION
### Description

Fix the integration test for gcs storage where reported here. 
https://github.com/quickwit-oss/quickwit/actions/runs/20378291223/job/58562301680


### How was this PR tested?

run the command `RUST_MIN_STACK=67108864 CARGO_BUILD_JOBS=4 cargo llvm-cov nextest --no-report --all-features --no-fail-fast --retries 4` that runs during code coverage. google_cloud_storage_test_suite test is successful now. 
