### PR TITLE
fix: Support datetime with timezone and with millis

### DIFF
--- a/quickwit/quickwit-datetime/src/java_date_time_format.rs
+++ b/quickwit/quickwit-datetime/src/java_date_time_format.rs
@@ -261,7 +261,10 @@ fn resolve_java_datetime_format_alias(java_datetime_format: &str) -> &str {
         OnceLock::new();
     let java_datetime_format_map = JAVA_DATE_FORMAT_ALIASES.get_or_init(|| {
         let mut m = HashMap::new();
-        m.insert("date_optional_time", "yyyy-MM-dd['T'HH[:mm[:ss[.SSS][Z]]]]");
+        m.insert(
+            "date_optional_time",
+            "yyyy[-MM[-dd['T'HH[:mm[:ss[.SSS][Z]]]]]]",
+        );
         m.insert(
             "strict_date_optional_time",
             "yyyy[-MM[-dd['T'HH[:mm[:ss[.SSS][Z]]]]]]",


### PR DESCRIPTION
### Description

Add support for datetimes without milliseconds or nanoseconds with a timezone set as it is supported by Elasticsearch.
The PR makes also `date_optional_time` and `strict_date_optional_time_nanos` more lenient with minutes and seconds as it was already the case for `strict_date_optional_time`.

### How was this PR tested?

Unit tests