### PR TITLE
Always refill permits on rate limiter; use governor clock instead of std

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -181,6 +181,7 @@ futures-util,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futur
 generic-array,https://github.com/fizyk20/generic-array,MIT,"Bartłomiej Kamiński <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>"
 getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
 glob,https://github.com/rust-lang/glob,MIT OR Apache-2.0,The Rust Project Developers
+governor,https://github.com/boinkor-net/governor,MIT,Andreas Fuchs <asf@boinkor.net>
 group,https://github.com/zkcrypto/group,MIT OR Apache-2.0,"Sean Bowe <ewillbefull@gmail.com>, Jack Grigg <jack@z.cash>"
 h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 half,https://github.com/VoidStarKat/half-rs,MIT OR Apache-2.0,Kathryn Long <squeeself@gmail.com>
@@ -284,6 +285,7 @@ new_string_template,https://github.com/hasezoey/new_string_template,MIT,hasezoey
 no-std-net,https://github.com/dunmatt/no-std-net,MIT,M@ Dunlap <mattdunlap@gmail.com>
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nom,https://github.com/rust-bakery/nom,MIT,contact@geoffroycouprie.com
+nonzero_ext,https://github.com/antifuchs/nonzero_ext,Apache-2.0,Andreas Fuchs <asf@boinkor.net>
 normalize-line-endings,https://github.com/derekdreery/normalize-line-endings,Apache-2.0,Richard Dodd <richdodj@gmail.com>
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-bigint,https://github.com/rust-num/num-bigint,MIT OR Apache-2.0,The Rust Project Developers
@@ -445,6 +447,7 @@ slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
 socket2,https://github.com/rust-lang/socket2,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
 spin,https://github.com/mvdnes/spin-rs,MIT,"Mathijs van de Nes <git@mathijs.vd-nes.nl>, John Ericson <git@JohnEricson.me>, Joshua Barretto <joshua.s.barretto@gmail.com>"
+spinning_top,https://github.com/rust-osdev/spinning_top,MIT OR Apache-2.0,Philipp Oppermann <dev@phil-opp.com>
 spki,https://github.com/RustCrypto/formats/tree/master/spki,Apache-2.0 OR MIT,RustCrypto Developers
 stable_deref_trait,https://github.com/storyyeller/stable_deref_trait,MIT OR Apache-2.0,Robert Grosse <n210241048576@gmail.com>
 static_assertions,https://github.com/nvzqz/static-assertions-rs,MIT OR Apache-2.0,Nikolai Vazquez

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2259,6 +2259,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3410,6 +3424,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
 dependencies = [
  "async-trait",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap 6.1.0",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot 0.12.5",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -4881,7 +4918,7 @@ checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 5.5.3",
  "skeptic",
  "smallvec",
  "tagptr",
@@ -5086,6 +5123,12 @@ checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
  "nom 8.0.0",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "normalize-line-endings"
@@ -6901,6 +6944,7 @@ dependencies = [
  "env_logger",
  "fnv",
  "futures",
+ "governor",
  "home",
  "hostname",
  "http 1.4.0",
@@ -9153,6 +9197,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -120,6 +120,7 @@ google-cloud-auth = "0.17.2"
 google-cloud-gax = "0.19.2"
 google-cloud-googleapis = { version = "0.16", features = ["pubsub"] }
 google-cloud-pubsub = "0.30"
+governor = "0.10.4"
 heck = "0.5"
 hex = "0.4"
 home = "0.5"

--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -21,6 +21,7 @@ dyn-clone = { workspace = true }
 env_logger = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
+governor = { workspace = true }
 home = { workspace = true }
 hostname = { workspace = true }
 http = { workspace = true }

--- a/quickwit/quickwit-common/src/rate_limiter.rs
+++ b/quickwit/quickwit-common/src/rate_limiter.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{Duration, Instant};
+use std::ops::Add;
+use std::time::Duration;
 
 use bytesize::ByteSize;
+use governor::clock::{Clock, DefaultClock, Reference};
+use governor::nanos::Nanos;
 
 use crate::tower::{ConstantRate, Rate};
 
@@ -53,72 +56,61 @@ impl Default for RateLimiterSettings {
 
 /// A bursty token-based rate limiter.
 #[derive(Debug, Clone)]
-pub struct RateLimiter {
+pub struct RateLimiter<C: Clock = DefaultClock> {
     // Maximum number of permits that can be accumulated.
     max_capacity: u64,
     // Number of permits available.
     available_permits: u64,
     refill_amount: u64,
     refill_period: Duration,
-    refill_period_micros: u64,
-    refill_at: Instant,
+    refill_period_nanos: u64,
+    refill_at: C::Instant,
+    clock: C,
 }
 
 #[cfg(any(test, feature = "testsuite"))]
-impl Default for RateLimiter {
+impl Default for RateLimiter<DefaultClock> {
     fn default() -> Self {
         Self::from_settings(RateLimiterSettings::default())
     }
 }
 
-impl RateLimiter {
-    /// Creates a new rate limiter from the given settings.
+impl RateLimiter<DefaultClock> {
+    /// Creates a new rate limiter from the given settings using the default clock.
     pub fn from_settings(settings: RateLimiterSettings) -> Self {
+        Self::from_settings_with_clock(settings, DefaultClock::default())
+    }
+}
+
+impl<C: Clock> RateLimiter<C> {
+    /// Creates a new rate limiter from the given settings with a custom clock.
+    pub fn from_settings_with_clock(settings: RateLimiterSettings, clock: C) -> Self {
         let max_capacity = settings.burst_limit;
         let refill_period = settings.refill_period;
         let rate_limit = settings.rate_limit.rescale(refill_period);
-        let now = Instant::now();
+        let now = clock.now();
 
         Self {
             max_capacity,
             available_permits: max_capacity,
             refill_amount: rate_limit.work(),
             refill_period,
-            refill_period_micros: refill_period.as_micros() as u64,
-            refill_at: now + refill_period,
+            refill_period_nanos: refill_period.as_nanos() as u64,
+            refill_at: now.add(Nanos::from(refill_period)),
+            clock,
         }
     }
 
     /// Returns the number of permits available.
-    pub fn available_permits(&self) -> u64 {
+    pub fn available_permits(&mut self) -> u64 {
+        self.refill(self.clock.now());
         self.available_permits
     }
 
     /// Acquires some permits from the rate limiter. Returns whether the permits were acquired.
     pub fn acquire(&mut self, num_permits: u64) -> bool {
-        if self.acquire_inner(num_permits) {
-            true
-        } else {
-            self.refill(Instant::now());
-            self.acquire_inner(num_permits)
-        }
-    }
-
-    /// Acquires some permits from the rate limiter.
-    /// If the permits are not available, returns the duration to wait before trying again.
-    ///
-    /// This method is currently only used in simian.
-    pub fn acquire_with_duration(&mut self, num_permits: u64) -> Result<(), Duration> {
-        if self.acquire_inner(num_permits) {
-            return Ok(());
-        }
-        self.refill(Instant::now());
-        if self.acquire_inner(num_permits) {
-            return Ok(());
-        }
-        let missing = num_permits - self.available_permits;
-        let wait = Duration::from_micros(missing * self.refill_period_micros / self.refill_amount);
-        Err(wait)
+        self.refill(self.clock.now());
+        self.acquire_inner(num_permits)
     }
 
     /// Acquires some permits expressed in bytes from the rate limiter. Returns whether the permits
@@ -131,7 +123,7 @@ impl RateLimiter {
     /// guarded by the rate limiter for one refill period.
     pub fn drain(&mut self) {
         self.available_permits = 0;
-        self.refill_at = Instant::now() + self.refill_period;
+        self.refill_at = self.clock.now().add(Nanos::from(self.refill_period));
     }
 
     /// Gives back some unused permits to the rate limiter.
@@ -148,20 +140,23 @@ impl RateLimiter {
         }
     }
 
-    fn refill(&mut self, now: Instant) {
-        if now < self.refill_at {
+    fn refill(&mut self, now: C::Instant) {
+        if now.lt(&self.refill_at) {
             return;
         }
-        let elapsed = (now - self.refill_at).as_micros() as u64;
+        let elapsed_nanos = now.duration_since(self.refill_at).as_u64();
         // More than one refill period may have elapsed so we need to take that into account.
-        let refill = self.refill_amount + self.refill_amount * elapsed / self.refill_period_micros;
+        let refill =
+            self.refill_amount + self.refill_amount * elapsed_nanos / self.refill_period_nanos;
         self.available_permits = self.max_capacity.min(self.available_permits + refill);
-        self.refill_at = now + self.refill_period;
+        self.refill_at = now.add(Nanos::from(self.refill_period));
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use governor::clock::FakeRelativeClock;
+
     use super::*;
 
     #[test]
@@ -171,7 +166,8 @@ mod tests {
             rate_limit: ConstantRate::bytes_per_sec(ByteSize::mb(1)),
             refill_period: Duration::from_millis(100),
         };
-        let mut rate_limiter = RateLimiter::from_settings(settings);
+        let clock = FakeRelativeClock::default();
+        let mut rate_limiter = RateLimiter::from_settings_with_clock(settings, clock.clone());
         assert_eq!(rate_limiter.max_capacity, ByteSize::mb(2).as_u64());
         assert_eq!(rate_limiter.available_permits, ByteSize::mb(2).as_u64());
         assert_eq!(rate_limiter.refill_amount, ByteSize::kb(100).as_u64());
@@ -181,12 +177,12 @@ mod tests {
         assert!(rate_limiter.acquire_bytes(ByteSize::mb(1)));
         assert!(!rate_limiter.acquire_bytes(ByteSize::kb(1)));
 
-        std::thread::sleep(Duration::from_millis(100));
+        clock.advance(Duration::from_millis(100));
 
         assert!(rate_limiter.acquire_bytes(ByteSize::kb(100)));
         assert!(!rate_limiter.acquire_bytes(ByteSize::kb(20)));
 
-        std::thread::sleep(Duration::from_millis(250));
+        clock.advance(Duration::from_millis(250));
 
         assert!(rate_limiter.acquire_bytes(ByteSize::kb(125)));
         assert!(rate_limiter.acquire_bytes(ByteSize::kb(125)));
@@ -200,14 +196,17 @@ mod tests {
             rate_limit: ConstantRate::bytes_per_sec(ByteSize::mb(1)),
             refill_period: Duration::from_millis(100),
         };
-        let mut rate_limiter = RateLimiter::from_settings(settings);
+        let clock = FakeRelativeClock::default();
+        let mut rate_limiter = RateLimiter::from_settings_with_clock(settings, clock.clone());
         rate_limiter.drain();
         assert_eq!(rate_limiter.available_permits, 0);
 
-        rate_limiter.refill(Instant::now() + Duration::from_millis(50));
+        clock.advance(Duration::from_millis(50));
+        rate_limiter.refill(clock.now());
         assert_eq!(rate_limiter.available_permits, 0);
 
-        rate_limiter.refill(Instant::now() + Duration::from_millis(100));
+        clock.advance(Duration::from_millis(50));
+        rate_limiter.refill(clock.now());
         assert!(rate_limiter.available_permits >= ByteSize::kb(100).as_u64());
     }
 
@@ -236,26 +235,40 @@ mod tests {
             rate_limit: ConstantRate::bytes_per_sec(ByteSize::mb(1)),
             refill_period: Duration::from_millis(100),
         };
-        let mut rate_limiter = RateLimiter::from_settings(settings);
+        let clock = FakeRelativeClock::default();
+        let mut rate_limiter = RateLimiter::from_settings_with_clock(settings, clock.clone());
 
         rate_limiter.available_permits = 0;
-        let now = Instant::now();
-        rate_limiter.refill(now);
         assert_eq!(rate_limiter.available_permits, 0);
 
         rate_limiter.available_permits = 0;
-        let now = now + Duration::from_millis(100);
-        rate_limiter.refill(now);
+        clock.advance(Duration::from_millis(100));
+        rate_limiter.refill(clock.now());
         assert_eq!(rate_limiter.available_permits, ByteSize::kb(100).as_u64());
 
         rate_limiter.available_permits = 0;
-        let now = now + Duration::from_millis(110);
-        rate_limiter.refill(now);
+        clock.advance(Duration::from_millis(110));
+        rate_limiter.refill(clock.now());
         assert_eq!(rate_limiter.available_permits, ByteSize::kb(110).as_u64());
 
         rate_limiter.available_permits = 0;
-        let now = now + Duration::from_millis(210);
-        rate_limiter.refill(now);
+        clock.advance(Duration::from_millis(210));
+        rate_limiter.refill(clock.now());
         assert_eq!(rate_limiter.available_permits, ByteSize::kb(210).as_u64());
+    }
+
+    #[test]
+    fn test_rate_limiter_available_permits() {
+        let settings = RateLimiterSettings {
+            burst_limit: ByteSize::mb(2).as_u64(),
+            rate_limit: ConstantRate::bytes_per_sec(ByteSize::mb(1)),
+            refill_period: Duration::from_millis(100),
+        };
+        let clock = FakeRelativeClock::default();
+        let mut rate_limiter = RateLimiter::from_settings_with_clock(settings, clock.clone());
+
+        rate_limiter.available_permits = 0;
+        clock.advance(Duration::from_millis(100));
+        assert_eq!(rate_limiter.available_permits(), ByteSize::kb(100).as_u64());
     }
 }

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -1096,7 +1096,7 @@ mod tests {
 
         let previous_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_up_rate_limiter
             .available_permits();
@@ -1109,7 +1109,7 @@ mod tests {
 
         let new_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_up_rate_limiter
             .available_permits();
@@ -1138,7 +1138,7 @@ mod tests {
 
         let previous_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_down_rate_limiter
             .available_permits();
@@ -1151,7 +1151,7 @@ mod tests {
 
         let new_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_down_rate_limiter
             .available_permits();
@@ -1174,7 +1174,7 @@ mod tests {
         };
         let previous_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_up_rate_limiter
             .available_permits();
@@ -1189,7 +1189,7 @@ mod tests {
 
         let new_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_up_rate_limiter
             .available_permits();
@@ -1212,7 +1212,7 @@ mod tests {
         };
         let previous_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_up_rate_limiter
             .available_permits();
@@ -1227,7 +1227,7 @@ mod tests {
 
         let new_available_permits = shard_table
             .table_entries
-            .get(&source_uid)
+            .get_mut(&source_uid)
             .unwrap()
             .scaling_up_rate_limiter
             .available_permits();


### PR DESCRIPTION
Calling `available_permits()` didn't actually supply an accurate portrayal of capacity, as enough time may have elapsed that a refill is needed. So now a refill is automatically triggered on any call to `available_permits()` or `acquire()`.

Additionally, the `governor` crate has a custom implementation of a clock that is faster than std::time. I benchmarked it as follows:

```
    while benchmark_start.elapsed() < Duration::from_seconds(20) {
        let acquire_start = Instant::now();
        let acquired = rate_limiter.acquire(100_000);
        let latency = acquire_start.elapsed();

        latencies.push(latency);
        iterations += 1;

        if acquired {
            successful_acquires += 1;
        } else {
            failed_acquires += 1;
        }
    }
```
With the following results:

| Metric | code in main | with refill changes, Instant::now | governor::DefaultClock | governor::QuantaUpkeepClock updating every 1ms |                                                                                                                                                       
  |--------|------|---------------------|--------------|-------------------|                                                                                                                                                       
  | Min    | 25ns | 49ns                | 31ns         | 25ns              |                                                                                                                                                       
  | Avg    | 51ns | 51ns                | 32ns         | 27ns              |                                                                                                                                                       
  | P50    | 51ns | 50ns                | 32ns         | 27ns              |                                                                                                                                                       
  | P90    | 52ns | 51ns                | 33ns         | 28ns              |                                                                                                                                                       
  | P99    | 52ns | 52ns                | 34ns         | 28ns              |                                                                                                                                                       
  | P99.9  | 68ns | 72ns                | 53ns         | 42ns              |                                                                                                                                                       
  | Max    | 45.04µs | 147.62µs         | 94.50µs      | 26.45µs           |  

Seeing as the benchmark itself used Instant::now, this is probably not scientific, but at these latencies this doesn't really matter.

I went with the default governor clock seeing as an OS thread updating every millisecond is overkill, and the speed of this is not going to contribute to any meaningful bottlenecks enough to optimize this further.