### PR TITLE
Bump tantivy to 58aa4b7

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2531,7 +2531,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 [[package]]
 name = "datasketches"
 version = "0.2.0"
-source = "git+https://github.com/fulmicoton-dd/datasketches-rust?rev=eb4ad64#eb4ad64d07d9660b0fbaed3aa3c2db73f4002771"
+source = "git+https://github.com/fulmicoton-dd/datasketches-rust?rev=7635fb8#7635fb86993b874bfca3ac4d294daa7b869d65d3"
 
 [[package]]
 name = "dbl"
@@ -5885,7 +5885,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -9995,7 +9995,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -10021,7 +10021,6 @@ dependencies = [
  "lz4_flex 0.13.0",
  "measure_time",
  "memmap2",
- "murmurhash32",
  "once_cell",
  "oneshot",
  "rayon",
@@ -10051,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "bitpacking",
 ]
@@ -10059,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -10074,7 +10073,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -10097,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -10109,7 +10108,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -10122,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -10131,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=04beab3b29#04beab3b29e2b4b7438624e07cd2a004d9e97185"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=58aa4b7#58aa4b707433a379b0ae716f29b0feff9c2479fc"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -376,7 +376,7 @@ quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry = { path = "quickwit-telemetry" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "04beab3b29", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "58aa4b7", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",


### PR DESCRIPTION
Updates tantivy dependency to the latest commit on main.