### PR TITLE
Set up diesel-guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,10 @@ jobs:
               - quickwit/**/*.toml
               - quickwit/**/*.proto
               - .github/workflows/ci.yml
+            migrations:
+              - quickwit/quickwit-metastore/migrations/**
+              - quickwit/diesel-guard.toml
+              - .github/workflows/ci.yml
       - name: Install Ubuntu packages
         if: always() && steps.modified.outputs.rust_src == 'true'
         run: |
@@ -169,13 +173,17 @@ jobs:
         if: always() && steps.modified.outputs.rust_src == 'true'
         uses: taiki-e/cache-cargo-install-action@59027ebf20a9617c4e819eb53ccd2673cb162b89 # v3.0.3
         with:
-          # 0.18 requires rustc 1.85
-          tool: cargo-deny@0.17.0
+          tool: cargo-deny@0.19.4
       - name: Install cargo machete
         if: always() && steps.modified.outputs.rust_src == 'true'
         uses: taiki-e/cache-cargo-install-action@59027ebf20a9617c4e819eb53ccd2673cb162b89 # v3.0.3
         with:
           tool: cargo-machete
+      - name: Install diesel-guard
+        if: always() && steps.modified.outputs.migrations == 'true'
+        uses: taiki-e/cache-cargo-install-action@59027ebf20a9617c4e819eb53ccd2673cb162b89 # v3.0.3
+        with:
+          tool: diesel-guard@0.10.0
       - name: cargo clippy
         if: always() && steps.modified.outputs.rust_src == 'true'
         run: cargo clippy --workspace --tests --all-features
@@ -199,6 +207,10 @@ jobs:
       - name: rustfmt
         if: always() && steps.modified.outputs.rust_src == 'true'
         run: cargo +nightly fmt --all -- --check
+        working-directory: ./quickwit
+      - name: diesel-guard (Postgres migrations lint)
+        if: always() && steps.modified.outputs.migrations == 'true'
+        run: make migrations-lint
         working-directory: ./quickwit
 
   thirdparty-license:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ fmt:
 fix:
 	@$(MAKE) -C $(QUICKWIT_SRC) fix
 
+migrations-lint:
+	@$(MAKE) -C $(QUICKWIT_SRC) migrations-lint
+
 typos:
 	typos
 

--- a/quickwit/Makefile
+++ b/quickwit/Makefile
@@ -21,7 +21,13 @@ fix:
 	@echo "Running cargo clippy --fix"
 	@cargo clippy --workspace --all-features --tests --fix --allow-dirty --allow-staged
 	@$(MAKE) fmt
+	@$(MAKE) migrations-lint
 	@$(MAKE) unused-deps
+
+migrations-lint:
+	@echo "Linting Postgres migrations with diesel-guard"
+	@(command -v diesel-guard >/dev/null || (echo "diesel-guard is not installed. Please install using 'cargo install diesel-guard'." && exit 1))
+	@diesel-guard check quickwit-metastore/migrations/postgresql/
 
 unused-deps:
 	@echo "Checking for unused dependencies"
@@ -78,4 +84,3 @@ rm-postgres:
 update-licenses:
 	 dd-rust-license-tool --config license-tool.toml write
 	 mv LICENSE-3rdparty.csv ../LICENSE-3rdparty.csv
-

--- a/quickwit/diesel-guard.toml
+++ b/quickwit/diesel-guard.toml
@@ -1,0 +1,7 @@
+# diesel-guard: lint dangerous Postgres migration patterns.
+# https://github.com/ayarotsky/diesel-guard
+#
+# Migrations at or before number 28 pre-date diesel-guard adoption and are
+# grandfathered in. Only newer migrations are checked.
+framework = "sqlx"
+start_after = "28"


### PR DESCRIPTION
### Description
Set up diesel-guard in order to "bad" migrations. I recommend removing the line `start_after = "28"` in the `diesel-guard.toml` to get a sense of what those are in the context of Quickwit. Fixes #6035.

### How was this PR tested?
Tested locally with `make migrations-lint`.