### PR TITLE
Fix typos in metrics.md

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -13,9 +13,11 @@ Currently Quickwit exposes metrics for three caches: `fastfields`, `shortlived`,
 | --------- | ----------- | ----------- | ---- |
 | `quickwit_cache_{cache_name}` | `in_cache_count` | Count of {cache_name} in cache | `gauge` |
 | `quickwit_cache_{cache_name}` | `in_cache_num_bytes` | Number of {cache_name} bytes in cache | `gauge` |
-| `quickwit_cache_{cache_name}` | `cache_hit_total` | Number of {cache_name} cache hits | `counter` |
+| `quickwit_cache_{cache_name}` | `cache_hits_total` | Number of {cache_name} cache hits | `counter` |
 | `quickwit_cache_{cache_name}` | `cache_hits_bytes` | Number of {cache_name} cache hits in bytes | `counter` |
-| `quickwit_cache_{cache_name}` | `cache_miss_total` | Number of {cache_name} cache hits | `counter` |
+| `quickwit_cache_{cache_name}` | `cache_misses_total` | Number of {cache_name} cache hits | `counter` |
+| `quickwit_cache_{cache_name}` | `cache_evict_total` | Number of {cache_name} cache entry evicted | `counter` |
+| `quickwit_cache_{cache_name}` | `cache_evict_bytes` | Number of {cache_name} cache entry evicted in bytes | `counter` |
 
 ## CLI Metrics
 


### PR DESCRIPTION
### Description

The documentation in metrics.md doesn't match the metrics defined in [metrics.rs](https://github.com/quickwit-oss/quickwit/blob/main/quickwit/quickwit-storage/src/metrics.rs#L189). This PR fixes the typos.

### How was this PR tested?

Documentation only.