### PR TITLE
Implement compactor pipeline update logic

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -7158,7 +7158,6 @@ dependencies = [
  "quickwit-metastore",
  "quickwit-proto",
  "quickwit-storage",
- "serde",
  "tokio",
  "tracing",
 ]

--- a/quickwit/quickwit-compaction/Cargo.toml
+++ b/quickwit/quickwit-compaction/Cargo.toml
@@ -24,6 +24,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+quickwit-actors = { workspace = true, features = ["testsuite"] }
 quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-proto = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-compaction/Cargo.toml
+++ b/quickwit/quickwit-compaction/Cargo.toml
@@ -20,7 +20,6 @@ quickwit-doc-mapper = { workspace = true }
 quickwit-indexing = { workspace = true }
 quickwit-proto = { workspace = true }
 quickwit-storage = { workspace = true }
-serde = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 

--- a/quickwit/quickwit-compaction/src/compaction_pipeline.rs
+++ b/quickwit/quickwit-compaction/src/compaction_pipeline.rs
@@ -129,8 +129,9 @@ impl CompactionPipeline {
     /// Returns pipeline status update by checking the health of individual pipeline actors.
     ///
     /// If the pipeline is already completed or failed (terminal status), returns the status
-    /// without re-checking actors. Otherwise checks actor health and:
-    /// - Marks the pipeline as completed or failed when appropriate.
+    /// without re-checking actors. The pipeline sits in this "completed" state (finished or failed)
+    /// until the supervisor cleans up the spot in favor of a new pipeline. This is done to
+    /// ensure that the planner acks the success/failure.
     pub fn pipeline_status_update(&mut self) -> PipelineStatusUpdate {
         self.update_status();
         self.build_status_update()
@@ -342,6 +343,7 @@ pub(crate) mod tests {
         assert!(pipeline.handles.is_none());
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
         assert!(pipeline.handles.is_some());
+        universe.assert_quit().await;
     }
 
     #[tokio::test]
@@ -362,6 +364,7 @@ pub(crate) mod tests {
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
         let update = pipeline.pipeline_status_update();
         assert_eq!(update.status, PipelineStatus::InProgress);
+        universe.assert_quit().await;
     }
 
     #[tokio::test]
@@ -378,5 +381,6 @@ pub(crate) mod tests {
         // Calling again still returns Failed (sticky).
         let update = pipeline.pipeline_status_update();
         assert!(matches!(update.status, PipelineStatus::Failed { .. }));
+        universe.assert_quit().await;
     }
 }

--- a/quickwit/quickwit-compaction/src/compaction_pipeline.rs
+++ b/quickwit/quickwit-compaction/src/compaction_pipeline.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use quickwit_actors::{ActorContext, ActorHandle, Health, Supervisable};
+use quickwit_actors::{ActorHandle, Health, SpawnContext, Supervisable};
 use quickwit_common::KillSwitch;
 use quickwit_common::io::{IoControls, Limiter};
 use quickwit_common::pubsub::EventBroker;
@@ -28,43 +28,55 @@ use quickwit_indexing::merge_policy::MergeOperation;
 use quickwit_indexing::{IndexingSplitStore, PublisherType, SplitsUpdateMailbox};
 use quickwit_proto::indexing::MergePipelineId;
 use quickwit_proto::metastore::MetastoreServiceClient;
+use quickwit_proto::types::{IndexUid, SourceId, SplitId};
 use tracing::{debug, error, info};
 
-use crate::CompactorSupervisor;
-
-pub struct CompactionPipelineHandles {
-    pub merge_split_downloader: ActorHandle<MergeSplitDownloader>,
-    pub merge_executor: ActorHandle<MergeExecutor>,
-    pub merge_packager: ActorHandle<Packager>,
-    pub merge_uploader: ActorHandle<Uploader>,
-    pub merge_publisher: ActorHandle<Publisher>,
+#[derive(Clone, Debug, PartialEq)]
+pub enum PipelineStatus {
+    InProgress { retry_count: usize },
+    Completed,
+    Failed { error: String },
 }
 
-/// A single-use merge execution pipeline. Processes one merge task and
-/// terminates.
+pub struct PipelineStatusUpdate {
+    pub task_id: String,
+    pub index_uid: IndexUid,
+    pub source_id: SourceId,
+    pub split_ids: Vec<SplitId>,
+    pub merged_split_id: SplitId,
+    pub status: PipelineStatus,
+}
+
+struct CompactionPipelineHandles {
+    merge_split_downloader: ActorHandle<MergeSplitDownloader>,
+    merge_executor: ActorHandle<MergeExecutor>,
+    merge_packager: ActorHandle<Packager>,
+    merge_uploader: ActorHandle<Uploader>,
+    merge_publisher: ActorHandle<Publisher>,
+}
+
+/// A single-use compaction pipeline. Processes one merge task and terminates.
 ///
 /// Owned by the `CompactorSupervisor`, which periodically calls
-/// `check_actor_health()` and acts on the result (retry, reap, etc.).
+/// `check_actor_health()` to collect status updates. The pipeline manages
+/// its own retry logic internally.
 pub struct CompactionPipeline {
-    pub task_id: String,
-    pub retry_count: usize,
-    pub kill_switch: KillSwitch,
-    pub scratch_directory: TempDirectory,
-    pub handles: Option<CompactionPipelineHandles>,
-
-    // Per-task parameters.
-    pub merge_operation: MergeOperation,
-    pub pipeline_id: MergePipelineId,
-    pub doc_mapper: Arc<DocMapper>,
-    pub merge_policy: Arc<dyn quickwit_indexing::merge_policy::MergePolicy>,
-    pub retention_policy: Option<RetentionPolicy>,
-
-    // Shared resources (cloned from CompactorSupervisor).
-    pub metastore: MetastoreServiceClient,
-    pub split_store: IndexingSplitStore,
-    pub io_throughput_limiter: Option<Limiter>,
-    pub max_concurrent_split_uploads: usize,
-    pub event_broker: EventBroker,
+    task_id: String,
+    merge_operation: MergeOperation,
+    pipeline_id: MergePipelineId,
+    status: PipelineStatus,
+    max_retries: usize,
+    kill_switch: KillSwitch,
+    scratch_directory: TempDirectory,
+    handles: Option<CompactionPipelineHandles>,
+    doc_mapper: Arc<DocMapper>,
+    merge_policy: Arc<dyn quickwit_indexing::merge_policy::MergePolicy>,
+    retention_policy: Option<RetentionPolicy>,
+    metastore: MetastoreServiceClient,
+    split_store: IndexingSplitStore,
+    io_throughput_limiter: Option<Limiter>,
+    max_concurrent_split_uploads: usize,
+    event_broker: EventBroker,
 }
 
 impl CompactionPipeline {
@@ -82,10 +94,12 @@ impl CompactionPipeline {
         io_throughput_limiter: Option<Limiter>,
         max_concurrent_split_uploads: usize,
         event_broker: EventBroker,
+        max_retries: usize,
     ) -> Self {
         CompactionPipeline {
             task_id,
-            retry_count: 0,
+            status: PipelineStatus::InProgress { retry_count: 0 },
+            max_retries,
             kill_switch: KillSwitch::default(),
             scratch_directory,
             handles: None,
@@ -115,84 +129,113 @@ impl CompactionPipeline {
         ]
     }
 
-    /// Checks child actor health.
+    /// Returns pipeline status update by checking the health of individual pipeline actors.
     ///
-    /// `check_for_progress` controls whether stall detection is performed
-    /// (actors that are alive but haven't recorded progress since last check).
-    /// The supervisor controls the cadence of progress checks.
-    ///
-    /// Returns:
-    /// - `Success` when all actors have completed (merge published).
-    /// - `FailureOrUnhealthy` when any actor has died or stalled.
-    /// - `Healthy` when actors are running and making progress.
-    pub fn check_actor_health(&self) -> Health {
+    /// If the pipeline is already completed or failed (terminal status), returns the status
+    /// without re-checking actors. Otherwise checks actor health and:
+    /// - Restarts the pipeline on failure if retries remain.
+    /// - Marks the pipeline as completed or failed when appropriate.
+    pub fn pipeline_status_update(
+        &mut self,
+        spawn_ctx: &SpawnContext,
+    ) -> PipelineStatusUpdate {
+        self.update_status(spawn_ctx);
+        self.build_status_update()
+    }
+
+    fn update_status(&mut self, spawn_ctx: &SpawnContext) {
+        // Pipeline is finished but yet to be cleaned up.
+        if matches!(
+            self.status,
+            PipelineStatus::Completed | PipelineStatus::Failed { .. }
+        ) {
+            return;
+        }
+        // Pipeline is not initialized yet.
         if self.handles.is_none() {
-            return Health::Healthy;
+            return;
         }
 
-        let mut healthy_actors: Vec<&str> = Vec::new();
-        let mut failure_or_unhealthy_actors: Vec<&str> = Vec::new();
-        let mut success_actors: Vec<&str> = Vec::new();
+        let mut healthy_actors: Vec<String> = Vec::new();
+        let mut failure_or_unhealthy_actors: Vec<String> = Vec::new();
+        let mut success_actors: Vec<String> = Vec::new();
 
         for supervisable in self.supervisables() {
             match supervisable.check_health(true) {
                 Health::Healthy => {
-                    healthy_actors.push(supervisable.name());
+                    healthy_actors.push(supervisable.name().to_string());
                 }
                 Health::FailureOrUnhealthy => {
-                    failure_or_unhealthy_actors.push(supervisable.name());
+                    failure_or_unhealthy_actors.push(supervisable.name().to_string());
                 }
                 Health::Success => {
-                    success_actors.push(supervisable.name());
+                    success_actors.push(supervisable.name().to_string());
                 }
             }
         }
 
         if !failure_or_unhealthy_actors.is_empty() {
-            error!(
-                task_id=%self.task_id,
-                healthy_actors=?healthy_actors,
-                failed_or_unhealthy_actors=?failure_or_unhealthy_actors,
-                success_actors=?success_actors,
-                "compaction pipeline actor failure detected"
+            let PipelineStatus::InProgress { retry_count } = self.status else {
+                return;
+            };
+            if retry_count < self.max_retries {
+                let new_retry_count = retry_count + 1;
+                info!(
+                    task_id=%self.task_id,
+                    retry_count=%new_retry_count,
+                    failed_actors=?failure_or_unhealthy_actors,
+                    "retrying compaction pipeline"
+                );
+                self.restart(spawn_ctx);
+                self.status = PipelineStatus::InProgress {
+                    retry_count: new_retry_count,
+                };
+                return;
+            }
+            let error_msg = format!(
+                "exhausted retries, failed actors: {:?}",
+                failure_or_unhealthy_actors
             );
-            return Health::FailureOrUnhealthy;
+            error!(task_id=%self.task_id, retry_count=%retry_count, "{error_msg}");
+            self.status = PipelineStatus::Failed { error: error_msg };
+            return;
         }
         if healthy_actors.is_empty() {
             debug!(task_id=%self.task_id, "all compaction pipeline actors completed");
-            return Health::Success;
+            self.status = PipelineStatus::Completed;
         }
-        Health::Healthy
     }
 
-    pub async fn terminate(&mut self) {
+    fn build_status_update(&self) -> PipelineStatusUpdate {
+        PipelineStatusUpdate {
+            task_id: self.task_id.clone(),
+            index_uid: self.pipeline_id.index_uid.clone(),
+            source_id: self.pipeline_id.source_id.clone(),
+            split_ids: self
+                .merge_operation
+                .splits_as_slice()
+                .iter()
+                .map(|split| split.split_id().to_string())
+                .collect(),
+            merged_split_id: self.merge_operation.merge_split_id.clone(),
+            status: self.status.clone(),
+        }
+    }
+
+    /// Terminates the current actor chain and re-spawns with a fresh kill
+    /// switch. Downloaded splits remain on disk in the scratch directory.
+    fn restart(&mut self, spawn_ctx: &SpawnContext) {
         self.kill_switch.kill();
-        if let Some(handles) = self.handles.take() {
-            tokio::join!(
-                handles.merge_split_downloader.kill(),
-                handles.merge_executor.kill(),
-                handles.merge_packager.kill(),
-                handles.merge_uploader.kill(),
-                handles.merge_publisher.kill(),
-            );
-        }
-    }
-
-    /// Terminates the current actor chain, increments retry count, and
-    /// re-spawns. Downloaded splits remain on disk in the scratch directory.
-    pub async fn restart(&mut self, ctx: &ActorContext<CompactorSupervisor>) {
-        self.terminate().await;
-        self.retry_count += 1;
-        if let Err(err) = self.spawn_pipeline(ctx) {
-            error!(task_id=%self.task_id, error=?err, "failed to respawn compaction pipeline");
-        }
+        self.handles = None;
+        self.kill_switch = KillSwitch::default();
+        // TODO: handle spawn failure gracefully instead of panicking.
+        self.spawn_pipeline(spawn_ctx)
+            .expect("failed to respawn compaction pipeline");
     }
 
     /// Spawns the 5-actor merge execution chain and sends the `MergeOperation`
     /// to the downloader to kick off execution.
-    fn spawn_pipeline(&mut self, ctx: &ActorContext<CompactorSupervisor>) -> anyhow::Result<()> {
-        self.kill_switch = ctx.kill_switch().child();
-
+    pub(crate) fn spawn_pipeline(&mut self, spawn_ctx: &SpawnContext) -> anyhow::Result<()> {
         info!(
             task_id=%self.task_id,
             pipeline_id=%self.pipeline_id,
@@ -206,9 +249,9 @@ impl CompactionPipeline {
             None,
             None,
         );
-        let (merge_publisher_mailbox, merge_publisher_handle) = ctx
-            .spawn_actor()
-            .set_kill_switch(self.kill_switch.clone())
+        let (merge_publisher_mailbox, merge_publisher_handle) = spawn_ctx
+            .spawn_builder()
+            .set_kill_switch(self.kill_switch.child())
             .spawn(merge_publisher);
 
         // Uploader
@@ -222,17 +265,17 @@ impl CompactionPipeline {
             self.max_concurrent_split_uploads,
             self.event_broker.clone(),
         );
-        let (merge_uploader_mailbox, merge_uploader_handle) = ctx
-            .spawn_actor()
-            .set_kill_switch(self.kill_switch.clone())
+        let (merge_uploader_mailbox, merge_uploader_handle) = spawn_ctx
+            .spawn_builder()
+            .set_kill_switch(self.kill_switch.child())
             .spawn(merge_uploader);
 
         // Packager
         let tag_fields = self.doc_mapper.tag_named_fields()?;
         let merge_packager = Packager::new("MergePackager", tag_fields, merge_uploader_mailbox);
-        let (merge_packager_mailbox, merge_packager_handle) = ctx
-            .spawn_actor()
-            .set_kill_switch(self.kill_switch.clone())
+        let (merge_packager_mailbox, merge_packager_handle) = spawn_ctx
+            .spawn_builder()
+            .set_kill_switch(self.kill_switch.child())
             .spawn(merge_packager);
 
         // MergeExecutor
@@ -249,9 +292,9 @@ impl CompactionPipeline {
             merge_executor_io_controls,
             merge_packager_mailbox,
         );
-        let (merge_executor_mailbox, merge_executor_handle) = ctx
-            .spawn_actor()
-            .set_kill_switch(self.kill_switch.clone())
+        let (merge_executor_mailbox, merge_executor_handle) = spawn_ctx
+            .spawn_builder()
+            .set_kill_switch(self.kill_switch.child())
             .spawn(merge_executor);
 
         // MergeSplitDownloader
@@ -261,9 +304,9 @@ impl CompactionPipeline {
             executor_mailbox: merge_executor_mailbox,
             io_controls: split_downloader_io_controls,
         };
-        let (merge_split_downloader_mailbox, merge_split_downloader_handle) = ctx
-            .spawn_actor()
-            .set_kill_switch(self.kill_switch.clone())
+        let (merge_split_downloader_mailbox, merge_split_downloader_handle) = spawn_ctx
+            .spawn_builder()
+            .set_kill_switch(self.kill_switch.child())
             .spawn(merge_split_downloader);
 
         // Kick off the pipeline.
@@ -286,10 +329,9 @@ impl CompactionPipeline {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Arc;
 
-    use quickwit_actors::Health;
     use quickwit_common::pubsub::EventBroker;
     use quickwit_common::temp_dir::TempDirectory;
     use quickwit_doc_mapper::default_doc_mapper_for_test;
@@ -301,13 +343,22 @@ mod tests {
     use quickwit_proto::types::{IndexUid, NodeId};
     use quickwit_storage::RamStorage;
 
-    use super::CompactionPipeline;
+    use quickwit_actors::Universe;
 
-    fn test_pipeline() -> CompactionPipeline {
+    use super::{CompactionPipeline, PipelineStatus};
+
+    pub fn test_pipeline(
+        task_id: &str,
+        split_ids: &[&str],
+        max_retries: usize,
+    ) -> CompactionPipeline {
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store_for_test(storage);
         let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
-        let splits = vec![SplitMetadata::for_test("split-1".to_string())];
+        let splits: Vec<SplitMetadata> = split_ids
+            .iter()
+            .map(|id| SplitMetadata::for_test(id.to_string()))
+            .collect();
         let merge_operation = MergeOperation::new_merge_operation(splits);
         let pipeline_id = MergePipelineId {
             node_id: NodeId::from("test-node"),
@@ -315,7 +366,7 @@ mod tests {
             source_id: "test-source".to_string(),
         };
         CompactionPipeline::new(
-            "test-task".to_string(),
+            task_id.to_string(),
             TempDirectory::for_test(),
             merge_operation,
             pipeline_id,
@@ -327,20 +378,68 @@ mod tests {
             None,
             2,
             EventBroker::default(),
+            max_retries,
         )
     }
 
-    #[test]
-    fn test_pipeline_no_handles_is_healthy() {
-        let pipeline = test_pipeline();
+    #[tokio::test]
+    async fn test_spawn_pipeline_creates_handles() {
+        let universe = Universe::new();
+        let mut pipeline = test_pipeline("task-1", &["split-1", "split-2"], 2);
         assert!(pipeline.handles.is_none());
-        assert_eq!(pipeline.check_actor_health(), Health::Healthy);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+        assert!(pipeline.handles.is_some());
     }
 
     #[tokio::test]
-    async fn test_pipeline_terminate_without_handles() {
-        let mut pipeline = test_pipeline();
-        pipeline.terminate().await;
-        assert!(pipeline.handles.is_none());
+    async fn test_status_update_unspawned_pipeline() {
+        let universe = Universe::new();
+        let mut pipeline = test_pipeline("task-1", &["split-1"], 2);
+        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
+        assert_eq!(update.status, PipelineStatus::InProgress { retry_count: 0 });
+        assert_eq!(update.task_id, "task-1");
+        assert_eq!(update.split_ids, vec!["split-1"]);
+        assert_eq!(update.source_id, "test-source");
+        assert_eq!(update.index_uid, IndexUid::for_test("test-index", 0));
+    }
+
+    #[tokio::test]
+    async fn test_status_update_healthy_pipeline() {
+        let universe = Universe::new();
+        let mut pipeline = test_pipeline("task-1", &["split-1"], 2);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
+        assert_eq!(update.status, PipelineStatus::InProgress { retry_count: 0 });
+    }
+
+    #[tokio::test]
+    async fn test_killed_pipeline_with_retries_restarts() {
+        let universe = Universe::new();
+        let mut pipeline = test_pipeline("task-1", &["split-1"], 2);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+
+        pipeline.kill_switch.kill();
+        // Let actors process the kill signal.
+        tokio::task::yield_now().await;
+        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
+        assert_eq!(update.status, PipelineStatus::InProgress { retry_count: 1 });
+        assert!(pipeline.handles.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_killed_pipeline_exhausted_retries_fails() {
+        let universe = Universe::new();
+        let mut pipeline = test_pipeline("task-1", &["split-1"], 0);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+
+        pipeline.kill_switch.kill();
+        // Let actors process the kill signal.
+        tokio::task::yield_now().await;
+        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
+        assert!(matches!(update.status, PipelineStatus::Failed { .. }));
+
+        // Calling again still returns Failed (sticky).
+        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
+        assert!(matches!(update.status, PipelineStatus::Failed { .. }));
     }
 }

--- a/quickwit/quickwit-compaction/src/compaction_pipeline.rs
+++ b/quickwit/quickwit-compaction/src/compaction_pipeline.rs
@@ -33,7 +33,7 @@ use tracing::{debug, error, info};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum PipelineStatus {
-    InProgress { retry_count: usize },
+    InProgress,
     Completed,
     Failed { error: String },
 }
@@ -65,7 +65,6 @@ pub struct CompactionPipeline {
     merge_operation: MergeOperation,
     pipeline_id: MergePipelineId,
     status: PipelineStatus,
-    max_retries: usize,
     kill_switch: KillSwitch,
     scratch_directory: TempDirectory,
     handles: Option<CompactionPipelineHandles>,
@@ -94,12 +93,10 @@ impl CompactionPipeline {
         io_throughput_limiter: Option<Limiter>,
         max_concurrent_split_uploads: usize,
         event_broker: EventBroker,
-        max_retries: usize,
     ) -> Self {
         CompactionPipeline {
             task_id,
-            status: PipelineStatus::InProgress { retry_count: 0 },
-            max_retries,
+            status: PipelineStatus::InProgress,
             kill_switch: KillSwitch::default(),
             scratch_directory,
             handles: None,
@@ -133,17 +130,13 @@ impl CompactionPipeline {
     ///
     /// If the pipeline is already completed or failed (terminal status), returns the status
     /// without re-checking actors. Otherwise checks actor health and:
-    /// - Restarts the pipeline on failure if retries remain.
     /// - Marks the pipeline as completed or failed when appropriate.
-    pub fn pipeline_status_update(
-        &mut self,
-        spawn_ctx: &SpawnContext,
-    ) -> PipelineStatusUpdate {
-        self.update_status(spawn_ctx);
+    pub fn pipeline_status_update(&mut self) -> PipelineStatusUpdate {
+        self.update_status();
         self.build_status_update()
     }
 
-    fn update_status(&mut self, spawn_ctx: &SpawnContext) {
+    fn update_status(&mut self) {
         // Pipeline is finished but yet to be cleaned up.
         if matches!(
             self.status,
@@ -156,51 +149,28 @@ impl CompactionPipeline {
             return;
         }
 
-        let mut healthy_actors: Vec<String> = Vec::new();
-        let mut failure_or_unhealthy_actors: Vec<String> = Vec::new();
-        let mut success_actors: Vec<String> = Vec::new();
+        let mut has_healthy = false;
+        let mut failure_actor_names: Vec<String> = Vec::new();
 
         for supervisable in self.supervisables() {
             match supervisable.check_health(true) {
                 Health::Healthy => {
-                    healthy_actors.push(supervisable.name().to_string());
+                    has_healthy = true;
                 }
                 Health::FailureOrUnhealthy => {
-                    failure_or_unhealthy_actors.push(supervisable.name().to_string());
+                    failure_actor_names.push(supervisable.name().to_string());
                 }
-                Health::Success => {
-                    success_actors.push(supervisable.name().to_string());
-                }
+                Health::Success => {}
             }
         }
 
-        if !failure_or_unhealthy_actors.is_empty() {
-            let PipelineStatus::InProgress { retry_count } = self.status else {
-                return;
-            };
-            if retry_count < self.max_retries {
-                let new_retry_count = retry_count + 1;
-                info!(
-                    task_id=%self.task_id,
-                    retry_count=%new_retry_count,
-                    failed_actors=?failure_or_unhealthy_actors,
-                    "retrying compaction pipeline"
-                );
-                self.restart(spawn_ctx);
-                self.status = PipelineStatus::InProgress {
-                    retry_count: new_retry_count,
-                };
-                return;
-            }
-            let error_msg = format!(
-                "exhausted retries, failed actors: {:?}",
-                failure_or_unhealthy_actors
-            );
-            error!(task_id=%self.task_id, retry_count=%retry_count, "{error_msg}");
+        if !failure_actor_names.is_empty() {
+            let error_msg = format!("failed actors: {:?}", failure_actor_names);
+            error!(task_id=%self.task_id, "{error_msg}");
             self.status = PipelineStatus::Failed { error: error_msg };
             return;
         }
-        if healthy_actors.is_empty() {
+        if !has_healthy {
             debug!(task_id=%self.task_id, "all compaction pipeline actors completed");
             self.status = PipelineStatus::Completed;
         }
@@ -220,17 +190,6 @@ impl CompactionPipeline {
             merged_split_id: self.merge_operation.merge_split_id.clone(),
             status: self.status.clone(),
         }
-    }
-
-    /// Terminates the current actor chain and re-spawns with a fresh kill
-    /// switch. Downloaded splits remain on disk in the scratch directory.
-    fn restart(&mut self, spawn_ctx: &SpawnContext) {
-        self.kill_switch.kill();
-        self.handles = None;
-        self.kill_switch = KillSwitch::default();
-        // TODO: handle spawn failure gracefully instead of panicking.
-        self.spawn_pipeline(spawn_ctx)
-            .expect("failed to respawn compaction pipeline");
     }
 
     /// Spawns the 5-actor merge execution chain and sends the `MergeOperation`
@@ -332,6 +291,7 @@ impl CompactionPipeline {
 pub(crate) mod tests {
     use std::sync::Arc;
 
+    use quickwit_actors::Universe;
     use quickwit_common::pubsub::EventBroker;
     use quickwit_common::temp_dir::TempDirectory;
     use quickwit_doc_mapper::default_doc_mapper_for_test;
@@ -343,15 +303,9 @@ pub(crate) mod tests {
     use quickwit_proto::types::{IndexUid, NodeId};
     use quickwit_storage::RamStorage;
 
-    use quickwit_actors::Universe;
-
     use super::{CompactionPipeline, PipelineStatus};
 
-    pub fn test_pipeline(
-        task_id: &str,
-        split_ids: &[&str],
-        max_retries: usize,
-    ) -> CompactionPipeline {
+    pub fn test_pipeline(task_id: &str, split_ids: &[&str]) -> CompactionPipeline {
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store_for_test(storage);
         let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
@@ -378,14 +332,13 @@ pub(crate) mod tests {
             None,
             2,
             EventBroker::default(),
-            max_retries,
         )
     }
 
     #[tokio::test]
     async fn test_spawn_pipeline_creates_handles() {
         let universe = Universe::new();
-        let mut pipeline = test_pipeline("task-1", &["split-1", "split-2"], 2);
+        let mut pipeline = test_pipeline("task-1", &["split-1", "split-2"]);
         assert!(pipeline.handles.is_none());
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
         assert!(pipeline.handles.is_some());
@@ -393,10 +346,9 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_status_update_unspawned_pipeline() {
-        let universe = Universe::new();
-        let mut pipeline = test_pipeline("task-1", &["split-1"], 2);
-        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
-        assert_eq!(update.status, PipelineStatus::InProgress { retry_count: 0 });
+        let mut pipeline = test_pipeline("task-1", &["split-1"]);
+        let update = pipeline.pipeline_status_update();
+        assert_eq!(update.status, PipelineStatus::InProgress);
         assert_eq!(update.task_id, "task-1");
         assert_eq!(update.split_ids, vec!["split-1"]);
         assert_eq!(update.source_id, "test-source");
@@ -406,40 +358,25 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_status_update_healthy_pipeline() {
         let universe = Universe::new();
-        let mut pipeline = test_pipeline("task-1", &["split-1"], 2);
+        let mut pipeline = test_pipeline("task-1", &["split-1"]);
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
-        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
-        assert_eq!(update.status, PipelineStatus::InProgress { retry_count: 0 });
+        let update = pipeline.pipeline_status_update();
+        assert_eq!(update.status, PipelineStatus::InProgress);
     }
 
     #[tokio::test]
-    async fn test_killed_pipeline_with_retries_restarts() {
+    async fn test_killed_pipeline_fails() {
         let universe = Universe::new();
-        let mut pipeline = test_pipeline("task-1", &["split-1"], 2);
+        let mut pipeline = test_pipeline("task-1", &["split-1"]);
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
 
         pipeline.kill_switch.kill();
-        // Let actors process the kill signal.
         tokio::task::yield_now().await;
-        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
-        assert_eq!(update.status, PipelineStatus::InProgress { retry_count: 1 });
-        assert!(pipeline.handles.is_some());
-    }
-
-    #[tokio::test]
-    async fn test_killed_pipeline_exhausted_retries_fails() {
-        let universe = Universe::new();
-        let mut pipeline = test_pipeline("task-1", &["split-1"], 0);
-        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
-
-        pipeline.kill_switch.kill();
-        // Let actors process the kill signal.
-        tokio::task::yield_now().await;
-        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
+        let update = pipeline.pipeline_status_update();
         assert!(matches!(update.status, PipelineStatus::Failed { .. }));
 
         // Calling again still returns Failed (sticky).
-        let update = pipeline.pipeline_status_update(universe.spawn_ctx());
+        let update = pipeline.pipeline_status_update();
         assert!(matches!(update.status, PipelineStatus::Failed { .. }));
     }
 }

--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -15,7 +15,7 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, SpawnContext};
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler};
 use quickwit_common::io::Limiter;
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
@@ -55,8 +55,6 @@ pub struct CompactorSupervisor {
 
     // Scratch directory root (<data_dir>/compaction/).
     compaction_root_directory: TempDirectory,
-
-    max_local_retries: usize,
 }
 
 impl CompactorSupervisor {
@@ -72,7 +70,6 @@ impl CompactorSupervisor {
         max_concurrent_split_uploads: usize,
         event_broker: EventBroker,
         compaction_root_directory: TempDirectory,
-        max_local_retries: usize,
     ) -> Self {
         let pipelines = (0..num_pipeline_slots).map(|_| None).collect();
         CompactorSupervisor {
@@ -86,20 +83,16 @@ impl CompactorSupervisor {
             max_concurrent_split_uploads,
             event_broker,
             compaction_root_directory,
-            max_local_retries,
         }
     }
 
-    fn check_pipeline_statuses(
-        &mut self,
-        spawn_ctx: &SpawnContext,
-    ) -> Vec<PipelineStatusUpdate> {
+    fn check_pipeline_statuses(&mut self) -> Vec<PipelineStatusUpdate> {
         let mut statuses = Vec::new();
         for slot in &mut self.pipelines {
             let Some(pipeline) = slot else {
                 continue;
             };
-            statuses.push(pipeline.pipeline_status_update(spawn_ctx));
+            statuses.push(pipeline.pipeline_status_update());
         }
         statuses
     }
@@ -110,7 +103,7 @@ impl CompactorSupervisor {
     ) -> WorkerStatusUpdateRequest {
         let in_progress_count = statuses
             .iter()
-            .filter(|s| matches!(s.status, PipelineStatus::InProgress { .. }))
+            .filter(|s| matches!(s.status, PipelineStatus::InProgress))
             .count();
         let available_slots = (self.pipelines.len() - in_progress_count) as u32;
 
@@ -120,7 +113,7 @@ impl CompactorSupervisor {
 
         for update in statuses {
             match &update.status {
-                PipelineStatus::InProgress { .. } => {
+                PipelineStatus::InProgress => {
                     in_progress_compactions.push(InProgressCompaction {
                         task_id: update.task_id.clone(),
                         index_uid: Some(update.index_uid.clone()),
@@ -182,7 +175,7 @@ impl Handler<CheckPipelineStatuses> for CompactorSupervisor {
         _msg: CheckPipelineStatuses,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        let statuses = self.check_pipeline_statuses(ctx.spawn_ctx());
+        let statuses = self.check_pipeline_statuses();
         let _request = self.build_worker_status_update(&statuses);
         // TODO: send request to planner via gRPC, clear completed/failed slots on success.
         ctx.schedule_self_msg(CHECK_PIPELINE_STATUSES_INTERVAL, CheckPipelineStatuses);
@@ -221,15 +214,13 @@ mod tests {
             2,
             EventBroker::default(),
             TempDirectory::for_test(),
-            2,
         )
     }
 
-    #[tokio::test]
-    async fn test_check_pipeline_statuses_empty_slots() {
-        let universe = Universe::new();
+    #[test]
+    fn test_check_pipeline_statuses_empty_slots() {
         let mut supervisor = test_supervisor(4);
-        let statuses = supervisor.check_pipeline_statuses(universe.spawn_ctx());
+        let statuses = supervisor.check_pipeline_statuses();
         assert!(statuses.is_empty());
     }
 
@@ -238,15 +229,15 @@ mod tests {
         let universe = Universe::new();
         let mut supervisor = test_supervisor(4);
 
-        let mut pipeline = test_pipeline("task-1", &["split-a", "split-b"], 2);
+        let mut pipeline = test_pipeline("task-1", &["split-a", "split-b"]);
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
         supervisor.pipelines[0] = Some(pipeline);
 
-        let mut pipeline = test_pipeline("task-2", &["split-c"], 2);
+        let mut pipeline = test_pipeline("task-2", &["split-c"]);
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
         supervisor.pipelines[2] = Some(pipeline);
 
-        let statuses = supervisor.check_pipeline_statuses(universe.spawn_ctx());
+        let statuses = supervisor.check_pipeline_statuses();
         assert_eq!(statuses.len(), 2);
         assert_eq!(statuses[0].task_id, "task-1");
         assert_eq!(statuses[0].split_ids, vec!["split-a", "split-b"]);
@@ -259,11 +250,11 @@ mod tests {
         let universe = Universe::new();
         let mut supervisor = test_supervisor(3);
 
-        let mut pipeline = test_pipeline("task-1", &["s1", "s2"], 2);
+        let mut pipeline = test_pipeline("task-1", &["s1", "s2"]);
         pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
         supervisor.pipelines[0] = Some(pipeline);
 
-        let statuses = supervisor.check_pipeline_statuses(universe.spawn_ctx());
+        let statuses = supervisor.check_pipeline_statuses();
         let request = supervisor.build_worker_status_update(&statuses);
 
         assert_eq!(request.worker_id, "test-node");
@@ -271,7 +262,10 @@ mod tests {
         assert_eq!(request.available_slots, 2);
         assert_eq!(request.in_progress_compactions.len(), 1);
         assert_eq!(request.in_progress_compactions[0].task_id, "task-1");
-        assert_eq!(request.in_progress_compactions[0].split_ids, vec!["s1", "s2"]);
+        assert_eq!(
+            request.in_progress_compactions[0].split_ids,
+            vec!["s1", "s2"]
+        );
         assert!(request.completed_compactions.is_empty());
         assert!(request.failed_compactions.is_empty());
     }
@@ -297,7 +291,7 @@ mod tests {
                 source_id: "src".to_string(),
                 split_ids: vec!["s1".to_string(), "s2".to_string()],
                 merged_split_id: "merged-1".to_string(),
-                status: PipelineStatus::InProgress { retry_count: 0 },
+                status: PipelineStatus::InProgress,
             },
             PipelineStatusUpdate {
                 task_id: "task-2".to_string(),
@@ -325,7 +319,10 @@ mod tests {
         assert_eq!(request.available_slots, 3);
         assert_eq!(request.in_progress_compactions.len(), 1);
         assert_eq!(request.in_progress_compactions[0].task_id, "task-1");
-        assert_eq!(request.in_progress_compactions[0].split_ids, vec!["s1", "s2"]);
+        assert_eq!(
+            request.in_progress_compactions[0].split_ids,
+            vec!["s1", "s2"]
+        );
         assert_eq!(request.completed_compactions.len(), 1);
         assert_eq!(request.completed_compactions[0].task_id, "task-2");
         assert_eq!(request.completed_compactions[0].merged_split_id, "merged-2");

--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -15,36 +15,34 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Health};
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, SpawnContext};
 use quickwit_common::io::Limiter;
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_indexing::IndexingSplitStore;
+use quickwit_proto::compaction::{
+    CompactionServiceClient, CompletedCompaction, FailedCompaction, InProgressCompaction,
+    WorkerStatusUpdateRequest,
+};
 use quickwit_proto::metastore::MetastoreServiceClient;
+use quickwit_proto::types::NodeId;
 use quickwit_storage::StorageResolver;
-use serde::Serialize;
-use tracing::{error, info};
+use tracing::info;
 
-use crate::compaction_pipeline::CompactionPipeline;
+use crate::compaction_pipeline::{CompactionPipeline, PipelineStatus, PipelineStatusUpdate};
 
-const SUPERVISE_LOOP_INTERVAL: Duration = Duration::from_secs(1);
+const CHECK_PIPELINE_STATUSES_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
-struct SuperviseLoop;
-
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct CompactorSupervisorState {
-    pub num_pipeline_slots: usize,
-    pub num_occupied_slots: usize,
-    pub num_completed_tasks: usize,
-    pub num_failed_tasks: usize,
-}
+struct CheckPipelineStatuses;
 
 /// Manages a pool of `CompactionPipeline`s, each executing a single merge task.
 ///
-/// Periodically checks pipeline health, handles retries on failure, and reaps
-/// completed/failed pipelines.
+/// Periodically collects pipeline status updates and forwards them to the
+/// compaction planner. Pipelines manage their own retry logic internally.
 pub struct CompactorSupervisor {
+    node_id: NodeId,
+    compaction_client: CompactionServiceClient,
     pipelines: Vec<Option<CompactionPipeline>>,
 
     // Shared resources distributed to pipelines when spawning actor chains.
@@ -59,15 +57,13 @@ pub struct CompactorSupervisor {
     compaction_root_directory: TempDirectory,
 
     max_local_retries: usize,
-
-    // dummy counters until we have real state
-    num_completed_tasks: usize,
-    num_failed_tasks: usize,
 }
 
 impl CompactorSupervisor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        node_id: NodeId,
+        compaction_client: CompactionServiceClient,
         num_pipeline_slots: usize,
         io_throughput_limiter: Option<Limiter>,
         split_store: IndexingSplitStore,
@@ -80,6 +76,8 @@ impl CompactorSupervisor {
     ) -> Self {
         let pipelines = (0..num_pipeline_slots).map(|_| None).collect();
         CompactorSupervisor {
+            node_id,
+            compaction_client,
             pipelines,
             io_throughput_limiter,
             split_store,
@@ -89,44 +87,68 @@ impl CompactorSupervisor {
             event_broker,
             compaction_root_directory,
             max_local_retries,
-            num_completed_tasks: 0,
-            num_failed_tasks: 0,
         }
     }
 
-    async fn supervise(&mut self, ctx: &ActorContext<Self>) {
+    fn check_pipeline_statuses(
+        &mut self,
+        spawn_ctx: &SpawnContext,
+    ) -> Vec<PipelineStatusUpdate> {
+        let mut statuses = Vec::new();
         for slot in &mut self.pipelines {
             let Some(pipeline) = slot else {
                 continue;
             };
+            statuses.push(pipeline.pipeline_status_update(spawn_ctx));
+        }
+        statuses
+    }
 
-            match pipeline.check_actor_health() {
-                Health::Healthy => {}
-                Health::Success => {
-                    info!(task_id=%pipeline.task_id, "compaction task completed");
-                    self.num_completed_tasks += 1;
-                    *slot = None;
+    fn build_worker_status_update(
+        &self,
+        statuses: &[PipelineStatusUpdate],
+    ) -> WorkerStatusUpdateRequest {
+        let in_progress_count = statuses
+            .iter()
+            .filter(|s| matches!(s.status, PipelineStatus::InProgress { .. }))
+            .count();
+        let available_slots = (self.pipelines.len() - in_progress_count) as u32;
+
+        let mut in_progress_compactions = Vec::new();
+        let mut completed_compactions = Vec::new();
+        let mut failed_compactions = Vec::new();
+
+        for update in statuses {
+            match &update.status {
+                PipelineStatus::InProgress { .. } => {
+                    in_progress_compactions.push(InProgressCompaction {
+                        task_id: update.task_id.clone(),
+                        index_uid: Some(update.index_uid.clone()),
+                        source_id: update.source_id.clone(),
+                        split_ids: update.split_ids.clone(),
+                    });
                 }
-                Health::FailureOrUnhealthy => {
-                    if pipeline.retry_count < self.max_local_retries {
-                        info!(
-                            task_id=%pipeline.task_id,
-                            retry_count=%pipeline.retry_count,
-                            "retrying compaction pipeline"
-                        );
-                        pipeline.restart(ctx).await;
-                    } else {
-                        error!(
-                            task_id=%pipeline.task_id,
-                            retry_count=%pipeline.retry_count,
-                            "compaction pipeline exhausted retries"
-                        );
-                        pipeline.terminate().await;
-                        self.num_failed_tasks += 1;
-                        *slot = None;
-                    }
+                PipelineStatus::Completed => {
+                    completed_compactions.push(CompletedCompaction {
+                        task_id: update.task_id.clone(),
+                        merged_split_id: update.merged_split_id.clone(),
+                    });
+                }
+                PipelineStatus::Failed { error } => {
+                    failed_compactions.push(FailedCompaction {
+                        task_id: update.task_id.clone(),
+                        error_message: error.clone(),
+                    });
                 }
             }
+        }
+
+        WorkerStatusUpdateRequest {
+            worker_id: self.node_id.to_string(),
+            available_slots,
+            in_progress_compactions,
+            completed_compactions,
+            failed_compactions,
         }
     }
 }
@@ -146,22 +168,24 @@ impl Actor for CompactorSupervisor {
             num_pipeline_slots=%self.pipelines.len(),
             "compactor supervisor started"
         );
-        ctx.schedule_self_msg(SUPERVISE_LOOP_INTERVAL, SuperviseLoop);
+        ctx.schedule_self_msg(CHECK_PIPELINE_STATUSES_INTERVAL, CheckPipelineStatuses);
         Ok(())
     }
 }
 
 #[async_trait]
-impl Handler<SuperviseLoop> for CompactorSupervisor {
+impl Handler<CheckPipelineStatuses> for CompactorSupervisor {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _msg: SuperviseLoop,
+        _msg: CheckPipelineStatuses,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        self.supervise(ctx).await;
-        ctx.schedule_self_msg(SUPERVISE_LOOP_INTERVAL, SuperviseLoop);
+        let statuses = self.check_pipeline_statuses(ctx.spawn_ctx());
+        let _request = self.build_worker_status_update(&statuses);
+        // TODO: send request to planner via gRPC, clear completed/failed slots on success.
+        ctx.schedule_self_msg(CHECK_PIPELINE_STATUSES_INTERVAL, CheckPipelineStatuses);
         Ok(())
     }
 }
@@ -172,16 +196,23 @@ mod tests {
 
     use quickwit_actors::Universe;
     use quickwit_common::temp_dir::TempDirectory;
+    use quickwit_proto::compaction::CompactionServiceClient;
     use quickwit_proto::metastore::{MetastoreServiceClient, MockMetastoreService};
+    use quickwit_proto::types::NodeId;
     use quickwit_storage::{RamStorage, StorageResolver};
 
     use super::*;
+    use crate::compaction_pipeline::tests::test_pipeline;
+    use crate::planner::StubCompactionService;
 
     fn test_supervisor(num_slots: usize) -> CompactorSupervisor {
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store_for_test(storage);
         let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
+        let compaction_client = CompactionServiceClient::new(StubCompactionService);
         CompactorSupervisor::new(
+            NodeId::from("test-node"),
+            compaction_client,
             num_slots,
             None,
             split_store,
@@ -195,25 +226,111 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_supervisor_starts_with_empty_slots() {
-        let universe = Universe::with_accelerated_time();
-        let supervisor = test_supervisor(4);
-        let (_mailbox, handle) = universe.spawn_builder().spawn(supervisor);
-        let obs = handle.process_pending_and_observe().await;
-        assert_eq!(obs.obs_type, quickwit_actors::ObservationType::Alive);
-        universe.assert_quit().await;
+    async fn test_check_pipeline_statuses_empty_slots() {
+        let universe = Universe::new();
+        let mut supervisor = test_supervisor(4);
+        let statuses = supervisor.check_pipeline_statuses(universe.spawn_ctx());
+        assert!(statuses.is_empty());
     }
 
     #[tokio::test]
-    async fn test_supervisor_supervise_reaps_no_handle_pipelines() {
-        // A pipeline with no handles returns Healthy, so it stays in its slot.
-        // We spawn the supervisor as an actor so we can get a context for supervise().
-        let universe = Universe::with_accelerated_time();
-        let supervisor = test_supervisor(2);
-        let (_mailbox, handle) = universe.spawn_builder().spawn(supervisor);
-        // Let the supervisor run one supervision loop (it schedules SuperviseLoop on init).
-        let obs = handle.process_pending_and_observe().await;
-        assert_eq!(obs.obs_type, quickwit_actors::ObservationType::Alive);
-        universe.assert_quit().await;
+    async fn test_check_pipeline_statuses_with_pipelines() {
+        let universe = Universe::new();
+        let mut supervisor = test_supervisor(4);
+
+        let mut pipeline = test_pipeline("task-1", &["split-a", "split-b"], 2);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+        supervisor.pipelines[0] = Some(pipeline);
+
+        let mut pipeline = test_pipeline("task-2", &["split-c"], 2);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+        supervisor.pipelines[2] = Some(pipeline);
+
+        let statuses = supervisor.check_pipeline_statuses(universe.spawn_ctx());
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[0].task_id, "task-1");
+        assert_eq!(statuses[0].split_ids, vec!["split-a", "split-b"]);
+        assert_eq!(statuses[1].task_id, "task-2");
+        assert_eq!(statuses[1].split_ids, vec!["split-c"]);
+    }
+
+    #[tokio::test]
+    async fn test_end_to_end_statuses_to_proto() {
+        let universe = Universe::new();
+        let mut supervisor = test_supervisor(3);
+
+        let mut pipeline = test_pipeline("task-1", &["s1", "s2"], 2);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+        supervisor.pipelines[0] = Some(pipeline);
+
+        let statuses = supervisor.check_pipeline_statuses(universe.spawn_ctx());
+        let request = supervisor.build_worker_status_update(&statuses);
+
+        assert_eq!(request.worker_id, "test-node");
+        // 3 slots, 1 in-progress = 2 available
+        assert_eq!(request.available_slots, 2);
+        assert_eq!(request.in_progress_compactions.len(), 1);
+        assert_eq!(request.in_progress_compactions[0].task_id, "task-1");
+        assert_eq!(request.in_progress_compactions[0].split_ids, vec!["s1", "s2"]);
+        assert!(request.completed_compactions.is_empty());
+        assert!(request.failed_compactions.is_empty());
+    }
+
+    #[test]
+    fn test_build_worker_status_update_empty() {
+        let supervisor = test_supervisor(4);
+        let request = supervisor.build_worker_status_update(&[]);
+        assert_eq!(request.worker_id, "test-node");
+        assert_eq!(request.available_slots, 4);
+        assert!(request.in_progress_compactions.is_empty());
+        assert!(request.completed_compactions.is_empty());
+        assert!(request.failed_compactions.is_empty());
+    }
+
+    #[test]
+    fn test_build_worker_status_update_mixed_statuses() {
+        let supervisor = test_supervisor(4);
+        let statuses = vec![
+            PipelineStatusUpdate {
+                task_id: "task-1".to_string(),
+                index_uid: quickwit_proto::types::IndexUid::for_test("test-index", 0),
+                source_id: "src".to_string(),
+                split_ids: vec!["s1".to_string(), "s2".to_string()],
+                merged_split_id: "merged-1".to_string(),
+                status: PipelineStatus::InProgress { retry_count: 0 },
+            },
+            PipelineStatusUpdate {
+                task_id: "task-2".to_string(),
+                index_uid: quickwit_proto::types::IndexUid::for_test("test-index", 0),
+                source_id: "src".to_string(),
+                split_ids: vec!["s3".to_string()],
+                merged_split_id: "merged-2".to_string(),
+                status: PipelineStatus::Completed,
+            },
+            PipelineStatusUpdate {
+                task_id: "task-3".to_string(),
+                index_uid: quickwit_proto::types::IndexUid::for_test("test-index", 0),
+                source_id: "src".to_string(),
+                split_ids: vec!["s4".to_string()],
+                merged_split_id: "merged-3".to_string(),
+                status: PipelineStatus::Failed {
+                    error: "boom".to_string(),
+                },
+            },
+        ];
+
+        let request = supervisor.build_worker_status_update(&statuses);
+
+        // 4 slots, 1 in-progress = 3 available
+        assert_eq!(request.available_slots, 3);
+        assert_eq!(request.in_progress_compactions.len(), 1);
+        assert_eq!(request.in_progress_compactions[0].task_id, "task-1");
+        assert_eq!(request.in_progress_compactions[0].split_ids, vec!["s1", "s2"]);
+        assert_eq!(request.completed_compactions.len(), 1);
+        assert_eq!(request.completed_compactions[0].task_id, "task-2");
+        assert_eq!(request.completed_compactions[0].merged_split_id, "merged-2");
+        assert_eq!(request.failed_compactions.len(), 1);
+        assert_eq!(request.failed_compactions[0].task_id, "task-3");
+        assert_eq!(request.failed_compactions[0].error_message, "boom");
     }
 }

--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -21,8 +21,8 @@ use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_indexing::IndexingSplitStore;
 use quickwit_proto::compaction::{
-    CompactionServiceClient, CompletedCompaction, FailedCompaction, InProgressCompaction,
-    WorkerStatusUpdateRequest,
+    CompactionFailure, CompactionInProgress, CompactionPlannerServiceClient, CompactionSuccess,
+    ReportStatusRequest,
 };
 use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_proto::types::NodeId;
@@ -42,7 +42,7 @@ struct CheckPipelineStatuses;
 /// compaction planner. Pipelines manage their own retry logic internally.
 pub struct CompactorSupervisor {
     node_id: NodeId,
-    compaction_client: CompactionServiceClient,
+    planner_client: CompactionPlannerServiceClient,
     pipelines: Vec<Option<CompactionPipeline>>,
 
     // Shared resources distributed to pipelines when spawning actor chains.
@@ -61,7 +61,7 @@ impl CompactorSupervisor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         node_id: NodeId,
-        compaction_client: CompactionServiceClient,
+        planner_client: CompactionPlannerServiceClient,
         num_pipeline_slots: usize,
         io_throughput_limiter: Option<Limiter>,
         split_store: IndexingSplitStore,
@@ -74,7 +74,7 @@ impl CompactorSupervisor {
         let pipelines = (0..num_pipeline_slots).map(|_| None).collect();
         CompactorSupervisor {
             node_id,
-            compaction_client,
+            planner_client,
             pipelines,
             io_throughput_limiter,
             split_store,
@@ -97,24 +97,24 @@ impl CompactorSupervisor {
         statuses
     }
 
-    fn build_worker_status_update(
+    fn build_report_status_request(
         &self,
         statuses: &[PipelineStatusUpdate],
-    ) -> WorkerStatusUpdateRequest {
+    ) -> ReportStatusRequest {
         let in_progress_count = statuses
             .iter()
             .filter(|s| matches!(s.status, PipelineStatus::InProgress))
             .count();
         let available_slots = (self.pipelines.len() - in_progress_count) as u32;
 
-        let mut in_progress_compactions = Vec::new();
-        let mut completed_compactions = Vec::new();
-        let mut failed_compactions = Vec::new();
+        let mut in_progress = Vec::new();
+        let mut successes = Vec::new();
+        let mut failures = Vec::new();
 
         for update in statuses {
             match &update.status {
                 PipelineStatus::InProgress => {
-                    in_progress_compactions.push(InProgressCompaction {
+                    in_progress.push(CompactionInProgress {
                         task_id: update.task_id.clone(),
                         index_uid: Some(update.index_uid.clone()),
                         source_id: update.source_id.clone(),
@@ -122,13 +122,13 @@ impl CompactorSupervisor {
                     });
                 }
                 PipelineStatus::Completed => {
-                    completed_compactions.push(CompletedCompaction {
+                    successes.push(CompactionSuccess {
                         task_id: update.task_id.clone(),
                         merged_split_id: update.merged_split_id.clone(),
                     });
                 }
                 PipelineStatus::Failed { error } => {
-                    failed_compactions.push(FailedCompaction {
+                    failures.push(CompactionFailure {
                         task_id: update.task_id.clone(),
                         error_message: error.clone(),
                     });
@@ -136,12 +136,12 @@ impl CompactorSupervisor {
             }
         }
 
-        WorkerStatusUpdateRequest {
-            worker_id: self.node_id.to_string(),
+        ReportStatusRequest {
+            node_id: self.node_id.to_string(),
             available_slots,
-            in_progress_compactions,
-            completed_compactions,
-            failed_compactions,
+            in_progress,
+            successes,
+            failures,
         }
     }
 }
@@ -176,7 +176,7 @@ impl Handler<CheckPipelineStatuses> for CompactorSupervisor {
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
         let statuses = self.check_pipeline_statuses();
-        let _request = self.build_worker_status_update(&statuses);
+        let _request = self.build_report_status_request(&statuses);
         // TODO: send request to planner via gRPC, clear completed/failed slots on success.
         ctx.schedule_self_msg(CHECK_PIPELINE_STATUSES_INTERVAL, CheckPipelineStatuses);
         Ok(())
@@ -189,20 +189,20 @@ mod tests {
 
     use quickwit_actors::Universe;
     use quickwit_common::temp_dir::TempDirectory;
-    use quickwit_proto::compaction::CompactionServiceClient;
+    use quickwit_proto::compaction::CompactionPlannerServiceClient;
     use quickwit_proto::metastore::{MetastoreServiceClient, MockMetastoreService};
     use quickwit_proto::types::NodeId;
     use quickwit_storage::{RamStorage, StorageResolver};
 
     use super::*;
     use crate::compaction_pipeline::tests::test_pipeline;
-    use crate::planner::StubCompactionService;
+    use crate::planner::StubCompactionPlannerService;
 
     fn test_supervisor(num_slots: usize) -> CompactorSupervisor {
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store_for_test(storage);
         let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
-        let compaction_client = CompactionServiceClient::new(StubCompactionService);
+        let compaction_client = CompactionPlannerServiceClient::new(StubCompactionPlannerService);
         CompactorSupervisor::new(
             NodeId::from("test-node"),
             compaction_client,
@@ -243,6 +243,7 @@ mod tests {
         assert_eq!(statuses[0].split_ids, vec!["split-a", "split-b"]);
         assert_eq!(statuses[1].task_id, "task-2");
         assert_eq!(statuses[1].split_ids, vec!["split-c"]);
+        universe.assert_quit().await;
     }
 
     #[tokio::test]
@@ -255,34 +256,32 @@ mod tests {
         supervisor.pipelines[0] = Some(pipeline);
 
         let statuses = supervisor.check_pipeline_statuses();
-        let request = supervisor.build_worker_status_update(&statuses);
+        let request = supervisor.build_report_status_request(&statuses);
 
-        assert_eq!(request.worker_id, "test-node");
+        assert_eq!(request.node_id, "test-node");
         // 3 slots, 1 in-progress = 2 available
         assert_eq!(request.available_slots, 2);
-        assert_eq!(request.in_progress_compactions.len(), 1);
-        assert_eq!(request.in_progress_compactions[0].task_id, "task-1");
-        assert_eq!(
-            request.in_progress_compactions[0].split_ids,
-            vec!["s1", "s2"]
-        );
-        assert!(request.completed_compactions.is_empty());
-        assert!(request.failed_compactions.is_empty());
+        assert_eq!(request.in_progress.len(), 1);
+        assert_eq!(request.in_progress[0].task_id, "task-1");
+        assert_eq!(request.in_progress[0].split_ids, vec!["s1", "s2"]);
+        assert!(request.successes.is_empty());
+        assert!(request.failures.is_empty());
+        universe.assert_quit().await;
     }
 
     #[test]
-    fn test_build_worker_status_update_empty() {
+    fn test_build_report_status_request_empty() {
         let supervisor = test_supervisor(4);
-        let request = supervisor.build_worker_status_update(&[]);
-        assert_eq!(request.worker_id, "test-node");
+        let request = supervisor.build_report_status_request(&[]);
+        assert_eq!(request.node_id, "test-node");
         assert_eq!(request.available_slots, 4);
-        assert!(request.in_progress_compactions.is_empty());
-        assert!(request.completed_compactions.is_empty());
-        assert!(request.failed_compactions.is_empty());
+        assert!(request.in_progress.is_empty());
+        assert!(request.successes.is_empty());
+        assert!(request.failures.is_empty());
     }
 
     #[test]
-    fn test_build_worker_status_update_mixed_statuses() {
+    fn test_build_report_status_request_mixed_statuses() {
         let supervisor = test_supervisor(4);
         let statuses = vec![
             PipelineStatusUpdate {
@@ -313,21 +312,17 @@ mod tests {
             },
         ];
 
-        let request = supervisor.build_worker_status_update(&statuses);
+        let request = supervisor.build_report_status_request(&statuses);
 
-        // 4 slots, 1 in-progress = 3 available
         assert_eq!(request.available_slots, 3);
-        assert_eq!(request.in_progress_compactions.len(), 1);
-        assert_eq!(request.in_progress_compactions[0].task_id, "task-1");
-        assert_eq!(
-            request.in_progress_compactions[0].split_ids,
-            vec!["s1", "s2"]
-        );
-        assert_eq!(request.completed_compactions.len(), 1);
-        assert_eq!(request.completed_compactions[0].task_id, "task-2");
-        assert_eq!(request.completed_compactions[0].merged_split_id, "merged-2");
-        assert_eq!(request.failed_compactions.len(), 1);
-        assert_eq!(request.failed_compactions[0].task_id, "task-3");
-        assert_eq!(request.failed_compactions[0].error_message, "boom");
+        assert_eq!(request.in_progress.len(), 1);
+        assert_eq!(request.in_progress[0].task_id, "task-1");
+        assert_eq!(request.in_progress[0].split_ids, vec!["s1", "s2"]);
+        assert_eq!(request.successes.len(), 1);
+        assert_eq!(request.successes[0].task_id, "task-2");
+        assert_eq!(request.successes[0].merged_split_id, "merged-2");
+        assert_eq!(request.failures.len(), 1);
+        assert_eq!(request.failures[0].task_id, "task-3");
+        assert_eq!(request.failures[0].error_message, "boom");
     }
 }

--- a/quickwit/quickwit-compaction/src/lib.rs
+++ b/quickwit/quickwit-compaction/src/lib.rs
@@ -27,7 +27,7 @@ use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_config::CompactorConfig;
 use quickwit_indexing::IndexingSplitStore;
-use quickwit_proto::compaction::CompactionServiceClient;
+use quickwit_proto::compaction::CompactionPlannerServiceClient;
 use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_proto::types::NodeId;
 use quickwit_storage::StorageResolver;
@@ -37,7 +37,7 @@ use tracing::info;
 pub async fn start_compactor_service(
     universe: &Universe,
     node_id: NodeId,
-    compaction_client: CompactionServiceClient,
+    compaction_client: CompactionPlannerServiceClient,
     compactor_config: &CompactorConfig,
     split_store: IndexingSplitStore,
     metastore: MetastoreServiceClient,

--- a/quickwit/quickwit-compaction/src/lib.rs
+++ b/quickwit/quickwit-compaction/src/lib.rs
@@ -27,12 +27,16 @@ use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_config::CompactorConfig;
 use quickwit_indexing::IndexingSplitStore;
+use quickwit_proto::compaction::CompactionServiceClient;
 use quickwit_proto::metastore::MetastoreServiceClient;
+use quickwit_proto::types::NodeId;
 use quickwit_storage::StorageResolver;
 use tracing::info;
 
 pub async fn start_compactor_service(
     universe: &Universe,
+    node_id: NodeId,
+    compaction_client: CompactionServiceClient,
     compactor_config: &CompactorConfig,
     split_store: IndexingSplitStore,
     metastore: MetastoreServiceClient,
@@ -41,8 +45,11 @@ pub async fn start_compactor_service(
     compaction_root_directory: TempDirectory,
 ) -> anyhow::Result<Mailbox<CompactorSupervisor>> {
     info!("starting compactor service");
+    // TODO: configure this for real
     let io_throughput_limiter = compactor_config.max_merge_write_throughput.map(io::limiter);
     let supervisor = CompactorSupervisor::new(
+        node_id,
+        compaction_client,
         compactor_config.max_concurrent_pipelines.get(),
         io_throughput_limiter,
         split_store,

--- a/quickwit/quickwit-compaction/src/lib.rs
+++ b/quickwit/quickwit-compaction/src/lib.rs
@@ -33,6 +33,7 @@ use quickwit_proto::types::NodeId;
 use quickwit_storage::StorageResolver;
 use tracing::info;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_compactor_service(
     universe: &Universe,
     node_id: NodeId,
@@ -58,7 +59,6 @@ pub async fn start_compactor_service(
         compactor_config.max_concurrent_split_uploads,
         event_broker,
         compaction_root_directory,
-        compactor_config.max_local_retries,
     );
     let (mailbox, _handle) = universe.spawn_builder().spawn(supervisor);
     Ok(mailbox)

--- a/quickwit/quickwit-compaction/src/planner/compaction_service.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_service.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use quickwit_proto::compaction::{CompactionResult, CompactionService, PingRequest, PingResponse};
+use quickwit_proto::compaction::{
+    CompactionResult, CompactionService, PingRequest, PingResponse, WorkerStatusUpdateRequest,
+    WorkerStatusUpdateResponse,
+};
 
 #[derive(Debug, Clone)]
 pub struct StubCompactionService;
@@ -22,5 +25,12 @@ pub struct StubCompactionService;
 impl CompactionService for StubCompactionService {
     async fn ping(&self, _request: PingRequest) -> CompactionResult<PingResponse> {
         Ok(PingResponse {})
+    }
+
+    async fn worker_status_update(
+        &self,
+        _request: WorkerStatusUpdateRequest,
+    ) -> CompactionResult<WorkerStatusUpdateResponse> {
+        Ok(WorkerStatusUpdateResponse {})
     }
 }

--- a/quickwit/quickwit-compaction/src/planner/compaction_service.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_service.rs
@@ -14,23 +14,23 @@
 
 use async_trait::async_trait;
 use quickwit_proto::compaction::{
-    CompactionResult, CompactionService, PingRequest, PingResponse, WorkerStatusUpdateRequest,
-    WorkerStatusUpdateResponse,
+    CompactionPlannerService, CompactionResult, PingRequest, PingResponse, ReportStatusRequest,
+    ReportStatusResponse,
 };
 
 #[derive(Debug, Clone)]
-pub struct StubCompactionService;
+pub struct StubCompactionPlannerService;
 
 #[async_trait]
-impl CompactionService for StubCompactionService {
+impl CompactionPlannerService for StubCompactionPlannerService {
     async fn ping(&self, _request: PingRequest) -> CompactionResult<PingResponse> {
         Ok(PingResponse {})
     }
 
-    async fn worker_status_update(
+    async fn report_status(
         &self,
-        _request: WorkerStatusUpdateRequest,
-    ) -> CompactionResult<WorkerStatusUpdateResponse> {
-        Ok(WorkerStatusUpdateResponse {})
+        _request: ReportStatusRequest,
+    ) -> CompactionResult<ReportStatusResponse> {
+        Ok(ReportStatusResponse {})
     }
 }

--- a/quickwit/quickwit-compaction/src/planner/mod.rs
+++ b/quickwit/quickwit-compaction/src/planner/mod.rs
@@ -14,4 +14,4 @@
 
 mod compaction_service;
 
-pub use compaction_service::StubCompactionService;
+pub use compaction_service::StubCompactionPlannerService;

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -256,9 +256,6 @@ pub struct CompactorConfig {
     /// Limits the IO throughput of the split downloader and the merge executor.
     #[serde(default)]
     pub max_merge_write_throughput: Option<ByteSize>,
-    /// Maximum local retries before reporting a merge as failed to the planner.
-    #[serde(default = "CompactorConfig::default_max_local_retries")]
-    pub max_local_retries: usize,
     /// Maximum size of the local split store cache in bytes.
     #[serde(default = "CompactorConfig::default_split_store_max_num_bytes")]
     pub split_store_max_num_bytes: ByteSize,
@@ -276,10 +273,6 @@ impl CompactorConfig {
         12
     }
 
-    fn default_max_local_retries() -> usize {
-        2
-    }
-
     pub fn default_split_store_max_num_bytes() -> ByteSize {
         ByteSize::gib(100)
     }
@@ -294,7 +287,6 @@ impl CompactorConfig {
             max_concurrent_pipelines: NonZeroUsize::new(2).unwrap(),
             max_concurrent_split_uploads: 4,
             max_merge_write_throughput: None,
-            max_local_retries: 2,
             split_store_max_num_bytes: ByteSize::mb(1),
             split_store_max_num_splits: 3,
         }
@@ -307,7 +299,6 @@ impl Default for CompactorConfig {
             max_concurrent_pipelines: Self::default_max_concurrent_pipelines(),
             max_concurrent_split_uploads: Self::default_max_concurrent_split_uploads(),
             max_merge_write_throughput: None,
-            max_local_retries: Self::default_max_local_retries(),
             split_store_max_num_bytes: Self::default_split_store_max_num_bytes(),
             split_store_max_num_splits: Self::default_split_store_max_num_splits(),
         }

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -683,7 +683,11 @@ impl ClusterSandbox {
 #[tokio::test]
 async fn test_sandbox_happy_path() {
     let sandbox = ClusterSandboxBuilder::default()
-        .add_node([QuickwitService::ControlPlane, QuickwitService::Metastore])
+        .add_node([
+            QuickwitService::ControlPlane,
+            QuickwitService::Metastore,
+            QuickwitService::Janitor,
+        ])
         .add_node([QuickwitService::Searcher])
         .add_node([QuickwitService::Indexer])
         .build_and_start()
@@ -696,7 +700,11 @@ async fn test_sandbox_happy_path() {
 #[tokio::test]
 async fn test_sandbox_add_node_dynamically() {
     let mut sandbox = ClusterSandboxBuilder::default()
-        .add_node([QuickwitService::ControlPlane, QuickwitService::Metastore])
+        .add_node([
+            QuickwitService::ControlPlane,
+            QuickwitService::Metastore,
+            QuickwitService::Janitor,
+        ])
         .add_node([QuickwitService::Searcher])
         .build_and_start()
         .await;

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -38,10 +38,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compaction service.
     let mut prost_config = prost_build::Config::default();
     prost_config.file_descriptor_set_path("src/codegen/quickwit/compaction_descriptor.bin");
+    prost_config.extern_path(".quickwit.common.IndexUid", "crate::types::IndexUid");
 
     Codegen::builder()
         .with_prost_config(prost_config)
         .with_protos(&["protos/quickwit/compaction.proto"])
+        .with_includes(&["protos"])
         .with_output_dir("src/codegen/quickwit")
         .with_result_type_path("crate::compaction::CompactionResult")
         .with_error_type_path("crate::compaction::CompactionError")

--- a/quickwit/quickwit-proto/protos/quickwit/compaction.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/compaction.proto
@@ -16,9 +16,39 @@ syntax = "proto3";
 
 package quickwit.compaction;
 
+import "quickwit/common.proto";
+
 service CompactionService {
   rpc Ping(PingRequest) returns (PingResponse);
+  rpc WorkerStatusUpdate(WorkerStatusUpdateRequest) returns (WorkerStatusUpdateResponse);
 }
 
 message PingRequest {}
 message PingResponse {}
+
+message WorkerStatusUpdateRequest {
+  string worker_id = 1;
+  uint32 available_slots = 2;
+  repeated InProgressCompaction in_progress_compactions = 3;
+  repeated CompletedCompaction completed_compactions = 4;
+  repeated FailedCompaction failed_compactions = 5;
+}
+
+message InProgressCompaction {
+  string task_id = 1;
+  quickwit.common.IndexUid index_uid = 2;
+  string source_id = 3;
+  repeated string split_ids = 4;
+}
+
+message CompletedCompaction {
+  string task_id = 1;
+  string merged_split_id = 2;
+}
+
+message FailedCompaction {
+  string task_id = 1;
+  string error_message = 2;
+}
+
+message WorkerStatusUpdateResponse {}

--- a/quickwit/quickwit-proto/protos/quickwit/compaction.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/compaction.proto
@@ -18,37 +18,37 @@ package quickwit.compaction;
 
 import "quickwit/common.proto";
 
-service CompactionService {
+service CompactionPlannerService {
   rpc Ping(PingRequest) returns (PingResponse);
-  rpc WorkerStatusUpdate(WorkerStatusUpdateRequest) returns (WorkerStatusUpdateResponse);
+  rpc ReportStatus(ReportStatusRequest) returns (ReportStatusResponse);
 }
 
 message PingRequest {}
 message PingResponse {}
 
-message WorkerStatusUpdateRequest {
-  string worker_id = 1;
+message ReportStatusRequest {
+  string node_id = 1;
   uint32 available_slots = 2;
-  repeated InProgressCompaction in_progress_compactions = 3;
-  repeated CompletedCompaction completed_compactions = 4;
-  repeated FailedCompaction failed_compactions = 5;
+  repeated CompactionInProgress in_progress = 3;
+  repeated CompactionSuccess successes = 4;
+  repeated CompactionFailure failures = 5;
 }
 
-message InProgressCompaction {
+message CompactionInProgress {
   string task_id = 1;
   quickwit.common.IndexUid index_uid = 2;
   string source_id = 3;
   repeated string split_ids = 4;
 }
 
-message CompletedCompaction {
+message CompactionSuccess {
   string task_id = 1;
   string merged_split_id = 2;
 }
 
-message FailedCompaction {
+message CompactionFailure {
   string task_id = 1;
   string error_message = 2;
 }
 
-message WorkerStatusUpdateResponse {}
+message ReportStatusResponse {}

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.compaction.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.compaction.rs
@@ -5,6 +5,51 @@ pub struct PingRequest {}
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PingResponse {}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WorkerStatusUpdateRequest {
+    #[prost(string, tag = "1")]
+    pub worker_id: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub available_slots: u32,
+    #[prost(message, repeated, tag = "3")]
+    pub in_progress_compactions: ::prost::alloc::vec::Vec<InProgressCompaction>,
+    #[prost(message, repeated, tag = "4")]
+    pub completed_compactions: ::prost::alloc::vec::Vec<CompletedCompaction>,
+    #[prost(message, repeated, tag = "5")]
+    pub failed_compactions: ::prost::alloc::vec::Vec<FailedCompaction>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct InProgressCompaction {
+    #[prost(string, tag = "1")]
+    pub task_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub index_uid: ::core::option::Option<crate::types::IndexUid>,
+    #[prost(string, tag = "3")]
+    pub source_id: ::prost::alloc::string::String,
+    #[prost(string, repeated, tag = "4")]
+    pub split_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CompletedCompaction {
+    #[prost(string, tag = "1")]
+    pub task_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub merged_split_id: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct FailedCompaction {
+    #[prost(string, tag = "1")]
+    pub task_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub error_message: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WorkerStatusUpdateResponse {}
 /// BEGIN quickwit-codegen
 #[allow(unused_imports)]
 use std::str::FromStr;
@@ -15,6 +60,11 @@ impl RpcName for PingRequest {
         "ping"
     }
 }
+impl RpcName for WorkerStatusUpdateRequest {
+    fn rpc_name() -> &'static str {
+        "worker_status_update"
+    }
+}
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]
 pub trait CompactionService: std::fmt::Debug + Send + Sync + 'static {
@@ -22,6 +72,10 @@ pub trait CompactionService: std::fmt::Debug + Send + Sync + 'static {
         &self,
         request: PingRequest,
     ) -> crate::compaction::CompactionResult<PingResponse>;
+    async fn worker_status_update(
+        &self,
+        request: WorkerStatusUpdateRequest,
+    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse>;
 }
 #[derive(Debug, Clone)]
 pub struct CompactionServiceClient {
@@ -136,6 +190,12 @@ impl CompactionService for CompactionServiceClient {
     ) -> crate::compaction::CompactionResult<PingResponse> {
         self.inner.0.ping(request).await
     }
+    async fn worker_status_update(
+        &self,
+        request: WorkerStatusUpdateRequest,
+    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
+        self.inner.0.worker_status_update(request).await
+    }
 }
 #[cfg(any(test, feature = "testsuite"))]
 pub mod mock_compaction_service {
@@ -151,6 +211,12 @@ pub mod mock_compaction_service {
             request: super::PingRequest,
         ) -> crate::compaction::CompactionResult<super::PingResponse> {
             self.inner.lock().await.ping(request).await
+        }
+        async fn worker_status_update(
+            &self,
+            request: super::WorkerStatusUpdateRequest,
+        ) -> crate::compaction::CompactionResult<super::WorkerStatusUpdateResponse> {
+            self.inner.lock().await.worker_status_update(request).await
         }
     }
 }
@@ -173,6 +239,22 @@ impl tower::Service<PingRequest> for InnerCompactionServiceClient {
         Box::pin(fut)
     }
 }
+impl tower::Service<WorkerStatusUpdateRequest> for InnerCompactionServiceClient {
+    type Response = WorkerStatusUpdateResponse;
+    type Error = crate::compaction::CompactionError;
+    type Future = BoxFuture<Self::Response, Self::Error>;
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+    fn call(&mut self, request: WorkerStatusUpdateRequest) -> Self::Future {
+        let svc = self.clone();
+        let fut = async move { svc.0.worker_status_update(request).await };
+        Box::pin(fut)
+    }
+}
 /// A tower service stack is a set of tower services.
 #[derive(Debug)]
 struct CompactionServiceTowerServiceStack {
@@ -183,6 +265,11 @@ struct CompactionServiceTowerServiceStack {
         PingResponse,
         crate::compaction::CompactionError,
     >,
+    worker_status_update_svc: quickwit_common::tower::BoxService<
+        WorkerStatusUpdateRequest,
+        WorkerStatusUpdateResponse,
+        crate::compaction::CompactionError,
+    >,
 }
 #[async_trait::async_trait]
 impl CompactionService for CompactionServiceTowerServiceStack {
@@ -191,6 +278,12 @@ impl CompactionService for CompactionServiceTowerServiceStack {
         request: PingRequest,
     ) -> crate::compaction::CompactionResult<PingResponse> {
         self.ping_svc.clone().ready().await?.call(request).await
+    }
+    async fn worker_status_update(
+        &self,
+        request: WorkerStatusUpdateRequest,
+    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
+        self.worker_status_update_svc.clone().ready().await?.call(request).await
     }
 }
 type PingLayer = quickwit_common::tower::BoxLayer<
@@ -203,9 +296,20 @@ type PingLayer = quickwit_common::tower::BoxLayer<
     PingResponse,
     crate::compaction::CompactionError,
 >;
+type WorkerStatusUpdateLayer = quickwit_common::tower::BoxLayer<
+    quickwit_common::tower::BoxService<
+        WorkerStatusUpdateRequest,
+        WorkerStatusUpdateResponse,
+        crate::compaction::CompactionError,
+    >,
+    WorkerStatusUpdateRequest,
+    WorkerStatusUpdateResponse,
+    crate::compaction::CompactionError,
+>;
 #[derive(Debug, Default)]
 pub struct CompactionServiceTowerLayerStack {
     ping_layers: Vec<PingLayer>,
+    worker_status_update_layers: Vec<WorkerStatusUpdateLayer>,
 }
 impl CompactionServiceTowerLayerStack {
     pub fn stack_layer<L>(mut self, layer: L) -> Self
@@ -235,8 +339,37 @@ impl CompactionServiceTowerLayerStack {
                 crate::compaction::CompactionError,
             >,
         >>::Service as tower::Service<PingRequest>>::Future: Send + 'static,
+        L: tower::Layer<
+                quickwit_common::tower::BoxService<
+                    WorkerStatusUpdateRequest,
+                    WorkerStatusUpdateResponse,
+                    crate::compaction::CompactionError,
+                >,
+            > + Clone + Send + Sync + 'static,
+        <L as tower::Layer<
+            quickwit_common::tower::BoxService<
+                WorkerStatusUpdateRequest,
+                WorkerStatusUpdateResponse,
+                crate::compaction::CompactionError,
+            >,
+        >>::Service: tower::Service<
+                WorkerStatusUpdateRequest,
+                Response = WorkerStatusUpdateResponse,
+                Error = crate::compaction::CompactionError,
+            > + Clone + Send + Sync + 'static,
+        <<L as tower::Layer<
+            quickwit_common::tower::BoxService<
+                WorkerStatusUpdateRequest,
+                WorkerStatusUpdateResponse,
+                crate::compaction::CompactionError,
+            >,
+        >>::Service as tower::Service<
+            WorkerStatusUpdateRequest,
+        >>::Future: Send + 'static,
     {
         self.ping_layers.push(quickwit_common::tower::BoxLayer::new(layer.clone()));
+        self.worker_status_update_layers
+            .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self
     }
     pub fn stack_ping_layer<L>(mut self, layer: L) -> Self
@@ -256,6 +389,28 @@ impl CompactionServiceTowerLayerStack {
         <L::Service as tower::Service<PingRequest>>::Future: Send + 'static,
     {
         self.ping_layers.push(quickwit_common::tower::BoxLayer::new(layer));
+        self
+    }
+    pub fn stack_worker_status_update_layer<L>(mut self, layer: L) -> Self
+    where
+        L: tower::Layer<
+                quickwit_common::tower::BoxService<
+                    WorkerStatusUpdateRequest,
+                    WorkerStatusUpdateResponse,
+                    crate::compaction::CompactionError,
+                >,
+            > + Send + Sync + 'static,
+        L::Service: tower::Service<
+                WorkerStatusUpdateRequest,
+                Response = WorkerStatusUpdateResponse,
+                Error = crate::compaction::CompactionError,
+            > + Clone + Send + Sync + 'static,
+        <L::Service as tower::Service<
+            WorkerStatusUpdateRequest,
+        >>::Future: Send + 'static,
+    {
+        self.worker_status_update_layers
+            .push(quickwit_common::tower::BoxLayer::new(layer));
         self
     }
     pub fn build<T>(self, instance: T) -> CompactionServiceClient
@@ -329,9 +484,18 @@ impl CompactionServiceTowerLayerStack {
                 quickwit_common::tower::BoxService::new(inner_client.clone()),
                 |svc, layer| layer.layer(svc),
             );
+        let worker_status_update_svc = self
+            .worker_status_update_layers
+            .into_iter()
+            .rev()
+            .fold(
+                quickwit_common::tower::BoxService::new(inner_client.clone()),
+                |svc, layer| layer.layer(svc),
+            );
         let tower_svc_stack = CompactionServiceTowerServiceStack {
             inner: inner_client,
             ping_svc,
+            worker_status_update_svc,
         };
         CompactionServiceClient::new(tower_svc_stack)
     }
@@ -409,16 +573,31 @@ where
     CompactionServiceMailbox<
         A,
     >: tower::Service<
-        PingRequest,
-        Response = PingResponse,
-        Error = crate::compaction::CompactionError,
-        Future = BoxFuture<PingResponse, crate::compaction::CompactionError>,
-    >,
+            PingRequest,
+            Response = PingResponse,
+            Error = crate::compaction::CompactionError,
+            Future = BoxFuture<PingResponse, crate::compaction::CompactionError>,
+        >
+        + tower::Service<
+            WorkerStatusUpdateRequest,
+            Response = WorkerStatusUpdateResponse,
+            Error = crate::compaction::CompactionError,
+            Future = BoxFuture<
+                WorkerStatusUpdateResponse,
+                crate::compaction::CompactionError,
+            >,
+        >,
 {
     async fn ping(
         &self,
         request: PingRequest,
     ) -> crate::compaction::CompactionResult<PingResponse> {
+        self.clone().call(request).await
+    }
+    async fn worker_status_update(
+        &self,
+        request: WorkerStatusUpdateRequest,
+    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
         self.clone().call(request).await
     }
 }
@@ -470,6 +649,20 @@ where
                 PingRequest::rpc_name(),
             ))
     }
+    async fn worker_status_update(
+        &self,
+        request: WorkerStatusUpdateRequest,
+    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
+        self.inner
+            .clone()
+            .worker_status_update(request)
+            .await
+            .map(|response| response.into_inner())
+            .map_err(|status| crate::error::grpc_status_to_service_error(
+                status,
+                WorkerStatusUpdateRequest::rpc_name(),
+            ))
+    }
 }
 #[derive(Debug)]
 pub struct CompactionServiceGrpcServerAdapter {
@@ -495,6 +688,17 @@ for CompactionServiceGrpcServerAdapter {
         self.inner
             .0
             .ping(request.into_inner())
+            .await
+            .map(tonic::Response::new)
+            .map_err(crate::error::grpc_error_to_grpc_status)
+    }
+    async fn worker_status_update(
+        &self,
+        request: tonic::Request<WorkerStatusUpdateRequest>,
+    ) -> Result<tonic::Response<WorkerStatusUpdateResponse>, tonic::Status> {
+        self.inner
+            .0
+            .worker_status_update(request.into_inner())
             .await
             .map(tonic::Response::new)
             .map_err(crate::error::grpc_error_to_grpc_status)
@@ -614,6 +818,35 @@ pub mod compaction_service_grpc_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn worker_status_update(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WorkerStatusUpdateRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::WorkerStatusUpdateResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/quickwit.compaction.CompactionService/WorkerStatusUpdate",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "quickwit.compaction.CompactionService",
+                        "WorkerStatusUpdate",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -633,6 +866,13 @@ pub mod compaction_service_grpc_server {
             &self,
             request: tonic::Request<super::PingRequest>,
         ) -> std::result::Result<tonic::Response<super::PingResponse>, tonic::Status>;
+        async fn worker_status_update(
+            &self,
+            request: tonic::Request<super::WorkerStatusUpdateRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::WorkerStatusUpdateResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct CompactionServiceGrpcServer<T> {
@@ -740,6 +980,55 @@ pub mod compaction_service_grpc_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = PingSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/quickwit.compaction.CompactionService/WorkerStatusUpdate" => {
+                    #[allow(non_camel_case_types)]
+                    struct WorkerStatusUpdateSvc<T: CompactionServiceGrpc>(pub Arc<T>);
+                    impl<
+                        T: CompactionServiceGrpc,
+                    > tonic::server::UnaryService<super::WorkerStatusUpdateRequest>
+                    for WorkerStatusUpdateSvc<T> {
+                        type Response = super::WorkerStatusUpdateResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::WorkerStatusUpdateRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactionServiceGrpc>::worker_status_update(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = WorkerStatusUpdateSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.compaction.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.compaction.rs
@@ -7,21 +7,21 @@ pub struct PingRequest {}
 pub struct PingResponse {}
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct WorkerStatusUpdateRequest {
+pub struct ReportStatusRequest {
     #[prost(string, tag = "1")]
-    pub worker_id: ::prost::alloc::string::String,
+    pub node_id: ::prost::alloc::string::String,
     #[prost(uint32, tag = "2")]
     pub available_slots: u32,
     #[prost(message, repeated, tag = "3")]
-    pub in_progress_compactions: ::prost::alloc::vec::Vec<InProgressCompaction>,
+    pub in_progress: ::prost::alloc::vec::Vec<CompactionInProgress>,
     #[prost(message, repeated, tag = "4")]
-    pub completed_compactions: ::prost::alloc::vec::Vec<CompletedCompaction>,
+    pub successes: ::prost::alloc::vec::Vec<CompactionSuccess>,
     #[prost(message, repeated, tag = "5")]
-    pub failed_compactions: ::prost::alloc::vec::Vec<FailedCompaction>,
+    pub failures: ::prost::alloc::vec::Vec<CompactionFailure>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct InProgressCompaction {
+pub struct CompactionInProgress {
     #[prost(string, tag = "1")]
     pub task_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
@@ -33,7 +33,7 @@ pub struct InProgressCompaction {
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct CompletedCompaction {
+pub struct CompactionSuccess {
     #[prost(string, tag = "1")]
     pub task_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
@@ -41,7 +41,7 @@ pub struct CompletedCompaction {
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct FailedCompaction {
+pub struct CompactionFailure {
     #[prost(string, tag = "1")]
     pub task_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
@@ -49,7 +49,7 @@ pub struct FailedCompaction {
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct WorkerStatusUpdateResponse {}
+pub struct ReportStatusResponse {}
 /// BEGIN quickwit-codegen
 #[allow(unused_imports)]
 use std::str::FromStr;
@@ -60,52 +60,54 @@ impl RpcName for PingRequest {
         "ping"
     }
 }
-impl RpcName for WorkerStatusUpdateRequest {
+impl RpcName for ReportStatusRequest {
     fn rpc_name() -> &'static str {
-        "worker_status_update"
+        "report_status"
     }
 }
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait::async_trait]
-pub trait CompactionService: std::fmt::Debug + Send + Sync + 'static {
+pub trait CompactionPlannerService: std::fmt::Debug + Send + Sync + 'static {
     async fn ping(
         &self,
         request: PingRequest,
     ) -> crate::compaction::CompactionResult<PingResponse>;
-    async fn worker_status_update(
+    async fn report_status(
         &self,
-        request: WorkerStatusUpdateRequest,
-    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse>;
+        request: ReportStatusRequest,
+    ) -> crate::compaction::CompactionResult<ReportStatusResponse>;
 }
 #[derive(Debug, Clone)]
-pub struct CompactionServiceClient {
-    inner: InnerCompactionServiceClient,
+pub struct CompactionPlannerServiceClient {
+    inner: InnerCompactionPlannerServiceClient,
 }
 #[derive(Debug, Clone)]
-struct InnerCompactionServiceClient(std::sync::Arc<dyn CompactionService>);
-impl CompactionServiceClient {
+struct InnerCompactionPlannerServiceClient(std::sync::Arc<dyn CompactionPlannerService>);
+impl CompactionPlannerServiceClient {
     pub fn new<T>(instance: T) -> Self
     where
-        T: CompactionService,
+        T: CompactionPlannerService,
     {
         #[cfg(any(test, feature = "testsuite"))]
         assert!(
             std::any::TypeId::of:: < T > () != std::any::TypeId::of:: <
-            MockCompactionService > (),
-            "`MockCompactionService` must be wrapped in a `MockCompactionServiceWrapper`: use `CompactionServiceClient::from_mock(mock)` to instantiate the client"
+            MockCompactionPlannerService > (),
+            "`MockCompactionPlannerService` must be wrapped in a `MockCompactionPlannerServiceWrapper`: use `CompactionPlannerServiceClient::from_mock(mock)` to instantiate the client"
         );
         Self {
-            inner: InnerCompactionServiceClient(std::sync::Arc::new(instance)),
+            inner: InnerCompactionPlannerServiceClient(std::sync::Arc::new(instance)),
         }
     }
     pub fn as_grpc_service(
         &self,
         max_message_size: bytesize::ByteSize,
-    ) -> compaction_service_grpc_server::CompactionServiceGrpcServer<
-        CompactionServiceGrpcServerAdapter,
+    ) -> compaction_planner_service_grpc_server::CompactionPlannerServiceGrpcServer<
+        CompactionPlannerServiceGrpcServerAdapter,
     > {
-        let adapter = CompactionServiceGrpcServerAdapter::new(self.clone());
-        compaction_service_grpc_server::CompactionServiceGrpcServer::new(adapter)
+        let adapter = CompactionPlannerServiceGrpcServerAdapter::new(self.clone());
+        compaction_planner_service_grpc_server::CompactionPlannerServiceGrpcServer::new(
+                adapter,
+            )
             .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
             .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
             .send_compressed(tonic::codec::CompressionEncoding::Gzip)
@@ -122,7 +124,7 @@ impl CompactionServiceClient {
         let (_, connection_keys_watcher) = tokio::sync::watch::channel(
             std::collections::HashSet::from_iter([addr]),
         );
-        let mut client = compaction_service_grpc_client::CompactionServiceGrpcClient::new(
+        let mut client = compaction_planner_service_grpc_client::CompactionPlannerServiceGrpcClient::new(
                 channel,
             )
             .max_decoding_message_size(max_message_size.0 as usize)
@@ -132,7 +134,7 @@ impl CompactionServiceClient {
                 .accept_compressed(compression_encoding)
                 .send_compressed(compression_encoding);
         }
-        let adapter = CompactionServiceGrpcClientAdapter::new(
+        let adapter = CompactionPlannerServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,
         );
@@ -142,9 +144,9 @@ impl CompactionServiceClient {
         balance_channel: quickwit_common::tower::BalanceChannel<std::net::SocketAddr>,
         max_message_size: bytesize::ByteSize,
         compression_encoding_opt: Option<tonic::codec::CompressionEncoding>,
-    ) -> CompactionServiceClient {
+    ) -> CompactionPlannerServiceClient {
         let connection_keys_watcher = balance_channel.connection_keys_watcher();
-        let mut client = compaction_service_grpc_client::CompactionServiceGrpcClient::new(
+        let mut client = compaction_planner_service_grpc_client::CompactionPlannerServiceGrpcClient::new(
                 balance_channel,
             )
             .max_decoding_message_size(max_message_size.0 as usize)
@@ -154,7 +156,7 @@ impl CompactionServiceClient {
                 .accept_compressed(compression_encoding)
                 .send_compressed(compression_encoding);
         }
-        let adapter = CompactionServiceGrpcClientAdapter::new(
+        let adapter = CompactionPlannerServiceGrpcClientAdapter::new(
             client,
             connection_keys_watcher,
         );
@@ -163,67 +165,69 @@ impl CompactionServiceClient {
     pub fn from_mailbox<A>(mailbox: quickwit_actors::Mailbox<A>) -> Self
     where
         A: quickwit_actors::Actor + std::fmt::Debug + Send + 'static,
-        CompactionServiceMailbox<A>: CompactionService,
+        CompactionPlannerServiceMailbox<A>: CompactionPlannerService,
     {
-        CompactionServiceClient::new(CompactionServiceMailbox::new(mailbox))
+        CompactionPlannerServiceClient::new(
+            CompactionPlannerServiceMailbox::new(mailbox),
+        )
     }
-    pub fn tower() -> CompactionServiceTowerLayerStack {
-        CompactionServiceTowerLayerStack::default()
+    pub fn tower() -> CompactionPlannerServiceTowerLayerStack {
+        CompactionPlannerServiceTowerLayerStack::default()
     }
     #[cfg(any(test, feature = "testsuite"))]
-    pub fn from_mock(mock: MockCompactionService) -> Self {
-        let mock_wrapper = mock_compaction_service::MockCompactionServiceWrapper {
+    pub fn from_mock(mock: MockCompactionPlannerService) -> Self {
+        let mock_wrapper = mock_compaction_planner_service::MockCompactionPlannerServiceWrapper {
             inner: tokio::sync::Mutex::new(mock),
         };
         Self::new(mock_wrapper)
     }
     #[cfg(any(test, feature = "testsuite"))]
     pub fn mocked() -> Self {
-        Self::from_mock(MockCompactionService::new())
+        Self::from_mock(MockCompactionPlannerService::new())
     }
 }
 #[async_trait::async_trait]
-impl CompactionService for CompactionServiceClient {
+impl CompactionPlannerService for CompactionPlannerServiceClient {
     async fn ping(
         &self,
         request: PingRequest,
     ) -> crate::compaction::CompactionResult<PingResponse> {
         self.inner.0.ping(request).await
     }
-    async fn worker_status_update(
+    async fn report_status(
         &self,
-        request: WorkerStatusUpdateRequest,
-    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
-        self.inner.0.worker_status_update(request).await
+        request: ReportStatusRequest,
+    ) -> crate::compaction::CompactionResult<ReportStatusResponse> {
+        self.inner.0.report_status(request).await
     }
 }
 #[cfg(any(test, feature = "testsuite"))]
-pub mod mock_compaction_service {
+pub mod mock_compaction_planner_service {
     use super::*;
     #[derive(Debug)]
-    pub struct MockCompactionServiceWrapper {
-        pub(super) inner: tokio::sync::Mutex<MockCompactionService>,
+    pub struct MockCompactionPlannerServiceWrapper {
+        pub(super) inner: tokio::sync::Mutex<MockCompactionPlannerService>,
     }
     #[async_trait::async_trait]
-    impl CompactionService for MockCompactionServiceWrapper {
+    impl CompactionPlannerService for MockCompactionPlannerServiceWrapper {
         async fn ping(
             &self,
             request: super::PingRequest,
         ) -> crate::compaction::CompactionResult<super::PingResponse> {
             self.inner.lock().await.ping(request).await
         }
-        async fn worker_status_update(
+        async fn report_status(
             &self,
-            request: super::WorkerStatusUpdateRequest,
-        ) -> crate::compaction::CompactionResult<super::WorkerStatusUpdateResponse> {
-            self.inner.lock().await.worker_status_update(request).await
+            request: super::ReportStatusRequest,
+        ) -> crate::compaction::CompactionResult<super::ReportStatusResponse> {
+            self.inner.lock().await.report_status(request).await
         }
     }
 }
 pub type BoxFuture<T, E> = std::pin::Pin<
     Box<dyn std::future::Future<Output = Result<T, E>> + Send + 'static>,
 >;
-impl tower::Service<PingRequest> for InnerCompactionServiceClient {
+impl tower::Service<PingRequest> for InnerCompactionPlannerServiceClient {
     type Response = PingResponse;
     type Error = crate::compaction::CompactionError;
     type Future = BoxFuture<Self::Response, Self::Error>;
@@ -239,8 +243,8 @@ impl tower::Service<PingRequest> for InnerCompactionServiceClient {
         Box::pin(fut)
     }
 }
-impl tower::Service<WorkerStatusUpdateRequest> for InnerCompactionServiceClient {
-    type Response = WorkerStatusUpdateResponse;
+impl tower::Service<ReportStatusRequest> for InnerCompactionPlannerServiceClient {
+    type Response = ReportStatusResponse;
     type Error = crate::compaction::CompactionError;
     type Future = BoxFuture<Self::Response, Self::Error>;
     fn poll_ready(
@@ -249,41 +253,41 @@ impl tower::Service<WorkerStatusUpdateRequest> for InnerCompactionServiceClient 
     ) -> std::task::Poll<Result<(), Self::Error>> {
         std::task::Poll::Ready(Ok(()))
     }
-    fn call(&mut self, request: WorkerStatusUpdateRequest) -> Self::Future {
+    fn call(&mut self, request: ReportStatusRequest) -> Self::Future {
         let svc = self.clone();
-        let fut = async move { svc.0.worker_status_update(request).await };
+        let fut = async move { svc.0.report_status(request).await };
         Box::pin(fut)
     }
 }
 /// A tower service stack is a set of tower services.
 #[derive(Debug)]
-struct CompactionServiceTowerServiceStack {
+struct CompactionPlannerServiceTowerServiceStack {
     #[allow(dead_code)]
-    inner: InnerCompactionServiceClient,
+    inner: InnerCompactionPlannerServiceClient,
     ping_svc: quickwit_common::tower::BoxService<
         PingRequest,
         PingResponse,
         crate::compaction::CompactionError,
     >,
-    worker_status_update_svc: quickwit_common::tower::BoxService<
-        WorkerStatusUpdateRequest,
-        WorkerStatusUpdateResponse,
+    report_status_svc: quickwit_common::tower::BoxService<
+        ReportStatusRequest,
+        ReportStatusResponse,
         crate::compaction::CompactionError,
     >,
 }
 #[async_trait::async_trait]
-impl CompactionService for CompactionServiceTowerServiceStack {
+impl CompactionPlannerService for CompactionPlannerServiceTowerServiceStack {
     async fn ping(
         &self,
         request: PingRequest,
     ) -> crate::compaction::CompactionResult<PingResponse> {
         self.ping_svc.clone().ready().await?.call(request).await
     }
-    async fn worker_status_update(
+    async fn report_status(
         &self,
-        request: WorkerStatusUpdateRequest,
-    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
-        self.worker_status_update_svc.clone().ready().await?.call(request).await
+        request: ReportStatusRequest,
+    ) -> crate::compaction::CompactionResult<ReportStatusResponse> {
+        self.report_status_svc.clone().ready().await?.call(request).await
     }
 }
 type PingLayer = quickwit_common::tower::BoxLayer<
@@ -296,22 +300,22 @@ type PingLayer = quickwit_common::tower::BoxLayer<
     PingResponse,
     crate::compaction::CompactionError,
 >;
-type WorkerStatusUpdateLayer = quickwit_common::tower::BoxLayer<
+type ReportStatusLayer = quickwit_common::tower::BoxLayer<
     quickwit_common::tower::BoxService<
-        WorkerStatusUpdateRequest,
-        WorkerStatusUpdateResponse,
+        ReportStatusRequest,
+        ReportStatusResponse,
         crate::compaction::CompactionError,
     >,
-    WorkerStatusUpdateRequest,
-    WorkerStatusUpdateResponse,
+    ReportStatusRequest,
+    ReportStatusResponse,
     crate::compaction::CompactionError,
 >;
 #[derive(Debug, Default)]
-pub struct CompactionServiceTowerLayerStack {
+pub struct CompactionPlannerServiceTowerLayerStack {
     ping_layers: Vec<PingLayer>,
-    worker_status_update_layers: Vec<WorkerStatusUpdateLayer>,
+    report_status_layers: Vec<ReportStatusLayer>,
 }
-impl CompactionServiceTowerLayerStack {
+impl CompactionPlannerServiceTowerLayerStack {
     pub fn stack_layer<L>(mut self, layer: L) -> Self
     where
         L: tower::Layer<
@@ -341,34 +345,32 @@ impl CompactionServiceTowerLayerStack {
         >>::Service as tower::Service<PingRequest>>::Future: Send + 'static,
         L: tower::Layer<
                 quickwit_common::tower::BoxService<
-                    WorkerStatusUpdateRequest,
-                    WorkerStatusUpdateResponse,
+                    ReportStatusRequest,
+                    ReportStatusResponse,
                     crate::compaction::CompactionError,
                 >,
             > + Clone + Send + Sync + 'static,
         <L as tower::Layer<
             quickwit_common::tower::BoxService<
-                WorkerStatusUpdateRequest,
-                WorkerStatusUpdateResponse,
+                ReportStatusRequest,
+                ReportStatusResponse,
                 crate::compaction::CompactionError,
             >,
         >>::Service: tower::Service<
-                WorkerStatusUpdateRequest,
-                Response = WorkerStatusUpdateResponse,
+                ReportStatusRequest,
+                Response = ReportStatusResponse,
                 Error = crate::compaction::CompactionError,
             > + Clone + Send + Sync + 'static,
         <<L as tower::Layer<
             quickwit_common::tower::BoxService<
-                WorkerStatusUpdateRequest,
-                WorkerStatusUpdateResponse,
+                ReportStatusRequest,
+                ReportStatusResponse,
                 crate::compaction::CompactionError,
             >,
-        >>::Service as tower::Service<
-            WorkerStatusUpdateRequest,
-        >>::Future: Send + 'static,
+        >>::Service as tower::Service<ReportStatusRequest>>::Future: Send + 'static,
     {
         self.ping_layers.push(quickwit_common::tower::BoxLayer::new(layer.clone()));
-        self.worker_status_update_layers
+        self.report_status_layers
             .push(quickwit_common::tower::BoxLayer::new(layer.clone()));
         self
     }
@@ -391,33 +393,32 @@ impl CompactionServiceTowerLayerStack {
         self.ping_layers.push(quickwit_common::tower::BoxLayer::new(layer));
         self
     }
-    pub fn stack_worker_status_update_layer<L>(mut self, layer: L) -> Self
+    pub fn stack_report_status_layer<L>(mut self, layer: L) -> Self
     where
         L: tower::Layer<
                 quickwit_common::tower::BoxService<
-                    WorkerStatusUpdateRequest,
-                    WorkerStatusUpdateResponse,
+                    ReportStatusRequest,
+                    ReportStatusResponse,
                     crate::compaction::CompactionError,
                 >,
             > + Send + Sync + 'static,
         L::Service: tower::Service<
-                WorkerStatusUpdateRequest,
-                Response = WorkerStatusUpdateResponse,
+                ReportStatusRequest,
+                Response = ReportStatusResponse,
                 Error = crate::compaction::CompactionError,
             > + Clone + Send + Sync + 'static,
-        <L::Service as tower::Service<
-            WorkerStatusUpdateRequest,
-        >>::Future: Send + 'static,
+        <L::Service as tower::Service<ReportStatusRequest>>::Future: Send + 'static,
     {
-        self.worker_status_update_layers
-            .push(quickwit_common::tower::BoxLayer::new(layer));
+        self.report_status_layers.push(quickwit_common::tower::BoxLayer::new(layer));
         self
     }
-    pub fn build<T>(self, instance: T) -> CompactionServiceClient
+    pub fn build<T>(self, instance: T) -> CompactionPlannerServiceClient
     where
-        T: CompactionService,
+        T: CompactionPlannerService,
     {
-        let inner_client = InnerCompactionServiceClient(std::sync::Arc::new(instance));
+        let inner_client = InnerCompactionPlannerServiceClient(
+            std::sync::Arc::new(instance),
+        );
         self.build_from_inner_client(inner_client)
     }
     pub fn build_from_channel(
@@ -426,8 +427,8 @@ impl CompactionServiceTowerLayerStack {
         channel: tonic::transport::Channel,
         max_message_size: bytesize::ByteSize,
         compression_encoding_opt: Option<tonic::codec::CompressionEncoding>,
-    ) -> CompactionServiceClient {
-        let client = CompactionServiceClient::from_channel(
+    ) -> CompactionPlannerServiceClient {
+        let client = CompactionPlannerServiceClient::from_channel(
             addr,
             channel,
             max_message_size,
@@ -441,8 +442,8 @@ impl CompactionServiceTowerLayerStack {
         balance_channel: quickwit_common::tower::BalanceChannel<std::net::SocketAddr>,
         max_message_size: bytesize::ByteSize,
         compression_encoding_opt: Option<tonic::codec::CompressionEncoding>,
-    ) -> CompactionServiceClient {
-        let client = CompactionServiceClient::from_balance_channel(
+    ) -> CompactionPlannerServiceClient {
+        let client = CompactionPlannerServiceClient::from_balance_channel(
             balance_channel,
             max_message_size,
             compression_encoding_opt,
@@ -453,29 +454,29 @@ impl CompactionServiceTowerLayerStack {
     pub fn build_from_mailbox<A>(
         self,
         mailbox: quickwit_actors::Mailbox<A>,
-    ) -> CompactionServiceClient
+    ) -> CompactionPlannerServiceClient
     where
         A: quickwit_actors::Actor + std::fmt::Debug + Send + 'static,
-        CompactionServiceMailbox<A>: CompactionService,
+        CompactionPlannerServiceMailbox<A>: CompactionPlannerService,
     {
-        let inner_client = InnerCompactionServiceClient(
-            std::sync::Arc::new(CompactionServiceMailbox::new(mailbox)),
+        let inner_client = InnerCompactionPlannerServiceClient(
+            std::sync::Arc::new(CompactionPlannerServiceMailbox::new(mailbox)),
         );
         self.build_from_inner_client(inner_client)
     }
     #[cfg(any(test, feature = "testsuite"))]
     pub fn build_from_mock(
         self,
-        mock: MockCompactionService,
-    ) -> CompactionServiceClient {
-        let client = CompactionServiceClient::from_mock(mock);
+        mock: MockCompactionPlannerService,
+    ) -> CompactionPlannerServiceClient {
+        let client = CompactionPlannerServiceClient::from_mock(mock);
         let inner_client = client.inner;
         self.build_from_inner_client(inner_client)
     }
     fn build_from_inner_client(
         self,
-        inner_client: InnerCompactionServiceClient,
-    ) -> CompactionServiceClient {
+        inner_client: InnerCompactionPlannerServiceClient,
+    ) -> CompactionPlannerServiceClient {
         let ping_svc = self
             .ping_layers
             .into_iter()
@@ -484,20 +485,20 @@ impl CompactionServiceTowerLayerStack {
                 quickwit_common::tower::BoxService::new(inner_client.clone()),
                 |svc, layer| layer.layer(svc),
             );
-        let worker_status_update_svc = self
-            .worker_status_update_layers
+        let report_status_svc = self
+            .report_status_layers
             .into_iter()
             .rev()
             .fold(
                 quickwit_common::tower::BoxService::new(inner_client.clone()),
                 |svc, layer| layer.layer(svc),
             );
-        let tower_svc_stack = CompactionServiceTowerServiceStack {
+        let tower_svc_stack = CompactionPlannerServiceTowerServiceStack {
             inner: inner_client,
             ping_svc,
-            worker_status_update_svc,
+            report_status_svc,
         };
-        CompactionServiceClient::new(tower_svc_stack)
+        CompactionPlannerServiceClient::new(tower_svc_stack)
     }
 }
 #[derive(Debug, Clone)]
@@ -515,10 +516,10 @@ where
     }
 }
 #[derive(Debug)]
-pub struct CompactionServiceMailbox<A: quickwit_actors::Actor> {
+pub struct CompactionPlannerServiceMailbox<A: quickwit_actors::Actor> {
     inner: MailboxAdapter<A, crate::compaction::CompactionError>,
 }
-impl<A: quickwit_actors::Actor> CompactionServiceMailbox<A> {
+impl<A: quickwit_actors::Actor> CompactionPlannerServiceMailbox<A> {
     pub fn new(instance: quickwit_actors::Mailbox<A>) -> Self {
         let inner = MailboxAdapter {
             inner: instance,
@@ -527,7 +528,7 @@ impl<A: quickwit_actors::Actor> CompactionServiceMailbox<A> {
         Self { inner }
     }
 }
-impl<A: quickwit_actors::Actor> Clone for CompactionServiceMailbox<A> {
+impl<A: quickwit_actors::Actor> Clone for CompactionPlannerServiceMailbox<A> {
     fn clone(&self) -> Self {
         let inner = MailboxAdapter {
             inner: self.inner.clone(),
@@ -536,7 +537,7 @@ impl<A: quickwit_actors::Actor> Clone for CompactionServiceMailbox<A> {
         Self { inner }
     }
 }
-impl<A, M, T, E> tower::Service<M> for CompactionServiceMailbox<A>
+impl<A, M, T, E> tower::Service<M> for CompactionPlannerServiceMailbox<A>
 where
     A: quickwit_actors::Actor
         + quickwit_actors::DeferableReplyHandler<M, Reply = Result<T, E>> + Send
@@ -567,10 +568,10 @@ where
     }
 }
 #[async_trait::async_trait]
-impl<A> CompactionService for CompactionServiceMailbox<A>
+impl<A> CompactionPlannerService for CompactionPlannerServiceMailbox<A>
 where
     A: quickwit_actors::Actor + std::fmt::Debug,
-    CompactionServiceMailbox<
+    CompactionPlannerServiceMailbox<
         A,
     >: tower::Service<
             PingRequest,
@@ -579,13 +580,10 @@ where
             Future = BoxFuture<PingResponse, crate::compaction::CompactionError>,
         >
         + tower::Service<
-            WorkerStatusUpdateRequest,
-            Response = WorkerStatusUpdateResponse,
+            ReportStatusRequest,
+            Response = ReportStatusResponse,
             Error = crate::compaction::CompactionError,
-            Future = BoxFuture<
-                WorkerStatusUpdateResponse,
-                crate::compaction::CompactionError,
-            >,
+            Future = BoxFuture<ReportStatusResponse, crate::compaction::CompactionError>,
         >,
 {
     async fn ping(
@@ -594,22 +592,22 @@ where
     ) -> crate::compaction::CompactionResult<PingResponse> {
         self.clone().call(request).await
     }
-    async fn worker_status_update(
+    async fn report_status(
         &self,
-        request: WorkerStatusUpdateRequest,
-    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
+        request: ReportStatusRequest,
+    ) -> crate::compaction::CompactionResult<ReportStatusResponse> {
         self.clone().call(request).await
     }
 }
 #[derive(Debug, Clone)]
-pub struct CompactionServiceGrpcClientAdapter<T> {
+pub struct CompactionPlannerServiceGrpcClientAdapter<T> {
     inner: T,
     #[allow(dead_code)]
     connection_addrs_rx: tokio::sync::watch::Receiver<
         std::collections::HashSet<std::net::SocketAddr>,
     >,
 }
-impl<T> CompactionServiceGrpcClientAdapter<T> {
+impl<T> CompactionPlannerServiceGrpcClientAdapter<T> {
     pub fn new(
         instance: T,
         connection_addrs_rx: tokio::sync::watch::Receiver<
@@ -623,9 +621,9 @@ impl<T> CompactionServiceGrpcClientAdapter<T> {
     }
 }
 #[async_trait::async_trait]
-impl<T> CompactionService
-for CompactionServiceGrpcClientAdapter<
-    compaction_service_grpc_client::CompactionServiceGrpcClient<T>,
+impl<T> CompactionPlannerService
+for CompactionPlannerServiceGrpcClientAdapter<
+    compaction_planner_service_grpc_client::CompactionPlannerServiceGrpcClient<T>,
 >
 where
     T: tonic::client::GrpcService<tonic::body::Body> + std::fmt::Debug + Clone + Send
@@ -649,38 +647,38 @@ where
                 PingRequest::rpc_name(),
             ))
     }
-    async fn worker_status_update(
+    async fn report_status(
         &self,
-        request: WorkerStatusUpdateRequest,
-    ) -> crate::compaction::CompactionResult<WorkerStatusUpdateResponse> {
+        request: ReportStatusRequest,
+    ) -> crate::compaction::CompactionResult<ReportStatusResponse> {
         self.inner
             .clone()
-            .worker_status_update(request)
+            .report_status(request)
             .await
             .map(|response| response.into_inner())
             .map_err(|status| crate::error::grpc_status_to_service_error(
                 status,
-                WorkerStatusUpdateRequest::rpc_name(),
+                ReportStatusRequest::rpc_name(),
             ))
     }
 }
 #[derive(Debug)]
-pub struct CompactionServiceGrpcServerAdapter {
-    inner: InnerCompactionServiceClient,
+pub struct CompactionPlannerServiceGrpcServerAdapter {
+    inner: InnerCompactionPlannerServiceClient,
 }
-impl CompactionServiceGrpcServerAdapter {
+impl CompactionPlannerServiceGrpcServerAdapter {
     pub fn new<T>(instance: T) -> Self
     where
-        T: CompactionService,
+        T: CompactionPlannerService,
     {
         Self {
-            inner: InnerCompactionServiceClient(std::sync::Arc::new(instance)),
+            inner: InnerCompactionPlannerServiceClient(std::sync::Arc::new(instance)),
         }
     }
 }
 #[async_trait::async_trait]
-impl compaction_service_grpc_server::CompactionServiceGrpc
-for CompactionServiceGrpcServerAdapter {
+impl compaction_planner_service_grpc_server::CompactionPlannerServiceGrpc
+for CompactionPlannerServiceGrpcServerAdapter {
     async fn ping(
         &self,
         request: tonic::Request<PingRequest>,
@@ -692,20 +690,20 @@ for CompactionServiceGrpcServerAdapter {
             .map(tonic::Response::new)
             .map_err(crate::error::grpc_error_to_grpc_status)
     }
-    async fn worker_status_update(
+    async fn report_status(
         &self,
-        request: tonic::Request<WorkerStatusUpdateRequest>,
-    ) -> Result<tonic::Response<WorkerStatusUpdateResponse>, tonic::Status> {
+        request: tonic::Request<ReportStatusRequest>,
+    ) -> Result<tonic::Response<ReportStatusResponse>, tonic::Status> {
         self.inner
             .0
-            .worker_status_update(request.into_inner())
+            .report_status(request.into_inner())
             .await
             .map(tonic::Response::new)
             .map_err(crate::error::grpc_error_to_grpc_status)
     }
 }
 /// Generated client implementations.
-pub mod compaction_service_grpc_client {
+pub mod compaction_planner_service_grpc_client {
     #![allow(
         unused_variables,
         dead_code,
@@ -716,10 +714,10 @@ pub mod compaction_service_grpc_client {
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
-    pub struct CompactionServiceGrpcClient<T> {
+    pub struct CompactionPlannerServiceGrpcClient<T> {
         inner: tonic::client::Grpc<T>,
     }
-    impl CompactionServiceGrpcClient<tonic::transport::Channel> {
+    impl CompactionPlannerServiceGrpcClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
@@ -730,7 +728,7 @@ pub mod compaction_service_grpc_client {
             Ok(Self::new(conn))
         }
     }
-    impl<T> CompactionServiceGrpcClient<T>
+    impl<T> CompactionPlannerServiceGrpcClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
@@ -748,7 +746,7 @@ pub mod compaction_service_grpc_client {
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
-        ) -> CompactionServiceGrpcClient<InterceptedService<T, F>>
+        ) -> CompactionPlannerServiceGrpcClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -762,7 +760,9 @@ pub mod compaction_service_grpc_client {
                 http::Request<tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
-            CompactionServiceGrpcClient::new(InterceptedService::new(inner, interceptor))
+            CompactionPlannerServiceGrpcClient::new(
+                InterceptedService::new(inner, interceptor),
+            )
         }
         /// Compress requests with the given encoding.
         ///
@@ -809,20 +809,23 @@ pub mod compaction_service_grpc_client {
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/quickwit.compaction.CompactionService/Ping",
+                "/quickwit.compaction.CompactionPlannerService/Ping",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
-                    GrpcMethod::new("quickwit.compaction.CompactionService", "Ping"),
+                    GrpcMethod::new(
+                        "quickwit.compaction.CompactionPlannerService",
+                        "Ping",
+                    ),
                 );
             self.inner.unary(req, path, codec).await
         }
-        pub async fn worker_status_update(
+        pub async fn report_status(
             &mut self,
-            request: impl tonic::IntoRequest<super::WorkerStatusUpdateRequest>,
+            request: impl tonic::IntoRequest<super::ReportStatusRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::WorkerStatusUpdateResponse>,
+            tonic::Response<super::ReportStatusResponse>,
             tonic::Status,
         > {
             self.inner
@@ -835,14 +838,14 @@ pub mod compaction_service_grpc_client {
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/quickwit.compaction.CompactionService/WorkerStatusUpdate",
+                "/quickwit.compaction.CompactionPlannerService/ReportStatus",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
-                        "quickwit.compaction.CompactionService",
-                        "WorkerStatusUpdate",
+                        "quickwit.compaction.CompactionPlannerService",
+                        "ReportStatus",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -850,7 +853,7 @@ pub mod compaction_service_grpc_client {
     }
 }
 /// Generated server implementations.
-pub mod compaction_service_grpc_server {
+pub mod compaction_planner_service_grpc_server {
     #![allow(
         unused_variables,
         dead_code,
@@ -859,30 +862,30 @@ pub mod compaction_service_grpc_server {
         clippy::let_unit_value,
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with CompactionServiceGrpcServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with CompactionPlannerServiceGrpcServer.
     #[async_trait]
-    pub trait CompactionServiceGrpc: std::marker::Send + std::marker::Sync + 'static {
+    pub trait CompactionPlannerServiceGrpc: std::marker::Send + std::marker::Sync + 'static {
         async fn ping(
             &self,
             request: tonic::Request<super::PingRequest>,
         ) -> std::result::Result<tonic::Response<super::PingResponse>, tonic::Status>;
-        async fn worker_status_update(
+        async fn report_status(
             &self,
-            request: tonic::Request<super::WorkerStatusUpdateRequest>,
+            request: tonic::Request<super::ReportStatusRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::WorkerStatusUpdateResponse>,
+            tonic::Response<super::ReportStatusResponse>,
             tonic::Status,
         >;
     }
     #[derive(Debug)]
-    pub struct CompactionServiceGrpcServer<T> {
+    pub struct CompactionPlannerServiceGrpcServer<T> {
         inner: Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
         max_encoding_message_size: Option<usize>,
     }
-    impl<T> CompactionServiceGrpcServer<T> {
+    impl<T> CompactionPlannerServiceGrpcServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -934,9 +937,9 @@ pub mod compaction_service_grpc_server {
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>>
-    for CompactionServiceGrpcServer<T>
+    for CompactionPlannerServiceGrpcServer<T>
     where
-        T: CompactionServiceGrpc,
+        T: CompactionPlannerServiceGrpc,
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
@@ -951,11 +954,11 @@ pub mod compaction_service_grpc_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
-                "/quickwit.compaction.CompactionService/Ping" => {
+                "/quickwit.compaction.CompactionPlannerService/Ping" => {
                     #[allow(non_camel_case_types)]
-                    struct PingSvc<T: CompactionServiceGrpc>(pub Arc<T>);
+                    struct PingSvc<T: CompactionPlannerServiceGrpc>(pub Arc<T>);
                     impl<
-                        T: CompactionServiceGrpc,
+                        T: CompactionPlannerServiceGrpc,
                     > tonic::server::UnaryService<super::PingRequest> for PingSvc<T> {
                         type Response = super::PingResponse;
                         type Future = BoxFuture<
@@ -968,7 +971,8 @@ pub mod compaction_service_grpc_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactionServiceGrpc>::ping(&inner, request).await
+                                <T as CompactionPlannerServiceGrpc>::ping(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -995,25 +999,25 @@ pub mod compaction_service_grpc_server {
                     };
                     Box::pin(fut)
                 }
-                "/quickwit.compaction.CompactionService/WorkerStatusUpdate" => {
+                "/quickwit.compaction.CompactionPlannerService/ReportStatus" => {
                     #[allow(non_camel_case_types)]
-                    struct WorkerStatusUpdateSvc<T: CompactionServiceGrpc>(pub Arc<T>);
+                    struct ReportStatusSvc<T: CompactionPlannerServiceGrpc>(pub Arc<T>);
                     impl<
-                        T: CompactionServiceGrpc,
-                    > tonic::server::UnaryService<super::WorkerStatusUpdateRequest>
-                    for WorkerStatusUpdateSvc<T> {
-                        type Response = super::WorkerStatusUpdateResponse;
+                        T: CompactionPlannerServiceGrpc,
+                    > tonic::server::UnaryService<super::ReportStatusRequest>
+                    for ReportStatusSvc<T> {
+                        type Response = super::ReportStatusResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::WorkerStatusUpdateRequest>,
+                            request: tonic::Request<super::ReportStatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactionServiceGrpc>::worker_status_update(
+                                <T as CompactionPlannerServiceGrpc>::report_status(
                                         &inner,
                                         request,
                                     )
@@ -1028,7 +1032,7 @@ pub mod compaction_service_grpc_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = WorkerStatusUpdateSvc(inner);
+                        let method = ReportStatusSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -1066,7 +1070,7 @@ pub mod compaction_service_grpc_server {
             }
         }
     }
-    impl<T> Clone for CompactionServiceGrpcServer<T> {
+    impl<T> Clone for CompactionPlannerServiceGrpcServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -1079,8 +1083,8 @@ pub mod compaction_service_grpc_server {
         }
     }
     /// Generated gRPC service name
-    pub const SERVICE_NAME: &str = "quickwit.compaction.CompactionService";
-    impl<T> tonic::server::NamedService for CompactionServiceGrpcServer<T> {
+    pub const SERVICE_NAME: &str = "quickwit.compaction.CompactionPlannerService";
+    impl<T> tonic::server::NamedService for CompactionPlannerServiceGrpcServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/quickwit/quickwit-proto/src/indexing/mod.rs
+++ b/quickwit/quickwit-proto/src/indexing/mod.rs
@@ -138,6 +138,7 @@ impl Display for IndexingPipelineId {
 /// Uniquely identifies a merge pipeline. There exists at most one merge pipeline per
 /// `(index_uid, source_id)` running on indexer at any given time fed by one or more indexing
 /// pipelines.
+/// TODO: Rework/remove this as part of splitting up merges.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct MergePipelineId {
     pub node_id: NodeId,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -591,7 +591,7 @@ pub async fn serve_quickwit(
     // Set up the "control plane proxy" for the metastore.
     let metastore_through_control_plane = MetastoreServiceClient::new(ControlPlaneMetastore::new(
         control_plane_client.clone(),
-        metastore_client,
+        metastore_client.clone(),
     ));
 
     // Setup ingest service v1.
@@ -791,14 +791,20 @@ pub async fn serve_quickwit(
         let compaction_root_directory = quickwit_common::temp_dir::Builder::default()
             .tempdir_in(&compaction_dir)
             .context("failed to create compaction temp directory")?;
+        // TODO: Real split store
         let split_store = IndexingSplitStore::create_without_local_store_for_test(Arc::new(
             RamStorage::default(),
         ));
+        let compaction_client = compaction_service_client_opt
+            .clone()
+            .expect("compactor service enabled but no compaction client available");
         let compactor_mailbox = start_compactor_service(
             &universe,
+            cluster.self_node_id().into(),
+            compaction_client,
             &node_config.compactor_config,
             split_store,
-            metastore_through_control_plane.clone(),
+            metastore_client.clone(),
             storage_resolver.clone(),
             event_broker.clone(),
             compaction_root_directory,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -72,7 +72,7 @@ use quickwit_common::tower::{
 };
 use quickwit_common::uri::Uri;
 use quickwit_common::{get_bool_from_env, spawn_named_task};
-use quickwit_compaction::planner::StubCompactionService;
+use quickwit_compaction::planner::StubCompactionPlannerService;
 use quickwit_compaction::{CompactorSupervisor, start_compactor_service};
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig};
@@ -95,7 +95,7 @@ use quickwit_metastore::{
     ControlPlaneMetastore, ListIndexesMetadataResponseExt, MetastoreResolver,
 };
 use quickwit_opentelemetry::otlp::{OtlpGrpcLogsService, OtlpGrpcTracesService};
-use quickwit_proto::compaction::CompactionServiceClient;
+use quickwit_proto::compaction::CompactionPlannerServiceClient;
 use quickwit_proto::control_plane::ControlPlaneServiceClient;
 use quickwit_proto::indexing::{IndexingServiceClient, ShardPositionsUpdate};
 use quickwit_proto::ingest::ingester::{
@@ -203,7 +203,7 @@ struct QuickwitServices {
     pub ingest_router_service: IngestRouterServiceClient,
     ingester_opt: Option<Ingester>,
 
-    pub compaction_service_client_opt: Option<CompactionServiceClient>,
+    pub compaction_service_client_opt: Option<CompactionPlannerServiceClient>,
     pub _compactor_supervisor_opt: Option<Mailbox<CompactorSupervisor>>,
     pub janitor_service_opt: Option<Mailbox<JanitorService>>,
     pub jaeger_service_opt: Option<JaegerService>,
@@ -271,28 +271,22 @@ async fn balance_channel_for_service(
     BalanceChannel::from_stream(service_change_stream)
 }
 
-/// Builds a `CompactionServiceClient` if the compaction service is available.
+/// Builds a `CompactionPlannerServiceClient` if the node runs the compactor.
 ///
-/// On janitor nodes with `QW_ENABLE_COMPACTION_SERVICE=true`, wraps a local stub.
-/// On non-janitor nodes with the flag set, waits up to 10s for a remote janitor
-/// exposing the gRPC endpoint and logs an error if none is found.
-async fn get_compaction_service_client_if_needed(
+/// On janitor+compactor nodes, wraps a local `StubCompactionPlannerService`.
+/// On compactor-only nodes, connects to a remote janitor via gRPC.
+async fn get_compaction_planner_client_if_needed(
     node_config: &NodeConfig,
     cluster: &Cluster,
-) -> anyhow::Result<Option<CompactionServiceClient>, anyhow::Error> {
-    if !node_config.indexer_config.enable_standalone_compactors {
+) -> anyhow::Result<Option<CompactionPlannerServiceClient>, anyhow::Error> {
+    if !node_config.is_service_enabled(QuickwitService::Compactor) {
         return Ok(None);
     }
-    // Only janitor nodes (which host the planner) and indexer nodes (which need
-    // to know whether to spawn local merge pipelines) care about this service.
-    if !node_config.is_service_enabled(QuickwitService::Indexer) {
-        return Ok(None);
-    }
-    if node_config.is_service_enabled(QuickwitService::Janitor)
-        && node_config.is_service_enabled(QuickwitService::Indexer)
-    {
-        info!("compaction service enabled on this node");
-        return Ok(Some(CompactionServiceClient::new(StubCompactionService)));
+    if node_config.is_service_enabled(QuickwitService::Janitor) {
+        info!("compaction planner service enabled on this node");
+        return Ok(Some(CompactionPlannerServiceClient::new(
+            StubCompactionPlannerService,
+        )));
     }
     let balance_channel = balance_channel_for_service(cluster, QuickwitService::Janitor).await;
     let found = balance_channel
@@ -301,10 +295,10 @@ async fn get_compaction_service_client_if_needed(
         })
         .await;
     if !found {
-        bail!("compaction service is enabled but no janitor node was found in the cluster")
+        bail!("compactor is enabled but no janitor node was found in the cluster")
     }
-    info!("remote compaction service detected on janitor node");
-    Ok(Some(CompactionServiceClient::from_balance_channel(
+    info!("remote compaction planner detected on janitor node");
+    Ok(Some(CompactionPlannerServiceClient::from_balance_channel(
         balance_channel,
         node_config.grpc_config.max_message_size,
         None,
@@ -600,12 +594,12 @@ pub async fn serve_quickwit(
         .context("failed to start ingest v1 service")?;
 
     let compaction_service_client_opt =
-        get_compaction_service_client_if_needed(&node_config, &cluster)
+        get_compaction_planner_client_if_needed(&node_config, &cluster)
             .await
             .context("failed to initialize compaction service client")?;
 
     let indexing_service_opt = if node_config.is_service_enabled(QuickwitService::Indexer) {
-        let merge_scheduler_mailbox_opt = if compaction_service_client_opt.is_none() {
+        let merge_scheduler_mailbox_opt = if !node_config.indexer_config.enable_standalone_compactors {
             Some(spawn_merge_scheduler_service(&universe, &node_config))
         } else {
             None
@@ -1923,18 +1917,22 @@ mod tests {
                 .await
                 .unwrap();
 
-        // Without standalone compactors, no compaction service.
+        // Without compactor service enabled, no planner client.
         let mut node_config = NodeConfig::for_test();
         node_config.enabled_services =
             HashSet::from([QuickwitService::Janitor, QuickwitService::Indexer]);
-        let result = get_compaction_service_client_if_needed(&node_config, &cluster)
+        let result = get_compaction_planner_client_if_needed(&node_config, &cluster)
             .await
             .unwrap();
         assert!(result.is_none());
 
-        // With standalone compactors enabled, compaction service client is returned.
-        node_config.indexer_config.enable_standalone_compactors = true;
-        let result = get_compaction_service_client_if_needed(&node_config, &cluster)
+        // With compactor + janitor enabled, planner client is returned (local stub).
+        node_config.enabled_services = HashSet::from([
+            QuickwitService::Janitor,
+            QuickwitService::Indexer,
+            QuickwitService::Compactor,
+        ]);
+        let result = get_compaction_planner_client_if_needed(&node_config, &cluster)
             .await
             .unwrap();
         assert!(result.is_some());
@@ -1948,9 +1946,9 @@ mod tests {
             .unwrap();
 
         let mut node_config = NodeConfig::for_test();
-        node_config.enabled_services = HashSet::from([QuickwitService::Indexer]);
-        node_config.indexer_config.enable_standalone_compactors = true;
-        let result = get_compaction_service_client_if_needed(&node_config, &cluster).await;
+        node_config.enabled_services =
+            HashSet::from([QuickwitService::Indexer, QuickwitService::Compactor]);
+        let result = get_compaction_planner_client_if_needed(&node_config, &cluster).await;
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
### Description
Changes the model of execution a little bit. 
Theres a full level of abstraction between the CompactionPipeline and the CompactionSupervisor. The supervisor just spawns pipelines and gets status updates. The pipeline manages the handles and reports the status back.

Added the proto for communicating with the planner service. Build the pipeline status updates, propagate them up, and build the proto for a request. 

Actual gRPC logic not yet implemented.

### How was this PR tested?
Unit tests.
