### PR TITLE
Catch empty AZ env vars

### DIFF
--- a/quickwit/quickwit-config/src/config_value.rs
+++ b/quickwit/quickwit-config/src/config_value.rs
@@ -19,6 +19,7 @@ use std::{any, fmt};
 use anyhow::{self, Context};
 use serde::{Deserialize, Deserializer};
 use tracing::log::warn;
+
 use crate::qw_env_vars::{QW_ENV_VARS, QW_NONE};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -69,12 +70,15 @@ where
         if E > QW_NONE
             && let Some(env_var_key) = QW_ENV_VARS.get(&E)
             && let Some(env_var_value) = env_vars.get(*env_var_key).filter(|val| {
-              if val.is_empty() {
-                warn!("environment variable `{}` is set but value is empty", *env_var_key);
-                false
-              } else {
-                true
-              }
+                if val.is_empty() {
+                    warn!(
+                        "environment variable `{}` is set but value is empty",
+                        *env_var_key
+                    );
+                    false
+                } else {
+                    true
+                }
             })
         {
             let value = env_var_value.parse::<T>().map_err(|error| {
@@ -125,7 +129,7 @@ where T: Deserialize<'de>
 mod tests {
     use super::*;
     use crate::qw_env_vars::{
-        QW_CLUSTER_ID, QW_GOSSIP_LISTEN_PORT, QW_NODE_ID, QW_REST_LISTEN_PORT, QW_AVAILABILITY_ZONE,
+        QW_AVAILABILITY_ZONE, QW_CLUSTER_ID, QW_GOSSIP_LISTEN_PORT, QW_NODE_ID, QW_REST_LISTEN_PORT,
     };
 
     #[test]
@@ -201,9 +205,9 @@ mod tests {
     #[test]
     fn test_config_value_resolve_optional_empty_string() {
         let mut env_vars = HashMap::new();
-        env_vars.insert(String::from("QW_AVAILABILITY_ZONE"), String::from(""));
+        env_vars.insert("QW_AVAILABILITY_ZONE".to_string(), "".to_string());
         let az = ConfigValue::<usize, QW_AVAILABILITY_ZONE>::none();
-        assert_eq!(az.resolve_optional(&env_vars).unwrap(), None);
+        assert!(az.resolve_optional(&env_vars).unwrap().is_none());
     }
 
     #[test]

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -224,9 +224,7 @@ impl NodeConfigBuilder {
         env_vars: &HashMap<String, String>,
     ) -> anyhow::Result<NodeConfig> {
         let node_id = self.node_id.resolve(env_vars).map(NodeId::new)?;
-        let availability_zone = self
-            .availability_zone
-            .resolve_optional(env_vars)?;
+        let availability_zone = self.availability_zone.resolve_optional(env_vars)?;
 
         let enabled_services = self
             .enabled_services


### PR DESCRIPTION
### Description
If the env var exists but there was a problem parsing the version, it might return `Some("")`, which we don't want.