### PR TITLE
fix: Set max gRPC message size for OTLP services

### DIFF
--- a/quickwit/quickwit-serve/src/grpc.rs
+++ b/quickwit/quickwit-serve/src/grpc.rs
@@ -163,7 +163,9 @@ pub(crate) async fn start_grpc_server(
             enabled_grpc_services.insert("otlp-traces");
             let trace_service = TraceServiceServer::new(otlp_traces_service)
                 .accept_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Zstd);
+                .accept_compressed(CompressionEncoding::Zstd)
+                .max_decoding_message_size(grpc_config.max_message_size.0 as usize)
+                .max_encoding_message_size(grpc_config.max_message_size.0 as usize);
             Some(trace_service)
         } else {
             None
@@ -173,7 +175,9 @@ pub(crate) async fn start_grpc_server(
             enabled_grpc_services.insert("otlp-logs");
             let logs_service = LogsServiceServer::new(otlp_logs_service)
                 .accept_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Zstd);
+                .accept_compressed(CompressionEncoding::Zstd)
+                .max_decoding_message_size(grpc_config.max_message_size.0 as usize)
+                .max_encoding_message_size(grpc_config.max_message_size.0 as usize);
             Some(logs_service)
         } else {
             None


### PR DESCRIPTION
### Description
Set max decoding and encoding message sizes for OTLP traces and logs using grpc_config.max_message_size.

### How was this PR tested?
Tested in prod with buffered batches sent to the OTLP service up to 25 MiB.

Before:
```
{ status: Status { code: OutOfRange, message: "Error, decoded message length too large: found 9933716 bytes, the limit is: 4194304 bytes", metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Thu, 22 Jan 2026 13:13:11 GMT"} }, source: None } }
```

(Default 4 MiB max decoding payload error from tonic).

Now we don't have any max decoding payload error!