### PR TITLE
Make regex lenient to start and end anchors

### DIFF
--- a/quickwit/rest-api-tests/scenarii/es_compatibility/0031-regex.yaml
+++ b/quickwit/rest-api-tests/scenarii/es_compatibility/0031-regex.yaml
@@ -13,6 +13,21 @@ expected:
       value: 100
       relation: "eq"
 ---
+# Regex always match from start to end (`(re)` equivalent to `^(re)$`)
+params:
+  size: 3
+json:
+  track_total_hits: true
+  query:
+    regexp:
+      type:
+        value: "event"
+expected:
+  hits:
+    total:
+      value: 0
+      relation: "eq"
+---
 # Regex with case_insensitive flag
 params:
   size: 3
@@ -44,4 +59,32 @@ expected:
   hits:
     total:
       value: 0
+      relation: "eq"
+---
+# leading ^ and trailing $ are ignored
+params:
+  size: 3
+json:
+  track_total_hits: true
+  query:
+    regexp:
+      type:
+        value: "pushevent"
+expected:
+  hits:
+    total:
+      value: 60
+      relation: "eq"
+---
+# regex in query_string
+params:
+  size: 10
+json:
+  query:
+    query_string:
+      query: "type:/pushevent/"
+expected:
+  hits:
+    total:
+      value: 60
       relation: "eq"


### PR DESCRIPTION
### Description

tantivy_fst returns an error if the regex starts with ^ or ends with $. This is a very strict behavior as strictly speaking it always behaves as if these were present. This PR strips these anchors. This is also how ES behaves.

### How was this PR tested?

ES compatibility integration tests executed on both QW and ES
