### PR TITLE
fix(ci): pin localstack to 4.14.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ POSTGRES_PASSWORD=quickwit-dev
 POSTGRES_DB=quickwit-metastore-dev
 
 # Update all services to the latest versions
-LOCALSTACK_VERSION=latest
+LOCALSTACK_VERSION=4.14.0  # last free version, see https://github.com/quickwit-oss/quickwit/pull/6303
 POSTGRES_VERSION=latest
 PULSAR_VERSION=latest
 CP_VERSION=latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,6 @@ env:
   AWS_ACCESS_KEY_ID: "placeholder"
   AWS_SECRET_ACCESS_KEY: "placeholder"
   CARGO_INCREMENTAL: 0
-  LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT: 1
   PUBSUB_EMULATOR_HOST: "localhost:8681"
   QW_DISABLE_TELEMETRY: 1
   QW_S3_ENDPOINT: "http://localhost:4566" # Services are exposed as localhost because we are not running coverage in a container.
@@ -38,14 +37,13 @@ jobs:
     # Setting a containing will require to fix the QW_S3_ENDPOINT to http://localstack:4566
     services:
       localstack:
-        image: localstack/localstack:latest
+        image: localstack/localstack:4.14.0
         ports:
           - "4566:4566"
           - "4571:4571"
           - "8080:8080"
         env:
           SERVICES: kinesis,s3,sqs
-          LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT: 1
         options: >-
           --health-cmd "curl -k https://localhost:4566"
           --health-interval 10s


### PR DESCRIPTION
## Context

LocalStack dropped their free community edition in March 2026 (version 2026.03.0), merging it with their paid product and requiring an `LOCALSTACK_AUTH_TOKEN` to start. A temporary escape hatch (`LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1`) was provided but **expired April 6, 2026**, leaving coverage CI permanently broken — 100% failure rate for the past month.

## Fix

Pin `localstack/localstack:latest` → `localstack/localstack:4.14.0`, the last free version (released Feb 26, 2026), which works without authentication indefinitely.

Also removes the now-defunct `LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT` env var.

## Long term

`4.14.0` will not receive further updates or security patches. 

A proper migration to open-source alternatives would be the next step