### PR TITLE
refactor: migrate metrics from prometheus crate to metrics-rs facade

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -174,6 +174,7 @@ crc-catalog,https://github.com/akhilles/crc-catalog,MIT OR Apache-2.0,Akhil Vela
 crc-fast,https://github.com/awesomized/crc-fast-rust,MIT OR Apache-2.0,Don MacAskill
 crc32fast,https://github.com/srijs/rust-crc32fast,MIT OR Apache-2.0,"Sam Rijs <srijs@airpost.net>, Alex Crichton <alex@alexcrichton.com>"
 criterion-plot,https://github.com/criterion-rs/criterion.rs,Apache-2.0 OR MIT,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
+critical-section,https://github.com/rust-embedded/critical-section,MIT OR Apache-2.0,The critical-section Authors
 cron,https://github.com/zslayton/cron,MIT OR Apache-2.0,Zack Slayton <zack.slayton@gmail.com>
 crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-channel Authors
 crossbeam-deque,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-deque Authors
@@ -404,6 +405,8 @@ memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <ja
 memmap2,https://github.com/RazrFalcon/memmap2-rs,MIT OR Apache-2.0,"Dan Burkert <dan@danburkert.com>, Yevhenii Reizner <razrfalcon@gmail.com>, The Contributors"
 metrics,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 metrics-exporter-dogstatsd,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
+metrics-exporter-otel,https://github.com/palindrom615/metrics,MIT,Whoemoon Jang <palindrom615@gmail.com>
+metrics-exporter-prometheus,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 metrics-util,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 mime_guess,https://github.com/abonander/mime_guess,MIT,Austin Bonander <austin.bonander@gmail.com>

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2256,6 +2256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "cron"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5010,6 +5016,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-otel"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e5a5d54deb1941f7f47d8b9370ab9d7c11827c93dc4eec8310013a4c0d86db"
+dependencies = [
+ "metrics",
+ "metrics-util",
+ "opentelemetry",
+ "portable-atomic",
+ "scc",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.14.0",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "metrics-util"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6539,6 +6572,9 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "portable-atomic-util"
@@ -7130,6 +7166,9 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "metrics-exporter-dogstatsd",
+ "metrics-exporter-otel",
+ "metrics-exporter-prometheus",
+ "metrics-util",
  "numfmt",
  "openssl-probe 0.1.6",
  "opentelemetry",
@@ -7245,6 +7284,7 @@ dependencies = [
  "backtrace",
  "bytesize",
  "coarsetime",
+ "dashmap 6.1.0",
  "dyn-clone",
  "env_logger",
  "fnv",
@@ -7255,7 +7295,11 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
+ "inventory",
  "itertools 0.14.0",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-util",
  "pin-project",
  "pnet",
  "prometheus",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -110,6 +110,7 @@ colored = "3.0"
 console-subscriber = "0.5"
 criterion = { version = "0.8", features = ["async_tokio"] }
 cron = "0.16"
+dashmap = "6"
 dialoguer = { version = "0.12", default-features = false }
 dotenvy = "0.15"
 dyn-clone = "1.0"
@@ -149,6 +150,7 @@ hyper-util = { version = "0.1", default-features = false, features = [
 ] }
 indexmap = { version = "2.12", features = ["serde"] }
 indicatif = "0.18"
+inventory = "0.3"
 itertools = "0.14"
 lambda_runtime = "0.13"
 json_comments = "0.2"
@@ -158,6 +160,9 @@ matches = "0.1"
 md5 = "0.8"
 metrics = "0.24"
 metrics-exporter-dogstatsd = "0.9"
+metrics-exporter-otel = "0.3"
+metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
+metrics-util = "0.20"
 mime_guess = "2.0"
 mini-moka = "0.10.3"
 mockall = "0.14"
@@ -170,7 +175,7 @@ openssl = { version = "0.10", default-features = false }
 openssl-probe = "0.1"
 opentelemetry = "0.31"
 opentelemetry-appender-tracing = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-json"] }
 ouroboros = "0.18"
 parquet = { version = "58", default-features = false, features = ["arrow", "snap", "variant_experimental", "zstd"] }

--- a/quickwit/quickwit-cli/Cargo.toml
+++ b/quickwit/quickwit-cli/Cargo.toml
@@ -57,6 +57,9 @@ tracing-subscriber = { workspace = true }
 
 metrics = { workspace = true }
 metrics-exporter-dogstatsd = { workspace = true }
+metrics-exporter-otel = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+metrics-util = { workspace = true }
 
 quickwit-actors = { workspace = true }
 quickwit-cluster = { workspace = true }

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -395,7 +395,6 @@ pub mod busy_detector {
             let delta = now - time.load(Ordering::Relaxed);
             CLI_METRICS
                 .thread_unpark_duration_microseconds
-                .with_label_values([])
                 .observe(delta as f64);
             if delta > ALLOWED_DELAY_MICROS {
                 emit_debug(delta, now);

--- a/quickwit/quickwit-cli/src/logger.rs
+++ b/quickwit/quickwit-cli/src/logger.rs
@@ -20,6 +20,8 @@ use anyhow::Context;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::{KeyValue, global};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+#[cfg(not(test))]
+use opentelemetry_otlp::MetricExporter;
 use opentelemetry_otlp::{
     LogExporter, Protocol as OtlpWireProtocol, SpanExporter, WithExportConfig,
 };
@@ -80,6 +82,22 @@ impl OtlpProtocol {
                 .build(),
         }
         .context("failed to initialize OTLP traces exporter")
+    }
+
+    #[cfg(not(test))]
+    fn metric_exporter(&self) -> anyhow::Result<MetricExporter> {
+        match self {
+            OtlpProtocol::Grpc => MetricExporter::builder().with_tonic().build(),
+            OtlpProtocol::HttpProtobuf => MetricExporter::builder()
+                .with_http()
+                .with_protocol(OtlpWireProtocol::HttpBinary)
+                .build(),
+            OtlpProtocol::HttpJson => MetricExporter::builder()
+                .with_http()
+                .with_protocol(OtlpWireProtocol::HttpJson)
+                .build(),
+        }
+        .context("failed to initialize OTLP metrics exporter")
     }
 }
 
@@ -238,11 +256,65 @@ pub fn setup_logging_and_tracing(
     ))
 }
 
-/// Set up DogStatsD metrics exporter and invariant recorder.
+/// Set up metrics recorders: Prometheus (always), OTLP (opt-in), DogStatsD.
+///
+/// Routes metrics by prefix:
+/// - `quickwit_*` → Prometheus + OTLP
+/// - `pomsky.*`   → DogStatsD
 #[cfg(not(test))]
 pub fn setup_metrics(build_info: &BuildInfo) -> anyhow::Result<()> {
-    // Reading both `CLOUDPREM_*` and `CP_*` env vars for backward compatibility. The former is
-    // deprecated and can be removed after 2026-04-01.
+    use quickwit_common::metrics::HistogramConfig;
+
+    let mut prom_builder = metrics_exporter_prometheus::PrometheusBuilder::new();
+    for config in quickwit_common::inventory::iter::<HistogramConfig>() {
+        prom_builder = prom_builder
+            .set_buckets_for_metric(
+                metrics_exporter_prometheus::Matcher::Full(config.full_name()),
+                &(config.buckets_fn)(),
+            )
+            .context("failed to set histogram buckets")?;
+    }
+    let prom_recorder = prom_builder.build_recorder();
+    let prom_handle = prom_recorder.handle();
+
+    quickwit_common::metrics::set_prom_handle(prom_handle);
+
+    let mut quickwit_fanout =
+        metrics_util::layers::FanoutBuilder::default().add_recorder(prom_recorder);
+
+    if get_bool_from_env(QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER_ENV_KEY, false) {
+        let global_protocol_str =
+            get_from_env("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc".to_string(), false);
+        let global_protocol = OtlpProtocol::from_str(&global_protocol_str)?;
+
+        let metrics_protocol_str =
+            get_from_env_opt::<String>("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", false);
+        let metrics_protocol = metrics_protocol_str
+            .as_deref()
+            .map(OtlpProtocol::from_str)
+            .transpose()?
+            .unwrap_or(global_protocol);
+
+        let metric_exporter = metrics_protocol.metric_exporter()?;
+        let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(metric_exporter).build();
+        let resource = opentelemetry_sdk::Resource::builder()
+            .with_service_name("quickwit")
+            .with_attribute(KeyValue::new("service.version", build_info.version.clone()))
+            .build();
+        let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource)
+            .build();
+        let meter = opentelemetry::metrics::MeterProvider::meter(&meter_provider, "quickwit");
+        let otel_recorder = metrics_exporter_otel::OpenTelemetryRecorder::new(meter);
+        for config in quickwit_common::inventory::iter::<HistogramConfig>() {
+            let key_name = metrics::KeyName::from(config.full_name());
+            otel_recorder.set_histogram_bounds(&key_name, (config.buckets_fn)());
+        }
+
+        quickwit_fanout = quickwit_fanout.add_recorder(otel_recorder);
+    }
+
     let host: String = quickwit_common::get_from_env_opt("CLOUDPREM_DOGSTATSD_SERVER_HOST", false)
         .unwrap_or_else(|| {
             quickwit_common::get_from_env(
@@ -270,13 +342,36 @@ pub fn setup_metrics(build_info: &BuildInfo) -> anyhow::Result<()> {
             global_labels.push(::metrics::Label::new(label_key, label_val));
         }
     }
-    metrics_exporter_dogstatsd::DogStatsDBuilder::default()
+    let dogstatsd_recorder = metrics_exporter_dogstatsd::DogStatsDBuilder::default()
         .set_global_prefix("cloudprem")
         .with_global_labels(global_labels)
         .with_remote_address(addr)
         .context("failed to parse DogStatsD server address")?
-        .install()
-        .context("failed to register DogStatsD exporter")?;
+        .build()
+        .context("failed to build DogStatsD recorder")?;
+
+    let quickwit_recorder = quickwit_fanout.build();
+
+    let mut router = metrics_util::layers::RouterBuilder::from_recorder(metrics::NoopRecorder);
+    router
+        .add_route(
+            metrics_util::MetricKindMask::ALL,
+            "quickwit_",
+            quickwit_recorder,
+        )
+        .add_route(
+            metrics_util::MetricKindMask::ALL,
+            "pomsky.",
+            dogstatsd_recorder,
+        );
+
+    let recorder = router.build();
+    metrics::set_global_recorder(recorder)
+        .map_err(|_| anyhow::anyhow!("failed to set global metrics recorder"))?;
+    for config in quickwit_common::inventory::iter::<HistogramConfig>() {
+        metrics::describe_histogram!(config.full_name(), config.help);
+    }
+
     quickwit_dst::invariants::set_invariant_recorder(invariant_recorder);
     Ok(())
 }

--- a/quickwit/quickwit-cli/src/metrics.rs
+++ b/quickwit/quickwit-cli/src/metrics.rs
@@ -16,13 +16,14 @@ use std::sync::LazyLock;
 
 use quickwit_common::metrics::Histogram;
 
-quickwit_common::define_histogram! {
-    THREAD_UNPARK_DURATION_MICROSECONDS,
-    name: "thread_unpark_duration_microseconds",
-    help: "Duration for which a thread of the main tokio runtime is unparked.",
-    subsystem: "cli",
-    buckets: quickwit_common::metrics::exponential_buckets(5.0, 5.0, 5).unwrap(),
-}
+pub static THREAD_UNPARK_DURATION_MICROSECONDS: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "thread_unpark_duration_microseconds",
+        help: "Duration for which a thread of the main tokio runtime is unparked.",
+        subsystem: "cli",
+        buckets: quickwit_common::metrics::exponential_buckets(5.0, 5.0, 5).unwrap(),
+    }
+});
 
 pub struct CliMetrics {
     pub thread_unpark_duration_microseconds: Histogram,

--- a/quickwit/quickwit-cli/src/metrics.rs
+++ b/quickwit/quickwit-cli/src/metrics.rs
@@ -14,26 +14,27 @@
 
 use std::sync::LazyLock;
 
-use quickwit_common::metrics::{HistogramVec, new_histogram_vec};
+use quickwit_common::metrics::Histogram;
+
+quickwit_common::define_histogram! {
+    THREAD_UNPARK_DURATION_MICROSECONDS,
+    name: "thread_unpark_duration_microseconds",
+    help: "Duration for which a thread of the main tokio runtime is unparked.",
+    subsystem: "cli",
+    buckets: quickwit_common::metrics::exponential_buckets(5.0, 5.0, 5).unwrap(),
+}
 
 pub struct CliMetrics {
-    pub thread_unpark_duration_microseconds: HistogramVec<0>,
+    pub thread_unpark_duration_microseconds: Histogram,
 }
 
 impl Default for CliMetrics {
     fn default() -> Self {
         CliMetrics {
-            thread_unpark_duration_microseconds: new_histogram_vec(
-                "thread_unpark_duration_microseconds",
-                "Duration for which a thread of the main tokio runtime is unparked.",
-                "cli",
-                &[],
-                [],
-                quickwit_common::metrics::exponential_buckets(5.0, 5.0, 5).unwrap(),
-            ),
+            thread_unpark_duration_microseconds: THREAD_UNPARK_DURATION_MICROSECONDS.clone(),
         }
     }
 }
 
-/// Serve counters exposes a bunch a set of metrics about the request received to quickwit.
+/// CLI counters exposes a set of metrics about the main tokio runtime.
 pub static CLI_METRICS: LazyLock<CliMetrics> = LazyLock::new(CliMetrics::default);

--- a/quickwit/quickwit-common/Cargo.toml
+++ b/quickwit/quickwit-common/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = { workspace = true }
 backtrace = { workspace = true, optional = true }
 bytesize = { workspace = true }
 coarsetime = { workspace = true }
+dashmap = { workspace = true }
 dyn-clone = { workspace = true }
 env_logger = { workspace = true }
 fnv = { workspace = true }
@@ -27,7 +28,10 @@ hostname = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true, optional = true }
+inventory = { workspace = true }
 itertools = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 pin-project = { workspace = true }
 pnet = { workspace = true }
 prometheus = { workspace = true }
@@ -62,6 +66,7 @@ jemalloc-profiled = [
 
 [dev-dependencies]
 hyper-util = { workspace = true }
+metrics-util = { workspace = true }
 proptest = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }

--- a/quickwit/quickwit-common/src/io.rs
+++ b/quickwit/quickwit-common/src/io.rs
@@ -34,10 +34,9 @@ use async_speed_limit::clock::StandardClock;
 use async_speed_limit::limiter::Consume;
 use bytesize::ByteSize;
 use pin_project::pin_project;
-use prometheus::IntCounter;
 use tokio::io::AsyncWrite;
 
-use crate::metrics::{IntCounterVec, new_counter_vec};
+use crate::metrics::{IntCounter, IntCounterVec, new_counter_vec};
 use crate::{KillSwitch, Progress, ProtectedZoneGuard};
 
 // Max 1MB at a time.

--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -62,6 +62,8 @@ use std::str::FromStr;
 
 pub use coolid::new_coolid;
 pub use cpus::num_cpus;
+#[doc(hidden)]
+pub use inventory;
 pub use kill_switch::KillSwitch;
 pub use path_hasher::PathHasher;
 pub use progress::{Progress, ProtectedZoneGuard};

--- a/quickwit/quickwit-common/src/metrics.rs
+++ b/quickwit/quickwit-common/src/metrics.rs
@@ -396,9 +396,8 @@ impl Drop for OwnedGaugeGuard {
 }
 
 /// Static registration entry for a histogram. One `HistogramConfig` is submitted per histogram
-/// declaration via the `define_histogram!` / `define_histogram_vec!` macros; at recorder install
-/// time the full set is read via `inventory::iter::<HistogramConfig>` and applied to the
-/// Prometheus / OTLP exporters.
+/// declaration via the `define_histogram!` macro; at recorder install time the full set is read
+/// via `inventory::iter::<HistogramConfig>` and applied to the Prometheus / OTLP exporters.
 pub struct HistogramConfig {
     pub name: &'static str,
     pub subsystem: &'static str,
@@ -509,8 +508,8 @@ pub fn new_gauge_vec<const N: usize>(
     }
 }
 
-/// Implementation details exposed only for the `define_histogram!` / `define_histogram_vec!`
-/// macros. Do not call these items directly.
+/// Implementation details exposed only for the `define_histogram!` macro. Do not call these
+/// items directly.
 #[doc(hidden)]
 pub mod __private {
     use std::sync::Arc;
@@ -692,16 +691,41 @@ pub fn index_label(index_id: &str) -> &str {
 
 pub static MEMORY_METRICS: LazyLock<MemoryMetrics> = LazyLock::new(MemoryMetrics::default);
 
-/// Declares a histogram with compile-time static registration.
+/// Creates a histogram (or labeled histogram vector) and registers its bucket bounds with
+/// `inventory` so the recorder install path can apply them to the Prometheus / OTLP exporters.
+///
+/// The macro expands to a block expression that evaluates to a `Histogram` or `HistogramVec<N>`.
+/// Wrap the call in `LazyLock::new(|| ...)` (or any other ownership pattern) at the call site:
+///
+/// ```ignore
+/// static LATENCY_SECONDS: LazyLock<Histogram> = LazyLock::new(|| {
+///     quickwit_common::define_histogram! {
+///         name: "latency_seconds",
+///         help: "Request latency in seconds.",
+///         subsystem: "search",
+///         buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
+///     }
+/// });
+///
+/// static REQUEST_DURATION_SECONDS: LazyLock<HistogramVec<2>> = LazyLock::new(|| {
+///     quickwit_common::define_histogram! {
+///         name: "request_duration_seconds",
+///         help: "Duration of requests in seconds.",
+///         subsystem: "search",
+///         const_labels: [("kind", "server")],
+///         labels: ["rpc", "status"],
+///         buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
+///     }
+/// });
+/// ```
 #[macro_export]
 macro_rules! define_histogram {
     (
-        $static_name:ident,
         name: $name:literal,
         help: $help:literal,
         subsystem: $subsystem:literal,
         buckets: $buckets:expr $(,)?
-    ) => {
+    ) => {{
         $crate::inventory::submit! {
             $crate::metrics::HistogramConfig {
                 name: $name,
@@ -710,26 +734,16 @@ macro_rules! define_histogram {
                 buckets_fn: || $buckets,
             }
         }
-
-        pub static $static_name: ::std::sync::LazyLock<$crate::metrics::Histogram> =
-            ::std::sync::LazyLock::new(|| {
-                $crate::metrics::__private::new_histogram($name, $subsystem)
-            });
-    };
-}
-
-/// Declares a labeled histogram (`HistogramVec<N>`) with compile-time static registration.
-#[macro_export]
-macro_rules! define_histogram_vec {
+        $crate::metrics::__private::new_histogram($name, $subsystem)
+    }};
     (
-        $static_name:ident,
         name: $name:literal,
         help: $help:literal,
         subsystem: $subsystem:literal,
         const_labels: [$(($ck:literal, $cv:literal)),* $(,)?],
         labels: [$($label:literal),+ $(,)?],
         buckets: $buckets:expr $(,)?
-    ) => {
+    ) => {{
         $crate::inventory::submit! {
             $crate::metrics::HistogramConfig {
                 name: $name,
@@ -738,18 +752,13 @@ macro_rules! define_histogram_vec {
                 buckets_fn: || $buckets,
             }
         }
-
-        pub static $static_name: ::std::sync::LazyLock<
-            $crate::metrics::HistogramVec<{ [$($label),+].len() }>,
-        > = ::std::sync::LazyLock::new(|| {
-            $crate::metrics::__private::new_histogram_vec(
-                $name,
-                $subsystem,
-                &[$(($ck, $cv)),*],
-                [$($label),+],
-            )
-        });
-    };
+        $crate::metrics::__private::new_histogram_vec(
+            $name,
+            $subsystem,
+            &[$(($ck, $cv)),*],
+            [$($label),+],
+        )
+    }};
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-common/src/metrics.rs
+++ b/quickwit/quickwit-common/src/metrics.rs
@@ -12,30 +12,245 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap};
-use std::sync::{LazyLock, OnceLock};
+use std::collections::BTreeMap;
+use std::hash::{BuildHasherDefault, Hasher};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, OnceLock};
 
-use prometheus::{Gauge, HistogramOpts, Opts, TextEncoder};
-pub use prometheus::{
-    Histogram, HistogramTimer, HistogramVec as PrometheusHistogramVec, IntCounter,
-    IntCounterVec as PrometheusIntCounterVec, IntGauge, IntGaugeVec as PrometheusIntGaugeVec,
-    exponential_buckets, linear_buckets,
-};
+use dashmap::DashMap;
+use fnv::FnvHasher;
+use metrics_exporter_prometheus::PrometheusHandle;
+pub use prometheus::{exponential_buckets, linear_buckets};
 
-#[derive(Clone)]
-pub struct HistogramVec<const N: usize> {
-    underlying: PrometheusHistogramVec,
+/// Cache keys come from `hash_label_values` (FNV), so they're already
+/// well-distributed u64 hashes. Routing them through `DashMap`'s default
+/// `SipHasher` would just rehash them on every lookup; this hasher returns
+/// the key verbatim to skip that redundant work.
+#[derive(Default)]
+struct NoHashHasher(u64);
+
+impl Hasher for NoHashHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        unreachable!("NoHashHasher only supports write_u64");
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
 }
 
-impl<const N: usize> HistogramVec<N> {
-    pub fn with_label_values(&self, label_values: [&str; N]) -> Histogram {
-        self.underlying.with_label_values(&label_values)
+type BuildNoHashHasher = BuildHasherDefault<NoHashHasher>;
+
+fn hash_label_values(values: &[&str]) -> u64 {
+    let mut h = FnvHasher::default();
+    for v in values {
+        // Length prefix prevents collisions when label boundaries shift,
+        // e.g. ["ab", "c"] vs ["a", "bc"].
+        Hasher::write_u64(&mut h, v.len() as u64);
+        Hasher::write(&mut h, v.as_bytes());
+    }
+    Hasher::finish(&h)
+}
+
+fn get_or_insert_cached<T: Clone>(
+    cache: &DashMap<u64, T, BuildNoHashHasher>,
+    label_values: &[&str],
+    build: impl FnOnce() -> T,
+) -> T {
+    let hash = hash_label_values(label_values);
+    cache.entry(hash).or_insert_with(build).value().clone()
+}
+
+fn atomic_f64_set(atomic: &AtomicU64, val: f64) {
+    atomic.store(val.to_bits(), Ordering::Relaxed);
+}
+
+fn atomic_f64_get(atomic: &AtomicU64) -> f64 {
+    f64::from_bits(atomic.load(Ordering::Relaxed))
+}
+
+fn atomic_f64_add(atomic: &AtomicU64, delta: f64) {
+    let _ = atomic.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| {
+        Some((f64::from_bits(old) + delta).to_bits())
+    });
+}
+
+fn make_metric_name(name: &str, subsystem: &str) -> String {
+    if subsystem.is_empty() {
+        format!("quickwit_{name}")
+    } else {
+        format!("quickwit_{subsystem}_{name}")
+    }
+}
+
+fn make_const_labels(const_labels: &[(&str, &str)]) -> Vec<metrics::Label> {
+    const_labels
+        .iter()
+        .map(|(k, v)| metrics::Label::new(k.to_string(), v.to_string()))
+        .collect()
+}
+
+fn compose_labels<const N: usize>(
+    const_labels: &[metrics::Label],
+    label_names: &[String; N],
+    label_values: &[&str; N],
+) -> Vec<metrics::Label> {
+    let mut labels = Vec::with_capacity(const_labels.len() + N);
+    labels.extend_from_slice(const_labels);
+    for (name, value) in label_names.iter().zip(label_values.iter()) {
+        labels.push(metrics::Label::new(name.clone(), value.to_string()));
+    }
+    labels
+}
+
+#[derive(Clone, Debug)]
+pub struct IntCounter {
+    inner: metrics::Counter,
+    value: Arc<AtomicU64>,
+}
+
+impl IntCounter {
+    /// Constructs a standalone counter that is NOT registered with the global recorder.
+    pub fn new(_name: &str, _help: &str) -> Result<Self, String> {
+        Ok(Self {
+            inner: metrics::Counter::noop(),
+            value: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    pub fn inc(&self) {
+        self.inc_by(1);
+    }
+
+    pub fn inc_by(&self, v: u64) {
+        self.inner.increment(v);
+        self.value.fetch_add(v, Ordering::Relaxed);
+    }
+
+    pub fn get(&self) -> u64 {
+        self.value.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IntGauge {
+    inner: metrics::Gauge,
+    value: Arc<AtomicI64>,
+}
+
+impl IntGauge {
+    pub fn set(&self, v: i64) {
+        self.inner.set(v as f64);
+        self.value.store(v, Ordering::Relaxed);
+    }
+
+    pub fn inc(&self) {
+        self.add(1);
+    }
+
+    pub fn dec(&self) {
+        self.sub(1);
+    }
+
+    pub fn add(&self, v: i64) {
+        self.inner.increment(v as f64);
+        self.value.fetch_add(v, Ordering::Relaxed);
+    }
+
+    pub fn sub(&self, v: i64) {
+        self.inner.decrement(v as f64);
+        self.value.fetch_sub(v, Ordering::Relaxed);
+    }
+
+    pub fn get(&self) -> i64 {
+        self.value.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Gauge {
+    inner: metrics::Gauge,
+    value: Arc<AtomicU64>,
+}
+
+impl Gauge {
+    pub fn set(&self, v: f64) {
+        self.inner.set(v);
+        atomic_f64_set(&self.value, v);
+    }
+
+    pub fn inc(&self) {
+        self.add(1.0);
+    }
+
+    pub fn dec(&self) {
+        self.sub(1.0);
+    }
+
+    pub fn add(&self, v: f64) {
+        self.inner.increment(v);
+        atomic_f64_add(&self.value, v);
+    }
+
+    pub fn sub(&self, v: f64) {
+        self.inner.decrement(v);
+        atomic_f64_add(&self.value, -v);
+    }
+
+    pub fn get(&self) -> f64 {
+        atomic_f64_get(&self.value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Histogram {
+    inner: metrics::Histogram,
+}
+
+impl Histogram {
+    pub fn observe(&self, v: f64) {
+        self.inner.record(v);
+    }
+
+    pub fn start_timer(&self) -> HistogramTimer {
+        HistogramTimer {
+            histogram: Some(self.clone()),
+            start: std::time::Instant::now(),
+        }
+    }
+}
+
+pub struct HistogramTimer {
+    histogram: Option<Histogram>,
+    start: std::time::Instant,
+}
+
+impl HistogramTimer {
+    pub fn observe_duration(mut self) {
+        if let Some(histogram) = self.histogram.take() {
+            histogram.observe(self.start.elapsed().as_secs_f64());
+        }
+    }
+}
+
+impl Drop for HistogramTimer {
+    fn drop(&mut self) {
+        if let Some(histogram) = self.histogram.take() {
+            histogram.observe(self.start.elapsed().as_secs_f64());
+        }
     }
 }
 
 #[derive(Clone)]
 pub struct IntCounterVec<const N: usize> {
-    underlying: PrometheusIntCounterVec,
+    name: String,
+    label_names: [String; N],
+    const_labels: Vec<metrics::Label>,
+    cache: Arc<DashMap<u64, IntCounter, BuildNoHashHasher>>,
 }
 
 impl<const N: usize> IntCounterVec<N> {
@@ -46,173 +261,64 @@ impl<const N: usize> IntCounterVec<N> {
         const_labels: &[(&str, &str)],
         label_names: [&str; N],
     ) -> IntCounterVec<N> {
-        let owned_const_labels: HashMap<String, String> = const_labels
-            .iter()
-            .map(|(label_name, label_value)| (label_name.to_string(), label_value.to_string()))
-            .collect();
-        let counter_opts = Opts::new(name, help)
-            .namespace("quickwit")
-            .subsystem(subsystem)
-            .const_labels(owned_const_labels);
-        let underlying = PrometheusIntCounterVec::new(counter_opts, &label_names)
-            .expect("failed to create counter vec");
-        IntCounterVec { underlying }
+        let full_name = make_metric_name(name, subsystem);
+        metrics::describe_counter!(full_name.clone(), help.to_string());
+        IntCounterVec {
+            name: full_name,
+            label_names: label_names.map(|s| s.to_string()),
+            const_labels: make_const_labels(const_labels),
+            cache: Arc::new(DashMap::with_hasher(BuildNoHashHasher::default())),
+        }
     }
 
     pub fn with_label_values(&self, label_values: [&str; N]) -> IntCounter {
-        self.underlying.with_label_values(&label_values)
+        get_or_insert_cached(&self.cache, &label_values, || {
+            let labels = compose_labels(&self.const_labels, &self.label_names, &label_values);
+            IntCounter {
+                inner: metrics::counter!(self.name.clone(), labels),
+                value: Arc::new(AtomicU64::new(0)),
+            }
+        })
     }
 }
 
 #[derive(Clone)]
 pub struct IntGaugeVec<const N: usize> {
-    underlying: PrometheusIntGaugeVec,
+    name: String,
+    label_names: [String; N],
+    const_labels: Vec<metrics::Label>,
+    cache: Arc<DashMap<u64, IntGauge, BuildNoHashHasher>>,
 }
 
 impl<const N: usize> IntGaugeVec<N> {
     pub fn with_label_values(&self, label_values: [&str; N]) -> IntGauge {
-        self.underlying.with_label_values(&label_values)
+        get_or_insert_cached(&self.cache, &label_values, || {
+            let labels = compose_labels(&self.const_labels, &self.label_names, &label_values);
+            IntGauge {
+                inner: metrics::gauge!(self.name.clone(), labels),
+                value: Arc::new(AtomicI64::new(0)),
+            }
+        })
     }
 }
 
-pub fn register_info(name: &'static str, help: &'static str, kvs: BTreeMap<&'static str, String>) {
-    let mut counter_opts = Opts::new(name, help).namespace("quickwit");
-    for (k, v) in kvs {
-        counter_opts = counter_opts.const_label(k, v);
+#[derive(Clone)]
+pub struct HistogramVec<const N: usize> {
+    name: String,
+    label_names: [String; N],
+    const_labels: Vec<metrics::Label>,
+    cache: Arc<DashMap<u64, Histogram, BuildNoHashHasher>>,
+}
+
+impl<const N: usize> HistogramVec<N> {
+    pub fn with_label_values(&self, label_values: [&str; N]) -> Histogram {
+        get_or_insert_cached(&self.cache, &label_values, || {
+            let labels = compose_labels(&self.const_labels, &self.label_names, &label_values);
+            Histogram {
+                inner: metrics::histogram!(self.name.clone(), labels),
+            }
+        })
     }
-    let counter = IntCounter::with_opts(counter_opts).expect("failed to create counter");
-    counter.inc();
-    prometheus::register(Box::new(counter)).expect("failed to register counter");
-}
-
-pub fn new_counter(
-    name: &str,
-    help: &str,
-    subsystem: &str,
-    const_labels: &[(&str, &str)],
-) -> IntCounter {
-    let owned_const_labels: HashMap<String, String> = const_labels
-        .iter()
-        .map(|(label_name, label_value)| (label_name.to_string(), label_value.to_string()))
-        .collect();
-    let counter_opts = Opts::new(name, help)
-        .namespace("quickwit")
-        .subsystem(subsystem)
-        .const_labels(owned_const_labels);
-    let counter = IntCounter::with_opts(counter_opts).expect("failed to create counter");
-    prometheus::register(Box::new(counter.clone())).expect("failed to register counter");
-    counter
-}
-
-pub fn new_counter_vec<const N: usize>(
-    name: &str,
-    help: &str,
-    subsystem: &str,
-    const_labels: &[(&str, &str)],
-    label_names: [&str; N],
-) -> IntCounterVec<N> {
-    let int_counter_vec = IntCounterVec::new(name, help, subsystem, const_labels, label_names);
-    let collector = Box::new(int_counter_vec.underlying.clone());
-    prometheus::register(collector).expect("failed to register counter vec");
-    int_counter_vec
-}
-
-pub fn new_float_gauge(
-    name: &str,
-    help: &str,
-    subsystem: &str,
-    const_labels: &[(&str, &str)],
-) -> Gauge {
-    let owned_const_labels: HashMap<String, String> = const_labels
-        .iter()
-        .map(|(label_name, label_value)| (label_name.to_string(), label_value.to_string()))
-        .collect();
-    let gauge_opts = Opts::new(name, help)
-        .namespace("quickwit")
-        .subsystem(subsystem)
-        .const_labels(owned_const_labels);
-    let gauge = Gauge::with_opts(gauge_opts).expect("failed to create float gauge");
-    prometheus::register(Box::new(gauge.clone())).expect("failed to register float gauge");
-    gauge
-}
-
-pub fn new_gauge(
-    name: &str,
-    help: &str,
-    subsystem: &str,
-    const_labels: &[(&str, &str)],
-) -> IntGauge {
-    let owned_const_labels: HashMap<String, String> = const_labels
-        .iter()
-        .map(|(label_name, label_value)| (label_name.to_string(), label_value.to_string()))
-        .collect();
-    let gauge_opts = Opts::new(name, help)
-        .namespace("quickwit")
-        .subsystem(subsystem)
-        .const_labels(owned_const_labels);
-    let gauge = IntGauge::with_opts(gauge_opts).expect("failed to create gauge");
-    prometheus::register(Box::new(gauge.clone())).expect("failed to register gauge");
-    gauge
-}
-
-pub fn new_gauge_vec<const N: usize>(
-    name: &str,
-    help: &str,
-    subsystem: &str,
-    const_labels: &[(&str, &str)],
-    label_names: [&str; N],
-) -> IntGaugeVec<N> {
-    let owned_const_labels: HashMap<String, String> = const_labels
-        .iter()
-        .map(|(label_name, label_value)| (label_name.to_string(), label_value.to_string()))
-        .collect();
-    let gauge_opts = Opts::new(name, help)
-        .namespace("quickwit")
-        .subsystem(subsystem)
-        .const_labels(owned_const_labels);
-    let underlying =
-        PrometheusIntGaugeVec::new(gauge_opts, &label_names).expect("failed to create gauge vec");
-
-    let collector = Box::new(underlying.clone());
-    prometheus::register(collector).expect("failed to register counter vec");
-
-    IntGaugeVec { underlying }
-}
-
-pub fn new_histogram(name: &str, help: &str, subsystem: &str, buckets: Vec<f64>) -> Histogram {
-    let histogram_opts = HistogramOpts::new(name, help)
-        .namespace("quickwit")
-        .subsystem(subsystem)
-        .buckets(buckets);
-    let histogram = Histogram::with_opts(histogram_opts).expect("failed to create histogram");
-    prometheus::register(Box::new(histogram.clone())).expect("failed to register histogram");
-    histogram
-}
-
-pub fn new_histogram_vec<const N: usize>(
-    name: &str,
-    help: &str,
-    subsystem: &str,
-    const_labels: &[(&str, &str)],
-    label_names: [&str; N],
-    buckets: Vec<f64>,
-) -> HistogramVec<N> {
-    let owned_const_labels: HashMap<String, String> = const_labels
-        .iter()
-        .map(|(label_name, label_value)| (label_name.to_string(), label_value.to_string()))
-        .collect();
-    let histogram_opts = HistogramOpts::new(name, help)
-        .namespace("quickwit")
-        .subsystem(subsystem)
-        .const_labels(owned_const_labels)
-        .buckets(buckets);
-    let underlying = PrometheusHistogramVec::new(histogram_opts, &label_names)
-        .expect("failed to create histogram vec");
-
-    let collector = Box::new(underlying.clone());
-    prometheus::register(collector).expect("failed to register histogram vec");
-
-    HistogramVec { underlying }
 }
 
 pub struct GaugeGuard<'a> {
@@ -289,15 +395,149 @@ impl Drop for OwnedGaugeGuard {
     }
 }
 
-pub fn metrics_text_payload() -> Result<String, String> {
-    let metric_families = prometheus::gather();
-    // Arbitrary non-zero size in order to skip a bunch of
-    // buffer growth-reallocations when encoding metrics.
-    let mut buffer = String::with_capacity(1024);
-    let encoder = TextEncoder::new();
-    match encoder.encode_utf8(&metric_families, &mut buffer) {
-        Ok(()) => Ok(buffer),
-        Err(e) => Err(e.to_string()),
+/// Static registration entry for a histogram. One `HistogramConfig` is submitted per histogram
+/// declaration via the `define_histogram!` / `define_histogram_vec!` macros; at recorder install
+/// time the full set is read via `inventory::iter::<HistogramConfig>` and applied to the
+/// Prometheus / OTLP exporters.
+pub struct HistogramConfig {
+    pub name: &'static str,
+    pub subsystem: &'static str,
+    pub help: &'static str,
+    pub buckets_fn: fn() -> Vec<f64>,
+}
+
+impl HistogramConfig {
+    pub fn full_name(&self) -> String {
+        make_metric_name(self.name, self.subsystem)
+    }
+}
+
+inventory::collect!(HistogramConfig);
+
+static PROM_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+pub fn set_prom_handle(handle: PrometheusHandle) {
+    let _ = PROM_HANDLE.set(handle);
+}
+
+pub fn render_prometheus_text() -> String {
+    match PROM_HANDLE.get() {
+        Some(handle) => handle.render(),
+        None => String::new(),
+    }
+}
+
+pub fn register_info(name: &'static str, help: &'static str, kvs: BTreeMap<&'static str, String>) {
+    let full_name = format!("quickwit_{name}");
+    metrics::describe_counter!(full_name.clone(), help.to_string());
+    let labels: Vec<metrics::Label> = kvs
+        .into_iter()
+        .map(|(k, v)| metrics::Label::new(k.to_string(), v))
+        .collect();
+    metrics::counter!(full_name, labels).increment(1);
+}
+
+pub fn new_counter(
+    name: &str,
+    help: &str,
+    subsystem: &str,
+    const_labels: &[(&str, &str)],
+) -> IntCounter {
+    let full_name = make_metric_name(name, subsystem);
+    metrics::describe_counter!(full_name.clone(), help.to_string());
+    let labels = make_const_labels(const_labels);
+    IntCounter {
+        inner: metrics::counter!(full_name, labels),
+        value: Arc::new(AtomicU64::new(0)),
+    }
+}
+
+pub fn new_counter_vec<const N: usize>(
+    name: &str,
+    help: &str,
+    subsystem: &str,
+    const_labels: &[(&str, &str)],
+    label_names: [&str; N],
+) -> IntCounterVec<N> {
+    IntCounterVec::new(name, help, subsystem, const_labels, label_names)
+}
+
+pub fn new_float_gauge(
+    name: &str,
+    help: &str,
+    subsystem: &str,
+    const_labels: &[(&str, &str)],
+) -> Gauge {
+    let full_name = make_metric_name(name, subsystem);
+    metrics::describe_gauge!(full_name.clone(), help.to_string());
+    let labels = make_const_labels(const_labels);
+    Gauge {
+        inner: metrics::gauge!(full_name, labels),
+        value: Arc::new(AtomicU64::new(0f64.to_bits())),
+    }
+}
+
+pub fn new_gauge(
+    name: &str,
+    help: &str,
+    subsystem: &str,
+    const_labels: &[(&str, &str)],
+) -> IntGauge {
+    let full_name = make_metric_name(name, subsystem);
+    metrics::describe_gauge!(full_name.clone(), help.to_string());
+    let labels = make_const_labels(const_labels);
+    IntGauge {
+        inner: metrics::gauge!(full_name, labels),
+        value: Arc::new(AtomicI64::new(0)),
+    }
+}
+
+pub fn new_gauge_vec<const N: usize>(
+    name: &str,
+    help: &str,
+    subsystem: &str,
+    const_labels: &[(&str, &str)],
+    label_names: [&str; N],
+) -> IntGaugeVec<N> {
+    let full_name = make_metric_name(name, subsystem);
+    metrics::describe_gauge!(full_name.clone(), help.to_string());
+    IntGaugeVec {
+        name: full_name,
+        label_names: label_names.map(|s| s.to_string()),
+        const_labels: make_const_labels(const_labels),
+        cache: Arc::new(DashMap::with_hasher(BuildNoHashHasher::default())),
+    }
+}
+
+/// Implementation details exposed only for the `define_histogram!` / `define_histogram_vec!`
+/// macros. Do not call these items directly.
+#[doc(hidden)]
+pub mod __private {
+    use std::sync::Arc;
+
+    use dashmap::DashMap;
+
+    use super::{BuildNoHashHasher, Histogram, HistogramVec, make_const_labels, make_metric_name};
+
+    pub fn new_histogram(name: &str, subsystem: &str) -> Histogram {
+        let full_name = make_metric_name(name, subsystem);
+        Histogram {
+            inner: metrics::histogram!(full_name),
+        }
+    }
+
+    pub fn new_histogram_vec<const N: usize>(
+        name: &str,
+        subsystem: &str,
+        const_labels: &[(&str, &str)],
+        label_names: [&str; N],
+    ) -> HistogramVec<N> {
+        HistogramVec {
+            name: make_metric_name(name, subsystem),
+            label_names: label_names.map(|s| s.to_string()),
+            const_labels: make_const_labels(const_labels),
+            cache: Arc::new(DashMap::with_hasher(BuildNoHashHasher::default())),
+        }
     }
 }
 
@@ -451,3 +691,429 @@ pub fn index_label(index_id: &str) -> &str {
 }
 
 pub static MEMORY_METRICS: LazyLock<MemoryMetrics> = LazyLock::new(MemoryMetrics::default);
+
+/// Declares a histogram with compile-time static registration.
+#[macro_export]
+macro_rules! define_histogram {
+    (
+        $static_name:ident,
+        name: $name:literal,
+        help: $help:literal,
+        subsystem: $subsystem:literal,
+        buckets: $buckets:expr $(,)?
+    ) => {
+        $crate::inventory::submit! {
+            $crate::metrics::HistogramConfig {
+                name: $name,
+                subsystem: $subsystem,
+                help: $help,
+                buckets_fn: || $buckets,
+            }
+        }
+
+        pub static $static_name: ::std::sync::LazyLock<$crate::metrics::Histogram> =
+            ::std::sync::LazyLock::new(|| {
+                $crate::metrics::__private::new_histogram($name, $subsystem)
+            });
+    };
+}
+
+/// Declares a labeled histogram (`HistogramVec<N>`) with compile-time static registration.
+#[macro_export]
+macro_rules! define_histogram_vec {
+    (
+        $static_name:ident,
+        name: $name:literal,
+        help: $help:literal,
+        subsystem: $subsystem:literal,
+        const_labels: [$(($ck:literal, $cv:literal)),* $(,)?],
+        labels: [$($label:literal),+ $(,)?],
+        buckets: $buckets:expr $(,)?
+    ) => {
+        $crate::inventory::submit! {
+            $crate::metrics::HistogramConfig {
+                name: $name,
+                subsystem: $subsystem,
+                help: $help,
+                buckets_fn: || $buckets,
+            }
+        }
+
+        pub static $static_name: ::std::sync::LazyLock<
+            $crate::metrics::HistogramVec<{ [$($label),+].len() }>,
+        > = ::std::sync::LazyLock::new(|| {
+            $crate::metrics::__private::new_histogram_vec(
+                $name,
+                $subsystem,
+                &[$(($ck, $cv)),*],
+                [$($label),+],
+            )
+        });
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use metrics_util::MetricKind;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshot};
+
+    use super::*;
+
+    type LabelPair = (String, String);
+
+    fn with_test_recorder<F, R>(f: F) -> (R, Snapshot)
+    where F: FnOnce() -> R {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let result = metrics::with_local_recorder(&recorder, f);
+        (result, snapshotter.snapshot())
+    }
+
+    fn entries_for(
+        snapshot: Snapshot,
+        name: &str,
+    ) -> Vec<(MetricKind, Vec<LabelPair>, DebugValue)> {
+        snapshot
+            .into_vec()
+            .into_iter()
+            .filter(|(ck, _, _, _)| ck.key().name() == name)
+            .map(|(ck, _, _, value)| {
+                let labels: Vec<LabelPair> = ck
+                    .key()
+                    .labels()
+                    .map(|l| (l.key().to_string(), l.value().to_string()))
+                    .collect();
+                (ck.kind(), labels, value)
+            })
+            .collect()
+    }
+
+    fn single_counter(snapshot: Snapshot, name: &str) -> u64 {
+        let entries = entries_for(snapshot, name);
+        assert_eq!(entries.len(), 1, "expected one counter entry for {name}");
+        let (kind, _, value) = entries.into_iter().next().unwrap();
+        assert_eq!(kind, MetricKind::Counter);
+        match value {
+            DebugValue::Counter(v) => v,
+            other => panic!("expected counter for {name}, got {other:?}"),
+        }
+    }
+
+    fn single_gauge(snapshot: Snapshot, name: &str) -> f64 {
+        let entries = entries_for(snapshot, name);
+        assert_eq!(entries.len(), 1, "expected one gauge entry for {name}");
+        let (kind, _, value) = entries.into_iter().next().unwrap();
+        assert_eq!(kind, MetricKind::Gauge);
+        match value {
+            DebugValue::Gauge(v) => v.into_inner(),
+            other => panic!("expected gauge for {name}, got {other:?}"),
+        }
+    }
+
+    fn single_histogram(snapshot: Snapshot, name: &str) -> Vec<f64> {
+        let entries = entries_for(snapshot, name);
+        assert_eq!(entries.len(), 1, "expected one histogram entry for {name}");
+        let (kind, _, value) = entries.into_iter().next().unwrap();
+        assert_eq!(kind, MetricKind::Histogram);
+        match value {
+            DebugValue::Histogram(v) => v.into_iter().map(|f| f.into_inner()).collect(),
+            other => panic!("expected histogram for {name}, got {other:?}"),
+        }
+    }
+
+    fn counter_by_labels(snapshot: Snapshot, name: &str) -> Vec<(Vec<LabelPair>, u64)> {
+        entries_for(snapshot, name)
+            .into_iter()
+            .map(|(kind, labels, value)| {
+                assert_eq!(kind, MetricKind::Counter);
+                let v = match value {
+                    DebugValue::Counter(v) => v,
+                    other => panic!("expected counter, got {other:?}"),
+                };
+                (labels, v)
+            })
+            .collect()
+    }
+
+    fn gauge_by_labels(snapshot: Snapshot, name: &str) -> Vec<(Vec<LabelPair>, f64)> {
+        entries_for(snapshot, name)
+            .into_iter()
+            .map(|(kind, labels, value)| {
+                assert_eq!(kind, MetricKind::Gauge);
+                let v = match value {
+                    DebugValue::Gauge(v) => v.into_inner(),
+                    other => panic!("expected gauge, got {other:?}"),
+                };
+                (labels, v)
+            })
+            .collect()
+    }
+
+    fn histogram_by_labels(snapshot: Snapshot, name: &str) -> Vec<(Vec<LabelPair>, Vec<f64>)> {
+        entries_for(snapshot, name)
+            .into_iter()
+            .map(|(kind, labels, value)| {
+                assert_eq!(kind, MetricKind::Histogram);
+                let v = match value {
+                    DebugValue::Histogram(v) => v.into_iter().map(|f| f.into_inner()).collect(),
+                    other => panic!("expected histogram, got {other:?}"),
+                };
+                (labels, v)
+            })
+            .collect()
+    }
+
+    fn has_label(labels: &[LabelPair], key: &str, value: &str) -> bool {
+        labels.iter().any(|(k, v)| k == key && v == value)
+    }
+
+    #[test]
+    fn int_counter() {
+        let (counter, snapshot) = with_test_recorder(|| {
+            let counter = new_counter("requests_total", "help", "test", &[]);
+            counter.inc();
+            counter.inc_by(5);
+            counter
+        });
+        assert_eq!(counter.get(), 6);
+        assert_eq!(single_counter(snapshot, "quickwit_test_requests_total"), 6);
+    }
+
+    #[test]
+    fn int_gauge() {
+        let (gauge, snapshot) = with_test_recorder(|| {
+            let gauge = new_gauge("connections", "help", "test", &[]);
+            gauge.set(10);
+            gauge.add(5);
+            gauge.sub(3);
+            gauge.inc();
+            gauge.dec();
+            gauge
+        });
+        assert_eq!(gauge.get(), 12);
+        assert_eq!(single_gauge(snapshot, "quickwit_test_connections"), 12f64);
+    }
+
+    #[test]
+    fn float_gauge() {
+        let (gauge, snapshot) = with_test_recorder(|| {
+            let gauge = new_float_gauge("load_factor", "help", "test", &[]);
+            gauge.set(2.5);
+            gauge.add(1.25);
+            gauge.sub(0.5);
+            gauge.inc();
+            gauge.dec();
+            gauge
+        });
+        assert_eq!(gauge.get(), 3.25);
+        assert_eq!(single_gauge(snapshot, "quickwit_test_load_factor"), 3.25);
+    }
+
+    #[test]
+    fn histogram_observe() {
+        let (_, snapshot) = with_test_recorder(|| {
+            let h = __private::new_histogram("latency_seconds", "test");
+            h.observe(0.1);
+            h.observe(0.25);
+            h.observe(1.5);
+        });
+        let values = single_histogram(snapshot, "quickwit_test_latency_seconds");
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0], 0.1);
+        assert_eq!(values[1], 0.25);
+        assert_eq!(values[2], 1.5);
+    }
+
+    #[test]
+    fn histogram_timer() {
+        let (_, snapshot) = with_test_recorder(|| {
+            // start_timer() + implicit drop records one observation.
+            let drop_h = __private::new_histogram("drop_timer_seconds", "test");
+            {
+                let _timer = drop_h.start_timer();
+            }
+            // observe_duration() consumes the timer; the subsequent drop must
+            // NOT record a second observation.
+            let explicit_h = __private::new_histogram("explicit_timer_seconds", "test");
+            let timer = explicit_h.start_timer();
+            timer.observe_duration();
+        });
+        let entries = snapshot.into_vec();
+        let histogram_len = |name: &str| -> usize {
+            let entry = entries
+                .iter()
+                .find(|(ck, _, _, _)| ck.key().name() == name)
+                .unwrap_or_else(|| panic!("histogram {name} not found"));
+            match &entry.3 {
+                DebugValue::Histogram(v) => v.len(),
+                other => panic!("expected histogram for {name}, got {other:?}"),
+            }
+        };
+        assert_eq!(
+            histogram_len("quickwit_test_drop_timer_seconds"),
+            1,
+            "HistogramTimer drop must record exactly one observation"
+        );
+        assert_eq!(
+            histogram_len("quickwit_test_explicit_timer_seconds"),
+            1,
+            "observe_duration + subsequent drop must record exactly one observation"
+        );
+    }
+
+    #[test]
+    fn int_counter_vec_caching_and_labels() {
+        let (handles, snapshot) = with_test_recorder(|| {
+            let vec = new_counter_vec(
+                "errors_total",
+                "help",
+                "test",
+                &[("env", "unit")],
+                ["status"],
+            );
+            let c500_first = vec.with_label_values(["500"]);
+            c500_first.inc_by(3);
+            let c500_second = vec.with_label_values(["500"]);
+            c500_second.inc_by(7);
+            let c404 = vec.with_label_values(["404"]);
+            c404.inc_by(2);
+            (c500_first, c500_second, c404)
+        });
+        let (c500_first, c500_second, c404) = handles;
+        assert_eq!(c500_first.get(), 10);
+        assert_eq!(c500_second.get(), 10);
+        assert_eq!(c404.get(), 2);
+
+        let entries = counter_by_labels(snapshot, "quickwit_test_errors_total");
+        assert_eq!(entries.len(), 2);
+        for (labels, _) in &entries {
+            assert!(
+                has_label(labels, "env", "unit"),
+                "const label missing: {labels:?}"
+            );
+        }
+        let lookup = |status: &str| -> u64 {
+            entries
+                .iter()
+                .find(|(labels, _)| has_label(labels, "status", status))
+                .map(|(_, v)| *v)
+                .unwrap_or_else(|| panic!("no entry for status={status}"))
+        };
+        assert_eq!(lookup("500"), 10);
+        assert_eq!(lookup("404"), 2);
+    }
+
+    #[test]
+    fn int_gauge_vec_caching_and_labels() {
+        let (handles, snapshot) = with_test_recorder(|| {
+            let vec = new_gauge_vec(
+                "queue_depth",
+                "help",
+                "test",
+                &[("region", "eu")],
+                ["queue"],
+            );
+            let primary_first = vec.with_label_values(["primary"]);
+            primary_first.set(5);
+            let primary_second = vec.with_label_values(["primary"]);
+            primary_second.add(3);
+            let secondary = vec.with_label_values(["secondary"]);
+            secondary.set(2);
+            (primary_first, primary_second, secondary)
+        });
+        let (primary_first, primary_second, secondary) = handles;
+        assert_eq!(primary_first.get(), 8);
+        assert_eq!(primary_second.get(), 8);
+        assert_eq!(secondary.get(), 2);
+
+        let entries = gauge_by_labels(snapshot, "quickwit_test_queue_depth");
+        assert_eq!(entries.len(), 2);
+        for (labels, _) in &entries {
+            assert!(has_label(labels, "region", "eu"));
+        }
+        let lookup = |queue: &str| -> f64 {
+            entries
+                .iter()
+                .find(|(labels, _)| has_label(labels, "queue", queue))
+                .map(|(_, v)| *v)
+                .unwrap_or_else(|| panic!("no entry for queue={queue}"))
+        };
+        assert_eq!(lookup("primary"), 8.0);
+        assert_eq!(lookup("secondary"), 2.0);
+    }
+
+    #[test]
+    fn histogram_vec_caching_and_labels() {
+        let (_, snapshot) = with_test_recorder(|| {
+            let vec = __private::new_histogram_vec(
+                "request_duration_seconds",
+                "test",
+                &[("service", "search")],
+                ["route"],
+            );
+            let h_search_first = vec.with_label_values(["/search"]);
+            h_search_first.observe(0.1);
+            let h_search_second = vec.with_label_values(["/search"]);
+            h_search_second.observe(0.3);
+            let h_health = vec.with_label_values(["/health"]);
+            h_health.observe(0.01);
+        });
+        let entries = histogram_by_labels(snapshot, "quickwit_test_request_duration_seconds");
+        assert_eq!(entries.len(), 2);
+        for (labels, _) in &entries {
+            assert!(has_label(labels, "service", "search"));
+        }
+        let lookup = |route: &str| -> Vec<f64> {
+            entries
+                .iter()
+                .find(|(labels, _)| has_label(labels, "route", route))
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| panic!("no entry for route={route}"))
+        };
+        let search = lookup("/search");
+        assert_eq!(
+            search.len(),
+            2,
+            "cached handle must share the underlying histogram"
+        );
+        assert_eq!(search[0], 0.1);
+        assert_eq!(search[1], 0.3);
+        let health = lookup("/health");
+        assert_eq!(health.len(), 1);
+        assert_eq!(health[0], 0.01);
+    }
+
+    #[test]
+    fn gauge_guard_lifecycle() {
+        let (_, snapshot) = with_test_recorder(|| {
+            let gauge = new_gauge("pending_bytes", "help", "test", &[]);
+            {
+                let mut guard = GaugeGuard::from_gauge(&gauge);
+                guard.add(3);
+                guard.add(2);
+                guard.sub(1);
+                assert_eq!(guard.get(), 4);
+                assert_eq!(gauge.get(), 4);
+            }
+            assert_eq!(gauge.get(), 0, "guard drop must restore gauge");
+        });
+        assert_eq!(single_gauge(snapshot, "quickwit_test_pending_bytes"), 0.0);
+    }
+
+    #[test]
+    fn owned_gauge_guard_lifecycle() {
+        let (_, snapshot) = with_test_recorder(|| {
+            let gauge = new_gauge("pending_items", "help", "test", &[]);
+            let gauge_view = gauge.clone();
+            {
+                let mut guard = OwnedGaugeGuard::from_gauge(gauge);
+                guard.add(5);
+                guard.sub(2);
+                assert_eq!(guard.get(), 3);
+                assert_eq!(gauge_view.get(), 3);
+            }
+            assert_eq!(gauge_view.get(), 0, "guard drop must restore gauge");
+        });
+        assert_eq!(single_gauge(snapshot, "quickwit_test_pending_items"), 0.0);
+    }
+}

--- a/quickwit/quickwit-common/src/runtimes.rs
+++ b/quickwit/quickwit-common/src/runtimes.rs
@@ -17,11 +17,10 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use prometheus::{Gauge, IntCounter, IntGauge};
 use tokio::runtime::Runtime;
 use tokio_metrics::{RuntimeMetrics, RuntimeMonitor};
 
-use crate::metrics::{new_counter, new_float_gauge, new_gauge};
+use crate::metrics::{Gauge, IntCounter, IntGauge, new_counter, new_float_gauge, new_gauge};
 
 static RUNTIMES: OnceLock<HashMap<RuntimeType, tokio::runtime::Runtime>> = OnceLock::new();
 

--- a/quickwit/quickwit-common/src/stream_utils.rs
+++ b/quickwit/quickwit-common/src/stream_utils.rs
@@ -18,12 +18,11 @@ use std::pin::Pin;
 
 use bytesize::ByteSize;
 use futures::{Stream, StreamExt, TryStreamExt, stream};
-use prometheus::IntGauge;
 use tokio::sync::{mpsc, watch};
 use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream, WatchStream};
 use tracing::warn;
 
-use crate::metrics::GaugeGuard;
+use crate::metrics::{GaugeGuard, IntGauge};
 use crate::tower::RpcName;
 
 pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send + Unpin + 'static>>;

--- a/quickwit/quickwit-common/src/thread_pool.rs
+++ b/quickwit/quickwit-common/src/thread_pool.rs
@@ -16,11 +16,10 @@ use std::fmt;
 use std::sync::{Arc, LazyLock};
 
 use futures::{Future, TryFutureExt};
-use prometheus::IntGauge;
 use tokio::sync::oneshot;
 use tracing::error;
 
-use crate::metrics::{GaugeGuard, IntGaugeVec, OwnedGaugeGuard, new_gauge_vec};
+use crate::metrics::{GaugeGuard, IntGauge, IntGaugeVec, OwnedGaugeGuard, new_gauge_vec};
 
 /// An executor backed by a thread pool to run CPU-intensive tasks.
 ///

--- a/quickwit/quickwit-common/src/tower/circuit_breaker.rs
+++ b/quickwit/quickwit-common/src/tower/circuit_breaker.rs
@@ -19,9 +19,10 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use pin_project::pin_project;
-use prometheus::IntCounter;
 use tokio::time::Instant;
 use tower::{Layer, Service};
+
+use crate::metrics::IntCounter;
 
 /// The circuit breaker layer implements the [circuit breaker pattern](https://martinfowler.com/bliki/CircuitBreaker.html).
 ///
@@ -49,7 +50,7 @@ pub struct CircuitBreakerLayer<Evaluator> {
     time_window: Duration,
     timeout: Duration,
     evaluator: Evaluator,
-    circuit_break_total: prometheus::IntCounter,
+    circuit_break_total: IntCounter,
 }
 
 pub trait CircuitBreakerEvaluator: Clone {
@@ -61,7 +62,7 @@ pub trait CircuitBreakerEvaluator: Clone {
         self,
         max_num_errors_per_secs: u32,
         timeout: Duration,
-        circuit_break_total: prometheus::IntCounter,
+        circuit_break_total: IntCounter,
     ) -> CircuitBreakerLayer<Self> {
         CircuitBreakerLayer {
             max_error_count_per_time_window: max_num_errors_per_secs,
@@ -301,7 +302,7 @@ mod tests {
 
         const TIMEOUT: Duration = Duration::from_millis(500);
 
-        let int_counter: prometheus::IntCounter =
+        let int_counter =
             IntCounter::new("circuit_break_total_test", "test circuit breaker counter").unwrap();
         let mut service = ServiceBuilder::new()
             .layer(TestCircuitBreakerEvaluator.make_layer(10, TIMEOUT, int_counter))

--- a/quickwit/quickwit-common/src/tower/metrics.rs
+++ b/quickwit/quickwit-common/src/tower/metrics.rs
@@ -21,7 +21,7 @@ use futures::{Future, ready};
 use pin_project::{pin_project, pinned_drop};
 use tower::{Layer, Service};
 
-use crate::define_histogram_vec;
+use crate::define_histogram;
 use crate::metrics::{
     HistogramVec, IntCounterVec, IntGaugeVec, exponential_buckets, new_counter_vec, new_gauge_vec,
 };
@@ -53,15 +53,16 @@ pub static GRPC_REQUESTS_IN_FLIGHT: LazyLock<IntGaugeVec<3>> = LazyLock::new(|| 
     )
 });
 
-define_histogram_vec! {
-    GRPC_REQUEST_DURATION_SECONDS,
-    name: "grpc_request_duration_seconds",
-    help: "Duration of gRPC request in seconds.",
-    subsystem: "",
-    const_labels: [],
-    labels: ["service", "kind", "rpc", "status"],
-    buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
-}
+pub static GRPC_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec<4>> = LazyLock::new(|| {
+    define_histogram! {
+        name: "grpc_request_duration_seconds",
+        help: "Duration of gRPC request in seconds.",
+        subsystem: "",
+        const_labels: [],
+        labels: ["service", "kind", "rpc", "status"],
+        buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
+    }
+});
 
 #[derive(Clone)]
 pub struct GrpcMetrics<S> {

--- a/quickwit/quickwit-common/src/tower/metrics.rs
+++ b/quickwit/quickwit-common/src/tower/metrics.rs
@@ -13,28 +13,64 @@
 // limitations under the License.
 
 use std::pin::Pin;
+use std::sync::LazyLock;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
 use futures::{Future, ready};
 use pin_project::{pin_project, pinned_drop};
-use prometheus::exponential_buckets;
 use tower::{Layer, Service};
 
+use crate::define_histogram_vec;
 use crate::metrics::{
-    HistogramVec, IntCounterVec, IntGaugeVec, new_counter_vec, new_gauge_vec, new_histogram_vec,
+    HistogramVec, IntCounterVec, IntGaugeVec, exponential_buckets, new_counter_vec, new_gauge_vec,
 };
 
 pub trait RpcName {
     fn rpc_name() -> &'static str;
 }
 
+/// Shared gRPC request metrics. `service` distinguishes Quickwit subsystems
+/// (`control_plane`, `indexing`, `ingest`, `metastore`, `cluster`, ...) and `kind` is
+/// `"client"` or `"server"`.
+pub static GRPC_REQUESTS_TOTAL: LazyLock<IntCounterVec<4>> = LazyLock::new(|| {
+    new_counter_vec(
+        "grpc_requests_total",
+        "Total number of gRPC requests processed.",
+        "",
+        &[],
+        ["service", "kind", "rpc", "status"],
+    )
+});
+
+pub static GRPC_REQUESTS_IN_FLIGHT: LazyLock<IntGaugeVec<3>> = LazyLock::new(|| {
+    new_gauge_vec(
+        "grpc_requests_in_flight",
+        "Number of gRPC requests in-flight.",
+        "",
+        &[],
+        ["service", "kind", "rpc"],
+    )
+});
+
+define_histogram_vec! {
+    GRPC_REQUEST_DURATION_SECONDS,
+    name: "grpc_request_duration_seconds",
+    help: "Duration of gRPC request in seconds.",
+    subsystem: "",
+    const_labels: [],
+    labels: ["service", "kind", "rpc", "status"],
+    buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
+}
+
 #[derive(Clone)]
 pub struct GrpcMetrics<S> {
     inner: S,
-    requests_total: IntCounterVec<2>,
-    requests_in_flight: IntGaugeVec<1>,
-    request_duration_seconds: HistogramVec<2>,
+    service: &'static str,
+    kind: &'static str,
+    requests_total: IntCounterVec<4>,
+    requests_in_flight: IntGaugeVec<3>,
+    request_duration_seconds: HistogramVec<4>,
 }
 
 impl<S, R> Service<R> for GrpcMetrics<S>
@@ -55,11 +91,15 @@ where
         let rpc_name = R::rpc_name();
         let inner = self.inner.call(request);
 
-        self.requests_in_flight.with_label_values([rpc_name]).inc();
+        self.requests_in_flight
+            .with_label_values([self.service, self.kind, rpc_name])
+            .inc();
 
         ResponseFuture {
             inner,
             start,
+            service: self.service,
+            kind: self.kind,
             rpc_name,
             status: "cancelled",
             requests_total: self.requests_total.clone(),
@@ -71,36 +111,21 @@ where
 
 #[derive(Clone)]
 pub struct GrpcMetricsLayer {
-    requests_total: IntCounterVec<2>,
-    requests_in_flight: IntGaugeVec<1>,
-    request_duration_seconds: HistogramVec<2>,
+    service: &'static str,
+    kind: &'static str,
+    requests_total: IntCounterVec<4>,
+    requests_in_flight: IntGaugeVec<3>,
+    request_duration_seconds: HistogramVec<4>,
 }
 
 impl GrpcMetricsLayer {
-    pub fn new(subsystem: &'static str, kind: &'static str) -> Self {
+    pub fn new(service: &'static str, kind: &'static str) -> Self {
         Self {
-            requests_total: new_counter_vec(
-                "grpc_requests_total",
-                "Total number of gRPC requests processed.",
-                subsystem,
-                &[("kind", kind)],
-                ["rpc", "status"],
-            ),
-            requests_in_flight: new_gauge_vec(
-                "grpc_requests_in_flight",
-                "Number of gRPC requests in-flight.",
-                subsystem,
-                &[("kind", kind)],
-                ["rpc"],
-            ),
-            request_duration_seconds: new_histogram_vec(
-                "grpc_request_duration_seconds",
-                "Duration of request in seconds.",
-                subsystem,
-                &[("kind", kind)],
-                ["rpc", "status"],
-                exponential_buckets(0.001, 2.0, 12).unwrap(),
-            ),
+            service,
+            kind,
+            requests_total: GRPC_REQUESTS_TOTAL.clone(),
+            requests_in_flight: GRPC_REQUESTS_IN_FLIGHT.clone(),
+            request_duration_seconds: GRPC_REQUEST_DURATION_SECONDS.clone(),
         }
     }
 }
@@ -111,6 +136,8 @@ impl<S> Layer<S> for GrpcMetricsLayer {
     fn layer(&self, inner: S) -> Self::Service {
         GrpcMetrics {
             inner,
+            service: self.service,
+            kind: self.kind,
             requests_total: self.requests_total.clone(),
             requests_in_flight: self.requests_in_flight.clone(),
             request_duration_seconds: self.request_duration_seconds.clone(),
@@ -118,31 +145,33 @@ impl<S> Layer<S> for GrpcMetricsLayer {
     }
 }
 
-/// Response future for [`PrometheusMetrics`].
+/// Response future for [`GrpcMetrics`].
 #[pin_project(PinnedDrop)]
 pub struct ResponseFuture<F> {
     #[pin]
     inner: F,
     start: Instant,
+    service: &'static str,
+    kind: &'static str,
     rpc_name: &'static str,
     status: &'static str,
-    requests_total: IntCounterVec<2>,
-    requests_in_flight: IntGaugeVec<1>,
-    request_duration_seconds: HistogramVec<2>,
+    requests_total: IntCounterVec<4>,
+    requests_in_flight: IntGaugeVec<3>,
+    request_duration_seconds: HistogramVec<4>,
 }
 
 #[pinned_drop]
 impl<F> PinnedDrop for ResponseFuture<F> {
     fn drop(self: Pin<&mut Self>) {
         let elapsed = self.start.elapsed().as_secs_f64();
-        let label_values = [self.rpc_name, self.status];
+        let label_values = [self.service, self.kind, self.rpc_name, self.status];
 
         self.requests_total.with_label_values(label_values).inc();
         self.request_duration_seconds
             .with_label_values(label_values)
             .observe(elapsed);
         self.requests_in_flight
-            .with_label_values([self.rpc_name])
+            .with_label_values([self.service, self.kind, self.rpc_name])
             .dec();
     }
 }
@@ -202,14 +231,14 @@ mod tests {
         assert_eq!(
             layer
                 .requests_total
-                .with_label_values(["hello", "success"])
+                .with_label_values(["quickwit_test", "server", "hello", "success"])
                 .get(),
             1
         );
         assert_eq!(
             layer
                 .requests_total
-                .with_label_values(["goodbye", "success"])
+                .with_label_values(["quickwit_test", "server", "goodbye", "success"])
                 .get(),
             0
         );
@@ -219,7 +248,7 @@ mod tests {
         assert_eq!(
             layer
                 .requests_total
-                .with_label_values(["goodbye", "success"])
+                .with_label_values(["quickwit_test", "server", "goodbye", "success"])
                 .get(),
             1
         );
@@ -230,7 +259,7 @@ mod tests {
         assert_eq!(
             layer
                 .requests_total
-                .with_label_values(["hello", "cancelled"])
+                .with_label_values(["quickwit_test", "server", "hello", "cancelled"])
                 .get(),
             1
         );

--- a/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
@@ -17,7 +17,7 @@ use std::sync::LazyLock;
 use mrecordlog::ResourceUsage;
 use quickwit_common::metrics::{
     Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, exponential_buckets,
-    linear_buckets, new_counter_vec, new_gauge, new_gauge_vec, new_histogram, new_histogram_vec,
+    linear_buckets, new_counter_vec, new_gauge, new_gauge_vec,
 };
 
 // Counter vec counting the different outcomes of ingest requests as
@@ -86,6 +86,32 @@ pub(super) struct IngestV2Metrics {
     pub ingest_attempts: IntCounterVec<1>,
 }
 
+quickwit_common::define_histogram! {
+    SHARD_LT_THROUGHPUT_MIB,
+    name: "shard_lt_throughput_mib",
+    help: "Shard long term throughput as reported through chitchat",
+    subsystem: "ingest",
+    buckets: linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
+}
+
+quickwit_common::define_histogram! {
+    SHARD_ST_THROUGHPUT_MIB,
+    name: "shard_st_throughput_mib",
+    help: "Shard short term throughput as reported through chitchat",
+    subsystem: "ingest",
+    buckets: linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
+}
+
+quickwit_common::define_histogram_vec! {
+    WAL_ACQUIRE_LOCK_REQUEST_DURATION_SECS,
+    name: "wal_acquire_lock_request_duration_secs",
+    help: "Duration of acquire lock requests in seconds.",
+    subsystem: "ingest",
+    const_labels: [],
+    labels: ["operation", "type"],
+    buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
+}
+
 impl Default for IngestV2Metrics {
     fn default() -> Self {
         Self {
@@ -116,18 +142,8 @@ impl Default for IngestV2Metrics {
                 "ingest",
                 &[("state", "closed")],
             ),
-            shard_lt_throughput_mib: new_histogram(
-                "shard_lt_throughput_mib",
-                "Shard long term throughput as reported through chitchat",
-                "ingest",
-                linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
-            ),
-            shard_st_throughput_mib: new_histogram(
-                "shard_st_throughput_mib",
-                "Shard short term throughput as reported through chitchat",
-                "ingest",
-                linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
-            ),
+            shard_lt_throughput_mib: SHARD_LT_THROUGHPUT_MIB.clone(),
+            shard_st_throughput_mib: SHARD_ST_THROUGHPUT_MIB.clone(),
             wal_acquire_lock_requests_in_flight: new_gauge_vec(
                 "wal_acquire_lock_requests_in_flight",
                 "Number of acquire lock requests in-flight.",
@@ -135,14 +151,7 @@ impl Default for IngestV2Metrics {
                 &[],
                 ["operation", "type"],
             ),
-            wal_acquire_lock_request_duration_secs: new_histogram_vec(
-                "wal_acquire_lock_request_duration_secs",
-                "Duration of acquire lock requests in seconds.",
-                "ingest",
-                &[],
-                ["operation", "type"],
-                exponential_buckets(0.001, 2.0, 12).unwrap(),
-            ),
+            wal_acquire_lock_request_duration_secs: WAL_ACQUIRE_LOCK_REQUEST_DURATION_SECS.clone(),
             wal_disk_used_bytes: new_gauge(
                 "wal_disk_used_bytes",
                 "WAL disk space used in bytes.",

--- a/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
@@ -86,31 +86,35 @@ pub(super) struct IngestV2Metrics {
     pub ingest_attempts: IntCounterVec<1>,
 }
 
-quickwit_common::define_histogram! {
-    SHARD_LT_THROUGHPUT_MIB,
-    name: "shard_lt_throughput_mib",
-    help: "Shard long term throughput as reported through chitchat",
-    subsystem: "ingest",
-    buckets: linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
-}
+pub static SHARD_LT_THROUGHPUT_MIB: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "shard_lt_throughput_mib",
+        help: "Shard long term throughput as reported through chitchat",
+        subsystem: "ingest",
+        buckets: linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
+    }
+});
 
-quickwit_common::define_histogram! {
-    SHARD_ST_THROUGHPUT_MIB,
-    name: "shard_st_throughput_mib",
-    help: "Shard short term throughput as reported through chitchat",
-    subsystem: "ingest",
-    buckets: linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
-}
+pub static SHARD_ST_THROUGHPUT_MIB: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "shard_st_throughput_mib",
+        help: "Shard short term throughput as reported through chitchat",
+        subsystem: "ingest",
+        buckets: linear_buckets(0.0f64, 1.0f64, 15).unwrap(),
+    }
+});
 
-quickwit_common::define_histogram_vec! {
-    WAL_ACQUIRE_LOCK_REQUEST_DURATION_SECS,
-    name: "wal_acquire_lock_request_duration_secs",
-    help: "Duration of acquire lock requests in seconds.",
-    subsystem: "ingest",
-    const_labels: [],
-    labels: ["operation", "type"],
-    buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
-}
+pub static WAL_ACQUIRE_LOCK_REQUEST_DURATION_SECS: LazyLock<HistogramVec<2>> =
+    LazyLock::new(|| {
+        quickwit_common::define_histogram! {
+            name: "wal_acquire_lock_request_duration_secs",
+            help: "Duration of acquire lock requests in seconds.",
+            subsystem: "ingest",
+            const_labels: [],
+            labels: ["operation", "type"],
+            buckets: exponential_buckets(0.001, 2.0, 12).unwrap(),
+        }
+    });
 
 impl Default for IngestV2Metrics {
     fn default() -> Self {

--- a/quickwit/quickwit-jaeger/src/metrics.rs
+++ b/quickwit/quickwit-jaeger/src/metrics.rs
@@ -14,9 +14,7 @@
 
 use std::sync::LazyLock;
 
-use quickwit_common::metrics::{
-    HistogramVec, IntCounterVec, exponential_buckets, new_counter_vec, new_histogram_vec,
-};
+use quickwit_common::metrics::{HistogramVec, IntCounterVec, exponential_buckets, new_counter_vec};
 
 pub struct JaegerServiceMetrics {
     pub requests_total: IntCounterVec<2>,
@@ -25,6 +23,16 @@ pub struct JaegerServiceMetrics {
     pub fetched_traces_total: IntCounterVec<2>,
     pub fetched_spans_total: IntCounterVec<2>,
     pub transferred_bytes_total: IntCounterVec<2>,
+}
+
+quickwit_common::define_histogram_vec! {
+    REQUEST_DURATION_SECONDS,
+    name: "request_duration_seconds",
+    help: "Duration of requests",
+    subsystem: "jaeger",
+    const_labels: [],
+    labels: ["operation", "index", "error"],
+    buckets: exponential_buckets(0.02, 2.0, 8).unwrap(),
 }
 
 impl Default for JaegerServiceMetrics {
@@ -44,14 +52,7 @@ impl Default for JaegerServiceMetrics {
                 &[],
                 ["operation", "index"],
             ),
-            request_duration_seconds: new_histogram_vec(
-                "request_duration_seconds",
-                "Duration of requests",
-                "jaeger",
-                &[],
-                ["operation", "index", "error"],
-                exponential_buckets(0.02, 2.0, 8).unwrap(),
-            ),
+            request_duration_seconds: REQUEST_DURATION_SECONDS.clone(),
             fetched_traces_total: new_counter_vec(
                 "fetched_traces_total",
                 "Number of traces retrieved from storage",

--- a/quickwit/quickwit-jaeger/src/metrics.rs
+++ b/quickwit/quickwit-jaeger/src/metrics.rs
@@ -25,15 +25,16 @@ pub struct JaegerServiceMetrics {
     pub transferred_bytes_total: IntCounterVec<2>,
 }
 
-quickwit_common::define_histogram_vec! {
-    REQUEST_DURATION_SECONDS,
-    name: "request_duration_seconds",
-    help: "Duration of requests",
-    subsystem: "jaeger",
-    const_labels: [],
-    labels: ["operation", "index", "error"],
-    buckets: exponential_buckets(0.02, 2.0, 8).unwrap(),
-}
+pub static REQUEST_DURATION_SECONDS: LazyLock<HistogramVec<3>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "request_duration_seconds",
+        help: "Duration of requests",
+        subsystem: "jaeger",
+        const_labels: [],
+        labels: ["operation", "index", "error"],
+        buckets: exponential_buckets(0.02, 2.0, 8).unwrap(),
+    }
+});
 
 impl Default for JaegerServiceMetrics {
     fn default() -> Self {

--- a/quickwit/quickwit-lambda-client/src/metrics.rs
+++ b/quickwit/quickwit-lambda-client/src/metrics.rs
@@ -17,8 +17,7 @@
 use std::sync::LazyLock;
 
 use quickwit_common::metrics::{
-    Histogram, HistogramVec, IntCounterVec, exponential_buckets, new_counter_vec, new_histogram,
-    new_histogram_vec,
+    Histogram, HistogramVec, IntCounterVec, exponential_buckets, new_counter_vec,
 };
 
 /// From 100ms to 73s seconds
@@ -38,6 +37,32 @@ pub struct LambdaMetrics {
     pub leaf_search_response_payload_size_bytes: Histogram,
 }
 
+quickwit_common::define_histogram_vec! {
+    LEAF_SEARCH_DURATION_SECONDS,
+    name: "leaf_search_duration_seconds",
+    help: "Duration of Lambda leaf search invocations in seconds.",
+    subsystem: "lambda",
+    const_labels: [],
+    labels: ["status"],
+    buckets: duration_buckets(),
+}
+
+quickwit_common::define_histogram! {
+    LEAF_SEARCH_REQUEST_PAYLOAD_SIZE_BYTES,
+    name: "leaf_search_request_payload_size_bytes",
+    help: "Size of the request payload sent to Lambda in bytes.",
+    subsystem: "lambda",
+    buckets: payload_size_buckets(),
+}
+
+quickwit_common::define_histogram! {
+    LEAF_SEARCH_RESPONSE_PAYLOAD_SIZE_BYTES,
+    name: "leaf_search_response_payload_size_bytes",
+    help: "Size of the response payload received from Lambda in bytes.",
+    subsystem: "lambda",
+    buckets: payload_size_buckets(),
+}
+
 impl Default for LambdaMetrics {
     fn default() -> Self {
         LambdaMetrics {
@@ -48,26 +73,10 @@ impl Default for LambdaMetrics {
                 &[],
                 ["status"],
             ),
-            leaf_search_duration_seconds: new_histogram_vec(
-                "leaf_search_duration_seconds",
-                "Duration of Lambda leaf search invocations in seconds.",
-                "lambda",
-                &[],
-                ["status"],
-                duration_buckets(),
-            ),
-            leaf_search_request_payload_size_bytes: new_histogram(
-                "leaf_search_request_payload_size_bytes",
-                "Size of the request payload sent to Lambda in bytes.",
-                "lambda",
-                payload_size_buckets(),
-            ),
-            leaf_search_response_payload_size_bytes: new_histogram(
-                "leaf_search_response_payload_size_bytes",
-                "Size of the response payload received from Lambda in bytes.",
-                "lambda",
-                payload_size_buckets(),
-            ),
+            leaf_search_duration_seconds: LEAF_SEARCH_DURATION_SECONDS.clone(),
+            leaf_search_request_payload_size_bytes: LEAF_SEARCH_REQUEST_PAYLOAD_SIZE_BYTES.clone(),
+            leaf_search_response_payload_size_bytes: LEAF_SEARCH_RESPONSE_PAYLOAD_SIZE_BYTES
+                .clone(),
         }
     }
 }

--- a/quickwit/quickwit-lambda-client/src/metrics.rs
+++ b/quickwit/quickwit-lambda-client/src/metrics.rs
@@ -37,31 +37,34 @@ pub struct LambdaMetrics {
     pub leaf_search_response_payload_size_bytes: Histogram,
 }
 
-quickwit_common::define_histogram_vec! {
-    LEAF_SEARCH_DURATION_SECONDS,
-    name: "leaf_search_duration_seconds",
-    help: "Duration of Lambda leaf search invocations in seconds.",
-    subsystem: "lambda",
-    const_labels: [],
-    labels: ["status"],
-    buckets: duration_buckets(),
-}
+pub static LEAF_SEARCH_DURATION_SECONDS: LazyLock<HistogramVec<1>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "leaf_search_duration_seconds",
+        help: "Duration of Lambda leaf search invocations in seconds.",
+        subsystem: "lambda",
+        const_labels: [],
+        labels: ["status"],
+        buckets: duration_buckets(),
+    }
+});
 
-quickwit_common::define_histogram! {
-    LEAF_SEARCH_REQUEST_PAYLOAD_SIZE_BYTES,
-    name: "leaf_search_request_payload_size_bytes",
-    help: "Size of the request payload sent to Lambda in bytes.",
-    subsystem: "lambda",
-    buckets: payload_size_buckets(),
-}
+pub static LEAF_SEARCH_REQUEST_PAYLOAD_SIZE_BYTES: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "leaf_search_request_payload_size_bytes",
+        help: "Size of the request payload sent to Lambda in bytes.",
+        subsystem: "lambda",
+        buckets: payload_size_buckets(),
+    }
+});
 
-quickwit_common::define_histogram! {
-    LEAF_SEARCH_RESPONSE_PAYLOAD_SIZE_BYTES,
-    name: "leaf_search_response_payload_size_bytes",
-    help: "Size of the response payload received from Lambda in bytes.",
-    subsystem: "lambda",
-    buckets: payload_size_buckets(),
-}
+pub static LEAF_SEARCH_RESPONSE_PAYLOAD_SIZE_BYTES: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "leaf_search_response_payload_size_bytes",
+        help: "Size of the response payload received from Lambda in bytes.",
+        subsystem: "lambda",
+        buckets: payload_size_buckets(),
+    }
+});
 
 impl Default for LambdaMetrics {
     fn default() -> Self {

--- a/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
@@ -14,9 +14,7 @@
 
 use std::sync::LazyLock;
 
-use quickwit_common::metrics::{
-    HistogramVec, IntCounterVec, exponential_buckets, new_counter_vec, new_histogram_vec,
-};
+use quickwit_common::metrics::{HistogramVec, IntCounterVec, exponential_buckets, new_counter_vec};
 
 pub struct OtlpServiceMetrics {
     pub requests_total: IntCounterVec<4>,
@@ -26,6 +24,16 @@ pub struct OtlpServiceMetrics {
     pub ingested_spans_total: IntCounterVec<4>,
     pub ingested_data_points_total: IntCounterVec<4>,
     pub ingested_bytes_total: IntCounterVec<4>,
+}
+
+quickwit_common::define_histogram_vec! {
+    REQUEST_DURATION_SECONDS,
+    name: "request_duration_seconds",
+    help: "Duration of requests",
+    subsystem: "otlp",
+    const_labels: [],
+    labels: ["service", "index", "transport", "format", "error"],
+    buckets: exponential_buckets(0.02, 2.0, 8).unwrap(),
 }
 
 impl Default for OtlpServiceMetrics {
@@ -45,14 +53,7 @@ impl Default for OtlpServiceMetrics {
                 &[],
                 ["service", "index", "transport", "format"],
             ),
-            request_duration_seconds: new_histogram_vec(
-                "request_duration_seconds",
-                "Duration of requests",
-                "otlp",
-                &[],
-                ["service", "index", "transport", "format", "error"],
-                exponential_buckets(0.02, 2.0, 8).unwrap(),
-            ),
+            request_duration_seconds: REQUEST_DURATION_SECONDS.clone(),
             ingested_log_records_total: new_counter_vec(
                 "ingested_log_records_total",
                 "Number of log records ingested",

--- a/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
@@ -26,15 +26,16 @@ pub struct OtlpServiceMetrics {
     pub ingested_bytes_total: IntCounterVec<4>,
 }
 
-quickwit_common::define_histogram_vec! {
-    REQUEST_DURATION_SECONDS,
-    name: "request_duration_seconds",
-    help: "Duration of requests",
-    subsystem: "otlp",
-    const_labels: [],
-    labels: ["service", "index", "transport", "format", "error"],
-    buckets: exponential_buckets(0.02, 2.0, 8).unwrap(),
-}
+pub static REQUEST_DURATION_SECONDS: LazyLock<HistogramVec<5>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "request_duration_seconds",
+        help: "Duration of requests",
+        subsystem: "otlp",
+        const_labels: [],
+        labels: ["service", "index", "transport", "format", "error"],
+        buckets: exponential_buckets(0.02, 2.0, 8).unwrap(),
+    }
+});
 
 impl Default for OtlpServiceMetrics {
     fn default() -> Self {

--- a/quickwit/quickwit-parquet-engine/src/metrics.rs
+++ b/quickwit/quickwit-parquet-engine/src/metrics.rs
@@ -58,21 +58,23 @@ pub struct ParquetEngineMetrics {
     pub errors_total: IntCounterVec<2>,
 }
 
-quickwit_common::define_histogram! {
-    INDEX_BATCH_DURATION_SECONDS,
-    name: "index_batch_duration_seconds",
-    help: "Histogram of add_batch durations in seconds, including any triggered flush.",
-    subsystem: "metrics_engine",
-    buckets: duration_buckets(),
-}
+pub static INDEX_BATCH_DURATION_SECONDS: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "index_batch_duration_seconds",
+        help: "Histogram of add_batch durations in seconds, including any triggered flush.",
+        subsystem: "metrics_engine",
+        buckets: duration_buckets(),
+    }
+});
 
-quickwit_common::define_histogram! {
-    QUERY_DURATION_SECONDS,
-    name: "query_duration_seconds",
-    help: "Histogram of query execution durations in seconds.",
-    subsystem: "metrics_engine",
-    buckets: duration_buckets(),
-}
+pub static QUERY_DURATION_SECONDS: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "query_duration_seconds",
+        help: "Histogram of query execution durations in seconds.",
+        subsystem: "metrics_engine",
+        buckets: duration_buckets(),
+    }
+});
 
 impl Default for ParquetEngineMetrics {
     fn default() -> Self {

--- a/quickwit/quickwit-parquet-engine/src/metrics.rs
+++ b/quickwit/quickwit-parquet-engine/src/metrics.rs
@@ -20,7 +20,7 @@
 use std::sync::LazyLock;
 
 use quickwit_common::metrics::{
-    Histogram, IntCounter, IntCounterVec, new_counter, new_counter_vec, new_histogram,
+    Histogram, IntCounter, IntCounterVec, new_counter, new_counter_vec,
 };
 
 /// Subsystem name for all metrics engine metrics.
@@ -58,6 +58,22 @@ pub struct ParquetEngineMetrics {
     pub errors_total: IntCounterVec<2>,
 }
 
+quickwit_common::define_histogram! {
+    INDEX_BATCH_DURATION_SECONDS,
+    name: "index_batch_duration_seconds",
+    help: "Histogram of add_batch durations in seconds, including any triggered flush.",
+    subsystem: "metrics_engine",
+    buckets: duration_buckets(),
+}
+
+quickwit_common::define_histogram! {
+    QUERY_DURATION_SECONDS,
+    name: "query_duration_seconds",
+    help: "Histogram of query execution durations in seconds.",
+    subsystem: "metrics_engine",
+    buckets: duration_buckets(),
+}
+
 impl Default for ParquetEngineMetrics {
     fn default() -> Self {
         Self {
@@ -80,12 +96,7 @@ impl Default for ParquetEngineMetrics {
                 &[],
                 ["kind"],
             ),
-            index_batch_duration_seconds: new_histogram(
-                "index_batch_duration_seconds",
-                "Histogram of add_batch durations in seconds, including any triggered flush.",
-                SUBSYSTEM,
-                duration_buckets(),
-            ),
+            index_batch_duration_seconds: INDEX_BATCH_DURATION_SECONDS.clone(),
             splits_written_total: new_counter(
                 "splits_written_total",
                 "Total number of splits written to storage.",
@@ -98,12 +109,7 @@ impl Default for ParquetEngineMetrics {
                 SUBSYSTEM,
                 &[],
             ),
-            query_duration_seconds: new_histogram(
-                "query_duration_seconds",
-                "Histogram of query execution durations in seconds.",
-                SUBSYSTEM,
-                duration_buckets(),
-            ),
+            query_duration_seconds: QUERY_DURATION_SECONDS.clone(),
             query_rows_returned: new_counter(
                 "query_rows_returned",
                 "Total number of rows returned from queries.",

--- a/quickwit/quickwit-search/src/metrics.rs
+++ b/quickwit/quickwit-search/src/metrics.rs
@@ -152,62 +152,68 @@ fn warmup_num_bytes_buckets() -> Vec<f64> {
     ]
 }
 
-quickwit_common::define_histogram_vec! {
-    ROOT_SEARCH_REQUEST_DURATION_SECONDS,
-    name: "root_search_request_duration_seconds",
-    help: "Duration of root search gRPC requests in seconds.",
-    subsystem: "search",
-    const_labels: [("kind", "server")],
-    labels: ["status"],
-    buckets: duration_buckets(),
-}
+pub static ROOT_SEARCH_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec<1>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "root_search_request_duration_seconds",
+        help: "Duration of root search gRPC requests in seconds.",
+        subsystem: "search",
+        const_labels: [("kind", "server")],
+        labels: ["status"],
+        buckets: duration_buckets(),
+    }
+});
 
-quickwit_common::define_histogram_vec! {
-    ROOT_SEARCH_TARGETED_SPLITS,
-    name: "root_search_targeted_splits",
-    help: "Number of splits targeted per root search GRPC request.",
-    subsystem: "search",
-    const_labels: [],
-    labels: ["status"],
-    buckets: targeted_splits_buckets(),
-}
+pub static ROOT_SEARCH_TARGETED_SPLITS: LazyLock<HistogramVec<1>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "root_search_targeted_splits",
+        help: "Number of splits targeted per root search GRPC request.",
+        subsystem: "search",
+        const_labels: [],
+        labels: ["status"],
+        buckets: targeted_splits_buckets(),
+    }
+});
 
-quickwit_common::define_histogram_vec! {
-    LEAF_SEARCH_REQUEST_DURATION_SECONDS,
-    name: "leaf_search_request_duration_seconds",
-    help: "Duration of leaf search gRPC requests in seconds.",
-    subsystem: "search",
-    const_labels: [("kind", "server")],
-    labels: ["status"],
-    buckets: duration_buckets(),
-}
+pub static LEAF_SEARCH_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec<1>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "leaf_search_request_duration_seconds",
+        help: "Duration of leaf search gRPC requests in seconds.",
+        subsystem: "search",
+        const_labels: [("kind", "server")],
+        labels: ["status"],
+        buckets: duration_buckets(),
+    }
+});
 
-quickwit_common::define_histogram_vec! {
-    LEAF_SEARCH_TARGETED_SPLITS,
-    name: "leaf_search_targeted_splits",
-    help: "Number of splits targeted per leaf search GRPC request.",
-    subsystem: "search",
-    const_labels: [],
-    labels: ["status"],
-    buckets: targeted_splits_buckets(),
-}
+pub static LEAF_SEARCH_TARGETED_SPLITS: LazyLock<HistogramVec<1>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "leaf_search_targeted_splits",
+        help: "Number of splits targeted per leaf search GRPC request.",
+        subsystem: "search",
+        const_labels: [],
+        labels: ["status"],
+        buckets: targeted_splits_buckets(),
+    }
+});
 
-quickwit_common::define_histogram! {
-    LEAF_SEARCH_SPLIT_DURATION_SECS,
-    name: "leaf_search_split_duration_secs",
-    help: "Number of seconds required to run a leaf search over a single split. The timer starts \
-           after the semaphore is obtained.",
-    subsystem: "search",
-    buckets: duration_buckets(),
-}
+pub static LEAF_SEARCH_SPLIT_DURATION_SECS: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "leaf_search_split_duration_secs",
+        help: "Number of seconds required to run a leaf search over a single split. The timer \
+               starts after the semaphore is obtained.",
+        subsystem: "search",
+        buckets: duration_buckets(),
+    }
+});
 
-quickwit_common::define_histogram! {
-    LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES,
-    name: "leaf_search_single_split_warmup_num_bytes",
-    help: "Size of the short lived cache for a single split once the warmup is done.",
-    subsystem: "search",
-    buckets: warmup_num_bytes_buckets(),
-}
+pub static LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES: LazyLock<Histogram> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "leaf_search_single_split_warmup_num_bytes",
+        help: "Size of the short lived cache for a single split once the warmup is done.",
+        subsystem: "search",
+        buckets: warmup_num_bytes_buckets(),
+    }
+});
 
 impl Default for SearchMetrics {
     fn default() -> Self {

--- a/quickwit/quickwit-search/src/metrics.rs
+++ b/quickwit/quickwit-search/src/metrics.rs
@@ -20,8 +20,7 @@ use std::sync::LazyLock;
 use bytesize::ByteSize;
 use quickwit_common::metrics::{
     Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, exponential_buckets,
-    linear_buckets, new_counter, new_counter_vec, new_gauge, new_gauge_vec, new_histogram,
-    new_histogram_vec,
+    linear_buckets, new_counter, new_counter_vec, new_gauge, new_gauge_vec,
 };
 
 fn print_if_not_null(
@@ -126,31 +125,92 @@ fn duration_buckets() -> Vec<f64> {
     exponential_buckets(0.008, 2.0, 15).unwrap()
 }
 
+fn targeted_splits_buckets() -> Vec<f64> {
+    [
+        linear_buckets(0.0, 10.0, 10).unwrap(),
+        linear_buckets(100.0, 100.0, 9).unwrap(),
+        linear_buckets(1000.0, 1000.0, 9).unwrap(),
+        linear_buckets(10000.0, 10000.0, 10).unwrap(),
+    ]
+    .iter()
+    .flatten()
+    .copied()
+    .collect()
+}
+
+fn warmup_num_bytes_buckets() -> Vec<f64> {
+    vec![
+        ByteSize::mb(10).as_u64() as f64,
+        ByteSize::mb(20).as_u64() as f64,
+        ByteSize::mb(50).as_u64() as f64,
+        ByteSize::mb(100).as_u64() as f64,
+        ByteSize::mb(200).as_u64() as f64,
+        ByteSize::mb(500).as_u64() as f64,
+        ByteSize::gb(1).as_u64() as f64,
+        ByteSize::gb(2).as_u64() as f64,
+        ByteSize::gb(5).as_u64() as f64,
+    ]
+}
+
+quickwit_common::define_histogram_vec! {
+    ROOT_SEARCH_REQUEST_DURATION_SECONDS,
+    name: "root_search_request_duration_seconds",
+    help: "Duration of root search gRPC requests in seconds.",
+    subsystem: "search",
+    const_labels: [("kind", "server")],
+    labels: ["status"],
+    buckets: duration_buckets(),
+}
+
+quickwit_common::define_histogram_vec! {
+    ROOT_SEARCH_TARGETED_SPLITS,
+    name: "root_search_targeted_splits",
+    help: "Number of splits targeted per root search GRPC request.",
+    subsystem: "search",
+    const_labels: [],
+    labels: ["status"],
+    buckets: targeted_splits_buckets(),
+}
+
+quickwit_common::define_histogram_vec! {
+    LEAF_SEARCH_REQUEST_DURATION_SECONDS,
+    name: "leaf_search_request_duration_seconds",
+    help: "Duration of leaf search gRPC requests in seconds.",
+    subsystem: "search",
+    const_labels: [("kind", "server")],
+    labels: ["status"],
+    buckets: duration_buckets(),
+}
+
+quickwit_common::define_histogram_vec! {
+    LEAF_SEARCH_TARGETED_SPLITS,
+    name: "leaf_search_targeted_splits",
+    help: "Number of splits targeted per leaf search GRPC request.",
+    subsystem: "search",
+    const_labels: [],
+    labels: ["status"],
+    buckets: targeted_splits_buckets(),
+}
+
+quickwit_common::define_histogram! {
+    LEAF_SEARCH_SPLIT_DURATION_SECS,
+    name: "leaf_search_split_duration_secs",
+    help: "Number of seconds required to run a leaf search over a single split. The timer starts \
+           after the semaphore is obtained.",
+    subsystem: "search",
+    buckets: duration_buckets(),
+}
+
+quickwit_common::define_histogram! {
+    LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES,
+    name: "leaf_search_single_split_warmup_num_bytes",
+    help: "Size of the short lived cache for a single split once the warmup is done.",
+    subsystem: "search",
+    buckets: warmup_num_bytes_buckets(),
+}
+
 impl Default for SearchMetrics {
     fn default() -> Self {
-        let targeted_splits_buckets: Vec<f64> = [
-            linear_buckets(0.0, 10.0, 10).unwrap(),
-            linear_buckets(100.0, 100.0, 9).unwrap(),
-            linear_buckets(1000.0, 1000.0, 9).unwrap(),
-            linear_buckets(10000.0, 10000.0, 10).unwrap(),
-        ]
-        .iter()
-        .flatten()
-        .copied()
-        .collect();
-
-        let pseudo_exponential_bytes_buckets = vec![
-            ByteSize::mb(10).as_u64() as f64,
-            ByteSize::mb(20).as_u64() as f64,
-            ByteSize::mb(50).as_u64() as f64,
-            ByteSize::mb(100).as_u64() as f64,
-            ByteSize::mb(200).as_u64() as f64,
-            ByteSize::mb(500).as_u64() as f64,
-            ByteSize::gb(1).as_u64() as f64,
-            ByteSize::gb(2).as_u64() as f64,
-            ByteSize::gb(5).as_u64() as f64,
-        ];
-
         let leaf_search_single_split_tasks = new_gauge_vec::<1>(
             "leaf_search_single_split_tasks",
             "Number of single split search tasks pending or ongoing",
@@ -167,22 +227,8 @@ impl Default for SearchMetrics {
                 &[("kind", "server")],
                 ["status"],
             ),
-            root_search_request_duration_seconds: new_histogram_vec(
-                "root_search_request_duration_seconds",
-                "Duration of root search gRPC requests in seconds.",
-                "search",
-                &[("kind", "server")],
-                ["status"],
-                duration_buckets(),
-            ),
-            root_search_targeted_splits: new_histogram_vec(
-                "root_search_targeted_splits",
-                "Number of splits targeted per root search GRPC request.",
-                "search",
-                &[],
-                ["status"],
-                targeted_splits_buckets.clone(),
-            ),
+            root_search_request_duration_seconds: ROOT_SEARCH_REQUEST_DURATION_SECONDS.clone(),
+            root_search_targeted_splits: ROOT_SEARCH_TARGETED_SPLITS.clone(),
             leaf_search_requests_total: new_counter_vec(
                 "leaf_search_requests_total",
                 "Total number of leaf search gRPC requests processed.",
@@ -190,23 +236,8 @@ impl Default for SearchMetrics {
                 &[("kind", "server")],
                 ["status"],
             ),
-            leaf_search_request_duration_seconds: new_histogram_vec(
-                "leaf_search_request_duration_seconds",
-                "Duration of leaf search gRPC requests in seconds.",
-                "search",
-                &[("kind", "server")],
-                ["status"],
-                duration_buckets(),
-            ),
-            leaf_search_targeted_splits: new_histogram_vec(
-                "leaf_search_targeted_splits",
-                "Number of splits targeted per leaf search GRPC request.",
-                "search",
-                &[],
-                ["status"],
-                targeted_splits_buckets,
-            ),
-
+            leaf_search_request_duration_seconds: LEAF_SEARCH_REQUEST_DURATION_SECONDS.clone(),
+            leaf_search_targeted_splits: LEAF_SEARCH_TARGETED_SPLITS.clone(),
             leaf_list_terms_splits_total: new_counter(
                 "leaf_list_terms_splits_total",
                 "Number of list terms splits total",
@@ -214,24 +245,13 @@ impl Default for SearchMetrics {
                 &[],
             ),
             split_search_outcome_total: SplitSearchOutcomeCounters::new_registered(),
-
-            leaf_search_split_duration_secs: new_histogram(
-                "leaf_search_split_duration_secs",
-                "Number of seconds required to run a leaf search over a single split. The timer \
-                 starts after the semaphore is obtained.",
-                "search",
-                duration_buckets(),
-            ),
+            leaf_search_split_duration_secs: LEAF_SEARCH_SPLIT_DURATION_SECS.clone(),
             leaf_search_single_split_tasks_ongoing: leaf_search_single_split_tasks
                 .with_label_values(["ongoing"]),
             leaf_search_single_split_tasks_pending: leaf_search_single_split_tasks
                 .with_label_values(["pending"]),
-            leaf_search_single_split_warmup_num_bytes: new_histogram(
-                "leaf_search_single_split_warmup_num_bytes",
-                "Size of the short lived cache for a single split once the warmup is done.",
-                "search",
-                pseudo_exponential_bytes_buckets,
-            ),
+            leaf_search_single_split_warmup_num_bytes: LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES
+                .clone(),
             job_assigned_total: new_counter_vec(
                 "job_assigned_total",
                 "Number of job assigned to searchers, per affinity rank.",

--- a/quickwit/quickwit-serve/src/metrics.rs
+++ b/quickwit/quickwit-serve/src/metrics.rs
@@ -27,16 +27,17 @@ pub struct ServeMetrics {
     pub circuit_break_total: IntCounter,
 }
 
-quickwit_common::define_histogram_vec! {
-    REQUEST_DURATION_SECS,
-    name: "request_duration_secs",
-    help: "Response time in seconds",
-    subsystem: "",
-    const_labels: [],
-    labels: ["method", "status_code"],
-    // last bucket is 163.84s
-    buckets: quickwit_common::metrics::exponential_buckets(0.02, 2.0, 14).unwrap(),
-}
+pub static REQUEST_DURATION_SECS: LazyLock<HistogramVec<2>> = LazyLock::new(|| {
+    quickwit_common::define_histogram! {
+        name: "request_duration_secs",
+        help: "Response time in seconds",
+        subsystem: "",
+        const_labels: [],
+        labels: ["method", "status_code"],
+        // last bucket is 163.84s
+        buckets: quickwit_common::metrics::exponential_buckets(0.02, 2.0, 14).unwrap(),
+    }
+});
 
 impl Default for ServeMetrics {
     fn default() -> Self {

--- a/quickwit/quickwit-serve/src/metrics.rs
+++ b/quickwit/quickwit-serve/src/metrics.rs
@@ -16,7 +16,7 @@ use std::sync::LazyLock;
 
 use quickwit_common::metrics::{
     HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, new_counter, new_counter_vec,
-    new_gauge_vec, new_histogram_vec,
+    new_gauge_vec,
 };
 
 pub struct ServeMetrics {
@@ -25,6 +25,17 @@ pub struct ServeMetrics {
     pub ongoing_requests: IntGaugeVec<1>,
     pub pending_requests: IntGaugeVec<1>,
     pub circuit_break_total: IntCounter,
+}
+
+quickwit_common::define_histogram_vec! {
+    REQUEST_DURATION_SECS,
+    name: "request_duration_secs",
+    help: "Response time in seconds",
+    subsystem: "",
+    const_labels: [],
+    labels: ["method", "status_code"],
+    // last bucket is 163.84s
+    buckets: quickwit_common::metrics::exponential_buckets(0.02, 2.0, 14).unwrap(),
 }
 
 impl Default for ServeMetrics {
@@ -43,15 +54,7 @@ impl Default for ServeMetrics {
                 &[],
                 ["method", "status_code"],
             ),
-            request_duration_secs: new_histogram_vec(
-                "request_duration_secs",
-                "Response time in seconds",
-                "",
-                &[],
-                ["method", "status_code"],
-                // last bucket is 163.84s
-                quickwit_common::metrics::exponential_buckets(0.02, 2.0, 14).unwrap(),
-            ),
+            request_duration_secs: REQUEST_DURATION_SECS.clone(),
             ongoing_requests: new_gauge_vec(
                 "ongoing_requests",
                 "Number of ongoing requests.",

--- a/quickwit/quickwit-serve/src/metrics_api.rs
+++ b/quickwit/quickwit-serve/src/metrics_api.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use tracing::error;
 use warp::hyper::StatusCode;
 use warp::reply::with_status;
 
@@ -31,18 +30,14 @@ pub struct MetricsApi;
     path = "/",
     responses(
         (status = 200, description = "Successfully fetched metrics.", body = String),
-        (status = 500, description = "Metrics not available.", body = String),
     ),
 )]
 /// Get Node Metrics
 ///
 /// These are in the form of prometheus metrics.
 pub fn metrics_handler() -> impl warp::Reply {
-    match quickwit_common::metrics::metrics_text_payload() {
-        Ok(metrics) => with_status(metrics, StatusCode::OK),
-        Err(e) => {
-            error!("failed to encode prometheus metrics: {e}");
-            with_status(String::new(), StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
+    with_status(
+        quickwit_common::metrics::render_prometheus_text(),
+        StatusCode::OK,
+    )
 }

--- a/quickwit/quickwit-storage/src/metrics.rs
+++ b/quickwit/quickwit-storage/src/metrics.rs
@@ -18,8 +18,8 @@ use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
 use quickwit_common::metrics::{
-    GaugeGuard, Histogram, IntCounter, IntCounterVec, IntGauge, new_counter, new_counter_vec,
-    new_gauge,
+    GaugeGuard, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, new_counter,
+    new_counter_vec, new_gauge,
 };
 use quickwit_config::CacheConfig;
 
@@ -49,15 +49,17 @@ pub struct StorageMetrics {
     pub object_storage_bulk_delete_request_duration: Histogram,
 }
 
-quickwit_common::define_histogram_vec! {
-    OBJECT_STORAGE_REQUEST_DURATION_SECONDS,
-    name: "object_storage_request_duration_seconds",
-    help: "Duration of object storage requests in seconds.",
-    subsystem: "storage",
-    const_labels: [],
-    labels: ["action"],
-    buckets: vec![0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0],
-}
+pub static OBJECT_STORAGE_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec<1>> =
+    LazyLock::new(|| {
+        quickwit_common::define_histogram! {
+            name: "object_storage_request_duration_seconds",
+            help: "Duration of object storage requests in seconds.",
+            subsystem: "storage",
+            const_labels: [],
+            labels: ["action"],
+            buckets: vec![0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0],
+        }
+    });
 
 impl Default for StorageMetrics {
     fn default() -> Self {

--- a/quickwit/quickwit-storage/src/metrics.rs
+++ b/quickwit/quickwit-storage/src/metrics.rs
@@ -19,7 +19,7 @@ use std::sync::{LazyLock, RwLock};
 
 use quickwit_common::metrics::{
     GaugeGuard, Histogram, IntCounter, IntCounterVec, IntGauge, new_counter, new_counter_vec,
-    new_gauge, new_histogram_vec,
+    new_gauge,
 };
 use quickwit_config::CacheConfig;
 
@@ -47,6 +47,16 @@ pub struct StorageMetrics {
     pub object_storage_bulk_delete_requests_total: IntCounter,
     pub object_storage_delete_request_duration: Histogram,
     pub object_storage_bulk_delete_request_duration: Histogram,
+}
+
+quickwit_common::define_histogram_vec! {
+    OBJECT_STORAGE_REQUEST_DURATION_SECONDS,
+    name: "object_storage_request_duration_seconds",
+    help: "Duration of object storage requests in seconds.",
+    subsystem: "storage",
+    const_labels: [],
+    labels: ["action"],
+    buckets: vec![0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0],
 }
 
 impl Default for StorageMetrics {
@@ -79,18 +89,10 @@ impl Default for StorageMetrics {
         let object_storage_bulk_delete_requests_total =
             object_storage_requests_total.with_label_values(["delete_objects"]);
 
-        let object_storage_request_duration = new_histogram_vec(
-            "object_storage_request_duration_seconds",
-            "Duration of object storage requests in seconds.",
-            "storage",
-            &[],
-            ["action"],
-            vec![0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0],
-        );
         let object_storage_delete_request_duration =
-            object_storage_request_duration.with_label_values(["delete_object"]);
+            OBJECT_STORAGE_REQUEST_DURATION_SECONDS.with_label_values(["delete_object"]);
         let object_storage_bulk_delete_request_duration =
-            object_storage_request_duration.with_label_values(["delete_objects"]);
+            OBJECT_STORAGE_REQUEST_DURATION_SECONDS.with_label_values(["delete_objects"]);
 
         StorageMetrics {
             fast_field_cache: CacheMetrics::for_component("fastfields"),


### PR DESCRIPTION
### Description

Replace the `prometheus` crate with the [`metrics-rs`](https://crates.io/crates/metrics) facade so a single call site can fan out to Prometheus, OTLP, and DogStatsD. A `FanoutBuilder` in `logger.rs` composes the three recorders and a `PrefixFilter` routes `quickwit_*` to Prometheus + OTLP and `pomsky.*` to DogStatsD.

#### Histogram-only static registration via `inventory`

`metrics-rs` does not expose bucket configuration through the `Recorder` trait — the Prometheus and OTLP exporters need bucket bounds configured up-front, before any observation. To avoid a full metric-registry refactor, **histograms only** are declared statically: new `define_histogram!` / `define_histogram_vec!` macros register a `HistogramConfig` via [`inventory`](https://crates.io/crates/inventory) at compile time, and the install path walks `inventory::iter::<HistogramConfig>()` to apply bounds to both exporters.

Counters and gauges continue to use the existing runtime `new_counter*` / `new_gauge*` helpers. Per discussion with @fulmicoton, migrating them to the same static style is out of scope for this PR.

#### Breaking change: gRPC metric naming

`GrpcMetricsLayer::new(subsystem, kind)` previously baked `subsystem` into the metric name (`quickwit_<subsystem>_grpc_requests_total`, ...). Since histograms now require a compile-time-fixed name, the subsystem is extracted into a dynamic `service` label on a single metric family:

```
quickwit_grpc_requests_total{service=..., kind=..., rpc=..., status=...}
quickwit_grpc_requests_in_flight{service=..., kind=..., rpc=...}
quickwit_grpc_request_duration_seconds{service=..., kind=..., rpc=..., status=...}
```
