### PR TITLE
update devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Quickwit",
-    "image": "mcr.microsoft.com/devcontainers/rust:latest",
+    "image": "mcr.microsoft.com/devcontainers/rust:bookworm",
     "customizations": {
         "codespaces": {
             "openFiles": [


### PR DESCRIPTION
the current config yields

```
The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution.
To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
```

I think it's better to use the older debian bookworm version ( Long Term Support (LTS), until June 30th, 2028 ) and keep using the moby:true flag

moby: false uses docker CE while moby:true uses the oss version

Alternatively, we could drop the devcontainer support