### PR TITLE
feat(elasticsearch_api): pushdown start/end timestamp on _mapping endpoint

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -9114,6 +9114,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs 0.15.0",
+ "serde_urlencoded",
  "serde_with",
  "tempfile",
  "thiserror 2.0.18",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -235,6 +235,7 @@ serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_json_borrow = "0.9"
 serde_qs = { version = "0.15" }
+serde_urlencoded = "0.7"
 serde_with = "3.16"
 serde_yaml = "0.9"
 serial_test = { version = "3.2", features = ["file_locks"] }

--- a/quickwit/quickwit-serve/Cargo.toml
+++ b/quickwit/quickwit-serve/Cargo.toml
@@ -89,6 +89,7 @@ itertools = { workspace = true }
 mockall = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
+serde_urlencoded = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/filter.rs
@@ -20,7 +20,7 @@ use warp::{Filter, Rejection};
 
 use super::model::{
     CatIndexQueryParams, DeleteQueryParams, FieldCapabilityQueryParams, FieldCapabilityRequestBody,
-    MultiSearchQueryParams, SearchQueryParamsCount,
+    IndexMappingQueryParams, MultiSearchQueryParams, SearchQueryParamsCount,
 };
 use crate::Body;
 use crate::decompression::get_body_bytes;
@@ -285,9 +285,10 @@ pub(crate) fn elastic_aliases_filter() -> impl Filter<Extract = (), Error = Reje
 }
 
 pub(crate) fn elastic_index_mapping_filter()
--> impl Filter<Extract = (String,), Error = Rejection> + Clone {
+-> impl Filter<Extract = (String, IndexMappingQueryParams), Error = Rejection> + Clone {
     warp::path!("_elastic" / String / "_mapping")
         .or(warp::path!("_elastic" / String / "_mappings"))
         .unify()
         .and(warp::get())
+        .and(warp::query())
 }

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/index_mapping_query_params.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/index_mapping_query_params.rs
@@ -1,0 +1,77 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+/// Query parameters accepted by `GET /_elastic/{index}/_mapping` and
+/// `/_mappings`.
+///
+/// Both fields are optional and absent by default. When present, they are
+/// forwarded into [`quickwit_proto::search::ListFieldsRequest`] verbatim,
+/// where they prune the set of splits considered for field discovery. Unit
+/// is **epoch seconds**, interval is half-open `[start_timestamp,
+/// end_timestamp)` — matching the `ListFieldsRequest` proto contract
+/// exactly.
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IndexMappingQueryParams {
+    #[serde(default)]
+    pub start_timestamp: Option<i64>,
+    #[serde(default)]
+    pub end_timestamp: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IndexMappingQueryParams;
+
+    #[test]
+    fn empty_query_string_yields_none() {
+        let params: IndexMappingQueryParams = serde_urlencoded::from_str("").unwrap();
+        assert!(params.start_timestamp.is_none());
+        assert!(params.end_timestamp.is_none());
+    }
+
+    #[test]
+    fn both_params_present_yield_some() {
+        let qs = "start_timestamp=1712160204&end_timestamp=1712764984";
+        let params: IndexMappingQueryParams = serde_urlencoded::from_str(qs).unwrap();
+        assert_eq!(params.start_timestamp, Some(1712160204));
+        assert_eq!(params.end_timestamp, Some(1712764984));
+    }
+
+    #[test]
+    fn only_start_timestamp_present() {
+        let qs = "start_timestamp=1712160204";
+        let params: IndexMappingQueryParams = serde_urlencoded::from_str(qs).unwrap();
+        assert_eq!(params.start_timestamp, Some(1712160204));
+        assert!(params.end_timestamp.is_none());
+    }
+
+    #[test]
+    fn only_end_timestamp_present() {
+        let qs = "end_timestamp=1712764984";
+        let params: IndexMappingQueryParams = serde_urlencoded::from_str(qs).unwrap();
+        assert!(params.start_timestamp.is_none());
+        assert_eq!(params.end_timestamp, Some(1712764984));
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let qs = "start_timestamp=1&unexpected=foo";
+        let result: Result<IndexMappingQueryParams, _> = serde_urlencoded::from_str(qs);
+        assert!(result.is_err());
+    }
+}

--- a/quickwit/quickwit-serve/src/elasticsearch_api/model/mod.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/model/mod.rs
@@ -17,6 +17,7 @@ mod bulk_query_params;
 mod cat_indices;
 mod error;
 mod field_capability;
+mod index_mapping_query_params;
 mod mappings;
 mod multi_search;
 mod scroll;
@@ -36,6 +37,7 @@ pub use field_capability::{
     FieldCapabilityQueryParams, FieldCapabilityRequestBody, FieldCapabilityResponse,
     build_list_field_request_for_es_api, convert_to_es_field_capabilities_response,
 };
+pub use index_mapping_query_params::IndexMappingQueryParams;
 pub(crate) use mappings::ElasticsearchMappingsResponse;
 pub use multi_search::{
     MultiSearchHeader, MultiSearchQueryParams, MultiSearchResponse, MultiSearchSingleResponse,

--- a/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/elasticsearch_api/rest_handler.rs
@@ -58,9 +58,9 @@ use super::model::{
     CatIndexQueryParams, DeleteQueryParams, ElasticsearchCatIndexResponse, ElasticsearchError,
     ElasticsearchResolveIndexEntryResponse, ElasticsearchResolveIndexResponse,
     ElasticsearchResponse, ElasticsearchStatsResponse, FieldCapabilityQueryParams,
-    FieldCapabilityRequestBody, FieldCapabilityResponse, MultiSearchHeader, MultiSearchQueryParams,
-    MultiSearchResponse, MultiSearchSingleResponse, ScrollQueryParams, SearchBody,
-    SearchQueryParams, SearchQueryParamsCount, StatsResponseEntry,
+    FieldCapabilityRequestBody, FieldCapabilityResponse, IndexMappingQueryParams,
+    MultiSearchHeader, MultiSearchQueryParams, MultiSearchResponse, MultiSearchSingleResponse,
+    ScrollQueryParams, SearchBody, SearchQueryParams, SearchQueryParamsCount, StatsResponseEntry,
     build_list_field_request_for_es_api, convert_to_es_field_capabilities_response,
 };
 use super::{TrackTotalHits, make_elastic_api_response};
@@ -201,6 +201,7 @@ async fn get_index_metadata(
 
 pub(crate) async fn es_compat_index_mapping(
     index_id: String,
+    params: IndexMappingQueryParams,
     mut metastore: MetastoreServiceClient,
     search_service: Arc<dyn SearchService>,
 ) -> Result<ElasticsearchMappingsResponse, ElasticsearchError> {
@@ -217,8 +218,8 @@ pub(crate) async fn es_compat_index_mapping(
     let list_fields_request = quickwit_proto::search::ListFieldsRequest {
         index_id_patterns,
         fields: Vec::new(),
-        start_timestamp: None,
-        end_timestamp: None,
+        start_timestamp: params.start_timestamp,
+        end_timestamp: params.end_timestamp,
         query_ast: None,
     };
     let list_fields_response = search_service


### PR DESCRIPTION
## Summary

Adds two optional URL query parameters to the ES-compatibility `_mapping` endpoint (`GET /_elastic/{index}/_mapping` and `/_mappings`):

- `start_timestamp` (epoch seconds)
- `end_timestamp` (epoch seconds)

When present, they are forwarded into `quickwit_proto::search::ListFieldsRequest.start_timestamp` / `end_timestamp` verbatim, enabling timestamp-based split pruning during field discovery. When absent, behaviour is **identical to today** (both proto fields stay `None`).

The proto already documents these fields:

```proto
// Time filter, expressed in seconds since epoch.
// That filter is to be interpreted as the semi-open interval:
// [start_timestamp, end_timestamp).
optional int64 start_timestamp = 3;
optional int64 end_timestamp = 4;
```

The infrastructure (`list_relevant_splits` honouring the window) has long been wired through `ListFieldsRequest`; this change just exposes the existing knob at the HTTP surface.

## Why

Today `es_compat_index_mapping` hardcodes `start_timestamp: None, end_timestamp: None`, so every call scans every published split for every dynamic field. On large clusters with many `custom.*` / `tag.*` fields and months of data, the response can balloon to tens of megabytes and 30+ seconds — long enough to time out behind any modestly aggressive HTTP gateway. With the time window pushed down, mapping responses shrink dramatically.

## Changes

- **New** `quickwit-serve/src/elasticsearch_api/model/index_mapping_query_params.rs` — `IndexMappingQueryParams` struct with `Option<i64>` fields, `serde::Deserialize`, `#[serde(deny_unknown_fields)]` (matching `SearchQueryParams` / `CatIndexQueryParams` convention), plus 5 parser-level unit tests.
- **Updated** `model/mod.rs` — module declaration + `pub use` re-export.
- **Updated** `elasticsearch_api/filter.rs::elastic_index_mapping_filter` — now extracts `(String, IndexMappingQueryParams)` via `.and(warp::query())`, mirroring the pattern in `elasticsearch_filter` and `elastic_index_count_filter`.
- **Updated** `elasticsearch_api/rest_handler.rs::es_compat_index_mapping` — accepts `params: IndexMappingQueryParams` as its second argument and reads `params.start_timestamp` / `params.end_timestamp` into `ListFieldsRequest`. The factory `es_compat_index_mapping_handler` needs no edits — warp threads the new tuple element through positionally.
- **Updated** `Cargo.toml` (workspace) and `quickwit-serve/Cargo.toml` — `serde_urlencoded` added as a dev-dependency for the parser-level tests (already a transitive dep via warp).

## Backward compatibility

Fully backward-compatible. Clients that omit the query parameters get exactly today's behaviour. The `deny_unknown_fields` setting matches the existing convention on neighbouring endpoints (`SearchQueryParams`, `CatIndexQueryParams`); this means a stray `?pretty=true` would now return 400 — but this matches `_search`'s existing behaviour, so the surface is consistent across endpoints.

## Test plan

- [x] `cargo test -p quickwit-serve` — 154 tests passed, 0 failed (5 new tests included).
- [x] `cargo build -p quickwit-serve` — builds clean.
- [x] `cargo clippy -p quickwit-serve --all-features --tests` — clean.
- [x] Unit tests cover: empty query string (`None`/`None`), both params present, only one present, unknown field rejected.

## Notes

- Did not update `CHANGELOG.md` because the `[Unreleased]` section is HTML-commented out in the file, suggesting maintainers update it during release. Happy to add an entry if preferred.
- No proto regeneration is required because the `ListFieldsRequest` fields already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)