### PR TITLE
paginate metric splits during query execution

### DIFF
--- a/quickwit/quickwit-datafusion/src/sources/metrics/metastore_provider.rs
+++ b/quickwit/quickwit-datafusion/src/sources/metrics/metastore_provider.rs
@@ -31,6 +31,12 @@ use tracing::{debug, instrument};
 use super::predicate::MetricsSplitQuery;
 use super::table_provider::MetricsSplitProvider;
 
+/// Per-page split count for metastore split pagination.
+///
+/// The list split RPCs are unary, so we need to page client side.
+/// TODO: Use streaming RPCs for listing Parquet splits.
+const SPLIT_PAGE_SIZE: usize = 200;
+
 /// `MetricsSplitProvider` backed by the Quickwit metastore RPC.
 #[derive(Debug, Clone)]
 pub struct MetastoreSplitProvider {
@@ -67,49 +73,74 @@ impl MetricsSplitProvider for MetastoreSplitProvider {
         )
     )]
     async fn list_splits(&self, query: &MetricsSplitQuery) -> DFResult<Vec<ParquetSplitMetadata>> {
-        let metastore_query = to_metastore_query(&self.index_uid, query);
+        let mut metastore_query = to_metastore_query(&self.index_uid, query);
+        metastore_query.limit = Some(SPLIT_PAGE_SIZE);
 
-        let records = match self.split_kind {
-            ParquetSplitKind::Metrics => {
-                let request = ListMetricsSplitsRequest::try_from_query(
-                    self.index_uid.clone(),
-                    &metastore_query,
-                )
-                .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?;
+        let mut splits: Vec<ParquetSplitMetadata> = Vec::new();
+        let mut num_pages: usize = 0;
 
-                self.metastore
-                    .clone()
-                    .list_metrics_splits(request)
-                    .await
-                    .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?
-                    .deserialize_splits()
-                    .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?
+        loop {
+            let records = match self.split_kind {
+                ParquetSplitKind::Metrics => {
+                    let request = ListMetricsSplitsRequest::try_from_query(
+                        self.index_uid.clone(),
+                        &metastore_query,
+                    )
+                    .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?;
+
+                    self.metastore
+                        .clone()
+                        .list_metrics_splits(request)
+                        .await
+                        .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?
+                        .deserialize_splits()
+                        .map_err(|err| {
+                            datafusion::error::DataFusionError::External(Box::new(err))
+                        })?
+                }
+                ParquetSplitKind::Sketches => {
+                    let request = ListSketchSplitsRequest::try_from_query(
+                        self.index_uid.clone(),
+                        &metastore_query,
+                    )
+                    .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?;
+
+                    self.metastore
+                        .clone()
+                        .list_sketch_splits(request)
+                        .await
+                        .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?
+                        .deserialize_splits()
+                        .map_err(|err| {
+                            datafusion::error::DataFusionError::External(Box::new(err))
+                        })?
+                }
+            };
+
+            num_pages += 1;
+            let page_len = records.len();
+
+            // The metastore guarantees only Published splits are returned because
+            // `to_metastore_query` sets `split_states = vec![Published]`. No
+            // client-side re-filter is needed here.
+            splits.extend(records.into_iter().map(|record| record.metadata));
+
+            // A short page (fewer rows than we asked for) means we've drained
+            // the result set. The Postgres backend orders by `split_id ASC`
+            // and applies `split_id > $after_split_id` for the cursor, so the
+            // last metadata's split_id is the correct next cursor.
+            if page_len < SPLIT_PAGE_SIZE {
+                break;
             }
-            ParquetSplitKind::Sketches => {
-                let request = ListSketchSplitsRequest::try_from_query(
-                    self.index_uid.clone(),
-                    &metastore_query,
-                )
-                .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?;
-
-                self.metastore
-                    .clone()
-                    .list_sketch_splits(request)
-                    .await
-                    .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?
-                    .deserialize_splits()
-                    .map_err(|err| datafusion::error::DataFusionError::External(Box::new(err)))?
-            }
-        };
-
-        // The metastore guarantees only Published splits are returned because
-        // `to_metastore_query` sets `split_states = vec![Published]`. No
-        // client-side re-filter is needed here.
-        let splits: Vec<ParquetSplitMetadata> =
-            records.into_iter().map(|record| record.metadata).collect();
+            let Some(last) = splits.last() else { break };
+            metastore_query.after_split_id = Some(last.split_id.as_str().to_string());
+        }
 
         tracing::Span::current().record("num_splits", splits.len());
-        debug!(num_splits = splits.len(), "metastore returned splits");
+        debug!(
+            num_splits = splits.len(),
+            num_pages, "metastore returned splits"
+        );
 
         Ok(splits)
     }


### PR DESCRIPTION
### Description
We were hitting grpc message limits when trying to query splits from the metastore. 

1) Results are not compressed (we could turn it on, but this would apply to all metastore clients - was it not enabled for some reason?)
2) `ListMetricsSplits` is unary RPC (while `ListSplits` is streaming 🙃 ), and we were not paginating. this PR adds pagination. we should eventually move to streaming RPC. 

### How was this PR tested?

Describe how you tested this PR.
