### PR TITLE
Fix infinite loop OOM bug caused by rebalancing shards from inactive ingesters

### DIFF
--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -3544,7 +3544,8 @@ mod tests {
     /// - `available_ingester_shards`: open shards per available ingester
     /// - `unavailable_ingester_shards`: open shards on unavailable ingesters
     fn test_compute_shards_to_rebalance_aux(
-        available_ingester_shards: &[usize], unavailable_ingester_shards: &[usize],
+        available_ingester_shards: &[usize],
+        unavailable_ingester_shards: &[usize],
     ) {
         let index_id = "test-index";
         let index_metadata = IndexMetadata::for_test(index_id, "ram://indexes/test-index");


### PR DESCRIPTION
Rebalances all shards from unavailable ingesters. Moves to only look at ingesters with more shards than allowed as candidates for rebalancing. Also moves to integer division to simplify target calculation.