### PR TITLE
chore(deps): bump the github-actions group with 6 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           shared-key: "quickwit-cargo"
       - name: Install nextest
         if: always() && steps.modified.outputs.rust_src == 'true'
-        uses: taiki-e/install-action@aba36d755ec7ca22d38b12111787c26115943952
+        uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1
         with:
           tool: cargo-nextest
       - name: cargo check without metrics
@@ -171,17 +171,17 @@ jobs:
           shared-key: "quickwit-cargo"
       - name: Install cargo deny
         if: always() && steps.modified.outputs.rust_src == 'true'
-        uses: taiki-e/cache-cargo-install-action@59027ebf20a9617c4e819eb53ccd2673cb162b89 # v3.0.3
+        uses: taiki-e/cache-cargo-install-action@f9eed3e4680f27610dc6d8c67be1b88593f7dade # v3.0.6
         with:
           tool: cargo-deny@0.19.4
       - name: Install cargo machete
         if: always() && steps.modified.outputs.rust_src == 'true'
-        uses: taiki-e/cache-cargo-install-action@59027ebf20a9617c4e819eb53ccd2673cb162b89 # v3.0.3
+        uses: taiki-e/cache-cargo-install-action@f9eed3e4680f27610dc6d8c67be1b88593f7dade # v3.0.6
         with:
           tool: cargo-machete
       - name: Install diesel-guard
         if: always() && steps.modified.outputs.migrations == 'true'
-        uses: taiki-e/cache-cargo-install-action@59027ebf20a9617c4e819eb53ccd2673cb162b89 # v3.0.3
+        uses: taiki-e/cache-cargo-install-action@f9eed3e4680f27610dc6d8c67be1b88593f7dade # v3.0.6
         with:
           tool: diesel-guard@0.10.0
       - name: cargo clippy
@@ -227,7 +227,7 @@ jobs:
           toolchain: stable
 
       - name: Cache cargo tools
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-tools-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/git
@@ -158,7 +158,7 @@ jobs:
         run: rustup update stable
 
       - name: Install cargo-llvm-cov, cargo-nextest, and protoc
-        uses: taiki-e/install-action@90558ad1e179036f31467972b00dec6cb80701fa # v2.66.3
+        uses: taiki-e/install-action@b651345a718c8f44efa2460560b3dbf29cbd7ee1 # v2.75.26
         with:
           tool: cargo-llvm-cov,nextest,protoc
 

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -87,7 +87,7 @@ jobs:
           fi
 
       - name: Build and push image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         id: build
         with:
           context: .
@@ -107,7 +107,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest-${{ matrix.platform_suffix }}
           path: /tmp/digests/*

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "yarn"
@@ -69,7 +69,7 @@ jobs:
       QW_TEST_DATABASE_URL: postgres://quickwit-dev:quickwit-dev@postgres:5432/quickwit-metastore-dev
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "yarn"


### PR DESCRIPTION
Bumps the github-actions group with 6 updates:

| Package | From | To |
| --- | --- | --- |
| [taiki-e/install-action](https://github.com/taiki-e/install-action) | `2.66.3` | `2.75.26` |
| [taiki-e/cache-cargo-install-action](https://github.com/taiki-e/cache-cargo-install-action) | `3.0.3` | `3.0.6` |
| [actions/cache](https://github.com/actions/cache) | `5.0.4` | `5.0.5` |
| [docker/build-push-action](https://github.com/docker/build-push-action) | `7.0.0` | `7.1.0` |
| [actions/upload-artifact](https://github.com/actions/upload-artifact) | `7.0.0` | `7.0.1` |
| [actions/setup-node](https://github.com/actions/setup-node) | `6.3.0` | `6.4.0` |

Updates `taiki-e/install-action` from 2.66.3 to 2.75.26
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/taiki-e/install-action/releases">taiki-e/install-action's releases</a>.</em></p>
<blockquote>
<h2>2.75.26</h2>
<ul>
<li>
<p>Update <code>wasm-bindgen@latest</code> to 0.2.120.</p>
</li>
<li>
<p>Update <code>mise@latest</code> to 2026.4.25.</p>
</li>
<li>
<p>Update <code>martin@latest</code> to 1.8.0.</p>
</li>
<li>
<p>Update <code>vacuum@latest</code> to 0.26.4.</p>
</li>
</ul>
<h2>2.75.25</h2>
<ul>
<li>
<p>Update <code>uv@latest</code> to 0.11.8.</p>
</li>
<li>
<p>Update <code>typos@latest</code> to 1.45.2.</p>
</li>
<li>
<p>Update <code>tombi@latest</code> to 0.9.25.</p>
</li>
<li>
<p>Update <code>mise@latest</code> to 2026.4.24.</p>
</li>
</ul>
<h2>2.75.24</h2>
<ul>
<li>
<p>Update <code>prek@latest</code> to 0.3.11.</p>
</li>
<li>
<p>Update <code>mise@latest</code> to 2026.4.23.</p>
</li>
<li>
<p>Update <code>vacuum@latest</code> to 0.26.3.</p>
</li>
</ul>
<h2>2.75.23</h2>
<ul>
<li>
<p>Update <code>vacuum@latest</code> to 0.26.2.</p>
</li>
<li>
<p>Update <code>tombi@latest</code> to 0.9.24.</p>
</li>
<li>
<p>Update <code>mise@latest</code> to 2026.4.22.</p>
</li>
<li>
<p>Update <code>martin@latest</code> to 1.7.0.</p>
</li>
<li>
<p>Update <code>git-cliff@latest</code> to 2.13.1.</p>
</li>
<li>
<p>Update <code>cargo-tarpaulin@latest</code> to 0.35.4.</p>
</li>
<li>
<p>Update <code>cargo-sort@latest</code> to 2.1.4.</p>
</li>
</ul>
<h2>2.75.22</h2>
<ul>
<li>
<p>Update <code>tombi@latest</code> to 0.9.22.</p>
</li>
<li>
<p>Update <code>biome@latest</code> to 2.4.13.</p>
</li>
</ul>
<h2>2.75.21</h2>
<ul>
<li>
<p>Update <code>mise@latest</code> to 2026.4.19.</p>
</li>
<li>
<p>Update <code>tombi@latest</code> to 0.9.21.</p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/taiki-e/install-action/blob/main/CHANGELOG.md">taiki-e/install-action's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<p>All notable changes to this project will be documented in this file.</p>
<p>This project adheres to <a href="https://semver.org">Semantic Versioning</a>.</p>
<!-- raw HTML omitted -->
<h2>[Unreleased]</h2>
<ul>
<li>Update <code>tombi@latest</code> to 0.9.26.</li>
</ul>
<h2>[2.75.27] - 2026-04-30</h2>
<ul>
<li>
<p>Update <code>cargo-udeps@latest</code> to 0.1.61.</p>
</li>
<li>
<p>Update <code>wasm-tools@latest</code> to 1.248.0.</p>
</li>
<li>
<p>Update <code>cargo-deb@latest</code> to 3.6.4.</p>
</li>
</ul>
<h2>[2.75.26] - 2026-04-29</h2>
<ul>
<li>
<p>Update <code>wasm-bindgen@latest</code> to 0.2.120.</p>
</li>
<li>
<p>Update <code>mise@latest</code> to 2026.4.25.</p>
</li>
<li>
<p>Update <code>martin@latest</code> to 1.8.0.</p>
</li>
<li>
<p>Update <code>vacuum@latest</code> to 0.26.4.</p>
</li>
</ul>
<h2>[2.75.25] - 2026-04-28</h2>
<ul>
<li>
<p>Update <code>uv@latest</code> to 0.11.8.</p>
</li>
<li>
<p>Update <code>typos@latest</code> to 1.45.2.</p>
</li>
<li>
<p>Update <code>tombi@latest</code> to 0.9.25.</p>
</li>
<li>
<p>Update <code>mise@latest</code> to 2026.4.24.</p>
</li>
</ul>
<h2>[2.75.24] - 2026-04-28</h2>
<ul>
<li>
<p>Update <code>prek@latest</code> to 0.3.11.</p>
</li>
<li>
<p>Update <code>mise@latest</code> to 2026.4.23.</p>
</li>
<li>
<p>Update <code>vacuum@latest</code> to 0.26.3.</p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/taiki-e/install-action/commit/b651345a718c8f44efa2460560b3dbf29cbd7ee1"><code>b651345</code></a> Release 2.75.26</li>
<li><a href="https://github.com/taiki-e/install-action/commit/e0091eefbfe9e508046565e179b70ef622be1cb6"><code>e0091ee</code></a> Update <code>wasm-bindgen@latest</code> to 0.2.120</li>
<li><a href="https://github.com/taiki-e/install-action/commit/96d4d757ef360f8e70bce10ffb04f9ca35fb6875"><code>96d4d75</code></a> Update tombi manifest</li>
<li><a href="https://github.com/taiki-e/install-action/commit/4a1aed1ca9fef35778911a63daf97df5d210fa1b"><code>4a1aed1</code></a> Update <code>mise@latest</code> to 2026.4.25</li>
<li><a href="https://github.com/taiki-e/install-action/commit/2e38aa6247aeba66de9417751c4530d4645de619"><code>2e38aa6</code></a> Update <code>martin@latest</code> to 1.8.0</li>
<li><a href="https://github.com/taiki-e/install-action/commit/443d4e78ebe387a7dcd97c3409561a95b438ea5f"><code>443d4e7</code></a> Update cyclonedx manifest</li>
<li><a href="https://github.com/taiki-e/install-action/commit/5ddd7264c74b5e6da8f3c8e11c60e2ccd7c2eca1"><code>5ddd726</code></a> Update cargo-udeps manifest</li>
<li><a href="https://github.com/taiki-e/install-action/commit/4b9684ed936a92791e5efdc286c72b92670ffff2"><code>4b9684e</code></a> Update <code>vacuum@latest</code> to 0.26.4</li>
<li><a href="https://github.com/taiki-e/install-action/commit/1329c298aa20c3257846c9b2e0e55967df3e3c37"><code>1329c29</code></a> Release 2.75.25</li>
<li><a href="https://github.com/taiki-e/install-action/commit/96c62cdc996ecd4636a16513f8017238bf1d29d7"><code>96c62cd</code></a> Update wasm-tools manifest</li>
<li>Additional commits viewable in <a href="https://github.com/taiki-e/install-action/compare/v2.66.3...b651345a718c8f44efa2460560b3dbf29cbd7ee1">compare view</a></li>
</ul>
</details>
<br />

Updates `taiki-e/cache-cargo-install-action` from 3.0.3 to 3.0.6
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/taiki-e/cache-cargo-install-action/releases">taiki-e/cache-cargo-install-action's releases</a>.</em></p>
<blockquote>
<h2>3.0.6</h2>
<ul>
<li>Improve robustness for network failure.</li>
</ul>
<h2>3.0.5</h2>
<ul>
<li>
<p>Implement workaround for <a href="https://redirect.github.com/actions/partner-runner-images/issues/169">windows-11-arm runner bug</a> which may causes issue that the action successfully completes but the crate is not installed.</p>
<p>We have not yet received any reports of this issue occurring with this action, but given the nature of the problem, it is possible that it could be affected.</p>
</li>
</ul>
<h2>3.0.4</h2>
<ul>
<li>Pin <code>actions/cache</code> action with commit hash.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/taiki-e/cache-cargo-install-action/blob/main/CHANGELOG.md">taiki-e/cache-cargo-install-action's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<p>All notable changes to this project will be documented in this file.</p>
<p>This project adheres to <a href="https://semver.org">Semantic Versioning</a>.</p>
<!-- raw HTML omitted -->
<h2>[Unreleased]</h2>
<h2>[3.0.6] - 2026-04-08</h2>
<ul>
<li>Improve robustness for network failure.</li>
</ul>
<h2>[3.0.5] - 2026-04-04</h2>
<ul>
<li>
<p>Implement workaround for <a href="https://redirect.github.com/actions/partner-runner-images/issues/169">windows-11-arm runner bug</a> which may causes issue that the action successfully completes but the crate is not installed.</p>
<p>We have not yet received any reports of this issue occurring with this action, but given the nature of the problem, it is possible that it could be affected.</p>
</li>
</ul>
<h2>[3.0.4] - 2026-03-28</h2>
<ul>
<li>Pin <code>actions/cache</code> action with commit hash.</li>
</ul>
<h2>[3.0.3] - 2026-03-08</h2>
<ul>
<li>Avoid triggering <a href="https://docs.zizmor.sh/audits/#ref-confusion">zizmor ref-confusion</a> when using this action in form of <code>uses: taiki-e/cache-cargo-install-action@v3</code>.</li>
</ul>
<h2>[3.0.2] - 2026-02-14</h2>
<ul>
<li>
<p>Improve support for Linux systems without tar is installed.</p>
</li>
<li>
<p>Work around issue where cache doesn't work with &quot;/bin/tar: unrecognized option: posix&quot; warning on Alpine-based image.</p>
</li>
</ul>
<h2>[3.0.1] - 2026-01-11</h2>
<ul>
<li>
<p>Improve support for Windows with MSYS2 bash. (<a href="https://redirect.github.com/taiki-e/cache-cargo-install-action/pull/15">#15</a>, thanks <a href="https://github.com/chitoku-k"><code>@​chitoku-k</code></a>)</p>
</li>
<li>
<p>Enable <a href="https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases">release immutability</a>.</p>
</li>
</ul>
<h2>[3.0.0] - 2025-12-30</h2>
<ul>
<li>Update <code>actions/cache</code> from 4 to 5. (<a href="https://redirect.github.com/taiki-e/cache-cargo-install-action/pull/14">#14</a>)</li>
</ul>
<h2>[2.3.1] - 2025-09-28</h2>
<ul>
<li>Fix version parsing failures on Windows caused by trailing carriage returns (<code>\r</code>) in JSON responses from crates.io API. (<a href="https://redirect.github.com/taiki-e/cache-cargo-install-action/pull/12">#12</a>, thanks <a href="https://github.com/Xevion"><code>@​Xevion</code></a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/f9eed3e4680f27610dc6d8c67be1b88593f7dade"><code>f9eed3e</code></a> Release 3.0.6</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/94a1b496f5c24b404f7e9407d9fff22d56cc11a9"><code>94a1b49</code></a> ci: Update config</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/a291a8786d7b367cce84843f45a9263549aea6dc"><code>a291a87</code></a> Revert &quot;Remove duplicated retry&quot;</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/8709271d385277c965012019776747766ec4d98c"><code>8709271</code></a> tools: Update tidy.sh</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/b2d7b8b1142c7464d3e69c65aa0f8333b8ca5da1"><code>b2d7b8b</code></a> Adjust base distro detection code</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/66c9585ef5ca780ee69399975a5e911f47905995"><code>66c9585</code></a> Update readme</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/a63c37907d76f5701a47530271bc26187aebf18b"><code>a63c379</code></a> Update readme</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/e49774959b2c270d7869b2fca809721f827b33fa"><code>e497749</code></a> Replace one grep with [[ == ]]</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/a8b9ecf8e0c0ea09d7481cfc583a5203ecd585b5"><code>a8b9ecf</code></a> Release 3.0.5</li>
<li><a href="https://github.com/taiki-e/cache-cargo-install-action/commit/24c6108ff15a872b706461c9bc47c2cbcb4e6872"><code>24c6108</code></a> Implement workaround for windows-11-arm runner bug</li>
<li>Additional commits viewable in <a href="https://github.com/taiki-e/cache-cargo-install-action/compare/v3.0.3...f9eed3e4680f27610dc6d8c67be1b88593f7dade">compare view</a></li>
</ul>
</details>
<br />

Updates `actions/cache` from 5.0.4 to 5.0.5
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/cache/releases">actions/cache's releases</a>.</em></p>
<blockquote>
<h2>v5.0.5</h2>
<h2>What's Changed</h2>
<ul>
<li>Update ts-http-runtime dependency by <a href="https://github.com/yacaovsnc"><code>@​yacaovsnc</code></a> in <a href="https://redirect.github.com/actions/cache/pull/1747">actions/cache#1747</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/cache/compare/v5...v5.0.5">https://github.com/actions/cache/compare/v5...v5.0.5</a></p>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/actions/cache/blob/main/RELEASES.md">actions/cache's changelog</a>.</em></p>
<blockquote>
<h1>Releases</h1>
<h2>How to prepare a release</h2>
<blockquote>
<p>[!NOTE]<br />
Relevant for maintainers with write access only.</p>
</blockquote>
<ol>
<li>Switch to a new branch from <code>main</code>.</li>
<li>Run <code>npm test</code> to ensure all tests are passing.</li>
<li>Update the version in <a href="https://github.com/actions/cache/blob/main/package.json"><code>https://github.com/actions/cache/blob/main/package.json</code></a>.</li>
<li>Run <code>npm run build</code> to update the compiled files.</li>
<li>Update this <a href="https://github.com/actions/cache/blob/main/RELEASES.md"><code>https://github.com/actions/cache/blob/main/RELEASES.md</code></a> with the new version and changes in the <code>## Changelog</code> section.</li>
<li>Run <code>licensed cache</code> to update the license report.</li>
<li>Run <code>licensed status</code> and resolve any warnings by updating the <a href="https://github.com/actions/cache/blob/main/.licensed.yml"><code>https://github.com/actions/cache/blob/main/.licensed.yml</code></a> file with the exceptions.</li>
<li>Commit your changes and push your branch upstream.</li>
<li>Open a pull request against <code>main</code> and get it reviewed and merged.</li>
<li>Draft a new release <a href="https://github.com/actions/cache/releases">https://github.com/actions/cache/releases</a> use the same version number used in <code>package.json</code>
<ol>
<li>Create a new tag with the version number.</li>
<li>Auto generate release notes and update them to match the changes you made in <code>RELEASES.md</code>.</li>
<li>Toggle the set as the latest release option.</li>
<li>Publish the release.</li>
</ol>
</li>
<li>Navigate to <a href="https://github.com/actions/cache/actions/workflows/release-new-action-version.yml">https://github.com/actions/cache/actions/workflows/release-new-action-version.yml</a>
<ol>
<li>There should be a workflow run queued with the same version number.</li>
<li>Approve the run to publish the new version and update the major tags for this action.</li>
</ol>
</li>
</ol>
<h2>Changelog</h2>
<h3>5.0.4</h3>
<ul>
<li>Bump <code>minimatch</code> to v3.1.5 (fixes ReDoS via globstar patterns)</li>
<li>Bump <code>undici</code> to v6.24.1 (WebSocket decompression bomb protection, header validation fixes)</li>
<li>Bump <code>fast-xml-parser</code> to v5.5.6</li>
</ul>
<h3>5.0.3</h3>
<ul>
<li>Bump <code>@actions/cache</code> to v5.0.5 (Resolves: <a href="https://github.com/actions/cache/security/dependabot/33">https://github.com/actions/cache/security/dependabot/33</a>)</li>
<li>Bump <code>@actions/core</code> to v2.0.3</li>
</ul>
<h3>5.0.2</h3>
<ul>
<li>Bump <code>@actions/cache</code> to v5.0.3 <a href="https://redirect.github.com/actions/cache/pull/1692">#1692</a></li>
</ul>
<h3>5.0.1</h3>
<ul>
<li>Update <code>@azure/storage-blob</code> to <code>^12.29.1</code> via <code>@actions/cache@5.0.1</code> <a href="https://redirect.github.com/actions/cache/pull/1685">#1685</a></li>
</ul>
<h3>5.0.0</h3>
<blockquote>
<p>[!IMPORTANT]
<code>actions/cache@v5</code> runs on the Node.js 24 runtime and requires a minimum Actions Runner version of <code>2.327.1</code>.</p>
</blockquote>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/cache/commit/27d5ce7f107fe9357f9df03efb73ab90386fccae"><code>27d5ce7</code></a> Merge pull request <a href="https://redirect.github.com/actions/cache/issues/1747">#1747</a> from actions/yacaovsnc/update-dependency</li>
<li><a href="https://github.com/actions/cache/commit/f280785d7b6e1884c7d12b9136eb0f4a1574fcfd"><code>f280785</code></a> licensed changes</li>
<li><a href="https://github.com/actions/cache/commit/619aeb1606e195be0b36fd0ff68dcf1aff6b65a7"><code>619aeb1</code></a> npm run build generated dist files</li>
<li><a href="https://github.com/actions/cache/commit/bcf16c2893940a4899761e55c7ac3c1cf88a04f6"><code>bcf16c2</code></a> Update ts-http-runtime to 0.3.5</li>
<li>See full diff in <a href="https://github.com/actions/cache/compare/668228422ae6a00e4ad889ee87cd7109ec5666a7...27d5ce7f107fe9357f9df03efb73ab90386fccae">compare view</a></li>
</ul>
</details>
<br />

Updates `docker/build-push-action` from 7.0.0 to 7.1.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/docker/build-push-action/releases">docker/build-push-action's releases</a>.</em></p>
<blockquote>
<h2>v7.1.0</h2>
<ul>
<li>Git context <a href="https://docs.docker.com/build/concepts/context/#url-queries">query format</a> support by <a href="https://github.com/crazy-max"><code>@​crazy-max</code></a> in <a href="https://redirect.github.com/docker/build-push-action/pull/1505">docker/build-push-action#1505</a></li>
<li>Bump <code>@​docker/actions-toolkit</code> from 0.79.0 to 0.87.0 by <a href="https://github.com/crazy-max"><code>@​crazy-max</code></a> in <a href="https://redirect.github.com/docker/build-push-action/pull/1505">docker/build-push-action#1505</a></li>
<li>Bump brace-expansion from 1.1.12 to 1.1.13 in <a href="https://redirect.github.com/docker/build-push-action/pull/1500">docker/build-push-action#1500</a></li>
<li>Bump fast-xml-parser from 5.4.2 to 5.5.7 in <a href="https://redirect.github.com/docker/build-push-action/pull/1489">docker/build-push-action#1489</a></li>
<li>Bump flatted from 3.3.3 to 3.4.2 in <a href="https://redirect.github.com/docker/build-push-action/pull/1491">docker/build-push-action#1491</a></li>
<li>Bump glob from 10.3.12 to 10.5.0 in <a href="https://redirect.github.com/docker/build-push-action/pull/1490">docker/build-push-action#1490</a></li>
<li>Bump handlebars from 4.7.8 to 4.7.9 in <a href="https://redirect.github.com/docker/build-push-action/pull/1497">docker/build-push-action#1497</a></li>
<li>Bump lodash from 4.17.23 to 4.18.1 in <a href="https://redirect.github.com/docker/build-push-action/pull/1510">docker/build-push-action#1510</a></li>
<li>Bump picomatch from 4.0.3 to 4.0.4 in <a href="https://redirect.github.com/docker/build-push-action/pull/1496">docker/build-push-action#1496</a></li>
<li>Bump undici from 6.23.0 to 6.24.1 in <a href="https://redirect.github.com/docker/build-push-action/pull/1486">docker/build-push-action#1486</a></li>
<li>Bump vite from 7.3.1 to 7.3.2 in <a href="https://redirect.github.com/docker/build-push-action/pull/1509">docker/build-push-action#1509</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/docker/build-push-action/compare/v7.0.0...v7.1.0">https://github.com/docker/build-push-action/compare/v7.0.0...v7.1.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/docker/build-push-action/commit/bcafcacb16a39f128d818304e6c9c0c18556b85f"><code>bcafcac</code></a> Merge pull request <a href="https://redirect.github.com/docker/build-push-action/issues/1509">#1509</a> from docker/dependabot/npm_and_yarn/vite-7.3.2</li>
<li><a href="https://github.com/docker/build-push-action/commit/18e62f1158d9c45a4a84a58a6828d21f8ed3644b"><code>18e62f1</code></a> Merge pull request <a href="https://redirect.github.com/docker/build-push-action/issues/1510">#1510</a> from docker/dependabot/npm_and_yarn/lodash-4.18.1</li>
<li><a href="https://github.com/docker/build-push-action/commit/46580d2c9d43b0888270cb6fa90956e483de56fc"><code>46580d2</code></a> chore: update generated content</li>
<li><a href="https://github.com/docker/build-push-action/commit/3f80b252ca2331f6ec3e890f4346b5506ee1dc81"><code>3f80b25</code></a> chore(deps): Bump lodash from 4.17.23 to 4.18.1</li>
<li><a href="https://github.com/docker/build-push-action/commit/efeec9557c40a646afe433e39a1e94ca689103f0"><code>efeec95</code></a> Merge pull request <a href="https://redirect.github.com/docker/build-push-action/issues/1505">#1505</a> from crazy-max/refactor-git-context</li>
<li><a href="https://github.com/docker/build-push-action/commit/ddf04b08eb12882258ed936fea4a2806754ff349"><code>ddf04b0</code></a> Merge pull request <a href="https://redirect.github.com/docker/build-push-action/issues/1511">#1511</a> from docker/dependabot/github_actions/crazy-max-dot-...</li>
<li><a href="https://github.com/docker/build-push-action/commit/db08d97a08e4a0d15f85d1c4e64dfd5f88cbe1a9"><code>db08d97</code></a> chore(deps): Bump the crazy-max-dot-github group with 2 updates</li>
<li><a href="https://github.com/docker/build-push-action/commit/ef1fb9688fc3626d0fd5e462f502cbbdc6456feb"><code>ef1fb96</code></a> Merge pull request <a href="https://redirect.github.com/docker/build-push-action/issues/1508">#1508</a> from docker/dependabot/github_actions/docker/login-a...</li>
<li><a href="https://github.com/docker/build-push-action/commit/2d8f2a1a378a5c302dcd7b2b4326cefa24180bb1"><code>2d8f2a1</code></a> chore: update generated content</li>
<li><a href="https://github.com/docker/build-push-action/commit/919ac7bd7d1aa8cb13fe4de76545abea8d8b5ed2"><code>919ac7b</code></a> fix test since secrets are not written to temp path anymore</li>
<li>Additional commits viewable in <a href="https://github.com/docker/build-push-action/compare/d08e5c354a6adb9ed34480a06d141179aa583294...bcafcacb16a39f128d818304e6c9c0c18556b85f">compare view</a></li>
</ul>
</details>
<br />

Updates `actions/upload-artifact` from 7.0.0 to 7.0.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/upload-artifact/releases">actions/upload-artifact's releases</a>.</em></p>
<blockquote>
<h2>v7.0.1</h2>
<h2>What's Changed</h2>
<ul>
<li>Update the readme with direct upload details by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/795">actions/upload-artifact#795</a></li>
<li>Readme: bump all the example versions to v7 by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/796">actions/upload-artifact#796</a></li>
<li>Include changes in typespec/ts-http-runtime 0.3.5 by <a href="https://github.com/yacaovsnc"><code>@​yacaovsnc</code></a> in <a href="https://redirect.github.com/actions/upload-artifact/pull/797">actions/upload-artifact#797</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/upload-artifact/compare/v7...v7.0.1">https://github.com/actions/upload-artifact/compare/v7...v7.0.1</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"><code>043fb46</code></a> Merge pull request <a href="https://redirect.github.com/actions/upload-artifact/issues/797">#797</a> from actions/yacaovsnc/update-dependency</li>
<li><a href="https://github.com/actions/upload-artifact/commit/634250c1388765ea7ed0f053e636f1f399000b94"><code>634250c</code></a> Include changes in typespec/ts-http-runtime 0.3.5</li>
<li><a href="https://github.com/actions/upload-artifact/commit/e454baaac2be505c9450e11b8f3215c6fc023ce8"><code>e454baa</code></a> Readme: bump all the example versions to v7 (<a href="https://redirect.github.com/actions/upload-artifact/issues/796">#796</a>)</li>
<li><a href="https://github.com/actions/upload-artifact/commit/74fad66b98a6d799dc004d3353ccd0e6f6b2530e"><code>74fad66</code></a> Update the readme with direct upload details (<a href="https://redirect.github.com/actions/upload-artifact/issues/795">#795</a>)</li>
<li>See full diff in <a href="https://github.com/actions/upload-artifact/compare/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f...043fb46d1a93c77aae656e7c1c64a875d1fc6a0a">compare view</a></li>
</ul>
</details>
<br />

Updates `actions/setup-node` from 6.3.0 to 6.4.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/setup-node/releases">actions/setup-node's releases</a>.</em></p>
<blockquote>
<h2>v6.4.0</h2>
<h2>What's Changed</h2>
<h3>Dependency updates:</h3>
<ul>
<li>Upgrade <a href="https://github.com/actions"><code>@​actions</code></a> dependencies by <a href="https://github.com/Copilot"><code>@​Copilot</code></a> in <a href="https://redirect.github.com/actions/setup-node/pull/1525">actions/setup-node#1525</a></li>
<li>Update Node.js versions in versions.yml and bump package to v6.4.0  by <a href="https://github.com/priya-kinthali"><code>@​priya-kinthali</code></a> in <a href="https://redirect.github.com/actions/setup-node/pull/1533">actions/setup-node#1533</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/Copilot"><code>@​Copilot</code></a> made their first contribution in <a href="https://redirect.github.com/actions/setup-node/pull/1525">actions/setup-node#1525</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/setup-node/compare/v6...v6.4.0">https://github.com/actions/setup-node/compare/v6...v6.4.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"><code>48b55a0</code></a> Update Node.js versions in versions.yml and bump package to v6.4.0 (<a href="https://redirect.github.com/actions/setup-node/issues/1533">#1533</a>)</li>
<li><a href="https://github.com/actions/setup-node/commit/ab72c7e7eba0eaa11f8cab0f5679243900c2cac9"><code>ab72c7e</code></a> Upgrade <a href="https://github.com/actions"><code>@​actions</code></a> dependencies (<a href="https://redirect.github.com/actions/setup-node/issues/1525">#1525</a>)</li>
<li>See full diff in <a href="https://github.com/actions/setup-node/compare/53b83947a5a98c8d113130e565377fae1a50d02f...48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e">compare view</a></li>
</ul>
</details>
<br />