### PR TITLE
Fix Kafka readiness test command

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -95,7 +95,7 @@ jobs:
           KAFKA_HEAP_OPTS: -Xms256M -Xmx256M
 
         options: >-
-          --health-cmd "cub kafka-ready -b localhost:9092 1 5"
+          --health-cmd "ub kafka-ready -b localhost:9092 1 5"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
           KAFKA_HEAP_OPTS: -Xms256M -Xmx256M
     healthcheck:
         # test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
-        test: ["CMD", "cub", "kafka-ready", "-b", "localhost:9092", "1", "5"]
+        test: ["CMD", "ub", "kafka-ready", "-b", "localhost:9092", "1", "5"]
         start_period: 5s
         interval: 5s
         timeout: 10s


### PR DESCRIPTION
### Description
The `cub` command for Confluent Utility Belt was renamed `ub` after it was rewritten in Go.

### How was this PR tested?
Tested locally (`make docker-compose-up` now works)
