### PR TITLE
fix(cross): bump libclang from 3.9 to 12 in cross images

### DIFF
--- a/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
@@ -9,8 +9,8 @@ ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \
-    apt-get install -y clang-3.9 \
-        libclang-3.9-dev \
+    apt-get install -y clang-12 \
+        libclang-12-dev \
         binutils-aarch64-linux-gnu \
         libsasl2-dev:arm64 \
         unzip && \

--- a/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/aarch64-unknown-linux-gnu.dockerfile
@@ -9,8 +9,8 @@ ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \
-    apt-get install -y clang-12 \
-        libclang-12-dev \
+    apt-get install -y clang-8 \
+        libclang-8-dev \
         binutils-aarch64-linux-gnu \
         libsasl2-dev:arm64 \
         unzip && \

--- a/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
@@ -3,8 +3,8 @@ FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4@sha256:7c9067212c2283be2a1d
 ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip"
 
 RUN apt-get update && \
-    apt-get install -y clang-3.9 \
-        libclang-3.9-dev \
+    apt-get install -y clang-12 \
+        libclang-12-dev \
         libsasl2-dev \
         unzip && \
     rm -rf /var/lib/apt/lists/*

--- a/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
+++ b/build/cross-images/x86_64-unknown-linux-gnu.dockerfile
@@ -3,8 +3,8 @@ FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4@sha256:7c9067212c2283be2a1d
 ARG PBC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip"
 
 RUN apt-get update && \
-    apt-get install -y clang-12 \
-        libclang-12-dev \
+    apt-get install -y clang-8 \
+        libclang-8-dev \
         libsasl2-dev \
         unzip && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Context

The nightly Linux builds (`x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`) are failing with the following panic:

```
thread 'main' panicked at clang-sys-1.8.1/src/lib.rs:1859:
A `libclang` function was called that is not supported by the loaded `libclang` instance.
    called function = `clang_getTranslationUnitTargetInfo`
    loaded `libclang` instance = 3.9.x
```

## Root cause

PR #5748 ("Add `--retries` parameter to CLI commands") updated OpenDAL as a side effect, which bumped `zstd-sys` from `2.0.13` to `2.0.15`. Starting from `2.0.15`, `zstd-sys` gained a `bindgen` dependency, which in turn requires `clang-sys 1.8.1`. That version calls `clang_getTranslationUnitTargetInfo`, a function only available in `libclang >= 5.0`. Our cross images ship `libclang 3.9.x`, which predates that API.

## Why clang-3.9 was used

`clang-3.9` was explicitly pinned in PR #2550 (Dec 2022) because the default `clang` version was breaking the **rocksdb** build. However, `rocksdb` has since been **removed from the dependency tree** entirely, so this constraint no longer applies.

## Fix

~~Bump `clang-3.9` / `libclang-3.9-dev` to `clang-12` / `libclang-12-dev` in both GNU cross images. `clang-12` is available in the Ubuntu 20.04 default apt repos (no extra LLVM apt source needed) and gives substantial headroom above the `libclang >= 5.0` requirement.~~ 
No, it's not available. 8 is though

## Remark

I am not super confortable skipping 10 versions. Should I?