### PR TITLE
Remove merge code from indexers; Renaming and cleanup

### DIFF
--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -150,7 +150,7 @@ mod tests {
     };
     use quickwit_cli::split::{DescribeSplitArgs, SplitCliCommand};
     use quickwit_cli::tool::{
-        ExtractSplitArgs, GarbageCollectIndexArgs, LocalIngestDocsArgs, LocalSearchArgs, MergeArgs,
+        ExtractSplitArgs, GarbageCollectIndexArgs, LocalIngestDocsArgs, LocalSearchArgs,
         ToolCliCommand,
     };
     use quickwit_common::uri::Uri;
@@ -736,31 +736,6 @@ mod tests {
                 config_uri,
                 dry_run: true,
             })) if &index_id == "wikipedia" && grace_period == Duration::from_secs(5 * 60) && config_uri == expected_config_uri
-        ));
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_merge_args() -> anyhow::Result<()> {
-        let app = build_cli().no_binary_name(true);
-        let matches = app.try_get_matches_from([
-            "tool",
-            "merge",
-            "--index",
-            "wikipedia",
-            "--source",
-            "ingest-source",
-            "--config",
-            "/config.yaml",
-        ])?;
-        let command = CliCommand::parse_cli_args(matches)?;
-        assert!(matches!(
-            command,
-            CliCommand::Tool(ToolCliCommand::Merge(MergeArgs {
-                index_id,
-                source_id,
-                ..
-            })) if &index_id == "wikipedia" && source_id == "ingest-source"
         ));
         Ok(())
     }

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -46,7 +46,7 @@ use quickwit_proto::indexing::CpuCapacity;
 use quickwit_proto::ingest::ingester::IngesterStatus;
 use quickwit_proto::metastore::{IndexMetadataRequest, MetastoreService, MetastoreServiceClient};
 use quickwit_proto::search::{CountHits, SearchResponse};
-use quickwit_proto::types::{IndexId, PipelineUid, SourceId, SplitId};
+use quickwit_proto::types::{IndexId, PipelineUid, SplitId};
 use quickwit_search::{SearchResponseRest, single_node_search};
 use quickwit_serve::{
     BodyFormat, SearchRequestQueryString, SortBy, search_request_from_api_request,
@@ -200,13 +200,6 @@ pub struct GarbageCollectIndexArgs {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct MergeArgs {
-    pub config_uri: Uri,
-    pub index_id: IndexId,
-    pub source_id: SourceId,
-}
-
-#[derive(Debug, Eq, PartialEq)]
 pub struct ExtractSplitArgs {
     pub config_uri: Uri,
     pub index_id: IndexId,
@@ -219,7 +212,6 @@ pub enum ToolCliCommand {
     GarbageCollect(GarbageCollectIndexArgs),
     LocalIngest(LocalIngestDocsArgs),
     LocalSearch(LocalSearchArgs),
-    Merge(MergeArgs),
     ExtractSplit(ExtractSplitArgs),
 }
 
@@ -232,7 +224,6 @@ impl ToolCliCommand {
             "gc" => Self::parse_garbage_collect_args(submatches),
             "local-ingest" => Self::parse_local_ingest_args(submatches),
             "local-search" => Self::parse_local_search_args(submatches),
-            "merge" => Self::parse_merge_args(submatches),
             "extract-split" => Self::parse_extract_split_args(submatches),
             _ => bail!("unknown tool subcommand `{subcommand}`"),
         }
@@ -322,24 +313,6 @@ impl ToolCliCommand {
         }))
     }
 
-    fn parse_merge_args(mut matches: ArgMatches) -> anyhow::Result<Self> {
-        let config_uri = matches
-            .remove_one::<String>("config")
-            .map(|uri_str| Uri::from_str(&uri_str))
-            .expect("`config` should be a required arg.")?;
-        let index_id = matches
-            .remove_one::<String>("index")
-            .expect("'index-id' should be a required arg.");
-        let source_id = matches
-            .remove_one::<String>("source")
-            .expect("'source-id' should be a required arg.");
-        Ok(Self::Merge(MergeArgs {
-            index_id,
-            source_id,
-            config_uri,
-        }))
-    }
-
     fn parse_garbage_collect_args(mut matches: ArgMatches) -> anyhow::Result<Self> {
         let config_uri = matches
             .get_one("config")
@@ -389,7 +362,6 @@ impl ToolCliCommand {
             Self::GarbageCollect(args) => garbage_collect_index_cli(args).await,
             Self::LocalIngest(args) => local_ingest_docs_cli(args).await,
             Self::LocalSearch(args) => local_search_cli(args).await,
-            Self::Merge(args) => merge_cli(args).await,
             Self::ExtractSplit(args) => extract_split_cli(args).await,
         }
     }
@@ -550,93 +522,6 @@ pub async fn local_search_cli(args: LocalSearchArgs) -> anyhow::Result<()> {
     println!("{search_response_json}");
     Ok(())
 }
-
-//TODO Claude: figure out a way to re-create this with the new compaction worker stuff
-pub async fn merge_cli(_args: MergeArgs) -> anyhow::Result<()> {
-    Ok(())
-}
-//     debug!(args=?args, "run-merge-operations");
-//     println!("❯ Merging splits locally...");
-//     let config = load_node_config(&args.config_uri).await?;
-//     let (storage_resolver, metastore_resolver) =
-//         get_resolvers(&config.storage_configs, &config.metastore_configs);
-//     let mut metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
-//     run_index_checklist(&mut metastore, &storage_resolver, &args.index_id, None).await?;
-//     // The indexing service needs to update its cluster chitchat state so that the control plane
-// is     // aware of the running tasks. We thus create a fake cluster to instantiate the indexing
-// service     // and avoid impacting potential control plane running on the cluster.
-//     let cluster = create_empty_cluster(&config).await?;
-//     let runtimes_config = RuntimesConfig::default();
-//     start_actor_runtimes(
-//         runtimes_config,
-//         &HashSet::from_iter([QuickwitService::Indexer]),
-//     )?;
-//     let indexer_config = IndexerConfig::default();
-//     let universe = Universe::new();
-//     let indexing_server = IndexingService::new(
-//         config.node_id,
-//         config.data_dir_path,
-//         indexer_config,
-//         runtimes_config.num_threads_blocking,
-//         cluster,
-//         metastore,
-//         None,
-//         IngesterPool::default(),
-//         storage_resolver,
-//         EventBroker::default(),
-//     )
-//     .await?;
-//     let (indexing_service_mailbox, indexing_service_handle) =
-//         universe.spawn_builder().spawn(indexing_server);
-//     let pipeline_id = indexing_service_mailbox
-//         .ask_for_res(SpawnPipeline {
-//             index_id: args.index_id,
-//             source_config: SourceConfig {
-//                 source_id: args.source_id,
-//                 num_pipelines: NonZeroUsize::MIN,
-//                 enabled: true,
-//                 source_params: SourceParams::Vec(VecSourceParams::default()),
-//                 transform_config: None,
-//                 input_format: SourceInputFormat::Json,
-//             },
-//             pipeline_uid: PipelineUid::random(),
-//         })
-//         .await?;
-//     let pipeline_handle: ActorHandle<MergePipeline> = indexing_service_mailbox
-//         .ask_for_res(DetachMergePipeline {
-//             pipeline_id: pipeline_id.merge_pipeline_id(),
-//         })
-//         .await?;
-//
-//     let mut check_interval = tokio::time::interval(Duration::from_secs(1));
-//     loop {
-//         check_interval.tick().await;
-//
-//         pipeline_handle.refresh_observe();
-//         let observation = pipeline_handle.last_observation();
-//
-//         if observation.num_ongoing_merges == 0 {
-//             info!("merge pipeline has no more ongoing merges, exiting");
-//             break;
-//         }
-//
-//         if pipeline_handle.state().is_exit() {
-//             info!("merge pipeline has exited, exiting");
-//             break;
-//         }
-//     }
-//
-//     let (pipeline_exit_status, _pipeline_statistics) = pipeline_handle.quit().await;
-//     indexing_service_handle.quit().await;
-//     if !matches!(
-//         pipeline_exit_status,
-//         ActorExitStatus::Success | ActorExitStatus::Quit
-//     ) {
-//         bail!(pipeline_exit_status);
-//     }
-//     println!("{} Merge successful.", "✔".color(GREEN_COLOR));
-//     Ok(())
-// }
 
 pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow::Result<()> {
     debug!(args=?args, "garbage-collect-index");

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -24,7 +24,7 @@ use anyhow::{Context, bail};
 use clap::{ArgMatches, Command, arg};
 use colored::{ColoredString, Colorize};
 use humantime::format_duration;
-use quickwit_actors::{ActorExitStatus, ActorHandle, Mailbox, Universe};
+use quickwit_actors::{ActorHandle, Universe};
 use quickwit_cluster::{
     ChannelTransport, Cluster, ClusterMember, FailureDetectorConfig, make_client_grpc_config,
 };
@@ -34,14 +34,12 @@ use quickwit_common::uri::Uri;
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{
     CLI_SOURCE_ID, IndexerConfig, NodeConfig, SourceConfig, SourceInputFormat, SourceParams,
-    TransformConfig, VecSourceParams,
+    TransformConfig,
 };
 use quickwit_index_management::{IndexService, clear_cache_directory};
 use quickwit_indexing::IndexingPipeline;
-use quickwit_indexing::actors::{IndexingService, MergePipeline, MergeSchedulerService};
-use quickwit_indexing::models::{
-    DetachIndexingPipeline, DetachMergePipeline, IndexingStatistics, SpawnPipeline,
-};
+use quickwit_indexing::actors::IndexingService;
+use quickwit_indexing::models::{DetachIndexingPipeline, IndexingStatistics, SpawnPipeline};
 use quickwit_ingest::IngesterPool;
 use quickwit_metastore::IndexMetadataResponseExt;
 use quickwit_proto::indexing::CpuCapacity;
@@ -55,7 +53,7 @@ use quickwit_serve::{
 };
 use quickwit_storage::{BundleStorage, Storage};
 use thousands::Separable;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::checklist::{GREEN_COLOR, RED_COLOR};
 use crate::{
@@ -447,7 +445,6 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
         &HashSet::from_iter([QuickwitService::Indexer]),
     )?;
     let universe = Universe::new();
-    let merge_scheduler_service_mailbox = universe.get_or_spawn_one();
     let indexing_server = IndexingService::new(
         config.node_id.clone(),
         config.data_dir_path.clone(),
@@ -456,7 +453,6 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
         cluster,
         metastore,
         None,
-        Some(merge_scheduler_service_mailbox),
         IngesterPool::default(),
         storage_resolver,
         EventBroker::default(),
@@ -469,11 +465,6 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
             index_id: args.index_id.clone(),
             source_config,
             pipeline_uid: PipelineUid::random(),
-        })
-        .await?;
-    let merge_pipeline_handle = indexing_server_mailbox
-        .ask_for_res(DetachMergePipeline {
-            pipeline_id: pipeline_id.merge_pipeline_id(),
         })
         .await?;
     let indexing_pipeline_handle = indexing_server_mailbox
@@ -493,11 +484,6 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
     let statistics =
         start_statistics_reporting_loop(indexing_pipeline_handle, args.input_path_opt.is_none())
             .await?;
-    merge_pipeline_handle
-        .mailbox()
-        .ask(quickwit_indexing::FinishPendingMergesAndShutdownPipeline)
-        .await?;
-    merge_pipeline_handle.join().await;
     // Shutdown the indexing server.
     universe
         .send_exit_with_success(&indexing_server_mailbox)
@@ -565,91 +551,92 @@ pub async fn local_search_cli(args: LocalSearchArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
-    debug!(args=?args, "run-merge-operations");
-    println!("❯ Merging splits locally...");
-    let config = load_node_config(&args.config_uri).await?;
-    let (storage_resolver, metastore_resolver) =
-        get_resolvers(&config.storage_configs, &config.metastore_configs);
-    let mut metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
-    run_index_checklist(&mut metastore, &storage_resolver, &args.index_id, None).await?;
-    // The indexing service needs to update its cluster chitchat state so that the control plane is
-    // aware of the running tasks. We thus create a fake cluster to instantiate the indexing service
-    // and avoid impacting potential control plane running on the cluster.
-    let cluster = create_empty_cluster(&config).await?;
-    let runtimes_config = RuntimesConfig::default();
-    start_actor_runtimes(
-        runtimes_config,
-        &HashSet::from_iter([QuickwitService::Indexer]),
-    )?;
-    let indexer_config = IndexerConfig::default();
-    let universe = Universe::new();
-    let merge_scheduler_service: Mailbox<MergeSchedulerService> = universe.get_or_spawn_one();
-    let indexing_server = IndexingService::new(
-        config.node_id,
-        config.data_dir_path,
-        indexer_config,
-        runtimes_config.num_threads_blocking,
-        cluster,
-        metastore,
-        None,
-        Some(merge_scheduler_service),
-        IngesterPool::default(),
-        storage_resolver,
-        EventBroker::default(),
-    )
-    .await?;
-    let (indexing_service_mailbox, indexing_service_handle) =
-        universe.spawn_builder().spawn(indexing_server);
-    let pipeline_id = indexing_service_mailbox
-        .ask_for_res(SpawnPipeline {
-            index_id: args.index_id,
-            source_config: SourceConfig {
-                source_id: args.source_id,
-                num_pipelines: NonZeroUsize::MIN,
-                enabled: true,
-                source_params: SourceParams::Vec(VecSourceParams::default()),
-                transform_config: None,
-                input_format: SourceInputFormat::Json,
-            },
-            pipeline_uid: PipelineUid::random(),
-        })
-        .await?;
-    let pipeline_handle: ActorHandle<MergePipeline> = indexing_service_mailbox
-        .ask_for_res(DetachMergePipeline {
-            pipeline_id: pipeline_id.merge_pipeline_id(),
-        })
-        .await?;
-
-    let mut check_interval = tokio::time::interval(Duration::from_secs(1));
-    loop {
-        check_interval.tick().await;
-
-        pipeline_handle.refresh_observe();
-        let observation = pipeline_handle.last_observation();
-
-        if observation.num_ongoing_merges == 0 {
-            info!("merge pipeline has no more ongoing merges, exiting");
-            break;
-        }
-
-        if pipeline_handle.state().is_exit() {
-            info!("merge pipeline has exited, exiting");
-            break;
-        }
-    }
-
-    let (pipeline_exit_status, _pipeline_statistics) = pipeline_handle.quit().await;
-    indexing_service_handle.quit().await;
-    if !matches!(
-        pipeline_exit_status,
-        ActorExitStatus::Success | ActorExitStatus::Quit
-    ) {
-        bail!(pipeline_exit_status);
-    }
-    println!("{} Merge successful.", "✔".color(GREEN_COLOR));
+//TODO Claude: figure out a way to re-create this with the new compaction worker stuff
+pub async fn merge_cli(_args: MergeArgs) -> anyhow::Result<()> {
     Ok(())
 }
+//     debug!(args=?args, "run-merge-operations");
+//     println!("❯ Merging splits locally...");
+//     let config = load_node_config(&args.config_uri).await?;
+//     let (storage_resolver, metastore_resolver) =
+//         get_resolvers(&config.storage_configs, &config.metastore_configs);
+//     let mut metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
+//     run_index_checklist(&mut metastore, &storage_resolver, &args.index_id, None).await?;
+//     // The indexing service needs to update its cluster chitchat state so that the control plane
+// is     // aware of the running tasks. We thus create a fake cluster to instantiate the indexing
+// service     // and avoid impacting potential control plane running on the cluster.
+//     let cluster = create_empty_cluster(&config).await?;
+//     let runtimes_config = RuntimesConfig::default();
+//     start_actor_runtimes(
+//         runtimes_config,
+//         &HashSet::from_iter([QuickwitService::Indexer]),
+//     )?;
+//     let indexer_config = IndexerConfig::default();
+//     let universe = Universe::new();
+//     let indexing_server = IndexingService::new(
+//         config.node_id,
+//         config.data_dir_path,
+//         indexer_config,
+//         runtimes_config.num_threads_blocking,
+//         cluster,
+//         metastore,
+//         None,
+//         IngesterPool::default(),
+//         storage_resolver,
+//         EventBroker::default(),
+//     )
+//     .await?;
+//     let (indexing_service_mailbox, indexing_service_handle) =
+//         universe.spawn_builder().spawn(indexing_server);
+//     let pipeline_id = indexing_service_mailbox
+//         .ask_for_res(SpawnPipeline {
+//             index_id: args.index_id,
+//             source_config: SourceConfig {
+//                 source_id: args.source_id,
+//                 num_pipelines: NonZeroUsize::MIN,
+//                 enabled: true,
+//                 source_params: SourceParams::Vec(VecSourceParams::default()),
+//                 transform_config: None,
+//                 input_format: SourceInputFormat::Json,
+//             },
+//             pipeline_uid: PipelineUid::random(),
+//         })
+//         .await?;
+//     let pipeline_handle: ActorHandle<MergePipeline> = indexing_service_mailbox
+//         .ask_for_res(DetachMergePipeline {
+//             pipeline_id: pipeline_id.merge_pipeline_id(),
+//         })
+//         .await?;
+//
+//     let mut check_interval = tokio::time::interval(Duration::from_secs(1));
+//     loop {
+//         check_interval.tick().await;
+//
+//         pipeline_handle.refresh_observe();
+//         let observation = pipeline_handle.last_observation();
+//
+//         if observation.num_ongoing_merges == 0 {
+//             info!("merge pipeline has no more ongoing merges, exiting");
+//             break;
+//         }
+//
+//         if pipeline_handle.state().is_exit() {
+//             info!("merge pipeline has exited, exiting");
+//             break;
+//         }
+//     }
+//
+//     let (pipeline_exit_status, _pipeline_statistics) = pipeline_handle.quit().await;
+//     indexing_service_handle.quit().await;
+//     if !matches!(
+//         pipeline_exit_status,
+//         ActorExitStatus::Success | ActorExitStatus::Quit
+//     ) {
+//         bail!(pipeline_exit_status);
+//     }
+//     println!("{} Merge successful.", "✔".color(GREEN_COLOR));
+//     Ok(())
+// }
 
 pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow::Result<()> {
     debug!(args=?args, "garbage-collect-index");

--- a/quickwit/quickwit-compaction/src/compaction_pipeline.rs
+++ b/quickwit/quickwit-compaction/src/compaction_pipeline.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Instant;
 
-use quickwit_actors::{ActorHandle, Health, SpawnContext, Supervisable};
+use quickwit_actors::{ActorHandle, HEARTBEAT, Health, SpawnContext, Supervisable};
 use quickwit_common::KillSwitch;
 use quickwit_common::io::{IoControls, Limiter};
 use quickwit_common::pubsub::EventBroker;
@@ -31,6 +32,8 @@ use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_proto::types::{IndexUid, SourceId, SplitId};
 use tracing::{debug, error, info};
 
+use crate::TaskId;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum PipelineStatus {
     InProgress,
@@ -39,11 +42,10 @@ pub enum PipelineStatus {
 }
 
 pub struct PipelineStatusUpdate {
-    pub task_id: String,
+    pub task_id: TaskId,
     pub index_uid: IndexUid,
     pub source_id: SourceId,
     pub split_ids: Vec<SplitId>,
-    pub merged_split_id: SplitId,
     pub status: PipelineStatus,
 }
 
@@ -53,6 +55,22 @@ struct CompactionPipelineHandles {
     merge_packager: ActorHandle<Packager>,
     merge_uploader: ActorHandle<Uploader>,
     merge_publisher: ActorHandle<Publisher>,
+    next_check_for_progress: Instant,
+}
+
+impl CompactionPipelineHandles {
+    /// Returns true once per HEARTBEAT interval. Between heartbeats we only
+    /// check whether actors are alive, not whether they are making progress.
+    /// This gives CPU-intensive actors (like the packager) up to 30s to
+    /// complete before being declared unhealthy.
+    fn should_check_for_progress(&mut self) -> bool {
+        let now = Instant::now();
+        let check_for_progress = now > self.next_check_for_progress;
+        if check_for_progress {
+            self.next_check_for_progress = now + *HEARTBEAT;
+        }
+        check_for_progress
+    }
 }
 
 /// A single-use compaction pipeline. Processes one merge task and terminates.
@@ -61,7 +79,7 @@ struct CompactionPipelineHandles {
 /// `check_actor_health()` to collect status updates. The pipeline manages
 /// its own retry logic internally.
 pub struct CompactionPipeline {
-    task_id: String,
+    task_id: TaskId,
     merge_operation: MergeOperation,
     pipeline_id: MergePipelineId,
     status: PipelineStatus,
@@ -81,7 +99,7 @@ pub struct CompactionPipeline {
 impl CompactionPipeline {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        task_id: String,
+        task_id: TaskId,
         scratch_directory: TempDirectory,
         merge_operation: MergeOperation,
         pipeline_id: MergePipelineId,
@@ -149,16 +167,21 @@ impl CompactionPipeline {
         ) {
             return;
         }
-        // Pipeline is not initialized yet.
-        if self.handles.is_none() {
+        let Some(handles) = self.handles.as_mut() else {
             return;
-        }
+        };
+
+        // We check whether actors are alive on every tick (1s), but only
+        // check whether they are making progress once per HEARTBEAT (30s).
+        // This gives CPU-intensive actors like the packager time to finish
+        // without being falsely declared unhealthy.
+        let check_for_progress = handles.should_check_for_progress();
 
         let mut has_healthy = false;
         let mut failure_actor_names: Vec<String> = Vec::new();
 
         for supervisable in self.supervisables() {
-            match supervisable.check_health(true) {
+            match supervisable.check_health(check_for_progress) {
                 Health::Healthy => {
                     has_healthy = true;
                 }
@@ -192,7 +215,6 @@ impl CompactionPipeline {
                 .iter()
                 .map(|split| split.split_id().to_string())
                 .collect(),
-            merged_split_id: self.merge_operation.merge_split_id.clone(),
             status: self.status.clone(),
         }
     }
@@ -286,6 +308,7 @@ impl CompactionPipeline {
             merge_packager: merge_packager_handle,
             merge_uploader: merge_uploader_handle,
             merge_publisher: merge_publisher_handle,
+            next_check_for_progress: Instant::now() + *HEARTBEAT,
         });
 
         Ok(())

--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -278,7 +278,10 @@ impl Handler<CheckPipelineStatuses> for CompactorSupervisor {
     ) -> Result<(), ActorExitStatus> {
         let statuses = self.check_pipeline_statuses();
         let request = self.build_report_status_request(&statuses);
-        match ctx.protect_future(self.planner_client.report_status(request)).await {
+        match ctx
+            .protect_future(self.planner_client.report_status(request))
+            .await
+        {
             Ok(response) => {
                 ctx.protect_future(self.process_new_tasks(response.new_tasks, ctx.spawn_ctx()))
                     .await;

--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -112,8 +112,8 @@ impl CompactorSupervisor {
     ) {
         for assignment in assignments {
             let task_id = assignment.task_id.clone();
-            if let Err(err) = self.spawn_task(assignment, spawn_ctx).await {
-                error!(task_id=%task_id, error=%err, "failed to spawn compaction task");
+            if let Err(error) = self.spawn_task(assignment, spawn_ctx).await {
+                error!(%task_id, %error, "failed to spawn compaction task");
             }
         }
     }
@@ -226,7 +226,6 @@ impl CompactorSupervisor {
                 PipelineStatus::Completed => {
                     successes.push(CompactionSuccess {
                         task_id: update.task_id.clone(),
-                        merged_split_id: update.merged_split_id.clone(),
                     });
                 }
                 PipelineStatus::Failed { error } => {
@@ -279,13 +278,13 @@ impl Handler<CheckPipelineStatuses> for CompactorSupervisor {
     ) -> Result<(), ActorExitStatus> {
         let statuses = self.check_pipeline_statuses();
         let request = self.build_report_status_request(&statuses);
-        match self.planner_client.report_status(request).await {
+        match ctx.protect_future(self.planner_client.report_status(request)).await {
             Ok(response) => {
-                self.process_new_tasks(response.new_tasks, ctx.spawn_ctx())
+                ctx.protect_future(self.process_new_tasks(response.new_tasks, ctx.spawn_ctx()))
                     .await;
             }
-            Err(err) => {
-                warn!(error=%err, "failed to report status to compaction planner");
+            Err(error) => {
+                warn!(%error, "failed to report status to compaction planner");
             }
         }
         ctx.schedule_self_msg(CHECK_PIPELINE_STATUSES_INTERVAL, CheckPipelineStatuses);
@@ -394,9 +393,9 @@ mod tests {
         let index_metadata =
             quickwit_metastore::IndexMetadata::for_test("test-index", "ram:///test-index");
         let config = &index_metadata.index_config;
-        let splits: Vec<quickwit_metastore::SplitMetadata> = split_ids
+        let splits: Vec<SplitMetadata> = split_ids
             .iter()
-            .map(|id| quickwit_metastore::SplitMetadata::for_test(id.to_string()))
+            .map(|id| SplitMetadata::for_test(id.to_string()))
             .collect();
         MergeTaskAssignment {
             task_id: task_id.to_string(),
@@ -513,7 +512,7 @@ mod tests {
         let assignment = test_assignment("planner-task-1", &["s1", "s2"]);
         let assignments = vec![assignment];
         let assignments_clone = assignments.clone();
-        let mut mock = quickwit_proto::compaction::MockCompactionPlannerService::new();
+        let mut mock = MockCompactionPlannerService::new();
         mock.expect_report_status().times(1).returning(move |_req| {
             Ok(quickwit_proto::compaction::ReportStatusResponse {
                 new_tasks: assignments_clone.clone(),
@@ -569,7 +568,6 @@ mod tests {
                 index_uid: quickwit_proto::types::IndexUid::for_test("test-index", 0),
                 source_id: "src".to_string(),
                 split_ids: vec!["s1".to_string(), "s2".to_string()],
-                merged_split_id: "merged-1".to_string(),
                 status: PipelineStatus::InProgress,
             },
             PipelineStatusUpdate {
@@ -577,7 +575,6 @@ mod tests {
                 index_uid: quickwit_proto::types::IndexUid::for_test("test-index", 0),
                 source_id: "src".to_string(),
                 split_ids: vec!["s3".to_string()],
-                merged_split_id: "merged-2".to_string(),
                 status: PipelineStatus::Completed,
             },
             PipelineStatusUpdate {
@@ -585,7 +582,6 @@ mod tests {
                 index_uid: quickwit_proto::types::IndexUid::for_test("test-index", 0),
                 source_id: "src".to_string(),
                 split_ids: vec!["s4".to_string()],
-                merged_split_id: "merged-3".to_string(),
                 status: PipelineStatus::Failed {
                     error: "boom".to_string(),
                 },
@@ -600,7 +596,6 @@ mod tests {
         assert_eq!(request.in_progress[0].split_ids, vec!["s1", "s2"]);
         assert_eq!(request.successes.len(), 1);
         assert_eq!(request.successes[0].task_id, "task-2");
-        assert_eq!(request.successes[0].merged_split_id, "merged-2");
         assert_eq!(request.failures.len(), 1);
         assert_eq!(request.failures[0].task_id, "task-3");
         assert_eq!(request.failures[0].error_message, "boom");

--- a/quickwit/quickwit-compaction/src/lib.rs
+++ b/quickwit/quickwit-compaction/src/lib.rs
@@ -20,6 +20,8 @@ mod compaction_pipeline;
 mod compactor_supervisor;
 pub mod planner;
 
+pub type TaskId = String;
+
 use std::sync::Arc;
 
 pub use compactor_supervisor::CompactorSupervisor;

--- a/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
@@ -32,11 +32,11 @@ use tracing::error;
 use ulid::Ulid;
 
 use super::compaction_state::CompactionState;
-use super::index_config_store::{IndexConfigStore, IndexEntry};
+use super::index_config_metastore::{IndexConfigMetastore, IndexEntry};
 
 pub struct CompactionPlanner {
     state: CompactionState,
-    index_config_store: IndexConfigStore,
+    index_config_metastore: IndexConfigMetastore,
     cursor: i64,
     metastore: MetastoreServiceClient,
 }
@@ -83,8 +83,8 @@ impl Handler<ScanAndPlan> for CompactionPlanner {
         _msg: ScanAndPlan,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        if let Err(err) = self.scan_and_plan().await {
-            error!(error=%err, "error scanning metastore and planning merges");
+        if let Err(error) = ctx.protect_future(self.scan_and_plan()).await {
+            error!(%error, "error scanning metastore and planning merges");
         }
         self.state.check_heartbeat_timeouts();
         ctx.schedule_self_msg(SCAN_AND_PLAN_INTERVAL, ScanAndPlan);
@@ -117,7 +117,7 @@ impl CompactionPlanner {
         let cursor = OffsetDateTime::now_utc().unix_timestamp() - STARTUP_LOOKBACK.as_secs() as i64;
         CompactionPlanner {
             state: CompactionState::new(),
-            index_config_store: IndexConfigStore::new(metastore.clone()),
+            index_config_metastore: IndexConfigMetastore::new(metastore.clone()),
             cursor,
             metastore,
         }
@@ -125,11 +125,11 @@ impl CompactionPlanner {
 
     async fn ingest_splits(&mut self, splits: Vec<Split>) {
         for split in splits {
-            if self.state.is_split_known(&split.split_metadata.split_id) {
+            if self.state.is_split_tracked(&split.split_metadata.split_id) {
                 continue;
             }
             let Ok(index_entry) = self
-                .index_config_store
+                .index_config_metastore
                 .get_for_split(&split.split_metadata)
                 .await
             else {
@@ -168,7 +168,7 @@ impl CompactionPlanner {
 
     fn run_merge_policies(&mut self) {
         for partition_key in self.state.partition_keys() {
-            if let Some(index_entry) = self.index_config_store.get(&partition_key.index_uid) {
+            if let Some(index_entry) = self.index_config_metastore.get(&partition_key.index_uid) {
                 self.state
                     .plan_partition(&partition_key, index_entry.merge_policy());
             }
@@ -181,7 +181,7 @@ impl CompactionPlanner {
 
         for (partition_key, operation) in pending {
             let task_id = Ulid::new().to_string();
-            let Some(index_entry) = self.index_config_store.get(&partition_key.index_uid) else {
+            let Some(index_entry) = self.index_config_metastore.get(&partition_key.index_uid) else {
                 error!(index_uid=%partition_key.index_uid, "index config not found for pending operation, skipping");
                 continue;
             };
@@ -352,9 +352,9 @@ mod tests {
 
         planner.ingest_splits(splits).await;
 
-        assert!(planner.state.is_split_known("fresh"));
-        assert!(planner.state.is_split_known("in-flight"));
-        assert!(!planner.state.is_split_known("mature"));
+        assert!(planner.state.is_split_tracked("fresh"));
+        assert!(planner.state.is_split_tracked("in-flight"));
+        assert!(!planner.state.is_split_tracked("mature"));
         assert_eq!(planner.cursor, 3000);
     }
 
@@ -393,7 +393,7 @@ mod tests {
         planner.cursor = 0;
         planner.ingest_splits(splits).await;
 
-        assert!(!planner.state.is_split_known("orphan"));
+        assert!(!planner.state.is_split_tracked("orphan"));
     }
 
     #[tokio::test]
@@ -420,8 +420,8 @@ mod tests {
         planner.cursor = 0;
         planner.scan_and_plan().await.unwrap();
 
-        assert!(planner.state.is_split_known("s1"));
-        assert!(planner.state.is_split_known("s2"));
+        assert!(planner.state.is_split_tracked("s1"));
+        assert!(planner.state.is_split_tracked("s2"));
         assert_eq!(planner.cursor, 6000);
     }
 
@@ -503,7 +503,6 @@ mod tests {
         // Report success for the task.
         planner.state.process_successes(&[CompactionSuccess {
             task_id,
-            merged_split_id: "merged-1".to_string(),
         }]);
 
         // The original splits are no longer tracked. Re-ingesting them

--- a/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
@@ -181,7 +181,8 @@ impl CompactionPlanner {
 
         for (partition_key, operation) in pending {
             let task_id = Ulid::new().to_string();
-            let Some(index_entry) = self.index_config_metastore.get(&partition_key.index_uid) else {
+            let Some(index_entry) = self.index_config_metastore.get(&partition_key.index_uid)
+            else {
                 error!(index_uid=%partition_key.index_uid, "index config not found for pending operation, skipping");
                 continue;
             };
@@ -501,9 +502,9 @@ mod tests {
         let task_id = assignments[0].task_id.clone();
 
         // Report success for the task.
-        planner.state.process_successes(&[CompactionSuccess {
-            task_id,
-        }]);
+        planner
+            .state
+            .process_successes(&[CompactionSuccess { task_id }]);
 
         // The original splits are no longer tracked. Re-ingesting them
         // (simulating the merged output being immature) creates new work.

--- a/quickwit/quickwit-compaction/src/planner/compaction_state.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_state.rs
@@ -22,6 +22,8 @@ use quickwit_proto::compaction::{CompactionFailure, CompactionInProgress, Compac
 use quickwit_proto::types::{DocMappingUid, IndexUid, NodeId, SourceId, SplitId};
 use tracing::{error, info, warn};
 
+use crate::TaskId;
+
 const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -44,7 +46,7 @@ impl CompactionPartitionKey {
 }
 
 struct InFlightCompaction {
-    task_id: String,
+    task_id: TaskId,
     split_ids: Vec<SplitId>,
     node_id: NodeId,
     last_heartbeat: Instant,
@@ -56,7 +58,7 @@ struct InFlightCompaction {
 pub struct CompactionState {
     needs_compaction: HashMap<CompactionPartitionKey, Vec<SplitMetadata>>,
     needs_compaction_split_ids: HashSet<SplitId>,
-    in_flight: HashMap<String, InFlightCompaction>,
+    in_flight: HashMap<TaskId, InFlightCompaction>,
     in_flight_split_ids: HashSet<SplitId>,
     /// TODO: add index_uid and source_id to MergeOperation so we don't need the partition key
     /// here.
@@ -75,7 +77,7 @@ impl CompactionState {
     }
 
     /// Returns true if the split is already tracked (either awaiting compaction or in-flight).
-    pub fn is_split_known(&self, split_id: &str) -> bool {
+    pub fn is_split_tracked(&self, split_id: &str) -> bool {
         self.needs_compaction_split_ids.contains(split_id)
             || self.in_flight_split_ids.contains(split_id)
     }
@@ -165,7 +167,7 @@ impl CompactionState {
 
     pub fn check_heartbeat_timeouts(&mut self) {
         let now = Instant::now();
-        let timed_out_task_ids: Vec<String> = self
+        let timed_out_task_ids: Vec<TaskId> = self
             .in_flight
             .iter()
             .filter(|(_, inflight)| now.duration_since(inflight.last_heartbeat) > HEARTBEAT_TIMEOUT)
@@ -174,7 +176,7 @@ impl CompactionState {
 
         for task_id in timed_out_task_ids {
             if let Some(inflight) = self.in_flight.remove(&task_id) {
-                error!(task_id=%task_id, node_id=%inflight.node_id, "compaction task timed out");
+                error!(%task_id, node_id=%inflight.node_id, "compaction task timed out");
                 for split_id in &inflight.split_ids {
                     self.in_flight_split_ids.remove(split_id.as_str());
                 }
@@ -193,7 +195,7 @@ impl CompactionState {
     }
 
     /// Records that an operation has been assigned to a worker.
-    pub fn record_assignment(&mut self, task_id: String, split_ids: Vec<SplitId>, node_id: NodeId) {
+    pub fn record_assignment(&mut self, task_id: TaskId, split_ids: Vec<SplitId>, node_id: NodeId) {
         self.in_flight.insert(
             task_id.clone(),
             InFlightCompaction {
@@ -253,11 +255,11 @@ mod tests {
         let index_uid = IndexUid::for_test("test-index", 0);
         let mut state = CompactionState::new();
 
-        assert!(!state.is_split_known("s1"));
+        assert!(!state.is_split_tracked("s1"));
 
         state.track_split(test_split("s1", &index_uid));
-        assert!(state.is_split_known("s1"));
-        assert!(!state.is_split_known("s2"));
+        assert!(state.is_split_tracked("s1"));
+        assert!(!state.is_split_tracked("s2"));
     }
 
     #[test]
@@ -313,21 +315,20 @@ mod tests {
         state.in_flight_split_ids.insert("s3".to_string());
         state.record_assignment("task-2".to_string(), vec!["s3".to_string()], node_id);
 
-        assert!(state.is_split_known("s1"));
-        assert!(state.is_split_known("s3"));
+        assert!(state.is_split_tracked("s1"));
+        assert!(state.is_split_tracked("s3"));
 
         state.process_successes(&[CompactionSuccess {
             task_id: "task-1".to_string(),
-            merged_split_id: "merged-1".to_string(),
         }]);
-        assert!(!state.is_split_known("s1"));
-        assert!(!state.is_split_known("s2"));
+        assert!(!state.is_split_tracked("s1"));
+        assert!(!state.is_split_tracked("s2"));
 
         state.process_failures(&[CompactionFailure {
             task_id: "task-2".to_string(),
             error_message: "boom".to_string(),
         }]);
-        assert!(!state.is_split_known("s3"));
+        assert!(!state.is_split_tracked("s3"));
     }
 
     #[test]
@@ -382,7 +383,7 @@ mod tests {
         state.record_assignment("task-1".to_string(), split_ids.clone(), NodeId::from("w1"));
 
         for split_id in &split_ids {
-            assert!(state.is_split_known(split_id));
+            assert!(state.is_split_tracked(split_id));
         }
     }
 

--- a/quickwit/quickwit-compaction/src/planner/index_config_metastore.rs
+++ b/quickwit/quickwit-compaction/src/planner/index_config_metastore.rs
@@ -23,7 +23,6 @@ use quickwit_proto::metastore::{IndexMetadataRequest, MetastoreService, Metastor
 use quickwit_proto::types::{DocMappingUid, IndexUid};
 
 /// Everything the planner needs to know about a single index.
-#[derive(Clone)]
 pub struct IndexEntry {
     config: IndexConfig,
     merge_policy: Arc<dyn MergePolicy>,
@@ -74,16 +73,16 @@ impl IndexEntry {
 /// Caches per-index configuration, merge policies, and doc mappers.
 /// Fetches from the metastore on demand. All accessors panic if called
 /// for an index that hasn't been loaded.
-pub struct IndexConfigStore {
+pub struct IndexConfigMetastore {
     indexes: HashMap<IndexUid, IndexEntry>,
-    metastore: MetastoreServiceClient,
+    metastore_client: MetastoreServiceClient,
 }
 
-impl IndexConfigStore {
-    pub fn new(metastore: MetastoreServiceClient) -> Self {
-        IndexConfigStore {
+impl IndexConfigMetastore {
+    pub fn new(metastore_client: MetastoreServiceClient) -> Self {
+        IndexConfigMetastore {
             indexes: HashMap::new(),
-            metastore,
+            metastore_client,
         }
     }
 
@@ -95,7 +94,7 @@ impl IndexConfigStore {
         doc_mapping_uid: &DocMappingUid,
     ) -> anyhow::Result<()> {
         let response = self
-            .metastore
+            .metastore_client
             .index_metadata(IndexMetadataRequest {
                 index_uid: Some(index_uid.clone()),
                 index_id: None,
@@ -171,7 +170,7 @@ mod tests {
             .times(1)
             .returning(move |_| Ok(response.clone()));
 
-        let mut store = IndexConfigStore::new(MetastoreServiceClient::from_mock(mock));
+        let mut store = IndexConfigMetastore::new(MetastoreServiceClient::from_mock(mock));
 
         // First call fetches from metastore.
         let entry = store
@@ -200,7 +199,7 @@ mod tests {
             })
         });
 
-        let mut store = IndexConfigStore::new(MetastoreServiceClient::from_mock(mock));
+        let mut store = IndexConfigMetastore::new(MetastoreServiceClient::from_mock(mock));
         let result = store
             .get_or_fetch(&IndexUid::for_test("missing", 0), &DocMappingUid::default())
             .await;
@@ -210,7 +209,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_returns_none_before_fetch() {
         let mock = MockMetastoreService::new();
-        let store = IndexConfigStore::new(MetastoreServiceClient::from_mock(mock));
+        let store = IndexConfigMetastore::new(MetastoreServiceClient::from_mock(mock));
         assert!(store.get(&IndexUid::for_test("test-index", 0)).is_none());
     }
 
@@ -224,7 +223,7 @@ mod tests {
         mock.expect_index_metadata()
             .returning(move |_| Ok(response.clone()));
 
-        let mut store = IndexConfigStore::new(MetastoreServiceClient::from_mock(mock));
+        let mut store = IndexConfigMetastore::new(MetastoreServiceClient::from_mock(mock));
         store
             .get_or_fetch(&index_uid, &DocMappingUid::default())
             .await
@@ -243,7 +242,7 @@ mod tests {
         mock.expect_index_metadata()
             .returning(move |_| Ok(response.clone()));
 
-        let mut store = IndexConfigStore::new(MetastoreServiceClient::from_mock(mock));
+        let mut store = IndexConfigMetastore::new(MetastoreServiceClient::from_mock(mock));
         let split = SplitMetadata {
             split_id: "split-1".to_string(),
             index_uid: index_uid.clone(),
@@ -264,7 +263,7 @@ mod tests {
         mock.expect_index_metadata()
             .returning(move |_| Ok(response.clone()));
 
-        let mut store = IndexConfigStore::new(MetastoreServiceClient::from_mock(mock));
+        let mut store = IndexConfigMetastore::new(MetastoreServiceClient::from_mock(mock));
         let entry = store
             .get_or_fetch(&index_uid, &DocMappingUid::default())
             .await
@@ -295,7 +294,7 @@ mod tests {
         mock.expect_index_metadata()
             .returning(move |_| Ok(response.clone()));
 
-        let mut store = IndexConfigStore::new(MetastoreServiceClient::from_mock(mock));
+        let mut store = IndexConfigMetastore::new(MetastoreServiceClient::from_mock(mock));
         let entry = store
             .get_or_fetch(&index_uid, &DocMappingUid::default())
             .await

--- a/quickwit/quickwit-compaction/src/planner/mod.rs
+++ b/quickwit/quickwit-compaction/src/planner/mod.rs
@@ -16,6 +16,6 @@ mod compaction_planner;
 #[allow(dead_code)]
 mod compaction_state;
 #[allow(dead_code)]
-mod index_config_store;
+mod index_config_metastore;
 
 pub use compaction_planner::CompactionPlanner;

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -869,8 +869,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    use quickwit_actors::{Command, Universe};
-    use quickwit_common::ServiceStream;
+    use quickwit_actors::Universe;
     use quickwit_config::{IndexingSettings, SourceInputFormat, SourceParams};
     use quickwit_doc_mapper::{DocMapper, default_doc_mapper_for_test};
     use quickwit_metastore::checkpoint::IndexCheckpointDelta;
@@ -883,7 +882,6 @@ mod tests {
     use quickwit_storage::RamStorage;
 
     use super::{IndexingPipeline, *};
-    use crate::actors::merge_pipeline::{MergePipeline, MergePipelineParams};
     use crate::merge_policy::default_merge_policy;
 
     #[test]

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -27,7 +27,7 @@ use quickwit_common::metrics::OwnedGaugeGuard;
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_common::{KillSwitch, is_metrics_index};
-use quickwit_config::{IndexingSettings, RetentionPolicy, SourceConfig};
+use quickwit_config::{IndexingSettings, SourceConfig};
 use quickwit_doc_mapper::DocMapper;
 use quickwit_ingest::IngesterPool;
 use quickwit_proto::indexing::IndexingPipelineId;
@@ -37,7 +37,6 @@ use quickwit_storage::{Storage, StorageResolver};
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, instrument};
 
-use super::MergePlanner;
 use crate::SplitsUpdateMailbox;
 use crate::actors::doc_processor::DocProcessor;
 use crate::actors::index_serializer::IndexSerializer;
@@ -431,7 +430,7 @@ impl IndexingPipeline {
         let publisher = Publisher::new(
             PublisherType::MainPublisher,
             self.params.metastore.clone(),
-            self.params.merge_planner_mailbox_opt.clone(),
+            None,
             Some(source_mailbox.clone()),
         );
         let (publisher_mailbox, publisher_handle) = ctx
@@ -460,7 +459,7 @@ impl IndexingPipeline {
             UploaderType::IndexUploader,
             self.params.metastore.clone(),
             self.params.merge_policy.clone(),
-            self.params.retention_policy.clone(),
+            None,
             self.params.split_store.clone(),
             SplitsUpdateMailbox::Sequencer(sequencer_mailbox),
             self.params.max_concurrent_split_uploads_index,
@@ -853,9 +852,6 @@ pub struct IndexingPipelineParams {
 
     // Merge-related parameters
     pub merge_policy: Arc<dyn MergePolicy>,
-    pub retention_policy: Option<RetentionPolicy>,
-    pub merge_planner_mailbox_opt: Option<Mailbox<MergePlanner>>,
-    pub max_concurrent_split_uploads_merge: usize,
 
     // Source-related parameters
     pub source_config: SourceConfig,
@@ -971,7 +967,6 @@ mod tests {
             .returning(|_| Ok(EmptyResponse {}));
 
         let universe = Universe::new();
-        let (merge_planner_mailbox, _) = universe.create_test_mailbox();
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store_for_test(storage.clone());
         let pipeline_params = IndexingPipelineParams {
@@ -986,12 +981,9 @@ mod tests {
             storage,
             split_store,
             merge_policy: default_merge_policy(),
-            retention_policy: None,
             queues_dir_path: PathBuf::from("./queues"),
             max_concurrent_split_uploads_index: 4,
-            max_concurrent_split_uploads_merge: 5,
             cooperative_indexing_permits: None,
-            merge_planner_mailbox_opt: Some(merge_planner_mailbox),
             event_broker: EventBroker::default(),
             params_fingerprint: 42u64,
         };
@@ -1097,7 +1089,6 @@ mod tests {
         let universe = Universe::new();
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store_for_test(storage.clone());
-        let (merge_planner_mailbox, _) = universe.create_test_mailbox();
         let pipeline_params = IndexingPipelineParams {
             pipeline_id,
             doc_mapper: Arc::new(default_doc_mapper_for_test()),
@@ -1111,11 +1102,8 @@ mod tests {
             storage,
             split_store,
             merge_policy: default_merge_policy(),
-            retention_policy: None,
             max_concurrent_split_uploads_index: 4,
-            max_concurrent_split_uploads_merge: 5,
             cooperative_indexing_permits: None,
-            merge_planner_mailbox_opt: Some(merge_planner_mailbox),
             event_broker: Default::default(),
             params_fingerprint: 42u64,
         };
@@ -1138,112 +1126,6 @@ mod tests {
     #[tokio::test]
     async fn test_indexing_pipeline_simple_gz() -> anyhow::Result<()> {
         indexing_pipeline_simple("data/test_corpus.json.gz").await
-    }
-
-    #[tokio::test]
-    async fn test_merge_pipeline_does_not_stop_on_indexing_pipeline_failure() {
-        let node_id = NodeId::from("test-node");
-        let pipeline_id = IndexingPipelineId {
-            node_id,
-            index_uid: IndexUid::new_with_random_ulid("test-index"),
-            source_id: "test-source".to_string(),
-            pipeline_uid: PipelineUid::for_test(0u128),
-        };
-        let source_config = SourceConfig {
-            source_id: "test-source".to_string(),
-            num_pipelines: NonZeroUsize::MIN,
-            enabled: true,
-            source_params: SourceParams::void(),
-            transform_config: None,
-            input_format: SourceInputFormat::Json,
-        };
-        let source_config_clone = source_config.clone();
-
-        let mut mock_metastore = MockMetastoreService::new();
-        mock_metastore
-            .expect_index_metadata()
-            .withf(|index_metadata_request| {
-                index_metadata_request.index_uid.as_ref().unwrap() == &("test-index", 2)
-            })
-            .returning(move |_| {
-                let mut index_metadata =
-                    IndexMetadata::for_test("test-index", "ram:///indexes/test-index");
-                index_metadata
-                    .add_source(source_config_clone.clone())
-                    .unwrap();
-                Ok(IndexMetadataResponse::try_from_index_metadata(&index_metadata).unwrap())
-            });
-        mock_metastore
-            .expect_list_splits()
-            .returning(|_| Ok(ServiceStream::empty()));
-        let metastore = MetastoreServiceClient::from_mock(mock_metastore);
-
-        let universe = Universe::with_accelerated_time();
-        let doc_mapper = Arc::new(default_doc_mapper_for_test());
-        let storage = Arc::new(RamStorage::default());
-        let split_store = IndexingSplitStore::create_without_local_store_for_test(storage.clone());
-        let merge_pipeline_params = MergePipelineParams {
-            pipeline_id: pipeline_id.merge_pipeline_id(),
-            doc_mapper: doc_mapper.clone(),
-            indexing_directory: TempDirectory::for_test(),
-            metastore: metastore.clone(),
-            split_store: split_store.clone(),
-            merge_policy: default_merge_policy(),
-            retention_policy: None,
-            max_concurrent_split_uploads: 2,
-            merge_io_throughput_limiter_opt: None,
-            merge_scheduler_service: universe.get_or_spawn_one(),
-            event_broker: Default::default(),
-        };
-        let merge_pipeline = MergePipeline::new(merge_pipeline_params, None, universe.spawn_ctx());
-        let merge_planner_mailbox = merge_pipeline.merge_planner_mailbox().clone();
-        let (_merge_pipeline_mailbox, merge_pipeline_handler) =
-            universe.spawn_builder().spawn(merge_pipeline);
-        let indexing_pipeline_params = IndexingPipelineParams {
-            pipeline_id,
-            doc_mapper,
-            source_config,
-            source_storage_resolver: StorageResolver::for_test(),
-            indexing_directory: TempDirectory::for_test(),
-            indexing_settings: IndexingSettings::for_test(),
-            ingester_pool: IngesterPool::default(),
-            metastore,
-            queues_dir_path: PathBuf::from("./queues"),
-            storage,
-            split_store,
-            merge_policy: default_merge_policy(),
-            retention_policy: None,
-            max_concurrent_split_uploads_index: 4,
-            max_concurrent_split_uploads_merge: 5,
-            cooperative_indexing_permits: None,
-            merge_planner_mailbox_opt: Some(merge_planner_mailbox.clone()),
-            event_broker: Default::default(),
-            params_fingerprint: 42u64,
-        };
-        let indexing_pipeline = IndexingPipeline::new(indexing_pipeline_params);
-        let (_indexing_pipeline_mailbox, indexing_pipeline_handler) =
-            universe.spawn_builder().spawn(indexing_pipeline);
-        let obs = indexing_pipeline_handler
-            .process_pending_and_observe()
-            .await;
-        assert_eq!(obs.generation, 1);
-        // Let's shutdown the indexer, this will trigger the indexing pipeline failure and the
-        // restart.
-        let indexer = universe.get::<Indexer>().into_iter().next().unwrap();
-        let _ = indexer.ask(Command::Quit).await;
-        for _ in 0..10 {
-            universe.sleep(*quickwit_actors::HEARTBEAT).await;
-            // Check indexing pipeline has restarted.
-            let obs = indexing_pipeline_handler
-                .process_pending_and_observe()
-                .await;
-            if obs.generation == 2 {
-                assert_eq!(merge_pipeline_handler.check_health(true), Health::Healthy);
-                universe.quit().await;
-                return;
-            }
-        }
-        panic!("Pipeline was apparently not restarted.");
     }
 
     async fn indexing_pipeline_all_failures_handling(test_file: &str) -> anyhow::Result<()> {
@@ -1308,7 +1190,6 @@ mod tests {
         let universe = Universe::new();
         let storage = Arc::new(RamStorage::default());
         let split_store = IndexingSplitStore::create_without_local_store_for_test(storage.clone());
-        let (merge_planner_mailbox, _) = universe.create_test_mailbox();
         // Create a minimal mapper with wrong date format to ensure that all documents will fail
         let broken_mapper = serde_json::from_str::<DocMapper>(
             r#"
@@ -1340,11 +1221,8 @@ mod tests {
             storage,
             split_store,
             merge_policy: default_merge_policy(),
-            retention_policy: None,
             max_concurrent_split_uploads_index: 4,
-            max_concurrent_split_uploads_merge: 5,
             cooperative_indexing_permits: None,
-            merge_planner_mailbox_opt: Some(merge_planner_mailbox),
             params_fingerprint: 42u64,
             event_broker: Default::default(),
         };

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use futures::TryStreamExt;
 use itertools::Itertools;
 use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorHandle, ActorState, Handler, Healthz, Mailbox,
@@ -27,9 +26,8 @@ use quickwit_actors::{
 };
 use quickwit_cluster::Cluster;
 use quickwit_common::fs::get_cache_directory_path;
-use quickwit_common::io::Limiter;
 use quickwit_common::pubsub::EventBroker;
-use quickwit_common::{io, temp_dir};
+use quickwit_common::temp_dir;
 use quickwit_config::{
     INGEST_API_SOURCE_ID, IndexConfig, IndexerConfig, SourceConfig, build_doc_mapper,
     indexing_pipeline_params_fingerprint,
@@ -40,29 +38,23 @@ use quickwit_ingest::{
 };
 use quickwit_metastore::{
     IndexMetadata, IndexMetadataResponseExt, IndexesMetadataResponseExt,
-    ListIndexesMetadataResponseExt, ListSplitsQuery, ListSplitsRequestExt, ListSplitsResponseExt,
-    SplitMetadata, SplitState,
+    ListIndexesMetadataResponseExt,
 };
 use quickwit_proto::indexing::{
     ApplyIndexingPlanRequest, ApplyIndexingPlanResponse, IndexingError, IndexingPipelineId,
-    IndexingTask, MergePipelineId, PipelineMetrics,
+    IndexingTask, PipelineMetrics,
 };
 use quickwit_proto::metastore::{
     IndexMetadataRequest, IndexMetadataSubrequest, IndexesMetadataRequest,
-    ListIndexesMetadataRequest, ListSplitsRequest, MetastoreResult, MetastoreService,
-    MetastoreServiceClient,
+    ListIndexesMetadataRequest, MetastoreService, MetastoreServiceClient,
 };
 use quickwit_proto::types::{IndexId, IndexUid, NodeId, PipelineUid, ShardId};
 use quickwit_storage::StorageResolver;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
-use super::merge_pipeline::{MergePipeline, MergePipelineParams};
-use super::{MergePlanner, MergeSchedulerService};
-use crate::actors::merge_pipeline::FinishPendingMergesAndShutdownPipeline;
-use crate::models::{DetachIndexingPipeline, DetachMergePipeline, ObservePipeline, SpawnPipeline};
+use crate::models::{DetachIndexingPipeline, ObservePipeline, SpawnPipeline};
 use crate::source::{AssignShards, Assignment};
 use crate::split_store::{IndexingSplitCache, SplitStoreQuota};
 use crate::{IndexingPipeline, IndexingPipelineParams, IndexingSplitStore, IndexingStatistics};
@@ -75,14 +67,8 @@ pub struct IndexingServiceCounters {
     pub num_running_pipelines: usize,
     pub num_successful_pipelines: usize,
     pub num_failed_pipelines: usize,
-    pub num_running_merge_pipelines: usize,
     pub num_deleted_queues: usize,
     pub num_delete_queue_failures: usize,
-}
-
-struct MergePipelineHandle {
-    mailbox: Mailbox<MergePlanner>,
-    handle: ActorHandle<MergePipeline>,
 }
 
 struct PipelineHandle {
@@ -104,16 +90,13 @@ pub struct IndexingService {
     cluster: Cluster,
     metastore: MetastoreServiceClient,
     ingest_api_service_opt: Option<Mailbox<IngestApiService>>,
-    merge_scheduler_service_opt: Option<Mailbox<MergeSchedulerService>>,
     ingester_pool: IngesterPool,
     storage_resolver: StorageResolver,
     indexing_pipelines: HashMap<PipelineUid, PipelineHandle>,
     counters: IndexingServiceCounters,
     local_split_store: Arc<IndexingSplitCache>,
     max_concurrent_split_uploads: usize,
-    merge_pipeline_handles: HashMap<MergePipelineId, MergePipelineHandle>,
     cooperative_indexing_permits: Option<Arc<Semaphore>>,
-    merge_io_throughput_limiter_opt: Option<Limiter>,
     event_broker: EventBroker,
 }
 
@@ -138,7 +121,6 @@ impl IndexingService {
         cluster: Cluster,
         metastore: MetastoreServiceClient,
         ingest_api_service_opt: Option<Mailbox<IngestApiService>>,
-        merge_scheduler_service_opt: Option<Mailbox<MergeSchedulerService>>,
         ingester_pool: IngesterPool,
         storage_resolver: StorageResolver,
         event_broker: EventBroker,
@@ -147,8 +129,6 @@ impl IndexingService {
             indexer_config.split_store_max_num_splits,
             indexer_config.split_store_max_num_bytes,
         )?;
-        let merge_io_throughput_limiter_opt =
-            indexer_config.max_merge_write_throughput.map(io::limiter);
         let split_cache_dir_path = get_cache_directory_path(&data_dir_path);
         let local_split_store =
             IndexingSplitCache::open(split_cache_dir_path, split_store_space_quota).await?;
@@ -167,15 +147,12 @@ impl IndexingService {
             cluster,
             metastore,
             ingest_api_service_opt,
-            merge_scheduler_service_opt,
             ingester_pool,
             storage_resolver,
             local_split_store: Arc::new(local_split_store),
             indexing_pipelines: Default::default(),
             counters: Default::default(),
             max_concurrent_split_uploads: indexer_config.max_concurrent_split_uploads,
-            merge_pipeline_handles: HashMap::new(),
-            merge_io_throughput_limiter_opt,
             cooperative_indexing_permits,
             event_broker,
         })
@@ -193,21 +170,6 @@ impl IndexingService {
                 IndexingError::Internal(message)
             })?;
         self.counters.num_running_pipelines -= 1;
-        Ok(pipeline_handle.handle)
-    }
-
-    async fn detach_merge_pipeline(
-        &mut self,
-        pipeline_id: &MergePipelineId,
-    ) -> Result<ActorHandle<MergePipeline>, IndexingError> {
-        let pipeline_handle = self
-            .merge_pipeline_handles
-            .remove(pipeline_id)
-            .ok_or_else(|| {
-                let message = format!("could not find merge pipeline `{pipeline_id}`");
-                IndexingError::Internal(message)
-            })?;
-        self.counters.num_running_merge_pipelines -= 1;
         Ok(pipeline_handle.handle)
     }
 
@@ -242,15 +204,8 @@ impl IndexingService {
             pipeline_uid,
         };
         let index_config = index_metadata.into_index_config();
-        self.spawn_pipeline_inner(
-            ctx,
-            pipeline_id.clone(),
-            index_config,
-            source_config,
-            None,
-            None,
-        )
-        .await?;
+        self.spawn_pipeline_inner(ctx, pipeline_id.clone(), index_config, source_config, None)
+            .await?;
         Ok(pipeline_id)
     }
 
@@ -260,7 +215,6 @@ impl IndexingService {
         indexing_pipeline_id: IndexingPipelineId,
         index_config: IndexConfig,
         source_config: SourceConfig,
-        immature_splits_opt: Option<Vec<SplitMetadata>>,
         expected_params_fingerprint: Option<u64>,
     ) -> Result<(), IndexingError> {
         if self
@@ -291,43 +245,15 @@ impl IndexingService {
             })?;
         let merge_policy =
             crate::merge_policy::merge_policy_from_settings(&index_config.indexing_settings);
-        let retention_policy = index_config.retention_policy_opt.clone();
         let split_store = IndexingSplitStore::new(storage.clone(), self.local_split_store.clone());
 
         let doc_mapper = build_doc_mapper(&index_config.doc_mapping, &index_config.search_settings)
             .map_err(|error| IndexingError::Internal(error.to_string()))?;
 
-        let merge_planner_mailbox_opt = if let Some(merge_scheduler_service) =
-            self.merge_scheduler_service_opt.clone()
-        {
-            let merge_pipeline_id = indexing_pipeline_id.merge_pipeline_id();
-            let merge_pipeline_params = MergePipelineParams {
-                pipeline_id: merge_pipeline_id,
-                doc_mapper: doc_mapper.clone(),
-                indexing_directory: indexing_directory.clone(),
-                metastore: self.metastore.clone(),
-                split_store: split_store.clone(),
-                merge_scheduler_service,
-                merge_policy: merge_policy.clone(),
-                retention_policy: retention_policy.clone(),
-                merge_io_throughput_limiter_opt: self.merge_io_throughput_limiter_opt.clone(),
-                max_concurrent_split_uploads: self.max_concurrent_split_uploads,
-                event_broker: self.event_broker.clone(),
-            };
-            Some(self.get_or_create_merge_pipeline(merge_pipeline_params, immature_splits_opt, ctx))
-        } else {
-            None
-        };
         // The concurrent uploads budget is split in 2: 1/2 for the indexing pipeline, 1/2 for the
         // merge pipeline. When there is no local merge pipeline, the indexing pipeline gets the
         // full budget.
-        let max_concurrent_split_uploads_index = if self.merge_scheduler_service_opt.is_some() {
-            (self.max_concurrent_split_uploads / 2).max(1)
-        } else {
-            self.max_concurrent_split_uploads
-        };
-        let max_concurrent_split_uploads_merge =
-            self.max_concurrent_split_uploads - max_concurrent_split_uploads_index;
+        let max_concurrent_split_uploads_index = self.max_concurrent_split_uploads;
 
         let params_fingerprint =
             indexing_pipeline_params_fingerprint(&index_config, &source_config);
@@ -359,12 +285,8 @@ impl IndexingService {
             split_store,
             max_concurrent_split_uploads_index,
             cooperative_indexing_permits: self.cooperative_indexing_permits.clone(),
-
-            // Merge-related parameters
+            // The merge policy is needed in the uploader for determining split maturity
             merge_policy,
-            retention_policy,
-            max_concurrent_split_uploads_merge,
-            merge_planner_mailbox_opt,
 
             // Source-related parameters
             source_config,
@@ -431,70 +353,6 @@ impl IndexingService {
         Ok(indexes_metadata)
     }
 
-    /// Fetches the immature splits candidates for merge for all the indexing pipelines for which a
-    /// merge pipeline is not running.
-    async fn fetch_immature_splits_for_new_merge_pipelines(
-        &mut self,
-        indexing_pipeline_ids: &[IndexingPipelineId],
-        ctx: &ActorContext<Self>,
-    ) -> MetastoreResult<HashMap<MergePipelineId, Vec<SplitMetadata>>> {
-        if self.merge_scheduler_service_opt.is_none() {
-            return Ok(Default::default());
-        }
-        let mut index_uids = Vec::new();
-
-        for indexing_pipeline_id in indexing_pipeline_ids {
-            let merge_pipeline_id = indexing_pipeline_id.merge_pipeline_id();
-
-            if !self.merge_pipeline_handles.contains_key(&merge_pipeline_id) {
-                index_uids.push(merge_pipeline_id.index_uid);
-            }
-        }
-        if index_uids.is_empty() {
-            return Ok(Default::default());
-        }
-        index_uids.sort_unstable();
-        index_uids.dedup();
-
-        let list_splits_query = ListSplitsQuery::try_from_index_uids(index_uids)
-            .expect("`index_uids` should not be empty")
-            .with_node_id(self.node_id.clone())
-            .with_split_state(SplitState::Published)
-            .retain_immature(OffsetDateTime::now_utc());
-        let list_splits_request =
-            ListSplitsRequest::try_from_list_splits_query(&list_splits_query)?;
-
-        let mut immature_splits_stream = ctx
-            .protect_future(self.metastore.list_splits(list_splits_request))
-            .await?;
-
-        let mut per_merge_pipeline_immature_splits: HashMap<MergePipelineId, Vec<SplitMetadata>> =
-            indexing_pipeline_ids
-                .iter()
-                .map(|indexing_pipeline_id| (indexing_pipeline_id.merge_pipeline_id(), Vec::new()))
-                .collect();
-
-        let mut num_immature_splits = 0usize;
-
-        while let Some(list_splits_response) = immature_splits_stream.try_next().await? {
-            for split_metadata in list_splits_response.deserialize_splits_metadata().await? {
-                num_immature_splits += 1;
-
-                let merge_pipeline_id = MergePipelineId {
-                    node_id: self.node_id.clone(),
-                    index_uid: split_metadata.index_uid.clone(),
-                    source_id: split_metadata.source_id.clone(),
-                };
-                per_merge_pipeline_immature_splits
-                    .entry(merge_pipeline_id)
-                    .or_default()
-                    .push(split_metadata);
-            }
-        }
-        info!("fetched {num_immature_splits} splits candidates for merge");
-        Ok(per_merge_pipeline_immature_splits)
-    }
-
     async fn handle_supervise(&mut self) -> Result<(), ActorExitStatus> {
         self.indexing_pipelines
             .retain(|pipeline_uid, pipeline_handle| {
@@ -522,48 +380,6 @@ impl IndexingService {
                     }
                 }
             });
-        let merge_pipelines_to_retain: HashSet<MergePipelineId> = self
-            .indexing_pipelines
-            .values()
-            .map(|pipeline_handle| pipeline_handle.indexing_pipeline_id.merge_pipeline_id())
-            .collect();
-
-        let merge_pipelines_to_shutdown: Vec<MergePipelineId> = self
-            .merge_pipeline_handles
-            .keys()
-            .filter(|running_merge_pipeline_id| {
-                !merge_pipelines_to_retain.contains(running_merge_pipeline_id)
-            })
-            .cloned()
-            .collect();
-
-        for merge_pipeline_to_shutdown in merge_pipelines_to_shutdown {
-            if let Some((_, merge_pipeline_handle)) = self
-                .merge_pipeline_handles
-                .remove_entry(&merge_pipeline_to_shutdown)
-            {
-                // We gracefully shutdown the merge pipeline, so we can complete the in-flight
-                // merges.
-                info!(
-                    index_uid=%merge_pipeline_to_shutdown.index_uid,
-                    source_id=%merge_pipeline_to_shutdown.source_id,
-                    "shutting down orphan merge pipeline"
-                );
-                // The queue capacity of the merge pipeline is unbounded, so `.send_message(...)`
-                // should not block.
-                // We avoid using `.quit()` here because it waits for the actor to exit.
-                merge_pipeline_handle
-                    .handle
-                    .mailbox()
-                    .send_message(FinishPendingMergesAndShutdownPipeline)
-                    .await
-                    .expect("merge pipeline mailbox should not be full");
-            }
-        }
-        // Finally, we remove the completed or failed merge pipelines.
-        self.merge_pipeline_handles
-            .retain(|_, merge_pipeline_handle| merge_pipeline_handle.handle.state().is_running());
-        self.counters.num_running_merge_pipelines = self.merge_pipeline_handles.len();
         self.update_chitchat_running_plan().await;
 
         let pipeline_metrics: HashMap<&IndexingPipelineId, PipelineMetrics> = self
@@ -579,33 +395,6 @@ impl IndexingService {
             .update_self_node_pipeline_metrics(&pipeline_metrics)
             .await;
         Ok(())
-    }
-
-    fn get_or_create_merge_pipeline(
-        &mut self,
-        merge_pipeline_params: MergePipelineParams,
-        immature_splits_opt: Option<Vec<SplitMetadata>>,
-        ctx: &ActorContext<Self>,
-    ) -> Mailbox<MergePlanner> {
-        if let Some(merge_pipeline_handle) = self
-            .merge_pipeline_handles
-            .get(&merge_pipeline_params.pipeline_id)
-        {
-            return merge_pipeline_handle.mailbox.clone();
-        }
-        let merge_pipeline_id = merge_pipeline_params.pipeline_id.clone();
-        let merge_pipeline =
-            MergePipeline::new(merge_pipeline_params, immature_splits_opt, ctx.spawn_ctx());
-        let merge_planner_mailbox = merge_pipeline.merge_planner_mailbox().clone();
-        let (_pipeline_mailbox, pipeline_handle) = ctx.spawn_actor().spawn(merge_pipeline);
-        let merge_pipeline_handle = MergePipelineHandle {
-            mailbox: merge_planner_mailbox.clone(),
-            handle: pipeline_handle,
-        };
-        self.merge_pipeline_handles
-            .insert(merge_pipeline_id, merge_pipeline_handle);
-        self.counters.num_running_merge_pipelines += 1;
-        merge_planner_mailbox
     }
 
     /// For all Ingest V2 pipelines, assigns the set of shards they should be working on.
@@ -714,10 +503,6 @@ impl IndexingService {
             .map(|index_metadata| (index_metadata.index_uid.clone(), index_metadata))
             .collect();
 
-        let mut per_merge_pipeline_immature_splits: HashMap<MergePipelineId, Vec<SplitMetadata>> =
-            self.fetch_immature_splits_for_new_merge_pipelines(&pipelines_to_spawn_ids, ctx)
-                .await?;
-
         let mut spawn_pipeline_failures: Vec<IndexingPipelineId> = Vec::new();
 
         for (task_to_spawn, id_to_spawn) in pipelines_to_spawn.iter().zip(pipelines_to_spawn_ids) {
@@ -725,17 +510,12 @@ impl IndexingService {
                 per_index_uid_indexes_metadata.get(task_to_spawn.index_uid())
             {
                 if let Some(source_config) = index_metadata.sources.get(&task_to_spawn.source_id) {
-                    let merge_pipeline_id = id_to_spawn.merge_pipeline_id();
-                    let immature_splits_opt =
-                        per_merge_pipeline_immature_splits.remove(&merge_pipeline_id);
-
                     if let Err(error) = self
                         .spawn_pipeline_inner(
                             ctx,
                             id_to_spawn.clone(),
                             index_metadata.index_config.clone(),
                             source_config.clone(),
-                            immature_splits_opt,
                             Some(task_to_spawn.params_fingerprint),
                         )
                         .await
@@ -914,19 +694,6 @@ impl Handler<DetachIndexingPipeline> for IndexingService {
     }
 }
 
-#[async_trait]
-impl Handler<DetachMergePipeline> for IndexingService {
-    type Reply = Result<ActorHandle<MergePipeline>, IndexingError>;
-
-    async fn handle(
-        &mut self,
-        msg: DetachMergePipeline,
-        _ctx: &ActorContext<Self>,
-    ) -> Result<Self::Reply, ActorExitStatus> {
-        Ok(self.detach_merge_pipeline(&msg.pipeline_id).await)
-    }
-}
-
 #[derive(Debug)]
 struct SuperviseLoop;
 
@@ -1030,18 +797,16 @@ mod tests {
     };
     use quickwit_ingest::{CreateQueueIfNotExistsRequest, init_ingest_api};
     use quickwit_metastore::{
-        AddSourceRequestExt, CreateIndexRequestExt, ListIndexesMetadataResponseExt, Split,
+        AddSourceRequestExt, CreateIndexRequestExt, ListIndexesMetadataResponseExt,
         metastore_for_test,
     };
     use quickwit_proto::indexing::IndexingTask;
     use quickwit_proto::metastore::{
         AddSourceRequest, CreateIndexRequest, DeleteIndexRequest, IndexMetadataResponse,
-        IndexesMetadataResponse, ListIndexesMetadataResponse, ListSplitsResponse,
-        MockMetastoreService,
+        IndexesMetadataResponse, ListIndexesMetadataResponse, MockMetastoreService,
     };
 
     use super::*;
-    use crate::actors::merge_pipeline::SUPERVISE_LOOP_INTERVAL;
 
     async fn spawn_indexing_service_for_test(
         data_dir_path: &Path,
@@ -1057,7 +822,6 @@ mod tests {
             init_ingest_api(universe, &queues_dir_path, &IngestApiConfig::default())
                 .await
                 .unwrap();
-        let merge_scheduler_mailbox: Mailbox<MergeSchedulerService> = universe.get_or_spawn_one();
         let indexing_server = IndexingService::new(
             NodeId::from("test-node"),
             data_dir_path.to_path_buf(),
@@ -1066,7 +830,6 @@ mod tests {
             cluster,
             metastore,
             Some(ingest_api_service),
-            Some(merge_scheduler_mailbox),
             IngesterPool::default(),
             storage_resolver.clone(),
             EventBroker::default(),
@@ -1166,15 +929,8 @@ mod tests {
             .await
             .unwrap();
         pipeline_handle.kill().await;
-        let _merge_pipeline = indexing_service
-            .ask_for_res(DetachMergePipeline {
-                pipeline_id: pipeline_id.merge_pipeline_id(),
-            })
-            .await
-            .unwrap();
         let observation = indexing_service_handle.process_pending_and_observe().await;
         assert_eq!(observation.num_running_pipelines, 0);
-        assert_eq!(observation.num_running_merge_pipelines, 0);
         universe.assert_quit().await;
     }
 
@@ -1525,263 +1281,6 @@ mod tests {
         universe.assert_quit().await;
     }
 
-    #[tokio::test]
-    async fn test_indexing_service_shutdown_merge_pipeline_when_no_indexing_pipeline() {
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
-            .await
-            .unwrap();
-        let metastore = metastore_for_test();
-
-        let index_id = append_random_suffix("test-indexing-service");
-        let index_uri = format!("ram:///indexes/{index_id}");
-        let index_config = IndexConfig::for_test(&index_id, &index_uri);
-
-        let source_config = SourceConfig {
-            source_id: "test-indexing-service--source".to_string(),
-            num_pipelines: NonZeroUsize::MIN,
-            enabled: true,
-            source_params: SourceParams::void(),
-            transform_config: None,
-            input_format: SourceInputFormat::Json,
-        };
-        let create_index_request =
-            CreateIndexRequest::try_from_index_config(&index_config).unwrap();
-        let index_uid: IndexUid = metastore
-            .create_index(create_index_request)
-            .await
-            .unwrap()
-            .index_uid()
-            .clone();
-        let add_source_request =
-            AddSourceRequest::try_from_source_config(index_uid.clone(), &source_config).unwrap();
-        metastore.add_source(add_source_request).await.unwrap();
-
-        // Test `IndexingService::new`.
-        let temp_dir = tempfile::tempdir().unwrap();
-        let data_dir_path = temp_dir.path().to_path_buf();
-        let indexer_config = IndexerConfig::for_test().unwrap();
-        let num_blocking_threads = 1;
-        let storage_resolver = StorageResolver::unconfigured();
-        let universe = Universe::with_accelerated_time();
-        let queues_dir_path = data_dir_path.join(QUEUES_DIR_NAME);
-        let ingest_api_service =
-            init_ingest_api(&universe, &queues_dir_path, &IngestApiConfig::default())
-                .await
-                .unwrap();
-        let merge_scheduler_service = universe.get_or_spawn_one();
-        let indexing_server = IndexingService::new(
-            NodeId::from("test-node"),
-            data_dir_path,
-            indexer_config,
-            num_blocking_threads,
-            cluster.clone(),
-            metastore.clone(),
-            Some(ingest_api_service),
-            Some(merge_scheduler_service),
-            IngesterPool::default(),
-            storage_resolver.clone(),
-            EventBroker::default(),
-        )
-        .await
-        .unwrap();
-        let (indexing_server_mailbox, indexing_server_handle) =
-            universe.spawn_builder().spawn(indexing_server);
-        let pipeline_id = indexing_server_mailbox
-            .ask_for_res(SpawnPipeline {
-                index_id: index_id.clone(),
-                source_config,
-                pipeline_uid: PipelineUid::default(),
-            })
-            .await
-            .unwrap();
-        let observation = indexing_server_handle.observe().await;
-        assert_eq!(observation.num_running_pipelines, 1);
-        assert_eq!(observation.num_failed_pipelines, 0);
-        assert_eq!(observation.num_successful_pipelines, 0);
-        assert_eq!(observation.num_running_merge_pipelines, 1);
-
-        // Test `shutdown_pipeline`
-        let pipeline = indexing_server_mailbox
-            .ask_for_res(DetachIndexingPipeline { pipeline_id })
-            .await
-            .unwrap();
-        pipeline.quit().await;
-
-        // Let the service cleanup the merge pipelines.
-        universe.sleep(*HEARTBEAT).await;
-
-        let observation = indexing_server_handle.process_pending_and_observe().await;
-        assert_eq!(observation.num_running_pipelines, 0);
-        assert_eq!(observation.num_running_merge_pipelines, 0);
-        universe.sleep(SUPERVISE_LOOP_INTERVAL).await;
-        // Check that the merge pipeline is also shut down as they are no more indexing pipeilne on
-        // the index.
-        assert!(universe.get_one::<MergePipeline>().is_none());
-        // It may or may not panic
-        universe.quit().await;
-    }
-
-    #[tokio::test]
-    async fn test_indexing_service_no_merge_pipeline_when_no_merge_scheduler() {
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
-            .await
-            .unwrap();
-        let metastore = metastore_for_test();
-
-        let index_id = append_random_suffix("test-indexing-service-no-merge");
-        let index_uri = format!("ram:///indexes/{index_id}");
-        let index_config = IndexConfig::for_test(&index_id, &index_uri);
-
-        let source_config = SourceConfig {
-            source_id: "test-source".to_string(),
-            num_pipelines: NonZeroUsize::MIN,
-            enabled: true,
-            source_params: SourceParams::void(),
-            transform_config: None,
-            input_format: SourceInputFormat::Json,
-        };
-        let create_index_request =
-            CreateIndexRequest::try_from_index_config(&index_config).unwrap();
-        let index_uid: IndexUid = metastore
-            .create_index(create_index_request)
-            .await
-            .unwrap()
-            .index_uid()
-            .clone();
-        let add_source_request =
-            AddSourceRequest::try_from_source_config(index_uid.clone(), &source_config).unwrap();
-        metastore.add_source(add_source_request).await.unwrap();
-
-        let temp_dir = tempfile::tempdir().unwrap();
-        let data_dir_path = temp_dir.path().to_path_buf();
-        let indexer_config = IndexerConfig::for_test().unwrap();
-        let num_blocking_threads = 1;
-        let storage_resolver = StorageResolver::unconfigured();
-        let universe = Universe::with_accelerated_time();
-        let queues_dir_path = data_dir_path.join(QUEUES_DIR_NAME);
-        let ingest_api_service =
-            init_ingest_api(&universe, &queues_dir_path, &IngestApiConfig::default())
-                .await
-                .unwrap();
-        let indexing_server = IndexingService::new(
-            NodeId::from("test-node"),
-            data_dir_path,
-            indexer_config,
-            num_blocking_threads,
-            cluster.clone(),
-            metastore.clone(),
-            Some(ingest_api_service),
-            None, // No merge scheduler — external merge service handles compaction.
-            IngesterPool::default(),
-            storage_resolver.clone(),
-            EventBroker::default(),
-        )
-        .await
-        .unwrap();
-        let (indexing_server_mailbox, indexing_server_handle) =
-            universe.spawn_builder().spawn(indexing_server);
-
-        indexing_server_mailbox
-            .ask_for_res(SpawnPipeline {
-                index_id: index_id.clone(),
-                source_config,
-                pipeline_uid: PipelineUid::default(),
-            })
-            .await
-            .unwrap();
-
-        let observation = indexing_server_handle.observe().await;
-        assert_eq!(observation.num_running_pipelines, 1);
-        assert_eq!(observation.num_running_merge_pipelines, 0);
-        assert!(universe.get_one::<MergePipeline>().is_none());
-
-        universe.quit().await;
-    }
-
-    #[tokio::test]
-    async fn test_indexing_service_spawns_merge_pipeline_with_merge_scheduler() {
-        quickwit_common::setup_logging_for_tests();
-        let transport = ChannelTransport::default();
-        let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
-            .await
-            .unwrap();
-        let metastore = metastore_for_test();
-
-        let index_id = append_random_suffix("test-indexing-service-with-merge");
-        let index_uri = format!("ram:///indexes/{index_id}");
-        let index_config = IndexConfig::for_test(&index_id, &index_uri);
-
-        let source_config = SourceConfig {
-            source_id: "test-source".to_string(),
-            num_pipelines: NonZeroUsize::MIN,
-            enabled: true,
-            source_params: SourceParams::void(),
-            transform_config: None,
-            input_format: SourceInputFormat::Json,
-        };
-        let create_index_request =
-            CreateIndexRequest::try_from_index_config(&index_config).unwrap();
-        let index_uid: IndexUid = metastore
-            .create_index(create_index_request)
-            .await
-            .unwrap()
-            .index_uid()
-            .clone();
-        let add_source_request =
-            AddSourceRequest::try_from_source_config(index_uid.clone(), &source_config).unwrap();
-        metastore.add_source(add_source_request).await.unwrap();
-
-        let temp_dir = tempfile::tempdir().unwrap();
-        let data_dir_path = temp_dir.path().to_path_buf();
-        let indexer_config = IndexerConfig::for_test().unwrap();
-        let num_blocking_threads = 1;
-        let storage_resolver = StorageResolver::unconfigured();
-        let universe = Universe::with_accelerated_time();
-        let queues_dir_path = data_dir_path.join(QUEUES_DIR_NAME);
-        let ingest_api_service =
-            init_ingest_api(&universe, &queues_dir_path, &IngestApiConfig::default())
-                .await
-                .unwrap();
-        let merge_scheduler_mailbox: Mailbox<MergeSchedulerService> = universe.get_or_spawn_one();
-        let indexing_server = IndexingService::new(
-            NodeId::from("test-node"),
-            data_dir_path,
-            indexer_config,
-            num_blocking_threads,
-            cluster.clone(),
-            metastore.clone(),
-            Some(ingest_api_service),
-            Some(merge_scheduler_mailbox),
-            IngesterPool::default(),
-            storage_resolver.clone(),
-            EventBroker::default(),
-        )
-        .await
-        .unwrap();
-        let (indexing_server_mailbox, indexing_server_handle) =
-            universe.spawn_builder().spawn(indexing_server);
-
-        indexing_server_mailbox
-            .ask_for_res(SpawnPipeline {
-                index_id: index_id.clone(),
-                source_config,
-                pipeline_uid: PipelineUid::default(),
-            })
-            .await
-            .unwrap();
-
-        let observation = indexing_server_handle.observe().await;
-        assert_eq!(observation.num_running_pipelines, 1);
-        assert_eq!(observation.num_running_merge_pipelines, 1);
-        assert!(universe.get_one::<MergePipeline>().is_some());
-
-        universe.quit().await;
-    }
-
     #[derive(Debug)]
     struct FreezePipeline;
     #[async_trait]
@@ -1886,7 +1385,6 @@ mod tests {
         let observation = indexing_service_handle.observe().await;
         assert_eq!(observation.num_running_pipelines, 1);
         assert_eq!(observation.num_failed_pipelines, 0);
-        assert_eq!(observation.num_running_merge_pipelines, 1);
         // Might generate panics
         universe.quit().await;
     }
@@ -1931,7 +1429,6 @@ mod tests {
         let indexer_config = IndexerConfig::for_test().unwrap();
         let num_blocking_threads = 1;
         let storage_resolver = StorageResolver::unconfigured();
-        let merge_scheduler_service: Mailbox<MergeSchedulerService> = universe.get_or_spawn_one();
         let mut indexing_server = IndexingService::new(
             NodeId::from("test-ingest-api-gc-node"),
             data_dir_path,
@@ -1940,7 +1437,6 @@ mod tests {
             cluster.clone(),
             metastore.clone(),
             Some(ingest_api_service.clone()),
-            Some(merge_scheduler_service),
             IngesterPool::default(),
             storage_resolver.clone(),
             EventBroker::default(),
@@ -2006,30 +1502,6 @@ mod tests {
                 let indexes_metadata = vec![index_metadata_1, index_metadata_2];
                 let failures = Vec::new();
                 let response = IndexesMetadataResponse::for_test(indexes_metadata, failures);
-                Ok(response)
-            });
-        mock_metastore
-            .expect_list_splits()
-            .withf(|request| {
-                let list_splits_query = request.deserialize_list_splits_query().unwrap();
-                list_splits_query.index_uids.unwrap() == [("test-index-0", 0)]
-            })
-            .return_once(|_request| Ok(ServiceStream::empty()));
-        mock_metastore
-            .expect_list_splits()
-            .withf(|request| {
-                let list_splits_query = request.deserialize_list_splits_query().unwrap();
-                list_splits_query.index_uids.unwrap() == [("test-index-1", 0), ("test-index-2", 0)]
-            })
-            .return_once(|_request| {
-                let splits = vec![Split {
-                    split_metadata: SplitMetadata::for_test("test-split".to_string()),
-                    split_state: SplitState::Published,
-                    update_timestamp: 0,
-                    publish_timestamp: Some(0),
-                }];
-                let list_splits_response = ListSplitsResponse::try_from_splits(splits).unwrap();
-                let response = ServiceStream::from(vec![Ok(list_splits_response)]);
                 Ok(response)
             });
 

--- a/quickwit/quickwit-indexing/src/lib.rs
+++ b/quickwit/quickwit-indexing/src/lib.rs
@@ -24,7 +24,6 @@ use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_storage::StorageResolver;
 use tracing::info;
 
-use crate::actors::MergeSchedulerService;
 pub use crate::actors::{
     FinishPendingMergesAndShutdownPipeline, IndexingError, IndexingPipeline,
     IndexingPipelineParams, IndexingService, PublisherType, Sequencer, SplitsUpdateMailbox,
@@ -71,7 +70,6 @@ pub async fn start_indexing_service(
     ingester_pool: IngesterPool,
     storage_resolver: StorageResolver,
     event_broker: EventBroker,
-    merge_scheduler_mailbox: Option<Mailbox<MergeSchedulerService>>,
 ) -> anyhow::Result<Mailbox<IndexingService>> {
     info!("starting indexer service");
     let ingest_api_service_mailbox = universe.get_one::<IngestApiService>();
@@ -83,7 +81,6 @@ pub async fn start_indexing_service(
         cluster,
         metastore.clone(),
         ingest_api_service_mailbox,
-        merge_scheduler_mailbox,
         ingester_pool,
         storage_resolver,
         event_broker,

--- a/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
+++ b/quickwit/quickwit-indexing/src/models/indexing_service_message.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use quickwit_config::SourceConfig;
-use quickwit_proto::indexing::{IndexingPipelineId, MergePipelineId};
+use quickwit_proto::indexing::IndexingPipelineId;
 use quickwit_proto::types::{IndexId, PipelineUid};
 
 #[derive(Clone, Debug)]
@@ -29,14 +29,6 @@ pub struct SpawnPipeline {
 #[derive(Debug)]
 pub struct DetachIndexingPipeline {
     pub pipeline_id: IndexingPipelineId,
-}
-
-/// Detaches a merge pipeline from the indexing service. The pipeline is no longer managed by the
-/// server. This is mostly useful for preventing the server killing an existing merge pipeline
-/// if a indexing pipeline is detached.
-#[derive(Debug)]
-pub struct DetachMergePipeline {
-    pub pipeline_id: MergePipelineId,
 }
 
 #[derive(Debug)]

--- a/quickwit/quickwit-indexing/src/models/mod.rs
+++ b/quickwit/quickwit-indexing/src/models/mod.rs
@@ -34,9 +34,7 @@ pub use indexed_split::{
     CommitTrigger, EmptySplit, IndexedSplit, IndexedSplitBatch, IndexedSplitBatchBuilder,
     IndexedSplitBuilder,
 };
-pub use indexing_service_message::{
-    DetachIndexingPipeline, DetachMergePipeline, ObservePipeline, SpawnPipeline,
-};
+pub use indexing_service_message::{DetachIndexingPipeline, ObservePipeline, SpawnPipeline};
 pub use indexing_statistics::IndexingStatistics;
 pub use merge_planner_message::NewSplits;
 pub use merge_scratch::MergeScratch;

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -111,7 +111,6 @@ impl TestSandbox {
         let num_blocking_threads = 1;
         let storage = storage_resolver.resolve(&index_uri).await?;
         let universe = Universe::with_accelerated_time();
-        let merge_scheduler_mailbox = universe.get_or_spawn_one();
         let queues_dir_path = temp_dir.path().join(QUEUES_DIR_NAME);
         let ingest_api_service =
             init_ingest_api(&universe, &queues_dir_path, &IngestApiConfig::default()).await?;
@@ -123,7 +122,6 @@ impl TestSandbox {
             cluster,
             metastore.clone(),
             Some(ingest_api_service),
-            Some(merge_scheduler_mailbox),
             IngesterPool::default(),
             storage_resolver.clone(),
             EventBroker::default(),

--- a/quickwit/quickwit-proto/protos/quickwit/compaction.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/compaction.proto
@@ -39,7 +39,6 @@ message CompactionInProgress {
 
 message CompactionSuccess {
   string task_id = 1;
-  string merged_split_id = 2;
 }
 
 message CompactionFailure {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.compaction.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.compaction.rs
@@ -30,8 +30,6 @@ pub struct CompactionInProgress {
 pub struct CompactionSuccess {
     #[prost(string, tag = "1")]
     pub task_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub merged_split_id: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -79,7 +79,7 @@ use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig};
 use quickwit_control_plane::control_plane::{ControlPlane, ControlPlaneEventSubscriber};
 use quickwit_control_plane::{IndexerNodeInfo, IndexerPool};
 use quickwit_index_management::{IndexService as IndexManager, IndexServiceError};
-use quickwit_indexing::actors::{IndexingService, MergeSchedulerService};
+use quickwit_indexing::actors::IndexingService;
 use quickwit_indexing::models::ShardPositionsService;
 use quickwit_indexing::start_indexing_service;
 use quickwit_ingest::{
@@ -308,16 +308,6 @@ async fn get_compaction_planner_client_if_needed(
         node_config.grpc_config.max_message_size,
         None,
     )))
-}
-
-fn spawn_merge_scheduler_service(
-    universe: &Universe,
-    node_config: &NodeConfig,
-) -> Mailbox<MergeSchedulerService> {
-    let (mailbox, _) = universe.spawn_builder().spawn(MergeSchedulerService::new(
-        node_config.indexer_config.merge_concurrency.get(),
-    ));
-    mailbox
 }
 
 async fn start_ingest_client_if_needed(
@@ -608,7 +598,6 @@ pub async fn serve_quickwit(
     .context("failed to initialize compaction service client")?;
 
     let indexing_service_opt = if node_config.is_service_enabled(QuickwitService::Indexer) {
-        let merge_scheduler_mailbox_opt = None;
         let indexing_service = start_indexing_service(
             &universe,
             &node_config,
@@ -618,7 +607,6 @@ pub async fn serve_quickwit(
             ingester_pool.clone(),
             storage_resolver.clone(),
             event_broker.clone(),
-            merge_scheduler_mailbox_opt,
         )
         .await
         .context("failed to start indexing service")?;

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -608,12 +608,7 @@ pub async fn serve_quickwit(
     .context("failed to initialize compaction service client")?;
 
     let indexing_service_opt = if node_config.is_service_enabled(QuickwitService::Indexer) {
-        let merge_scheduler_mailbox_opt =
-            if !node_config.indexer_config.enable_standalone_compactors {
-                Some(spawn_merge_scheduler_service(&universe, &node_config))
-            } else {
-                None
-            };
+        let merge_scheduler_mailbox_opt = None;
         let indexing_service = start_indexing_service(
             &universe,
             &node_config,


### PR DESCRIPTION
### Description
Fully removes the merge code from the indexing service and pipelines. The only thing that remains is the merge policy, which is needed by the uploader to determine if splits are mature. Though they likely aren't, it's best kept like this for compatibility reasons.

### How was this PR tested?
The entire feature branch was tested on a load-bearing cluster and worked successfully to merge splits.
