### PR TITLE
Re-order CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,13 @@ jobs:
         uses: taiki-e/cache-cargo-install-action@34ce5120836e5f9f1508d8713d7fdea0e8facd6f # v3.0.1
         with:
           tool: cargo-nextest
+      - name: cargo build
+        if: always() && steps.modified.outputs.rust_src == 'true'
+        run: cargo build --features=postgres --tests --bin quickwit
+        working-directory: ./quickwit
       - name: cargo nextest
         if: always() && steps.modified.outputs.rust_src == 'true'
         run: cargo nextest run --features=postgres --retries 1
-        working-directory: ./quickwit
-      - name: cargo build
-        if: always() && steps.modified.outputs.rust_src == 'true'
-        run: cargo build --features=postgres --bin quickwit
         working-directory: ./quickwit
       - name: Install python packages
         if: always() && steps.modified.outputs.rust_src == 'true'


### PR DESCRIPTION
### Description
`cargo docs` builds docs for all dependencies too. Running it without dependencies drops down lint time from 13 min to 3 min (!!!)

Also, changing the order of CI events- first we build (everything, both the binary and the tests), and then running the tests shaves another 5 minutes off of that.

Before / After
<img width="300" height="346" alt="Screenshot 2026-01-28 at 12 48 49 PM" src="https://github.com/user-attachments/assets/2232058b-f00b-4345-9981-0aae2d36e80d" /> <img width="300" height="347" alt="Screenshot 2026-01-28 at 12 49 01 PM" src="https://github.com/user-attachments/assets/27a6b9f3-add1-4da3-81c7-81f095a3a723" />
