### PR TITLE
Use gRPC Tonic transport for exporting OTEL spans.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5563,6 +5563,8 @@ dependencies = [
  "prost 0.14.1",
  "reqwest",
  "thiserror 2.0.17",
+ "tokio",
+ "tonic 0.14.2",
  "tracing",
 ]
 

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -164,7 +164,7 @@ openssl = { version = "0.10", default-features = false }
 openssl-probe = "0.1"
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
 ouroboros = "0.18"
 percent-encoding = "2.3"
 pin-project = "1.1"

--- a/quickwit/quickwit-cli/src/logger.rs
+++ b/quickwit/quickwit-cli/src/logger.rs
@@ -94,7 +94,7 @@ pub fn setup_logging_and_tracing(
     // It is thus set on layers, see https://github.com/tokio-rs/tracing/issues/1817
     let provider_opt = if get_bool_from_env(QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER_ENV_KEY, false) {
         let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
-            .with_http()
+            .with_tonic()
             .build()
             .context("failed to initialize OpenTelemetry OTLP exporter")?;
         let batch_processor = trace::BatchSpanProcessor::builder(otlp_exporter)


### PR DESCRIPTION
Tested locally with

`QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER=true OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7281 cargo run -- run --config ../config/quickwit.yaml`