### PR TITLE
Indexing pipeline crashloop failure fixes

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -7771,6 +7771,7 @@ dependencies = [
  "quickwit-common",
  "quickwit-dst",
  "quickwit-proto",
+ "regex",
  "serde",
  "serde_json",
  "siphasher",

--- a/quickwit/quickwit-common/src/stream_utils.rs
+++ b/quickwit/quickwit-common/src/stream_utils.rs
@@ -267,6 +267,11 @@ impl<T> TrackedSender<T> {
             .await
             .map_err(|send_error| mpsc::error::SendError(send_error.0.0))
     }
+
+    /// Completes when the receiving half of the channel is dropped.
+    pub async fn closed(&self) {
+        self.sender.closed().await
+    }
 }
 
 pub struct TrackedUnboundedSender<T> {

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -38,9 +38,7 @@ use tracing::{debug, error, info, instrument};
 
 use super::{DocProcessor, IndexSerializer, Indexer, MergePlanner, Packager};
 use crate::SplitsUpdateMailbox;
-use crate::actors::pipeline_shared::{
-    SPAWN_PIPELINE_SEMAPHORE, SUPERVISE_INTERVAL, Spawn, SuperviseLoop, wait_duration_before_retry,
-};
+use crate::actors::pipeline_shared::{SPAWN_PIPELINE_SEMAPHORE, SUPERVISE_INTERVAL, Spawn, SuperviseLoop, wait_duration_before_retry, MAX_PIPELINE_FAILURES};
 use crate::actors::sequencer::Sequencer;
 use crate::actors::uploader::UploaderType;
 use crate::actors::{Publisher, Uploader};
@@ -88,6 +86,8 @@ pub struct IndexingPipeline {
     // requiring a respawn of the pipeline.
     // We keep the list of shards here however, to reassign them after a respawn.
     shard_ids: BTreeSet<ShardId>,
+    // Total failures observed over this actor's lifetime. See `MAX_PIPELINE_FAILURES`.
+    failure_count: usize,
     _indexing_pipelines_gauge_guard: OwnedGaugeGuard,
 }
 
@@ -138,7 +138,26 @@ impl IndexingPipeline {
                 ..Default::default()
             },
             shard_ids: Default::default(),
+            failure_count: 0,
             _indexing_pipelines_gauge_guard: indexing_pipelines_gauge_guard,
+        }
+    }
+
+    /// Records a pipeline failure and exits the process if the lifetime failure count
+    /// exceeds `MAX_PIPELINE_FAILURES`. This is a last-resort break-glass: returning
+    /// `ActorExitStatus::Failure` would just be caught by the supervise loop and respawned
+    /// in-process, which is exactly the cycle we want to escape. A `std::process::exit`
+    /// terminates the entire process so it can be restarted fresh.
+    fn record_failure_and_maybe_exit(&mut self) {
+        self.failure_count += 1;
+        if self.failure_count > MAX_PIPELINE_FAILURES {
+            error!(
+                pipeline_id=?self.params.pipeline_id,
+                failure_count = self.failure_count,
+                max_allowed = MAX_PIPELINE_FAILURES,
+                "indexing pipeline exceeded failure limit, exiting process to force a pod restart"
+            );
+            std::process::exit(1);
         }
     }
 
@@ -257,6 +276,7 @@ impl IndexingPipeline {
         match health {
             Health::Healthy => {}
             Health::FailureOrUnhealthy => {
+                self.record_failure_and_maybe_exit();
                 self.terminate().await;
                 let first_retry_delay = wait_duration_before_retry(0);
                 ctx.schedule_self_msg(first_retry_delay, Spawn { retry_count: 0 });
@@ -493,6 +513,7 @@ impl Handler<Spawn> for IndexingPipeline {
                 info!(error = ?spawn_error, "could not spawn pipeline, index might have been deleted");
                 return Err(ActorExitStatus::Success);
             }
+            self.record_failure_and_maybe_exit();
             let retry_delay = wait_duration_before_retry(spawn.retry_count + 1);
             error!(error = ?spawn_error, retry_count = spawn.retry_count, retry_delay = ?retry_delay, "error while spawning indexing pipeline, retrying after some time");
             ctx.schedule_self_msg(
@@ -566,7 +587,8 @@ pub struct IndexingPipelineParams {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
+    use crate::actors::pipeline_shared::MAX_RETRY_DELAY;
+use std::num::NonZeroUsize;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
@@ -590,12 +612,12 @@ mod tests {
 
     #[test]
     fn test_wait_duration() {
-        assert_eq!(wait_duration_before_retry(0), Duration::from_secs(1));
-        assert_eq!(wait_duration_before_retry(1), Duration::from_secs(2));
-        assert_eq!(wait_duration_before_retry(2), Duration::from_secs(4));
-        assert_eq!(wait_duration_before_retry(3), Duration::from_secs(8));
-        assert_eq!(wait_duration_before_retry(9), Duration::from_secs(512));
-        assert_eq!(wait_duration_before_retry(10), Duration::from_secs(600));
+        // `RETRY_BASE_DURATION` is 10ms and `MAX_RETRY_DELAY` is 50ms under `cfg(test)`.
+        assert_eq!(wait_duration_before_retry(0), Duration::from_millis(10));
+        assert_eq!(wait_duration_before_retry(1), Duration::from_millis(20));
+        assert_eq!(wait_duration_before_retry(2), Duration::from_millis(40));
+        assert_eq!(wait_duration_before_retry(3), MAX_RETRY_DELAY);
+        assert_eq!(wait_duration_before_retry(20), MAX_RETRY_DELAY);
     }
 
     async fn test_indexing_pipeline_num_fails_before_success(
@@ -730,6 +752,87 @@ mod tests {
     #[tokio::test]
     async fn test_indexing_pipeline_retry_1_gz() -> anyhow::Result<()> {
         test_indexing_pipeline_num_fails_before_success(1, "data/test_corpus.json.gz").await
+    }
+
+    /// Verifies the `record_failure_and_maybe_exit` failsafe via a re-exec fork: the parent
+    /// spawns the test binary as a child that runs a doomed pipeline, and asserts the child
+    /// exits with status 1.
+    #[tokio::test]
+    async fn test_indexing_pipeline_exits_after_max_failures() {
+        // Presence of this env var tells us we're the child.
+        const CHILD_ENV: &str = "QW_PIPELINE_EXIT_TEST_CHILD";
+        if std::env::var(CHILD_ENV).is_err() {
+            // Parent: re-exec ourselves filtered to just this test, with CHILD_ENV set.
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "actors::indexing_pipeline::tests::test_indexing_pipeline_exits_after_max_failures",
+                    "--exact",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, "1")
+                .status()
+                .unwrap();
+            // Parent: `Some(1)` = normal exit via `std::process::exit(1)`, as expected.
+            assert_eq!(
+                status.code(),
+                Some(1),
+                "child process should have exited with code 1"
+            );
+            return;
+        }
+
+        // Child: build a pipeline whose spawn always errors; the failsafe will eventually
+        // call `std::process::exit(1)` and this process dies before reaching the panic below.
+        let pipeline_id = IndexingPipelineId {
+            node_id: NodeId::from("test-node"),
+            index_uid: IndexUid::for_test("test-index", 2),
+            source_id: "test-source".to_string(),
+            pipeline_uid: PipelineUid::for_test(0u128),
+        };
+        let source_config = SourceConfig {
+            source_id: "test-source".to_string(),
+            num_pipelines: NonZeroUsize::MIN,
+            enabled: true,
+            source_params: SourceParams::file_from_str("data/test_corpus.json").unwrap(),
+            transform_config: None,
+            input_format: SourceInputFormat::Json,
+        };
+        let mut mock_metastore = MockMetastoreService::new();
+        mock_metastore
+            .expect_index_metadata()
+            .returning(|_| Err(MetastoreError::Timeout("forever".to_string())));
+
+        let universe = Universe::new();
+        let (merge_planner_mailbox, _) = universe.create_test_mailbox();
+        let storage = Arc::new(RamStorage::default());
+        let split_store = IndexingSplitStore::create_without_local_store_for_test(storage.clone());
+        let pipeline_params = IndexingPipelineParams {
+            pipeline_id,
+            doc_mapper: Arc::new(default_doc_mapper_for_test()),
+            source_config,
+            source_storage_resolver: StorageResolver::for_test(),
+            indexing_directory: TempDirectory::for_test(),
+            indexing_settings: IndexingSettings::for_test(),
+            ingester_pool: IngesterPool::default(),
+            metastore: MetastoreServiceClient::from_mock(mock_metastore),
+            storage,
+            split_store,
+            merge_policy: default_merge_policy(),
+            retention_policy: None,
+            queues_dir_path: PathBuf::from("./queues"),
+            max_concurrent_split_uploads_index: 4,
+            max_concurrent_split_uploads_merge: 5,
+            cooperative_indexing_permits: None,
+            merge_planner_mailbox,
+            event_broker: EventBroker::default(),
+            params_fingerprint: 42u64,
+        };
+        let pipeline = IndexingPipeline::new(pipeline_params);
+        let (_pipeline_mailbox, pipeline_handle) = universe.spawn_builder().spawn(pipeline);
+        // `record_failure_and_maybe_exit` calls `std::process::exit(1)` once the 11th failure
+        // is recorded, so this `join` should never return.
+        let _ = pipeline_handle.join().await;
+        panic!("pipeline should have exited the process before reaching this point");
     }
 
     async fn indexing_pipeline_simple(test_file: &str) -> anyhow::Result<()> {

--- a/quickwit/quickwit-indexing/src/actors/pipeline_shared.rs
+++ b/quickwit/quickwit-indexing/src/actors/pipeline_shared.rs
@@ -18,25 +18,45 @@ use std::time::Duration;
 
 use tokio::sync::Semaphore;
 
-pub(crate) const SUPERVISE_INTERVAL: Duration = Duration::from_secs(1);
+/// Cap on the retry wait. Beyond this, the `MAX_PIPELINE_FAILURES` counter is the failsafe
+/// that eventually forces a pod restart.
+pub(crate) const MAX_RETRY_DELAY: Duration = if cfg!(any(test, feature = "testsuite")) {
+    Duration::from_millis(50)
+} else {
+    Duration::from_secs(300) // 5 min.
+};
 
-const MAX_RETRY_DELAY: Duration = Duration::from_secs(600); // 10 min.
+/// Base duration for the exponential-backoff retry schedule.
+pub(crate) const RETRY_BASE_DURATION: Duration = if cfg!(any(test, feature = "testsuite")) {
+    Duration::from_millis(10)
+} else {
+    Duration::from_secs(1)
+};
+
+/// Maximum number of failures (either spawn errors or runtime unhealthy transitions) a single
+/// pipeline may accumulate before the process exits to force a pod restart. A stuck pipeline is
+/// treated as a signal that the pod itself has accumulated state (e.g. dead fetch streams,
+/// stale chitchat view, invalid publish tokens) that only a fresh process will clear.
+pub(crate) const MAX_PIPELINE_FAILURES: usize = 10;
+
+pub(crate) const SUPERVISE_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
 pub(crate) struct SuperviseLoop;
 
 /// Calculates the wait time based on retry count.
-// retry_count, wait_time
+// retry_count, wait_time (prod: base 1s, cap 5min)
 // 0   1s
 // 1   2s
 // 2   4s
 // 3   8s
 // ...
-// >=8   5mn
+// 8   256s
+// >=9 300s (cap)
 pub(crate) fn wait_duration_before_retry(retry_count: usize) -> Duration {
     // Protect against a `retry_count` that will lead to an overflow.
     let max_power = (retry_count as u32).min(31);
-    Duration::from_secs(2u64.pow(max_power)).min(MAX_RETRY_DELAY)
+    (RETRY_BASE_DURATION * 2u32.pow(max_power)).min(MAX_RETRY_DELAY)
 }
 
 /// Spawning an indexing pipeline puts a lot of pressure on the file system, metastore, etc. so

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -119,9 +119,20 @@ impl FetchStreamTask {
         };
 
         loop {
-            if has_drained_queue && self.shard_status_rx.changed().await.is_err() {
-                // The shard was dropped.
-                break;
+            if has_drained_queue {
+                tokio::select! {
+                    biased;
+                    _ = self.fetch_message_tx.closed() => {
+                        // The consumer was dropped.
+                        return;
+                    }
+                    changed = self.shard_status_rx.changed() => {
+                        if changed.is_err() {
+                            // The shard was dropped.
+                            break;
+                        }
+                    }
+                }
             }
             has_drained_queue = true;
 
@@ -1274,6 +1285,54 @@ pub(super) mod tests {
             fetch_payload.mrecord_batch.as_ref().unwrap().mrecord_buffer,
             "\0\0test-doc-foo"
         );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_task_terminates_on_consumer_drop() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mrecordlog = Arc::new(RwLock::new(Some(
+            MultiRecordLogAsync::open(tempdir.path()).await.unwrap(),
+        )));
+        let client_id = "test-client".to_string();
+        let index_uid: IndexUid = IndexUid::for_test("test-index", 0);
+        let source_id = "test-source".to_string();
+        let shard_id = ShardId::from(1);
+        let queue_id = queue_id(&index_uid, &source_id, &shard_id);
+
+        // Create the queue so the task does not exit via the "queue was dropped" path and instead
+        // progresses into the `shard_status_rx.changed()` await where the pre-fix zombie lived.
+        let mut mrecordlog_guard = mrecordlog.write().await;
+        mrecordlog_guard
+            .as_mut()
+            .unwrap()
+            .create_queue(&queue_id)
+            .await
+            .unwrap();
+        drop(mrecordlog_guard);
+
+        let open_fetch_stream_request = OpenFetchStreamRequest {
+            client_id: client_id.clone(),
+            index_uid: Some(index_uid.clone()),
+            source_id: source_id.clone(),
+            shard_id: Some(shard_id.clone()),
+            from_position_exclusive: Some(Position::Beginning),
+        };
+        // Keep `_shard_status_tx` alive so `shard_status_rx.changed()` cannot resolve (the task
+        // must exit via the consumer-closed branch, not the shard-dropped branch).
+        let (_shard_status_tx, shard_status_rx) = watch::channel(ShardStatus::default());
+        let (fetch_stream, fetch_task_handle) = FetchStreamTask::spawn(
+            open_fetch_stream_request,
+            mrecordlog.clone(),
+            shard_status_rx,
+            1024,
+        );
+        // Simulate the RPC consumer hanging up.
+        drop(fetch_stream);
+
+        timeout(Duration::from_secs(1), fetch_task_handle)
+            .await
+            .expect("fetch task should terminate after consumer is dropped")
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
### Description

Fixes meant to address some symptoms but not necessarily the root cause of the indexing pipeline retry storm bug.

Kills the indexing pipeline pod if a pipeline fails more than 10 times.

Separately, listens for fetch stream channel closure before checking for changes, which might prevent some of the latency buildup we'd been seeing.

### How was this PR tested?
Unit tests. 
