### PR TITLE
Elasticsearch api add aggregations alias

### DIFF
--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/search_body.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/search_body.rs
@@ -73,7 +73,7 @@ pub struct SearchBody {
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_field_sorts")]
     pub sort: Option<Vec<SortField>>,
-    #[serde(default)]
+    #[serde(default, alias = "aggregations")]
     pub aggs: serde_json::Map<String, serde_json::Value>,
     #[serde(default)]
     pub track_total_hits: Option<TrackTotalHits>,


### PR DESCRIPTION
### Description

- Trino sends `aggregations` in the request body and quickwit only accepts `aggs`. Both are valid and function identically so adding an alias here
