### PR TITLE
Fix `test_gcp_pubsub_source` flaky test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
     # It is not an official docker image
     # if we prefer we can build a docker from the official docker image (gcloud cli)
     # and install the pubsub emulator https://cloud.google.com/pubsub/docs/emulator
-    image: thekevjames/gcloud-pubsub-emulator:${GCLOUD_EMULATOR:-455.0.0}
+    image: thekevjames/gcloud-pubsub-emulator:${GCLOUD_EMULATOR:-550.0.0}
     container_name: gcp-pubsub-emulator
     ports:
       - "${MAP_HOST_GCLOUD_EMULATOR:-127.0.0.1}:8681:8681"

--- a/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
+++ b/quickwit/quickwit-indexing/src/source/gcp_pubsub_source.rs
@@ -358,7 +358,6 @@ mod gcp_pubsub_emulator_tests {
             .unwrap_err();
     }
 
-    #[ignore]
     #[tokio::test]
     async fn test_gcp_pubsub_source() {
         let universe = Universe::with_accelerated_time();


### PR DESCRIPTION
### Description
The test no longer seems flaky.

### How was this PR tested?
Ran the test locally a thousand times:
```
for i in (seq 1 1000)
  echo "Run $i"
  PUBSUB_EMULATOR_HOST=localhost:8681 c t --manifest-path quickwit/Cargo.toml -p quickwit-indexing --all-features -- gcp_pubsub_source
  or break
end
```
