### PR TITLE
feat: wire ParquetMergePipeline into IndexingService

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -8595,6 +8595,7 @@ dependencies = [
  "mockall",
  "oneshot 0.2.1",
  "openssl",
+ "parquet",
  "percent-encoding",
  "proptest",
  "prost 0.14.3",

--- a/quickwit/quickwit-indexing/Cargo.toml
+++ b/quickwit/quickwit-indexing/Cargo.toml
@@ -114,6 +114,7 @@ ci-test = []
 bytes = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 mockall = { workspace = true }
+parquet = { workspace = true }
 proptest = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -85,6 +85,12 @@ struct MergePipelineHandle {
     handle: ActorHandle<MergePipeline>,
 }
 
+#[cfg(feature = "metrics")]
+struct ParquetMergePipelineHandle {
+    mailbox: Mailbox<super::metrics_pipeline::ParquetMergePlanner>,
+    handle: ActorHandle<super::metrics_pipeline::ParquetMergePipeline>,
+}
+
 pub type BoxedPipelineHandle = Box<dyn PipelineHandle>;
 
 /// The indexing service is (single) actor service running on indexer and in charge
@@ -108,6 +114,8 @@ pub struct IndexingService {
     local_split_store: Arc<IndexingSplitCache>,
     pub(crate) max_concurrent_split_uploads: usize,
     merge_pipeline_handles: HashMap<MergePipelineId, MergePipelineHandle>,
+    #[cfg(feature = "metrics")]
+    parquet_merge_pipeline_handles: HashMap<IndexUid, ParquetMergePipelineHandle>,
     cooperative_indexing_permits: Option<Arc<Semaphore>>,
     merge_io_throughput_limiter_opt: Option<Limiter>,
     pub(crate) event_broker: EventBroker,
@@ -171,6 +179,8 @@ impl IndexingService {
             counters: Default::default(),
             max_concurrent_split_uploads: indexer_config.max_concurrent_split_uploads,
             merge_pipeline_handles: HashMap::new(),
+            #[cfg(feature = "metrics")]
+            parquet_merge_pipeline_handles: HashMap::new(),
             merge_io_throughput_limiter_opt,
             cooperative_indexing_permits,
             event_broker,
@@ -577,6 +587,49 @@ impl IndexingService {
         self.merge_pipeline_handles
             .retain(|_, merge_pipeline_handle| merge_pipeline_handle.handle.state().is_running());
         self.counters.num_running_merge_pipelines = self.merge_pipeline_handles.len();
+
+        // Parquet merge pipeline cleanup: shut down orphans whose parent
+        // metrics pipelines are gone, then reap completed/failed ones.
+        #[cfg(feature = "metrics")]
+        {
+            let parquet_index_uids_to_retain: HashSet<IndexUid> = self
+                .indexing_pipelines
+                .values()
+                .filter(|h| {
+                    quickwit_common::is_parquet_pipeline_index(
+                        &h.indexing_pipeline_id().index_uid.index_id,
+                    )
+                })
+                .map(|h| h.indexing_pipeline_id().index_uid.clone())
+                .collect();
+
+            let parquet_to_shutdown: Vec<IndexUid> = self
+                .parquet_merge_pipeline_handles
+                .keys()
+                .filter(|uid| !parquet_index_uids_to_retain.contains(uid))
+                .cloned()
+                .collect();
+
+            for index_uid in parquet_to_shutdown {
+                if let Some((_, handle)) =
+                    self.parquet_merge_pipeline_handles.remove_entry(&index_uid)
+                {
+                    info!(
+                        index_uid=%index_uid,
+                        "shutting down orphan parquet merge pipeline"
+                    );
+                    handle
+                        .handle
+                        .mailbox()
+                        .send_message(FinishPendingMergesAndShutdownPipeline)
+                        .await
+                        .expect("parquet merge pipeline mailbox should not be full");
+                }
+            }
+            self.parquet_merge_pipeline_handles
+                .retain(|_, handle| handle.handle.state().is_running());
+        }
+
         self.update_chitchat_running_plan().await;
 
         let pipeline_metrics: HashMap<&IndexingPipelineId, PipelineMetrics> = self
@@ -618,6 +671,73 @@ impl IndexingService {
         self.merge_pipeline_handles
             .insert(merge_pipeline_id, merge_pipeline_handle);
         self.counters.num_running_merge_pipelines += 1;
+        Ok(merge_planner_mailbox)
+    }
+
+    /// Returns the Parquet merge planner mailbox for the given index, creating
+    /// a new ParquetMergePipeline if one isn't already running.
+    ///
+    /// Keyed by IndexUid (not MergePipelineId) because Parquet merge pipelines
+    /// are shared across all sources for the same index — unlike Tantivy merge
+    /// pipelines which are per-source.
+    #[cfg(feature = "metrics")]
+    pub(crate) fn get_or_create_parquet_merge_pipeline(
+        &mut self,
+        index_uid: IndexUid,
+        index_config: &IndexConfig,
+        storage: Arc<dyn quickwit_storage::Storage>,
+        indexing_directory: quickwit_common::temp_dir::TempDirectory,
+        immature_splits_opt: Option<Vec<quickwit_parquet_engine::split::ParquetSplitMetadata>>,
+        ctx: &ActorContext<Self>,
+    ) -> Result<Mailbox<super::metrics_pipeline::ParquetMergePlanner>, IndexingError> {
+        if let Some(handle) = self.parquet_merge_pipeline_handles.get(&index_uid) {
+            return Ok(handle.mailbox.clone());
+        }
+
+        // Convert the config-crate merge policy into the engine-crate type.
+        let cfg = index_config.indexing_settings.parquet_merge_policy();
+        let engine_config = quickwit_parquet_engine::merge::policy::ParquetMergePolicyConfig {
+            merge_factor: cfg.merge_factor,
+            max_merge_factor: cfg.max_merge_factor,
+            max_merge_ops: cfg.max_merge_ops,
+            target_split_size_bytes: cfg.target_split_size_bytes,
+            maturation_period: cfg.maturation_period,
+            max_finalize_merge_operations: cfg.max_finalize_merge_operations,
+        };
+        let merge_policy: Arc<dyn quickwit_parquet_engine::merge::policy::ParquetMergePolicy> =
+            Arc::new(
+                quickwit_parquet_engine::merge::policy::ConstWriteAmplificationParquetMergePolicy::new(
+                    engine_config,
+                ),
+            );
+
+        let writer_config = quickwit_parquet_engine::storage::ParquetWriterConfig::default();
+
+        let params = super::metrics_pipeline::ParquetMergePipelineParams {
+            index_uid: index_uid.clone(),
+            indexing_directory,
+            metastore: self.metastore.clone(),
+            storage,
+            merge_policy,
+            merge_scheduler_service: self.merge_scheduler_service.clone(),
+            max_concurrent_split_uploads: self.max_concurrent_split_uploads,
+            event_broker: self.event_broker.clone(),
+            writer_config,
+        };
+
+        let pipeline = super::metrics_pipeline::ParquetMergePipeline::new(
+            params,
+            immature_splits_opt,
+            ctx.spawn_ctx(),
+        );
+        let merge_planner_mailbox = pipeline.merge_planner_mailbox().clone();
+        let (_pipeline_mailbox, pipeline_handle) = ctx.spawn_actor().spawn(pipeline);
+        let handle = ParquetMergePipelineHandle {
+            mailbox: merge_planner_mailbox.clone(),
+            handle: pipeline_handle,
+        };
+        self.parquet_merge_pipeline_handles
+            .insert(index_uid, handle);
         Ok(merge_planner_mailbox)
     }
 

--- a/quickwit/quickwit-indexing/src/actors/merge_scheduler_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_scheduler_service.rs
@@ -318,22 +318,28 @@ struct ScheduleMerge {
     split_downloader_mailbox: Mailbox<MergeSplitDownloader>,
 }
 
-/// The higher, the sooner we will execute the merge operation.
-/// A good merge operation
-/// - strongly reduces the number splits
-/// - is light.
-fn score_merge_operation(merge_operation: &MergeOperation) -> u64 {
-    let total_num_bytes: u64 = merge_operation.total_num_bytes();
+/// Scores a merge operation for priority scheduling.
+///
+/// Higher score = scheduled sooner. Prefers merges that strongly reduce
+/// split count relative to their total byte cost. Used by both Tantivy
+/// and Parquet merge scheduling.
+fn score_merge(num_splits: usize, total_num_bytes: u64) -> u64 {
     if total_num_bytes == 0 {
-        // Silly corner case that should never happen.
         return u64::MAX;
     }
-    // We will remove splits.len() and add 1 merge splits.
-    let delta_num_splits = (merge_operation.splits.len() - 1) as u64;
-    // We use integer arithmetic to avoid `f64 are not ordered` silliness.
+    // We will remove num_splits and add 1 merged split.
+    let delta_num_splits = (num_splits - 1) as u64;
+    // Integer arithmetic to avoid `f64 are not ordered` silliness.
     (delta_num_splits << 48)
         .checked_div(total_num_bytes)
         .unwrap_or(1u64)
+}
+
+fn score_merge_operation(merge_operation: &MergeOperation) -> u64 {
+    score_merge(
+        merge_operation.splits.len(),
+        merge_operation.total_num_bytes(),
+    )
 }
 
 impl ScheduleMerge {
@@ -406,14 +412,10 @@ impl Handler<PermitReleased> for MergeSchedulerService {
 
 #[cfg(feature = "metrics")]
 fn score_parquet_merge_operation(merge_operation: &ParquetMergeOperation) -> u64 {
-    let total_num_bytes = merge_operation.total_size_bytes();
-    if total_num_bytes == 0 {
-        return u64::MAX;
-    }
-    let delta_num_splits = (merge_operation.splits.len() - 1) as u64;
-    (delta_num_splits << 48)
-        .checked_div(total_num_bytes)
-        .unwrap_or(1u64)
+    score_merge(
+        merge_operation.splits.len(),
+        merge_operation.total_size_bytes(),
+    )
 }
 
 #[cfg(feature = "metrics")]

--- a/quickwit/quickwit-indexing/src/actors/merge_scheduler_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_scheduler_service.rs
@@ -267,6 +267,7 @@ impl MergeSchedulerService {
             } = PeekMut::pop(next_merge);
             // The permit is owned by the task and released via Drop when
             // the executor finishes, triggering PermitReleased back here.
+            // Drop-based release ensures the semaphore is freed even on panic.
             let parquet_merge_task = ParquetMergeTask {
                 merge_operation,
                 merge_permit,

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/indexing_service_impl.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/indexing_service_impl.rs
@@ -75,9 +75,8 @@ impl IndexingService {
             &index_config,
             storage.clone(),
             indexing_directory.clone(),
-            // TODO: fetch immature Parquet splits from metastore for seeding
-            // the merge planner on first spawn. For now, the planner starts
-            // empty and picks up new splits from the publisher feedback loop.
+            // None here means the pipeline's fetch_immature_splits() will
+            // query the metastore on first spawn (same path as respawn).
             None,
             ctx,
         )?;

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/indexing_service_impl.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/indexing_service_impl.rs
@@ -67,6 +67,21 @@ impl IndexingService {
             IndexingError::Internal(format!("failed to parse partition_key: {error}"))
         })?;
 
+        // Spawn the Parquet merge pipeline (or reuse an existing one for this
+        // index). The planner mailbox is wired into the MetricsPipeline's
+        // Publisher so newly ingested splits are fed back for merging.
+        let merge_planner_mailbox = self.get_or_create_parquet_merge_pipeline(
+            indexing_pipeline_id.index_uid.clone(),
+            &index_config,
+            storage.clone(),
+            indexing_directory.clone(),
+            // TODO: fetch immature Parquet splits from metastore for seeding
+            // the merge planner on first spawn. For now, the planner starts
+            // empty and picks up new splits from the publisher feedback loop.
+            None,
+            ctx,
+        )?;
+
         let pipeline_params = MetricsPipelineParams {
             pipeline_id: indexing_pipeline_id.clone(),
             metastore: self.metastore.clone(),
@@ -83,6 +98,7 @@ impl IndexingService {
             use_sketch_processors,
             partition_key,
             max_num_partitions: index_config.doc_mapping.max_num_partitions,
+            parquet_merge_planner_mailbox_opt: Some(merge_planner_mailbox),
         };
         let pipeline = MetricsPipeline::new(pipeline_params);
         let (mailbox, handle) = ctx.spawn_actor().spawn(pipeline);

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/mod.rs
@@ -45,6 +45,10 @@ mod publisher_impl;
 )]
 mod parquet_e2e_test;
 
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod parquet_merge_pipeline_test;
+
 pub use parquet_doc_processor::{
     ParquetDocProcessor, ParquetDocProcessorCounters, ParquetDocProcessorError, is_arrow_ipc,
 };

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_executor.rs
@@ -43,11 +43,18 @@ use crate::models::PublishLock;
 /// ready-to-upload Parquet files with complete metadata.
 pub struct ParquetMergeExecutor {
     uploader_mailbox: Mailbox<ParquetUploader>,
+    writer_config: ParquetWriterConfig,
 }
 
 impl ParquetMergeExecutor {
-    pub fn new(uploader_mailbox: Mailbox<ParquetUploader>) -> Self {
-        Self { uploader_mailbox }
+    pub fn new(
+        uploader_mailbox: Mailbox<ParquetUploader>,
+        writer_config: ParquetWriterConfig,
+    ) -> Self {
+        Self {
+            uploader_mailbox,
+            writer_config,
+        }
     }
 }
 
@@ -99,36 +106,38 @@ impl Handler<ParquetMergeScratch> for ParquetMergeExecutor {
         // Run the CPU-intensive merge on the dedicated thread pool.
         let input_paths = scratch.downloaded_parquet_files.clone();
         let output_dir_clone = output_dir.clone();
+        let writer_config = self.writer_config.clone();
         let merge_result = run_cpu_intensive(move || {
             let config = MergeConfig {
                 num_outputs: 1,
-                writer_config: ParquetWriterConfig::default(),
+                writer_config,
             };
             merge_sorted_parquet_files(&input_paths, &output_dir_clone, &config)
         })
         .await;
 
-        // We return Ok(()) on merge failure rather than Err to keep the actor
-        // alive — same strategy as Tantivy's MergeExecutor. This prevents a
-        // single "split of death" from crash-looping the entire pipeline.
-        // The trade-off: failed splits aren't retried until pipeline respawn.
         let outputs: Vec<MergeOutputFile> = match merge_result {
             Ok(Ok(outputs)) => outputs,
             Ok(Err(merge_err)) => {
                 warn!(
                     error = %merge_err,
                     merge_split_id = %merge_split_id,
-                    "parquet merge failed"
+                    "parquet merge failed — input splits will not be retried until \
+                     the pipeline restarts with metastore re-seeding"
                 );
-                // Input splits were drained from the planner by operations().
-                // They remain published but won't be re-planned until respawn.
+                // The input splits were drained from the planner by operations().
+                // They remain published in the metastore but won't be re-planned
+                // until the pipeline restarts and re-seeds from the metastore.
+                // TODO: implement fetch_immature_parquet_splits() for respawn
+                // (same as Tantivy's fetch_immature_splits pattern).
                 return Ok(());
             }
             Err(panicked) => {
                 warn!(
                     error = %panicked,
                     merge_split_id = %merge_split_id,
-                    "parquet merge panicked"
+                    "parquet merge panicked — input splits will not be retried until \
+                     the pipeline restarts with metastore re-seeding"
                 );
                 return Ok(());
             }

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_executor.rs
@@ -126,10 +126,9 @@ impl Handler<ParquetMergeScratch> for ParquetMergeExecutor {
                      the pipeline restarts with metastore re-seeding"
                 );
                 // The input splits were drained from the planner by operations().
-                // They remain published in the metastore but won't be re-planned
-                // until the pipeline restarts and re-seeds from the metastore.
-                // TODO: implement fetch_immature_parquet_splits() for respawn
-                // (same as Tantivy's fetch_immature_splits pattern).
+                // They remain published in the metastore and will be re-seeded
+                // into the planner when the pipeline respawns (via
+                // fetch_immature_splits on the ParquetMergePipeline supervisor).
                 return Ok(());
             }
             Err(panicked) => {

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
@@ -244,6 +244,11 @@ impl ParquetMergePipeline {
             "spawning parquet merge pipeline"
         );
 
+        // On first spawn, use the initial splits provided by the IndexingService.
+        // On subsequent spawns (after crash/respawn), we start empty.
+        // TODO: implement fetch_immature_parquet_splits() to re-query the
+        // metastore on respawn, matching the Tantivy MergePipeline pattern
+        // (see merge_pipeline.rs:441-471).
         let immature_splits = self.initial_immature_splits_opt.take().unwrap_or_default();
 
         // Spawn actors bottom-up: each actor's constructor needs a mailbox
@@ -288,7 +293,8 @@ impl ParquetMergePipeline {
             .spawn(merge_uploader);
 
         // 4. Merge executor
-        let merge_executor = ParquetMergeExecutor::new(merge_uploader_mailbox);
+        let merge_executor =
+            ParquetMergeExecutor::new(merge_uploader_mailbox, self.params.writer_config.clone());
         let (merge_executor_mailbox, merge_executor_handle) = ctx
             .spawn_actor()
             .set_kill_switch(self.kill_switch.clone())
@@ -490,6 +496,10 @@ pub struct ParquetMergePipelineParams {
     pub merge_scheduler_service: Mailbox<MergeSchedulerService>,
     pub max_concurrent_split_uploads: usize,
     pub event_broker: EventBroker,
+    /// Parquet writer config for merge output (compression, page size, etc.).
+    /// Should match the ingest pipeline's writer config so merged files have
+    /// consistent compression.
+    pub writer_config: quickwit_parquet_engine::storage::ParquetWriterConfig,
 }
 
 #[cfg(test)]
@@ -527,6 +537,7 @@ mod tests {
             merge_scheduler_service: universe.get_or_spawn_one(),
             max_concurrent_split_uploads: 4,
             event_broker: EventBroker::default(),
+            writer_config: quickwit_parquet_engine::storage::ParquetWriterConfig::default(),
         }
     }
 

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
@@ -423,16 +423,32 @@ impl ParquetMergePipeline {
             return Ok(immature_splits);
         }
         // On subsequent spawns, query the metastore for published splits.
+        // Dispatch to the correct RPC based on whether this is a metrics or
+        // sketches index — they use separate Postgres tables.
         let index_uid = self.params.index_uid.clone();
         let query = quickwit_metastore::ListParquetSplitsQuery::for_index(index_uid.clone());
-        let list_request = quickwit_proto::metastore::ListMetricsSplitsRequest::try_from_query(
-            index_uid.clone(),
-            &query,
-        )?;
-        let response = ctx
-            .protect_future(self.params.metastore.list_metrics_splits(list_request))
-            .await?;
-        let records = response.deserialize_splits()?;
+        let is_sketch = quickwit_common::is_sketches_index(&index_uid.index_id);
+        let records = if is_sketch {
+            let list_request =
+                quickwit_proto::metastore::ListSketchSplitsRequest::try_from_query(
+                    index_uid.clone(),
+                    &query,
+                )?;
+            let response = ctx
+                .protect_future(self.params.metastore.list_sketch_splits(list_request))
+                .await?;
+            response.deserialize_splits()?
+        } else {
+            let list_request =
+                quickwit_proto::metastore::ListMetricsSplitsRequest::try_from_query(
+                    index_uid.clone(),
+                    &query,
+                )?;
+            let response = ctx
+                .protect_future(self.params.metastore.list_metrics_splits(list_request))
+                .await?;
+            response.deserialize_splits()?
+        };
         let splits: Vec<ParquetSplitMetadata> = records.into_iter().map(|r| r.metadata).collect();
         info!(
             num_splits = splits.len(),

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
@@ -38,8 +38,8 @@ use quickwit_actors::{
 use quickwit_common::KillSwitch;
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
-use quickwit_parquet_engine::merge::policy::ParquetMergePolicy;
 use quickwit_metastore::{ListParquetSplitsRequestExt, ListParquetSplitsResponseExt};
+use quickwit_parquet_engine::merge::policy::ParquetMergePolicy;
 use quickwit_parquet_engine::split::ParquetSplitMetadata;
 use quickwit_proto::metastore::{MetastoreService, MetastoreServiceClient};
 use quickwit_proto::types::IndexUid;
@@ -424,19 +424,16 @@ impl ParquetMergePipeline {
         }
         // On subsequent spawns, query the metastore for published splits.
         let index_uid = self.params.index_uid.clone();
-        let query =
-            quickwit_metastore::ListParquetSplitsQuery::for_index(index_uid.clone());
-        let list_request =
-            quickwit_proto::metastore::ListMetricsSplitsRequest::try_from_query(
-                index_uid.clone(),
-                &query,
-            )?;
+        let query = quickwit_metastore::ListParquetSplitsQuery::for_index(index_uid.clone());
+        let list_request = quickwit_proto::metastore::ListMetricsSplitsRequest::try_from_query(
+            index_uid.clone(),
+            &query,
+        )?;
         let response = ctx
             .protect_future(self.params.metastore.list_metrics_splits(list_request))
             .await?;
         let records = response.deserialize_splits()?;
-        let splits: Vec<ParquetSplitMetadata> =
-            records.into_iter().map(|r| r.metadata).collect();
+        let splits: Vec<ParquetSplitMetadata> = records.into_iter().map(|r| r.metadata).collect();
         info!(
             num_splits = splits.len(),
             "fetched published parquet splits for merge planning on respawn"
@@ -587,13 +584,11 @@ mod tests {
     fn make_pipeline_params(universe: &Universe) -> ParquetMergePipelineParams {
         let mut mock_metastore = MockMetastoreService::new();
         // Allow list_metrics_splits for respawn seeding (returns empty).
-        mock_metastore
-            .expect_list_metrics_splits()
-            .returning(|_| {
-                Ok(quickwit_proto::metastore::ListMetricsSplitsResponse {
-                    splits_serialized_json: Vec::new(),
-                })
-            });
+        mock_metastore.expect_list_metrics_splits().returning(|_| {
+            Ok(quickwit_proto::metastore::ListMetricsSplitsResponse {
+                splits_serialized_json: Vec::new(),
+            })
+        });
         let storage = Arc::new(quickwit_storage::RamStorage::default());
         let merge_policy = Arc::new(ConstWriteAmplificationParquetMergePolicy::new(
             ParquetMergePolicyConfig {

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
@@ -54,6 +54,7 @@ use super::{METRICS_PUBLISHER_NAME, ParquetUploader};
 use crate::actors::pipeline_shared::wait_duration_before_retry;
 use crate::actors::publisher::DisconnectMergePlanner;
 use crate::actors::{MergeSchedulerService, Publisher, Sequencer, UploaderType};
+use crate::models::MergeStatistics;
 
 /// Limits concurrent Parquet merge pipeline spawns to avoid overwhelming the
 /// metastore. This is a separate semaphore from the Tantivy merge pipeline's.
@@ -108,13 +109,12 @@ pub struct ParquetMergePipeline {
     /// the new planner instance.
     merge_planner_mailbox: Mailbox<ParquetMergePlanner>,
     merge_planner_inbox: Inbox<ParquetMergePlanner>,
+    previous_generations_statistics: MergeStatistics,
+    statistics: MergeStatistics,
     handles_opt: Option<ParquetMergePipelineHandles>,
     /// Child kill switch — killing this kills all actors in the pipeline
     /// without affecting the supervisor itself.
     kill_switch: KillSwitch,
-    /// Increments on each spawn. Used for log correlation.
-    generation: usize,
-    num_spawn_attempts: usize,
     /// Immature splits passed to the planner on first spawn. On subsequent
     /// spawns (after crash/respawn), the planner starts empty and picks up
     /// new splits from the feedback loop.
@@ -124,9 +124,11 @@ pub struct ParquetMergePipeline {
 
 #[async_trait]
 impl Actor for ParquetMergePipeline {
-    type ObservableState = ();
+    type ObservableState = MergeStatistics;
 
-    fn observable_state(&self) {}
+    fn observable_state(&self) -> Self::ObservableState {
+        self.statistics.clone()
+    }
 
     fn name(&self) -> String {
         "ParquetMergePipeline".to_string()
@@ -154,10 +156,10 @@ impl ParquetMergePipeline {
             );
         Self {
             params,
+            previous_generations_statistics: MergeStatistics::default(),
+            statistics: MergeStatistics::default(),
             handles_opt: None,
             kill_switch: KillSwitch::default(),
-            generation: 0,
-            num_spawn_attempts: 0,
             merge_planner_inbox,
             merge_planner_mailbox,
             initial_immature_splits_opt,
@@ -206,7 +208,7 @@ impl ParquetMergePipeline {
         }
         if !failure_or_unhealthy_actors.is_empty() {
             error!(
-                generation = self.generation,
+                generation = self.generation(),
                 healthy_actors = ?healthy_actors,
                 failed_or_unhealthy_actors = ?failure_or_unhealthy_actors,
                 success_actors = ?success_actors,
@@ -216,13 +218,13 @@ impl ParquetMergePipeline {
         }
         if healthy_actors.is_empty() {
             info!(
-                generation = self.generation,
+                generation = self.generation(),
                 "parquet merge pipeline completed successfully"
             );
             return Health::Success;
         }
         debug!(
-            generation = self.generation,
+            generation = self.generation(),
             healthy_actors = ?healthy_actors,
             success_actors = ?success_actors,
             "parquet merge pipeline is running and healthy"
@@ -230,18 +232,22 @@ impl ParquetMergePipeline {
         Health::Healthy
     }
 
-    #[instrument(name="spawn_parquet_merge_pipeline", level="info", skip_all, fields(generation=self.generation))]
+    fn generation(&self) -> usize {
+        self.statistics.generation
+    }
+
+    #[instrument(name="spawn_parquet_merge_pipeline", level="info", skip_all, fields(generation=self.generation()))]
     async fn spawn_pipeline(&mut self, ctx: &ActorContext<Self>) -> anyhow::Result<()> {
         let _spawn_permit = ctx
             .protect_future(SPAWN_PIPELINE_SEMAPHORE.acquire())
             .await
             .expect("semaphore should not be closed");
 
-        self.num_spawn_attempts += 1;
+        self.statistics.num_spawn_attempts += 1;
         self.kill_switch = ctx.kill_switch().child();
 
         info!(
-            generation = self.generation,
+            generation = self.generation(),
             root_dir = %self.params.indexing_directory.path().display(),
             "spawning parquet merge pipeline"
         );
@@ -326,7 +332,8 @@ impl ParquetMergePipeline {
             )
             .spawn(merge_planner);
 
-        self.generation += 1;
+        self.previous_generations_statistics = self.statistics.clone();
+        self.statistics.generation += 1;
         self.handles_opt = Some(ParquetMergePipelineHandles {
             merge_planner: merge_planner_handle,
             merge_split_downloader: merge_split_downloader_handle,
@@ -351,6 +358,28 @@ impl ParquetMergePipeline {
                 handles.merge_publisher.kill(),
             );
         }
+    }
+
+    async fn perform_observe(&mut self) {
+        let Some(handles) = &self.handles_opt else {
+            return;
+        };
+        handles.merge_planner.refresh_observe();
+        handles.merge_uploader.refresh_observe();
+        handles.merge_publisher.refresh_observe();
+        let num_ongoing_merges = crate::metrics::INDEXER_METRICS
+            .ongoing_merge_operations
+            .get();
+        self.statistics = self
+            .previous_generations_statistics
+            .clone()
+            .add_actor_counters(
+                &handles.merge_uploader.last_observation(),
+                &handles.merge_publisher.last_observation(),
+            )
+            .set_generation(self.statistics.generation)
+            .set_num_spawn_attempts(self.statistics.num_spawn_attempts)
+            .set_ongoing_merges(usize::try_from(num_ongoing_merges).unwrap_or(0));
     }
 
     async fn perform_health_check(
@@ -425,6 +454,7 @@ impl Handler<SuperviseLoop> for ParquetMergePipeline {
         supervise_loop_token: SuperviseLoop,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
+        self.perform_observe().await;
         self.perform_health_check(ctx).await?;
         ctx.schedule_self_msg(SUPERVISE_LOOP_INTERVAL, supervise_loop_token);
         Ok(())

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
@@ -429,21 +429,19 @@ impl ParquetMergePipeline {
         let query = quickwit_metastore::ListParquetSplitsQuery::for_index(index_uid.clone());
         let is_sketch = quickwit_common::is_sketches_index(&index_uid.index_id);
         let records = if is_sketch {
-            let list_request =
-                quickwit_proto::metastore::ListSketchSplitsRequest::try_from_query(
-                    index_uid.clone(),
-                    &query,
-                )?;
+            let list_request = quickwit_proto::metastore::ListSketchSplitsRequest::try_from_query(
+                index_uid.clone(),
+                &query,
+            )?;
             let response = ctx
                 .protect_future(self.params.metastore.list_sketch_splits(list_request))
                 .await?;
             response.deserialize_splits()?
         } else {
-            let list_request =
-                quickwit_proto::metastore::ListMetricsSplitsRequest::try_from_query(
-                    index_uid.clone(),
-                    &query,
-                )?;
+            let list_request = quickwit_proto::metastore::ListMetricsSplitsRequest::try_from_query(
+                index_uid.clone(),
+                &query,
+            )?;
             let response = ctx
                 .protect_future(self.params.metastore.list_metrics_splits(list_request))
                 .await?;

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline.rs
@@ -39,8 +39,10 @@ use quickwit_common::KillSwitch;
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_parquet_engine::merge::policy::ParquetMergePolicy;
+use quickwit_metastore::{ListParquetSplitsRequestExt, ListParquetSplitsResponseExt};
 use quickwit_parquet_engine::split::ParquetSplitMetadata;
-use quickwit_proto::metastore::MetastoreServiceClient;
+use quickwit_proto::metastore::{MetastoreService, MetastoreServiceClient};
+use quickwit_proto::types::IndexUid;
 use quickwit_storage::Storage;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, instrument};
@@ -244,12 +246,7 @@ impl ParquetMergePipeline {
             "spawning parquet merge pipeline"
         );
 
-        // On first spawn, use the initial splits provided by the IndexingService.
-        // On subsequent spawns (after crash/respawn), we start empty.
-        // TODO: implement fetch_immature_parquet_splits() to re-query the
-        // metastore on respawn, matching the Tantivy MergePipeline pattern
-        // (see merge_pipeline.rs:441-471).
-        let immature_splits = self.initial_immature_splits_opt.take().unwrap_or_default();
+        let immature_splits = self.fetch_immature_splits(ctx).await?;
 
         // Spawn actors bottom-up: each actor's constructor needs a mailbox
         // for the actor below it in the chain, so we start from the publisher
@@ -378,6 +375,45 @@ impl ParquetMergePipeline {
         }
         Ok(())
     }
+
+    /// Fetch published Parquet splits from the metastore for merge planning.
+    ///
+    /// On first spawn, uses the initial splits provided by the IndexingService
+    /// (avoids per-pipeline metastore queries when many pipelines start).
+    /// On subsequent spawns (after crash/respawn), queries the metastore
+    /// directly to recover splits that were in-flight during the crash.
+    ///
+    /// The planner's `record_splits_if_necessary` filters out mature splits,
+    /// so we don't need to filter here.
+    async fn fetch_immature_splits(
+        &mut self,
+        ctx: &ActorContext<Self>,
+    ) -> anyhow::Result<Vec<ParquetSplitMetadata>> {
+        // On first spawn, use the initial splits provided by the IndexingService.
+        if let Some(immature_splits) = self.initial_immature_splits_opt.take() {
+            return Ok(immature_splits);
+        }
+        // On subsequent spawns, query the metastore for published splits.
+        let index_uid = self.params.index_uid.clone();
+        let query =
+            quickwit_metastore::ListParquetSplitsQuery::for_index(index_uid.clone());
+        let list_request =
+            quickwit_proto::metastore::ListMetricsSplitsRequest::try_from_query(
+                index_uid.clone(),
+                &query,
+            )?;
+        let response = ctx
+            .protect_future(self.params.metastore.list_metrics_splits(list_request))
+            .await?;
+        let records = response.deserialize_splits()?;
+        let splits: Vec<ParquetSplitMetadata> =
+            records.into_iter().map(|r| r.metadata).collect();
+        info!(
+            num_splits = splits.len(),
+            "fetched published parquet splits for merge planning on respawn"
+        );
+        Ok(splits)
+    }
 }
 
 #[async_trait]
@@ -481,6 +517,8 @@ impl Handler<Spawn> for ParquetMergePipeline {
 /// All actors in the pipeline share these resources via `Arc`/`Clone`.
 #[derive(Clone)]
 pub struct ParquetMergePipelineParams {
+    /// Index UID for metastore queries when re-seeding on respawn.
+    pub index_uid: IndexUid,
     /// Root temp directory for scratch files (downloads, merge output).
     pub indexing_directory: TempDirectory,
     /// Metastore client for staging/publishing merged splits and for
@@ -517,7 +555,15 @@ mod tests {
     use super::*;
 
     fn make_pipeline_params(universe: &Universe) -> ParquetMergePipelineParams {
-        let mock_metastore = MockMetastoreService::new();
+        let mut mock_metastore = MockMetastoreService::new();
+        // Allow list_metrics_splits for respawn seeding (returns empty).
+        mock_metastore
+            .expect_list_metrics_splits()
+            .returning(|_| {
+                Ok(quickwit_proto::metastore::ListMetricsSplitsResponse {
+                    splits_serialized_json: Vec::new(),
+                })
+            });
         let storage = Arc::new(quickwit_storage::RamStorage::default());
         let merge_policy = Arc::new(ConstWriteAmplificationParquetMergePolicy::new(
             ParquetMergePolicyConfig {
@@ -530,6 +576,7 @@ mod tests {
             },
         ));
         ParquetMergePipelineParams {
+            index_uid: quickwit_proto::types::IndexUid::for_test("test-merge-index", 0),
             indexing_directory: TempDirectory::for_test(),
             metastore: MetastoreServiceClient::from_mock(mock_metastore),
             storage,

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
@@ -477,11 +477,11 @@ async fn test_merge_pipeline_end_to_end() {
         merged_meta.zonemap_regexes.keys().collect::<Vec<_>>()
     );
 
-    // Tags: both the ingest and merge paths currently extract only "service"
-    // tags (see extract_service_names in split_writer.rs and merge/writer.rs).
-    // Other well-known tags (host, env, datacenter, region) are NOT yet
-    // extracted. This is a known limitation — when it's fixed, extend these
-    // assertions to cover all tag columns.
+    // low_cardinality_tags: only "service" is extracted in both the ingest
+    // and merge paths (see extract_service_names in split_writer.rs and
+    // merge/writer.rs). Other tag columns (host, env, etc.) are fully
+    // covered by zonemap regexes and row keys for pruning — this field
+    // is a secondary optimization for exact-match Postgres queries.
     assert!(
         merged_meta.low_cardinality_tags.contains_key("service"),
         "tags must include 'service'; got: {:?}",

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
@@ -17,44 +17,132 @@
 //! Tests the full actor chain: seeds splits → planner plans merge →
 //! downloader downloads from storage → executor merges → uploader uploads →
 //! publisher publishes with replaced_split_ids.
+//!
+//! Verifies:
+//! - Staged metadata (num_rows, time_range, metric_names, tags, merge_ops,
+//!   row_keys, zonemap_regexes)
+//! - Merged Parquet file contents (row count, column values, sort order)
+//! - Parquet KV headers (qh.sort_fields, qh.num_merge_ops, qh.row_keys,
+//!   qh.zonemap_regexes)
+//! - Cross-validation: metadata agrees with file contents
 
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
+use arrow::array::{
+    Array, ArrayRef, DictionaryArray, Float64Array, Int32Array, Int64Array, StringArray,
+    UInt8Array, UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Int32Type, Schema as ArrowSchema};
+use arrow::record_batch::RecordBatch;
 use quickwit_actors::Universe;
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
 use quickwit_common::test_utils::wait_until_predicate;
+use quickwit_metastore::StageParquetSplitsRequestExt;
 use quickwit_parquet_engine::merge::policy::{
     ConstWriteAmplificationParquetMergePolicy, ParquetMergePolicyConfig,
 };
+use quickwit_parquet_engine::sorted_series::SORTED_SERIES_COLUMN;
 use quickwit_parquet_engine::split::{ParquetSplitId, ParquetSplitMetadata, TimeRange};
 use quickwit_parquet_engine::storage::{ParquetWriter, ParquetWriterConfig};
 use quickwit_parquet_engine::table_config::TableConfig;
-use quickwit_parquet_engine::test_helpers::create_test_batch_with_tags;
-use quickwit_proto::metastore::{EmptyResponse, MetastoreServiceClient, MockMetastoreService};
+use quickwit_parquet_engine::test_helpers::create_nullable_dict_array;
+use quickwit_proto::metastore::{
+    EmptyResponse, MetastoreServiceClient, MockMetastoreService, StageMetricsSplitsRequest,
+};
 use quickwit_storage::{RamStorage, Storage};
 
 use super::parquet_merge_pipeline::{ParquetMergePipeline, ParquetMergePipelineParams};
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+/// Creates a RecordBatch with configurable metric name, timestamp range, and
+/// tag values. This allows building diverse inputs to verify the merge engine
+/// handles heterogeneous data correctly.
+fn create_custom_test_batch(
+    metric_name: &str,
+    ts_start: u64,
+    num_rows: usize,
+    service_val: &str,
+    host_val: &str,
+) -> RecordBatch {
+    let dict_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+
+    let fields = vec![
+        Field::new("metric_name", dict_type.clone(), false),
+        Field::new("metric_type", DataType::UInt8, false),
+        Field::new("timestamp_secs", DataType::UInt64, false),
+        Field::new("value", DataType::Float64, false),
+        Field::new("timeseries_id", DataType::Int64, false),
+        Field::new("service", dict_type.clone(), true),
+        Field::new("host", dict_type.clone(), true),
+    ];
+    let schema = Arc::new(ArrowSchema::new(fields));
+
+    let metric_names: Vec<&str> = vec![metric_name; num_rows];
+    let mn_keys: Vec<i32> = (0..num_rows).map(|i| i as i32).collect();
+    let mn_values = StringArray::from(metric_names);
+    let metric_name_arr: ArrayRef = Arc::new(
+        DictionaryArray::<Int32Type>::try_new(Int32Array::from(mn_keys), Arc::new(mn_values))
+            .unwrap(),
+    );
+
+    let metric_type: ArrayRef = Arc::new(UInt8Array::from(vec![0u8; num_rows]));
+
+    let timestamps: Vec<u64> = (0..num_rows).map(|i| ts_start + i as u64).collect();
+    let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+
+    let values: Vec<f64> = (0..num_rows).map(|i| 42.0 + i as f64).collect();
+    let value: ArrayRef = Arc::new(Float64Array::from(values));
+
+    // Each row gets a unique timeseries_id based on the metric name hash + row
+    // index. This ensures split-a and split-b have non-overlapping IDs.
+    let ts_id_base: i64 = metric_name.bytes().map(|b| b as i64).sum::<i64>() * 1000;
+    let timeseries_ids: Vec<i64> = (0..num_rows).map(|i| ts_id_base + i as i64).collect();
+    let timeseries_id: ArrayRef = Arc::new(Int64Array::from(timeseries_ids));
+
+    let service_vals: Vec<Option<&str>> = vec![Some(service_val); num_rows];
+    let service: ArrayRef = create_nullable_dict_array(&service_vals);
+
+    let host_vals: Vec<Option<&str>> = vec![Some(host_val); num_rows];
+    let host: ArrayRef = create_nullable_dict_array(&host_vals);
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            metric_name_arr,
+            metric_type,
+            timestamp_secs,
+            value,
+            timeseries_id,
+            service,
+            host,
+        ],
+    )
+    .unwrap()
+}
 
 /// Write a sorted Parquet file to the given directory using the standard
 /// writer (which computes sorted_series, row_keys, zonemaps, and KV metadata).
 fn write_test_parquet_file(
     dir: &Path,
     filename: &str,
-    num_rows: usize,
+    batch: &RecordBatch,
     split_metadata: &ParquetSplitMetadata,
 ) -> u64 {
     let table_config = TableConfig::default();
     let writer = ParquetWriter::new(ParquetWriterConfig::default(), &table_config)
         .expect("failed to create ParquetWriter");
 
-    let batch = create_test_batch_with_tags(num_rows, &["service", "host"]);
     let path = dir.join(filename);
     let (file_size, _write_metadata) = writer
-        .write_to_file_with_metadata(&batch, &path, Some(split_metadata))
+        .write_to_file_with_metadata(batch, &path, Some(split_metadata))
         .expect("failed to write test Parquet file");
     file_size
 }
@@ -64,31 +152,137 @@ fn make_test_split_metadata(
     split_id: &str,
     num_rows: u64,
     size_bytes: u64,
+    ts_start: u64,
+    metric_name: &str,
 ) -> ParquetSplitMetadata {
     let table_config = TableConfig::default();
     ParquetSplitMetadata::metrics_builder()
         .split_id(ParquetSplitId::new(split_id))
         .index_uid("test-merge-index:00000000000000000000000001")
         .partition_id(0)
-        .time_range(TimeRange::new(100, 100 + num_rows))
+        .time_range(TimeRange::new(ts_start, ts_start + num_rows))
         .num_rows(num_rows)
         .size_bytes(size_bytes)
         .sort_fields(table_config.effective_sort_fields())
         .window_start_secs(0)
         .window_duration_secs(900)
-        .add_metric_name("cpu.usage")
+        .add_metric_name(metric_name)
         .build()
 }
 
-/// Full integration test: seed splits → merge → verify replace publish.
+// ---------------------------------------------------------------------------
+// Parquet reading helpers (for verifying merged output)
+// ---------------------------------------------------------------------------
+
+/// Read a Parquet file from raw bytes into a single concatenated RecordBatch.
+fn read_parquet_from_bytes(data: &[u8]) -> RecordBatch {
+    let bytes = bytes::Bytes::copy_from_slice(data);
+    let builder =
+        parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+    let reader = builder.build().unwrap();
+
+    let batches: Vec<RecordBatch> = reader.collect::<Result<Vec<_>, _>>().unwrap();
+    assert!(!batches.is_empty(), "expected at least one batch");
+
+    let schema = batches[0].schema();
+    arrow::compute::concat_batches(&schema, &batches).unwrap()
+}
+
+/// Extract the Parquet file-level KV metadata from raw bytes.
+fn extract_parquet_kv_metadata(data: &[u8]) -> HashMap<String, String> {
+    let bytes = bytes::Bytes::copy_from_slice(data);
+    let builder =
+        parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+    let kv = builder
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .expect("kv metadata must be present");
+    kv.iter()
+        .filter_map(|entry| entry.value.as_ref().map(|v| (entry.key.clone(), v.clone())))
+        .collect()
+}
+
+/// Extract string values from a column that may be Dictionary-encoded or plain
+/// Utf8. Handles all representations uniformly.
+fn extract_string_column(batch: &RecordBatch, name: &str) -> Vec<String> {
+    let idx = batch.schema().index_of(name).unwrap();
+    let col = batch.column(idx);
+
+    if let Some(dict) = col.as_any().downcast_ref::<DictionaryArray<Int32Type>>() {
+        let values = dict
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        return (0..dict.len())
+            .map(|i| {
+                let key = dict.keys().value(i) as usize;
+                values.value(key).to_string()
+            })
+            .collect();
+    }
+
+    if let Some(str_arr) = col.as_any().downcast_ref::<StringArray>() {
+        return (0..str_arr.len())
+            .map(|i| str_arr.value(i).to_string())
+            .collect();
+    }
+
+    panic!(
+        "column '{}' is neither Dict<Int32, Utf8> nor Utf8, got {:?}",
+        name,
+        col.data_type()
+    );
+}
+
+fn extract_u64_column(batch: &RecordBatch, name: &str) -> Vec<u64> {
+    let idx = batch.schema().index_of(name).unwrap();
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("expected UInt64")
+        .values()
+        .to_vec()
+}
+
+fn extract_binary_column(batch: &RecordBatch, name: &str) -> Vec<Vec<u8>> {
+    let idx = batch.schema().index_of(name).unwrap();
+    let col = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<arrow::array::BinaryArray>()
+        .expect("expected Binary");
+    (0..col.len()).map(|i| col.value(i).to_vec()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Integration test
+// ---------------------------------------------------------------------------
+
+/// Full integration test: seed splits → merge → verify everything.
 ///
-/// Creates 2 real sorted Parquet files in RamStorage, seeds the merge
-/// pipeline with their metadata, and verifies the pipeline:
+/// Creates 2 real sorted Parquet files with DIFFERENT data:
+/// - split-a: 50 rows, metric "cpu.usage", timestamps 100–149,
+///   service="web", host="host-1"
+/// - split-b: 50 rows, metric "mem.usage", timestamps 200–249,
+///   service="api", host="host-2"
+///
+/// Then verifies the merge pipeline:
 /// 1. Plans a merge (merge_factor=2)
 /// 2. Downloads files from storage
 /// 3. Executes the merge via the k-way merge engine
 /// 4. Uploads the merged output
 /// 5. Publishes with replaced_split_ids matching the input splits
+///
+/// And asserts:
+/// - Staged metadata correctness (num_rows, time_range, metric_names, tags,
+///   num_merge_ops, row_keys, zonemaps)
+/// - Merged Parquet file data (row count, column values, sort order)
+/// - Parquet KV headers (qh.sort_fields, qh.num_merge_ops, qh.row_keys,
+///   qh.zonemap_regexes)
+/// - Cross-validation: metadata matches file contents
 #[tokio::test]
 async fn test_merge_pipeline_end_to_end() {
     quickwit_common::setup_logging_for_tests();
@@ -97,10 +291,11 @@ async fn test_merge_pipeline_end_to_end() {
     let temp_dir = tempfile::tempdir().unwrap();
     let ram_storage: Arc<dyn Storage> = Arc::new(RamStorage::default());
 
-    // --- Step 1: Create real sorted Parquet files and upload to storage ---
+    // --- Step 1: Create diverse Parquet files and upload to storage ---
 
-    let meta_a = make_test_split_metadata("split-a", 50, 0);
-    let size_a = write_test_parquet_file(temp_dir.path(), "split-a.parquet", 50, &meta_a);
+    let batch_a = create_custom_test_batch("cpu.usage", 100, 50, "web", "host-1");
+    let meta_a = make_test_split_metadata("split-a", 50, 0, 100, "cpu.usage");
+    let size_a = write_test_parquet_file(temp_dir.path(), "split-a.parquet", &batch_a, &meta_a);
     let meta_a = {
         let mut m = meta_a;
         m.size_bytes = size_a;
@@ -108,8 +303,9 @@ async fn test_merge_pipeline_end_to_end() {
         m
     };
 
-    let meta_b = make_test_split_metadata("split-b", 50, 0);
-    let size_b = write_test_parquet_file(temp_dir.path(), "split-b.parquet", 50, &meta_b);
+    let batch_b = create_custom_test_batch("mem.usage", 200, 50, "api", "host-2");
+    let meta_b = make_test_split_metadata("split-b", 50, 0, 200, "mem.usage");
+    let size_b = write_test_parquet_file(temp_dir.path(), "split-b.parquet", &batch_b, &meta_b);
     let meta_b = {
         let mut m = meta_b;
         m.size_bytes = size_b;
@@ -129,14 +325,24 @@ async fn test_merge_pipeline_end_to_end() {
         .await
         .unwrap();
 
-    // --- Step 2: Set up mock metastore ---
+    // --- Step 2: Set up mock metastore (capture staged metadata) ---
 
     let mut mock_metastore = MockMetastoreService::new();
 
-    // Expect staging of the merged output split.
-    mock_metastore
-        .expect_stage_metrics_splits()
-        .returning(|_| Ok(EmptyResponse {}));
+    // Capture the staged split metadata for verification.
+    let staged_metadata: Arc<std::sync::Mutex<Vec<ParquetSplitMetadata>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let staged_metadata_clone = staged_metadata.clone();
+
+    mock_metastore.expect_stage_metrics_splits().returning(
+        move |request: StageMetricsSplitsRequest| {
+            let splits = request
+                .deserialize_splits_metadata()
+                .expect("failed to deserialize staged metadata");
+            staged_metadata_clone.lock().unwrap().extend(splits);
+            Ok(EmptyResponse {})
+        },
+    );
 
     // Capture the publish request to verify replaced_split_ids.
     let publish_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -199,7 +405,7 @@ async fn test_merge_pipeline_end_to_end() {
     .await
     .expect("timed out waiting for merge publish");
 
-    // --- Step 5: Verify ---
+    // --- Step 5: Verify replaced_split_ids ---
 
     let mut replaced_sorted: Vec<String> = replaced_ids.lock().unwrap().clone();
     replaced_sorted.sort();
@@ -207,6 +413,236 @@ async fn test_merge_pipeline_end_to_end() {
         replaced_sorted,
         vec!["split-a".to_string(), "split-b".to_string()],
         "publish should replace both input splits"
+    );
+
+    // --- Step 6: Verify staged metadata ---
+
+    let staged = staged_metadata.lock().unwrap().clone();
+    assert_eq!(staged.len(), 1, "exactly one merged split should be staged");
+    let merged_meta = &staged[0];
+
+    // MC-1: total row count preserved.
+    assert_eq!(merged_meta.num_rows, 100, "merged split must have 100 rows");
+
+    // Time range covers both inputs: min(100) to max(249+1=250).
+    assert_eq!(
+        merged_meta.time_range.start_secs, 100,
+        "time_range.start should be min of inputs"
+    );
+    assert_eq!(
+        merged_meta.time_range.end_secs, 250,
+        "time_range.end should be max timestamp + 1"
+    );
+
+    // Metric names from both inputs.
+    let expected_metrics: HashSet<String> = ["cpu.usage", "mem.usage"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(
+        merged_meta.metric_names, expected_metrics,
+        "merged split must contain both metric names"
+    );
+
+    // num_merge_ops: max(0, 0) + 1 = 1.
+    assert_eq!(
+        merged_meta.num_merge_ops, 1,
+        "first merge should set num_merge_ops to 1"
+    );
+
+    // Sort fields should be preserved from inputs.
+    let table_config = TableConfig::default();
+    assert_eq!(
+        merged_meta.sort_fields,
+        table_config.effective_sort_fields(),
+        "sort_fields must be preserved through merge"
+    );
+
+    // Row keys should be present (the writer always computes them).
+    assert!(
+        merged_meta.row_keys_proto.is_some(),
+        "merged split must have row_keys_proto"
+    );
+    let row_keys_bytes = merged_meta.row_keys_proto.as_ref().unwrap();
+    assert!(
+        !row_keys_bytes.is_empty(),
+        "row_keys_proto must not be empty"
+    );
+
+    // Zonemap regexes should be present for string sort columns.
+    assert!(
+        !merged_meta.zonemap_regexes.is_empty(),
+        "merged split must have zonemap regexes"
+    );
+    // metric_name is a string sort column, so it must have a zonemap regex.
+    assert!(
+        merged_meta.zonemap_regexes.contains_key("metric_name"),
+        "zonemap_regexes must include metric_name; got keys: {:?}",
+        merged_meta.zonemap_regexes.keys().collect::<Vec<_>>()
+    );
+
+    // Tags: both the ingest and merge paths currently extract only "service"
+    // tags (see extract_service_names in split_writer.rs and merge/writer.rs).
+    // Other well-known tags (host, env, datacenter, region) are NOT yet
+    // extracted. This is a known limitation — when it's fixed, extend these
+    // assertions to cover all tag columns.
+    assert!(
+        merged_meta.low_cardinality_tags.contains_key("service"),
+        "tags must include 'service'; got: {:?}",
+        merged_meta.low_cardinality_tags.keys().collect::<Vec<_>>()
+    );
+    let service_tags = &merged_meta.low_cardinality_tags["service"];
+    let expected_services: HashSet<String> = ["web", "api"].iter().map(|s| s.to_string()).collect();
+    assert_eq!(
+        *service_tags, expected_services,
+        "service tag values must include both inputs"
+    );
+
+    // --- Step 7: Read back merged Parquet file and verify contents ---
+
+    let merged_parquet_path = &merged_meta.parquet_file;
+    let merged_bytes = ram_storage
+        .get_all(Path::new(merged_parquet_path))
+        .await
+        .expect("merged parquet file must exist in storage");
+
+    let merged_batch = read_parquet_from_bytes(&merged_bytes);
+
+    // MC-1: row count matches metadata.
+    assert_eq!(
+        merged_batch.num_rows(),
+        100,
+        "Parquet file row count must match metadata"
+    );
+    assert_eq!(
+        merged_batch.num_rows() as u64,
+        merged_meta.num_rows,
+        "Parquet row count must equal staged metadata num_rows"
+    );
+
+    // Verify all expected metric names are present.
+    let metric_names_in_file: HashSet<String> = extract_string_column(&merged_batch, "metric_name")
+        .into_iter()
+        .collect();
+    assert_eq!(
+        metric_names_in_file, expected_metrics,
+        "Parquet file must contain both metric names"
+    );
+
+    // Verify all expected timestamps are present.
+    let timestamps_in_file = extract_u64_column(&merged_batch, "timestamp_secs");
+    assert_eq!(
+        timestamps_in_file.len(),
+        100,
+        "must have 100 timestamp values"
+    );
+    let ts_min = *timestamps_in_file.iter().min().unwrap();
+    let ts_max = *timestamps_in_file.iter().max().unwrap();
+    assert_eq!(ts_min, 100, "min timestamp must be 100");
+    assert_eq!(ts_max, 249, "max timestamp must be 249");
+
+    // Cross-validate: metadata time_range matches actual timestamps.
+    assert_eq!(
+        merged_meta.time_range.start_secs, ts_min,
+        "metadata time_range.start must match actual min timestamp"
+    );
+    assert_eq!(
+        merged_meta.time_range.end_secs,
+        ts_max + 1,
+        "metadata time_range.end must be actual max timestamp + 1"
+    );
+
+    // Verify all tag values from both inputs survive in the Parquet data
+    // (even if the metadata doesn't track all tag columns yet).
+    let services_in_file: HashSet<String> = extract_string_column(&merged_batch, "service")
+        .into_iter()
+        .collect();
+    assert_eq!(
+        services_in_file, expected_services,
+        "Parquet file must contain both service values"
+    );
+    let expected_hosts: HashSet<String> =
+        ["host-1", "host-2"].iter().map(|s| s.to_string()).collect();
+    let hosts_in_file: HashSet<String> = extract_string_column(&merged_batch, "host")
+        .into_iter()
+        .collect();
+    assert_eq!(
+        hosts_in_file, expected_hosts,
+        "Parquet file must contain both host values"
+    );
+
+    // Verify sort order: sorted_series column must be monotonically
+    // non-decreasing (the fundamental invariant of the Parquet writer).
+    let sorted_series = extract_binary_column(&merged_batch, SORTED_SERIES_COLUMN);
+    for i in 1..sorted_series.len() {
+        assert!(
+            sorted_series[i] >= sorted_series[i - 1],
+            "sorted_series must be monotonically non-decreasing at row {}: {:?} < {:?}",
+            i,
+            &sorted_series[i],
+            &sorted_series[i - 1]
+        );
+    }
+
+    // Verify sort order semantics: cpu.usage rows should come before
+    // mem.usage rows (metric_name is the first sort column, ascending).
+    let metric_name_vec = extract_string_column(&merged_batch, "metric_name");
+    let first_mem_idx = metric_name_vec
+        .iter()
+        .position(|n| n == "mem.usage")
+        .expect("must have mem.usage rows");
+    let last_cpu_idx = metric_name_vec
+        .iter()
+        .rposition(|n| n == "cpu.usage")
+        .expect("must have cpu.usage rows");
+    assert!(
+        last_cpu_idx < first_mem_idx,
+        "all cpu.usage rows (last at {}) must precede all mem.usage rows (first at {})",
+        last_cpu_idx,
+        first_mem_idx
+    );
+
+    // --- Step 8: Verify Parquet KV metadata headers ---
+
+    let kv_metadata = extract_parquet_kv_metadata(&merged_bytes);
+
+    // qh.sort_fields must match the table config.
+    let qh_sort_fields = kv_metadata
+        .get("qh.sort_fields")
+        .expect("qh.sort_fields must be present");
+    assert_eq!(
+        qh_sort_fields,
+        &table_config.effective_sort_fields(),
+        "qh.sort_fields must match table config"
+    );
+
+    // qh.num_merge_ops must be "1" (first merge).
+    let qh_merge_ops = kv_metadata
+        .get("qh.num_merge_ops")
+        .expect("qh.num_merge_ops must be present");
+    assert_eq!(qh_merge_ops, "1", "qh.num_merge_ops must be 1");
+
+    // qh.row_keys must be present and non-empty.
+    let qh_row_keys = kv_metadata
+        .get("qh.row_keys")
+        .expect("qh.row_keys must be present");
+    assert!(!qh_row_keys.is_empty(), "qh.row_keys must not be empty");
+
+    // qh.zonemap_regexes must be present and contain metric_name.
+    let qh_zonemaps = kv_metadata
+        .get("qh.zonemap_regexes")
+        .expect("qh.zonemap_regexes must be present");
+    let zonemaps_parsed: HashMap<String, String> =
+        serde_json::from_str(qh_zonemaps).expect("qh.zonemap_regexes must be valid JSON");
+    assert!(
+        zonemaps_parsed.contains_key("metric_name"),
+        "qh.zonemap_regexes must include metric_name"
+    );
+
+    // Cross-validate: metadata zonemap_regexes should match Parquet header.
+    assert_eq!(
+        merged_meta.zonemap_regexes, zonemaps_parsed,
+        "metadata zonemap_regexes must match Parquet qh.zonemap_regexes"
     );
 
     universe.assert_quit().await;

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
@@ -1,0 +1,211 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration test for the Parquet merge pipeline.
+//!
+//! Tests the full actor chain: seeds splits → planner plans merge →
+//! downloader downloads from storage → executor merges → uploader uploads →
+//! publisher publishes with replaced_split_ids.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use quickwit_actors::Universe;
+use quickwit_common::pubsub::EventBroker;
+use quickwit_common::temp_dir::TempDirectory;
+use quickwit_common::test_utils::wait_until_predicate;
+use quickwit_parquet_engine::merge::policy::{
+    ConstWriteAmplificationParquetMergePolicy, ParquetMergePolicyConfig,
+};
+use quickwit_parquet_engine::split::{ParquetSplitId, ParquetSplitMetadata, TimeRange};
+use quickwit_parquet_engine::storage::{ParquetWriter, ParquetWriterConfig};
+use quickwit_parquet_engine::table_config::TableConfig;
+use quickwit_parquet_engine::test_helpers::create_test_batch_with_tags;
+use quickwit_proto::metastore::{EmptyResponse, MetastoreServiceClient, MockMetastoreService};
+use quickwit_storage::{RamStorage, Storage};
+
+use super::parquet_merge_pipeline::{ParquetMergePipeline, ParquetMergePipelineParams};
+
+/// Write a sorted Parquet file to the given directory using the standard
+/// writer (which computes sorted_series, row_keys, zonemaps, and KV metadata).
+fn write_test_parquet_file(
+    dir: &Path,
+    filename: &str,
+    num_rows: usize,
+    split_metadata: &ParquetSplitMetadata,
+) -> u64 {
+    let table_config = TableConfig::default();
+    let writer = ParquetWriter::new(ParquetWriterConfig::default(), &table_config)
+        .expect("failed to create ParquetWriter");
+
+    let batch = create_test_batch_with_tags(num_rows, &["service", "host"]);
+    let path = dir.join(filename);
+    let (file_size, _write_metadata) = writer
+        .write_to_file_with_metadata(&batch, &path, Some(split_metadata))
+        .expect("failed to write test Parquet file");
+    file_size
+}
+
+/// Create a ParquetSplitMetadata consistent with the test Parquet writer.
+fn make_test_split_metadata(
+    split_id: &str,
+    num_rows: u64,
+    size_bytes: u64,
+) -> ParquetSplitMetadata {
+    let table_config = TableConfig::default();
+    ParquetSplitMetadata::metrics_builder()
+        .split_id(ParquetSplitId::new(split_id))
+        .index_uid("test-merge-index:00000000000000000000000001")
+        .partition_id(0)
+        .time_range(TimeRange::new(100, 100 + num_rows))
+        .num_rows(num_rows)
+        .size_bytes(size_bytes)
+        .sort_fields(table_config.effective_sort_fields())
+        .window_start_secs(0)
+        .window_duration_secs(900)
+        .add_metric_name("cpu.usage")
+        .build()
+}
+
+/// Full integration test: seed splits → merge → verify replace publish.
+///
+/// Creates 2 real sorted Parquet files in RamStorage, seeds the merge
+/// pipeline with their metadata, and verifies the pipeline:
+/// 1. Plans a merge (merge_factor=2)
+/// 2. Downloads files from storage
+/// 3. Executes the merge via the k-way merge engine
+/// 4. Uploads the merged output
+/// 5. Publishes with replaced_split_ids matching the input splits
+#[tokio::test]
+async fn test_merge_pipeline_end_to_end() {
+    quickwit_common::setup_logging_for_tests();
+
+    let universe = Universe::with_accelerated_time();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let ram_storage: Arc<dyn Storage> = Arc::new(RamStorage::default());
+
+    // --- Step 1: Create real sorted Parquet files and upload to storage ---
+
+    let meta_a = make_test_split_metadata("split-a", 50, 0);
+    let size_a = write_test_parquet_file(temp_dir.path(), "split-a.parquet", 50, &meta_a);
+    let meta_a = {
+        let mut m = meta_a;
+        m.size_bytes = size_a;
+        m.parquet_file = "split-a.parquet".to_string();
+        m
+    };
+
+    let meta_b = make_test_split_metadata("split-b", 50, 0);
+    let size_b = write_test_parquet_file(temp_dir.path(), "split-b.parquet", 50, &meta_b);
+    let meta_b = {
+        let mut m = meta_b;
+        m.size_bytes = size_b;
+        m.parquet_file = "split-b.parquet".to_string();
+        m
+    };
+
+    // Upload files to RamStorage.
+    let content_a = std::fs::read(temp_dir.path().join("split-a.parquet")).unwrap();
+    ram_storage
+        .put(Path::new("split-a.parquet"), Box::new(content_a))
+        .await
+        .unwrap();
+    let content_b = std::fs::read(temp_dir.path().join("split-b.parquet")).unwrap();
+    ram_storage
+        .put(Path::new("split-b.parquet"), Box::new(content_b))
+        .await
+        .unwrap();
+
+    // --- Step 2: Set up mock metastore ---
+
+    let mut mock_metastore = MockMetastoreService::new();
+
+    // Expect staging of the merged output split.
+    mock_metastore
+        .expect_stage_metrics_splits()
+        .returning(|_| Ok(EmptyResponse {}));
+
+    // Capture the publish request to verify replaced_split_ids.
+    let publish_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let publish_called_clone = publish_called.clone();
+    let replaced_ids = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let replaced_ids_clone = replaced_ids.clone();
+
+    mock_metastore
+        .expect_publish_metrics_splits()
+        .returning(move |request| {
+            replaced_ids_clone
+                .lock()
+                .unwrap()
+                .extend(request.replaced_split_ids.clone());
+            publish_called_clone.store(true, Ordering::SeqCst);
+            Ok(EmptyResponse {})
+        });
+
+    let metastore = MetastoreServiceClient::from_mock(mock_metastore);
+
+    // --- Step 3: Spawn the merge pipeline ---
+
+    let merge_policy = Arc::new(ConstWriteAmplificationParquetMergePolicy::new(
+        ParquetMergePolicyConfig {
+            merge_factor: 2,
+            max_merge_factor: 2,
+            max_merge_ops: 5,
+            target_split_size_bytes: 256 * 1024 * 1024,
+            maturation_period: Duration::from_secs(3600),
+            max_finalize_merge_operations: 3,
+        },
+    ));
+
+    let params = ParquetMergePipelineParams {
+        indexing_directory: TempDirectory::for_test(),
+        metastore,
+        storage: ram_storage.clone(),
+        merge_policy,
+        merge_scheduler_service: universe.get_or_spawn_one(),
+        max_concurrent_split_uploads: 4,
+        event_broker: EventBroker::default(),
+    };
+
+    let initial_splits = vec![meta_a, meta_b];
+    let pipeline = ParquetMergePipeline::new(params, Some(initial_splits), universe.spawn_ctx());
+    let (_pipeline_mailbox, _pipeline_handle) = universe.spawn_builder().spawn(pipeline);
+
+    // --- Step 4: Wait for publish with replaced_split_ids ---
+
+    wait_until_predicate(
+        || {
+            let publish_called = publish_called.clone();
+            async move { publish_called.load(Ordering::SeqCst) }
+        },
+        Duration::from_secs(30),
+        Duration::from_millis(100),
+    )
+    .await
+    .expect("timed out waiting for merge publish");
+
+    // --- Step 5: Verify ---
+
+    let mut replaced_sorted: Vec<String> = replaced_ids.lock().unwrap().clone();
+    replaced_sorted.sort();
+    assert_eq!(
+        replaced_sorted,
+        vec!["split-a".to_string(), "split-b".to_string()],
+        "publish should replace both input splits"
+    );
+
+    universe.assert_quit().await;
+}

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
@@ -171,6 +171,7 @@ async fn test_merge_pipeline_end_to_end() {
     ));
 
     let params = ParquetMergePipelineParams {
+        index_uid: quickwit_proto::types::IndexUid::for_test("test-merge-index", 0),
         indexing_directory: TempDirectory::for_test(),
         metastore,
         storage: ram_storage.clone(),

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
@@ -19,11 +19,10 @@
 //! publisher publishes with replaced_split_ids.
 //!
 //! Verifies:
-//! - Staged metadata (num_rows, time_range, metric_names, tags, merge_ops,
-//!   row_keys, zonemap_regexes)
+//! - Staged metadata (num_rows, time_range, metric_names, tags, merge_ops, row_keys,
+//!   zonemap_regexes)
 //! - Merged Parquet file contents (row count, column values, sort order)
-//! - Parquet KV headers (qh.sort_fields, qh.num_merge_ops, qh.row_keys,
-//!   qh.zonemap_regexes)
+//! - Parquet KV headers (qh.sort_fields, qh.num_merge_ops, qh.row_keys, qh.zonemap_regexes)
 //! - Cross-validation: metadata agrees with file contents
 
 use std::collections::{HashMap, HashSet};
@@ -264,10 +263,8 @@ fn extract_binary_column(batch: &RecordBatch, name: &str) -> Vec<Vec<u8>> {
 /// Full integration test: seed splits → merge → verify everything.
 ///
 /// Creates 2 real sorted Parquet files with DIFFERENT data:
-/// - split-a: 50 rows, metric "cpu.usage", timestamps 100–149,
-///   service="web", host="host-1"
-/// - split-b: 50 rows, metric "mem.usage", timestamps 200–249,
-///   service="api", host="host-2"
+/// - split-a: 50 rows, metric "cpu.usage", timestamps 100–149, service="web", host="host-1"
+/// - split-b: 50 rows, metric "mem.usage", timestamps 200–249, service="api", host="host-2"
 ///
 /// Then verifies the merge pipeline:
 /// 1. Plans a merge (merge_factor=2)
@@ -277,11 +274,10 @@ fn extract_binary_column(batch: &RecordBatch, name: &str) -> Vec<Vec<u8>> {
 /// 5. Publishes with replaced_split_ids matching the input splits
 ///
 /// And asserts:
-/// - Staged metadata correctness (num_rows, time_range, metric_names, tags,
-///   num_merge_ops, row_keys, zonemaps)
+/// - Staged metadata correctness (num_rows, time_range, metric_names, tags, num_merge_ops,
+///   row_keys, zonemaps)
 /// - Merged Parquet file data (row count, column values, sort order)
-/// - Parquet KV headers (qh.sort_fields, qh.num_merge_ops, qh.row_keys,
-///   qh.zonemap_regexes)
+/// - Parquet KV headers (qh.sort_fields, qh.num_merge_ops, qh.row_keys, qh.zonemap_regexes)
 /// - Cross-validation: metadata matches file contents
 #[tokio::test]
 async fn test_merge_pipeline_end_to_end() {

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/parquet_merge_pipeline_test.rs
@@ -178,6 +178,7 @@ async fn test_merge_pipeline_end_to_end() {
         merge_scheduler_service: universe.get_or_spawn_one(),
         max_concurrent_split_uploads: 4,
         event_broker: EventBroker::default(),
+        writer_config: ParquetWriterConfig::default(),
     };
 
     let initial_splits = vec![meta_a, meta_b];

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/pipeline.rs
@@ -96,6 +96,12 @@ pub struct MetricsPipelineParams {
     pub partition_key: quickwit_doc_mapper::RoutingExpr,
     /// Maximum number of index partitions allowed in a workbench.
     pub max_num_partitions: NonZeroU32,
+    /// Parquet merge planner mailbox for the publisher feedback loop.
+    /// When set, the publisher sends ParquetNewSplits to the planner
+    /// after publishing ingest splits so they can be considered for merging.
+    /// `None` when no merge pipeline is running for this index.
+    pub parquet_merge_planner_mailbox_opt:
+        Option<quickwit_actors::Mailbox<super::ParquetMergePlanner>>,
 }
 
 pub struct MetricsPipeline {
@@ -313,14 +319,19 @@ impl MetricsPipeline {
             .spawn_ctx()
             .create_mailbox::<SourceActor>("SourceActor", QueueCapacity::Unbounded);
 
-        // Publisher
-        let publisher = Publisher::new(
+        // Publisher — optionally wired to the Parquet merge planner for
+        // merge feedback. When set, the publisher sends ParquetNewSplits
+        // after publishing ingest splits so they can be considered for merging.
+        let mut publisher = Publisher::new(
             super::METRICS_PUBLISHER_NAME,
             QueueCapacity::Bounded(1),
             self.params.metastore.clone(),
             None,
             Some(source_mailbox.clone()),
         );
+        if let Some(planner_mailbox) = &self.params.parquet_merge_planner_mailbox_opt {
+            publisher = publisher.set_parquet_merge_planner_mailbox(planner_mailbox.clone());
+        }
         let (publisher_mailbox, publisher_handle) = ctx
             .spawn_actor()
             .set_kill_switch(self.kill_switch.clone())

--- a/quickwit/quickwit-indexing/src/actors/metrics_pipeline/pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/metrics_pipeline/pipeline.rs
@@ -346,9 +346,14 @@ impl MetricsPipeline {
             .set_kill_switch(self.kill_switch.clone())
             .spawn(uploader);
 
-        // ParquetPackager
+        // ParquetPackager — read sort schema and window duration from index config.
         let writer_config = quickwit_parquet_engine::storage::ParquetWriterConfig::default();
-        let table_config = quickwit_parquet_engine::table_config::TableConfig::default();
+        let parquet_indexing_config = self.params.indexing_settings.parquet_indexing();
+        let mut table_config = quickwit_parquet_engine::table_config::TableConfig::default();
+        if let Some(ref sort_fields) = parquet_indexing_config.sort_fields {
+            table_config.sort_fields = Some(sort_fields.clone());
+        }
+        table_config.window_duration_secs = parquet_indexing_config.window_duration_secs;
         let split_kind = if self.params.use_sketch_processors {
             quickwit_parquet_engine::split::ParquetSplitKind::Sketches
         } else {

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -192,6 +192,27 @@ pub fn default_merge_policy() -> Arc<dyn MergePolicy> {
     merge_policy_from_settings(&indexing_settings)
 }
 
+/// Creates a Parquet merge policy from the index's `ParquetMergePolicyConfig`.
+#[cfg(feature = "metrics")]
+pub fn parquet_merge_policy_from_settings(
+    settings: &IndexingSettings,
+) -> Arc<dyn quickwit_parquet_engine::merge::policy::ParquetMergePolicy> {
+    let config = settings.parquet_merge_policy();
+    let engine_config = quickwit_parquet_engine::merge::policy::ParquetMergePolicyConfig {
+        merge_factor: config.merge_factor,
+        max_merge_factor: config.max_merge_factor,
+        max_merge_ops: config.max_merge_ops,
+        target_split_size_bytes: config.target_split_size_bytes,
+        maturation_period: config.maturation_period,
+        max_finalize_merge_operations: config.max_finalize_merge_operations,
+    };
+    Arc::new(
+        quickwit_parquet_engine::merge::policy::ConstWriteAmplificationParquetMergePolicy::new(
+            engine_config,
+        ),
+    )
+}
+
 pub fn nop_merge_policy() -> Arc<dyn MergePolicy> {
     Arc::new(NopMergePolicy)
 }


### PR DESCRIPTION
## Summary

Stacked on #6356 (Phase 3f). Wires the ParquetMergePipeline into the IndexingService so Parquet compaction actually runs in production.

### What this does

Mirrors the Tantivy merge pipeline wiring pattern:

- **IndexingService** stores `parquet_merge_pipeline_handles` (keyed by `IndexUid`, shared across sources for the same index)
- **`get_or_create_parquet_merge_pipeline()`** creates or reuses a merge pipeline, converting the config-crate `ParquetMergePolicyConfig` to the engine-crate type
- **`spawn_metrics_pipeline()`** now spawns the merge pipeline first, then passes the planner mailbox to `MetricsPipelineParams`
- **MetricsPipeline** wires the planner mailbox to the Publisher via `set_parquet_merge_planner_mailbox()`, enabling the ingest→merge feedback loop
- **`handle_supervise()`** cleans up orphan Parquet merge pipelines when their parent metrics pipeline is gone

### Data flow after this PR

```
Ingest: Source → DocProcessor → Indexer → Packager → Uploader → Publisher
                                                                    │
                                                          ParquetNewSplits
                                                                    ↓
Merge:  MergePlanner → Downloader → Executor → Uploader → Publisher
            ↑                                                   │
            └───────────── ParquetNewSplits ────────────────────┘
```

### Known TODO

Immature Parquet splits are not yet fetched from the metastore when spawning a new merge pipeline (seeding). The planner starts empty and picks up splits from the publisher feedback loop. Seeding will be added as a follow-up.

## Test plan

- [x] Compiles with `--features metrics`
- [x] Integration test passes (`test_merge_pipeline_end_to_end`)
- [x] `cargo +nightly fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)