### PR TITLE
Upgrade to Rust 1.92

### DIFF
--- a/quickwit/quickwit-actors/src/actor.rs
+++ b/quickwit/quickwit-actors/src/actor.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use thiserror::Error;
-use tracing::error;
 
 use crate::{ActorContext, QueueCapacity, SendError};
 

--- a/quickwit/quickwit-indexing/src/source/ingest/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest/mod.rs
@@ -410,9 +410,8 @@ impl IngestSource {
                 .assigned_shards
                 .keys()
                 .filter(|&shard_id| !new_assigned_shard_ids.contains(shard_id))
-                .cloned()
                 .any(|removed_shard_id| {
-                    let Some(assigned_shard) = self.assigned_shards.get(&removed_shard_id) else {
+                    let Some(assigned_shard) = self.assigned_shards.get(removed_shard_id) else {
                         return false;
                     };
                     assigned_shard.status != IndexingStatus::Complete

--- a/quickwit/quickwit-serve/src/otlp_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/otlp_api/rest_handler.rs
@@ -25,7 +25,6 @@ use quickwit_proto::opentelemetry::proto::collector::trace::v1::{
 use quickwit_proto::types::IndexId;
 use quickwit_proto::{ServiceError, ServiceErrorCode, tonic};
 use serde::{self, Serialize};
-use tracing::error;
 use warp::{Filter, Rejection};
 
 use crate::decompression::get_body_bytes;

--- a/quickwit/rust-toolchain.toml
+++ b/quickwit/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91"
+channel = "1.92"
 components = ["cargo", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
### Description
Upgrade and fix clippy warnings.

### How was this PR tested?
`make test-all` (`test_file_source_sqs_notifications` failed :/)
