### PR TITLE
enforce yarn version in quickwit-ui

### DIFF
--- a/quickwit/quickwit-ui/package.json
+++ b/quickwit/quickwit-ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.0",
   "license": "Apache-2.0",
   "private": true,
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@babel/core": "7.28.5",
     "@babel/runtime": "7.28.6",


### PR DESCRIPTION
it should warn users against using an incompatible yarn version

but

it does not supports version range so the user need to have yarn 1.22.22 exactly
in the other hand, this version is 2 years old and unlikely to change often
