### PR TITLE
Fix `test_metastore_get_identity` flaky test

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -1670,15 +1670,15 @@ impl MetastoreService for PostgresqlMetastore {
         &self,
         _: GetClusterIdentityRequest,
     ) -> MetastoreResult<GetClusterIdentityResponse> {
+        // `ON CONFLICT DO NOTHING RETURNING` returns NULL if no insert happens.
+        // To always get the value, we use this pattern:
         let (uuid,) = sqlx::query_as(
             r"
-                WITH insert AS (
-                    INSERT INTO kv (key, value)
-                           VALUES ('cluster_identity', $1)
-                           ON CONFLICT (key) DO NOTHING
-                )
-                SELECT value FROM kv where key = 'cluster_identity';
-                ",
+                INSERT INTO kv (key, value)
+                VALUES ('cluster_identity', $1)
+                ON CONFLICT (key) DO UPDATE SET key = EXCLUDED.key
+                RETURNING value
+            ",
         )
         .bind(Uuid::new_v4().hyphenated().to_string())
         .fetch_one(&self.connection_pool)


### PR DESCRIPTION
### Description
This test always succeeds when run in isolation but is flaky when multiple tests are executed simultaneously because the pattern insert with CTE followed by SELECT ... is not atomic. Here's Gemini explanation:

> This error is a classic example of a PostgreSQL race condition involving Common Table Expressions (CTEs) and visibility. While it looks like the query should be atomic, the WITH clause and the SELECT statement don't necessarily see the results of each other the way you'd expect if another process is interacting with the database at the exact same millisecond.


### How was this PR tested?
Ran this multiple times: `QW_TEST_DATABASE_URL=postgres://[...] c t --manifest-path quickwit/Cargo.toml -p quickwit-metastore --all-features --`
