### PR TITLE
Bump tantivy to 9b61999

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -5674,7 +5674,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -9603,7 +9603,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -9659,7 +9659,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "bitpacking",
 ]
@@ -9667,7 +9667,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -9705,7 +9705,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -9739,7 +9739,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=b86caee#b86caeefe26f889592746aef32e79adcb50c26ce"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=9b61999#9b619998bd272f1cad8d1cb39979b5362c673ed7"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -357,7 +357,7 @@ quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry = { path = "quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "b86caee", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "9b61999", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",


### PR DESCRIPTION
Updates tantivy dependency to the latest commit on main.