### PR TITLE
Route DataFusion scan tasks by file affinity

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3016,8 +3016,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d75c8241c447c26614c9d235dd3d4d72e93112c8716b9509d2ff0d84e06b8e"
+source = "git+https://github.com/datafusion-contrib/datafusion-distributed.git?rev=d7de9c3fb99fd7fa99da925b460dc2d4529c04a2#d7de9c3fb99fd7fa99da925b460dc2d4529c04a2"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -8422,6 +8421,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-build 0.14.3",
  "serde_json",
+ "siphasher",
  "tokio",
  "tonic 0.14.5",
  "tonic-prost",

--- a/quickwit/quickwit-datafusion/Cargo.toml
+++ b/quickwit/quickwit-datafusion/Cargo.toml
@@ -39,7 +39,7 @@ datafusion-substrait = "53"
 datafusion-datasource = "53"
 datafusion-physical-plan = "53"
 datafusion-datasource-parquet = "53"
-datafusion-distributed = "1.0"
+datafusion-distributed = { git = "https://github.com/datafusion-contrib/datafusion-distributed.git", rev = "d7de9c3fb99fd7fa99da925b460dc2d4529c04a2" }
 object_store = "0.13"
 
 [dev-dependencies]

--- a/quickwit/quickwit-df-core/Cargo.toml
+++ b/quickwit/quickwit-df-core/Cargo.toml
@@ -15,13 +15,14 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 prost = { workspace = true }            # substrait Plan::decode (runtime only)
 serde_json = { workspace = true }
+siphasher = { workspace = true }
 tracing = { workspace = true }
 url = "2"
 
 arrow = { workspace = true }
 datafusion = "53"
 datafusion-substrait = "53"
-datafusion-distributed = "1.0"
+datafusion-distributed = { git = "https://github.com/datafusion-contrib/datafusion-distributed.git", rev = "d7de9c3fb99fd7fa99da925b460dc2d4529c04a2" }
 object_store = "0.13"
 
 # gRPC surface is opt-in. The extension traits + session builder do not need

--- a/quickwit/quickwit-df-core/proto/datafusion.proto
+++ b/quickwit/quickwit-df-core/proto/datafusion.proto
@@ -68,6 +68,11 @@ message ExecuteSqlRequest {
 
   // Optional per-request session overrides.
   map<string, string> properties = 2;
+
+  // When true, the server returns the service-level EXPLAIN output for the
+  // final SQL statement instead of executing it. DDL statements before the
+  // final query are still executed for side effects.
+  bool explain = 3;
 }
 
 message ExecuteSqlResponse {

--- a/quickwit/quickwit-df-core/src/codegen/quickwit.datafusion.rs
+++ b/quickwit/quickwit-df-core/src/codegen/quickwit.datafusion.rs
@@ -45,6 +45,11 @@ pub struct ExecuteSqlRequest {
         ::prost::alloc::string::String,
         ::prost::alloc::string::String,
     >,
+    /// When true, the server returns the service-level EXPLAIN output for the
+    /// final SQL statement instead of executing it. DDL statements before the
+    /// final query are still executed for side effects.
+    #[prost(bool, tag = "3")]
+    pub explain: bool,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecuteSqlResponse {

--- a/quickwit/quickwit-df-core/src/grpc.rs
+++ b/quickwit/quickwit-df-core/src/grpc.rs
@@ -208,11 +208,17 @@ impl data_fusion_service_server::DataFusionService for DataFusionServiceGrpcImpl
         let req = request.into_inner();
         let service = Arc::clone(&self.service);
 
+        let output = if req.explain {
+            DataFusionOutput::Explain
+        } else {
+            DataFusionOutput::Records
+        };
         let execution = service
-            .execute(DataFusionRequest::records(
-                DataFusionInput::Sql(&req.sql),
-                &req.properties,
-            ))
+            .execute(DataFusionRequest {
+                input: DataFusionInput::Sql(&req.sql),
+                output,
+                properties: &req.properties,
+            })
             .await
             .map_err(|err| {
                 warn!(error = %err, "DataFusion SQL execution error");

--- a/quickwit/quickwit-df-core/src/service.rs
+++ b/quickwit/quickwit-df-core/src/service.rs
@@ -225,18 +225,18 @@ pub struct DataFusionRatioStatistics {
 }
 
 impl DataFusionExecutionMetadata {
-    pub fn physical_plan_display(&self) -> String {
-        physical_plan_display(&self.physical_plan)
+    pub async fn physical_plan_display(&self) -> String {
+        physical_plan_display(&self.physical_plan).await
     }
 
-    pub fn physical_plan_metadata(&self) -> DataFusionPhysicalPlanMetadata {
-        physical_plan_metadata(&self.physical_plan)
+    pub async fn physical_plan_metadata(&self) -> DataFusionPhysicalPlanMetadata {
+        physical_plan_metadata(&self.physical_plan).await
     }
 }
 
 impl SubstraitExecutionMetadata {
-    pub fn physical_plan_display(&self) -> String {
-        physical_plan_display(&self.physical_plan)
+    pub async fn physical_plan_display(&self) -> String {
+        physical_plan_display(&self.physical_plan).await
     }
 }
 
@@ -461,7 +461,7 @@ impl DataFusionService {
                 execute_stream(Arc::clone(&physical_plan), ctx.task_ctx())?
             }
             DataFusionOutput::Explain => {
-                explain_stream(&logical_plan_display, &physical_plan, None)?
+                explain_stream(&logical_plan_display, &physical_plan, None).await?
             }
             DataFusionOutput::ExplainAnalyze => {
                 let analyze_execution_start = Instant::now();
@@ -469,12 +469,13 @@ impl DataFusionService {
                     execute_plan_for_metrics(Arc::clone(&physical_plan), ctx.task_ctx()).await?;
                 analyze_execution_duration = Some(analyze_execution_start.elapsed());
                 analyze_output_rows = Some(num_rows);
-                let physical_plan_metadata = physical_plan_metadata(&physical_plan);
+                let physical_plan_metadata = physical_plan_metadata(&physical_plan).await;
                 explain_stream(
                     &logical_plan_display,
                     &physical_plan,
                     Some(&physical_plan_metadata),
-                )?
+                )
+                .await?
             }
         };
         let stream_creation_duration = stream_creation_start.elapsed();
@@ -813,7 +814,7 @@ async fn execute_plan_for_metrics(
     Ok(num_rows)
 }
 
-fn explain_stream(
+async fn explain_stream(
     logical_plan: &str,
     physical_plan: &Arc<dyn ExecutionPlan>,
     physical_plan_metadata: Option<&DataFusionPhysicalPlanMetadata>,
@@ -827,7 +828,7 @@ fn explain_stream(
         plan_types.push("execution_statistics_json".to_string());
         plans.push(physical_plan_metadata.statistics.to_json_string());
     } else {
-        physical_plan_display_text = physical_plan_display(physical_plan);
+        physical_plan_display_text = physical_plan_display(physical_plan).await;
         plans.push(physical_plan_display_text);
     }
     let plan_type: ArrayRef = Arc::new(StringArray::from(plan_types));
@@ -850,10 +851,10 @@ fn explain_schema() -> SchemaRef {
     ]))
 }
 
-fn physical_plan_metadata(
+async fn physical_plan_metadata(
     physical_plan: &Arc<dyn ExecutionPlan>,
 ) -> DataFusionPhysicalPlanMetadata {
-    let (physical_plan, show_metrics) = physical_plan_with_metrics(physical_plan);
+    let (physical_plan, show_metrics) = physical_plan_with_metrics(physical_plan).await;
     let display = if physical_plan.as_any().is::<DistributedExec>() {
         display_plan_ascii(physical_plan.as_ref(), show_metrics)
     } else {
@@ -868,18 +869,20 @@ fn physical_plan_metadata(
     }
 }
 
-fn physical_plan_display(physical_plan: &Arc<dyn ExecutionPlan>) -> String {
-    physical_plan_metadata(physical_plan).display
+async fn physical_plan_display(physical_plan: &Arc<dyn ExecutionPlan>) -> String {
+    physical_plan_metadata(physical_plan).await.display
 }
 
-fn physical_plan_with_metrics(
+async fn physical_plan_with_metrics(
     physical_plan: &Arc<dyn ExecutionPlan>,
 ) -> (Arc<dyn ExecutionPlan>, bool) {
     if physical_plan.as_any().is::<DistributedExec>() {
         return match rewrite_distributed_plan_with_metrics(
             Arc::clone(physical_plan),
             DistributedMetricsFormat::PerTask,
-        ) {
+        )
+        .await
+        {
             Ok(physical_plan) => (physical_plan, true),
             Err(_) => (Arc::clone(physical_plan), false),
         };

--- a/quickwit/quickwit-df-core/src/session.rs
+++ b/quickwit/quickwit-df-core/src/session.rs
@@ -45,7 +45,7 @@ use datafusion::execution::object_store::ObjectStoreRegistry;
 use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_distributed::{
-    DistributedExt, DistributedPhysicalOptimizerRule, TaskEstimator, WorkerResolver,
+    DistributedExt, SessionStateBuilderExt, TaskEstimator, TaskRoutingContext, WorkerResolver,
 };
 
 use crate::data_source::{
@@ -346,7 +346,7 @@ impl DataFusionSessionBuilder {
             builder = builder
                 .with_distributed_worker_resolver(ArcWorkerResolver(Arc::clone(resolver)))
                 .with_distributed_task_estimator(ArcTaskEstimator(Arc::clone(&self.task_estimator)))
-                .with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule));
+                .with_distributed_planner();
         }
 
         Ok(SessionContext::new_with_state(builder.build()))
@@ -385,6 +385,10 @@ impl TaskEstimator for ArcTaskEstimator {
         cfg: &datafusion::config::ConfigOptions,
     ) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
         self.0.scale_up_leaf_node(plan, task_count, cfg)
+    }
+
+    fn route_tasks(&self, routing_ctx: &TaskRoutingContext<'_>) -> DFResult<Option<Vec<url::Url>>> {
+        self.0.route_tasks(routing_ctx)
     }
 }
 

--- a/quickwit/quickwit-df-core/src/task_estimator.rs
+++ b/quickwit/quickwit-df-core/src/task_estimator.rs
@@ -71,19 +71,35 @@ impl TaskEstimator for DataSourceExecPartitionEstimator {
 
     fn route_tasks(&self, routing_ctx: &TaskRoutingContext<'_>) -> DFResult<Option<Vec<Url>>> {
         if routing_ctx.available_urls.is_empty() {
+            log_routing_fallback(routing_ctx, "no_available_workers");
             return Ok(None);
         }
-        let Some(file_scan) = single_file_scan_config(routing_ctx.plan) else {
+        let mut file_scans = Vec::new();
+        collect_file_scan_configs(routing_ctx.plan, &mut file_scans);
+        let [file_scan] = file_scans.as_slice() else {
+            let reason = if file_scans.is_empty() {
+                "no_file_scan_config"
+            } else {
+                "multiple_file_scan_configs"
+            };
+            log_routing_fallback(routing_ctx, reason);
             return Ok(None);
         };
         let task_affinities = file_scan_task_affinities(file_scan, routing_ctx.task_count);
         if task_affinities.len() != routing_ctx.task_count {
+            tracing::info!(
+                strategy = "file_rendezvous",
+                reason = "task_affinity_count_mismatch",
+                task_count = routing_ctx.task_count,
+                task_affinity_count = task_affinities.len(),
+                available_worker_count = routing_ctx.available_urls.len(),
+                "datafusion task routing fell back to default routing"
+            );
             return Ok(None);
         }
-        Ok(Some(route_by_rendezvous(
-            &task_affinities,
-            routing_ctx.available_urls,
-        )))
+        let routes = route_by_rendezvous(&task_affinities, routing_ctx.available_urls);
+        log_rendezvous_routes(routing_ctx, &task_affinities, &routes);
+        Ok(Some(routes))
     }
 }
 
@@ -91,15 +107,6 @@ impl TaskEstimator for DataSourceExecPartitionEstimator {
 struct TaskAffinity {
     task_index: usize,
     affinity_key: String,
-}
-
-fn single_file_scan_config(plan: &Arc<dyn ExecutionPlan>) -> Option<&FileScanConfig> {
-    let mut file_scans = Vec::new();
-    collect_file_scan_configs(plan, &mut file_scans);
-    match file_scans.as_slice() {
-        [file_scan] => Some(*file_scan),
-        _ => None,
-    }
 }
 
 fn collect_file_scan_configs<'a>(
@@ -209,6 +216,67 @@ fn rendezvous_affinity(url: &Url, key: &str) -> u64 {
     key.hash(&mut state);
     url.as_str().hash(&mut state);
     state.finish()
+}
+
+fn affinity_fingerprint(key: &str) -> u64 {
+    let mut state = SipHasher::new();
+    key.hash(&mut state);
+    state.finish()
+}
+
+fn log_routing_fallback(routing_ctx: &TaskRoutingContext<'_>, reason: &'static str) {
+    tracing::info!(
+        strategy = "file_rendezvous",
+        reason,
+        task_count = routing_ctx.task_count,
+        available_worker_count = routing_ctx.available_urls.len(),
+        "datafusion task routing fell back to default routing"
+    );
+}
+
+fn log_rendezvous_routes(
+    routing_ctx: &TaskRoutingContext<'_>,
+    task_affinities: &[TaskAffinity],
+    routes: &[Url],
+) {
+    const ROUTE_SAMPLE_SIZE: usize = 16;
+
+    let mut route_distribution: Vec<(&str, usize)> = Vec::new();
+    for route in routes {
+        let route = route.as_str();
+        match route_distribution
+            .iter_mut()
+            .find(|(worker_url, _)| *worker_url == route)
+        {
+            Some((_, task_count)) => *task_count += 1,
+            None => route_distribution.push((route, 1)),
+        }
+    }
+    route_distribution.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+
+    let route_sample: Vec<(usize, u64, &str)> = task_affinities
+        .iter()
+        .take(ROUTE_SAMPLE_SIZE)
+        .filter_map(|task_affinity| {
+            routes.get(task_affinity.task_index).map(|route| {
+                (
+                    task_affinity.task_index,
+                    affinity_fingerprint(&task_affinity.affinity_key),
+                    route.as_str(),
+                )
+            })
+        })
+        .collect();
+
+    tracing::info!(
+        strategy = "file_rendezvous",
+        task_count = routes.len(),
+        available_worker_count = routing_ctx.available_urls.len(),
+        route_sample_size = route_sample.len(),
+        route_distribution = ?route_distribution,
+        route_sample = ?route_sample,
+        "datafusion task routing selected workers"
+    );
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-df-core/src/task_estimator.rs
+++ b/quickwit/quickwit-df-core/src/task_estimator.rs
@@ -19,12 +19,19 @@
 //! count equals the file-group count; for tantivy sources it equals the total
 //! segment count across splits.
 
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use datafusion::common::Result as DFResult;
 use datafusion::config::ConfigOptions;
+use datafusion::datasource::physical_plan::FileScanConfig;
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::{PartitionIsolatorExec, TaskEstimation, TaskEstimator};
+use datafusion_distributed::{
+    PartitionIsolatorExec, TaskEstimation, TaskEstimator, TaskRoutingContext,
+};
+use siphasher::sip::SipHasher;
+use url::Url;
 
 /// Estimates distributed task count from the partition count of a
 /// `DataSourceExec` leaf. Returns `None` for any other plan node, letting the
@@ -60,5 +67,211 @@ impl TaskEstimator for DataSourceExecPartitionEstimator {
             Arc::clone(plan),
             task_count,
         )))
+    }
+
+    fn route_tasks(&self, routing_ctx: &TaskRoutingContext<'_>) -> DFResult<Option<Vec<Url>>> {
+        if routing_ctx.available_urls.is_empty() {
+            return Ok(None);
+        }
+        let Some(file_scan) = single_file_scan_config(routing_ctx.plan) else {
+            return Ok(None);
+        };
+        let task_affinities = file_scan_task_affinities(file_scan, routing_ctx.task_count);
+        if task_affinities.len() != routing_ctx.task_count {
+            return Ok(None);
+        }
+        Ok(Some(route_by_rendezvous(
+            &task_affinities,
+            routing_ctx.available_urls,
+        )))
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct TaskAffinity {
+    task_index: usize,
+    affinity_key: String,
+}
+
+fn single_file_scan_config(plan: &Arc<dyn ExecutionPlan>) -> Option<&FileScanConfig> {
+    let mut file_scans = Vec::new();
+    collect_file_scan_configs(plan, &mut file_scans);
+    match file_scans.as_slice() {
+        [file_scan] => Some(*file_scan),
+        _ => None,
+    }
+}
+
+fn collect_file_scan_configs<'a>(
+    plan: &'a Arc<dyn ExecutionPlan>,
+    file_scans: &mut Vec<&'a FileScanConfig>,
+) {
+    if let Some(data_source_exec) = plan.as_any().downcast_ref::<DataSourceExec>()
+        && let Some(file_scan) = data_source_exec
+            .data_source()
+            .as_any()
+            .downcast_ref::<FileScanConfig>()
+    {
+        file_scans.push(file_scan);
+    }
+
+    for child in plan.children() {
+        collect_file_scan_configs(child, file_scans);
+    }
+}
+
+fn file_scan_task_affinities(file_scan: &FileScanConfig, task_count: usize) -> Vec<TaskAffinity> {
+    partition_groups(file_scan.file_groups.len(), task_count)
+        .into_iter()
+        .enumerate()
+        .map(|(task_index, partition_group)| {
+            let mut file_keys = Vec::new();
+            for partition_idx in partition_group {
+                if let Some(file_group) = file_scan.file_groups.get(partition_idx) {
+                    for file in file_group.files() {
+                        file_keys.push(format!(
+                            "{}{}",
+                            file_scan.object_store_url.as_str(),
+                            file.object_meta.location.as_ref()
+                        ));
+                    }
+                }
+            }
+            file_keys.sort_unstable();
+            let affinity_key = if file_keys.is_empty() {
+                format!("empty-task-{task_index}")
+            } else {
+                file_keys.join("\n")
+            };
+            TaskAffinity {
+                task_index,
+                affinity_key,
+            }
+        })
+        .collect()
+}
+
+fn partition_groups(input_partitions: usize, task_count: usize) -> Vec<Vec<usize>> {
+    if task_count == 0 {
+        return Vec::new();
+    }
+    let q = input_partitions / task_count;
+    let r = input_partitions % task_count;
+    let mut off = 0;
+    (0..task_count)
+        .map(|i| q + usize::from(i < r))
+        .map(|n| {
+            let result = (off..(off + n)).collect();
+            off += n;
+            result
+        })
+        .collect()
+}
+
+fn route_by_rendezvous(task_affinities: &[TaskAffinity], available_urls: &[Url]) -> Vec<Url> {
+    let mut routes: Vec<Option<Url>> = vec![None; task_affinities.len()];
+    let mut task_order: Vec<usize> = (0..task_affinities.len()).collect();
+    task_order.sort_unstable_by(|&left, &right| {
+        task_affinities[left]
+            .affinity_key
+            .cmp(&task_affinities[right].affinity_key)
+            .then_with(|| {
+                task_affinities[left]
+                    .task_index
+                    .cmp(&task_affinities[right].task_index)
+            })
+    });
+
+    for task_idx in task_order {
+        let task = &task_affinities[task_idx];
+        let mut candidates: Vec<usize> = (0..available_urls.len()).collect();
+        candidates.sort_unstable_by(|&left, &right| {
+            let left_score = rendezvous_affinity(&available_urls[left], &task.affinity_key);
+            let right_score = rendezvous_affinity(&available_urls[right], &task.affinity_key);
+            right_score.cmp(&left_score).then_with(|| {
+                available_urls[left]
+                    .as_str()
+                    .cmp(available_urls[right].as_str())
+            })
+        });
+        let chosen_idx = candidates[0];
+        routes[task.task_index] = Some(available_urls[chosen_idx].clone());
+    }
+
+    routes
+        .into_iter()
+        .map(|route| route.expect("every task should be routed"))
+        .collect()
+}
+
+fn rendezvous_affinity(url: &Url, key: &str) -> u64 {
+    let mut state = SipHasher::new();
+    key.hash(&mut state);
+    url.as_str().hash(&mut state);
+    state.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(value: &str) -> Url {
+        Url::parse(value).unwrap()
+    }
+
+    fn task(task_index: usize, affinity_key: &str) -> TaskAffinity {
+        TaskAffinity {
+            task_index,
+            affinity_key: affinity_key.to_string(),
+        }
+    }
+
+    #[test]
+    fn partition_groups_match_partition_isolator_layout() {
+        assert_eq!(partition_groups(2, 1), vec![vec![0, 1]]);
+        assert_eq!(partition_groups(6, 2), vec![vec![0, 1, 2], vec![3, 4, 5]]);
+        assert_eq!(
+            partition_groups(10, 3),
+            vec![vec![0, 1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]
+        );
+    }
+
+    #[test]
+    fn rendezvous_routing_is_stable_across_url_order() {
+        let tasks = vec![
+            task(0, "s3://bucket/metrics-0.parquet"),
+            task(1, "s3://bucket/metrics-1.parquet"),
+            task(2, "s3://bucket/metrics-2.parquet"),
+            task(3, "s3://bucket/metrics-3.parquet"),
+            task(4, "s3://bucket/metrics-4.parquet"),
+            task(5, "s3://bucket/metrics-5.parquet"),
+        ];
+        let urls = vec![
+            url("http://node-0:7281"),
+            url("http://node-1:7281"),
+            url("http://node-2:7281"),
+        ];
+        let mut reversed_urls = urls.clone();
+        reversed_urls.reverse();
+
+        let routes = route_by_rendezvous(&tasks, &urls);
+        let reversed_routes = route_by_rendezvous(&tasks, &reversed_urls);
+
+        assert_eq!(routes, reversed_routes);
+    }
+
+    #[test]
+    fn rendezvous_routing_uses_best_affinity_node_per_task() {
+        let tasks = vec![task(0, "s3://bucket/metrics.parquet")];
+        let urls = vec![url("http://node-0:7281"), url("http://node-1:7281")];
+
+        let routes = route_by_rendezvous(&tasks, &urls);
+        let expected = urls
+            .iter()
+            .max_by_key(|url| rendezvous_affinity(url, "s3://bucket/metrics.parquet"))
+            .unwrap()
+            .clone();
+
+        assert_eq!(routes, vec![expected]);
     }
 }

--- a/quickwit/quickwit-integration-tests/src/tests/metrics_distributed_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/metrics_distributed_tests.rs
@@ -80,9 +80,25 @@ async fn execute_datafusion_sql(
     client: &mut DataFusionServiceClient<tonic::transport::Channel>,
     sql: impl Into<String>,
 ) -> Vec<RecordBatch> {
+    execute_datafusion_sql_with_explain(client, sql, false).await
+}
+
+async fn explain_datafusion_sql(
+    client: &mut DataFusionServiceClient<tonic::transport::Channel>,
+    sql: impl Into<String>,
+) -> Vec<RecordBatch> {
+    execute_datafusion_sql_with_explain(client, sql, true).await
+}
+
+async fn execute_datafusion_sql_with_explain(
+    client: &mut DataFusionServiceClient<tonic::transport::Channel>,
+    sql: impl Into<String>,
+    explain: bool,
+) -> Vec<RecordBatch> {
     let request = ExecuteSqlRequest {
         sql: sql.into(),
         properties: Default::default(),
+        explain,
     };
     let mut stream = client.execute_sql(request).await.unwrap().into_inner();
     let mut batches = Vec::new();
@@ -234,8 +250,7 @@ async fn test_distributed_tasks_not_shuffles() {
     let query = r#"SELECT SUM(value) as total, COUNT(*) as cnt FROM "dist-test""#;
 
     let mut client = datafusion_client(&sandbox);
-    let explain_batches =
-        execute_datafusion_sql(&mut client, format!("{ddl}; EXPLAIN VERBOSE {query}")).await;
+    let explain_batches = explain_datafusion_sql(&mut client, format!("{ddl}; {query}")).await;
     let plan_str = explain_plan_text(&explain_batches);
     println!("=== DataFusion EXPLAIN output ===\n{plan_str}");
 


### PR DESCRIPTION
## Summary

This stacks on the parquet footer/range cache work and uses the new `datafusion-distributed` task routing API to keep repeated parquet scan work sticky to the same searchers.

- switches the DataFusion session setup to `with_distributed_planner()` and forwards `TaskEstimator::route_tasks` through the `ArcTaskEstimator` wrapper
- pins `datafusion-distributed` to the merged routing API commit until the crate has a release with this API
- routes single-file-scan `DataSourceExec` tasks by deterministic rendezvous hashing over each task's parquet file set and the available worker URLs
- falls back to default routing when the plan is not a single `FileScanConfig` or when task/file grouping does not line up

## Routing Details

The estimator already controls how a `DataSourceExec` leaf is split into distributed tasks: it asks for one task per output partition and uses `PartitionIsolatorExec` to group those partitions into task-local inputs.

With the new API, `route_tasks` receives the physical plan, the task count, and the currently available worker URLs. Quickwit inspects the plan for exactly one `FileScanConfig`, reconstructs the same contiguous partition groups that `PartitionIsolatorExec` will assign to each task, and derives an affinity key from the sorted list of parquet file paths in that task group. The object store URL is included in the key so identical paths in different stores do not collide.

Each task is then assigned with rendezvous hashing: for every `(task affinity key, worker URL)` pair we compute a stable hash and pick the highest-scoring worker. The returned `Vec<Url>` is ordered by task index, which is the shape expected by `datafusion-distributed`. This gives us stable cache affinity without requiring a central routing table or consistent worker ordering from cluster discovery.

This is intentionally naive for now: no file-size weighting, no task cost model, and no load cap. The goal is cache locality for repeated metrics parquet scans, not global load optimization. If the plan shape is ambiguous, Quickwit returns `None` and lets the distributed planner use its default routing.

## Testing

- `cargo test -p quickwit-df-core`
- `cargo test -p quickwit-datafusion`
- `cargo check -p quickwit-serve --features datafusion`