### PR TITLE
UI warning when statistics are wrong

### DIFF
--- a/quickwit/quickwit-ui/src/components/IndexSummary.tsx
+++ b/quickwit/quickwit-ui/src/components/IndexSummary.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import styled from "@emotion/styled";
-import { Paper } from "@mui/material";
+import { Alert, Paper } from "@mui/material";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { FC, ReactNode } from "react";
@@ -75,6 +75,12 @@ export function IndexSummary({ index }: { index: Index }) {
   return (
     <Paper variant="outlined">
       <ItemContainer>
+        {index.split_limit_reached && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            Split limit reached. Only the first 10,000 splits were retrieved.
+            The actual total may be higher. Statistics shown are incomplete.
+          </Alert>
+        )}
         <IndexRow title="Created at:">
           {dayjs
             .unix(index.metadata.create_timestamp)

--- a/quickwit/quickwit-ui/src/services/client.ts
+++ b/quickwit/quickwit-ui/src/services/client.ts
@@ -81,7 +81,8 @@ export class Client {
     ]);
     return {
       metadata: metadata,
-      splits: splits,
+      splits: splits[0],
+      split_limit_reached: splits[1],
     };
   }
 
@@ -89,14 +90,16 @@ export class Client {
     return this.fetch(`${this.apiRoot()}indexes/${indexId}`, {});
   }
 
-  async getAllSplits(indexId: string): Promise<Array<SplitMetadata>> {
+  async getAllSplits(
+    indexId: string,
+  ): Promise<[Array<SplitMetadata>, boolean]> {
     // TODO: restrieve all the splits.
     const results: { splits: Array<SplitMetadata> } = await this.fetch(
       `${this.apiRoot()}indexes/${indexId}/splits?limit=10000`,
       {},
     );
 
-    return results["splits"];
+    return [results["splits"], results["splits"].length === 10000];
   }
 
   async listIndexes(): Promise<Array<IndexMetadata>> {

--- a/quickwit/quickwit-ui/src/utils/models.ts
+++ b/quickwit/quickwit-ui/src/utils/models.ts
@@ -282,6 +282,7 @@ export type Range = {
 export type Index = {
   metadata: IndexMetadata;
   splits: SplitMetadata[];
+  split_limit_reached: boolean;
 };
 
 export type Cluster = {


### PR DESCRIPTION
### Description

UI only gets 10k splits to compute statistics. Add a warning about it.

### How was this PR tested?

<img width="1086" height="231" alt="image" src="https://github.com/user-attachments/assets/710d9801-205b-4db8-9f8f-685362accf41" />


