### PR TITLE
Improve ingester lock instrumentation

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast/capacity_score.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast/capacity_score.rs
@@ -64,7 +64,7 @@ impl BroadcastIngesterCapacityScoreTask {
         }
 
         let mut guard = state
-            .lock_fully()
+            .lock_fully("broadcast_capacity_score")
             .await
             .context("failed to acquire ingester state lock")?;
 
@@ -222,7 +222,7 @@ mod tests {
         let (_temp_dir, state) =
             IngesterState::for_test_with_disk_capacity(cluster.clone(), ByteSize::b(1000)).await;
         let index_uid = IndexUid::for_test("test-index", 0);
-        let mut state_guard = state.lock_partially().await.unwrap();
+        let mut state_guard = state.lock_partially("test").await.unwrap();
         let shard = IngesterShard::new_solo(
             index_uid.clone(),
             SourceId::from("test-source"),

--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast/local_shards.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast/local_shards.rs
@@ -259,7 +259,7 @@ impl BroadcastLocalShardsTask {
     async fn snapshot_local_shards(&mut self) -> Option<LocalShardsSnapshot> {
         let state = self.weak_state.upgrade()?;
 
-        let Ok(mut state_guard) = state.lock_partially().await else {
+        let Ok(mut state_guard) = state.lock_partially("snapshot_local_shards").await else {
             return Some(LocalShardsSnapshot::default());
         };
         #[allow(clippy::mutable_key_type)]
@@ -542,7 +542,7 @@ mod tests {
         let previous_snapshot = task.snapshot_local_shards().await.unwrap();
         assert!(previous_snapshot.per_source_shard_infos.is_empty());
 
-        let mut state_guard = state.lock_partially().await.unwrap();
+        let mut state_guard = state.lock_partially("test").await.unwrap();
 
         let index_uid = IndexUid::for_test("test-index", 0);
         let shard_00 = IngesterShard::new_solo(

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -36,8 +36,9 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, warn};
 
 use super::models::ShardStatus;
+use super::state::{track_acquire_lock, warn_on_long_lock_hold};
 use crate::mrecordlog_async::MultiRecordLogAsync;
-use crate::{ClientId, IngesterPool, with_lock_metrics};
+use crate::{ClientId, IngesterPool};
 
 /// A fetch stream task is responsible for waiting and pushing new records written to a shard's
 /// record log into a channel named `fetch_message_tx`.
@@ -128,8 +129,8 @@ impl FetchStreamTask {
             let mut mrecord_buffer = BytesMut::with_capacity(self.batch_num_bytes);
             let mut mrecord_lengths = Vec::new();
 
-            let mrecordlog_guard =
-                with_lock_metrics!(self.mrecordlog.read().await, "fetch", "read");
+            let (mrecordlog_guard, acquired_at) =
+                track_acquire_lock("fetch_stream", "partial", self.mrecordlog.read()).await;
 
             let Ok(mrecords) = mrecordlog_guard
                 .as_ref()
@@ -152,6 +153,8 @@ impl FetchStreamTask {
             }
             // Drop the lock while we send the message.
             drop(mrecordlog_guard);
+
+            warn_on_long_lock_hold("fetch_stream", "partial", acquired_at);
 
             if !mrecord_lengths.is_empty() {
                 let from_position_exclusive = if self.from_position_inclusive == 0 {

--- a/quickwit/quickwit-ingest/src/ingest_v2/idle.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/idle.rs
@@ -18,7 +18,6 @@ use tokio::task::JoinHandle;
 use tracing::info;
 
 use super::state::WeakIngesterState;
-use crate::with_lock_metrics;
 
 const RUN_INTERVAL_PERIOD: Duration = if cfg!(test) {
     Duration::from_millis(50)
@@ -58,9 +57,7 @@ impl CloseIdleShardsTask {
             let Some(state) = self.weak_state.upgrade() else {
                 return;
             };
-            let Ok(mut state_guard) =
-                with_lock_metrics!(state.lock_partially(), "close_idle_shards", "write").await
-            else {
+            let Ok(mut state_guard) = state.lock_partially("close_idle_shards").await else {
                 return;
             };
 
@@ -101,7 +98,7 @@ mod tests {
         let idle_shard_timeout = RUN_INTERVAL_PERIOD * 4;
         let join_handle = CloseIdleShardsTask::spawn(weak_state, idle_shard_timeout);
 
-        let mut state_guard = state.lock_partially().await.unwrap();
+        let mut state_guard = state.lock_partially("test").await.unwrap();
         let now = Instant::now();
 
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -127,7 +124,7 @@ mod tests {
 
         tokio::time::sleep(RUN_INTERVAL_PERIOD * 2).await;
 
-        let state_guard = state.lock_partially().await.unwrap();
+        let state_guard = state.lock_partially("test").await.unwrap();
         state_guard
             .shards
             .get(&queue_id_01)
@@ -142,7 +139,7 @@ mod tests {
 
         tokio::time::sleep(idle_shard_timeout).await;
 
-        let state_guard = state.lock_partially().await.unwrap();
+        let state_guard = state.lock_partially("test").await.unwrap();
         state_guard
             .shards
             .get(&queue_id_02)

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -66,7 +66,7 @@ use crate::ingest_v2::doc_mapper::get_or_try_build_doc_mapper;
 use crate::ingest_v2::metrics::report_wal_usage;
 use crate::ingest_v2::models::IngesterShardType;
 use crate::mrecordlog_async::MultiRecordLogAsync;
-use crate::{FollowerId, estimate_size, with_lock_metrics};
+use crate::{FollowerId, estimate_size};
 
 /// Minimum interval between two reset shards operations.
 const MIN_RESET_SHARDS_INTERVAL: Duration = if cfg!(any(test, feature = "testsuite")) {
@@ -282,7 +282,10 @@ impl Ingester {
 
         let mut per_source_shard_ids: HashMap<(IndexUid, SourceId), Vec<ShardId>> = HashMap::new();
 
-        let state_guard = with_lock_metrics!(self.state.lock_fully().await, "reset_shards", "read")
+        let state_guard = self
+            .state
+            .lock_fully("reset_shards_init")
+            .await
             .expect("ingester should be ready");
 
         for queue_id in state_guard.mrecordlog.list_queues() {
@@ -318,9 +321,11 @@ impl Ingester {
 
         match advise_reset_shards_result {
             Ok(Ok(advise_reset_shards_response)) => {
-                let mut state_guard =
-                    with_lock_metrics!(self.state.lock_fully().await, "reset_shards", "write")
-                        .expect("ingester should be ready");
+                let mut state_guard = self
+                    .state
+                    .lock_fully("reset_shards_apply")
+                    .await
+                    .expect("ingester should be ready");
 
                 state_guard
                     .reset_shards(&advise_reset_shards_response)
@@ -452,8 +457,7 @@ impl Ingester {
         let commit_type = persist_request.commit_type();
         let force_commit = commit_type == CommitTypeV2::Force;
 
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully().await, "persist", "write")?;
+        let mut state_guard = self.state.lock_fully("persist").await?;
         let status = state_guard.status();
 
         if !status.accepts_write_requests() {
@@ -850,7 +854,7 @@ impl Ingester {
         let leader_id: NodeId = open_replication_stream_request.leader_id.into();
         let follower_id: NodeId = open_replication_stream_request.follower_id.into();
 
-        let mut state_guard = self.state.lock_partially().await?;
+        let mut state_guard = self.state.lock_partially("open_replication_stream").await?;
         let status = state_guard.status();
 
         if !status.accepts_write_requests() {
@@ -894,7 +898,7 @@ impl Ingester {
     ) -> IngestV2Result<ServiceStream<IngestV2Result<FetchMessage>>> {
         let queue_id = open_fetch_stream_request.queue_id();
 
-        let mut state_guard = self.state.lock_partially().await?;
+        let mut state_guard = self.state.lock_partially("open_fetch_stream").await?;
 
         let shard = state_guard.shards.get_mut(&queue_id).ok_or_else(|| {
             rate_limited_error!(limit_per_min=6, queue_id=%queue_id, "shard not found");
@@ -938,8 +942,7 @@ impl Ingester {
         &self,
         init_shards_request: InitShardsRequest,
     ) -> IngestV2Result<InitShardsResponse> {
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully().await, "init_shards", "write")?;
+        let mut state_guard = self.state.lock_fully("init_shards").await?;
         let status = state_guard.status();
 
         if !status.accepts_write_requests() {
@@ -998,18 +1001,17 @@ impl Ingester {
                 self.self_node_id, truncate_shards_request.ingester_id,
             )));
         }
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully().await, "truncate_shards", "write")?;
+        let mut state_guard = self.state.lock_fully("truncate_shards_rpc").await?;
 
         for subrequest in truncate_shards_request.subrequests {
             let queue_id = subrequest.queue_id();
             let truncate_up_to_position_inclusive = subrequest.truncate_up_to_position_inclusive();
 
             if truncate_up_to_position_inclusive.is_eof() {
-                state_guard.delete_shard(&queue_id, "indexer-rpc").await;
+                state_guard.delete_shard(&queue_id, "indexer RPC").await;
             } else {
                 state_guard
-                    .truncate_shard(&queue_id, truncate_up_to_position_inclusive, "indexer-rpc")
+                    .truncate_shard(&queue_id, truncate_up_to_position_inclusive, "indexer RPC")
                     .await;
             }
         }
@@ -1025,8 +1027,7 @@ impl Ingester {
         &self,
         close_shards_request: CloseShardsRequest,
     ) -> IngestV2Result<CloseShardsResponse> {
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_partially().await, "close_shards", "write")?;
+        let mut state_guard = self.state.lock_partially("close_shards").await?;
 
         let mut successes = Vec::with_capacity(close_shards_request.shard_pkeys.len());
 
@@ -1044,7 +1045,7 @@ impl Ingester {
     }
 
     pub async fn debug_info(&self) -> JsonValue {
-        let state_guard = match self.state.lock_fully().await {
+        let state_guard = match self.state.lock_fully("debug_info").await {
             Ok(state_guard) => state_guard,
             Err(_) => {
                 return json!({
@@ -1165,8 +1166,7 @@ impl IngesterService for Ingester {
                     })
             })
             .collect();
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully(), "retain_shards", "write").await?;
+        let mut state_guard = self.state.lock_fully("retain_shards").await?;
         let remove_queue_ids: HashSet<QueueId> = state_guard
             .shards
             .keys()
@@ -1203,7 +1203,7 @@ impl IngesterService for Ingester {
     ) -> IngestV2Result<DecommissionResponse> {
         // Retire the ingester immediately by setting its status to `Retiring`.
         info!("retiring ingester");
-        let mut state_guard = self.state.lock_partially().await?;
+        let mut state_guard = self.state.lock_partially("retire").await?;
         state_guard.set_status(IngesterStatus::Retiring).await;
         drop(state_guard); // Dropping explicitly for readability.
 
@@ -1224,7 +1224,7 @@ impl IngesterService for Ingester {
             tokio::time::sleep(DECOMMISSION_DELAY).await;
 
             info!("decommissioning ingester");
-            let mut state_guard = match self_clone.state.lock_partially().await {
+            let mut state_guard = match self_clone.state.lock_partially("decommission").await {
                 Ok(state_guard) => state_guard,
                 Err(error) => {
                     error!(%error, "failed to decommission ingester");
@@ -1253,9 +1253,7 @@ impl EventSubscriber<ShardPositionsUpdate> for WeakIngesterState {
             warn!("ingester state update failed");
             return;
         };
-        let Ok(mut state_guard) =
-            with_lock_metrics!(state.lock_fully().await, "gc_shards", "write")
-        else {
+        let Ok(mut state_guard) = state.lock_fully("truncate_shards_gossip").await else {
             error!("failed to lock the ingester state");
             return;
         };
@@ -1265,10 +1263,10 @@ impl EventSubscriber<ShardPositionsUpdate> for WeakIngesterState {
         for (shard_id, shard_position) in shard_positions_update.updated_shard_positions {
             let queue_id = queue_id(&index_uid, &source_id, &shard_id);
             if shard_position.is_eof() {
-                state_guard.delete_shard(&queue_id, "indexer-gossip").await;
+                state_guard.delete_shard(&queue_id, "indexer gossip").await;
             } else if !shard_position.is_beginning() {
                 state_guard
-                    .truncate_shard(&queue_id, shard_position, "indexer-gossip")
+                    .truncate_shard(&queue_id, shard_position, "indexer gossip")
                     .await;
             }
         }
@@ -1462,7 +1460,7 @@ mod tests {
     #[tokio::test]
     async fn test_ingester_init() {
         let (ingester_ctx, ingester) = IngesterForTest::default().build().await;
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
@@ -1529,7 +1527,7 @@ mod tests {
             .init(ingester_ctx.tempdir.path(), RateLimiterSettings::default())
             .await;
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 1);
 
         let solo_shard_02 = state_guard.shards.get(&queue_id_02).unwrap();
@@ -1550,7 +1548,7 @@ mod tests {
     async fn test_ingester_broadcasts_local_shards() {
         let (ingester_ctx, ingester) = IngesterForTest::default().build().await;
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
 
@@ -1581,7 +1579,7 @@ mod tests {
         assert_eq!(shard_info.shard_state, ShardState::Open);
         assert_eq!(shard_info.short_term_ingestion_rate, 0);
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         state_guard
             .shards
             .get_mut(&queue_id_01)
@@ -1599,7 +1597,7 @@ mod tests {
         let shard_info = shard_infos.iter().next().unwrap();
         assert_eq!(shard_info.shard_state, ShardState::Closed);
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         state_guard.shards.remove(&queue_id_01).unwrap();
         drop(state_guard);
 
@@ -1635,7 +1633,7 @@ mod tests {
             doc_mapping_uid: Some(doc_mapping_uid),
             ..Default::default()
         };
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         ingester
             .init_primary_shard(
@@ -1699,7 +1697,7 @@ mod tests {
         assert_eq!(init_shard_success.subrequest_id, 0);
         assert_eq!(init_shard_success.shard, Some(shard));
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         let queue_id = queue_id(&index_uid, &source_id, &ShardId::from(1));
         let shard = state_guard.shards.get(&queue_id).unwrap();
@@ -1803,7 +1801,7 @@ mod tests {
             Some(Position::offset(2u64))
         );
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 2);
 
         let queue_id_01 = queue_id(&index_uid_0, &source_id, &ShardId::from(1));
@@ -2172,7 +2170,7 @@ mod tests {
 
         let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
         let solo_shard =
@@ -2218,7 +2216,7 @@ mod tests {
             PersistFailureReason::NodeUnavailable,
         );
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         let shard = state_guard.shards.get(&queue_id).unwrap();
         shard.assert_is_closed();
 
@@ -2229,7 +2227,7 @@ mod tests {
     async fn test_ingester_persist_deletes_dangling_shard() {
         let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
 
@@ -2267,7 +2265,7 @@ mod tests {
             PersistFailureReason::NodeUnavailable
         );
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 0);
     }
 
@@ -2388,7 +2386,7 @@ mod tests {
             Some(Position::offset(2u64))
         );
 
-        let leader_state_guard = leader.state.lock_fully().await.unwrap();
+        let leader_state_guard = leader.state.lock_fully("test").await.unwrap();
         assert_eq!(leader_state_guard.shards.len(), 2);
 
         let queue_id_01 = queue_id(&index_uid, &source_id, &ShardId::from(1));
@@ -2419,7 +2417,7 @@ mod tests {
             ],
         );
 
-        let follower_state_guard = follower.state.lock_fully().await.unwrap();
+        let follower_state_guard = follower.state.lock_fully("test").await.unwrap();
         assert_eq!(follower_state_guard.shards.len(), 2);
 
         let replica_shard_01 = follower_state_guard.shards.get(&queue_id_01).unwrap();
@@ -2601,7 +2599,7 @@ mod tests {
             Some(Position::offset(1u64))
         );
 
-        let leader_state_guard = leader.state.lock_fully().await.unwrap();
+        let leader_state_guard = leader.state.lock_fully("test").await.unwrap();
         assert_eq!(leader_state_guard.shards.len(), 2);
 
         let queue_id_01 = queue_id(&index_uid, &source_id, &ShardId::from(1));
@@ -2631,7 +2629,7 @@ mod tests {
             ],
         );
 
-        let follower_state_guard = follower.state.lock_fully().await.unwrap();
+        let follower_state_guard = follower.state.lock_fully("test").await.unwrap();
         assert_eq!(follower_state_guard.shards.len(), 2);
 
         let replica_shard_01 = follower_state_guard.shards.get(&queue_id_01).unwrap();
@@ -2672,7 +2670,7 @@ mod tests {
         let queue_id = solo_shard.queue_id();
         ingester
             .state
-            .lock_fully()
+            .lock_fully("test")
             .await
             .unwrap()
             .shards
@@ -2702,7 +2700,7 @@ mod tests {
             PersistFailureReason::NoShardsAvailable
         );
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 1);
 
         let solo_shard = state_guard.shards.get(&queue_id).unwrap();
@@ -2740,7 +2738,7 @@ mod tests {
             doc_mapping_uid: Some(doc_mapping_uid),
             ..Default::default()
         };
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         ingester
             .init_primary_shard(
@@ -2780,7 +2778,7 @@ mod tests {
             PersistFailureReason::NoShardsAvailable
         );
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 1);
 
         let queue_id_01 = queue_id(&index_uid, &source_id, &ShardId::from(1));
@@ -2820,7 +2818,7 @@ mod tests {
             doc_mapping_uid: Some(doc_mapping_uid),
             ..Default::default()
         };
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         ingester
             .init_primary_shard(
@@ -2857,7 +2855,7 @@ mod tests {
         assert_eq!(persist_failure.source_id, "test-source");
         assert_eq!(persist_failure.reason(), PersistFailureReason::WalFull);
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 1);
 
         let queue_id_01 = queue_id(&index_uid, &source_id, &ShardId::from(1));
@@ -2993,7 +2991,7 @@ mod tests {
             .into_open_response()
             .unwrap();
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert!(state_guard.replication_tasks.contains_key("test-leader"));
     }
 
@@ -3034,7 +3032,7 @@ mod tests {
         };
         let queue_id = queue_id(&index_uid, &source_id, &ShardId::from(1));
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         ingester
             .init_primary_shard(
@@ -3086,7 +3084,7 @@ mod tests {
         );
         assert_eq!(mrecord_batch.mrecord_lengths, [14]);
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         let records = [MRecord::new_doc("test-doc-bar").encode()].into_iter();
 
@@ -3159,7 +3157,7 @@ mod tests {
             doc_mapping_uid: Some(doc_mapping_uid_02),
             ..Default::default()
         };
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let now = Instant::now();
 
         ingester
@@ -3244,7 +3242,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         assert_eq!(state_guard.shards.len(), 1);
         assert_eq!(state_guard.doc_mappers.len(), 1);
@@ -3264,7 +3262,7 @@ mod tests {
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let solo_shard =
             IngesterShard::new_solo(index_uid.clone(), source_id.clone(), ShardId::from(1)).build();
         state_guard.shards.insert(solo_shard.queue_id(), solo_shard);
@@ -3284,7 +3282,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 0);
     }
 
@@ -3360,7 +3358,7 @@ mod tests {
         };
         let queue_id_02 = queue_id(&index_uid, &source_id, &ShardId::from(2));
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let now = Instant::now();
 
         ingester
@@ -3402,7 +3400,7 @@ mod tests {
 
         ingester.reset_shards().await;
 
-        let state_guard = ingester.state.lock_partially().await.unwrap();
+        let state_guard = ingester.state.lock_partially("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 1);
 
         let shard_02 = state_guard.shards.get(&queue_id_02).unwrap();
@@ -3445,7 +3443,7 @@ mod tests {
             shard_17.shard_id(),
         );
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let now = Instant::now();
 
         ingester
@@ -3475,7 +3473,7 @@ mod tests {
         drop(state_guard);
 
         {
-            let state_guard = ingester.state.lock_fully().await.unwrap();
+            let state_guard = ingester.state.lock_fully("test").await.unwrap();
             assert_eq!(state_guard.shards.len(), 2);
         }
 
@@ -3489,7 +3487,7 @@ mod tests {
         ingester.retain_shards(retain_shards_request).await.unwrap();
 
         {
-            let state_guard = ingester.state.lock_fully().await.unwrap();
+            let state_guard = ingester.state.lock_fully("test").await.unwrap();
             assert_eq!(state_guard.shards.len(), 1);
             assert!(state_guard.shards.contains_key(&queue_id_17));
         }
@@ -3518,7 +3516,7 @@ mod tests {
             publish_position_inclusive: Some(Position::Beginning),
             ..Default::default()
         };
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         ingester
             .init_primary_shard(
                 &mut state_guard.inner,
@@ -3575,7 +3573,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state_guard = ingester.state.lock_partially().await.unwrap();
+        let state_guard = ingester.state.lock_partially("test").await.unwrap();
         let shard = state_guard.shards.get(&queue_id).unwrap();
         shard.assert_is_closed();
 
@@ -3601,7 +3599,7 @@ mod tests {
         assert_eq!(observation.node_id, ingester_ctx.node_id);
         assert_eq!(observation.status(), IngesterStatus::Ready);
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         state_guard
             .set_status(IngesterStatus::Decommissioning)
             .await;
@@ -3621,7 +3619,7 @@ mod tests {
     async fn test_ingester_decommission() {
         let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
 
@@ -3650,7 +3648,7 @@ mod tests {
         .await
         .unwrap();
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         let shard = state_guard.shards.get(&queue_id).unwrap();
         shard.assert_is_closed();
     }
@@ -3658,7 +3656,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_decommissioning_status() {
         let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
         ingester
             .check_decommissioning_status(&mut state_guard)
@@ -3736,7 +3734,7 @@ mod tests {
         };
         let queue_id_02 = queue_id(&index_uid, &source_id, &ShardId::from(2));
 
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let now = Instant::now();
 
         ingester
@@ -3803,7 +3801,7 @@ mod tests {
         // Yield so that the event is processed.
         yield_now().await;
 
-        let state_guard = ingester.state.lock_fully().await.unwrap();
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert_eq!(state_guard.shards.len(), 1);
 
         assert!(state_guard.shards.contains_key(&queue_id_01));
@@ -3844,7 +3842,7 @@ mod tests {
             doc_mapping_uid: Some(doc_mapping_uid),
             ..Default::default()
         };
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let now = Instant::now();
 
         ingester
@@ -3864,7 +3862,7 @@ mod tests {
         for _ in 0..10 {
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            let state_guard = ingester.state.lock_partially().await.unwrap();
+            let state_guard = ingester.state.lock_partially("test").await.unwrap();
             let shard = state_guard.shards.get(&queue_id_01).unwrap();
 
             if shard.is_closed() {
@@ -3913,7 +3911,7 @@ mod tests {
             doc_mapping_uid: Some(doc_mapping_uid),
             ..Default::default()
         };
-        let mut state_guard = ingester.state.lock_fully().await.unwrap();
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
         let now = Instant::now();
 
         ingester

--- a/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
@@ -80,6 +80,7 @@ pub(super) struct IngestV2Metrics {
     pub shard_st_throughput_mib: Histogram,
     pub wal_acquire_lock_requests_in_flight: IntGaugeVec<2>,
     pub wal_acquire_lock_request_duration_secs: HistogramVec<2>,
+    pub wal_lock_hold_duration_secs: HistogramVec<2>,
     pub wal_disk_used_bytes: IntGauge,
     pub wal_memory_used_bytes: IntGauge,
     pub ingest_results: IngestResultMetrics,
@@ -138,6 +139,14 @@ impl Default for IngestV2Metrics {
             wal_acquire_lock_request_duration_secs: new_histogram_vec(
                 "wal_acquire_lock_request_duration_secs",
                 "Duration of acquire lock requests in seconds.",
+                "ingest",
+                &[],
+                ["operation", "type"],
+                exponential_buckets(0.001, 2.0, 12).unwrap(),
+            ),
+            wal_lock_hold_duration_secs: new_histogram_vec(
+                "wal_lock_hold_duration_secs",
+                "Duration for which the WAL lock was held in seconds.",
                 "ingest",
                 &[],
                 ["operation", "type"],

--- a/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
@@ -37,9 +37,9 @@ use super::metrics::report_wal_usage;
 use super::models::IngesterShard;
 use super::mrecordlog_utils::check_enough_capacity;
 use super::state::IngesterState;
+use crate::estimate_size;
 use crate::ingest_v2::mrecordlog_utils::{AppendDocBatchError, append_non_empty_doc_batch};
 use crate::metrics::INGEST_METRICS;
-use crate::{estimate_size, with_lock_metrics};
 
 pub(super) const SYN_REPLICATION_STREAM_CAPACITY: usize = 5;
 
@@ -449,8 +449,7 @@ impl ReplicationTask {
         };
         let queue_id = replica_shard.queue_id();
 
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully(), "init_replica", "write").await?;
+        let mut state_guard = self.state.lock_fully("init_replica").await?;
 
         match state_guard.mrecordlog.create_queue(&queue_id).await {
             Ok(_) => {}
@@ -522,8 +521,7 @@ impl ReplicationTask {
         // queue in the WAL and should be deleted.
         let mut shards_to_delete: HashSet<QueueId> = HashSet::new();
 
-        let mut state_guard =
-            with_lock_metrics!(self.state.lock_fully(), "replicate", "write").await?;
+        let mut state_guard = self.state.lock_fully("replicate").await?;
 
         if state_guard.status() != IngesterStatus::Ready {
             replicate_failures.reserve_exact(replicate_request.subrequests.len());
@@ -1137,7 +1135,7 @@ mod tests {
         let init_replica_response = into_init_replica_response(ack_replication_message);
         assert_eq!(init_replica_response.replication_seqno, 2);
 
-        let state_guard = state.lock_fully().await.unwrap();
+        let state_guard = state.lock_fully("test").await.unwrap();
 
         let queue_id_01 = queue_id(&index_uid, "test-source", &ShardId::from(1));
 
@@ -1240,7 +1238,7 @@ mod tests {
             Position::offset(1u64)
         );
 
-        let state_guard = state.lock_fully().await.unwrap();
+        let state_guard = state.lock_fully("test").await.unwrap();
 
         state_guard
             .mrecordlog
@@ -1296,7 +1294,7 @@ mod tests {
             Position::offset(1u64)
         );
 
-        let state_guard = state.lock_fully().await.unwrap();
+        let state_guard = state.lock_fully("test").await.unwrap();
 
         state_guard.mrecordlog.assert_records_eq(
             &queue_id_01,
@@ -1346,7 +1344,7 @@ mod tests {
         .with_state(ShardState::Closed)
         .build();
         state
-            .lock_fully()
+            .lock_fully("test")
             .await
             .unwrap()
             .shards
@@ -1431,7 +1429,7 @@ mod tests {
         .build();
         let queue_id_01 = replica_shard.queue_id();
         state
-            .lock_fully()
+            .lock_fully("test")
             .await
             .unwrap()
             .shards
@@ -1473,7 +1471,7 @@ mod tests {
             ReplicateFailureReason::ShardNotFound
         );
 
-        let state_guard = state.lock_partially().await.unwrap();
+        let state_guard = state.lock_partially("test").await.unwrap();
         assert!(!state_guard.shards.contains_key(&queue_id_01));
     }
 
@@ -1526,7 +1524,7 @@ mod tests {
             leader_id,
         )
         .build();
-        let mut state_guard = state.lock_fully().await.unwrap();
+        let mut state_guard = state.lock_fully("test").await.unwrap();
 
         state_guard
             .shards
@@ -1576,7 +1574,7 @@ mod tests {
             ReplicateFailureReason::ShardClosed
         );
 
-        let state_guard = state.lock_partially().await.unwrap();
+        let state_guard = state.lock_partially("test").await.unwrap();
         let replica_shard = state_guard.shards.get(&queue_id_01).unwrap();
         replica_shard.assert_is_closed();
 
@@ -1624,7 +1622,7 @@ mod tests {
         .build();
         let queue_id_01 = replica_shard.queue_id();
         state
-            .lock_fully()
+            .lock_fully("test")
             .await
             .unwrap()
             .shards

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -310,33 +310,49 @@ impl IngesterState {
             .expect("channel should be open");
     }
 
-    pub async fn lock_partially(&self) -> IngestV2Result<PartiallyLockedIngesterState<'_>> {
+    pub async fn lock_partially(
+        &self,
+        operation: &'static str,
+    ) -> IngestV2Result<PartiallyLockedIngesterState<'_>> {
         if *self.status_rx.borrow() == IngesterStatus::Initializing {
             return Err(IngestV2Error::Internal(
                 "ingester is initializing".to_string(),
             ));
         }
-        let inner_guard = self.inner.lock().await;
+        let (inner_guard, acquired_at) =
+            track_acquire_lock(operation, "partial", self.inner.lock()).await;
 
         if inner_guard.status() == IngesterStatus::Failed {
             return Err(IngestV2Error::Internal(
                 "failed to initialize ingester".to_string(),
             ));
         }
-        let partial_lock = PartiallyLockedIngesterState { inner: inner_guard };
-        Ok(partial_lock)
+        let partially_locked_state = PartiallyLockedIngesterState {
+            inner: inner_guard,
+            operation,
+            acquired_at,
+        };
+        Ok(partially_locked_state)
     }
 
-    pub async fn lock_fully(&self) -> IngestV2Result<FullyLockedIngesterState<'_>> {
+    pub async fn lock_fully(
+        &self,
+        operation: &'static str,
+    ) -> IngestV2Result<FullyLockedIngesterState<'_>> {
         if *self.status_rx.borrow() == IngesterStatus::Initializing {
             return Err(IngestV2Error::Internal(
                 "ingester is initializing".to_string(),
             ));
         }
-        // We assume that the mrecordlog lock is the most "expensive" one to acquire, so we acquire
-        // it first.
-        let mrecordlog_opt_guard = self.mrecordlog.write().await;
-        let inner_guard = self.inner.lock().await;
+        // We assume that the mrecordlog lock is the most "expensive" one to acquire, so we
+        // acquire it first.
+        let ((mrecordlog_opt_guard, inner_guard), acquired_at) =
+            track_acquire_lock(operation, "full", async {
+                let mrecordlog_opt_guard = self.mrecordlog.write().await;
+                let inner_guard = self.inner.lock().await;
+                (mrecordlog_opt_guard, inner_guard)
+            })
+            .await;
 
         if inner_guard.status() == IngesterStatus::Failed {
             return Err(IngestV2Error::Internal(
@@ -348,11 +364,13 @@ impl IngesterState {
                 .as_mut()
                 .expect("mrecordlog should be initialized")
         });
-        let full_lock = FullyLockedIngesterState {
+        let fully_locked_state = FullyLockedIngesterState {
             inner: inner_guard,
             mrecordlog: mrecordlog_guard,
+            operation,
+            acquired_at,
         };
-        Ok(full_lock)
+        Ok(fully_locked_state)
     }
 
     // Leaks the mrecordlog lock for use in fetch tasks. It's safe to do so because fetch tasks
@@ -372,6 +390,8 @@ impl IngesterState {
 
 pub(super) struct PartiallyLockedIngesterState<'a> {
     pub inner: MutexGuard<'a, InnerIngesterState>,
+    operation: &'static str,
+    acquired_at: Instant,
 }
 
 impl fmt::Debug for PartiallyLockedIngesterState<'_> {
@@ -394,9 +414,17 @@ impl DerefMut for PartiallyLockedIngesterState<'_> {
     }
 }
 
+impl Drop for PartiallyLockedIngesterState<'_> {
+    fn drop(&mut self) {
+        warn_on_long_lock_hold(self.operation, "partial", self.acquired_at);
+    }
+}
+
 pub(super) struct FullyLockedIngesterState<'a> {
     pub inner: MutexGuard<'a, InnerIngesterState>,
     pub mrecordlog: RwLockMappedWriteGuard<'a, MultiRecordLogAsync>,
+    operation: &'static str,
+    acquired_at: Instant,
 }
 
 impl fmt::Debug for FullyLockedIngesterState<'_> {
@@ -417,6 +445,81 @@ impl DerefMut for FullyLockedIngesterState<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
+}
+
+impl Drop for FullyLockedIngesterState<'_> {
+    fn drop(&mut self) {
+        warn_on_long_lock_hold(self.operation, "full", self.acquired_at);
+    }
+}
+
+pub(super) fn warn_on_long_lock_hold(
+    operation: &'static str,
+    lock_type: &'static str,
+    acquired_at: Instant,
+) {
+    let elapsed = acquired_at.elapsed();
+
+    crate::ingest_v2::metrics::INGEST_V2_METRICS
+        .wal_lock_hold_duration_secs
+        .with_label_values([operation, lock_type])
+        .observe(elapsed.as_secs_f64());
+
+    if elapsed > Duration::from_secs(1) {
+        quickwit_common::rate_limited_warn!(
+            limit_per_min = 6,
+            "held {} lock for {} operation for {}",
+            lock_type,
+            operation,
+            elapsed.pretty_display()
+        );
+    }
+}
+
+/// Wraps a lock-acquisition future with the in-flight gauge, the acquire duration histogram, and
+/// a rate-limited warning when acquisition takes longer than 1s. Used by `lock_partially` /
+/// `lock_fully` and by other ingest_v2 sites that acquire WAL-related locks (e.g. fetch tasks
+/// reading the mrecordlog directly).
+pub(super) async fn track_acquire_lock<F, R>(
+    operation: &'static str,
+    lock_type: &'static str,
+    acquire_future: F,
+) -> (R, Instant)
+where
+    F: std::future::Future<Output = R>,
+{
+    let metrics = &crate::ingest_v2::metrics::INGEST_V2_METRICS;
+
+    metrics
+        .wal_acquire_lock_requests_in_flight
+        .with_label_values([operation, lock_type])
+        .inc();
+
+    let now = Instant::now();
+    let guard = acquire_future.await;
+    let acquired_at = Instant::now();
+
+    let elapsed = acquired_at.duration_since(now);
+
+    if elapsed > Duration::from_secs(1) {
+        quickwit_common::rate_limited_warn!(
+            limit_per_min = 6,
+            "acquiring {} lock for {} operation took {}",
+            lock_type,
+            operation,
+            elapsed.pretty_display()
+        );
+    }
+    metrics
+        .wal_acquire_lock_requests_in_flight
+        .with_label_values([operation, lock_type])
+        .dec();
+    metrics
+        .wal_acquire_lock_request_duration_secs
+        .with_label_values([operation, lock_type])
+        .observe(elapsed.as_secs_f64());
+
+    (guard, acquired_at)
 }
 
 impl FullyLockedIngesterState<'_> {
@@ -559,10 +662,10 @@ mod tests {
         assert_eq!(inner_guard.status(), IngesterStatus::Initializing);
         assert_eq!(*state.status_rx.borrow(), IngesterStatus::Initializing);
 
-        let error = state.lock_partially().await.unwrap_err().to_string();
+        let error = state.lock_partially("test").await.unwrap_err().to_string();
         assert!(error.contains("ingester is initializing"));
 
-        let error = state.lock_fully().await.unwrap_err().to_string();
+        let error = state.lock_fully("test").await.unwrap_err().to_string();
         assert!(error.contains("ingester is initializing"));
     }
 
@@ -578,10 +681,10 @@ mod tests {
             .set_status(IngesterStatus::Failed)
             .await;
 
-        let error = state.lock_partially().await.unwrap_err().to_string();
+        let error = state.lock_partially("test").await.unwrap_err().to_string();
         assert!(error.to_string().ends_with("failed to initialize ingester"));
 
-        let error = state.lock_fully().await.unwrap_err().to_string();
+        let error = state.lock_fully("test").await.unwrap_err().to_string();
         assert!(error.contains("failed to initialize ingester"));
     }
 
@@ -599,9 +702,9 @@ mod tests {
             .await
             .unwrap();
 
-        state.lock_partially().await.unwrap();
+        state.lock_partially("test").await.unwrap();
 
-        let locked_state = state.lock_fully().await.unwrap();
+        let locked_state = state.lock_fully("test").await.unwrap();
         assert_eq!(locked_state.status(), IngesterStatus::Ready);
         assert_eq!(*locked_state.status_tx.borrow(), IngesterStatus::Ready);
     }
@@ -634,7 +737,7 @@ mod tests {
         .await
         .unwrap();
         let (_temp_dir, state) = IngesterState::for_test(cluster).await;
-        let mut state_guard = state.lock_partially().await.unwrap();
+        let mut state_guard = state.lock_partially("test").await.unwrap();
 
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
@@ -680,7 +783,7 @@ mod tests {
         .await
         .unwrap();
         let (_temp_dir, state) = IngesterState::for_test(cluster).await;
-        let mut locked_state = state.lock_partially().await.unwrap();
+        let mut locked_state = state.lock_partially("test").await.unwrap();
 
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
@@ -730,7 +833,7 @@ mod tests {
         .await
         .unwrap();
         let (_temp_dir, state) = IngesterState::for_test(cluster).await;
-        let mut locked_state = state.lock_partially().await.unwrap();
+        let mut locked_state = state.lock_partially("test").await.unwrap();
 
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
@@ -764,7 +867,7 @@ mod tests {
             .init(temp_dir.path(), RateLimiterSettings::default())
             .await;
 
-        let mut state_guard = state.lock_fully().await.unwrap();
+        let mut state_guard = state.lock_fully("test").await.unwrap();
         state_guard.set_status(IngesterStatus::Failed).await;
         assert_eq!(state_guard.status(), IngesterStatus::Failed);
         assert_eq!(*state.status_rx.borrow(), IngesterStatus::Failed);
@@ -795,7 +898,7 @@ mod tests {
     async fn test_get_shard_snapshot() {
         let cluster = test_cluster().await;
         let (_temp_dir, state) = IngesterState::for_test(cluster).await;
-        let mut state_guard = state.lock_partially().await.unwrap();
+        let mut state_guard = state.lock_partially("test").await.unwrap();
 
         let index_uid = IndexUid::for_test("test-index", 0);
 

--- a/quickwit/quickwit-ingest/src/lib.rs
+++ b/quickwit/quickwit-ingest/src/lib.rs
@@ -105,39 +105,6 @@ pub async fn start_ingest_api_service(
     init_ingest_api(universe, &queues_dir_path, config).await
 }
 
-#[macro_export]
-macro_rules! with_lock_metrics {
-    ($future:expr, $($label:tt),*) => {
-        {
-            $crate::ingest_v2::metrics::INGEST_V2_METRICS
-                .wal_acquire_lock_requests_in_flight
-                .with_label_values([$($label),*])
-                .inc();
-
-            let now = std::time::Instant::now();
-            let guard = $future;
-
-            let elapsed = now.elapsed();
-            if elapsed > std::time::Duration::from_secs(1) {
-                quickwit_common::rate_limited_warn!(
-                    limit_per_min=6,
-                    "lock acquisition took {}ms", elapsed.as_millis()
-                );
-            }
-            $crate::ingest_v2::metrics::INGEST_V2_METRICS
-                .wal_acquire_lock_requests_in_flight
-                .with_label_values([$($label),*])
-                .dec();
-            $crate::ingest_v2::metrics::INGEST_V2_METRICS
-                .wal_acquire_lock_request_duration_secs
-                .with_label_values([$($label),*])
-                .observe(elapsed.as_secs_f64());
-
-            guard
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
### Description
Improve ingester lock instrumentation:
- remove overkill macro
- instrument all places where we acquire lock
- track lock hold durations

Will move to static metrics (and will maybe have to reintroduce macro) when metrics PR is merged.

### How was this PR tested?
cargo test
