### PR TITLE
use the multi-arch version on node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24@sha256:07119ef199300cdb02a130537d64c946c4a699f3e539d6f7983d3c0fbdfe1533 AS ui-builder
+FROM node:24@sha256:b2b2184ba9b78c022e1d6a7924ec6fba577adf28f15c9d9c457730cc4ad3807a AS ui-builder
 
 COPY quickwit/quickwit-ui /quickwit/quickwit-ui
 


### PR DESCRIPTION
instead of pinning the amd64

### Description

the previous version [sha256-0711xxx](https://hub.docker.com/layers/library/node/24.0/images/sha256-07119ef199300cdb02a130537d64c946c4a699f3e539d6f7983d3c0fbdfe1533
) use amd64 arch

instead we can use the index digest [sha256-65e675xxx](https://hub.docker.com/layers/library/node/24/images/sha256-65e675dd6142029a393fd9f0d398a7dd0a71c8dd7940dd0220c810fef31320fb) which allows to pick whatever arch for this build. 

### How was this PR tested?

it was not
