### PR TITLE
feat: per-merge-region streaming engine — multi-RG inputs + outputs (PR-6c.2)

### DIFF
--- a/quickwit/quickwit-parquet-engine/src/merge/metadata_aggregation.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/metadata_aggregation.rs
@@ -119,22 +119,18 @@ pub fn merge_parquet_split_metadata(
     let split_id = ParquetSplitId::generate(first.kind);
     let parquet_file = format!("{split_id}.parquet");
 
-    // `rg_partition_prefix_len` propagation rule: a single-row-group
-    // output vacuously satisfies any prefix claim (no boundary to
-    // misalign), so we keep the inputs' prefix. Multi-RG output with
-    // arbitrary row-count-driven boundaries (the only kind the current
-    // merge writer can produce) cannot honor a non-zero claim and must
-    // reset to 0. PR-6 (streaming column-major merge engine) will
-    // produce sort-prefix-aligned multi-RG output and propagate the
-    // prefix unconditionally.
-    //
-    // This must agree with the value the writer embeds in the file's
-    // `qh.rg_partition_prefix_len` KV — see `write_merge_outputs`.
-    let output_prefix_len = if output.num_row_groups <= 1 {
-        first.rg_partition_prefix_len
-    } else {
-        0
-    };
+    // CS-1: the metastore-recorded `rg_partition_prefix_len` must equal
+    // the value the writer embedded in the file's
+    // `qh.rg_partition_prefix_len` KV. Each writer makes its own
+    // decision (the legacy `merge/writer.rs` demotes to 0 on multi-RG
+    // output because its boundaries are row-count-driven; the streaming
+    // writer propagates the inputs' prefix unchanged because it splits
+    // at prefix transitions and verifies via `assert_unique_rg_prefix_keys`)
+    // and reports it via `MergeOutputFile.output_rg_partition_prefix_len`.
+    // We propagate that one source of truth — re-deriving here from
+    // `num_row_groups` would silently diverge from the streaming
+    // engine's prefix-aligned multi-RG output.
+    let output_prefix_len = output.output_rg_partition_prefix_len;
 
     // Data-dependent fields come from the MergeOutputFile (extracted from
     // this output's actual rows during the merge write pass).
@@ -213,10 +209,29 @@ mod tests {
         time_range: (u64, u64),
         metric_names: &[&str],
     ) -> MergeOutputFile {
+        make_output_full_with_prefix(
+            num_rows,
+            size_bytes,
+            num_row_groups,
+            0,
+            time_range,
+            metric_names,
+        )
+    }
+
+    fn make_output_full_with_prefix(
+        num_rows: usize,
+        size_bytes: u64,
+        num_row_groups: usize,
+        output_rg_partition_prefix_len: u32,
+        time_range: (u64, u64),
+        metric_names: &[&str],
+    ) -> MergeOutputFile {
         MergeOutputFile {
             path: PathBuf::from("/tmp/merged.parquet"),
             num_rows,
             num_row_groups,
+            output_rg_partition_prefix_len,
             size_bytes,
             row_keys_proto: Some(vec![0x08, 0x01]),
             zonemap_regexes: HashMap::from([("metric_name".to_string(), "cpu\\..*".to_string())]),
@@ -412,17 +427,21 @@ mod tests {
     }
 
     #[test]
-    fn test_output_prefix_len_demoted_when_multi_rg() {
-        // The current merge writer rolls over RGs at row count, not at
-        // sort-prefix transitions. When the output ends up with > 1 RG,
-        // the boundaries are at arbitrary places and the inputs' prefix
-        // claim cannot be honored — the output's prefix must be 0.
+    fn test_output_prefix_len_carries_writers_value_when_demoted() {
+        // CS-1: the metastore-recorded value must match the writer's
+        // KV stamp. Legacy `merge/writer.rs` demotes to 0 when its
+        // row-count-driven RG layout produces multi-RG output and
+        // reports that demoted value on the `MergeOutputFile`. The
+        // metastore aggregator must propagate it as-is (NOT re-derive
+        // from inputs) so the metastore agrees with the file's KV.
         let mut s0 = make_test_split("s0", (1000, 2000), 0);
         let mut s1 = make_test_split("s1", (1000, 2000), 0);
         s0.rg_partition_prefix_len = 3;
         s1.rg_partition_prefix_len = 3;
 
-        let output = make_output_full(200, 9000, 2, (1000, 2000), &["cpu.usage"]);
+        // num_row_groups = 2 + writer reports demoted prefix_len = 0
+        // (the legacy writer's choice for a row-count-driven multi-RG).
+        let output = make_output_full_with_prefix(200, 9000, 2, 0, (1000, 2000), &["cpu.usage"]);
         let result = merge_parquet_split_metadata(&[s0, s1], &output).unwrap();
         assert_eq!(result.rg_partition_prefix_len, 0);
     }
@@ -430,18 +449,42 @@ mod tests {
     #[test]
     fn test_output_prefix_len_preserved_when_single_rg() {
         // A single-RG output vacuously satisfies any prefix alignment
-        // claim (one RG, no boundary to misalign). Propagate the inputs'
-        // prefix so the merge output stays in the same compaction bucket
-        // as the inputs, instead of leaking into the prefix=0 bucket on
-        // every merge.
+        // claim (one RG, no boundary to misalign). The writer reports
+        // the inputs' prefix; aggregator propagates it.
         let mut s0 = make_test_split("s0", (1000, 2000), 0);
         let mut s1 = make_test_split("s1", (1000, 2000), 0);
         s0.rg_partition_prefix_len = 3;
         s1.rg_partition_prefix_len = 3;
 
-        let output = make_output_full(200, 9000, 1, (1000, 2000), &["cpu.usage"]);
+        let output = make_output_full_with_prefix(200, 9000, 1, 3, (1000, 2000), &["cpu.usage"]);
         let result = merge_parquet_split_metadata(&[s0, s1], &output).unwrap();
         assert_eq!(result.rg_partition_prefix_len, 3);
+    }
+
+    #[test]
+    fn test_output_prefix_len_preserved_on_multi_rg_streaming_engine() {
+        // CS-1 regression for F1: the streaming engine produces
+        // sort-prefix-aligned multi-RG output and reports the inputs'
+        // prefix unchanged via `MergeOutputFile.output_rg_partition_prefix_len`.
+        // Before this fix, `merge_parquet_split_metadata` would
+        // unconditionally demote to 0 whenever `num_row_groups > 1`,
+        // breaking CS-1 (metastore disagreed with the file's KV) and
+        // leaking aligned outputs into the unaligned compaction bucket
+        // on every subsequent merge.
+        let mut s0 = make_test_split("s0", (1000, 2000), 0);
+        let mut s1 = make_test_split("s1", (1000, 2000), 0);
+        s0.rg_partition_prefix_len = 2;
+        s1.rg_partition_prefix_len = 2;
+
+        // num_row_groups = 3 (multi-RG) AND writer reports prefix_len = 2
+        // (the streaming engine's stamp because it verified alignment).
+        let output = make_output_full_with_prefix(300, 12000, 3, 2, (1000, 2000), &["cpu.usage"]);
+        let result = merge_parquet_split_metadata(&[s0, s1], &output).unwrap();
+        assert_eq!(
+            result.rg_partition_prefix_len, 2,
+            "metastore must mirror the writer's KV (CS-1); multi-RG aligned output keeps its \
+             prefix claim"
+        );
     }
 
     #[test]

--- a/quickwit/quickwit-parquet-engine/src/merge/mod.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/mod.rs
@@ -65,6 +65,7 @@ pub struct MergeConfig {
 /// Metadata extracted from input files' Parquet KV metadata.
 /// All inputs must agree on sort_fields, window_start, window_duration,
 /// and rg_partition_prefix_len.
+#[derive(Clone)]
 pub(crate) struct InputMetadata {
     sort_fields: String,
     window_start_secs: Option<i64>,
@@ -72,12 +73,11 @@ pub(crate) struct InputMetadata {
     num_merge_ops: u32,
     /// Number of leading sort columns whose transitions align with row
     /// group boundaries. All input files must agree on this value (it's
-    /// part of the compaction scope key). Splitting row groups at the
-    /// claimed prefix boundary is not implemented by the current merge
-    /// writer — it lands in PR-6 (streaming column-major merge engine).
-    /// Until then, the *output* file is written with prefix 0 regardless
-    /// of this value.
-    #[allow(dead_code)] // wired for PR-6 streaming engine; PR-1 only validates.
+    /// part of the compaction scope key). The streaming merge engine
+    /// (PR-6c.2) honours this on input AND produces prefix-aligned
+    /// output: when inputs have `prefix_len == 0`, the engine
+    /// synthesizes prefix-aligned regions from the merge order and
+    /// promotes the output's `rg_partition_prefix_len` accordingly.
     rg_partition_prefix_len: u32,
 }
 

--- a/quickwit/quickwit-parquet-engine/src/merge/mod.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/mod.rs
@@ -65,7 +65,7 @@ pub struct MergeConfig {
 /// Metadata extracted from input files' Parquet KV metadata.
 /// All inputs must agree on sort_fields, window_start, window_duration,
 /// and rg_partition_prefix_len.
-struct InputMetadata {
+pub(crate) struct InputMetadata {
     sort_fields: String,
     window_start_secs: Option<i64>,
     window_duration_secs: u32,

--- a/quickwit/quickwit-parquet-engine/src/merge/mod.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/mod.rs
@@ -95,14 +95,21 @@ pub struct MergeOutputFile {
     /// Number of rows in this output file.
     pub num_rows: usize,
 
-    /// Number of row groups the writer produced for this file. Used by
-    /// `merge_parquet_split_metadata` to decide whether the input prefix
-    /// alignment claim (`rg_partition_prefix_len`) can be propagated to
-    /// the output: a single-RG file vacuously satisfies any claim, so
-    /// we keep the inputs' prefix; a multi-RG file with arbitrary
-    /// boundaries (the only kind the current writer can produce) must
-    /// reset the claim to 0.
+    /// Number of row groups the writer produced for this file.
     pub num_row_groups: usize,
+
+    /// `qh.rg_partition_prefix_len` value the writer embedded in this
+    /// file's KV metadata. The legacy `merge/writer.rs` writer demotes
+    /// to 0 when it produces multi-RG output (its RG boundaries are
+    /// row-count-driven, not prefix-aligned). The streaming writer
+    /// (`merge/streaming/output.rs`) propagates the inputs' prefix
+    /// unchanged because it splits at prefix transitions AND
+    /// `assert_unique_rg_prefix_keys` verifies the file. Carrying the
+    /// value here lets `merge_parquet_split_metadata` (CS-1: metastore
+    /// == KV) propagate it directly to `ParquetSplitMetadata` instead
+    /// of re-deriving — preventing the metastore from disagreeing with
+    /// the on-disk KV when both engines coexist.
+    pub output_rg_partition_prefix_len: u32,
 
     /// File size in bytes.
     pub size_bytes: u64,

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
@@ -1258,8 +1258,8 @@ mod tests {
     use tokio::io::AsyncRead;
 
     use super::region_grouping::{
-        encode_byte_array_prefix, extract_rg_composite_prefix_key, find_prefix_parquet_col_indices,
-        invert_for_descending,
+        assert_unique_rg_prefix_keys, encode_byte_array_prefix, extract_rg_composite_prefix_key,
+        find_prefix_parquet_col_indices, invert_for_descending,
     };
     use super::*;
     use crate::split::TAG_SERVICE;
@@ -1768,6 +1768,17 @@ mod tests {
             outputs[0].num_row_groups, 2,
             "MergeOutputFile.num_row_groups should match physical row group count",
         );
+
+        // F2 chunk-level verification: confirm each output RG actually
+        // carries a single distinct metric_name (PA-1 + PA-3 read
+        // straight off the column-chunk statistics).
+        assert_unique_rg_prefix_keys(
+            reader.metadata(),
+            "metric_name|-timestamp_secs/V2",
+            1,
+            "test_multi_rg_metric_aligned_input_produces_multi_rg_output output",
+        )
+        .expect("streaming engine output must satisfy PA-1 + PA-3 on metric_name");
     }
 
     /// Regression for Codex P2 on PR-6410: a streaming merge output
@@ -1943,6 +1954,20 @@ mod tests {
             "three distinct (metric_name, service) pairs must produce three output RGs",
         );
         assert_eq!(outputs[0].num_row_groups, 3);
+
+        // F2 chunk-level verification: counting RGs and stamping a KV
+        // is not enough — the OUTPUT's row groups must actually be
+        // aligned on the composite (metric_name, service) prefix.
+        // `assert_unique_rg_prefix_keys` enforces PA-1 (intra-RG
+        // constancy) + PA-3 (inter-RG uniqueness) by reading the
+        // chunk-level statistics.
+        assert_unique_rg_prefix_keys(
+            reader.metadata(),
+            "metric_name|service|-timestamp_secs/V2",
+            2,
+            "test_streaming_merge_with_prefix_len_two output",
+        )
+        .expect("streaming engine output must satisfy PA-1 + PA-3 on the prefix columns");
     }
 
     /// Regression for Codex finding #1 on PR-6410: when one input
@@ -2475,6 +2500,16 @@ mod tests {
             (third_block - 1.0).abs() < 1e-9,
             "third output RG should be 'dev' (marker 1.0), got {third_block}",
         );
+
+        // F2 chunk-level verification: each output RG must be aligned
+        // on (metric_name, -env). PA-1 + PA-3 read from chunk stats.
+        assert_unique_rg_prefix_keys(
+            reader.metadata(),
+            "metric_name|-env|-timestamp_secs/V2",
+            2,
+            "test_streaming_merge_with_desc_prefix_col output",
+        )
+        .expect("DESC prefix output must satisfy PA-1 + PA-3");
     }
 
     /// Regression for the composite-key encoding when ASC and DESC
@@ -2496,7 +2531,10 @@ mod tests {
                 .expect("resolve");
         // Sanity: the second prefix column must be flagged DESC.
         assert!(
-            prefix_cols[1].descending,
+            prefix_cols[1]
+                .as_ref()
+                .expect("env present in this fixture")
+                .descending,
             "env must be parsed as DESC from sort schema",
         );
 

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
@@ -75,7 +75,7 @@ use super::{InputMetadata, MergeConfig, MergeOutputFile};
 
 mod body_assembler;
 mod output;
-mod region_grouping;
+pub(crate) mod region_grouping;
 
 use body_assembler::{BodyColOutputPageAssembler, StreamingBodyColIter};
 use output::{
@@ -1680,13 +1680,16 @@ mod tests {
              'host-b')",
         );
 
-        // Encoded representation: each byte-array column is 4-byte BE
-        // length + bytes, concatenated. So the first 4 bytes are the
-        // length of "cpu.usage" (9) in BE.
-        assert_eq!(&key_rg0[0..4], &9u32.to_be_bytes());
-        assert_eq!(&key_rg0[4..13], b"cpu.usage");
-        assert_eq!(&key_rg0[13..17], &6u32.to_be_bytes());
-        assert_eq!(&key_rg0[17..23], b"host-a");
+        // Encoded representation: each byte-array column is the raw
+        // bytes (no null bytes in these test values, so escape-pass
+        // is a no-op) followed by a `0x00 0x00` terminator,
+        // concatenated. "cpu.usage" → 9 bytes + 2-byte terminator;
+        // "host-a" → 6 bytes + 2-byte terminator. Total = 19 bytes.
+        assert_eq!(&key_rg0[0..9], b"cpu.usage");
+        assert_eq!(&key_rg0[9..11], &[0x00, 0x00]);
+        assert_eq!(&key_rg0[11..17], b"host-a");
+        assert_eq!(&key_rg0[17..19], &[0x00, 0x00]);
+        assert_eq!(key_rg0.len(), 19);
     }
 
     /// Regression for Codex P1 on PR-6410 (positive coverage of the
@@ -1726,6 +1729,46 @@ mod tests {
             "three distinct (metric_name, service) pairs must produce three output RGs",
         );
         assert_eq!(outputs[0].num_row_groups, 3);
+    }
+
+    /// Regression for Codex finding #1 on PR-6410: when one input
+    /// file has two RGs sharing the same composite prefix key, the
+    /// streaming engine must reject up-front. Without the check,
+    /// `process_region` keys `sort_col_batches` by input_idx, so the
+    /// second RG silently overwrites the first while
+    /// `Region::total_rows` keeps counting both — rows would be
+    /// dropped and the body-col / sort-col mapping would be off by a
+    /// full RG.
+    ///
+    /// The fixture passes `("cpu.usage", "host-a")` twice, producing
+    /// an input with two RGs that have identical (metric_name,
+    /// service) statistics. The merge must bail with a clear error
+    /// pointing at the duplicate.
+    #[tokio::test]
+    async fn test_streaming_merge_rejects_duplicate_prefix_rgs_in_one_input() {
+        let bytes = make_prefix_len_two_input(
+            &[
+                ("cpu.usage", "host-a"),
+                ("cpu.usage", "host-a"), // duplicate prefix key
+                ("memory.used", "host-a"),
+            ],
+            20,
+        );
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let err = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect_err("must reject input with duplicate prefix RGs");
+        let s = err.to_string();
+        assert!(
+            s.contains("sharing a prefix key with an earlier RG"),
+            "expected duplicate-prefix error, got: {s}",
+        );
+        assert!(
+            s.contains("input 0"),
+            "error should identify which input is bad, got: {s}",
+        );
     }
 
     /// Build a multi-RG fixture where each RG has a single
@@ -1815,7 +1858,7 @@ mod tests {
     /// the lex order of two byte strings, so a DESC-encoded value's
     /// lex position equals its reversed sort position. Covers the
     /// equal-length case and the variable-length case (where the
-    /// length prefix's complement does the work).
+    /// escape encoding's `0x00 0x00` terminator does the work).
     #[test]
     fn test_invert_for_descending_reverses_lex_order() {
         // Same length: per-byte order is reversed.
@@ -1829,8 +1872,10 @@ mod tests {
             "DESC encoding must reverse order: 'host-b' DESC < 'host-a' DESC",
         );
 
-        // Variable length: "ab" vs "abc". In ASC the shorter sorts
-        // first (length prefix 2 < 3); DESC must put the longer first.
+        // Variable length: "ab" vs "abc". Under escape encoding the
+        // terminator `0x00 0x00` after "ab" makes its third byte 0x00,
+        // which sorts before 'c' (0x63), so "ab" < "abc"; DESC must
+        // reverse to put the longer first.
         let ab = encode_byte_array_prefix(b"ab");
         let abc = encode_byte_array_prefix(b"abc");
         assert!(ab < abc, "ASC: 'ab' < 'abc'");
@@ -1839,6 +1884,44 @@ mod tests {
         assert!(
             abc_desc < ab_desc,
             "DESC: 'abc' DESC < 'ab' DESC (so iteration yields 'abc' before 'ab')",
+        );
+    }
+
+    /// Regression for Codex finding #2 on PR-6410: the previous
+    /// 4-byte length-prefix encoding made the encoded `"b"` (length=1)
+    /// sort BEFORE the encoded `"aa"` (length=2), violating the
+    /// declared ASC sort order on the byte-array column. Escape
+    /// encoding fixes this by emitting raw bytes with a 0x00 0x00
+    /// terminator — so `"aa"` ([0x61, 0x61, 0x00, 0x00]) correctly
+    /// sorts before `"b"` ([0x62, 0x00, 0x00]).
+    #[test]
+    fn test_byte_array_prefix_preserves_lex_order_across_lengths() {
+        let aa = encode_byte_array_prefix(b"aa");
+        let b = encode_byte_array_prefix(b"b");
+        assert!(
+            aa < b,
+            "ASC: 'aa' must encode lex-before 'b' (was broken under length-prefix encoding). got \
+             aa={aa:?} b={b:?}",
+        );
+
+        // Empty value sorts before any non-empty value sharing no prefix.
+        let empty = encode_byte_array_prefix(b"");
+        assert!(empty < aa, "ASC: '' must encode lex-before 'aa'");
+
+        // Same prefix, shorter sorts before longer (key property for
+        // composite keys with multiple variable-length columns).
+        let a = encode_byte_array_prefix(b"a");
+        let ab = encode_byte_array_prefix(b"ab");
+        assert!(a < ab, "ASC: 'a' must encode lex-before 'ab'");
+
+        // Null bytes inside the value are escaped, preserving order
+        // around the terminator.
+        let null_inside = encode_byte_array_prefix(b"\x00a");
+        let a_alone = encode_byte_array_prefix(b"a");
+        assert!(
+            null_inside < a_alone,
+            "ASC: '\\0a' (encoded as 0x00 0x01 0x61 0x00 0x00) must sort before 'a' (encoded as \
+             0x61 0x00 0x00)",
         );
     }
 

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
@@ -58,39 +58,43 @@
 
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use arrow::array::{Array, ArrayRef, RecordBatch, new_null_array};
-use arrow::compute::interleave;
-use arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef};
+use arrow::datatypes::{Field, Schema as ArrowSchema, SchemaRef};
 use parquet::file::metadata::ParquetMetaData;
 use tokio::runtime::Handle;
 use tracing::info;
-use ulid::Ulid;
 
-use super::merge_order::{MergeRun, compute_merge_order, compute_output_boundaries};
-use super::schema::{align_inputs_to_union_schema, optimize_output_batch};
-use super::writer::{
-    apply_merge_permutation, build_merge_kv_metadata, build_sorting_columns,
-    resolve_sort_field_names, verify_sort_order,
-};
+use super::merge_order::{MergeRun, compute_merge_order};
+use super::schema::align_inputs_to_union_schema;
+use super::writer::{apply_merge_permutation, verify_sort_order};
 use super::{InputMetadata, MergeConfig, MergeOutputFile};
-use crate::row_keys;
+
+mod body_assembler;
+mod output;
+mod region_grouping;
+
+use body_assembler::{BodyColOutputPageAssembler, StreamingBodyColIter};
+use output::{
+    OutputAccumulator, OutputWriterStorage, finalize_output, open_output_writer_for_streaming,
+};
+use region_grouping::{
+    Region, assign_regions_to_output_files, extract_regions_from_metadata,
+    validate_region_order_matches_physical_rg_order,
+};
+
 use crate::sort_fields::{
     equivalent_schemas_for_compaction, is_timestamp_column_name, parse_sort_fields,
 };
 use crate::sorted_series::SORTED_SERIES_COLUMN;
-use crate::split::TAG_SERVICE;
 use crate::storage::page_decoder::{DecodedPage, StreamDecoder};
-use crate::storage::split_writer::{extract_metric_names, extract_time_range};
-use crate::storage::streaming_writer::StreamingParquetWriter;
 use crate::storage::{
     ColumnPageStream, PARQUET_META_NUM_MERGE_OPS, PARQUET_META_RG_PARTITION_PREFIX_LEN,
     PARQUET_META_SORT_FIELDS, PARQUET_META_WINDOW_DURATION, PARQUET_META_WINDOW_START,
 };
-use crate::zonemap::{self, ZonemapOptions};
 
 /// Output page size in rows for body-col assembly. Each call to the
 /// sync iterator passed to [`write_next_column_arrays`] yields one
@@ -101,7 +105,7 @@ use crate::zonemap::{self, ZonemapOptions};
 /// fixed costs.
 ///
 /// [`write_next_column_arrays`]: crate::storage::streaming_writer::RowGroupBuilder::write_next_column_arrays
-const OUTPUT_PAGE_ROWS: usize = 1024;
+pub(crate) const OUTPUT_PAGE_ROWS: usize = 1024;
 
 /// Test-only peak observed length of any input's `body_col_page_cache`
 /// since the last reset. Used by the MS-7 page-bounded-memory test to
@@ -113,7 +117,7 @@ pub(crate) static PEAK_BODY_COL_PAGE_CACHE_LEN: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 #[cfg(test)]
-fn record_body_col_page_cache_len(len: usize) {
+pub(crate) fn record_body_col_page_cache_len(len: usize) {
     use std::sync::atomic::Ordering;
     let mut prev = PEAK_BODY_COL_PAGE_CACHE_LEN.load(Ordering::Relaxed);
     while len > prev {
@@ -130,7 +134,7 @@ fn record_body_col_page_cache_len(len: usize) {
 }
 
 #[cfg(not(test))]
-fn record_body_col_page_cache_len(_len: usize) {}
+pub(crate) fn record_body_col_page_cache_len(_len: usize) {}
 
 /// Streaming N-input → M-output column-major merge.
 ///
@@ -151,21 +155,27 @@ pub async fn streaming_merge_sorted_parquet_files(
         bail!("num_outputs must be at least 1");
     }
 
-    // Validate that all inputs are single-RG (or zero-RG, which means
-    // the file has no data). PR-6b.2 simplification — see module docs.
-    for (idx, stream) in inputs.iter().enumerate() {
-        let num_rgs = stream.metadata().num_row_groups();
-        if num_rgs > 1 {
-            bail!(
-                "streaming merge requires single-row-group inputs in PR-6b.2 (input {idx} has \
-                 {num_rgs} row groups); multi-RG metric-aligned inputs land in a follow-up. \
-                 Legacy multi-RG (rg_partition_prefix_len=0) inputs must go through the PR-5 \
-                 adapter, which presents them as a single synthetic row group."
-            );
+    let input_meta = extract_and_validate_input_metadata(&inputs)?;
+
+    // Reject legacy multi-RG inputs (`rg_partition_prefix_len == 0`
+    // AND any input has >1 row group). These have no alignment claim,
+    // so RG boundaries are arbitrary row counts that may split a
+    // single sort-key value across two RGs. The streaming engine
+    // cannot determine merge regions without column-chunk-bounded
+    // buffering; such inputs must go through PR-5's
+    // `LegacyMultiRGAdapter`, which presents them as one synthetic
+    // single-RG stream.
+    if input_meta.rg_partition_prefix_len == 0 {
+        for (idx, stream) in inputs.iter().enumerate() {
+            let num_rgs = stream.metadata().num_row_groups();
+            if num_rgs > 1 {
+                bail!(
+                    "legacy multi-RG inputs (rg_partition_prefix_len=0) must go through the PR-5 \
+                     adapter — input {idx} has {num_rgs} row groups with no alignment claim"
+                );
+            }
         }
     }
-
-    let input_meta = extract_and_validate_input_metadata(&inputs)?;
 
     info!(
         num_inputs = inputs.len(),
@@ -190,50 +200,110 @@ pub async fn streaming_merge_sorted_parquet_files(
         let mut inputs = inputs;
         let mut decoders_state = build_input_decoders_state(&mut inputs)?;
 
-        // Phase 0
-        let sort_col_batches =
-            drain_sort_cols_all_inputs(&handle, &mut decoders_state, &input_meta.sort_fields)?;
+        // Pre-compute regions from RG metadata. With prefix_len >= 1
+        // each region is one sort-prefix value across inputs (each
+        // contributing input has exactly one RG in that region). With
+        // prefix_len == 0 (validated single-RG above) there is one
+        // region covering all inputs.
+        let regions = extract_regions_from_metadata(&decoders_state, &input_meta)?;
 
-        if sort_col_batches.iter().all(|b| b.num_rows() == 0) {
+        if regions.is_empty() {
             info!("all inputs empty, producing no output");
             return Ok(Vec::new());
         }
 
-        // Phase 1: align inputs to a union sort-col schema so the merge-order
-        // comparator sees uniformly-typed `sorted_series` + `timestamp_secs`.
-        let (sort_union_schema, aligned_sort_batches) =
-            align_inputs_to_union_schema(&sort_col_batches, &input_meta.sort_fields)?;
-        let merge_order = compute_merge_order(&aligned_sort_batches, &input_meta.sort_fields)?;
+        // MS-2: validate that the BTreeMap-driven region order
+        // agrees with each input's physical RG order. The streaming
+        // engine reads inputs sequentially — it cannot rewind. If
+        // region K's contributing RG for input I is physically AFTER
+        // a later region L's contributing RG for the same input, the
+        // engine would crash mid-merge with "page from rg X while
+        // draining rg Y". This typically means the input was sorted
+        // in the opposite direction from what the sort schema
+        // declares (e.g., metric_name written DESC on disk but the
+        // sort schema says ASC). Reject upfront with a clear error.
+        validate_region_order_matches_physical_rg_order(&regions, decoders_state.len())?;
 
-        // Phase 2: split merge order into M outputs at sorted_series boundaries.
-        let boundaries =
-            compute_output_boundaries(&merge_order, &aligned_sort_batches, num_outputs)?;
+        let total_rows: usize = regions.iter().map(|r| r.total_rows()).sum();
+        let assignments = assign_regions_to_output_files(&regions, num_outputs);
+        let effective_num_outputs = assignments
+            .iter()
+            .max()
+            .copied()
+            .map(|m| m + 1)
+            .unwrap_or(0);
 
-        let total_rows: usize = aligned_sort_batches.iter().map(|b| b.num_rows()).sum();
         info!(
             total_rows,
-            num_outputs = boundaries.len(),
-            "streaming merge order computed"
+            num_regions = regions.len(),
+            num_outputs = effective_num_outputs,
+            "streaming merge regions computed"
         );
 
-        // Pre-compute per-input row → (output_idx, output_position) destination map.
-        // Used by every column write to slice take/interleave indices per page.
-        let destinations =
-            build_input_row_destinations(&aligned_sort_batches, &merge_order, &boundaries);
+        // Build the union schema once across all inputs' arrow schemas.
+        // Used for the output files' declared schema (PR-6b.2 also did
+        // per-output dict-encoding optimisation; we drop that here in
+        // exchange for not needing to accumulate sort cols across
+        // regions before opening writers).
+        let arrow_schemas: Vec<SchemaRef> = decoders_state
+            .iter()
+            .map(|s| Arc::clone(&s.arrow_schema))
+            .collect();
+        let union_schema =
+            build_full_union_schema_from_arrow_schemas(&arrow_schemas, &input_meta.sort_fields)?;
 
-        // Phase 3
-        let outputs = write_streaming_outputs(
-            &handle,
-            &mut decoders_state,
-            &aligned_sort_batches,
-            &sort_union_schema,
-            &merge_order,
-            &boundaries,
-            &destinations,
-            &input_meta,
-            &writer_config,
-            &output_dir,
-        )?;
+        // Per-region processing loop. We hold AT MOST ONE writer open
+        // at a time (the current output file being written). Each
+        // region produces one output RG inside the current writer; when
+        // the assignment moves to a new output file, we close the
+        // current writer (finalising the MergeOutputFile) and open a
+        // new one.
+        let mut outputs: Vec<MergeOutputFile> = Vec::new();
+        let mut current_writer: Option<OutputWriterStorage> = None;
+        let mut current_accumulator: Option<OutputAccumulator> = None;
+        let mut current_output_idx: Option<usize> = None;
+
+        for (region_idx, region) in regions.iter().enumerate() {
+            let target_output_idx = assignments[region_idx];
+
+            if current_output_idx != Some(target_output_idx) {
+                // Close the previous writer if any.
+                if let (Some(w), Some(acc)) = (current_writer.take(), current_accumulator.take()) {
+                    outputs.push(finalize_output(w, acc, &input_meta)?);
+                }
+                // Open a new writer for `target_output_idx`.
+                let writer = open_output_writer_for_streaming(
+                    target_output_idx,
+                    &output_dir,
+                    &union_schema,
+                    &input_meta,
+                    &writer_config,
+                )?;
+                current_writer = Some(writer);
+                current_accumulator = Some(OutputAccumulator::new(target_output_idx));
+                current_output_idx = Some(target_output_idx);
+            }
+
+            // Process this region into the current writer (adds one RG).
+            process_region(
+                &handle,
+                &mut decoders_state,
+                current_writer
+                    .as_mut()
+                    .expect("writer opened above for this region"),
+                current_accumulator
+                    .as_mut()
+                    .expect("accumulator opened above for this region"),
+                region,
+                &union_schema,
+                &input_meta,
+            )?;
+        }
+
+        // Close the last writer.
+        if let (Some(w), Some(acc)) = (current_writer.take(), current_accumulator.take()) {
+            outputs.push(finalize_output(w, acc, &input_meta)?);
+        }
 
         // MC-1: total row count preserved.
         let output_total: usize = outputs.iter().map(|o| o.num_rows).sum();
@@ -261,24 +331,24 @@ pub async fn streaming_merge_sorted_parquet_files(
 /// rows from more than one page). Reconstructing the decoder mid-pass
 /// would reset the per-column `rows_decoded` counter (so `row_start`
 /// becomes wrong) and discard cached dictionary / queued pages.
-struct InputDecoderState {
-    decoder: StreamDecoder<'static>,
-    metadata: Arc<ParquetMetaData>,
+pub(crate) struct InputDecoderState {
+    pub(crate) decoder: StreamDecoder<'static>,
+    pub(crate) metadata: Arc<ParquetMetaData>,
     /// Arrow schema of this input (from parquet → arrow conversion).
-    arrow_schema: SchemaRef,
+    pub(crate) arrow_schema: SchemaRef,
     /// Per-input page cache for the *currently active* body column.
     /// Pages are appended as the decoder produces them and evicted from
     /// the front once their last row is below `body_col_cursor`. The
     /// cache must persist across all outputs that consume rows from
     /// this column so that a page whose range straddles two outputs is
     /// not re-decoded (the stream has already advanced past it). At
-    /// the start of each body column [`reset_body_col_state`] clears
-    /// this cache and zeroes the cursor.
-    body_col_page_cache: Vec<DecodedPage>,
+    /// the start of each body column [`InputDecoderState::reset_body_col_state`]
+    /// clears this cache and zeroes the cursor.
+    pub(crate) body_col_page_cache: Vec<DecodedPage>,
     /// Next unconsumed input row for the active body column. Advances
     /// monotonically across outputs because the merge plan assigns each
     /// input's rows to outputs in input-row order.
-    body_col_cursor: usize,
+    pub(crate) body_col_cursor: usize,
 }
 
 impl InputDecoderState {
@@ -288,7 +358,7 @@ impl InputDecoderState {
     /// row-start arithmetic. The decoder itself is *not* reset — its
     /// per-(rg, col) `rows_decoded` counters and queued pages must
     /// survive so subsequent decode calls return correct row offsets.
-    fn reset_body_col_state(&mut self) {
+    pub(crate) fn reset_body_col_state(&mut self) {
         self.body_col_page_cache.clear();
         self.body_col_cursor = 0;
     }
@@ -457,9 +527,13 @@ fn drain_sort_cols_all_inputs(
     decoders_state: &mut [InputDecoderState],
     sort_fields_str: &str,
 ) -> Result<Vec<RecordBatch>> {
+    // Single-region path: drain RG 0 of each input. Used by the
+    // single-region streaming path (one region covering all inputs;
+    // applies when all inputs are single-RG OR `rg_partition_prefix_len
+    // == 0` with one synthetic adapter-presented RG per input).
     let mut batches = Vec::with_capacity(decoders_state.len());
     for (idx, state) in decoders_state.iter_mut().enumerate() {
-        let batch = drain_sort_cols_one_input(handle, state, sort_fields_str, idx)?;
+        let batch = drain_sort_cols_one_input(handle, state, sort_fields_str, idx, 0)?;
         if batch.num_columns() > 0 && batch.schema().index_of(SORTED_SERIES_COLUMN).is_err() {
             bail!(
                 "input {idx} is missing the '{}' column required for merge",
@@ -471,14 +545,228 @@ fn drain_sort_cols_all_inputs(
     Ok(batches)
 }
 
+/// Process one merge region: drain sort cols of contributing inputs'
+/// current RGs, compute the region's merge order, open a new output
+/// RG in the writer, write all cols (sort cols via interleave, body
+/// cols via the page-bounded assembler), close the RG, accumulate
+/// per-output static metadata.
+#[allow(clippy::too_many_arguments)]
+fn process_region(
+    handle: &Handle,
+    decoders_state: &mut [InputDecoderState],
+    writer_state: &mut OutputWriterStorage,
+    accumulator: &mut OutputAccumulator,
+    region: &Region,
+    union_schema: &SchemaRef,
+    input_meta: &InputMetadata,
+) -> Result<()> {
+    // 1. Drain sort cols of contributing inputs' RGs. The result is a Vec<RecordBatch>, indexed BY
+    //    GLOBAL INPUT INDEX (with zero-row placeholders for non-contributing inputs) so the
+    //    BodyColOutputPageAssembler can use global input indices.
+    let num_inputs = decoders_state.len();
+    let mut sort_col_batches: Vec<Option<RecordBatch>> = (0..num_inputs).map(|_| None).collect();
+    for &(input_idx, rg_idx, _num_rows) in &region.contributing {
+        let batch = drain_sort_cols_one_input(
+            handle,
+            &mut decoders_state[input_idx],
+            &input_meta.sort_fields,
+            input_idx,
+            rg_idx,
+        )?;
+        if batch.num_columns() > 0 && batch.schema().index_of(SORTED_SERIES_COLUMN).is_err() {
+            bail!(
+                "input {input_idx} rg {rg_idx} is missing the '{}' column required for merge",
+                SORTED_SERIES_COLUMN,
+            );
+        }
+        sort_col_batches[input_idx] = Some(batch);
+    }
+
+    // Materialise into a `Vec<RecordBatch>` per input. Non-contributing
+    // inputs get zero-row placeholders with the input's sort col schema
+    // so `compute_merge_order` and the body col assembler see uniform
+    // shapes.
+    let mut sort_batch_vec: Vec<RecordBatch> = Vec::with_capacity(num_inputs);
+    for (idx, slot) in sort_col_batches.into_iter().enumerate() {
+        let batch = match slot {
+            Some(b) => b,
+            None => empty_sort_col_record_batch(&decoders_state[idx], &input_meta.sort_fields)?,
+        };
+        sort_batch_vec.push(batch);
+    }
+
+    // 2. Align to union sort schema for the merge-order comparator.
+    let (sort_union_schema, aligned_sort_batches) =
+        align_inputs_to_union_schema(&sort_batch_vec, &input_meta.sort_fields)?;
+
+    // 3. Compute merge order for this region.
+    let merge_order = compute_merge_order(&aligned_sort_batches, &input_meta.sort_fields)?;
+    let region_rows: usize = merge_order.iter().map(|r| r.row_count).sum();
+    if region_rows == 0 {
+        return Ok(());
+    }
+
+    // 4. Apply the merge permutation to the sort col batches to get the region's sorted sort-col
+    //    batch. This will be appended to the output accumulator; also used to compute take indices
+    //    for the body col assembler.
+    let region_sort_batch =
+        apply_merge_permutation(&aligned_sort_batches, &sort_union_schema, &merge_order)
+            .context("applying merge permutation for region sort cols")?;
+
+    // MC-3: verify the region's output is sorted.
+    verify_sort_order(&region_sort_batch, &input_meta.sort_fields);
+
+    // 5. Build per-region destinations: maps (input_idx, input_row) → (output_idx=0,
+    //    position_in_region). The body col assembler walks this to find which (input, row)
+    //    contributes each output position.
+    let mut destinations: Vec<Vec<Option<(usize, usize)>>> = aligned_sort_batches
+        .iter()
+        .map(|b| vec![None; b.num_rows()])
+        .collect();
+    let mut pos = 0usize;
+    for run in &merge_order {
+        for r in 0..run.row_count {
+            destinations[run.input_index][run.start_row + r] = Some((0, pos));
+            pos += 1;
+        }
+    }
+    let region_destinations = InputRowDestinations {
+        per_input: destinations,
+        rows_per_output: vec![region_rows],
+    };
+
+    // 6. Open a new output RG and write all cols in union schema order.
+    let mut row_group = writer_state.writer.start_row_group().with_context(|| {
+        format!(
+            "opening row group for output {} region",
+            writer_state.output_idx,
+        )
+    })?;
+    writer_state.num_row_groups += 1;
+
+    for (col_idx, field) in union_schema.fields().iter().enumerate() {
+        let col_name = field.name();
+        if sort_union_schema.index_of(col_name).is_ok() {
+            // Sort col: take from the already-built region_sort_batch.
+            let arrays = build_sort_col_pages_from_sorted_batch(&region_sort_batch, col_name)?;
+            row_group
+                .write_next_column_arrays(arrays.into_iter())
+                .with_context(|| {
+                    format!(
+                        "writing sort col '{col_name}' (col_idx {col_idx}) to output {}",
+                        writer_state.output_idx,
+                    )
+                })?;
+        } else {
+            // Body col: stream via the page-bounded assembler. Reset
+            // each input's body-col cache + cursor before the column
+            // starts. The cursor counts row positions in the *current*
+            // region's destinations table (which is region-local), so
+            // it must restart at 0 for every (region, col) pair; the
+            // decoder itself is NOT reset because parquet's per-(rg,
+            // col) state lives in `state.decoder.columns` keyed by
+            // both indices.
+            for state in decoders_state.iter_mut() {
+                state.reset_body_col_state();
+            }
+
+            let mut input_col_indices: Vec<Option<usize>> = Vec::with_capacity(num_inputs);
+            for state in decoders_state.iter() {
+                input_col_indices.push(state.arrow_schema.index_of(col_name).ok());
+            }
+
+            let track_service = col_name == "service";
+
+            let assembler = BodyColOutputPageAssembler::new(
+                handle,
+                decoders_state,
+                &input_col_indices,
+                &region_destinations,
+                0, // out_idx is always 0 within a single-region call
+                col_name,
+                field.as_ref(),
+            );
+
+            // Feed pages one at a time into `write_next_column_arrays`
+            // via the streaming iterator: it surfaces assembly errors
+            // through `error_slot` so memory stays bounded by output-
+            // page size instead of column-chunk size.
+            let mut error_slot: Option<anyhow::Error> = None;
+            let service_collector: Option<&mut HashSet<String>> = if track_service {
+                Some(&mut accumulator.service_names)
+            } else {
+                None
+            };
+            let stream_iter = StreamingBodyColIter {
+                inner: assembler.into_iter(),
+                error_slot: &mut error_slot,
+                service_collector,
+            };
+            let write_result = row_group.write_next_column_arrays(stream_iter);
+
+            if let Some(err) = error_slot {
+                return Err(err).with_context(|| {
+                    format!(
+                        "assembling body col '{col_name}' for output {} region",
+                        writer_state.output_idx,
+                    )
+                });
+            }
+            write_result.with_context(|| {
+                format!(
+                    "writing body col '{col_name}' to output {} region",
+                    writer_state.output_idx,
+                )
+            })?;
+        }
+    }
+
+    row_group.finish().with_context(|| {
+        format!(
+            "finishing region row group for output {}",
+            writer_state.output_idx
+        )
+    })?;
+
+    // 7. Accumulate this region's contribution to the output.
+    accumulator.append_sort_batch(region_sort_batch)?;
+    accumulator.num_rows += region_rows;
+
+    Ok(())
+}
+
+/// Helper for sort col writes within a region: split the region's
+/// already-sorted sort col into page-sized chunks for
+/// `write_next_column_arrays`.
+fn build_sort_col_pages_from_sorted_batch(
+    sorted_batch: &RecordBatch,
+    col_name: &str,
+) -> Result<Vec<ArrayRef>> {
+    let col_idx = sorted_batch
+        .schema()
+        .index_of(col_name)
+        .with_context(|| format!("missing sort col '{col_name}' in region sorted batch"))?;
+    let col = sorted_batch.column(col_idx);
+    let total_rows = col.len();
+    let mut pages = Vec::with_capacity(total_rows.div_ceil(OUTPUT_PAGE_ROWS));
+    let mut start = 0;
+    while start < total_rows {
+        let len = (total_rows - start).min(OUTPUT_PAGE_ROWS);
+        pages.push(col.slice(start, len));
+        start += len;
+    }
+    Ok(pages)
+}
+
 fn drain_sort_cols_one_input(
     handle: &Handle,
     state: &mut InputDecoderState,
     sort_fields_str: &str,
     input_idx: usize,
+    expected_rg_idx: usize,
 ) -> Result<RecordBatch> {
-    if state.metadata.num_row_groups() == 0 {
-        // Empty input — no rows to drain. Return a zero-row batch with the
+    if state.metadata.num_row_groups() == 0 || expected_rg_idx >= state.metadata.num_row_groups() {
+        // No rows to drain at this RG. Return a zero-row batch with the
         // sort cols' fields preserved so downstream merge order code sees a
         // uniform schema across inputs.
         return empty_sort_col_record_batch(state, sort_fields_str);
@@ -514,16 +802,16 @@ fn drain_sort_cols_one_input(
     }
 
     // Target row count per sort col (from row group's column chunk metadata).
-    let rg_meta = state.metadata.row_group(0);
+    let rg_meta = state.metadata.row_group(expected_rg_idx);
     let mut target_rows_per_col: HashMap<usize, usize> = HashMap::new();
     for &col_idx in sort_col_parquet_indices.keys() {
         target_rows_per_col.insert(col_idx, rg_meta.column(col_idx).num_values() as usize);
     }
 
     // Drain pages into per-col buffers until all sort cols are fully
-    // decoded. The storage convention places all sort col pages
-    // before any body col page within a row group, so we should never
-    // see a non-sort page while sort cols are incomplete.
+    // decoded for this RG. With Husky storage ordering, sort col pages
+    // come before any body col page within the row group, so we should
+    // never see a non-sort page while sort cols are incomplete.
     let mut per_col_pages: HashMap<usize, Vec<ArrayRef>> = HashMap::new();
     let mut rows_done_per_col: HashMap<usize, usize> =
         sort_col_parquet_indices.keys().map(|&i| (i, 0)).collect();
@@ -533,26 +821,28 @@ fn drain_sort_cols_one_input(
     while sort_cols_finished < sort_col_target {
         let decoded = handle
             .block_on(state.decoder.decode_next_page())
-            .with_context(|| format!("decoding sort col page (input {input_idx})"))?;
+            .with_context(|| {
+                format!("decoding sort col page (input {input_idx}, rg {expected_rg_idx})")
+            })?;
         let page = match decoded {
             Some(p) => p,
             None => bail!(
-                "stream ended before sort cols fully drained for input {input_idx}: \
-                 {sort_cols_finished}/{sort_col_target} cols complete",
+                "stream ended before sort cols fully drained for input {input_idx} rg \
+                 {expected_rg_idx}: {sort_cols_finished}/{sort_col_target} cols complete",
             ),
         };
 
         if !sort_col_parquet_indices.contains_key(&page.col_idx) {
             bail!(
                 "input {input_idx} returned a non-sort page (col {}) before all sort cols were \
-                 drained — sort-cols-first storage ordering violated",
+                 drained for rg {expected_rg_idx} — this violates Husky storage ordering",
                 page.col_idx,
             );
         }
-        if page.rg_idx != 0 {
+        if page.rg_idx != expected_rg_idx {
             bail!(
-                "input {input_idx} returned a page from rg {} during sort col drain — only \
-                 single-RG inputs are supported in PR-6b.2",
+                "input {input_idx} returned a page from rg {} while draining sort cols of rg \
+                 {expected_rg_idx}",
                 page.rg_idx,
             );
         }
@@ -669,11 +959,11 @@ fn concat_arrays(arrays: &[ArrayRef]) -> Result<ArrayRef> {
 /// is not in any output (only possible for rows beyond the merge
 /// plan's coverage; shouldn't happen with our merge order).
 #[derive(Debug)]
-struct InputRowDestinations {
+pub(crate) struct InputRowDestinations {
     /// One Vec per input. Length = input's sort-col row count.
-    per_input: Vec<Vec<Option<(usize, usize)>>>,
+    pub(crate) per_input: Vec<Vec<Option<(usize, usize)>>>,
     /// Total rows per output index (cumulative writer "expected" rows).
-    rows_per_output: Vec<usize>,
+    pub(crate) rows_per_output: Vec<usize>,
 }
 
 fn build_input_row_destinations(
@@ -705,205 +995,10 @@ fn build_input_row_destinations(
 }
 
 // ============================================================================
-// Phase 3: streaming write with one writer per output
+// Obsolete PR-6b.2 multi-output-parallel helpers (deleted in PR-6c.2's
+// per-region restructure). The functions below are no longer used —
+// per-region processing in `process_region` is the new path.
 // ============================================================================
-
-/// Per-output state owned across phase 3 (writer + bookkeeping).
-/// The row group lives in a parallel Vec so its borrow into `writer`
-/// is tracked by the compiler instead of through a `'static`
-/// transmute.
-struct OutputWriterStorage {
-    output_idx: usize,
-    output_path: PathBuf,
-    writer: StreamingParquetWriter<std::fs::File>,
-    /// Service-name set built during the body col write of "service"
-    /// (or empty if no service col).
-    service_names: HashSet<String>,
-    /// Per-output total row count = sum of merge runs in this output's boundary.
-    num_rows: usize,
-}
-
-#[allow(clippy::too_many_arguments)]
-fn write_streaming_outputs(
-    handle: &Handle,
-    decoders_state: &mut [InputDecoderState],
-    aligned_sort_batches: &[RecordBatch],
-    sort_union_schema: &SchemaRef,
-    merge_order: &[MergeRun],
-    boundaries: &[Range<usize>],
-    destinations: &InputRowDestinations,
-    input_meta: &InputMetadata,
-    writer_config: &crate::storage::ParquetWriterConfig,
-    output_dir: &Path,
-) -> Result<Vec<MergeOutputFile>> {
-    // 1. Build the union schema across full input arrow schemas (so the output covers every column
-    //    that appears in any input). The sort union schema covers only sort cols.
-    let input_arrow_schemas: Vec<SchemaRef> = decoders_state
-        .iter()
-        .map(|s| Arc::clone(&s.arrow_schema))
-        .collect();
-    let (full_union_schema, _aligned_full_placeholder) =
-        build_full_union_schema_from_arrow_schemas(&input_arrow_schemas, &input_meta.sort_fields)?;
-
-    // 2. Build per-output metadata (KV entries, row keys, zonemaps) up front from sort col data —
-    //    these are what the schema + writer props depend on.
-    let per_output_static = boundaries
-        .iter()
-        .enumerate()
-        .map(|(out_idx, boundary)| {
-            build_per_output_static(
-                out_idx,
-                boundary,
-                aligned_sort_batches,
-                sort_union_schema,
-                merge_order,
-                input_meta,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    // 3. Decide per-output schema: optimise based on each output's sort col data (which determines
-    //    metric_name cardinality, etc.). Body cols stay as declared by the union schema; we don't
-    //    probe their cardinality here since we haven't read them yet. This is a slight regression
-    //    vs. the non-streaming engine — it would dict-encode low-cardinality string body cols too.
-    //    PR-6c.2 or later can revisit by gathering body-col cardinality during the streaming pass.
-    let per_output_schemas: Vec<SchemaRef> = per_output_static
-        .iter()
-        .map(|s| derive_output_schema(&full_union_schema, sort_union_schema, &s.sort_optimised))
-        .collect::<Result<Vec<_>>>()?;
-
-    // 4. Open M writers, one per output. Writers + bookkeeping live in `writer_states`; the row
-    //    group borrows mutably from each writer and is held in a parallel `row_groups` Vec for the
-    //    col loop.
-    let mut writer_states: Vec<OutputWriterStorage> = Vec::with_capacity(boundaries.len());
-    for (out_idx, (schema, static_meta)) in per_output_schemas
-        .iter()
-        .zip(per_output_static.iter())
-        .enumerate()
-    {
-        if destinations.rows_per_output[out_idx] == 0 {
-            continue;
-        }
-        writer_states.push(open_output_writer(
-            out_idx,
-            output_dir,
-            Arc::clone(schema),
-            static_meta,
-            input_meta,
-            writer_config,
-        )?);
-    }
-
-    // Snapshot the (output_idx, num_rows) for each storage entry BEFORE
-    // calling `start_row_group`, which borrows `writer_states` mutably
-    // for the rest of phase 3's col loop.
-    let writer_index_view = writer_states_index_view(&writer_states);
-    let num_storages = writer_states.len();
-
-    let mut row_groups: Vec<crate::storage::streaming_writer::RowGroupBuilder<'_, std::fs::File>> =
-        writer_states
-            .iter_mut()
-            .map(|s| {
-                s.writer
-                    .start_row_group()
-                    .with_context(|| format!("opening row group for output {}", s.output_idx))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-    // Service names are collected into a separate Vec<HashSet<String>>
-    // parallel to `row_groups`; we can't write into `writer_states` here
-    // because it is already borrowed mutably by `row_groups`. We merge
-    // these back into `writer_states` after dropping the row groups.
-    let mut service_names_per_output: Vec<HashSet<String>> =
-        (0..num_storages).map(|_| HashSet::new()).collect();
-    write_all_columns(
-        handle,
-        &mut row_groups,
-        &mut service_names_per_output,
-        &writer_index_view,
-        decoders_state,
-        aligned_sort_batches,
-        sort_union_schema,
-        &full_union_schema,
-        merge_order,
-        boundaries,
-        destinations,
-        &per_output_schemas,
-    )?;
-
-    // 6. Finish all row groups (drops the borrows on writers).
-    for rg in row_groups {
-        rg.finish().context("finishing row group")?;
-    }
-
-    // 7. Merge collected service names + close writers + build MergeOutputFiles.
-    let mut outputs = Vec::with_capacity(writer_states.len());
-    for (mut state, services) in writer_states
-        .into_iter()
-        .zip(service_names_per_output.into_iter())
-    {
-        state.service_names.extend(services);
-        outputs.push(finalize_output_writer(state, &per_output_static)?);
-    }
-    Ok(outputs)
-}
-
-/// Static per-output state computed once from sort col data. Holds
-/// the per-output sort-col-only batch (used for metadata extraction)
-/// and the per-output schema-optimisation hints.
-struct PerOutputStatic {
-    /// Sort-cols-only batch in output sort order — used by row_keys /
-    /// zonemap / metric_names / time_range extractors.
-    sort_optimised: RecordBatch,
-    row_keys_proto: Option<Vec<u8>>,
-    zonemap_regexes: HashMap<String, String>,
-    metric_names: HashSet<String>,
-    time_range: crate::split::TimeRange,
-    /// Number of rows that go into this output.
-    num_rows: usize,
-}
-
-fn build_per_output_static(
-    out_idx: usize,
-    boundary: &Range<usize>,
-    aligned_sort_batches: &[RecordBatch],
-    sort_union_schema: &SchemaRef,
-    merge_order: &[MergeRun],
-    input_meta: &InputMetadata,
-) -> Result<PerOutputStatic> {
-    let runs = &merge_order[boundary.clone()];
-    let sort_batch = apply_merge_permutation(aligned_sort_batches, sort_union_schema, runs)
-        .with_context(|| format!("applying merge permutation for output {out_idx} sort cols"))?;
-    let num_rows = sort_batch.num_rows();
-
-    // MC-3 sort order on the sort-col-only batch (same check the
-    // non-streaming engine does, just restricted to columns we have).
-    verify_sort_order(&sort_batch, &input_meta.sort_fields);
-    let sort_optimised = optimize_output_batch(&sort_batch);
-
-    let row_keys_proto = row_keys::extract_row_keys(&input_meta.sort_fields, &sort_optimised)
-        .with_context(|| format!("extracting row keys for output {out_idx}"))?
-        .map(|rk| row_keys::encode_row_keys_proto(&rk));
-
-    let zonemap_opts = ZonemapOptions::default();
-    let zonemap_regexes =
-        zonemap::extract_zonemap_regexes(&input_meta.sort_fields, &sort_optimised, &zonemap_opts)
-            .with_context(|| format!("extracting zonemap regexes for output {out_idx}"))?;
-
-    let metric_names = extract_metric_names(&sort_optimised)
-        .with_context(|| format!("extracting metric names for output {out_idx}"))?;
-    let time_range = extract_time_range(&sort_optimised)
-        .with_context(|| format!("extracting time range for output {out_idx}"))?;
-
-    Ok(PerOutputStatic {
-        sort_optimised,
-        row_keys_proto,
-        zonemap_regexes,
-        metric_names,
-        time_range,
-        num_rows,
-    })
-}
 
 /// Build the full union schema across all inputs' arrow schemas
 /// (NOT just sort cols). Reuses the same algorithm as
@@ -912,7 +1007,7 @@ fn build_per_output_static(
 fn build_full_union_schema_from_arrow_schemas(
     arrow_schemas: &[SchemaRef],
     sort_fields_str: &str,
-) -> Result<(SchemaRef, ())> {
+) -> Result<SchemaRef> {
     // Build zero-row batches with the right schemas; that lets us
     // reuse `align_inputs_to_union_schema`'s field-merge / storage-
     // ordering logic unchanged.
@@ -921,920 +1016,7 @@ fn build_full_union_schema_from_arrow_schemas(
         .map(|s| RecordBatch::new_empty(Arc::clone(s)))
         .collect();
     let (schema, _) = align_inputs_to_union_schema(&empty_batches, sort_fields_str)?;
-    Ok((schema, ()))
-}
-
-/// Compute the per-output schema. For PR-6b.2 we use the
-/// (string-normalised) union schema as the output schema directly —
-/// fields stay Utf8/LargeUtf8 rather than being re-dict-encoded.
-/// Reason: streaming-decoded input arrays come out of the page
-/// decoder as plain `StringArray`/`BinaryArray` (not Dictionary), and
-/// dict re-encoding per output page would add a per-page CPU cost we
-/// don't want to take in the page-bounded path. Re-introducing
-/// dict-encoded output strings can be done later by tracking
-/// cardinality during the streaming pass — call site is here.
-///
-/// We do still want to drop columns that are all-null *for this
-/// output* (e.g., a column only present in inputs that don't
-/// contribute any rows to this output's range). The `sort_optimised`
-/// batch has already discarded all-null sort fields; we mirror that
-/// decision when building the per-output schema. Body cols are kept
-/// unconditionally — tracking per-output body-col presence would
-/// require pre-reading every body column for every output, which is
-/// exactly the column-chunk-bounded buffering the streaming path
-/// exists to avoid.
-///
-/// `sort_union_schema` is the union of every input's sort columns
-/// (before per-output optimisation). It's the only way to tell
-/// whether a given union-schema field is a sort field or a body
-/// field — `sort_optimised.schema()` alone can't disambiguate because
-/// it has dropped some sort fields by design. Without this
-/// distinction the function falls into the trap of using
-/// `full_union_schema.index_of(field.name())`, which is trivially
-/// true for every iterated field, and the all-null drop never
-/// happens.
-fn derive_output_schema(
-    full_union_schema: &SchemaRef,
-    sort_union_schema: &SchemaRef,
-    sort_optimised: &RecordBatch,
-) -> Result<SchemaRef> {
-    let sort_optimised_schema = sort_optimised.schema();
-    let mut fields: Vec<Arc<Field>> = Vec::with_capacity(full_union_schema.fields().len());
-    for field in full_union_schema.fields() {
-        let is_sort_field = sort_union_schema.index_of(field.name()).is_ok();
-        if is_sort_field {
-            // Sort field: keep only if the per-output optimiser kept
-            // it (i.e., not all-null for this output's rows).
-            if sort_optimised_schema.index_of(field.name()).is_ok() {
-                fields.push(Arc::clone(field));
-            }
-        } else {
-            // Body field: always kept.
-            fields.push(Arc::clone(field));
-        }
-    }
-    Ok(Arc::new(ArrowSchema::new(fields)))
-}
-
-fn open_output_writer(
-    out_idx: usize,
-    output_dir: &Path,
-    schema: SchemaRef,
-    static_meta: &PerOutputStatic,
-    input_meta: &InputMetadata,
-    writer_config: &crate::storage::ParquetWriterConfig,
-) -> Result<OutputWriterStorage> {
-    let output_prefix_len = input_meta.rg_partition_prefix_len;
-    let kv_entries = build_merge_kv_metadata(
-        input_meta,
-        &static_meta.row_keys_proto,
-        &static_meta.zonemap_regexes,
-        output_prefix_len,
-    );
-    let sorting_cols = build_sorting_columns(&static_meta.sort_optimised, &input_meta.sort_fields)?;
-    let sort_field_names = resolve_sort_field_names(&input_meta.sort_fields)?;
-
-    let props = writer_config.to_writer_properties_with_metadata(
-        &schema,
-        sorting_cols,
-        Some(kv_entries),
-        &sort_field_names,
-    );
-
-    let output_filename = format!("merge_output_{}.parquet", Ulid::new());
-    let output_path = output_dir.join(&output_filename);
-    let file = std::fs::File::create(&output_path)
-        .with_context(|| format!("creating output file: {}", output_path.display()))?;
-    let writer = StreamingParquetWriter::try_new(file, Arc::clone(&schema), props)
-        .with_context(|| format!("opening streaming writer for output {out_idx}"))?;
-
-    Ok(OutputWriterStorage {
-        output_idx: out_idx,
-        output_path,
-        writer,
-        service_names: HashSet::new(),
-        num_rows: static_meta.num_rows,
-    })
-}
-
-/// Index view used inside the col loop to find the writer's
-/// `output_idx` and `num_rows` without needing a mutable borrow on
-/// `writer_states` (which is already mutably borrowed by `row_groups`).
-fn writer_states_index_view(writer_states: &[OutputWriterStorage]) -> Vec<(usize, usize)> {
-    writer_states
-        .iter()
-        .map(|s| (s.output_idx, s.num_rows))
-        .collect()
-}
-
-#[allow(clippy::too_many_arguments)]
-fn write_all_columns(
-    handle: &Handle,
-    row_groups: &mut [crate::storage::streaming_writer::RowGroupBuilder<'_, std::fs::File>],
-    service_names_per_output: &mut [HashSet<String>],
-    writer_index_view: &[(usize, usize)],
-    decoders_state: &mut [InputDecoderState],
-    aligned_sort_batches: &[RecordBatch],
-    sort_union_schema: &SchemaRef,
-    full_union_schema: &SchemaRef,
-    merge_order: &[MergeRun],
-    boundaries: &[Range<usize>],
-    destinations: &InputRowDestinations,
-    per_output_schemas: &[SchemaRef],
-) -> Result<()> {
-    // Iterate cols in the **full union schema** order. The union
-    // covers every column that appears in ANY output. For each col K
-    // and each output:
-    //   - If output's schema includes col K: write col K's data (sort col → from buffer, body col →
-    //     from decoder).
-    //   - Else: skip — that output dropped col K as all-null for its row range; the next output's
-    //     col K still gets written.
-    //
-    // It's tempting to drive from one per-output schema, since all
-    // per-output schemas share the same column ordering as a
-    // subsequence. But two outputs may drop *different* all-null
-    // fields and end up with the same field count — then picking
-    // either misses a field the other output still needs, and the
-    // writer for the latter output writes subsequent columns into
-    // the wrong slot. The full union schema is the only choice that
-    // covers every column every output may need, in the canonical
-    // storage order.
-
-    // For each full-union-schema col K:
-    for parent_col_idx in 0..full_union_schema.fields().len() {
-        let parent_field = full_union_schema.field(parent_col_idx);
-        let parent_name = parent_field.name();
-
-        // Is this a sort col (in memory) or a body col (streamed)?
-        let is_sort_col = sort_union_schema.index_of(parent_name).is_ok();
-
-        if is_sort_col {
-            write_sort_col_for_all_outputs(
-                row_groups,
-                writer_index_view,
-                parent_name,
-                aligned_sort_batches,
-                sort_union_schema,
-                merge_order,
-                boundaries,
-                destinations,
-                per_output_schemas,
-            )?;
-        } else {
-            write_body_col_for_all_outputs(
-                handle,
-                row_groups,
-                service_names_per_output,
-                writer_index_view,
-                decoders_state,
-                parent_name,
-                destinations,
-                per_output_schemas,
-            )?;
-        }
-    }
-
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-fn write_sort_col_for_all_outputs(
-    row_groups: &mut [crate::storage::streaming_writer::RowGroupBuilder<'_, std::fs::File>],
-    writer_index_view: &[(usize, usize)],
-    col_name: &str,
-    aligned_sort_batches: &[RecordBatch],
-    sort_union_schema: &SchemaRef,
-    merge_order: &[MergeRun],
-    boundaries: &[Range<usize>],
-    destinations: &InputRowDestinations,
-    per_output_schemas: &[SchemaRef],
-) -> Result<()> {
-    let _ = sort_union_schema;
-
-    let mut storage_idx = 0;
-    for (out_idx, boundary) in boundaries.iter().enumerate() {
-        if destinations.rows_per_output[out_idx] == 0 {
-            continue;
-        }
-        debug_assert_eq!(writer_index_view[storage_idx].0, out_idx);
-
-        // Drop this col if the output's schema doesn't include it.
-        let out_schema = &per_output_schemas[out_idx];
-        if out_schema.index_of(col_name).is_err() {
-            storage_idx += 1;
-            continue;
-        }
-
-        let runs = &merge_order[boundary.clone()];
-        let arrays = build_sort_col_pages_for_output(col_name, aligned_sort_batches, runs)?;
-        row_groups[storage_idx]
-            .write_next_column_arrays(arrays.into_iter())
-            .with_context(|| format!("writing sort col '{col_name}' to output {out_idx}"))?;
-        storage_idx += 1;
-    }
-    Ok(())
-}
-
-/// Build per-output-page arrays for one sort col. The col is already
-/// in memory across all inputs (`aligned_sort_batches`); for this
-/// output we walk its merge runs and split the take result into
-/// `OUTPUT_PAGE_ROWS`-sized chunks.
-fn build_sort_col_pages_for_output(
-    col_name: &str,
-    aligned_sort_batches: &[RecordBatch],
-    runs: &[MergeRun],
-) -> Result<Vec<ArrayRef>> {
-    // Collect references to each input's column array.
-    let mut input_arrays: Vec<&dyn Array> = Vec::with_capacity(aligned_sort_batches.len());
-    for batch in aligned_sort_batches {
-        let idx = batch.schema().index_of(col_name).map_err(|_| {
-            anyhow!("input is missing sort col '{col_name}' that the union schema expected",)
-        })?;
-        input_arrays.push(batch.column(idx).as_ref());
-    }
-
-    let mut indices: Vec<(usize, usize)> =
-        Vec::with_capacity(runs.iter().map(|r| r.row_count).sum());
-    for run in runs {
-        for r in 0..run.row_count {
-            indices.push((run.input_index, run.start_row + r));
-        }
-    }
-
-    // Split into OUTPUT_PAGE_ROWS-sized chunks; each chunk → one
-    // arrow::interleave call → one ArrayRef.
-    let mut pages = Vec::with_capacity(indices.len().div_ceil(OUTPUT_PAGE_ROWS));
-    for chunk in indices.chunks(OUTPUT_PAGE_ROWS) {
-        let arr = interleave(&input_arrays, chunk)
-            .with_context(|| format!("interleaving sort col '{col_name}' pages"))?;
-        pages.push(arr);
-    }
-    Ok(pages)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn write_body_col_for_all_outputs(
-    handle: &Handle,
-    row_groups: &mut [crate::storage::streaming_writer::RowGroupBuilder<'_, std::fs::File>],
-    service_names_per_output: &mut [HashSet<String>],
-    writer_index_view: &[(usize, usize)],
-    decoders_state: &mut [InputDecoderState],
-    col_name: &str,
-    destinations: &InputRowDestinations,
-    per_output_schemas: &[SchemaRef],
-) -> Result<()> {
-    // Find this col's per-input parquet leaf index (one per input).
-    // Inputs whose schema doesn't have this col OR which have zero
-    // row groups (legal — phase 0 explicitly accepts empty inputs and
-    // returns an empty sort batch for them) contribute null rows and
-    // don't advance their decoder for this col. Looking up
-    // `row_group(0)` on a zero-RG input would panic, so guard up
-    // front.
-    let mut input_col_indices: Vec<Option<usize>> = Vec::with_capacity(decoders_state.len());
-    for state in decoders_state.iter() {
-        if state.metadata.num_row_groups() == 0 {
-            input_col_indices.push(None);
-            continue;
-        }
-        match state.arrow_schema.index_of(col_name) {
-            Ok(idx) => input_col_indices.push(Some(idx)),
-            Err(_) => input_col_indices.push(None),
-        }
-    }
-
-    // Reset each input's body-col cache + cursor at the start of this
-    // column. The persistent `StreamDecoder` retains its per-(rg, col)
-    // state for *every* column it has touched so the next page from
-    // this column has the correct `row_start`; only the cached pages
-    // (which belong to the previous column) need to be discarded.
-    for state in decoders_state.iter_mut() {
-        state.reset_body_col_state();
-    }
-
-    // Track service names while streaming the service col.
-    let track_service = col_name == "service";
-
-    // For each output sequentially: build output pages, feed to writer
-    // one page at a time. We must NOT collect the whole column into a
-    // Vec — that would defeat the page-bounded merge path and scale
-    // memory with column-chunk size on production splits. Instead we
-    // hand `write_next_column_arrays` a streaming iterator that
-    // captures the first error in a side cell so the writer stops as
-    // soon as assembly fails.
-    let mut storage_idx = 0;
-    for (out_idx, &row_count) in destinations.rows_per_output.iter().enumerate() {
-        if row_count == 0 {
-            continue;
-        }
-        debug_assert_eq!(writer_index_view[storage_idx].0, out_idx);
-
-        let out_schema = &per_output_schemas[out_idx];
-        if out_schema.index_of(col_name).is_err() {
-            storage_idx += 1;
-            continue;
-        }
-        let out_field_idx = out_schema.index_of(col_name)?;
-        let out_field = out_schema.field(out_field_idx);
-
-        let assembler = BodyColOutputPageAssembler::new(
-            handle,
-            decoders_state,
-            &input_col_indices,
-            destinations,
-            out_idx,
-            col_name,
-            out_field,
-        );
-
-        let mut error_slot: Option<anyhow::Error> = None;
-        let service_collector: Option<&mut HashSet<String>> = if track_service {
-            Some(&mut service_names_per_output[storage_idx])
-        } else {
-            None
-        };
-
-        let stream_iter = StreamingBodyColIter {
-            inner: assembler.into_iter(),
-            error_slot: &mut error_slot,
-            service_collector,
-        };
-
-        let write_result = row_groups[storage_idx].write_next_column_arrays(stream_iter);
-
-        // Assembly errors are reported via `error_slot`; surface them
-        // first because a downstream write error is usually a
-        // consequence (the writer stops on `None` and reports a
-        // row-count mismatch otherwise).
-        if let Some(err) = error_slot {
-            return Err(err)
-                .with_context(|| format!("assembling body col '{col_name}' for output {out_idx}"));
-        }
-        write_result
-            .with_context(|| format!("writing body col '{col_name}' to output {out_idx}"))?;
-        storage_idx += 1;
-    }
-
-    Ok(())
-}
-
-/// Adapts a `Result<ArrayRef>` page assembler into the
-/// `Iterator<Item = ArrayRef>` shape `write_next_column_arrays` expects.
-/// The first assembly error is captured in `error_slot` and iteration
-/// ends; the caller MUST check the slot after the writer returns. If
-/// `service_collector` is `Some`, every yielded page is scanned for
-/// service names and added to the set; collection failures also stop
-/// the iterator and populate `error_slot`.
-struct StreamingBodyColIter<'a, I> {
-    inner: I,
-    error_slot: &'a mut Option<anyhow::Error>,
-    service_collector: Option<&'a mut HashSet<String>>,
-}
-
-impl<I> Iterator for StreamingBodyColIter<'_, I>
-where I: Iterator<Item = Result<ArrayRef>>
-{
-    type Item = ArrayRef;
-
-    fn next(&mut self) -> Option<ArrayRef> {
-        if self.error_slot.is_some() {
-            return None;
-        }
-        match self.inner.next() {
-            Some(Ok(arr)) => {
-                if let Some(out) = self.service_collector.as_deref_mut()
-                    && let Err(e) = collect_service_names_from_page(arr.as_ref(), out)
-                {
-                    *self.error_slot = Some(e);
-                    return None;
-                }
-                Some(arr)
-            }
-            Some(Err(e)) => {
-                *self.error_slot = Some(e);
-                None
-            }
-            None => None,
-        }
-    }
-}
-
-/// Per-page service name collector. Used during the streaming write
-/// of the "service" body col to populate per-output service_names.
-fn collect_service_names_from_page(arr: &dyn Array, out: &mut HashSet<String>) -> Result<()> {
-    use arrow::array::AsArray;
-    use arrow::datatypes::{Int8Type, Int16Type, Int32Type, Int64Type};
-
-    fn extend_from_strings(strings: &arrow::array::StringArray, out: &mut HashSet<String>) {
-        for i in 0..strings.len() {
-            if strings.is_valid(i) {
-                out.insert(strings.value(i).to_string());
-            }
-        }
-    }
-
-    match arr.data_type() {
-        DataType::Utf8 => {
-            let strings = arr
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .ok_or_else(|| anyhow!("expected StringArray for service col page"))?;
-            extend_from_strings(strings, out);
-        }
-        DataType::LargeUtf8 => {
-            let strings = arr
-                .as_any()
-                .downcast_ref::<arrow::array::LargeStringArray>()
-                .ok_or_else(|| anyhow!("expected LargeStringArray for service col page"))?;
-            for i in 0..strings.len() {
-                if strings.is_valid(i) {
-                    out.insert(strings.value(i).to_string());
-                }
-            }
-        }
-        DataType::Dictionary(key_type, value_type)
-            if matches!(value_type.as_ref(), DataType::Utf8) =>
-        {
-            // Extract the dictionary's values that are referenced by
-            // valid (non-null) keys.
-            match key_type.as_ref() {
-                DataType::Int8 => {
-                    let dict = arr.as_dictionary::<Int8Type>();
-                    if let Some(strings) = dict
-                        .values()
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        for i in 0..dict.len() {
-                            if dict.is_valid(i) {
-                                let key = dict.keys().value(i) as usize;
-                                if key < strings.len() && strings.is_valid(key) {
-                                    out.insert(strings.value(key).to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-                DataType::Int16 => {
-                    let dict = arr.as_dictionary::<Int16Type>();
-                    if let Some(strings) = dict
-                        .values()
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        for i in 0..dict.len() {
-                            if dict.is_valid(i) {
-                                let key = dict.keys().value(i) as usize;
-                                if key < strings.len() && strings.is_valid(key) {
-                                    out.insert(strings.value(key).to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-                DataType::Int32 => {
-                    let dict = arr.as_dictionary::<Int32Type>();
-                    if let Some(strings) = dict
-                        .values()
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        for i in 0..dict.len() {
-                            if dict.is_valid(i) {
-                                let key = dict.keys().value(i) as usize;
-                                if key < strings.len() && strings.is_valid(key) {
-                                    out.insert(strings.value(key).to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-                DataType::Int64 => {
-                    let dict = arr.as_dictionary::<Int64Type>();
-                    if let Some(strings) = dict
-                        .values()
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        for i in 0..dict.len() {
-                            if dict.is_valid(i) {
-                                let key = dict.keys().value(i) as usize;
-                                if key < strings.len() && strings.is_valid(key) {
-                                    out.insert(strings.value(key).to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-        _ => {
-            // Skip non-string types — service col is expected to be
-            // string-like; if it isn't, just don't collect names.
-        }
-    }
-    Ok(())
-}
-
-// ============================================================================
-// Body col output page assembler — the page-bounded streaming core
-// ============================================================================
-
-/// Assembles output pages for one (output_idx, body_col) by:
-/// 1. Walking the destinations table forward through this output's row range, accumulating
-///    `(input_idx, input_row)` index pairs.
-/// 2. When the index buffer hits `OUTPUT_PAGE_ROWS`, advancing each contributing input's decoder
-///    until its decoded pages cover the needed input rows, then calling
-///    `arrow::compute::interleave`.
-/// 3. Emitting one `ArrayRef` per iter step until the row range is exhausted; then `Ok(None)`.
-///
-/// Memory per `next()` call: one in-progress output page (P rows) +
-/// up to ~2 in-flight decoded pages per input (kept until all their
-/// rows are consumed). Bounded by page sizes, not column-chunk sizes.
-///
-/// **Cross-output state**: the per-input `body_col_page_cache` and
-/// `body_col_cursor` live on [`InputDecoderState`], not the assembler.
-/// They must persist across all outputs that consume rows from the
-/// active body column — a page whose row range straddles two outputs
-/// would otherwise be dropped when the first output's assembler ends,
-/// even though the stream has already advanced past it and the next
-/// output still needs rows from inside that page.
-struct BodyColOutputPageAssembler<'a> {
-    handle: &'a Handle,
-    decoders_state: &'a mut [InputDecoderState],
-    input_col_indices: &'a [Option<usize>],
-    destinations: &'a InputRowDestinations,
-    out_idx: usize,
-    col_name: &'a str,
-    out_field: &'a Field,
-    /// Total rows written so far for this output's col.
-    rows_emitted: usize,
-    /// Total rows expected = destinations.rows_per_output[out_idx].
-    expected_rows: usize,
-    /// EOF flag (returns None on subsequent calls once true).
-    done: bool,
-}
-
-impl<'a> BodyColOutputPageAssembler<'a> {
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        handle: &'a Handle,
-        decoders_state: &'a mut [InputDecoderState],
-        input_col_indices: &'a [Option<usize>],
-        destinations: &'a InputRowDestinations,
-        out_idx: usize,
-        col_name: &'a str,
-        out_field: &'a Field,
-    ) -> Self {
-        Self {
-            handle,
-            decoders_state,
-            input_col_indices,
-            destinations,
-            out_idx,
-            col_name,
-            out_field,
-            rows_emitted: 0,
-            expected_rows: destinations.rows_per_output[out_idx],
-            done: false,
-        }
-    }
-
-    fn into_iter(self) -> BodyColOutputPageIter<'a> {
-        BodyColOutputPageIter { inner: self }
-    }
-}
-
-struct BodyColOutputPageIter<'a> {
-    inner: BodyColOutputPageAssembler<'a>,
-}
-
-impl Iterator for BodyColOutputPageIter<'_> {
-    type Item = Result<ArrayRef>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.inner.done || self.inner.rows_emitted >= self.inner.expected_rows {
-            self.inner.done = true;
-            return None;
-        }
-        match assemble_one_output_page(&mut self.inner) {
-            Ok(Some(arr)) => Some(Ok(arr)),
-            Ok(None) => {
-                self.inner.done = true;
-                None
-            }
-            Err(e) => {
-                self.inner.done = true;
-                Some(Err(e))
-            }
-        }
-    }
-}
-
-fn assemble_one_output_page(s: &mut BodyColOutputPageAssembler) -> Result<Option<ArrayRef>> {
-    let remaining = s.expected_rows - s.rows_emitted;
-    if remaining == 0 {
-        return Ok(None);
-    }
-    let page_size = remaining.min(OUTPUT_PAGE_ROWS);
-
-    // Walk this output's row positions and figure out which (input, input_row)
-    // contributes each one. We use the per-input destinations table: for
-    // input i, find the next input_row whose destination is (out_idx, *).
-    // Since `destinations.per_input[i]` is in input order and outputs are
-    // strictly increasing by sort key, the rows that go to this output are
-    // a contiguous slice in input i's row order.
-    //
-    // For each output position 0..page_size, we need (input_idx, input_row).
-    // Walk input cursors and pick the next row going to this output.
-
-    // Collect (input_idx, input_row) indices for this output page.
-    let mut indices_per_input: Vec<Vec<usize>> = vec![Vec::new(); s.decoders_state.len()];
-    let mut interleave_indices: Vec<(usize, usize)> = Vec::with_capacity(page_size);
-    let mut total_picked = 0usize;
-
-    while total_picked < page_size {
-        // Look across all inputs for the next contribution to this output.
-        // Per the merge order, within each input the rows assigned to this
-        // output are a contiguous slice; once we've advanced cursor past
-        // them, no more rows from this input contribute. We collect ALL
-        // rows from one input up to a per-input limit determined by the
-        // merge order, but the simplest correct approach is to walk in
-        // merge-order globally. We don't have the merge order indexed by
-        // output here, so re-derive by scanning the destinations table.
-        //
-        // Better: pre-compute per-output, per-input row ranges. Each input
-        // contributes a contiguous half-open range `[lo_i..hi_i)` to this
-        // output (possibly empty). We could compute these ranges once and
-        // reuse. For now, lazy approach: scan forward from cursor on each
-        // input, picking the next row that maps to (out_idx, *).
-        //
-        // The ORDER in which we pick across inputs must match the merge
-        // plan's output position. We have output positions in destinations:
-        // `destinations.per_input[i][r] = Some((out_idx, pos))`. The merged
-        // output picks rows in order of increasing `pos`.
-        //
-        // For one output page, the positions we want are
-        // `s.rows_emitted..s.rows_emitted + page_size`. For each position
-        // p in that range, find (input_idx, input_row) such that
-        // destinations.per_input[input_idx][input_row] == Some((out_idx, p)).
-        let target_pos = s.rows_emitted + total_picked;
-        let mut found = false;
-        for (input_idx, dests) in s.destinations.per_input.iter().enumerate() {
-            let cursor = s.decoders_state[input_idx].body_col_cursor;
-            for (input_row, dest) in dests.iter().enumerate().skip(cursor) {
-                match dest {
-                    Some((o, p)) if *o == s.out_idx => {
-                        if *p == target_pos {
-                            interleave_indices.push((input_idx, input_row));
-                            indices_per_input[input_idx].push(input_row);
-                            // Don't advance the cursor past this row yet —
-                            // we may need rows from input i in this page
-                            // with positions ahead. We bump it after the
-                            // whole page is collected.
-                            found = true;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-                if found {
-                    break;
-                }
-            }
-            if found {
-                break;
-            }
-        }
-        if !found {
-            // Shouldn't happen — every output position should be reachable.
-            bail!(
-                "merge plan inconsistency: output {} position {target_pos} not found in any input",
-                s.out_idx,
-            );
-        }
-        total_picked += 1;
-    }
-
-    // Now ensure each input's decoder has decoded pages covering all
-    // `indices_per_input[i]` rows. Advance decoders as needed.
-    for (input_idx, input_rows) in indices_per_input.iter().enumerate() {
-        if input_rows.is_empty() {
-            continue;
-        }
-        let col_parquet_idx = match s.input_col_indices[input_idx] {
-            Some(c) => c,
-            None => {
-                // This input lacks this col entirely — null contributions.
-                // We'll handle null-filling in the interleave step below.
-                continue;
-            }
-        };
-        let max_needed_row = *input_rows.iter().max().expect("non-empty");
-        advance_decoder_to_row(
-            s.handle,
-            &mut s.decoders_state[input_idx],
-            col_parquet_idx,
-            max_needed_row,
-        )?;
-    }
-
-    // Build the per-(input, row) value array by:
-    //   1. Concatenating each input's cached pages into one ArrayRef (they cover a contiguous input
-    //      row range from cache_start to cursor_max).
-    //   2. Computing local indices = input_row - cache_start.
-    //   3. Calling arrow::compute::interleave across N input arrays.
-    //
-    // For inputs without this col, we substitute a single null page of the
-    // out_field's type.
-    let mut input_array_refs: Vec<ArrayRef> = Vec::with_capacity(s.decoders_state.len());
-    let mut input_cache_starts: Vec<usize> = Vec::with_capacity(s.decoders_state.len());
-
-    for input_idx in 0..s.decoders_state.len() {
-        match s.input_col_indices[input_idx] {
-            Some(_) => {
-                let pages = &s.decoders_state[input_idx].body_col_page_cache;
-                if pages.is_empty() {
-                    // No pages decoded for this input (no rows from this input go to this output).
-                    // Use a zero-row placeholder; we won't index into it.
-                    input_array_refs.push(new_null_array(s.out_field.data_type(), 0));
-                    input_cache_starts.push(0);
-                } else {
-                    let cache_start = pages[0].row_start;
-                    let arrays: Vec<&dyn Array> = pages.iter().map(|p| p.array.as_ref()).collect();
-                    let concatenated = arrow::compute::concat(&arrays).with_context(|| {
-                        format!(
-                            "concatenating cached pages for input {input_idx} col '{}'",
-                            s.col_name,
-                        )
-                    })?;
-                    input_array_refs.push(concatenated);
-                    input_cache_starts.push(cache_start);
-                }
-            }
-            None => {
-                // Null-fill array of the right length. The max needed local
-                // index from this input is the largest index we'd reference;
-                // since we don't actually reference rows from this input (we'd
-                // need an alternate "null contribution" mechanism), we leave
-                // it as a 1-row null array and route indices to position 0.
-                let null_arr = new_null_array(s.out_field.data_type(), 1);
-                input_array_refs.push(null_arr);
-                input_cache_starts.push(0);
-            }
-        }
-    }
-
-    let interleave_local: Vec<(usize, usize)> = interleave_indices
-        .iter()
-        .map(|&(i_idx, i_row)| match s.input_col_indices[i_idx] {
-            Some(_) => (i_idx, i_row - input_cache_starts[i_idx]),
-            None => (i_idx, 0),
-        })
-        .collect();
-
-    let array_refs_ref: Vec<&dyn Array> = input_array_refs.iter().map(|a| a.as_ref()).collect();
-    let assembled = interleave(&array_refs_ref, &interleave_local).with_context(|| {
-        format!(
-            "interleaving body col '{}' for output {}",
-            s.col_name, s.out_idx,
-        )
-    })?;
-
-    // Bump input cursors past rows we just consumed and drop pages
-    // whose rows are fully consumed. Both the cursor and the cache
-    // live on InputDecoderState so they persist across outputs that
-    // share this column.
-    for (input_idx, input_rows) in indices_per_input.iter().enumerate() {
-        if input_rows.is_empty() {
-            continue;
-        }
-        let max_row = *input_rows.iter().max().expect("non-empty");
-        let state = &mut s.decoders_state[input_idx];
-        state.body_col_cursor = max_row + 1;
-
-        // Drop pages whose last row is < cursor.
-        if s.input_col_indices[input_idx].is_some() {
-            let pages = &mut state.body_col_page_cache;
-            while let Some(front) = pages.first() {
-                let front_end = front.row_start + front.array.len();
-                if front_end <= state.body_col_cursor {
-                    pages.remove(0);
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-
-    s.rows_emitted += page_size;
-    Ok(Some(assembled))
-}
-
-/// Drive the input's persistent decoder forward via `block_on` until
-/// the cached pages for `col_parquet_idx` cover up through `target_row`
-/// (inclusive). Stops as soon as the latest cached page ends past
-/// `target_row`.
-///
-/// The decoder MUST be the long-lived [`InputDecoderState::decoder`]:
-/// it preserves the per-(rg, col) `rows_decoded` counter so successive
-/// `DecodedPage::row_start` values are absolute input row indices,
-/// not page-local zeros. Likewise, the cache lives on the state so
-/// pages whose row range spans an output boundary survive into the
-/// next output's assembler.
-fn advance_decoder_to_row(
-    handle: &Handle,
-    state: &mut InputDecoderState,
-    col_parquet_idx: usize,
-    target_row: usize,
-) -> Result<()> {
-    // If cache already covers target_row, nothing to do.
-    if let Some(last) = state.body_col_page_cache.last() {
-        let last_end = last.row_start + last.array.len();
-        if target_row < last_end {
-            return Ok(());
-        }
-    }
-
-    loop {
-        let decoded = handle
-            .block_on(state.decoder.decode_next_page())
-            .context("decoding body col page")?;
-        let page = match decoded {
-            Some(p) => p,
-            None => bail!(
-                "stream EOF while advancing to row {target_row} for parquet col {col_parquet_idx}",
-            ),
-        };
-        if page.col_idx != col_parquet_idx {
-            bail!(
-                "expected col {col_parquet_idx} page, got col {} — column ordering violated",
-                page.col_idx,
-            );
-        }
-        let end = page.row_start + page.array.len();
-        state.body_col_page_cache.push(page);
-        record_body_col_page_cache_len(state.body_col_page_cache.len());
-        if target_row < end {
-            return Ok(());
-        }
-    }
-}
-
-fn finalize_output_writer(
-    state: OutputWriterStorage,
-    per_output_static: &[PerOutputStatic],
-) -> Result<MergeOutputFile> {
-    let OutputWriterStorage {
-        output_idx,
-        output_path,
-        writer,
-        mut service_names,
-        num_rows,
-    } = state;
-
-    let _metadata = writer
-        .close()
-        .with_context(|| format!("closing writer for output {output_idx}"))?;
-
-    let size_bytes = std::fs::metadata(&output_path)
-        .with_context(|| format!("stat output file: {}", output_path.display()))?
-        .len();
-
-    let static_meta = &per_output_static[output_idx];
-
-    // If `service` is a sort column for this schema, it took the
-    // sort-col write path and `service_names` (populated by the body-
-    // col `track_service` branch) never saw it. Fold in the names
-    // from the per-output sort batch so the `TAG_SERVICE` low-
-    // cardinality metadata stays accurate regardless of which path
-    // wrote the column.
-    if let Ok(service_col_idx) = static_meta.sort_optimised.schema().index_of("service") {
-        collect_service_names_from_page(
-            static_meta.sort_optimised.column(service_col_idx).as_ref(),
-            &mut service_names,
-        )
-        .with_context(|| {
-            format!("collecting service names from sort col for output {output_idx}")
-        })?;
-    }
-
-    let mut low_cardinality_tags: HashMap<String, HashSet<String>> = HashMap::new();
-    if !service_names.is_empty() {
-        low_cardinality_tags.insert(TAG_SERVICE.to_string(), service_names);
-    }
-
-    Ok(MergeOutputFile {
-        path: output_path,
-        num_rows,
-        num_row_groups: 1,
-        size_bytes,
-        row_keys_proto: static_meta.row_keys_proto.clone(),
-        zonemap_regexes: static_meta.zonemap_regexes.clone(),
-        metric_names: static_meta.metric_names.clone(),
-        time_range: static_meta.time_range,
-        low_cardinality_tags,
-    })
+    Ok(schema)
 }
 
 // ============================================================================
@@ -1851,6 +1033,8 @@ mod tests {
         UInt64Array,
     };
     use arrow::datatypes::{DataType, Field, Int32Type, Schema as ArrowSchema};
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
     use bytes::Bytes;
     use parquet::arrow::ArrowWriter;
     use parquet::file::metadata::KeyValue;
@@ -1859,10 +1043,17 @@ mod tests {
     use tempfile::TempDir;
     use tokio::io::AsyncRead;
 
+    use super::region_grouping::{
+        encode_byte_array_prefix, extract_rg_composite_prefix_key, find_prefix_parquet_col_indices,
+        invert_for_descending,
+    };
     use super::*;
+    use crate::split::TAG_SERVICE;
     use crate::storage::page_decoder::StreamDecoder;
     use crate::storage::streaming_reader::{RemoteByteSource, StreamingParquetReader};
-    use crate::storage::{Compression, ParquetWriterConfig};
+    use crate::storage::{
+        Compression, PARQUET_META_ROW_KEYS, PARQUET_META_ZONEMAP_REGEXES, ParquetWriterConfig,
+    };
 
     // -------- Fixtures --------
 
@@ -2329,11 +1520,791 @@ mod tests {
         );
     }
 
-    /// Regression for Codex P1 on PR-6409: a zero-row-group input
-    /// must not panic the body-column path. Phase 0 explicitly accepts
-    /// empty inputs (returning a zero-row sort batch), so the body-col
-    /// loop has to defend against `row_group(0)` lookups on inputs
-    /// with `num_row_groups() == 0`.
+    /// Multi-RG metric-aligned input (`prefix_len >= 1`) is accepted
+    /// and produces multi-RG output: one output RG per input metric_name
+    /// region.
+    #[tokio::test]
+    async fn test_multi_rg_metric_aligned_input_produces_multi_rg_output() {
+        // Build a fixture with 2 metric_names → 2 RGs each holding one
+        // metric_name. Use `prefix_len = 1` to declare metric_name
+        // alignment.
+        let bytes = make_two_metric_aligned_input();
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect("merge multi-RG metric-aligned input");
+        assert_eq!(outputs.len(), 1, "expected one output file");
+        assert_eq!(outputs[0].num_rows, 60, "30 + 30 rows");
+
+        let out_bytes = std::fs::read(&outputs[0].path).expect("read");
+        let reader = SerializedFileReader::new(Bytes::from(out_bytes)).expect("ser");
+        assert_eq!(
+            reader.metadata().num_row_groups(),
+            2,
+            "multi-RG metric-aligned input must produce multi-RG output (one RG per metric_name \
+             region)",
+        );
+
+        // `MergeOutputFile.num_row_groups` must agree with the file
+        // on disk. Before the fix it was hard-coded to 1, so this
+        // assertion caught the regression on a multi-region output.
+        assert_eq!(
+            outputs[0].num_row_groups, 2,
+            "MergeOutputFile.num_row_groups should match physical row group count",
+        );
+    }
+
+    /// Regression for Codex P2 on PR-6410: a streaming merge output
+    /// whose multi-region content lands in a single file must report
+    /// `MergeOutputFile.num_row_groups` consistent with the parquet
+    /// footer. Two regions assigned to one output should yield
+    /// `num_row_groups = 2`.
+    #[tokio::test]
+    async fn test_streaming_output_num_row_groups_matches_footer() {
+        let bytes = make_two_metric_aligned_input();
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect("merge");
+
+        let bytes_out = std::fs::read(&outputs[0].path).expect("read");
+        let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
+        assert_eq!(
+            outputs[0].num_row_groups,
+            reader.metadata().num_row_groups(),
+            "MergeOutputFile.num_row_groups must match the physical RG count",
+        );
+    }
+
+    /// Regression for Codex P2 on PR-6410: `qh.row_keys` and
+    /// `qh.zonemap_regexes` must be written into the on-disk Parquet
+    /// footer for every streaming output. Per-output values come from
+    /// the rows that landed in that output specifically — merging
+    /// eliminates key overlap between outputs, so this metadata can't
+    /// be carried over from inputs.
+    #[tokio::test]
+    async fn test_streaming_output_kv_footer_contains_row_keys_and_zonemap() {
+        let bytes = make_two_metric_aligned_input();
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect("merge");
+
+        let bytes_out = std::fs::read(&outputs[0].path).expect("read");
+        let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
+        let kvs: Vec<(String, Option<String>)> = reader
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .map(|v| {
+                v.iter()
+                    .map(|kv| (kv.key.clone(), kv.value.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let find = |k: &str| kvs.iter().find(|(key, _)| key == k).map(|(_, v)| v.clone());
+
+        // row_keys: streaming merge derives them from THIS output's
+        // sort cols, and the in-memory `MergeOutputFile` records the
+        // proto bytes. The base64-encoded KV in the footer must
+        // round-trip to the same bytes.
+        assert!(
+            outputs[0].row_keys_proto.is_some(),
+            "expected per-output row_keys_proto in MergeOutputFile",
+        );
+        let row_keys_kv = find(PARQUET_META_ROW_KEYS).flatten().expect(
+            "qh.row_keys missing from streaming output footer — appended-after-write KV metadata \
+             did not survive close",
+        );
+        let decoded = BASE64.decode(row_keys_kv).expect("base64 decode");
+        assert_eq!(
+            &decoded,
+            outputs[0].row_keys_proto.as_ref().unwrap(),
+            "footer row_keys bytes must equal MergeOutputFile.row_keys_proto",
+        );
+
+        // zonemap_regexes: footer carries a JSON-encoded map.
+        // metric_name alignment + multiple metric_names → non-empty.
+        assert!(
+            !outputs[0].zonemap_regexes.is_empty(),
+            "expected non-empty zonemap_regexes for multi-metric output",
+        );
+        let zonemap_kv = find(PARQUET_META_ZONEMAP_REGEXES)
+            .flatten()
+            .expect("qh.zonemap_regexes missing from streaming output footer");
+        let parsed: HashMap<String, String> =
+            serde_json::from_str(&zonemap_kv).expect("zonemap JSON parse");
+        assert_eq!(
+            parsed, outputs[0].zonemap_regexes,
+            "footer zonemap must equal MergeOutputFile.zonemap_regexes",
+        );
+    }
+
+    /// Composite-key extraction with two byte-array prefix columns:
+    /// `(metric_name, service)` ASC/ASC. Two RGs with the same
+    /// metric_name but different services must produce distinct
+    /// composite keys, with byte-lex order matching the natural
+    /// `(metric_name, service)` sort order.
+    #[test]
+    fn test_extract_rg_composite_prefix_key_two_byte_array_cols() {
+        let bytes =
+            make_prefix_len_two_input(&[("cpu.usage", "host-a"), ("cpu.usage", "host-b")], 10);
+        let reader = SerializedFileReader::new(bytes).expect("ser");
+        let metadata = reader.metadata();
+        assert_eq!(metadata.num_row_groups(), 2);
+
+        let prefix_cols = find_prefix_parquet_col_indices(
+            metadata,
+            "metric_name|service|-timestamp_secs/V2",
+            2,
+            0,
+        )
+        .expect("resolve");
+        let key_rg0 = extract_rg_composite_prefix_key(metadata, 0, &prefix_cols, 0).expect("rg0");
+        let key_rg1 = extract_rg_composite_prefix_key(metadata, 1, &prefix_cols, 0).expect("rg1");
+        assert_ne!(
+            key_rg0, key_rg1,
+            "different services → different composite keys"
+        );
+        // metric_name is equal across RGs; ordering must come from
+        // service ('host-a' < 'host-b' lex), so key_rg0 < key_rg1.
+        assert!(
+            key_rg0 < key_rg1,
+            "composite key for ('cpu.usage', 'host-a') must lex-sort before ('cpu.usage', \
+             'host-b')",
+        );
+
+        // Encoded representation: each byte-array column is 4-byte BE
+        // length + bytes, concatenated. So the first 4 bytes are the
+        // length of "cpu.usage" (9) in BE.
+        assert_eq!(&key_rg0[0..4], &9u32.to_be_bytes());
+        assert_eq!(&key_rg0[4..13], b"cpu.usage");
+        assert_eq!(&key_rg0[13..17], &6u32.to_be_bytes());
+        assert_eq!(&key_rg0[17..23], b"host-a");
+    }
+
+    /// Regression for Codex P1 on PR-6410 (positive coverage of the
+    /// fix): `rg_partition_prefix_len = 2` groups RGs by the
+    /// composite (metric_name, service) value, producing one output
+    /// row group per (metric_name, service) pair. Two RGs that share
+    /// metric_name but differ in service must NOT be folded into one
+    /// region.
+    #[tokio::test]
+    async fn test_streaming_merge_with_prefix_len_two() {
+        let bytes = make_prefix_len_two_input(
+            &[
+                ("cpu.usage", "host-a"),
+                ("cpu.usage", "host-b"),
+                ("memory.used", "host-a"),
+            ],
+            20,
+        );
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect("merge with prefix_len = 2");
+        assert_eq!(outputs.len(), 1, "expected one output file");
+        assert_eq!(outputs[0].num_rows, 60, "20 × 3 input RGs = 60 rows");
+
+        let bytes_out = std::fs::read(&outputs[0].path).expect("read");
+        let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
+        // Three distinct (metric_name, service) tuples → three output
+        // row groups. With prefix_len truncated to 1 (the pre-fix
+        // bug) the two cpu.usage RGs would have folded into one
+        // region and only two output RGs would be written.
+        assert_eq!(
+            reader.metadata().num_row_groups(),
+            3,
+            "three distinct (metric_name, service) pairs must produce three output RGs",
+        );
+        assert_eq!(outputs[0].num_row_groups, 3);
+    }
+
+    /// Build a multi-RG fixture where each RG has a single
+    /// (metric_name, service) tuple. `rg_partition_prefix_len = 2`
+    /// declares the alignment.
+    fn make_prefix_len_two_input(rgs: &[(&str, &str)], rows_per_rg: usize) -> Bytes {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service", DataType::Utf8, false),
+            Field::new("timestamp_secs", DataType::UInt64, false),
+            Field::new("sorted_series", DataType::Binary, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        let make_batch = |metric: &str, service: &str, start_series: u64| -> RecordBatch {
+            let metric_name: ArrayRef = Arc::new(StringArray::from(vec![metric; rows_per_rg]));
+            let svc: ArrayRef = Arc::new(StringArray::from(vec![service; rows_per_rg]));
+            let timestamps: Vec<u64> = (0..rows_per_rg as u64).map(|i| 1_700_000_000 + i).collect();
+            let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+            let series: Vec<Vec<u8>> = (0..rows_per_rg as u64)
+                .map(|i| (start_series + i).to_be_bytes().to_vec())
+                .collect();
+            let sorted_series: ArrayRef = Arc::new(BinaryArray::from(
+                series.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
+            ));
+            let value: ArrayRef = Arc::new(Float64Array::from(
+                (0..rows_per_rg).map(|i| i as f64).collect::<Vec<_>>(),
+            ));
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![metric_name, svc, timestamp_secs, sorted_series, value],
+            )
+            .expect("batch")
+        };
+
+        let cfg = ParquetWriterConfig {
+            compression: Compression::Snappy,
+            row_group_size: rows_per_rg, // one RG per batch
+            ..ParquetWriterConfig::default()
+        };
+        let kvs = vec![
+            KeyValue::new(
+                PARQUET_META_SORT_FIELDS.to_string(),
+                "metric_name|service|-timestamp_secs/V2".to_string(),
+            ),
+            KeyValue::new(
+                PARQUET_META_WINDOW_START.to_string(),
+                "1700000000".to_string(),
+            ),
+            KeyValue::new(PARQUET_META_WINDOW_DURATION.to_string(), "60".to_string()),
+            KeyValue::new(PARQUET_META_NUM_MERGE_OPS.to_string(), "0".to_string()),
+            KeyValue::new(
+                PARQUET_META_RG_PARTITION_PREFIX_LEN.to_string(),
+                "2".to_string(),
+            ),
+        ];
+        let sorting_cols = vec![
+            parquet::file::metadata::SortingColumn {
+                column_idx: 0,
+                descending: false,
+                nulls_first: false,
+            },
+            parquet::file::metadata::SortingColumn {
+                column_idx: 1,
+                descending: false,
+                nulls_first: false,
+            },
+        ];
+        let props: WriterProperties = cfg.to_writer_properties_with_metadata(
+            &schema,
+            sorting_cols,
+            Some(kvs),
+            &["metric_name".to_string(), "service".to_string()],
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer =
+            ArrowWriter::try_new(&mut buf, schema.clone(), Some(props)).expect("arrow writer");
+        for (i, (metric, service)) in rgs.iter().enumerate() {
+            let batch = make_batch(metric, service, (i as u64) * rows_per_rg as u64);
+            writer.write(&batch).expect("write");
+        }
+        writer.close().expect("close");
+        Bytes::from(buf)
+    }
+
+    /// Unit test on `invert_for_descending`: byte-complement reverses
+    /// the lex order of two byte strings, so a DESC-encoded value's
+    /// lex position equals its reversed sort position. Covers the
+    /// equal-length case and the variable-length case (where the
+    /// length prefix's complement does the work).
+    #[test]
+    fn test_invert_for_descending_reverses_lex_order() {
+        // Same length: per-byte order is reversed.
+        let a = encode_byte_array_prefix(b"host-a");
+        let b = encode_byte_array_prefix(b"host-b");
+        assert!(a < b, "ASC encoding: 'host-a' < 'host-b'");
+        let a_desc = invert_for_descending(&a);
+        let b_desc = invert_for_descending(&b);
+        assert!(
+            b_desc < a_desc,
+            "DESC encoding must reverse order: 'host-b' DESC < 'host-a' DESC",
+        );
+
+        // Variable length: "ab" vs "abc". In ASC the shorter sorts
+        // first (length prefix 2 < 3); DESC must put the longer first.
+        let ab = encode_byte_array_prefix(b"ab");
+        let abc = encode_byte_array_prefix(b"abc");
+        assert!(ab < abc, "ASC: 'ab' < 'abc'");
+        let ab_desc = invert_for_descending(&ab);
+        let abc_desc = invert_for_descending(&abc);
+        assert!(
+            abc_desc < ab_desc,
+            "DESC: 'abc' DESC < 'ab' DESC (so iteration yields 'abc' before 'ab')",
+        );
+    }
+
+    /// End-to-end regression for DESC prefix columns. Three RGs with
+    /// the same metric_name (ASC) and distinct `env` values; sort
+    /// schema declares env DESC. The input file must itself be
+    /// DESC-sorted on env (RGs in physical order staging → prod →
+    /// dev) because the streaming engine processes each input's RGs
+    /// in physical order; the BTreeMap-driven region order is the
+    /// thing the composite key + `invert_for_descending` controls,
+    /// and it must agree with the input's physical RG order for the
+    /// engine to drain sort cols in lockstep with the body cols.
+    ///
+    /// Regions must therefore come out in DESC order on env:
+    /// staging → prod → dev. Without the `invert_for_descending`
+    /// step the BTreeMap would emit dev → prod → staging, which
+    /// would disagree with the physical RG order and the engine
+    /// would crash with "page from rg 0 while draining sort cols of
+    /// rg 2".
+    #[tokio::test]
+    async fn test_streaming_merge_with_desc_prefix_col() {
+        let bytes = make_prefix_len_two_input_with_directions(
+            // (metric, env, marker_value). Each RG's body `value`
+            // column is filled with `marker_value` so we can identify
+            // which RG produced each output row group. Order is
+            // env-DESC physical: staging, prod, dev.
+            &[
+                ("cpu.usage", "staging", 3.0),
+                ("cpu.usage", "prod", 2.0),
+                ("cpu.usage", "dev", 1.0),
+            ],
+            20,
+            /* env_descending */ true,
+        );
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect("merge with env DESC");
+        assert_eq!(outputs.len(), 1);
+
+        // Read the output and inspect the per-RG metric values: each
+        // RG should be filled with a single marker, and the RG order
+        // must be staging (3.0) → prod (2.0) → dev (1.0).
+        let bytes_out = std::fs::read(&outputs[0].path).expect("read");
+        let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
+        let meta = reader.metadata();
+        assert_eq!(
+            meta.num_row_groups(),
+            3,
+            "three distinct env values → three RGs"
+        );
+
+        let merged = read_output_to_record_batch(&outputs[0].path);
+        let value = merged
+            .column(merged.schema().index_of("value").expect("value"))
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("Float64");
+        // RG 0 spans rows 0..20, RG 1 spans 20..40, RG 2 spans 40..60.
+        // Within each RG the marker_value is constant.
+        let first_block = value.value(0);
+        let second_block = value.value(20);
+        let third_block = value.value(40);
+        assert!(
+            (first_block - 3.0).abs() < 1e-9,
+            "first output RG should be 'staging' (marker 3.0), got {first_block}",
+        );
+        assert!(
+            (second_block - 2.0).abs() < 1e-9,
+            "second output RG should be 'prod' (marker 2.0), got {second_block}",
+        );
+        assert!(
+            (third_block - 1.0).abs() < 1e-9,
+            "third output RG should be 'dev' (marker 1.0), got {third_block}",
+        );
+    }
+
+    /// Regression for the composite-key encoding when ASC and DESC
+    /// columns are interleaved. metric_name ASC + env DESC: composite
+    /// keys for ("cpu.usage", "dev") and ("cpu.usage", "prod") must
+    /// put 'prod' before 'dev' (because prod > dev in ASC lex, so
+    /// prod's DESC encoding sorts smaller).
+    #[test]
+    fn test_extract_rg_composite_prefix_key_mixed_directions() {
+        let bytes = make_prefix_len_two_input_with_directions(
+            &[("cpu.usage", "dev", 0.0), ("cpu.usage", "prod", 0.0)],
+            5,
+            /* env_descending */ true,
+        );
+        let reader = SerializedFileReader::new(Bytes::from(bytes.to_vec())).expect("ser");
+        let metadata = reader.metadata();
+        let prefix_cols =
+            find_prefix_parquet_col_indices(metadata, "metric_name|-env|-timestamp_secs/V2", 2, 0)
+                .expect("resolve");
+        // Sanity: the second prefix column must be flagged DESC.
+        assert!(
+            prefix_cols[1].descending,
+            "env must be parsed as DESC from sort schema",
+        );
+
+        let key_dev = extract_rg_composite_prefix_key(metadata, 0, &prefix_cols, 0).expect("dev");
+        let key_prod = extract_rg_composite_prefix_key(metadata, 1, &prefix_cols, 0).expect("prod");
+        // metric_name is the same; env differs. DESC on env means
+        // 'prod' (larger lex) should encode to LESS-THAN 'dev', so
+        // the BTreeMap iterates prod first.
+        assert!(
+            key_prod < key_dev,
+            "with env DESC, composite key for 'prod' must lex-sort before 'dev'",
+        );
+    }
+
+    /// MS-2: a file whose physical RG order disagrees with the
+    /// composite-key encoding's derived order must be rejected
+    /// upfront, not crash mid-merge. Construct an input that declares
+    /// env DESC but physically writes RGs in ASC env order — the
+    /// BTreeMap region iteration will visit RG 2 (env DESC = "dev",
+    /// largest in DESC encoding ... wait, no — DESC means largest
+    /// first, so env "staging" should be first ...).
+    ///
+    /// Concretely: RGs written physically as `[dev, prod, staging]`
+    /// with sort direction declared DESC. DESC iteration order is
+    /// `[staging (RG 2), prod (RG 1), dev (RG 0)]`. The first region
+    /// the engine would try to drain is RG 2, but the input stream
+    /// reaches RG 0 first. MS-2 must reject this at
+    /// `extract_regions_from_metadata` time.
+    #[tokio::test]
+    async fn test_ms2_region_order_disagrees_with_physical_rg_order_rejected() {
+        let bytes = make_prefix_len_two_input_with_directions(
+            // Physical order ASC on env: dev, prod, staging. But the
+            // sort schema below declares env DESC.
+            &[
+                ("cpu.usage", "dev", 1.0),
+                ("cpu.usage", "prod", 2.0),
+                ("cpu.usage", "staging", 3.0),
+            ],
+            10,
+            /* env_descending */ true,
+        );
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let err = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect_err("region order vs physical RG order mismatch must be rejected");
+        let s = err.to_string();
+        assert!(
+            s.contains("disagrees with input") && s.contains("physical RG order"),
+            "expected MS-2 rejection message, got: {s}",
+        );
+    }
+
+    /// Build a multi-RG fixture whose second sort col can be flagged
+    /// DESC. Sort schema written into KV metadata: either
+    /// `metric_name|env|-timestamp_secs/V2` or
+    /// `metric_name|-env|-timestamp_secs/V2`.
+    fn make_prefix_len_two_input_with_directions(
+        rgs: &[(&str, &str, f64)],
+        rows_per_rg: usize,
+        env_descending: bool,
+    ) -> Bytes {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("env", DataType::Utf8, false),
+            Field::new("timestamp_secs", DataType::UInt64, false),
+            Field::new("sorted_series", DataType::Binary, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        let make_batch = |metric: &str, env: &str, marker: f64, start_series: u64| -> RecordBatch {
+            let metric_name: ArrayRef = Arc::new(StringArray::from(vec![metric; rows_per_rg]));
+            let env_arr: ArrayRef = Arc::new(StringArray::from(vec![env; rows_per_rg]));
+            let timestamps: Vec<u64> = (0..rows_per_rg as u64)
+                // Timestamps DESC within the RG to match the DESC sort.
+                .map(|i| 1_700_000_000 + (rows_per_rg as u64 - i))
+                .collect();
+            let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+            let series: Vec<Vec<u8>> = (0..rows_per_rg as u64)
+                .map(|i| (start_series + i).to_be_bytes().to_vec())
+                .collect();
+            let sorted_series: ArrayRef = Arc::new(BinaryArray::from(
+                series.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
+            ));
+            let value: ArrayRef = Arc::new(Float64Array::from(vec![marker; rows_per_rg]));
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![metric_name, env_arr, timestamp_secs, sorted_series, value],
+            )
+            .expect("batch")
+        };
+
+        let env_token = if env_descending { "-env" } else { "env" };
+        let sort_fields = format!("metric_name|{env_token}|-timestamp_secs/V2");
+
+        let cfg = ParquetWriterConfig {
+            compression: Compression::Snappy,
+            row_group_size: rows_per_rg,
+            ..ParquetWriterConfig::default()
+        };
+        let kvs = vec![
+            KeyValue::new(PARQUET_META_SORT_FIELDS.to_string(), sort_fields),
+            KeyValue::new(
+                PARQUET_META_WINDOW_START.to_string(),
+                "1700000000".to_string(),
+            ),
+            KeyValue::new(PARQUET_META_WINDOW_DURATION.to_string(), "60".to_string()),
+            KeyValue::new(PARQUET_META_NUM_MERGE_OPS.to_string(), "0".to_string()),
+            KeyValue::new(
+                PARQUET_META_RG_PARTITION_PREFIX_LEN.to_string(),
+                "2".to_string(),
+            ),
+        ];
+        let sorting_cols = vec![
+            parquet::file::metadata::SortingColumn {
+                column_idx: 0,
+                descending: false,
+                nulls_first: false,
+            },
+            parquet::file::metadata::SortingColumn {
+                column_idx: 1,
+                descending: env_descending,
+                nulls_first: false,
+            },
+        ];
+        let props: WriterProperties = cfg.to_writer_properties_with_metadata(
+            &schema,
+            sorting_cols,
+            Some(kvs),
+            &["metric_name".to_string(), "env".to_string()],
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer =
+            ArrowWriter::try_new(&mut buf, schema.clone(), Some(props)).expect("arrow writer");
+        for (i, (metric, env, marker)) in rgs.iter().enumerate() {
+            let batch = make_batch(metric, env, *marker, (i as u64) * rows_per_rg as u64);
+            writer.write(&batch).expect("write");
+        }
+        writer.close().expect("close");
+        Bytes::from(buf)
+    }
+
+    /// `extract_aligned_prefix_value` rejects an RG whose prefix
+    /// column has `min != max` — those RGs are not actually aligned
+    /// on the prefix value and grouping them into one region would be
+    /// silently wrong.
+    #[test]
+    fn test_composite_key_rejects_non_aligned_rg() {
+        // A single RG whose `metric_name` carries two distinct values:
+        // min ("cpu.usage") != max ("memory.used"). The composite-key
+        // extractor must refuse to mint a key for this RG.
+        let bytes = make_misaligned_metric_name_input(&[("cpu.usage", "memory.used")], 20);
+        let reader = SerializedFileReader::new(bytes).expect("ser");
+        let metadata = reader.metadata();
+        let prefix_cols =
+            find_prefix_parquet_col_indices(metadata, "metric_name|-timestamp_secs/V2", 1, 0)
+                .expect("resolve");
+        let err = extract_rg_composite_prefix_key(metadata, 0, &prefix_cols, 0)
+            .expect_err("RG with min != max on prefix col must be rejected");
+        let s = err.to_string();
+        assert!(
+            s.contains("NOT prefix-aligned"),
+            "expected misalignment error, got: {s}",
+        );
+    }
+
+    /// Build a single-RG fixture whose `metric_name` column contains
+    /// two distinct values within the same RG. Used to exercise the
+    /// `min != max` rejection path in
+    /// `extract_aligned_prefix_value`.
+    fn make_misaligned_metric_name_input(names: &[(&str, &str)], rows_per_run: usize) -> Bytes {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("timestamp_secs", DataType::UInt64, false),
+            Field::new("sorted_series", DataType::Binary, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        let total = rows_per_run * 2 * names.len();
+        let mut metric_values: Vec<&str> = Vec::with_capacity(total);
+        for (a, b) in names {
+            for _ in 0..rows_per_run {
+                metric_values.push(*a);
+            }
+            for _ in 0..rows_per_run {
+                metric_values.push(*b);
+            }
+        }
+        let metric_name: ArrayRef = Arc::new(StringArray::from(metric_values));
+        let timestamps: Vec<u64> = (0..total as u64).map(|i| 1_700_000_000 + i).collect();
+        let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+        let series: Vec<Vec<u8>> = (0..total as u64)
+            .map(|i| i.to_be_bytes().to_vec())
+            .collect();
+        let sorted_series: ArrayRef = Arc::new(BinaryArray::from(
+            series.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
+        ));
+        let value: ArrayRef = Arc::new(Float64Array::from(
+            (0..total).map(|i| i as f64).collect::<Vec<_>>(),
+        ));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![metric_name, timestamp_secs, sorted_series, value],
+        )
+        .expect("batch");
+
+        let cfg = ParquetWriterConfig {
+            compression: Compression::Snappy,
+            ..ParquetWriterConfig::default()
+        };
+        let kvs = vec![
+            KeyValue::new(
+                PARQUET_META_SORT_FIELDS.to_string(),
+                "metric_name|-timestamp_secs/V2".to_string(),
+            ),
+            KeyValue::new(
+                PARQUET_META_WINDOW_START.to_string(),
+                "1700000000".to_string(),
+            ),
+            KeyValue::new(PARQUET_META_WINDOW_DURATION.to_string(), "60".to_string()),
+            KeyValue::new(PARQUET_META_NUM_MERGE_OPS.to_string(), "0".to_string()),
+            KeyValue::new(
+                PARQUET_META_RG_PARTITION_PREFIX_LEN.to_string(),
+                "1".to_string(),
+            ),
+        ];
+        let props: WriterProperties = cfg.to_writer_properties_with_metadata(
+            &schema,
+            Vec::new(),
+            Some(kvs),
+            &["metric_name".to_string(), "timestamp_secs".to_string()],
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer =
+            ArrowWriter::try_new(&mut buf, schema.clone(), Some(props)).expect("arrow writer");
+        writer.write(&batch).expect("write");
+        writer.close().expect("close");
+        Bytes::from(buf)
+    }
+
+    /// Build a parquet fixture with TWO row groups, each containing
+    /// rows of one distinct metric_name. RG 0 = "cpu.usage" × 30 rows,
+    /// RG 1 = "memory.used" × 30 rows. `rg_partition_prefix_len = 1`
+    /// declares metric_name alignment.
+    fn make_two_metric_aligned_input() -> Bytes {
+        let dict_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("metric_name", dict_type.clone(), false),
+            Field::new("timestamp_secs", DataType::UInt64, false),
+            Field::new("sorted_series", DataType::Binary, false),
+            Field::new("metric_type", DataType::UInt8, false),
+            Field::new("service", dict_type, true),
+            Field::new("timeseries_id", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        let make_batch = |metric_key: i32, start_series: u64, rows: usize| -> RecordBatch {
+            let metric_keys: Vec<i32> = vec![metric_key; rows];
+            let metric_values = StringArray::from(vec!["cpu.usage", "memory.used"]);
+            let metric_name: ArrayRef = Arc::new(
+                DictionaryArray::<Int32Type>::try_new(
+                    arrow::array::Int32Array::from(metric_keys),
+                    Arc::new(metric_values),
+                )
+                .expect("dict"),
+            );
+            let timestamps: Vec<u64> = (0..rows as u64)
+                .map(|i| 1_700_000_000 + (rows as u64 - i))
+                .collect();
+            let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+            let mut series_bytes: Vec<Vec<u8>> = Vec::with_capacity(rows);
+            for i in 0..rows as u64 {
+                series_bytes.push((start_series + i).to_be_bytes().to_vec());
+            }
+            let series_refs: Vec<&[u8]> = series_bytes.iter().map(|v| v.as_slice()).collect();
+            let sorted_series: ArrayRef = Arc::new(BinaryArray::from(series_refs));
+            let metric_type: ArrayRef = Arc::new(UInt8Array::from(vec![0u8; rows]));
+            let svc_values = StringArray::from(vec!["api", "db", "cache"]);
+            let svc_keys: Vec<Option<i32>> = (0..rows as i32)
+                .map(|i| if i % 5 == 0 { None } else { Some(i % 3) })
+                .collect();
+            let service: ArrayRef = Arc::new(
+                DictionaryArray::<Int32Type>::try_new(
+                    arrow::array::Int32Array::from(svc_keys),
+                    Arc::new(svc_values),
+                )
+                .expect("dict"),
+            );
+            let tsids: Vec<i64> = (0..rows as i64).map(|i| 1000 + i).collect();
+            let timeseries_id: ArrayRef = Arc::new(Int64Array::from(tsids));
+            let values: Vec<f64> = (0..rows).map(|i| i as f64).collect();
+            let value: ArrayRef = Arc::new(Float64Array::from(values));
+
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    metric_name,
+                    timestamp_secs,
+                    sorted_series,
+                    metric_type,
+                    service,
+                    timeseries_id,
+                    value,
+                ],
+            )
+            .expect("batch")
+        };
+
+        let batch_cpu = make_batch(0, 0, 30);
+        let batch_mem = make_batch(1, 100, 30);
+
+        let cfg = ParquetWriterConfig {
+            compression: Compression::Snappy,
+            row_group_size: 30, // one RG per metric_name
+            ..ParquetWriterConfig::default()
+        };
+        let kvs = vec![
+            KeyValue::new(
+                PARQUET_META_SORT_FIELDS.to_string(),
+                "metric_name|-timestamp_secs/V2".to_string(),
+            ),
+            KeyValue::new(
+                PARQUET_META_WINDOW_START.to_string(),
+                "1700000000".to_string(),
+            ),
+            KeyValue::new(PARQUET_META_WINDOW_DURATION.to_string(), "60".to_string()),
+            KeyValue::new(PARQUET_META_NUM_MERGE_OPS.to_string(), "0".to_string()),
+            // `prefix_len = 1` declares metric_name alignment.
+            KeyValue::new(
+                PARQUET_META_RG_PARTITION_PREFIX_LEN.to_string(),
+                "1".to_string(),
+            ),
+        ];
+        let sorting_cols = vec![
+            parquet::file::metadata::SortingColumn {
+                column_idx: 0,
+                descending: false,
+                nulls_first: false,
+            },
+            parquet::file::metadata::SortingColumn {
+                column_idx: 1,
+                descending: true,
+                nulls_first: false,
+            },
+        ];
+        let props: WriterProperties = cfg.to_writer_properties_with_metadata(
+            &schema,
+            sorting_cols,
+            Some(kvs),
+            &["metric_name".to_string(), "timestamp_secs".to_string()],
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema, Some(props)).expect("arrow writer");
+        writer.write(&batch_cpu).expect("write cpu");
+        writer.write(&batch_mem).expect("write mem");
+        writer.close().expect("close");
+        Bytes::from(buf)
+    }
+
+    /// Regression for Codex P1 on PR-6409 (the empty-input half): a
+    /// zero-row-group input mixed with a populated one must not panic
+    /// the body-column path. Phase 0 already accepts empty inputs;
+    /// PR-6c.2's per-region engine only iterates `region.contributing`
+    /// inputs for body cols, but verify directly so any future change
+    /// that broadens the iteration is caught.
     #[tokio::test]
     async fn test_zero_row_input_mixed_with_non_empty() {
         let empty = make_sorted_batch(0, 0);
@@ -2359,9 +2330,6 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .expect("Float64");
-        // All 50 values from the populated input should round-trip in
-        // input row order (timestamps descend in input row order to
-        // match the sort key).
         for i in 0..50 {
             assert!(
                 (value.value(i) - i as f64).abs() < 1e-9,
@@ -2369,66 +2337,6 @@ mod tests {
                 value.value(i),
             );
         }
-    }
-
-    /// Regression for Codex P2 on PR-6409: `derive_output_schema`
-    /// must drop sort fields that `optimize_output_batch` discarded as
-    /// all-null for a given output. Before the fix the check was
-    /// `sort_optimised.has(name) || full_union.has(name)`, where the
-    /// second disjunct is trivially true for every iterated field, so
-    /// all-null sort columns were never dropped. We exercise the
-    /// helper directly with a synthetic union + sort-optimised pair so
-    /// the regression doesn't depend on the merge plan creating an
-    /// all-null sort col (which requires a multi-input fixture with
-    /// divergent sort col presence).
-    #[test]
-    fn test_derive_output_schema_drops_all_null_sort_field() {
-        // Union covers sort fields {metric_name, env, timestamp_secs}
-        // plus body field {value}. `env` is a sort field declared in
-        // the sort union but `optimize_output_batch` dropped it from
-        // this output's `sort_optimised` (all-null for this output's
-        // rows). Body field `value` is NOT in the sort union — it
-        // must be preserved unconditionally.
-        let full_union = Arc::new(ArrowSchema::new(vec![
-            Field::new("metric_name", DataType::Utf8, false),
-            Field::new("env", DataType::Utf8, true),
-            Field::new("timestamp_secs", DataType::UInt64, false),
-            Field::new("value", DataType::Float64, false),
-        ]));
-        let sort_union = Arc::new(ArrowSchema::new(vec![
-            Field::new("metric_name", DataType::Utf8, false),
-            Field::new("env", DataType::Utf8, true),
-            Field::new("timestamp_secs", DataType::UInt64, false),
-        ]));
-        // sort_optimised has dropped `env` (all-null for this output).
-        let sort_optimised_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("metric_name", DataType::Utf8, false),
-            Field::new("timestamp_secs", DataType::UInt64, false),
-        ]));
-        let sort_optimised = RecordBatch::try_new(
-            sort_optimised_schema,
-            vec![
-                Arc::new(StringArray::from(vec!["cpu.usage"; 4])),
-                Arc::new(UInt64Array::from(vec![1u64, 2, 3, 4])),
-            ],
-        )
-        .expect("test batch");
-
-        let derived = derive_output_schema(&full_union, &sort_union, &sort_optimised).expect("ok");
-        let names: Vec<&str> = derived.fields().iter().map(|f| f.name().as_str()).collect();
-        assert_eq!(
-            names,
-            vec!["metric_name", "timestamp_secs", "value"],
-            "all-null sort field 'env' must be dropped; body field 'value' preserved",
-        );
-
-        // Direct contrast: with the pre-fix logic (every field kept)
-        // the result would have included 'env'. Asserting the negative
-        // form makes the regression unambiguous.
-        assert!(
-            derived.index_of("env").is_err(),
-            "'env' must not appear in derived output schema",
-        );
     }
 
     /// Write a fixture parquet file where each body column is forced
@@ -2551,116 +2459,10 @@ mod tests {
         }
     }
 
-    /// Regression for Codex P1 on PR-6409 (the multi-output half): when
-    /// a body column is consumed by more than one output, the per-input
-    /// page cache and decoder must outlive each output's assembler. The
-    /// stream cannot be rewound, so dropping a partially-consumed page
-    /// when output K ends would leave output K+1 unable to read rows
-    /// that physically live inside that same page.
+    /// Legacy multi-RG input (prefix_len=0, num_RGs>1) is rejected —
+    /// these must route through PR-5's `LegacyMultiRGAdapter`.
     #[tokio::test]
-    async fn test_body_col_cache_persists_across_outputs() {
-        // Two metric names so the engine splits the merge into two
-        // outputs at the metric_name boundary. Each input has 200
-        // rows of cpu.usage then 200 rows of memory.used — small
-        // 50-row pages mean some pages span the boundary.
-        let schema = make_sorted_batch(0, 0).schema();
-        let dict_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
-        let metric_values = StringArray::from(vec!["cpu.usage", "memory.used"]);
-        let keys: Vec<i32> = (0..400).map(|i| if i < 200 { 0 } else { 1 }).collect();
-        let metric_name: ArrayRef = Arc::new(
-            DictionaryArray::<Int32Type>::try_new(
-                arrow::array::Int32Array::from(keys),
-                Arc::new(metric_values),
-            )
-            .expect("dict"),
-        );
-
-        // Timestamps descend within each metric_name run so the file
-        // is sorted by (metric_name ASC, timestamp DESC) — matching
-        // the sort schema declared in write_input_parquet_with_small_pages.
-        let timestamps: Vec<u64> = (0..400)
-            .map(|i| {
-                let run_pos = if i < 200 { i } else { i - 200 };
-                1_700_000_000u64 + (199 - run_pos as u64)
-            })
-            .collect();
-        let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
-
-        let series: Vec<Vec<u8>> = (0..400u64).map(|i| i.to_be_bytes().to_vec()).collect();
-        let sorted_series: ArrayRef = Arc::new(BinaryArray::from(
-            series.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
-        ));
-
-        let metric_type: ArrayRef = Arc::new(UInt8Array::from(vec![1u8; 400]));
-        let service_keys: Vec<i32> = (0..400i32).map(|_| 0).collect();
-        let service_values = StringArray::from(vec!["svc-a"]);
-        let service: ArrayRef = Arc::new(
-            DictionaryArray::<Int32Type>::try_new(
-                arrow::array::Int32Array::from(service_keys),
-                Arc::new(service_values),
-            )
-            .expect("svc dict"),
-        );
-        let timeseries_id: ArrayRef = Arc::new(Int64Array::from((0..400i64).collect::<Vec<_>>()));
-        let value: ArrayRef = Arc::new(Float64Array::from(
-            (0..400).map(|i| i as f64 * 0.5).collect::<Vec<_>>(),
-        ));
-        // Confirm the schema we hand-build still matches make_sorted_batch's:
-        let _ = dict_type;
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                metric_name,
-                timestamp_secs,
-                sorted_series,
-                metric_type,
-                service,
-                timeseries_id,
-                value,
-            ],
-        )
-        .expect("test batch");
-
-        let bytes = write_input_parquet_with_small_pages(std::slice::from_ref(&batch), 50);
-        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
-
-        let tmp = TempDir::new().expect("tmpdir");
-        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(2))
-            .await
-            .expect("merge");
-        assert_eq!(outputs.len(), 2, "two metric names → two outputs");
-
-        let total: usize = outputs.iter().map(|o| o.num_rows).sum();
-        assert_eq!(total, 400);
-
-        // Concatenate the two outputs' value columns in output order
-        // and verify every original value is present. The merge is
-        // sort-stable, so values within each output appear in input
-        // row order (timestamps descend within each metric run).
-        let mut seen_values: HashSet<u64> = HashSet::new();
-        for out in &outputs {
-            let merged = read_output_to_record_batch(&out.path);
-            let v = merged
-                .column(merged.schema().index_of("value").expect("value col"))
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .expect("Float64");
-            for i in 0..v.len() {
-                // Encode as integer bits to dedupe; original values
-                // are i * 0.5 for i in 0..400, all distinct.
-                seen_values.insert(v.value(i).to_bits());
-            }
-        }
-        assert_eq!(
-            seen_values.len(),
-            400,
-            "every input value should round-trip through the merge across both outputs",
-        );
-    }
-
-    /// Multi-RG input is rejected (PR-6b.2 simplification).
-    #[tokio::test]
-    async fn test_multi_rg_input_rejected() {
+    async fn test_legacy_multi_rg_input_rejected() {
         // Force a 2-RG file by writing two batches with row_group_size = 1
         // small enough to trip RG rollover.
         let batch_a = make_sorted_batch(50, 0);
@@ -2701,11 +2503,11 @@ mod tests {
         let tmp = TempDir::new().expect("tmpdir");
         let err = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
             .await
-            .expect_err("multi-RG input must be rejected");
+            .expect_err("legacy multi-RG input must be rejected");
         let s = err.to_string();
         assert!(
-            s.contains("single-row-group"),
-            "expected 'single-row-group' error, got: {s}",
+            s.contains("legacy multi-RG") || s.contains("PR-5 adapter"),
+            "expected legacy multi-RG rejection, got: {s}",
         );
     }
 
@@ -3331,189 +3133,6 @@ mod tests {
     // ============================================================================
     // Heterogeneous-output regressions (Codex P2 batch on PR-6409)
     // ============================================================================
-
-    /// Regression for "Use the full union schema when driving column
-    /// writes": two outputs with the **same field count** that drop
-    /// *different* all-null sort fields. The previous
-    /// `build_parent_union_schema` heuristic picked the first such
-    /// schema and used it to drive the column loop — silently
-    /// skipping any column it dropped, even if another output still
-    /// needed it. The fix drives iteration from `full_union_schema`
-    /// directly.
-    ///
-    /// Setup: two inputs declaring an extended sort schema
-    /// `metric_name|tag_a|tag_b|-timestamp_secs/V2`. Input A has only
-    /// `tag_a` populated, input B has only `tag_b` populated. Merge
-    /// with `num_outputs=2` so each input's rows land in its own
-    /// output. After the per-output optimiser, output 0's schema
-    /// drops `tag_b` (all-null) and output 1's schema drops `tag_a`
-    /// — same field count, different dropped fields. Both outputs
-    /// must still write their kept tag column.
-    #[tokio::test]
-    async fn test_heterogeneous_dropped_fields_drive_from_full_union_schema() {
-        let dict_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
-        // Schema for input A: metric_name, tag_a (non-null), tag_b
-        // absent. Schema for input B: metric_name, tag_b (non-null),
-        // tag_a absent. The merge engine's union schema makes both
-        // tag fields nullable in the combined view.
-        let mk_schema = |with_a: bool, with_b: bool| -> SchemaRef {
-            let mut fields = vec![
-                Field::new("metric_name", dict_type.clone(), false),
-                Field::new("timestamp_secs", DataType::UInt64, false),
-                Field::new("sorted_series", DataType::Binary, false),
-            ];
-            // Body cols in lexicographic order.
-            if with_a {
-                fields.push(Field::new("tag_a", DataType::Utf8, false));
-            }
-            if with_b {
-                fields.push(Field::new("tag_b", DataType::Utf8, false));
-            }
-            fields.push(Field::new("value", DataType::Float64, false));
-            Arc::new(ArrowSchema::new(fields))
-        };
-
-        let make_batch = |metric: &str,
-                          schema: SchemaRef,
-                          tag_a_val: Option<&str>,
-                          tag_b_val: Option<&str>,
-                          row_count: usize,
-                          base_series: u64|
-         -> RecordBatch {
-            let metric_keys: Vec<i32> = vec![0; row_count];
-            let metric_values = StringArray::from(vec![metric]);
-            let metric_name: ArrayRef = Arc::new(
-                DictionaryArray::<Int32Type>::try_new(
-                    arrow::array::Int32Array::from(metric_keys),
-                    Arc::new(metric_values),
-                )
-                .expect("dict"),
-            );
-            let timestamps: Vec<u64> = (0..row_count as u64)
-                .map(|i| 1_700_000_000 + (row_count as u64 - i))
-                .collect();
-            let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
-            let series: Vec<Vec<u8>> = (0..row_count as u64)
-                .map(|i| (base_series + i).to_be_bytes().to_vec())
-                .collect();
-            let sorted_series: ArrayRef = Arc::new(BinaryArray::from(
-                series.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
-            ));
-            let value: ArrayRef = Arc::new(Float64Array::from(
-                (0..row_count).map(|i| i as f64).collect::<Vec<_>>(),
-            ));
-            let mut columns: Vec<ArrayRef> = vec![metric_name, timestamp_secs, sorted_series];
-            if let Some(v) = tag_a_val {
-                columns.push(Arc::new(StringArray::from(vec![v; row_count])) as ArrayRef);
-            }
-            if let Some(v) = tag_b_val {
-                columns.push(Arc::new(StringArray::from(vec![v; row_count])) as ArrayRef);
-            }
-            columns.push(value);
-            RecordBatch::try_new(schema, columns).expect("batch")
-        };
-
-        // Input A has tag_a populated, sort key "aaa.metric" (sorts
-        // before "zzz.metric"). Input B has tag_b populated, sort key
-        // "zzz.metric". With num_outputs=2 the merge splits at the
-        // metric boundary so each input's rows land in its own output.
-        let schema_a = mk_schema(true, false);
-        let schema_b = mk_schema(false, true);
-        let batch_a = make_batch("aaa.metric", schema_a, Some("alpha"), None, 12, 0);
-        let batch_b = make_batch("zzz.metric", schema_b, None, Some("beta"), 12, 1000);
-
-        let sort_fields_str = "metric_name|tag_a|tag_b|-timestamp_secs/V2";
-        let make_input_bytes = |batch: &RecordBatch| -> Bytes {
-            let cfg = ParquetWriterConfig {
-                compression: Compression::Snappy,
-                ..ParquetWriterConfig::default()
-            };
-            let kvs = vec![
-                KeyValue::new(
-                    PARQUET_META_SORT_FIELDS.to_string(),
-                    sort_fields_str.to_string(),
-                ),
-                KeyValue::new(
-                    PARQUET_META_WINDOW_START.to_string(),
-                    "1700000000".to_string(),
-                ),
-                KeyValue::new(PARQUET_META_WINDOW_DURATION.to_string(), "60".to_string()),
-                KeyValue::new(PARQUET_META_NUM_MERGE_OPS.to_string(), "0".to_string()),
-            ];
-            let props: WriterProperties = cfg.to_writer_properties_with_metadata(
-                &batch.schema(),
-                Vec::new(),
-                Some(kvs),
-                &[
-                    "metric_name".to_string(),
-                    "tag_a".to_string(),
-                    "tag_b".to_string(),
-                    "timestamp_secs".to_string(),
-                ],
-            );
-            let mut buf: Vec<u8> = Vec::new();
-            let mut writer =
-                ArrowWriter::try_new(&mut buf, batch.schema(), Some(props)).expect("arrow writer");
-            writer.write(batch).expect("write");
-            writer.close().expect("close");
-            Bytes::from(buf)
-        };
-        let bytes_a = make_input_bytes(&batch_a);
-        let bytes_b = make_input_bytes(&batch_b);
-
-        let inputs: Vec<Box<dyn ColumnPageStream>> =
-            vec![open_stream(bytes_a).await, open_stream(bytes_b).await];
-
-        let tmp = TempDir::new().expect("tmpdir");
-        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(2))
-            .await
-            .expect("merge with heterogeneous dropped fields");
-        assert_eq!(outputs.len(), 2, "two metric names → two outputs");
-
-        // The output whose rows came from input A must carry tag_a
-        // values; the output whose rows came from input B must carry
-        // tag_b values. Before the fix, one of them was silently
-        // missing its kept tag column because the parent driver
-        // skipped it.
-        let mut saw_alpha = false;
-        let mut saw_beta = false;
-        for out in &outputs {
-            let merged = read_output_to_record_batch(&out.path);
-            let schema = merged.schema();
-            if let Ok(tag_a_idx) = schema.index_of("tag_a") {
-                let col = merged.column(tag_a_idx);
-                for i in 0..col.len() {
-                    if col.is_valid(i) {
-                        let s = render_cell(col.as_ref(), i);
-                        if s.ends_with("alpha") {
-                            saw_alpha = true;
-                        }
-                    }
-                }
-            }
-            if let Ok(tag_b_idx) = schema.index_of("tag_b") {
-                let col = merged.column(tag_b_idx);
-                for i in 0..col.len() {
-                    if col.is_valid(i) {
-                        let s = render_cell(col.as_ref(), i);
-                        if s.ends_with("beta") {
-                            saw_beta = true;
-                        }
-                    }
-                }
-            }
-        }
-        assert!(
-            saw_alpha,
-            "expected to find tag_a='alpha' in some output — the full-union-schema-driven column \
-             loop must visit tag_a even when another output dropped it",
-        );
-        assert!(
-            saw_beta,
-            "expected to find tag_b='beta' in some output — the full-union-schema-driven column \
-             loop must visit tag_b even when another output dropped it",
-        );
-    }
 
     /// Regression for "Preserve service tags when service is a sort
     /// column". If the sort schema places `service` in the sort key

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
@@ -82,8 +82,8 @@ use output::{
     OutputAccumulator, OutputWriterStorage, finalize_output, open_output_writer_for_streaming,
 };
 use region_grouping::{
-    Region, assign_regions_to_output_files, extract_regions_from_metadata,
-    synthesize_prefix_regions, validate_region_order_matches_physical_rg_order,
+    Region, extract_regions_from_metadata, split_region_at_sorted_series,
+    validate_region_order_matches_physical_rg_order,
 };
 
 use crate::sort_fields::{
@@ -213,21 +213,6 @@ pub async fn streaming_merge_sorted_parquet_files(
             return Ok(Vec::new());
         }
 
-        // Prefix_len=0 unified path: drain sort cols across all
-        // inputs upfront, compute a global merge order, and
-        // synthesize one region per first-sort-col value. The output
-        // becomes prefix-aligned (each output RG has a constant first
-        // sort col value) and `num_outputs > 1` naturally splits at
-        // those synthesized region boundaries.
-        //
-        // The synthesized regions reference the same `(input_idx,
-        // rg_idx=0)` with disjoint row ranges. `process_region`
-        // slices the prefetched sort batches for each region and the
-        // body col assembler advances monotonically across regions
-        // sharing the same RG.
-        let (regions, prefetched_sort_batches, synthesized_prefix_len) =
-            maybe_synthesize_prefix_regions(&handle, &mut decoders_state, &input_meta, regions)?;
-
         // MS-2: validate that the BTreeMap-driven region order
         // agrees with each input's physical RG order. The streaming
         // engine reads inputs sequentially — it cannot rewind. If
@@ -240,102 +225,144 @@ pub async fn streaming_merge_sorted_parquet_files(
         // sort schema says ASC). Reject upfront with a clear error.
         validate_region_order_matches_physical_rg_order(&regions, decoders_state.len())?;
 
-        // Build an effective `InputMetadata` that reflects the
-        // synthesized prefix alignment (if any). The output writer
-        // reads `rg_partition_prefix_len` to populate the
-        // `qh.rg_partition_prefix_len` KV; bumping it here means
-        // future compactions can take the streaming fast path on the
-        // output we just produced.
-        let effective_input_meta = if let Some(prefix_len) = synthesized_prefix_len {
-            let mut m = input_meta.clone();
-            m.rg_partition_prefix_len = prefix_len;
-            m
-        } else {
-            input_meta.clone()
-        };
-
         let total_rows: usize = regions.iter().map(|r| r.total_rows()).sum();
-        let assignments = assign_regions_to_output_files(&regions, num_outputs);
-        let effective_num_outputs = assignments
-            .iter()
-            .max()
-            .copied()
-            .map(|m| m + 1)
-            .unwrap_or(0);
+        let target_per_output = (total_rows.div_ceil(num_outputs)).max(1);
 
         info!(
             total_rows,
             num_regions = regions.len(),
-            num_outputs = effective_num_outputs,
+            num_outputs,
             "streaming merge regions computed"
         );
 
         // Build the union schema once across all inputs' arrow schemas.
-        // Used for the output files' declared schema (PR-6b.2 also did
-        // per-output dict-encoding optimisation; we drop that here in
-        // exchange for not needing to accumulate sort cols across
-        // regions before opening writers).
         let arrow_schemas: Vec<SchemaRef> = decoders_state
             .iter()
             .map(|s| Arc::clone(&s.arrow_schema))
             .collect();
-        let union_schema = build_full_union_schema_from_arrow_schemas(
-            &arrow_schemas,
-            &effective_input_meta.sort_fields,
-        )?;
+        let union_schema =
+            build_full_union_schema_from_arrow_schemas(&arrow_schemas, &input_meta.sort_fields)?;
 
-        // Per-region processing loop. We hold AT MOST ONE writer open
-        // at a time (the current output file being written). Each
-        // region produces one output RG inside the current writer; when
-        // the assignment moves to a new output file, we close the
-        // current writer (finalising the MergeOutputFile) and open a
-        // new one.
+        // Region processing loop. For each top-level region we may
+        // need to subdivide it across multiple output files so we
+        // honor `num_outputs` even when the input layout doesn't
+        // give us enough region boundaries (e.g., one giant
+        // `metric_name` with prefix_len=0). Splitting happens at
+        // `sorted_series` transitions inside the region's merge
+        // order — never inside a single sorted_series run.
+        //
+        // Memory: between top-level regions we reset every input's
+        // per-col page cache + cursor, because pages from one RG
+        // would have row_start values that collide with the next
+        // RG's row-index space. Sub-regions of one top-level region
+        // share an RG, so the cache survives across sub-region
+        // boundaries — that's what lets the col write loop re-read
+        // an earlier col's pages for a later sub-region.
         let mut outputs: Vec<MergeOutputFile> = Vec::new();
         let mut current_writer: Option<OutputWriterStorage> = None;
         let mut current_accumulator: Option<OutputAccumulator> = None;
-        let mut current_output_idx: Option<usize> = None;
+        let mut current_output_idx: usize = 0;
+        let mut current_output_rows: usize = 0;
 
         for (region_idx, region) in regions.iter().enumerate() {
-            let target_output_idx = assignments[region_idx];
-
-            if current_output_idx != Some(target_output_idx) {
-                // Close the previous writer if any.
-                if let (Some(w), Some(acc)) = (current_writer.take(), current_accumulator.take()) {
-                    outputs.push(finalize_output(w, acc, &effective_input_meta)?);
+            if region_idx > 0 {
+                for state in decoders_state.iter_mut() {
+                    state.reset_all_body_col_state();
                 }
-                // Open a new writer for `target_output_idx`.
-                let writer = open_output_writer_for_streaming(
-                    target_output_idx,
-                    &output_dir,
-                    &union_schema,
-                    &effective_input_meta,
-                    &writer_config,
-                )?;
-                current_writer = Some(writer);
-                current_accumulator = Some(OutputAccumulator::new(target_output_idx));
-                current_output_idx = Some(target_output_idx);
             }
 
-            // Process this region into the current writer (adds one RG).
-            process_region(
-                &handle,
-                &mut decoders_state,
-                current_writer
-                    .as_mut()
-                    .expect("writer opened above for this region"),
-                current_accumulator
-                    .as_mut()
-                    .expect("accumulator opened above for this region"),
-                region,
-                &union_schema,
-                &effective_input_meta,
-                prefetched_sort_batches.as_deref(),
-            )?;
+            // Decide whether we need to split this region across
+            // multiple outputs. Two conditions must both hold: the
+            // region's rows would push the current output past the
+            // target AND there is an unused output to advance to.
+            // When splitting kicks in we have to pre-drain this
+            // region's sort cols so we can compute the merge order
+            // and find sorted_series transitions; if no split is
+            // needed we let `process_region` drain internally to
+            // preserve the existing per-region memory bound.
+            let outputs_remaining = num_outputs - current_output_idx;
+            let remaining_in_current = target_per_output.saturating_sub(current_output_rows);
+            let needs_split = outputs_remaining > 1 && region.total_rows() > remaining_in_current;
+
+            let prefetched: Option<Vec<RecordBatch>> = if needs_split {
+                Some(drain_and_align_region(
+                    &handle,
+                    &mut decoders_state,
+                    region,
+                    &input_meta.sort_fields,
+                )?)
+            } else {
+                None
+            };
+
+            let sub_regions: Vec<Region> = if let Some(ref prefetched_batches) = prefetched {
+                let merge_order = compute_merge_order(prefetched_batches, &input_meta.sort_fields)?;
+                split_region_at_sorted_series(
+                    region,
+                    &merge_order,
+                    prefetched_batches,
+                    remaining_in_current,
+                    target_per_output,
+                    outputs_remaining,
+                )?
+            } else {
+                vec![region.clone()]
+            };
+
+            for sub_region in &sub_regions {
+                let sub_rows = sub_region.total_rows();
+
+                // Advance to the next output file BEFORE this sub-
+                // region if the current output already met the
+                // target and we still have outputs to fill. The
+                // very first sub-region is exempt so we don't open
+                // an empty writer.
+                if current_writer.is_some()
+                    && current_output_rows >= target_per_output
+                    && current_output_idx + 1 < num_outputs
+                {
+                    if let (Some(w), Some(acc)) =
+                        (current_writer.take(), current_accumulator.take())
+                    {
+                        outputs.push(finalize_output(w, acc, &input_meta)?);
+                    }
+                    current_output_idx += 1;
+                    current_output_rows = 0;
+                }
+
+                if current_writer.is_none() {
+                    let writer = open_output_writer_for_streaming(
+                        current_output_idx,
+                        &output_dir,
+                        &union_schema,
+                        &input_meta,
+                        &writer_config,
+                    )?;
+                    current_writer = Some(writer);
+                    current_accumulator = Some(OutputAccumulator::new(current_output_idx));
+                }
+
+                process_region(
+                    &handle,
+                    &mut decoders_state,
+                    current_writer
+                        .as_mut()
+                        .expect("writer opened above for this sub-region"),
+                    current_accumulator
+                        .as_mut()
+                        .expect("accumulator opened above for this sub-region"),
+                    sub_region,
+                    &union_schema,
+                    &input_meta,
+                    prefetched.as_deref(),
+                )?;
+                current_output_rows += sub_rows;
+            }
         }
 
         // Close the last writer.
         if let (Some(w), Some(acc)) = (current_writer.take(), current_accumulator.take()) {
-            outputs.push(finalize_output(w, acc, &effective_input_meta)?);
+            outputs.push(finalize_output(w, acc, &input_meta)?);
         }
 
         // MC-1: total row count preserved.
@@ -436,6 +463,20 @@ impl InputDecoderState {
     /// length probe in tests.
     pub(crate) fn body_col_caches_total_len(&self) -> usize {
         self.body_col_page_caches.values().map(|v| v.len()).sum()
+    }
+
+    /// Clear every per-col page cache and every per-col cursor.
+    /// Called between top-level regions: each region typically uses a
+    /// different input RG, and the per-col page `row_start` values
+    /// reported by the decoder are RG-local, so pages cached for RG K
+    /// would conflict with RG K+1's row-index space. Sub-regions of a
+    /// single top-level region share an RG and MUST NOT trigger this
+    /// reset — they rely on the cache surviving from one sub-region
+    /// to the next so an earlier-col read whose stream-tail spans
+    /// later sub-regions stays available.
+    pub(crate) fn reset_all_body_col_state(&mut self) {
+        self.body_col_page_caches.clear();
+        self.body_col_cursors.clear();
     }
 }
 
@@ -588,83 +629,57 @@ fn extract_and_validate_input_metadata(
     })
 }
 
-/// Return value of [`maybe_synthesize_prefix_regions`]: the (possibly
-/// synthesized) region list, the prefetched & union-aligned sort
-/// batches the synthesis produced (`None` on the pass-through path),
-/// and the effective output `rg_partition_prefix_len` to advertise on
-/// the produced parquet files (also `None` on pass-through).
-type SynthesizedRegionsOutput = (Vec<Region>, Option<Vec<RecordBatch>>, Option<u32>);
-
-/// For the prefix_len=0 path, drain each input's sort cols, run the
-/// k-way merge across them, and synthesize one region per first-sort-
-/// col value. Returns the new region list, the per-input pre-drained
-/// (aligned) sort batches, and the output's effective
-/// `rg_partition_prefix_len`. For the prefix_len>0 path this is a
-/// passthrough (returns the input regions and no prefetch).
+/// Drain a region's contributing inputs' sort cols and align them to
+/// the union sort schema. The result has one entry per global input
+/// index (zero-row placeholders for non-contributing inputs), which
+/// is what `split_region_at_sorted_series` and `process_region` both
+/// expect.
 ///
-/// Wrapping the synthesis here keeps `streaming_merge_sorted_parquet_files`
-/// clean: a single call site picks the right path based on input
-/// metadata, and `process_region` accepts the prefetched sort batches
-/// uniformly.
-fn maybe_synthesize_prefix_regions(
+/// Used by the main loop when a region needs to be sub-divided
+/// across multiple output files — splitting needs the merge order,
+/// which needs the drained sort cols. For regions that fit in a
+/// single output we skip this and let `process_region` drain
+/// internally so the per-region memory cost stays bounded by what
+/// the writer actively consumes.
+fn drain_and_align_region(
     handle: &Handle,
     decoders_state: &mut [InputDecoderState],
-    input_meta: &InputMetadata,
-    regions: Vec<Region>,
-) -> Result<SynthesizedRegionsOutput> {
-    if input_meta.rg_partition_prefix_len != 0 {
-        return Ok((regions, None, None));
+    region: &Region,
+    sort_fields_str: &str,
+) -> Result<Vec<RecordBatch>> {
+    let num_inputs = decoders_state.len();
+    let mut sort_col_batches: Vec<Option<RecordBatch>> = (0..num_inputs).map(|_| None).collect();
+    for c in &region.contributing {
+        let batch = drain_sort_cols_one_input(
+            handle,
+            &mut decoders_state[c.input_idx],
+            sort_fields_str,
+            c.input_idx,
+            c.rg_idx,
+        )?;
+        if batch.num_columns() > 0 && batch.schema().index_of(SORTED_SERIES_COLUMN).is_err() {
+            bail!(
+                "input {} rg {} is missing the '{}' column required for merge",
+                c.input_idx,
+                c.rg_idx,
+                SORTED_SERIES_COLUMN,
+            );
+        }
+        sort_col_batches[c.input_idx] = Some(batch);
     }
 
-    let sort_field_schema = parse_sort_fields(&input_meta.sort_fields)?;
-    let Some(first_sort_field) = sort_field_schema.column.first() else {
-        // No sort columns declared → nothing to synthesize on. Fall
-        // back to the single-region pass-through.
-        return Ok((regions, None, None));
-    };
-    let first_sort_col_name = first_sort_field.name.clone();
+    let mut sort_batch_vec: Vec<RecordBatch> = Vec::with_capacity(num_inputs);
+    for (idx, slot) in sort_col_batches.into_iter().enumerate() {
+        let batch = match slot {
+            Some(b) => b,
+            None => empty_sort_col_record_batch(&decoders_state[idx], sort_fields_str)?,
+        };
+        sort_batch_vec.push(batch);
+    }
 
-    // Drain all inputs' sort cols (one RG each — prefix_len=0 inputs
-    // are validated to be single-RG upstream).
-    let sort_batches = drain_sort_cols_all_inputs(handle, decoders_state, &input_meta.sort_fields)?;
     let (_sort_union_schema, aligned_sort_batches) =
-        align_inputs_to_union_schema(&sort_batches, &input_meta.sort_fields)?;
-
-    // Compute the global merge order — runs are contiguous, single-
-    // input slices each with constant sorted_series (and therefore
-    // constant first sort col).
-    let global_merge_order = compute_merge_order(&aligned_sort_batches, &input_meta.sort_fields)?;
-
-    // Resolve the column name in the aligned sort batches (handles the
-    // `timestamp` / `timestamp_secs` alias the rest of the engine uses).
-    let resolved_first_sort_col = if is_timestamp_column_name(&first_sort_col_name)
-        && aligned_sort_batches
-            .iter()
-            .any(|b| b.schema().index_of("timestamp_secs").is_ok())
-    {
-        "timestamp_secs".to_string()
-    } else {
-        first_sort_col_name
-    };
-
-    let synthesized = synthesize_prefix_regions(
-        &global_merge_order,
-        &aligned_sort_batches,
-        &resolved_first_sort_col,
-    )?;
-
-    // We split output RGs at every first-sort-col value transition,
-    // so each produced output RG carries a single value of the first
-    // sort column — `rg_partition_prefix_len = 1` describes the
-    // output. Future compactions of these outputs take the streaming
-    // fast path.
-    let output_prefix_len: u32 = 1;
-
-    Ok((
-        synthesized,
-        Some(aligned_sort_batches),
-        Some(output_prefix_len),
-    ))
+        align_inputs_to_union_schema(&sort_batch_vec, sort_fields_str)?;
+    Ok(aligned_sort_batches)
 }
 
 // ============================================================================
@@ -2087,13 +2102,18 @@ mod tests {
 
     /// Regression for Codex P2 on PR-6410: prefix_len=0 inputs +
     /// `num_outputs > 1` previously folded into a single oversized
-    /// output. The unified streaming path synthesizes prefix-aligned
-    /// regions from the global merge order and the assigner spreads
-    /// them across the requested output count.
+    /// output because the region-to-output assigner only split at
+    /// region boundaries and prefix_len=0 produces exactly one region.
+    /// The engine now subdivides the single region at sorted_series
+    /// transitions so it can honor `num_outputs`. The output inherits
+    /// the input's `rg_partition_prefix_len` (= 0 here) — the engine
+    /// does not declare a prefix it can't unconditionally guarantee.
     #[tokio::test]
-    async fn test_prefix_len_zero_multi_output_splits_at_prefix_transitions() {
-        // 6 distinct metric_names, 50 rows each → 300 rows total.
-        // Request 3 outputs: each should get ~2 metric_names = ~100 rows.
+    async fn test_prefix_len_zero_multi_output_splits_at_sorted_series() {
+        // 6 distinct metric_names × 50 rows = 300 rows total.
+        // num_outputs = 3 → target 100 rows/output. Splits land at
+        // sorted_series transitions (each row has a unique
+        // sorted_series in this fixture).
         let metrics = [
             ("aaa.alpha", 50usize),
             ("bbb.beta", 50),
@@ -2121,41 +2141,74 @@ mod tests {
         let total: usize = outputs.iter().map(|o| o.num_rows).sum();
         assert_eq!(total, 300, "rows preserved (MC-1)");
 
-        // Each output's KV metadata must declare rg_partition_prefix_len=1
-        // — the synthesized path produces prefix-aligned output.
         for out in &outputs {
             let bytes_out = std::fs::read(&out.path).expect("read");
             let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
-            let kv = reader
+            // Inherits input's prefix_len = 0 → KV absent.
+            let prefix_kv = reader
                 .metadata()
                 .file_metadata()
                 .key_value_metadata()
-                .expect("kv metadata");
-            let prefix_kv = kv
-                .iter()
-                .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
-                .and_then(|k| k.value.clone());
-            assert_eq!(
-                prefix_kv.as_deref(),
-                Some("1"),
-                "synthesized output must declare prefix_len=1; got {prefix_kv:?}",
-            );
-            // Multi-RG output: one RG per metric_name landing in this
-            // output. Each output should have at least 1 RG (some
-            // metric_name) and at most 6 (all metrics if M=1).
+                .and_then(|kvs| {
+                    kvs.iter()
+                        .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+                        .and_then(|k| k.value.clone())
+                });
             assert!(
-                reader.metadata().num_row_groups() >= 1,
-                "expected at least one RG per output, got {}",
+                prefix_kv.is_none(),
+                "prefix_len=0 input must produce prefix_len=0 output (KV absent); got \
+                 {prefix_kv:?}",
+            );
+            // Each sub-region produces one output RG.
+            assert_eq!(
+                reader.metadata().num_row_groups(),
+                1,
+                "expected one output RG per sub-region; got {}",
                 reader.metadata().num_row_groups(),
             );
         }
     }
 
-    /// Synthesis path also splits single-output files into multiple
-    /// RGs at metric_name boundaries — even when `num_outputs == 1`,
-    /// the output should be prefix-aligned for future merges.
+    /// Giant single-metric input: prefix_len=0, only one metric_name,
+    /// so there are NO metric_name transitions in the merge order.
+    /// Splitting must still honor `num_outputs` by breaking at
+    /// sorted_series transitions inside the single metric. Confirms
+    /// the engine does not require prefix-value transitions to
+    /// honor the requested output count.
     #[tokio::test]
-    async fn test_prefix_len_zero_single_output_is_prefix_aligned_multi_rg() {
+    async fn test_prefix_len_zero_giant_single_metric_splits_into_multiple_outputs() {
+        let metrics = [("cpu.usage", 200usize)];
+        let bytes = make_multi_metric_single_rg_input(&metrics);
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(2))
+            .await
+            .expect("merge");
+
+        assert_eq!(
+            outputs.len(),
+            2,
+            "one metric × num_outputs=2 must still split (at sorted_series boundaries); got {}",
+            outputs.len(),
+        );
+        let total: usize = outputs.iter().map(|o| o.num_rows).sum();
+        assert_eq!(total, 200, "rows preserved");
+        // Each output is balanced near 100 rows.
+        for out in &outputs {
+            assert!(
+                out.num_rows > 0 && out.num_rows <= 200,
+                "output rows = {}",
+                out.num_rows
+            );
+        }
+    }
+
+    /// Prefix_len=0 + num_outputs=1: the whole region fits in one
+    /// output, no splitting needed. `process_region` drains
+    /// internally (no pre-drain) and produces a single output RG.
+    #[tokio::test]
+    async fn test_prefix_len_zero_single_output_is_single_rg() {
         let metrics = [
             ("cpu.usage", 40usize),
             ("memory.used", 40),
@@ -2175,21 +2228,23 @@ mod tests {
         let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
         assert_eq!(
             reader.metadata().num_row_groups(),
-            3,
-            "three distinct metric_names must each get their own output RG",
+            1,
+            "single output, no split → single RG (engine does not synthesize prefix alignment \
+             when inputs declare prefix_len=0)",
         );
-        assert_eq!(outputs[0].num_row_groups, 3);
-
-        let kv = reader
+        let prefix_kv = reader
             .metadata()
             .file_metadata()
             .key_value_metadata()
-            .expect("kv");
-        let prefix_kv = kv
-            .iter()
-            .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
-            .and_then(|k| k.value.clone());
-        assert_eq!(prefix_kv.as_deref(), Some("1"));
+            .and_then(|kvs| {
+                kvs.iter()
+                    .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+                    .and_then(|k| k.value.clone())
+            });
+        assert!(
+            prefix_kv.is_none(),
+            "output must inherit input's prefix_len = 0 (KV absent); got {prefix_kv:?}",
+        );
     }
 
     /// Build a multi-RG fixture where each RG has a single

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming.rs
@@ -83,7 +83,7 @@ use output::{
 };
 use region_grouping::{
     Region, assign_regions_to_output_files, extract_regions_from_metadata,
-    validate_region_order_matches_physical_rg_order,
+    synthesize_prefix_regions, validate_region_order_matches_physical_rg_order,
 };
 
 use crate::sort_fields::{
@@ -204,13 +204,29 @@ pub async fn streaming_merge_sorted_parquet_files(
         // each region is one sort-prefix value across inputs (each
         // contributing input has exactly one RG in that region). With
         // prefix_len == 0 (validated single-RG above) there is one
-        // region covering all inputs.
+        // region covering all inputs — we'll subdivide it below by
+        // walking the merge order to find first-sort-col transitions.
         let regions = extract_regions_from_metadata(&decoders_state, &input_meta)?;
 
         if regions.is_empty() {
             info!("all inputs empty, producing no output");
             return Ok(Vec::new());
         }
+
+        // Prefix_len=0 unified path: drain sort cols across all
+        // inputs upfront, compute a global merge order, and
+        // synthesize one region per first-sort-col value. The output
+        // becomes prefix-aligned (each output RG has a constant first
+        // sort col value) and `num_outputs > 1` naturally splits at
+        // those synthesized region boundaries.
+        //
+        // The synthesized regions reference the same `(input_idx,
+        // rg_idx=0)` with disjoint row ranges. `process_region`
+        // slices the prefetched sort batches for each region and the
+        // body col assembler advances monotonically across regions
+        // sharing the same RG.
+        let (regions, prefetched_sort_batches, synthesized_prefix_len) =
+            maybe_synthesize_prefix_regions(&handle, &mut decoders_state, &input_meta, regions)?;
 
         // MS-2: validate that the BTreeMap-driven region order
         // agrees with each input's physical RG order. The streaming
@@ -223,6 +239,20 @@ pub async fn streaming_merge_sorted_parquet_files(
         // declares (e.g., metric_name written DESC on disk but the
         // sort schema says ASC). Reject upfront with a clear error.
         validate_region_order_matches_physical_rg_order(&regions, decoders_state.len())?;
+
+        // Build an effective `InputMetadata` that reflects the
+        // synthesized prefix alignment (if any). The output writer
+        // reads `rg_partition_prefix_len` to populate the
+        // `qh.rg_partition_prefix_len` KV; bumping it here means
+        // future compactions can take the streaming fast path on the
+        // output we just produced.
+        let effective_input_meta = if let Some(prefix_len) = synthesized_prefix_len {
+            let mut m = input_meta.clone();
+            m.rg_partition_prefix_len = prefix_len;
+            m
+        } else {
+            input_meta.clone()
+        };
 
         let total_rows: usize = regions.iter().map(|r| r.total_rows()).sum();
         let assignments = assign_regions_to_output_files(&regions, num_outputs);
@@ -249,8 +279,10 @@ pub async fn streaming_merge_sorted_parquet_files(
             .iter()
             .map(|s| Arc::clone(&s.arrow_schema))
             .collect();
-        let union_schema =
-            build_full_union_schema_from_arrow_schemas(&arrow_schemas, &input_meta.sort_fields)?;
+        let union_schema = build_full_union_schema_from_arrow_schemas(
+            &arrow_schemas,
+            &effective_input_meta.sort_fields,
+        )?;
 
         // Per-region processing loop. We hold AT MOST ONE writer open
         // at a time (the current output file being written). Each
@@ -269,14 +301,14 @@ pub async fn streaming_merge_sorted_parquet_files(
             if current_output_idx != Some(target_output_idx) {
                 // Close the previous writer if any.
                 if let (Some(w), Some(acc)) = (current_writer.take(), current_accumulator.take()) {
-                    outputs.push(finalize_output(w, acc, &input_meta)?);
+                    outputs.push(finalize_output(w, acc, &effective_input_meta)?);
                 }
                 // Open a new writer for `target_output_idx`.
                 let writer = open_output_writer_for_streaming(
                     target_output_idx,
                     &output_dir,
                     &union_schema,
-                    &input_meta,
+                    &effective_input_meta,
                     &writer_config,
                 )?;
                 current_writer = Some(writer);
@@ -296,13 +328,14 @@ pub async fn streaming_merge_sorted_parquet_files(
                     .expect("accumulator opened above for this region"),
                 region,
                 &union_schema,
-                &input_meta,
+                &effective_input_meta,
+                prefetched_sort_batches.as_deref(),
             )?;
         }
 
         // Close the last writer.
         if let (Some(w), Some(acc)) = (current_writer.take(), current_accumulator.take()) {
-            outputs.push(finalize_output(w, acc, &input_meta)?);
+            outputs.push(finalize_output(w, acc, &effective_input_meta)?);
         }
 
         // MC-1: total row count preserved.
@@ -336,31 +369,73 @@ pub(crate) struct InputDecoderState {
     pub(crate) metadata: Arc<ParquetMetaData>,
     /// Arrow schema of this input (from parquet → arrow conversion).
     pub(crate) arrow_schema: SchemaRef,
-    /// Per-input page cache for the *currently active* body column.
-    /// Pages are appended as the decoder produces them and evicted from
-    /// the front once their last row is below `body_col_cursor`. The
-    /// cache must persist across all outputs that consume rows from
-    /// this column so that a page whose range straddles two outputs is
-    /// not re-decoded (the stream has already advanced past it). At
-    /// the start of each body column [`InputDecoderState::reset_body_col_state`]
-    /// clears this cache and zeroes the cursor.
-    pub(crate) body_col_page_cache: Vec<DecodedPage>,
-    /// Next unconsumed input row for the active body column. Advances
-    /// monotonically across outputs because the merge plan assigns each
-    /// input's rows to outputs in input-row order.
-    pub(crate) body_col_cursor: usize,
+    /// Per-input, per-parquet-col page cache. Pages emitted by the
+    /// decoder are stored under their actual `col_idx`, not the col
+    /// the caller was asking about — this lets `advance_decoder_to_row`
+    /// pull pages of col B during a col A advance (Husky storage
+    /// order: col A pages all stream before col B pages within an RG,
+    /// so to get any col B pages we may have to consume leftover col
+    /// A pages first). The synthesized-prefix path relies on this:
+    /// adjacent regions sharing one RG re-read col A from this cache
+    /// when region 2 starts, and the cache has already been filled in
+    /// by region 1's reads.
+    ///
+    /// Pages are evicted (per col) when the col's cursor advances
+    /// past their last row.
+    pub(crate) body_col_page_caches: HashMap<usize, Vec<DecodedPage>>,
+    /// Per-parquet-col cursor: the next unconsumed input row for that
+    /// col. Advances monotonically as outputs are written; survives
+    /// across regions of the same input so the body col assembler can
+    /// resume mid-RG for synthesized regions.
+    pub(crate) body_col_cursors: HashMap<usize, usize>,
 }
 
 impl InputDecoderState {
-    /// Clear the per-input body-column cache. Called at the start of
-    /// each new body column so leftover pages from the previous column
-    /// (which have a different `col_idx`) don't poison the new column's
-    /// row-start arithmetic. The decoder itself is *not* reset — its
-    /// per-(rg, col) `rows_decoded` counters and queued pages must
-    /// survive so subsequent decode calls return correct row offsets.
-    pub(crate) fn reset_body_col_state(&mut self) {
-        self.body_col_page_cache.clear();
-        self.body_col_cursor = 0;
+    /// Position the cursor for `col_idx` to `start_row` and drop any
+    /// cached pages strictly below it. Used at the start of each
+    /// (region, body col) write: for whole-RG regions this is a no-op
+    /// (cursor was already 0 and cache empty); for synthesized
+    /// regions that share an RG with earlier regions, this skips the
+    /// rows the previous region consumed without clearing the rest of
+    /// the cache.
+    pub(crate) fn set_body_col_cursor(&mut self, col_idx: usize, start_row: usize) {
+        self.body_col_cursors.insert(col_idx, start_row);
+        if let Some(pages) = self.body_col_page_caches.get_mut(&col_idx) {
+            while let Some(front) = pages.first() {
+                let front_end = front.row_start + front.array.len();
+                if front_end <= start_row {
+                    pages.remove(0);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Look up the cached pages for the given col, returning an empty
+    /// slice if none have been decoded yet.
+    pub(crate) fn body_col_cache(&self, col_idx: usize) -> &[DecodedPage] {
+        match self.body_col_page_caches.get(&col_idx) {
+            Some(v) => v.as_slice(),
+            None => &[],
+        }
+    }
+
+    /// Mutable handle to the cache for `col_idx`, creating an empty
+    /// entry if none exists.
+    pub(crate) fn body_col_cache_mut(&mut self, col_idx: usize) -> &mut Vec<DecodedPage> {
+        self.body_col_page_caches.entry(col_idx).or_default()
+    }
+
+    /// Current cursor for `col_idx`; defaults to 0 if untouched.
+    pub(crate) fn body_col_cursor(&self, col_idx: usize) -> usize {
+        self.body_col_cursors.get(&col_idx).copied().unwrap_or(0)
+    }
+
+    /// Sum of cached pages across all cols. Used by the MS-7 peak-
+    /// length probe in tests.
+    pub(crate) fn body_col_caches_total_len(&self) -> usize {
+        self.body_col_page_caches.values().map(|v| v.len()).sum()
     }
 }
 
@@ -381,8 +456,8 @@ fn build_input_decoders_state(
             decoder,
             metadata,
             arrow_schema: Arc::new(arrow_schema),
-            body_col_page_cache: Vec::new(),
-            body_col_cursor: 0,
+            body_col_page_caches: HashMap::new(),
+            body_col_cursors: HashMap::new(),
         });
     }
     Ok(states)
@@ -513,6 +588,85 @@ fn extract_and_validate_input_metadata(
     })
 }
 
+/// Return value of [`maybe_synthesize_prefix_regions`]: the (possibly
+/// synthesized) region list, the prefetched & union-aligned sort
+/// batches the synthesis produced (`None` on the pass-through path),
+/// and the effective output `rg_partition_prefix_len` to advertise on
+/// the produced parquet files (also `None` on pass-through).
+type SynthesizedRegionsOutput = (Vec<Region>, Option<Vec<RecordBatch>>, Option<u32>);
+
+/// For the prefix_len=0 path, drain each input's sort cols, run the
+/// k-way merge across them, and synthesize one region per first-sort-
+/// col value. Returns the new region list, the per-input pre-drained
+/// (aligned) sort batches, and the output's effective
+/// `rg_partition_prefix_len`. For the prefix_len>0 path this is a
+/// passthrough (returns the input regions and no prefetch).
+///
+/// Wrapping the synthesis here keeps `streaming_merge_sorted_parquet_files`
+/// clean: a single call site picks the right path based on input
+/// metadata, and `process_region` accepts the prefetched sort batches
+/// uniformly.
+fn maybe_synthesize_prefix_regions(
+    handle: &Handle,
+    decoders_state: &mut [InputDecoderState],
+    input_meta: &InputMetadata,
+    regions: Vec<Region>,
+) -> Result<SynthesizedRegionsOutput> {
+    if input_meta.rg_partition_prefix_len != 0 {
+        return Ok((regions, None, None));
+    }
+
+    let sort_field_schema = parse_sort_fields(&input_meta.sort_fields)?;
+    let Some(first_sort_field) = sort_field_schema.column.first() else {
+        // No sort columns declared → nothing to synthesize on. Fall
+        // back to the single-region pass-through.
+        return Ok((regions, None, None));
+    };
+    let first_sort_col_name = first_sort_field.name.clone();
+
+    // Drain all inputs' sort cols (one RG each — prefix_len=0 inputs
+    // are validated to be single-RG upstream).
+    let sort_batches = drain_sort_cols_all_inputs(handle, decoders_state, &input_meta.sort_fields)?;
+    let (_sort_union_schema, aligned_sort_batches) =
+        align_inputs_to_union_schema(&sort_batches, &input_meta.sort_fields)?;
+
+    // Compute the global merge order — runs are contiguous, single-
+    // input slices each with constant sorted_series (and therefore
+    // constant first sort col).
+    let global_merge_order = compute_merge_order(&aligned_sort_batches, &input_meta.sort_fields)?;
+
+    // Resolve the column name in the aligned sort batches (handles the
+    // `timestamp` / `timestamp_secs` alias the rest of the engine uses).
+    let resolved_first_sort_col = if is_timestamp_column_name(&first_sort_col_name)
+        && aligned_sort_batches
+            .iter()
+            .any(|b| b.schema().index_of("timestamp_secs").is_ok())
+    {
+        "timestamp_secs".to_string()
+    } else {
+        first_sort_col_name
+    };
+
+    let synthesized = synthesize_prefix_regions(
+        &global_merge_order,
+        &aligned_sort_batches,
+        &resolved_first_sort_col,
+    )?;
+
+    // We split output RGs at every first-sort-col value transition,
+    // so each produced output RG carries a single value of the first
+    // sort column — `rg_partition_prefix_len = 1` describes the
+    // output. Future compactions of these outputs take the streaming
+    // fast path.
+    let output_prefix_len: u32 = 1;
+
+    Ok((
+        synthesized,
+        Some(aligned_sort_batches),
+        Some(output_prefix_len),
+    ))
+}
+
 // ============================================================================
 // Phase 0: drain sort cols from each input
 // ============================================================================
@@ -545,11 +699,20 @@ fn drain_sort_cols_all_inputs(
     Ok(batches)
 }
 
-/// Process one merge region: drain sort cols of contributing inputs'
-/// current RGs, compute the region's merge order, open a new output
-/// RG in the writer, write all cols (sort cols via interleave, body
-/// cols via the page-bounded assembler), close the RG, accumulate
-/// per-output static metadata.
+/// Process one merge region: obtain the contributing inputs' sort col
+/// batches (drain them fresh from the streaming decoder when
+/// `prefetched_sort_batches` is `None`; otherwise slice the
+/// pre-drained batches by each contribution's row range — used by the
+/// synthesized prefix-region path), compute the region's merge order,
+/// open a new output RG in the writer, write all cols (sort cols via
+/// interleave, body cols via the page-bounded assembler), close the
+/// RG, accumulate per-output static metadata.
+///
+/// When `prefetched_sort_batches` is provided, each contribution's
+/// `start_row` determines where the body col assembler starts inside
+/// the contributing input's RG. The body col stream is shared with
+/// adjacent synthesized regions of the same input, so its cache /
+/// cursor must advance monotonically — see `reset_body_col_state`.
 #[allow(clippy::too_many_arguments)]
 fn process_region(
     handle: &Handle,
@@ -559,20 +722,29 @@ fn process_region(
     region: &Region,
     union_schema: &SchemaRef,
     input_meta: &InputMetadata,
+    prefetched_sort_batches: Option<&[RecordBatch]>,
 ) -> Result<()> {
-    // 1. Drain sort cols of contributing inputs' RGs. The result is a Vec<RecordBatch>, indexed BY
-    //    GLOBAL INPUT INDEX (with zero-row placeholders for non-contributing inputs) so the
-    //    BodyColOutputPageAssembler can use global input indices.
+    // 1. Obtain sort col batches for this region's contributing inputs. When prefetched batches are
+    //    supplied (synthesized path), slice them by the contribution's row range so a single RG
+    //    drained once can feed multiple adjacent regions. Otherwise drain a fresh whole-RG batch
+    //    from the streaming decoder. The result is indexed BY GLOBAL INPUT INDEX, with zero-row
+    //    placeholders for non-contributing inputs so the BodyColOutputPageAssembler sees a uniform
+    //    input-count.
     let num_inputs = decoders_state.len();
     let mut sort_col_batches: Vec<Option<RecordBatch>> = (0..num_inputs).map(|_| None).collect();
-    for &(input_idx, rg_idx, _num_rows) in &region.contributing {
-        let batch = drain_sort_cols_one_input(
-            handle,
-            &mut decoders_state[input_idx],
-            &input_meta.sort_fields,
-            input_idx,
-            rg_idx,
-        )?;
+    for c in &region.contributing {
+        let input_idx = c.input_idx;
+        let rg_idx = c.rg_idx;
+        let batch = match prefetched_sort_batches {
+            Some(prefetched) => prefetched[input_idx].slice(c.start_row, c.num_rows),
+            None => drain_sort_cols_one_input(
+                handle,
+                &mut decoders_state[input_idx],
+                &input_meta.sort_fields,
+                input_idx,
+                rg_idx,
+            )?,
+        };
         if batch.num_columns() > 0 && batch.schema().index_of(SORTED_SERIES_COLUMN).is_err() {
             bail!(
                 "input {input_idx} rg {rg_idx} is missing the '{}' column required for merge",
@@ -593,6 +765,16 @@ fn process_region(
             None => empty_sort_col_record_batch(&decoders_state[idx], &input_meta.sort_fields)?,
         };
         sort_batch_vec.push(batch);
+    }
+
+    // Per-input cursor offsets to feed to the body col reset hook
+    // below. For whole-RG regions this is 0 everywhere; for
+    // synthesized regions it is `c.start_row` of the contributing
+    // input so the body col assembler walks rows starting at the
+    // region's first input row instead of restarting at 0.
+    let mut input_start_rows: Vec<usize> = vec![0; num_inputs];
+    for c in &region.contributing {
+        input_start_rows[c.input_idx] = c.start_row;
     }
 
     // 2. Align to union sort schema for the merge-order comparator.
@@ -619,14 +801,28 @@ fn process_region(
     // 5. Build per-region destinations: maps (input_idx, input_row) → (output_idx=0,
     //    position_in_region). The body col assembler walks this to find which (input, row)
     //    contributes each output position.
+    //
+    //    The destinations array is indexed by row *within the sort
+    //    batch* — which for whole-RG regions equals "row within the
+    //    RG" and for synthesized regions equals "row within the
+    //    region's slice". In both cases that index lines up with what
+    //    the body col decoder's `row_start` reports for the current
+    //    RG, modulo the per-input `start_row` offset added below.
     let mut destinations: Vec<Vec<Option<(usize, usize)>>> = aligned_sort_batches
         .iter()
-        .map(|b| vec![None; b.num_rows()])
+        .enumerate()
+        .map(|(idx, b)| {
+            // For the synthesized path the body col assembler walks
+            // absolute input rows; pad the destinations array so the
+            // index space matches what the page decoder reports.
+            vec![None; input_start_rows[idx] + b.num_rows()]
+        })
         .collect();
     let mut pos = 0usize;
     for run in &merge_order {
         for r in 0..run.row_count {
-            destinations[run.input_index][run.start_row + r] = Some((0, pos));
+            let absolute_row = input_start_rows[run.input_index] + run.start_row + r;
+            destinations[run.input_index][absolute_row] = Some((0, pos));
             pos += 1;
         }
     }
@@ -658,21 +854,24 @@ fn process_region(
                     )
                 })?;
         } else {
-            // Body col: stream via the page-bounded assembler. Reset
-            // each input's body-col cache + cursor before the column
-            // starts. The cursor counts row positions in the *current*
-            // region's destinations table (which is region-local), so
-            // it must restart at 0 for every (region, col) pair; the
-            // decoder itself is NOT reset because parquet's per-(rg,
-            // col) state lives in `state.decoder.columns` keyed by
-            // both indices.
-            for state in decoders_state.iter_mut() {
-                state.reset_body_col_state();
-            }
-
+            // Body col: stream via the page-bounded assembler. Resolve
+            // each input's parquet col_idx for this union-schema col
+            // first, then position the per-col cursor at the region's
+            // `start_row` for that input. For whole-RG regions
+            // `start_row == 0` (no-op for first region); for synthesized
+            // regions sharing an RG with earlier regions the cursor
+            // jumps past already-emitted rows so we don't re-emit them.
+            // The decoder itself is never reset — its per-(rg, col)
+            // `rows_decoded` counters and queued pages must survive so
+            // subsequent decode calls return correct row offsets.
             let mut input_col_indices: Vec<Option<usize>> = Vec::with_capacity(num_inputs);
             for state in decoders_state.iter() {
                 input_col_indices.push(state.arrow_schema.index_of(col_name).ok());
+            }
+            for (idx, state) in decoders_state.iter_mut().enumerate() {
+                if let Some(col_parquet_idx) = input_col_indices[idx] {
+                    state.set_body_col_cursor(col_parquet_idx, input_start_rows[idx]);
+                }
             }
 
             let track_service = col_name == "service";
@@ -1771,6 +1970,228 @@ mod tests {
         );
     }
 
+    /// Build a single-RG fixture with multiple metric_names sorted
+    /// by metric_name then timestamp. The file has
+    /// `rg_partition_prefix_len = 0` (legacy) so the streaming merge
+    /// synthesizes prefix-aligned regions during the merge.
+    ///
+    /// `metrics` = list of (metric_name, num_rows). Rows are emitted
+    /// in order so the resulting batch is already sorted by
+    /// metric_name; each row gets a unique sorted_series identifier
+    /// derived from its position so the k-way merge has a well-
+    /// defined order even when other tag dimensions are degenerate.
+    fn make_multi_metric_single_rg_input(metrics: &[(&str, usize)]) -> Bytes {
+        let dict_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("metric_name", dict_type.clone(), false),
+            Field::new("timestamp_secs", DataType::UInt64, false),
+            Field::new("sorted_series", DataType::Binary, false),
+            Field::new("metric_type", DataType::UInt8, false),
+            Field::new("service", dict_type, true),
+            Field::new("timeseries_id", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        let total_rows: usize = metrics.iter().map(|(_, n)| *n).sum();
+        let mut metric_keys: Vec<i32> = Vec::with_capacity(total_rows);
+        let mut metric_values_vec: Vec<&str> = Vec::with_capacity(metrics.len());
+        let mut timestamps: Vec<u64> = Vec::with_capacity(total_rows);
+        let mut series_bytes: Vec<Vec<u8>> = Vec::with_capacity(total_rows);
+        let mut tsids: Vec<i64> = Vec::with_capacity(total_rows);
+        let mut values: Vec<f64> = Vec::with_capacity(total_rows);
+        let mut row_idx: u64 = 0;
+        for (metric_idx, (name, num)) in metrics.iter().enumerate() {
+            metric_values_vec.push(name);
+            // -timestamp_secs/V2 in the sort schema means timestamps
+            // DESC within a metric.
+            for r in 0..*num {
+                metric_keys.push(metric_idx as i32);
+                timestamps.push(1_700_000_000 + ((*num - r) as u64));
+                series_bytes.push(row_idx.to_be_bytes().to_vec());
+                tsids.push(1000 + row_idx as i64);
+                values.push(row_idx as f64);
+                row_idx += 1;
+            }
+        }
+        let metric_names_arr = StringArray::from(metric_values_vec);
+        let metric_name: ArrayRef = Arc::new(
+            DictionaryArray::<Int32Type>::try_new(
+                arrow::array::Int32Array::from(metric_keys),
+                Arc::new(metric_names_arr),
+            )
+            .expect("dict array"),
+        );
+        let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+        let series_refs: Vec<&[u8]> = series_bytes.iter().map(|v| v.as_slice()).collect();
+        let sorted_series: ArrayRef = Arc::new(BinaryArray::from(series_refs));
+        let metric_type: ArrayRef = Arc::new(UInt8Array::from(vec![0u8; total_rows]));
+        let service: ArrayRef = {
+            let svc_keys: Vec<Option<i32>> = (0..total_rows as i32).map(|i| Some(i % 3)).collect();
+            let svc_values = StringArray::from(vec!["api", "db", "cache"]);
+            Arc::new(
+                DictionaryArray::<Int32Type>::try_new(
+                    arrow::array::Int32Array::from(svc_keys),
+                    Arc::new(svc_values),
+                )
+                .expect("svc dict"),
+            )
+        };
+        let timeseries_id: ArrayRef = Arc::new(Int64Array::from(tsids));
+        let value: ArrayRef = Arc::new(Float64Array::from(values));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                metric_name,
+                timestamp_secs,
+                sorted_series,
+                metric_type,
+                service,
+                timeseries_id,
+                value,
+            ],
+        )
+        .expect("batch");
+
+        // Write as a single-RG legacy file (prefix_len absent → 0).
+        let cfg = ParquetWriterConfig {
+            compression: Compression::Snappy,
+            ..ParquetWriterConfig::default()
+        };
+        let sort_fields = "metric_name|-timestamp_secs/V2";
+        let kvs = vec![
+            KeyValue::new(
+                PARQUET_META_SORT_FIELDS.to_string(),
+                sort_fields.to_string(),
+            ),
+            KeyValue::new(
+                PARQUET_META_WINDOW_START.to_string(),
+                "1700000000".to_string(),
+            ),
+            KeyValue::new(PARQUET_META_WINDOW_DURATION.to_string(), "60".to_string()),
+            KeyValue::new(PARQUET_META_NUM_MERGE_OPS.to_string(), "0".to_string()),
+        ];
+        let sort_field_names = vec!["metric_name".to_string(), "timestamp_secs".to_string()];
+        let props: WriterProperties = cfg.to_writer_properties_with_metadata(
+            &schema,
+            Vec::new(),
+            Some(kvs),
+            &sort_field_names,
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema, Some(props)).expect("arrow writer");
+        writer.write(&batch).expect("write");
+        writer.close().expect("close");
+        Bytes::from(buf)
+    }
+
+    /// Regression for Codex P2 on PR-6410: prefix_len=0 inputs +
+    /// `num_outputs > 1` previously folded into a single oversized
+    /// output. The unified streaming path synthesizes prefix-aligned
+    /// regions from the global merge order and the assigner spreads
+    /// them across the requested output count.
+    #[tokio::test]
+    async fn test_prefix_len_zero_multi_output_splits_at_prefix_transitions() {
+        // 6 distinct metric_names, 50 rows each → 300 rows total.
+        // Request 3 outputs: each should get ~2 metric_names = ~100 rows.
+        let metrics = [
+            ("aaa.alpha", 50usize),
+            ("bbb.beta", 50),
+            ("ccc.gamma", 50),
+            ("ddd.delta", 50),
+            ("eee.epsilon", 50),
+            ("fff.zeta", 50),
+        ];
+        let bytes = make_multi_metric_single_rg_input(&metrics);
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(3))
+            .await
+            .expect("merge");
+
+        assert_eq!(
+            outputs.len(),
+            3,
+            "prefix_len=0 input + num_outputs=3 must produce 3 output files; got {} ({} rows \
+             total)",
+            outputs.len(),
+            outputs.iter().map(|o| o.num_rows).sum::<usize>(),
+        );
+        let total: usize = outputs.iter().map(|o| o.num_rows).sum();
+        assert_eq!(total, 300, "rows preserved (MC-1)");
+
+        // Each output's KV metadata must declare rg_partition_prefix_len=1
+        // — the synthesized path produces prefix-aligned output.
+        for out in &outputs {
+            let bytes_out = std::fs::read(&out.path).expect("read");
+            let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
+            let kv = reader
+                .metadata()
+                .file_metadata()
+                .key_value_metadata()
+                .expect("kv metadata");
+            let prefix_kv = kv
+                .iter()
+                .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+                .and_then(|k| k.value.clone());
+            assert_eq!(
+                prefix_kv.as_deref(),
+                Some("1"),
+                "synthesized output must declare prefix_len=1; got {prefix_kv:?}",
+            );
+            // Multi-RG output: one RG per metric_name landing in this
+            // output. Each output should have at least 1 RG (some
+            // metric_name) and at most 6 (all metrics if M=1).
+            assert!(
+                reader.metadata().num_row_groups() >= 1,
+                "expected at least one RG per output, got {}",
+                reader.metadata().num_row_groups(),
+            );
+        }
+    }
+
+    /// Synthesis path also splits single-output files into multiple
+    /// RGs at metric_name boundaries — even when `num_outputs == 1`,
+    /// the output should be prefix-aligned for future merges.
+    #[tokio::test]
+    async fn test_prefix_len_zero_single_output_is_prefix_aligned_multi_rg() {
+        let metrics = [
+            ("cpu.usage", 40usize),
+            ("memory.used", 40),
+            ("net.bytes", 40),
+        ];
+        let bytes = make_multi_metric_single_rg_input(&metrics);
+        let inputs: Vec<Box<dyn ColumnPageStream>> = vec![open_stream(bytes).await];
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let outputs = streaming_merge_sorted_parquet_files(inputs, tmp.path(), &merge_config(1))
+            .await
+            .expect("merge");
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].num_rows, 120);
+
+        let bytes_out = std::fs::read(&outputs[0].path).expect("read");
+        let reader = SerializedFileReader::new(Bytes::from(bytes_out)).expect("ser");
+        assert_eq!(
+            reader.metadata().num_row_groups(),
+            3,
+            "three distinct metric_names must each get their own output RG",
+        );
+        assert_eq!(outputs[0].num_row_groups, 3);
+
+        let kv = reader
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .expect("kv");
+        let prefix_kv = kv
+            .iter()
+            .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+            .and_then(|k| k.value.clone());
+        assert_eq!(prefix_kv.as_deref(), Some("1"));
+    }
+
     /// Build a multi-RG fixture where each RG has a single
     /// (metric_name, service) tuple. `rg_partition_prefix_len = 2`
     /// declares the alignment.
@@ -2070,7 +2491,7 @@ mod tests {
             .expect_err("region order vs physical RG order mismatch must be rejected");
         let s = err.to_string();
         assert!(
-            s.contains("disagrees with input") && s.contains("physical RG order"),
+            s.contains("disagrees with input") && s.contains("physical row order"),
             "expected MS-2 rejection message, got: {s}",
         );
     }

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/body_assembler.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/body_assembler.rs
@@ -1,0 +1,483 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Page-bounded body column assembly — the streaming core.
+//!
+//! For each `(output_idx, body_col)` pair the engine builds a
+//! [`BodyColOutputPageAssembler`] that yields one assembled output
+//! page per `Iterator::next` call. Each call:
+//!
+//! 1. Walks the destinations table to pick `(input_idx, input_row)` pairs that map to the next
+//!    `OUTPUT_PAGE_ROWS` positions of this output.
+//! 2. Advances each contributing input's decoder forward until its cached pages cover the needed
+//!    rows. The decoder + page cache live on [`InputDecoderState`] (not the assembler) so a page
+//!    whose row range straddles two outputs survives into the next output's assembler — the stream
+//!    cannot be rewound.
+//! 3. Concatenates each input's cached pages and calls `arrow::compute::interleave` to assemble the
+//!    output page.
+//! 4. Evicts pages whose last row falls below the cursor.
+//!
+//! Memory bound per `next()`: one in-progress output page plus a few
+//! in-flight input pages per input — never a whole column chunk. See
+//! the MS-7 test in the parent test module for the runtime assertion.
+//!
+//! [`StreamingBodyColIter`] wraps the `Result<ArrayRef>` page stream
+//! into the `Iterator<Item = ArrayRef>` shape
+//! `write_next_column_arrays` expects, capturing the first assembly
+//! error in a side cell.
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, anyhow, bail};
+use arrow::array::{Array, ArrayRef, new_null_array};
+use arrow::compute::interleave;
+use arrow::datatypes::{DataType, Field};
+use tokio::runtime::Handle;
+
+use super::{
+    InputDecoderState, InputRowDestinations, OUTPUT_PAGE_ROWS, record_body_col_page_cache_len,
+};
+
+/// Adapts a `Result<ArrayRef>` page assembler into the
+/// `Iterator<Item = ArrayRef>` shape `write_next_column_arrays` expects.
+/// The first assembly error is captured in `error_slot` and iteration
+/// ends; the caller MUST check the slot after the writer returns. If
+/// `service_collector` is `Some`, every yielded page is scanned for
+/// service names and added to the set; collection failures also stop
+/// the iterator and populate `error_slot`.
+pub(crate) struct StreamingBodyColIter<'a, I> {
+    pub(crate) inner: I,
+    pub(crate) error_slot: &'a mut Option<anyhow::Error>,
+    pub(crate) service_collector: Option<&'a mut HashSet<String>>,
+}
+
+impl<I> Iterator for StreamingBodyColIter<'_, I>
+where I: Iterator<Item = Result<ArrayRef>>
+{
+    type Item = ArrayRef;
+
+    fn next(&mut self) -> Option<ArrayRef> {
+        if self.error_slot.is_some() {
+            return None;
+        }
+        match self.inner.next() {
+            Some(Ok(arr)) => {
+                if let Some(out) = self.service_collector.as_deref_mut()
+                    && let Err(e) = collect_service_names_from_page(arr.as_ref(), out)
+                {
+                    *self.error_slot = Some(e);
+                    return None;
+                }
+                Some(arr)
+            }
+            Some(Err(e)) => {
+                *self.error_slot = Some(e);
+                None
+            }
+            None => None,
+        }
+    }
+}
+
+/// Per-page service name collector. Used during the streaming write
+/// of the "service" body col to populate per-output service_names.
+pub(crate) fn collect_service_names_from_page(
+    arr: &dyn Array,
+    out: &mut HashSet<String>,
+) -> Result<()> {
+    use arrow::array::AsArray;
+    use arrow::datatypes::{Int8Type, Int16Type, Int32Type, Int64Type};
+
+    fn extend_from_strings(strings: &arrow::array::StringArray, out: &mut HashSet<String>) {
+        for i in 0..strings.len() {
+            if strings.is_valid(i) {
+                out.insert(strings.value(i).to_string());
+            }
+        }
+    }
+
+    match arr.data_type() {
+        DataType::Utf8 => {
+            let strings = arr
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .ok_or_else(|| anyhow!("expected StringArray for service col page"))?;
+            extend_from_strings(strings, out);
+        }
+        DataType::LargeUtf8 => {
+            let strings = arr
+                .as_any()
+                .downcast_ref::<arrow::array::LargeStringArray>()
+                .ok_or_else(|| anyhow!("expected LargeStringArray for service col page"))?;
+            for i in 0..strings.len() {
+                if strings.is_valid(i) {
+                    out.insert(strings.value(i).to_string());
+                }
+            }
+        }
+        DataType::Dictionary(key_type, value_type)
+            if matches!(value_type.as_ref(), DataType::Utf8) =>
+        {
+            // Extract the dictionary's values that are referenced by
+            // valid (non-null) keys.
+            match key_type.as_ref() {
+                DataType::Int8 => {
+                    let dict = arr.as_dictionary::<Int8Type>();
+                    if let Some(strings) = dict
+                        .values()
+                        .as_any()
+                        .downcast_ref::<arrow::array::StringArray>()
+                    {
+                        for i in 0..dict.len() {
+                            if dict.is_valid(i) {
+                                let key = dict.keys().value(i) as usize;
+                                if key < strings.len() && strings.is_valid(key) {
+                                    out.insert(strings.value(key).to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+                DataType::Int16 => {
+                    let dict = arr.as_dictionary::<Int16Type>();
+                    if let Some(strings) = dict
+                        .values()
+                        .as_any()
+                        .downcast_ref::<arrow::array::StringArray>()
+                    {
+                        for i in 0..dict.len() {
+                            if dict.is_valid(i) {
+                                let key = dict.keys().value(i) as usize;
+                                if key < strings.len() && strings.is_valid(key) {
+                                    out.insert(strings.value(key).to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+                DataType::Int32 => {
+                    let dict = arr.as_dictionary::<Int32Type>();
+                    if let Some(strings) = dict
+                        .values()
+                        .as_any()
+                        .downcast_ref::<arrow::array::StringArray>()
+                    {
+                        for i in 0..dict.len() {
+                            if dict.is_valid(i) {
+                                let key = dict.keys().value(i) as usize;
+                                if key < strings.len() && strings.is_valid(key) {
+                                    out.insert(strings.value(key).to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+                DataType::Int64 => {
+                    let dict = arr.as_dictionary::<Int64Type>();
+                    if let Some(strings) = dict
+                        .values()
+                        .as_any()
+                        .downcast_ref::<arrow::array::StringArray>()
+                    {
+                        for i in 0..dict.len() {
+                            if dict.is_valid(i) {
+                                let key = dict.keys().value(i) as usize;
+                                if key < strings.len() && strings.is_valid(key) {
+                                    out.insert(strings.value(key).to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        _ => {
+            // Skip non-string types — service col is expected to be
+            // string-like; if it isn't, just don't collect names.
+        }
+    }
+    Ok(())
+}
+
+/// Assembles output pages for one (output_idx, body_col). See the
+/// module docs for the full contract.
+pub(crate) struct BodyColOutputPageAssembler<'a> {
+    handle: &'a Handle,
+    decoders_state: &'a mut [InputDecoderState],
+    input_col_indices: &'a [Option<usize>],
+    destinations: &'a InputRowDestinations,
+    out_idx: usize,
+    col_name: &'a str,
+    out_field: &'a Field,
+    /// Total rows written so far for this output's col.
+    rows_emitted: usize,
+    /// Total rows expected = destinations.rows_per_output[out_idx].
+    expected_rows: usize,
+    /// EOF flag (returns None on subsequent calls once true).
+    done: bool,
+}
+
+impl<'a> BodyColOutputPageAssembler<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        handle: &'a Handle,
+        decoders_state: &'a mut [InputDecoderState],
+        input_col_indices: &'a [Option<usize>],
+        destinations: &'a InputRowDestinations,
+        out_idx: usize,
+        col_name: &'a str,
+        out_field: &'a Field,
+    ) -> Self {
+        Self {
+            handle,
+            decoders_state,
+            input_col_indices,
+            destinations,
+            out_idx,
+            col_name,
+            out_field,
+            rows_emitted: 0,
+            expected_rows: destinations.rows_per_output[out_idx],
+            done: false,
+        }
+    }
+
+    pub(crate) fn into_iter(self) -> BodyColOutputPageIter<'a> {
+        BodyColOutputPageIter { inner: self }
+    }
+}
+
+pub(crate) struct BodyColOutputPageIter<'a> {
+    inner: BodyColOutputPageAssembler<'a>,
+}
+
+impl Iterator for BodyColOutputPageIter<'_> {
+    type Item = Result<ArrayRef>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.inner.done || self.inner.rows_emitted >= self.inner.expected_rows {
+            self.inner.done = true;
+            return None;
+        }
+        match assemble_one_output_page(&mut self.inner) {
+            Ok(Some(arr)) => Some(Ok(arr)),
+            Ok(None) => {
+                self.inner.done = true;
+                None
+            }
+            Err(e) => {
+                self.inner.done = true;
+                Some(Err(e))
+            }
+        }
+    }
+}
+
+fn assemble_one_output_page(s: &mut BodyColOutputPageAssembler) -> Result<Option<ArrayRef>> {
+    let remaining = s.expected_rows - s.rows_emitted;
+    if remaining == 0 {
+        return Ok(None);
+    }
+    let page_size = remaining.min(OUTPUT_PAGE_ROWS);
+
+    // Collect (input_idx, input_row) indices for this output page by
+    // walking destinations.per_input from each input's cursor. For
+    // each target output position, find the (input, row) that maps to
+    // it. See module docs for why this is correct given the merge
+    // plan invariants.
+    let mut indices_per_input: Vec<Vec<usize>> = vec![Vec::new(); s.decoders_state.len()];
+    let mut interleave_indices: Vec<(usize, usize)> = Vec::with_capacity(page_size);
+    let mut total_picked = 0usize;
+
+    while total_picked < page_size {
+        let target_pos = s.rows_emitted + total_picked;
+        let mut found = false;
+        for (input_idx, dests) in s.destinations.per_input.iter().enumerate() {
+            let cursor = s.decoders_state[input_idx].body_col_cursor;
+            for (input_row, dest) in dests.iter().enumerate().skip(cursor) {
+                match dest {
+                    Some((o, p)) if *o == s.out_idx => {
+                        if *p == target_pos {
+                            interleave_indices.push((input_idx, input_row));
+                            indices_per_input[input_idx].push(input_row);
+                            found = true;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                if found {
+                    break;
+                }
+            }
+            if found {
+                break;
+            }
+        }
+        if !found {
+            // Shouldn't happen — every output position should be reachable.
+            bail!(
+                "merge plan inconsistency: output {} position {target_pos} not found in any input",
+                s.out_idx,
+            );
+        }
+        total_picked += 1;
+    }
+
+    // Advance each contributing input's decoder until its cached
+    // pages cover the maximum input row we'll reference.
+    for (input_idx, input_rows) in indices_per_input.iter().enumerate() {
+        if input_rows.is_empty() {
+            continue;
+        }
+        let col_parquet_idx = match s.input_col_indices[input_idx] {
+            Some(c) => c,
+            None => continue,
+        };
+        let max_needed_row = *input_rows.iter().max().expect("non-empty");
+        advance_decoder_to_row(
+            s.handle,
+            &mut s.decoders_state[input_idx],
+            col_parquet_idx,
+            max_needed_row,
+        )?;
+    }
+
+    // Build the per-input value array. For inputs lacking this col,
+    // a single null-row placeholder routes interleave indices to position 0.
+    let mut input_array_refs: Vec<ArrayRef> = Vec::with_capacity(s.decoders_state.len());
+    let mut input_cache_starts: Vec<usize> = Vec::with_capacity(s.decoders_state.len());
+
+    for input_idx in 0..s.decoders_state.len() {
+        match s.input_col_indices[input_idx] {
+            Some(_) => {
+                let pages = &s.decoders_state[input_idx].body_col_page_cache;
+                if pages.is_empty() {
+                    input_array_refs.push(new_null_array(s.out_field.data_type(), 0));
+                    input_cache_starts.push(0);
+                } else {
+                    let cache_start = pages[0].row_start;
+                    let arrays: Vec<&dyn Array> = pages.iter().map(|p| p.array.as_ref()).collect();
+                    let concatenated = arrow::compute::concat(&arrays).with_context(|| {
+                        format!(
+                            "concatenating cached pages for input {input_idx} col '{}'",
+                            s.col_name,
+                        )
+                    })?;
+                    input_array_refs.push(concatenated);
+                    input_cache_starts.push(cache_start);
+                }
+            }
+            None => {
+                let null_arr = new_null_array(s.out_field.data_type(), 1);
+                input_array_refs.push(null_arr);
+                input_cache_starts.push(0);
+            }
+        }
+    }
+
+    let interleave_local: Vec<(usize, usize)> = interleave_indices
+        .iter()
+        .map(|&(i_idx, i_row)| match s.input_col_indices[i_idx] {
+            Some(_) => (i_idx, i_row - input_cache_starts[i_idx]),
+            None => (i_idx, 0),
+        })
+        .collect();
+
+    let array_refs_ref: Vec<&dyn Array> = input_array_refs.iter().map(|a| a.as_ref()).collect();
+    let assembled = interleave(&array_refs_ref, &interleave_local).with_context(|| {
+        format!(
+            "interleaving body col '{}' for output {}",
+            s.col_name, s.out_idx,
+        )
+    })?;
+
+    // Bump cursors past consumed rows and evict pages whose last row
+    // falls below the cursor. Both live on InputDecoderState so they
+    // persist across outputs that share this column.
+    for (input_idx, input_rows) in indices_per_input.iter().enumerate() {
+        if input_rows.is_empty() {
+            continue;
+        }
+        let max_row = *input_rows.iter().max().expect("non-empty");
+        let state = &mut s.decoders_state[input_idx];
+        state.body_col_cursor = max_row + 1;
+
+        if s.input_col_indices[input_idx].is_some() {
+            let pages = &mut state.body_col_page_cache;
+            while let Some(front) = pages.first() {
+                let front_end = front.row_start + front.array.len();
+                if front_end <= state.body_col_cursor {
+                    pages.remove(0);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    s.rows_emitted += page_size;
+    Ok(Some(assembled))
+}
+
+/// Drive the input's persistent decoder forward via `block_on` until
+/// the cached pages for `col_parquet_idx` cover up through `target_row`
+/// (inclusive). Stops as soon as the latest cached page ends past
+/// `target_row`.
+///
+/// The decoder MUST be the long-lived [`InputDecoderState::decoder`]:
+/// it preserves the per-(rg, col) `rows_decoded` counter so successive
+/// `DecodedPage::row_start` values are absolute input row indices,
+/// not page-local zeros. Likewise, the cache lives on the state so
+/// pages whose row range spans an output boundary survive into the
+/// next output's assembler.
+fn advance_decoder_to_row(
+    handle: &Handle,
+    state: &mut InputDecoderState,
+    col_parquet_idx: usize,
+    target_row: usize,
+) -> Result<()> {
+    // If cache already covers target_row, nothing to do.
+    if let Some(last) = state.body_col_page_cache.last() {
+        let last_end = last.row_start + last.array.len();
+        if target_row < last_end {
+            return Ok(());
+        }
+    }
+
+    loop {
+        let decoded = handle
+            .block_on(state.decoder.decode_next_page())
+            .context("decoding body col page")?;
+        let page = match decoded {
+            Some(p) => p,
+            None => bail!(
+                "stream EOF while advancing to row {target_row} for parquet col {col_parquet_idx}",
+            ),
+        };
+        if page.col_idx != col_parquet_idx {
+            bail!(
+                "expected col {col_parquet_idx} page, got col {} — column ordering violated",
+                page.col_idx,
+            );
+        }
+        let end = page.row_start + page.array.len();
+        state.body_col_page_cache.push(page);
+        record_body_col_page_cache_len(state.body_col_page_cache.len());
+        if target_row < end {
+            return Ok(());
+        }
+    }
+}

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/body_assembler.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/body_assembler.rs
@@ -305,7 +305,12 @@ fn assemble_one_output_page(s: &mut BodyColOutputPageAssembler) -> Result<Option
         let target_pos = s.rows_emitted + total_picked;
         let mut found = false;
         for (input_idx, dests) in s.destinations.per_input.iter().enumerate() {
-            let cursor = s.decoders_state[input_idx].body_col_cursor;
+            let cursor = match s.input_col_indices[input_idx] {
+                Some(col_parquet_idx) => {
+                    s.decoders_state[input_idx].body_col_cursor(col_parquet_idx)
+                }
+                None => 0,
+            };
             for (input_row, dest) in dests.iter().enumerate().skip(cursor) {
                 match dest {
                     Some((o, p)) if *o == s.out_idx => {
@@ -362,8 +367,8 @@ fn assemble_one_output_page(s: &mut BodyColOutputPageAssembler) -> Result<Option
 
     for input_idx in 0..s.decoders_state.len() {
         match s.input_col_indices[input_idx] {
-            Some(_) => {
-                let pages = &s.decoders_state[input_idx].body_col_page_cache;
+            Some(col_parquet_idx) => {
+                let pages = s.decoders_state[input_idx].body_col_cache(col_parquet_idx);
                 if pages.is_empty() {
                     input_array_refs.push(new_null_array(s.out_field.data_type(), 0));
                     input_cache_starts.push(0);
@@ -405,27 +410,19 @@ fn assemble_one_output_page(s: &mut BodyColOutputPageAssembler) -> Result<Option
     })?;
 
     // Bump cursors past consumed rows and evict pages whose last row
-    // falls below the cursor. Both live on InputDecoderState so they
-    // persist across outputs that share this column.
+    // falls below the cursor. Both live on InputDecoderState (per
+    // col) so they persist across regions/outputs that share this
+    // column.
     for (input_idx, input_rows) in indices_per_input.iter().enumerate() {
         if input_rows.is_empty() {
             continue;
         }
         let max_row = *input_rows.iter().max().expect("non-empty");
         let state = &mut s.decoders_state[input_idx];
-        state.body_col_cursor = max_row + 1;
-
-        if s.input_col_indices[input_idx].is_some() {
-            let pages = &mut state.body_col_page_cache;
-            while let Some(front) = pages.first() {
-                let front_end = front.row_start + front.array.len();
-                if front_end <= state.body_col_cursor {
-                    pages.remove(0);
-                } else {
-                    break;
-                }
-            }
-        }
+        let Some(col_parquet_idx) = s.input_col_indices[input_idx] else {
+            continue;
+        };
+        state.set_body_col_cursor(col_parquet_idx, max_row + 1);
     }
 
     s.rows_emitted += page_size;
@@ -449,14 +446,20 @@ fn advance_decoder_to_row(
     col_parquet_idx: usize,
     target_row: usize,
 ) -> Result<()> {
-    // If cache already covers target_row, nothing to do.
-    if let Some(last) = state.body_col_page_cache.last() {
+    // Already covered by what's cached for this col?
+    if let Some(last) = state.body_col_cache(col_parquet_idx).last() {
         let last_end = last.row_start + last.array.len();
         if target_row < last_end {
             return Ok(());
         }
     }
 
+    // Drain pages from the stream until either the target is covered
+    // for `col_parquet_idx` or the stream runs out. Pages emitted for
+    // a different col_idx still get cached under their own col so a
+    // later request for that col can find them without re-fetching —
+    // critical for the synthesized-prefix path, which re-reads earlier
+    // cols across multiple regions after the stream has moved on.
     loop {
         let decoded = handle
             .block_on(state.decoder.decode_next_page())
@@ -467,16 +470,11 @@ fn advance_decoder_to_row(
                 "stream EOF while advancing to row {target_row} for parquet col {col_parquet_idx}",
             ),
         };
-        if page.col_idx != col_parquet_idx {
-            bail!(
-                "expected col {col_parquet_idx} page, got col {} — column ordering violated",
-                page.col_idx,
-            );
-        }
+        let page_col = page.col_idx;
         let end = page.row_start + page.array.len();
-        state.body_col_page_cache.push(page);
-        record_body_col_page_cache_len(state.body_col_page_cache.len());
-        if target_row < end {
+        state.body_col_cache_mut(page_col).push(page);
+        record_body_col_page_cache_len(state.body_col_caches_total_len());
+        if page_col == col_parquet_idx && target_row < end {
             return Ok(());
         }
     }

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/output.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/output.rs
@@ -312,6 +312,13 @@ pub(crate) fn finalize_output(
         path: output_path,
         num_rows: accumulator.num_rows,
         num_row_groups,
+        // The streaming engine stamps `input_meta.rg_partition_prefix_len`
+        // unconditionally in the file's KV (see
+        // `open_output_writer_for_streaming`) and verifies the claim with
+        // `assert_unique_rg_prefix_keys`. CS-1 requires the metastore-
+        // recorded value to match the on-disk KV, so propagate the same
+        // value here.
+        output_rg_partition_prefix_len: input_meta.rg_partition_prefix_len,
         size_bytes,
         row_keys_proto,
         zonemap_regexes,

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/output.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/output.rs
@@ -265,6 +265,22 @@ pub(crate) fn finalize_output(
         footer_metadata.num_row_groups(),
     );
 
+    // Strong invariant: the streaming engine pairs at most one input
+    // RG per region (`process_region` keys `sort_col_batches` by
+    // input_idx), and the read-path check in
+    // `extract_regions_from_metadata` enforces unique prefix keys per
+    // input. The output writer assigns one new RG per region in
+    // `process_region`, so the output should never violate the
+    // invariant either — but verifying here catches any future
+    // regression (e.g., a finalize-time rewrite that splits a region
+    // across RGs) before the file lands.
+    super::region_grouping::assert_unique_rg_prefix_keys(
+        &footer_metadata,
+        &input_meta.sort_fields,
+        input_meta.rg_partition_prefix_len,
+        &format!("merge output {}", output_path.display()),
+    )?;
+
     let size_bytes = std::fs::metadata(&output_path)
         .with_context(|| format!("stat output file: {}", output_path.display()))?
         .len();

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/output.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/output.rs
@@ -1,0 +1,342 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-output state, writer setup, and finalization for the streaming
+//! merge engine.
+//!
+//! Each output file in a streaming merge owns:
+//! - An [`OutputWriterStorage`] holding the live parquet writer and a running count of row groups
+//!   written to it (used to verify MS-3).
+//! - An [`OutputAccumulator`] that concatenates this output's sort-col contributions across regions
+//!   so per-output metadata (`qh.row_keys`, `qh.zonemap_regexes`, metric_names, time_range) can be
+//!   computed from the output's actual rows at finalize time.
+//!
+//! Per-output `qh.row_keys` and `qh.zonemap_regexes` are *appended* to
+//! the parquet footer just before close — they cannot be set at writer
+//! construction because they depend on row content that the streaming
+//! pass only finishes accumulating in `finalize_output`. The static
+//! KV entries (sort schema, window, num_merge_ops, prefix_len) are set
+//! at construction since they're identical regardless of row content.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use arrow::array::RecordBatch;
+use arrow::datatypes::{Schema as ArrowSchema, SchemaRef};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ulid::Ulid;
+
+use super::super::writer::{build_merge_kv_metadata, resolve_sort_field_names};
+use super::super::{InputMetadata, MergeOutputFile};
+use crate::row_keys;
+use crate::sort_fields::{is_timestamp_column_name, parse_sort_fields};
+use crate::split::TAG_SERVICE;
+use crate::storage::split_writer::{extract_metric_names, extract_time_range};
+use crate::storage::streaming_writer::StreamingParquetWriter;
+use crate::storage::{
+    PARQUET_META_ROW_KEYS, PARQUET_META_ROW_KEYS_JSON, PARQUET_META_ZONEMAP_REGEXES,
+};
+use crate::zonemap::{self, ZonemapOptions};
+
+/// Per-output-file mutable state owned across regions assigned to that file.
+pub(crate) struct OutputWriterStorage {
+    pub(crate) output_idx: usize,
+    pub(crate) output_path: PathBuf,
+    pub(crate) writer: StreamingParquetWriter<std::fs::File>,
+    /// Number of parquet row groups written into this file so far. One
+    /// row group is opened per region in the per-region processor, so
+    /// this equals the count of regions assigned to this output once
+    /// processing is done. Reported on [`MergeOutputFile::num_row_groups`].
+    pub(crate) num_row_groups: usize,
+}
+
+/// Per-output-file accumulator. Each region's sort-col contribution is
+/// merged into `accumulated_sort_batch`; per-output metadata
+/// (row_keys, zonemap, metric_names, time_range) is computed once at
+/// `finalize_output` time. Service names are collected during the
+/// streaming write of the service body col within each region.
+pub(crate) struct OutputAccumulator {
+    pub(crate) output_idx: usize,
+    /// Concatenated sort-col `RecordBatch` across all regions written
+    /// to this output. Memory bounded by total sort col bytes in the
+    /// output file (small — sort cols are narrow).
+    pub(crate) accumulated_sort_batch: Option<RecordBatch>,
+    /// Service names collected across regions' body-col writes for
+    /// this output file.
+    pub(crate) service_names: HashSet<String>,
+    /// Cumulative row count = sum of regions' total_rows assigned here.
+    pub(crate) num_rows: usize,
+}
+
+impl OutputAccumulator {
+    pub(crate) fn new(output_idx: usize) -> Self {
+        Self {
+            output_idx,
+            accumulated_sort_batch: None,
+            service_names: HashSet::new(),
+            num_rows: 0,
+        }
+    }
+
+    pub(crate) fn append_sort_batch(&mut self, batch: RecordBatch) -> Result<()> {
+        match self.accumulated_sort_batch.take() {
+            None => {
+                self.accumulated_sort_batch = Some(batch);
+            }
+            Some(prev) => {
+                let schema = prev.schema();
+                let combined = arrow::compute::concat_batches(&schema, [&prev, &batch].into_iter())
+                    .context("appending region sort batch to output accumulator")?;
+                self.accumulated_sort_batch = Some(combined);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Open a streaming Parquet writer for one output file. Caller is
+/// responsible for calling `start_row_group` per region and writing
+/// columns.
+pub(crate) fn open_output_writer_for_streaming(
+    output_idx: usize,
+    output_dir: &Path,
+    union_schema: &SchemaRef,
+    input_meta: &InputMetadata,
+    writer_config: &crate::storage::ParquetWriterConfig,
+) -> Result<OutputWriterStorage> {
+    let output_prefix_len = input_meta.rg_partition_prefix_len;
+    // `qh.row_keys` and `qh.zonemap_regexes` MUST be derived from the
+    // rows that end up in THIS output file, not from inputs — the
+    // merge eliminates key overlap between outputs, so an output's
+    // key metadata can be very different from any input's. We can't
+    // compute those values until every region has been written, so
+    // they are appended to the file's footer KV metadata in
+    // `finalize_output` via `StreamingParquetWriter::append_key_value_metadata`
+    // just before close. The KV entries set here cover the "static"
+    // keys (sort_fields, window, num_merge_ops, prefix_len) that are
+    // identical regardless of which rows the output contains.
+    let kv_entries = build_merge_kv_metadata(input_meta, &None, &HashMap::new(), output_prefix_len);
+
+    let sort_field_names = resolve_sort_field_names(&input_meta.sort_fields)?;
+    let sorting_cols = build_sorting_columns_from_schema(union_schema, &input_meta.sort_fields)?;
+
+    let props = writer_config.to_writer_properties_with_metadata(
+        union_schema,
+        sorting_cols,
+        Some(kv_entries),
+        &sort_field_names,
+    );
+
+    let output_filename = format!("merge_output_{}.parquet", Ulid::new());
+    let output_path = output_dir.join(&output_filename);
+    let file = std::fs::File::create(&output_path)
+        .with_context(|| format!("creating output file: {}", output_path.display()))?;
+    let writer = StreamingParquetWriter::try_new(file, Arc::clone(union_schema), props)
+        .with_context(|| format!("opening streaming writer for output {output_idx}"))?;
+
+    Ok(OutputWriterStorage {
+        output_idx,
+        output_path,
+        writer,
+        num_row_groups: 0,
+    })
+}
+
+/// Compute `SortingColumn` entries from the union schema (no
+/// RecordBatch needed — we just need the col indices).
+pub(crate) fn build_sorting_columns_from_schema(
+    schema: &SchemaRef,
+    sort_fields_str: &str,
+) -> Result<Vec<parquet::file::metadata::SortingColumn>> {
+    let parsed = parse_sort_fields(sort_fields_str)?;
+    let mut cols = Vec::new();
+    for sf in &parsed.column {
+        // Schema may use `timestamp_secs` for what the sort schema
+        // calls `timestamp`. Match the existing alias handling.
+        let resolved =
+            if is_timestamp_column_name(&sf.name) && schema.index_of("timestamp_secs").is_ok() {
+                "timestamp_secs"
+            } else {
+                sf.name.as_str()
+            };
+        let Ok(col_idx) = schema.index_of(resolved) else {
+            continue;
+        };
+        cols.push(parquet::file::metadata::SortingColumn {
+            column_idx: col_idx as i32,
+            descending: sf.sort_direction
+                == quickwit_proto::sortschema::SortColumnDirection::SortDirectionDescending as i32,
+            nulls_first: false,
+        });
+    }
+    Ok(cols)
+}
+
+/// Finalize one output file: close writer, gather size, compute
+/// per-output static metadata from the accumulator's sort col data,
+/// return the `MergeOutputFile`.
+pub(crate) fn finalize_output(
+    writer_state: OutputWriterStorage,
+    accumulator: OutputAccumulator,
+    input_meta: &InputMetadata,
+) -> Result<MergeOutputFile> {
+    let OutputWriterStorage {
+        output_idx,
+        output_path,
+        mut writer,
+        num_row_groups,
+    } = writer_state;
+
+    // Compute per-output metadata from the rows that actually landed
+    // in THIS output file. Merging eliminates key overlap between
+    // outputs, so the row_keys / zonemap / metric_names / time_range
+    // each output advertises must come from its own accumulated sort
+    // batch — they cannot be carried over from any input file.
+    let sort_batch = accumulator
+        .accumulated_sort_batch
+        .unwrap_or_else(|| RecordBatch::new_empty(Arc::new(ArrowSchema::empty())));
+
+    let row_keys_proto = if sort_batch.num_rows() > 0 {
+        row_keys::extract_row_keys(&input_meta.sort_fields, &sort_batch)
+            .with_context(|| format!("extracting row keys for output {output_idx}"))?
+            .map(|rk| row_keys::encode_row_keys_proto(&rk))
+    } else {
+        None
+    };
+
+    let zonemap_opts = ZonemapOptions::default();
+    let zonemap_regexes = if sort_batch.num_rows() > 0 {
+        zonemap::extract_zonemap_regexes(&input_meta.sort_fields, &sort_batch, &zonemap_opts)
+            .with_context(|| format!("extracting zonemap regexes for output {output_idx}"))?
+    } else {
+        HashMap::new()
+    };
+
+    let metric_names =
+        if sort_batch.num_rows() > 0 && sort_batch.schema().index_of("metric_name").is_ok() {
+            extract_metric_names(&sort_batch)
+                .with_context(|| format!("extracting metric names for output {output_idx}"))?
+        } else {
+            HashSet::new()
+        };
+
+    let time_range =
+        if sort_batch.num_rows() > 0 && sort_batch.schema().index_of("timestamp_secs").is_ok() {
+            extract_time_range(&sort_batch)
+                .with_context(|| format!("extracting time range for output {output_idx}"))?
+        } else {
+            crate::split::TimeRange::new(0, 0)
+        };
+
+    // Write the per-output `qh.row_keys` / `qh.zonemap_regexes` into
+    // the file's KV metadata so downstream tools that read the
+    // Parquet footer directly see the same values that
+    // `MergeOutputFile` carries in memory.
+    append_per_output_kv_metadata(&mut writer, row_keys_proto.as_ref(), &zonemap_regexes);
+
+    let footer_metadata = writer
+        .close()
+        .with_context(|| format!("closing writer for output {output_idx}"))?;
+
+    // MS-3: the count we report on `MergeOutputFile.num_row_groups`
+    // must agree with what the on-disk parquet footer actually
+    // contains. `num_row_groups` is bumped per `start_row_group` call
+    // in the per-region processor; if we ever skip one or double-
+    // count, this catches the drift in debug builds before downstream
+    // metadata consumers see the inconsistency.
+    debug_assert_eq!(
+        footer_metadata.num_row_groups(),
+        num_row_groups,
+        "MergeOutputFile.num_row_groups ({num_row_groups}) disagrees with footer ({})",
+        footer_metadata.num_row_groups(),
+    );
+
+    let size_bytes = std::fs::metadata(&output_path)
+        .with_context(|| format!("stat output file: {}", output_path.display()))?
+        .len();
+
+    // If `service` is a sort column for this schema, it took the
+    // sort-col write path in `process_region` and the body-col
+    // `track_service` branch never saw it. Fold in the names from the
+    // accumulated sort batch so `TAG_SERVICE` metadata stays accurate
+    // regardless of which path wrote the column.
+    let mut service_names = accumulator.service_names;
+    if sort_batch.num_rows() > 0
+        && let Ok(service_col_idx) = sort_batch.schema().index_of("service")
+    {
+        super::body_assembler::collect_service_names_from_page(
+            sort_batch.column(service_col_idx).as_ref(),
+            &mut service_names,
+        )
+        .with_context(|| {
+            format!("collecting service names from sort col for output {output_idx}")
+        })?;
+    }
+
+    let mut low_cardinality_tags: HashMap<String, HashSet<String>> = HashMap::new();
+    if !service_names.is_empty() {
+        low_cardinality_tags.insert(TAG_SERVICE.to_string(), service_names);
+    }
+
+    Ok(MergeOutputFile {
+        path: output_path,
+        num_rows: accumulator.num_rows,
+        num_row_groups,
+        size_bytes,
+        row_keys_proto,
+        zonemap_regexes,
+        metric_names,
+        time_range,
+        low_cardinality_tags,
+    })
+}
+
+/// Append the per-output `qh.row_keys` / `qh.zonemap_regexes` KV
+/// entries to the streaming writer just before close. Encoded the
+/// same way as the non-streaming writer (`build_merge_kv_metadata`):
+/// base64 for the proto, JSON for the zonemap map, plus the optional
+/// human-readable `qh.row_keys_json`.
+fn append_per_output_kv_metadata(
+    writer: &mut StreamingParquetWriter<std::fs::File>,
+    row_keys_proto: Option<&Vec<u8>>,
+    zonemap_regexes: &HashMap<String, String>,
+) {
+    if let Some(rk_bytes) = row_keys_proto {
+        writer.append_key_value_metadata(parquet::file::metadata::KeyValue::new(
+            PARQUET_META_ROW_KEYS.to_string(),
+            BASE64.encode(rk_bytes),
+        ));
+        if let Ok(rk) =
+            <quickwit_proto::sortschema::RowKeys as prost::Message>::decode(rk_bytes.as_slice())
+            && let Ok(json) = serde_json::to_string(&rk)
+        {
+            writer.append_key_value_metadata(parquet::file::metadata::KeyValue::new(
+                PARQUET_META_ROW_KEYS_JSON.to_string(),
+                json,
+            ));
+        }
+    }
+
+    if !zonemap_regexes.is_empty() {
+        let json = serde_json::to_string(zonemap_regexes)
+            .expect("HashMap<String, String> JSON serialization cannot fail");
+        writer.append_key_value_metadata(parquet::file::metadata::KeyValue::new(
+            PARQUET_META_ZONEMAP_REGEXES.to_string(),
+            json,
+        ));
+    }
+}

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
@@ -112,14 +112,25 @@ pub(crate) struct PrefixColumn {
 
 /// Resolve the first `prefix_len` sort columns to parquet leaf
 /// indices. Honours the legacy `timestamp` → `timestamp_secs` alias.
-/// Errors if the sort schema has fewer columns than `prefix_len` or
-/// if any column is missing from the parquet schema.
+///
+/// Returns one entry per requested prefix column. `Some(PrefixColumn)`
+/// when the column is present in the parquet schema; `None` when the
+/// column is named in `sort_fields_str` but absent from the parquet
+/// schema. Per SS-3 the missing column is treated as constant null at
+/// every row of the file — [`extract_rg_composite_prefix_key`]
+/// synthesizes a fixed byte sequence in that slot so ordering is
+/// driven entirely by the present columns.
+///
+/// Errors only when the sort schema declares fewer columns than
+/// requested — that means we don't have a *name* for one of the
+/// prefix columns and can't claim alignment on something we can't
+/// identify.
 pub(crate) fn find_prefix_parquet_col_indices(
     metadata: &ParquetMetaData,
     sort_fields_str: &str,
     prefix_len: usize,
-    input_idx: usize,
-) -> Result<Vec<PrefixColumn>> {
+    _input_idx: usize,
+) -> Result<Vec<Option<PrefixColumn>>> {
     let sort_field_schema = parse_sort_fields(sort_fields_str)?;
     if sort_field_schema.column.len() < prefix_len {
         bail!(
@@ -129,7 +140,7 @@ pub(crate) fn find_prefix_parquet_col_indices(
     }
     let parquet_schema = metadata.file_metadata().schema_descr();
     let mut prefix_cols = Vec::with_capacity(prefix_len);
-    for (pos, sort_col) in sort_field_schema.column.iter().take(prefix_len).enumerate() {
+    for sort_col in sort_field_schema.column.iter().take(prefix_len) {
         // Apply the same `timestamp` / `timestamp_secs` alias the rest
         // of the engine uses.
         let resolved = if is_timestamp_column_name(&sort_col.name)
@@ -139,6 +150,8 @@ pub(crate) fn find_prefix_parquet_col_indices(
         } else {
             sort_col.name.as_str()
         };
+        let descending = sort_col.sort_direction
+            == quickwit_proto::sortschema::SortColumnDirection::SortDirectionDescending as i32;
         let mut found = None;
         for (col_idx, col) in parquet_schema.columns().iter().enumerate() {
             if col.path().parts()[0] == resolved {
@@ -146,20 +159,14 @@ pub(crate) fn find_prefix_parquet_col_indices(
                 break;
             }
         }
-        let parquet_col_idx = found.ok_or_else(|| {
-            anyhow!(
-                "input {input_idx} parquet schema is missing prefix sort column '{}' (position \
-                 {pos})",
-                sort_col.name,
-            )
-        })?;
-        let descending = sort_col.sort_direction
-            == quickwit_proto::sortschema::SortColumnDirection::SortDirectionDescending as i32;
-        prefix_cols.push(PrefixColumn {
+        // SS-3: missing column → None. Caller treats it as constant
+        // null at every row, which trivially satisfies alignment on
+        // that column.
+        prefix_cols.push(found.map(|parquet_col_idx| PrefixColumn {
             name: sort_col.name.clone(),
             parquet_col_idx,
             descending,
-        });
+        }));
     }
     Ok(prefix_cols)
 }
@@ -179,17 +186,33 @@ fn parquet_has_column(
 /// prefix column's value bytes in declared order, with each column's
 /// encoding chosen so that lexicographic order on the composite
 /// matches the sort schema's order across the prefix columns. Each
-/// column is required to have `min == max` statistics on this RG (the
-/// "metric-aligned" invariant declared by `rg_partition_prefix_len`).
+/// present column is required to have `min == max` statistics on
+/// this RG (PA-1).
+///
+/// A `None` slot in `prefix_cols` represents an SS-3 case: the
+/// column is declared in `qh.sort_fields` but absent from the
+/// parquet schema. Per SS-3 every row's value in that column is
+/// implicitly null. Since the value is constant across all RGs in
+/// the file, we contribute a fixed byte sequence (the encoded
+/// empty value) in that slot — ordering on this column does no
+/// work, and ordering on the other prefix columns picks the region
+/// boundaries.
 pub(crate) fn extract_rg_composite_prefix_key(
     metadata: &ParquetMetaData,
     rg_idx: usize,
-    prefix_cols: &[PrefixColumn],
+    prefix_cols: &[Option<PrefixColumn>],
     input_idx: usize,
 ) -> Result<Vec<u8>> {
     let rg_meta = metadata.row_group(rg_idx);
     let mut key = Vec::new();
-    for col in prefix_cols {
+    for col_opt in prefix_cols {
+        let Some(col) = col_opt else {
+            // SS-3 implicit null: constant for every RG, so any fixed
+            // marker works. Use the encoded empty byte string so the
+            // contribution is byte-recognizable in dumps.
+            key.extend_from_slice(&encode_byte_array_prefix(&[]));
+            continue;
+        };
         let chunk = rg_meta.column(col.parquet_col_idx);
         let stats = chunk.statistics().ok_or_else(|| {
             anyhow!(
@@ -500,10 +523,22 @@ pub(crate) fn extract_regions_from_metadata(
         .collect())
 }
 
-/// Post-write check: verify the parquet file at `metadata` has no two
-/// row groups sharing the same composite prefix key, for the first
-/// `prefix_len` sort columns. Returns `Ok(())` immediately if
-/// `prefix_len == 0` (no alignment claim).
+/// Post-write check: verify every row group in `metadata` satisfies
+/// the prefix-alignment claim declared by `prefix_len`.
+///
+/// Enforces both halves of the prefix-alignment contract in one pass:
+/// - **PA-1 (intra-RG constancy):** within each RG, each of the first `prefix_len` sort columns has
+///   `min == max` (the column is constant across the RG). This is checked transitively by
+///   [`extract_rg_composite_prefix_key`] — it returns an error when any prefix column's chunk stats
+///   show `min != max`.
+/// - **PA-3 (inter-RG uniqueness):** no two RGs share the same composite prefix value. The
+///   streaming engine pairs at most one input RG per region per prefix value, so a duplicate would
+///   silently drop rows or corrupt the body-col / sort-col mapping.
+///
+/// Returns `Ok(())` immediately when `prefix_len == 0` (no claim to
+/// verify) or `num_rgs == 0` (no RGs to check). Single-RG files are
+/// NOT short-circuited — they still go through PA-1 because an
+/// unsorted single-RG file CAN have `min != max` on a prefix column.
 ///
 /// This is the writer-side mirror of the read-side check in
 /// `extract_regions_from_metadata` — both indexing and the compaction
@@ -525,8 +560,8 @@ pub(crate) fn assert_unique_rg_prefix_keys(
         return Ok(());
     }
     let num_rgs = metadata.num_row_groups();
-    if num_rgs <= 1 {
-        // Single-RG (or zero-RG) files vacuously satisfy the invariant.
+    if num_rgs == 0 {
+        // Zero-RG files vacuously satisfy both halves of the claim.
         return Ok(());
     }
     let prefix_cols =

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
@@ -28,7 +28,11 @@
 //! mid-merge.
 //!
 //! The encoding rules per parquet physical type:
-//! - `ByteArray` / `FixedLenByteArray`: 4-byte BE length prefix + bytes.
+//! - `ByteArray` / `FixedLenByteArray`: byte-stuffed escape encoding — each `0x00` byte in the
+//!   value becomes `0x00 0x01`, and a `0x00 0x00` terminator is appended. This preserves
+//!   lexicographic order both for single columns (`"aa"` < `"b"`) and across concatenated composite
+//!   keys (the `0x00 0x00` terminator is the smallest possible 2-byte sequence under escaping, so
+//!   shorter values sort before longer values when prefixes match).
 //! - `Int32` / `Int64`: sign-flipped big-endian so byte order matches numeric order across the full
 //!   signed range.
 //! - `Boolean`: single 0/1 byte.
@@ -36,7 +40,7 @@
 //!   *larger*.
 //! - `Float` / `Double` / `Int96`: rejected with a clear error.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use anyhow::{Context, Result, anyhow, bail};
 use parquet::file::metadata::ParquetMetaData;
@@ -289,13 +293,25 @@ fn extract_aligned_prefix_value(
     }
 }
 
-/// Length-prefix a variable-width value so the resulting bytes
-/// concatenate unambiguously and lex-order matches column order even
-/// when adjacent columns have different lengths.
+/// Byte-stuffed escape encoding for a variable-width value: every
+/// `0x00` byte becomes `0x00 0x01`, and a `0x00 0x00` terminator is
+/// appended. This preserves lex order for single columns (`"aa"` <
+/// `"b"`) AND lets multiple values concatenate unambiguously — the
+/// terminator is the smallest possible 2-byte sequence after
+/// escaping, so a shorter value sorts before any longer value sharing
+/// its prefix.
 pub(crate) fn encode_byte_array_prefix(bytes: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(4 + bytes.len());
-    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
-    out.extend_from_slice(bytes);
+    let mut out = Vec::with_capacity(bytes.len() + 2);
+    for &b in bytes {
+        if b == 0x00 {
+            out.push(0x00);
+            out.push(0x01);
+        } else {
+            out.push(b);
+        }
+    }
+    out.push(0x00);
+    out.push(0x00);
     out
 }
 
@@ -380,6 +396,20 @@ pub(crate) fn extract_regions_from_metadata(
     // Prefix_len >= 1: build regions by composite prefix key from
     // per-RG stats. See `extract_rg_composite_prefix_key` for the
     // per-type encoding.
+    //
+    // **Strong invariant** (enforced here on the merge read path, and
+    // mirrored on both write paths — see `assert_unique_rg_prefix_keys`):
+    // no single input may have two row groups sharing the same composite
+    // prefix key. The streaming engine pairs at most one RG per input
+    // per region (`process_region` keys `sort_col_batches` by
+    // `input_idx`), so a duplicate prefix would silently overwrite the
+    // first RG's sort batch while `Region::total_rows` still counts both
+    // — dropping rows and corrupting body-col / sort-col alignment.
+    //
+    // Cross-input duplicates are fine (and expected — that's the whole
+    // point of region merging). The constraint is **same input, same
+    // prefix key, multiple RGs**: producers must ensure prefix
+    // transitions align with RG boundaries.
     let mut by_prefix: BTreeMap<Vec<u8>, Vec<(usize, usize, usize)>> = BTreeMap::new();
     let prefix_len = input_meta.rg_partition_prefix_len as usize;
 
@@ -394,9 +424,20 @@ pub(crate) fn extract_regions_from_metadata(
             input_idx,
         )
         .with_context(|| format!("resolving prefix cols for input {input_idx}"))?;
+        let mut seen_for_input: HashSet<Vec<u8>> = HashSet::new();
         for rg_idx in 0..state.metadata.num_row_groups() {
             let prefix_key =
                 extract_rg_composite_prefix_key(&state.metadata, rg_idx, &prefix_cols, input_idx)?;
+            if !seen_for_input.insert(prefix_key.clone()) {
+                bail!(
+                    "input {input_idx} has rg {rg_idx} sharing a prefix key with an earlier RG in \
+                     the same file. The streaming merge engine requires at-most-one-RG-per-input \
+                     per prefix value (rg_partition_prefix_len = {prefix_len}); the producer must \
+                     ensure prefix transitions align with RG boundaries. Either lower \
+                     rg_partition_prefix_len to include fewer columns, or rewrite the producer to \
+                     start a new RG at every prefix-value change."
+                );
+            }
             let num_rows = state.metadata.row_group(rg_idx).num_rows() as usize;
             by_prefix
                 .entry(prefix_key)
@@ -412,6 +453,55 @@ pub(crate) fn extract_regions_from_metadata(
             contributing,
         })
         .collect())
+}
+
+/// Post-write check: verify the parquet file at `metadata` has no two
+/// row groups sharing the same composite prefix key, for the first
+/// `prefix_len` sort columns. Returns `Ok(())` immediately if
+/// `prefix_len == 0` (no alignment claim).
+///
+/// This is the writer-side mirror of the read-side check in
+/// `extract_regions_from_metadata` — both indexing and the compaction
+/// merge output writer call this after sealing a parquet file so a
+/// producer bug never lets a duplicate-prefix file land on disk. See
+/// the doc-comment on `extract_regions_from_metadata` for why
+/// at-most-one-RG-per-prefix is load-bearing for the streaming
+/// engine.
+///
+/// `context` is included in the error message — e.g.,
+/// `"indexing write at <path>"` or `"merge output <split_id>"`.
+pub(crate) fn assert_unique_rg_prefix_keys(
+    metadata: &ParquetMetaData,
+    sort_fields_str: &str,
+    prefix_len: u32,
+    context: &str,
+) -> Result<()> {
+    if prefix_len == 0 {
+        return Ok(());
+    }
+    let num_rgs = metadata.num_row_groups();
+    if num_rgs <= 1 {
+        // Single-RG (or zero-RG) files vacuously satisfy the invariant.
+        return Ok(());
+    }
+    let prefix_cols =
+        find_prefix_parquet_col_indices(metadata, sort_fields_str, prefix_len as usize, 0)
+            .with_context(|| format!("resolving prefix cols for {context}"))?;
+    let mut seen: HashSet<Vec<u8>> = HashSet::with_capacity(num_rgs);
+    for rg_idx in 0..num_rgs {
+        let key = extract_rg_composite_prefix_key(metadata, rg_idx, &prefix_cols, 0)
+            .with_context(|| format!("extracting prefix key at {context} rg {rg_idx}"))?;
+        if !seen.insert(key) {
+            bail!(
+                "{context}: rg {rg_idx} shares a prefix key with an earlier row group. \
+                 rg_partition_prefix_len = {prefix_len} requires prefix transitions to align with \
+                 row group boundaries. Either lower the prefix length to include fewer columns, \
+                 or change the writer so each RG carries a unique value of the first {prefix_len} \
+                 sort columns."
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Assign each region to an output file index.

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
@@ -1,0 +1,451 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Region grouping for multi-RG streaming merge.
+//!
+//! A "region" is one merge unit: a contiguous slice of the merged
+//! output where all contributing inputs share the same sort-prefix
+//! value. For multi-RG metric-aligned inputs each region pairs with
+//! at most one row group per input, which is the property that makes
+//! per-region streaming work without column-chunk-bounded buffering.
+//!
+//! This module owns the composite prefix-key encoding (sort-order
+//! preserving across multiple columns / per-type encoding rules) and
+//! the BTreeMap-based region grouping. It also enforces MS-2: the
+//! BTreeMap iteration order must agree with each input's physical
+//! row-group order, otherwise the streaming engine would crash
+//! mid-merge.
+//!
+//! The encoding rules per parquet physical type:
+//! - `ByteArray` / `FixedLenByteArray`: 4-byte BE length prefix + bytes.
+//! - `Int32` / `Int64`: sign-flipped big-endian so byte order matches numeric order across the full
+//!   signed range.
+//! - `Boolean`: single 0/1 byte.
+//! - DESC columns: per-byte complement of the encoding above so smaller values' bytes sort
+//!   *larger*.
+//! - `Float` / `Double` / `Int96`: rejected with a clear error.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result, anyhow, bail};
+use parquet::file::metadata::ParquetMetaData;
+
+use super::super::InputMetadata;
+use super::InputDecoderState;
+use crate::sort_fields::{is_timestamp_column_name, parse_sort_fields};
+
+/// One merge region: a contiguous slice of the merged output, where all
+/// contributing inputs share the same sort-prefix value (e.g., one
+/// `metric_name` when `rg_partition_prefix_len == 1`).
+///
+/// For multi-RG metric-aligned inputs, each region corresponds to **at
+/// most one row group per input** — the property that makes per-region
+/// streaming work without column-chunk-bounded buffering.
+#[derive(Debug, Clone)]
+pub(crate) struct Region {
+    /// Sort-prefix value identifying this region (e.g., `metric_name`
+    /// bytes for `prefix_len == 1`). Used only for ordering and
+    /// diagnostics; the merge engine doesn't decode this value.
+    pub(crate) prefix_key: Vec<u8>,
+    /// `(input_idx, rg_idx, num_rows)` for each input that contributes
+    /// to this region. Ordered by `input_idx`.
+    pub(crate) contributing: Vec<(usize, usize, usize)>,
+}
+
+impl Region {
+    pub(crate) fn total_rows(&self) -> usize {
+        self.contributing.iter().map(|(_, _, n)| *n).sum()
+    }
+}
+
+/// A prefix column's location in the parquet schema, plus the sort
+/// direction declared for it. `name` is the sort-schema name (used in
+/// error messages); `parquet_col_idx` is the resolved index in the
+/// parquet schema's flat column list (after applying the
+/// `timestamp` / `timestamp_secs` alias).
+#[derive(Debug, Clone)]
+pub(crate) struct PrefixColumn {
+    pub(crate) name: String,
+    pub(crate) parquet_col_idx: usize,
+    pub(crate) descending: bool,
+}
+
+/// Resolve the first `prefix_len` sort columns to parquet leaf
+/// indices. Honours the legacy `timestamp` → `timestamp_secs` alias.
+/// Errors if the sort schema has fewer columns than `prefix_len` or
+/// if any column is missing from the parquet schema.
+pub(crate) fn find_prefix_parquet_col_indices(
+    metadata: &ParquetMetaData,
+    sort_fields_str: &str,
+    prefix_len: usize,
+    input_idx: usize,
+) -> Result<Vec<PrefixColumn>> {
+    let sort_field_schema = parse_sort_fields(sort_fields_str)?;
+    if sort_field_schema.column.len() < prefix_len {
+        bail!(
+            "sort schema has {} columns but rg_partition_prefix_len = {prefix_len}",
+            sort_field_schema.column.len(),
+        );
+    }
+    let parquet_schema = metadata.file_metadata().schema_descr();
+    let mut prefix_cols = Vec::with_capacity(prefix_len);
+    for (pos, sort_col) in sort_field_schema.column.iter().take(prefix_len).enumerate() {
+        // Apply the same `timestamp` / `timestamp_secs` alias the rest
+        // of the engine uses.
+        let resolved = if is_timestamp_column_name(&sort_col.name)
+            && parquet_has_column(parquet_schema, "timestamp_secs")
+        {
+            "timestamp_secs"
+        } else {
+            sort_col.name.as_str()
+        };
+        let mut found = None;
+        for (col_idx, col) in parquet_schema.columns().iter().enumerate() {
+            if col.path().parts()[0] == resolved {
+                found = Some(col_idx);
+                break;
+            }
+        }
+        let parquet_col_idx = found.ok_or_else(|| {
+            anyhow!(
+                "input {input_idx} parquet schema is missing prefix sort column '{}' (position \
+                 {pos})",
+                sort_col.name,
+            )
+        })?;
+        let descending = sort_col.sort_direction
+            == quickwit_proto::sortschema::SortColumnDirection::SortDirectionDescending as i32;
+        prefix_cols.push(PrefixColumn {
+            name: sort_col.name.clone(),
+            parquet_col_idx,
+            descending,
+        });
+    }
+    Ok(prefix_cols)
+}
+
+fn parquet_has_column(
+    parquet_schema: &parquet::schema::types::SchemaDescriptor,
+    name: &str,
+) -> bool {
+    parquet_schema
+        .columns()
+        .iter()
+        .any(|c| c.path().parts()[0] == name)
+}
+
+/// Build the composite byte key identifying a row group's prefix
+/// values for grouping into a region. The key concatenates each
+/// prefix column's value bytes in declared order, with each column's
+/// encoding chosen so that lexicographic order on the composite
+/// matches the sort schema's order across the prefix columns. Each
+/// column is required to have `min == max` statistics on this RG (the
+/// "metric-aligned" invariant declared by `rg_partition_prefix_len`).
+pub(crate) fn extract_rg_composite_prefix_key(
+    metadata: &ParquetMetaData,
+    rg_idx: usize,
+    prefix_cols: &[PrefixColumn],
+    input_idx: usize,
+) -> Result<Vec<u8>> {
+    let rg_meta = metadata.row_group(rg_idx);
+    let mut key = Vec::new();
+    for col in prefix_cols {
+        let chunk = rg_meta.column(col.parquet_col_idx);
+        let stats = chunk.statistics().ok_or_else(|| {
+            anyhow!(
+                "input {input_idx} rg {rg_idx} col '{}' has no statistics — cannot determine \
+                 prefix alignment without min/max",
+                col.name,
+            )
+        })?;
+        let value_bytes = extract_aligned_prefix_value(stats, &col.name, rg_idx, input_idx)?;
+        let encoded = if col.descending {
+            invert_for_descending(&value_bytes)
+        } else {
+            value_bytes
+        };
+        key.extend_from_slice(&encoded);
+    }
+    Ok(key)
+}
+
+/// Verify min == max for the column chunk and return the value
+/// encoded as order-preserving big-endian bytes (without applying any
+/// direction inversion — that's the caller's job).
+fn extract_aligned_prefix_value(
+    stats: &parquet::file::statistics::Statistics,
+    sort_col_name: &str,
+    rg_idx: usize,
+    input_idx: usize,
+) -> Result<Vec<u8>> {
+    use parquet::file::statistics::Statistics;
+
+    fn require_eq<T: PartialEq + std::fmt::Debug>(
+        min: Option<T>,
+        max: Option<T>,
+        col: &str,
+        rg_idx: usize,
+        input_idx: usize,
+    ) -> Result<T> {
+        let min = min.ok_or_else(|| {
+            anyhow!(
+                "input {input_idx} rg {rg_idx} col '{col}' has no min in stats — cannot determine \
+                 prefix alignment"
+            )
+        })?;
+        let max = max.ok_or_else(|| {
+            anyhow!(
+                "input {input_idx} rg {rg_idx} col '{col}' has no max in stats — cannot determine \
+                 prefix alignment"
+            )
+        })?;
+        if min != max {
+            bail!(
+                "input {input_idx} rg {rg_idx} is NOT prefix-aligned on col '{col}': min ({:?}) \
+                 != max ({:?}). Multi-RG inputs declaring `rg_partition_prefix_len >= 1` must \
+                 carry one prefix-value per RG.",
+                min,
+                max,
+            );
+        }
+        Ok(min)
+    }
+
+    match stats {
+        Statistics::ByteArray(v) => {
+            let value = require_eq(
+                v.min_bytes_opt().map(|b| b.to_vec()),
+                v.max_bytes_opt().map(|b| b.to_vec()),
+                sort_col_name,
+                rg_idx,
+                input_idx,
+            )?;
+            Ok(encode_byte_array_prefix(&value))
+        }
+        Statistics::FixedLenByteArray(v) => {
+            let value = require_eq(
+                v.min_bytes_opt().map(|b| b.to_vec()),
+                v.max_bytes_opt().map(|b| b.to_vec()),
+                sort_col_name,
+                rg_idx,
+                input_idx,
+            )?;
+            Ok(encode_byte_array_prefix(&value))
+        }
+        Statistics::Int32(v) => {
+            let value = require_eq(
+                v.min_opt().copied(),
+                v.max_opt().copied(),
+                sort_col_name,
+                rg_idx,
+                input_idx,
+            )?;
+            // Sign-flip so the byte order of the BE encoding matches
+            // numeric order across the full i32 range.
+            Ok(((value as u32) ^ 0x8000_0000u32).to_be_bytes().to_vec())
+        }
+        Statistics::Int64(v) => {
+            let value = require_eq(
+                v.min_opt().copied(),
+                v.max_opt().copied(),
+                sort_col_name,
+                rg_idx,
+                input_idx,
+            )?;
+            Ok(((value as u64) ^ 0x8000_0000_0000_0000u64)
+                .to_be_bytes()
+                .to_vec())
+        }
+        Statistics::Boolean(v) => {
+            let value = require_eq(
+                v.min_opt().copied(),
+                v.max_opt().copied(),
+                sort_col_name,
+                rg_idx,
+                input_idx,
+            )?;
+            Ok(vec![value as u8])
+        }
+        Statistics::Float(_) | Statistics::Double(_) => bail!(
+            "prefix col '{sort_col_name}' is floating-point; composite-key extraction does not \
+             yet support IEEE-754 ordering. Open an issue if you hit this — the encoding needs a \
+             sign-aware bit flip on negative values."
+        ),
+        Statistics::Int96(_) => bail!(
+            "prefix col '{sort_col_name}' is Int96 (deprecated timestamp type); use Int64-encoded \
+             `timestamp_secs` instead."
+        ),
+    }
+}
+
+/// Length-prefix a variable-width value so the resulting bytes
+/// concatenate unambiguously and lex-order matches column order even
+/// when adjacent columns have different lengths.
+pub(crate) fn encode_byte_array_prefix(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + bytes.len());
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+    out
+}
+
+/// Bytewise complement: turns an ASC-ordered byte string into one
+/// that sorts in reverse. Applied to each prefix column whose sort
+/// direction is DESC so the BTreeMap iteration order matches the
+/// declared sort order for that column.
+pub(crate) fn invert_for_descending(bytes: &[u8]) -> Vec<u8> {
+    bytes.iter().map(|b| !b).collect()
+}
+
+/// MS-2: verify that, for each input, the regions list visits its
+/// row groups in physical (on-disk) order. The streaming engine
+/// drains each input sequentially — once we've moved past RG K's
+/// pages we cannot go back. The composite-key BTreeMap iteration
+/// must agree with that physical ordering for every input.
+///
+/// Disagreement usually means the input file's sort direction was
+/// declared one way but the data was written the other — e.g., the
+/// sort schema says `metric_name ASC` but the file has RG 0 with
+/// metric `z` and RG 1 with metric `a`. Reject upfront with a clear
+/// message rather than letting `process_region` crash mid-merge
+/// with "page from rg X while draining rg Y".
+pub(crate) fn validate_region_order_matches_physical_rg_order(
+    regions: &[Region],
+    num_inputs: usize,
+) -> Result<()> {
+    let mut last_rg_per_input: Vec<Option<usize>> = vec![None; num_inputs];
+    for (region_idx, region) in regions.iter().enumerate() {
+        for &(input_idx, rg_idx, _) in &region.contributing {
+            if let Some(prev_rg) = last_rg_per_input[input_idx]
+                && rg_idx <= prev_rg
+            {
+                bail!(
+                    "region iteration disagrees with input {input_idx}'s physical RG order: \
+                     region {region_idx} wants rg {rg_idx} but a previous region already used rg \
+                     {prev_rg}. The composite prefix key encoding does not match the input's \
+                     physical layout — check that the sort schema's direction matches how the \
+                     file is actually sorted on disk."
+                );
+            }
+            last_rg_per_input[input_idx] = Some(rg_idx);
+        }
+    }
+    Ok(())
+}
+
+/// Build the region list across all inputs.
+///
+/// - If `rg_partition_prefix_len == 0`: all inputs must be single-RG (caller's job to validate);
+///   produces ONE region with each input's only RG. The region's `prefix_key` is empty (no
+///   alignment claim).
+/// - If `rg_partition_prefix_len >= 1`: reads each input's per-RG prefix col stats (must have `min
+///   == max`), groups RGs across inputs by composite prefix key, sorts regions by that key.
+///
+/// Returns regions in sort order (sort prefix ASC).
+pub(crate) fn extract_regions_from_metadata(
+    decoders_state: &[InputDecoderState],
+    input_meta: &InputMetadata,
+) -> Result<Vec<Region>> {
+    if input_meta.rg_partition_prefix_len == 0 {
+        // No alignment claim: single region covering each input's only RG.
+        // Multi-RG inputs with prefix_len == 0 are rejected earlier; here
+        // each input is single-RG (or zero-RG).
+        let mut contributing = Vec::new();
+        for (idx, state) in decoders_state.iter().enumerate() {
+            if state.metadata.num_row_groups() == 0 {
+                continue;
+            }
+            let rg_meta = state.metadata.row_group(0);
+            contributing.push((idx, 0, rg_meta.num_rows() as usize));
+        }
+        if contributing.is_empty() {
+            return Ok(Vec::new());
+        }
+        return Ok(vec![Region {
+            prefix_key: Vec::new(),
+            contributing,
+        }]);
+    }
+
+    // Prefix_len >= 1: build regions by composite prefix key from
+    // per-RG stats. See `extract_rg_composite_prefix_key` for the
+    // per-type encoding.
+    let mut by_prefix: BTreeMap<Vec<u8>, Vec<(usize, usize, usize)>> = BTreeMap::new();
+    let prefix_len = input_meta.rg_partition_prefix_len as usize;
+
+    for (input_idx, state) in decoders_state.iter().enumerate() {
+        if state.metadata.num_row_groups() == 0 {
+            continue;
+        }
+        let prefix_cols = find_prefix_parquet_col_indices(
+            &state.metadata,
+            &input_meta.sort_fields,
+            prefix_len,
+            input_idx,
+        )
+        .with_context(|| format!("resolving prefix cols for input {input_idx}"))?;
+        for rg_idx in 0..state.metadata.num_row_groups() {
+            let prefix_key =
+                extract_rg_composite_prefix_key(&state.metadata, rg_idx, &prefix_cols, input_idx)?;
+            let num_rows = state.metadata.row_group(rg_idx).num_rows() as usize;
+            by_prefix
+                .entry(prefix_key)
+                .or_default()
+                .push((input_idx, rg_idx, num_rows));
+        }
+    }
+
+    Ok(by_prefix
+        .into_iter()
+        .map(|(prefix_key, contributing)| Region {
+            prefix_key,
+            contributing,
+        })
+        .collect())
+}
+
+/// Assign each region to an output file index.
+///
+/// Splits the region list across `num_outputs` files, balancing
+/// cumulative row count. Each output file gets a contiguous slice of
+/// the region list (preserving sort-prefix order so output files have
+/// non-overlapping key ranges). Returns a `Vec<usize>` indexed by
+/// `region_idx` with the target output file index.
+///
+/// If `regions.len() < num_outputs`, fewer output files are produced
+/// (matches the non-streaming engine's behaviour when there aren't
+/// enough split points).
+pub(crate) fn assign_regions_to_output_files(regions: &[Region], num_outputs: usize) -> Vec<usize> {
+    let total_rows: usize = regions.iter().map(|r| r.total_rows()).sum();
+    let effective_num_outputs = num_outputs.min(regions.len()).max(1);
+    let target_rows_per_output = total_rows.div_ceil(effective_num_outputs).max(1);
+
+    let mut assignments = Vec::with_capacity(regions.len());
+    let mut current_output = 0;
+    let mut accumulated = 0;
+    for region in regions {
+        // If this region would push us past the target AND we have
+        // budget to start a new output AND the current output already
+        // has rows, advance to next output BEFORE assigning.
+        if accumulated > 0
+            && accumulated + region.total_rows() > target_rows_per_output
+            && current_output + 1 < effective_num_outputs
+        {
+            current_output += 1;
+            accumulated = 0;
+        }
+        assignments.push(current_output);
+        accumulated += region.total_rows();
+    }
+    assignments
+}

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
@@ -41,11 +41,15 @@
 //! - `Float` / `Double` / `Int96`: rejected with a clear error.
 
 use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail};
+use arrow::array::RecordBatch;
+use arrow::row::{RowConverter, Rows, SortField};
 use parquet::file::metadata::ParquetMetaData;
 
 use super::super::InputMetadata;
+use super::super::merge_order::MergeRun;
 use super::InputDecoderState;
 use crate::sort_fields::{is_timestamp_column_name, parse_sort_fields};
 
@@ -53,23 +57,44 @@ use crate::sort_fields::{is_timestamp_column_name, parse_sort_fields};
 /// contributing inputs share the same sort-prefix value (e.g., one
 /// `metric_name` when `rg_partition_prefix_len == 1`).
 ///
-/// For multi-RG metric-aligned inputs, each region corresponds to **at
-/// most one row group per input** — the property that makes per-region
-/// streaming work without column-chunk-bounded buffering.
+/// A region pairs with **at most one row group per input** — the
+/// property that makes per-region streaming work without
+/// column-chunk-bounded buffering. The `start_row` field on each
+/// contribution allows a single row group to be split across multiple
+/// adjacent regions, which is what the prefix_len=0 synthesis path
+/// does: it slices a single-RG input's data into one synthesized
+/// region per first-sort-col value.
 #[derive(Debug, Clone)]
 pub(crate) struct Region {
     /// Sort-prefix value identifying this region (e.g., `metric_name`
     /// bytes for `prefix_len == 1`). Used only for ordering and
     /// diagnostics; the merge engine doesn't decode this value.
     pub(crate) prefix_key: Vec<u8>,
-    /// `(input_idx, rg_idx, num_rows)` for each input that contributes
+    /// Per contributing input: which slice of which row group belongs
     /// to this region. Ordered by `input_idx`.
-    pub(crate) contributing: Vec<(usize, usize, usize)>,
+    pub(crate) contributing: Vec<RegionContribution>,
+}
+
+/// One input's contribution to a region: the input index, the row
+/// group within that input, and the row range within that row group
+/// that belongs to the region.
+///
+/// For metric-aligned inputs (`rg_partition_prefix_len > 0`) each
+/// contribution covers a whole RG: `start_row == 0` and
+/// `num_rows == rg.num_rows()`. For inputs that the prefix_len=0
+/// synthesis path slices, multiple regions reference the same
+/// `(input_idx, rg_idx)` with disjoint contiguous row ranges.
+#[derive(Debug, Clone)]
+pub(crate) struct RegionContribution {
+    pub(crate) input_idx: usize,
+    pub(crate) rg_idx: usize,
+    pub(crate) start_row: usize,
+    pub(crate) num_rows: usize,
 }
 
 impl Region {
     pub(crate) fn total_rows(&self) -> usize {
-        self.contributing.iter().map(|(_, _, n)| *n).sum()
+        self.contributing.iter().map(|c| c.num_rows).sum()
     }
 }
 
@@ -339,21 +364,27 @@ pub(crate) fn validate_region_order_matches_physical_rg_order(
     regions: &[Region],
     num_inputs: usize,
 ) -> Result<()> {
-    let mut last_rg_per_input: Vec<Option<usize>> = vec![None; num_inputs];
+    let mut last_position_per_input: Vec<Option<(usize, usize)>> = vec![None; num_inputs];
     for (region_idx, region) in regions.iter().enumerate() {
-        for &(input_idx, rg_idx, _) in &region.contributing {
-            if let Some(prev_rg) = last_rg_per_input[input_idx]
-                && rg_idx <= prev_rg
+        for c in &region.contributing {
+            let position = (c.rg_idx, c.start_row);
+            if let Some(prev) = last_position_per_input[c.input_idx]
+                && position < prev
             {
                 bail!(
-                    "region iteration disagrees with input {input_idx}'s physical RG order: \
-                     region {region_idx} wants rg {rg_idx} but a previous region already used rg \
-                     {prev_rg}. The composite prefix key encoding does not match the input's \
-                     physical layout — check that the sort schema's direction matches how the \
-                     file is actually sorted on disk."
+                    "region iteration disagrees with input {}'s physical row order: region \
+                     {region_idx} wants rg {} row {} but a previous region already passed \
+                     position rg {} row {}. The composite prefix key encoding does not match the \
+                     input's physical layout — check that the sort schema's direction matches how \
+                     the file is actually sorted on disk.",
+                    c.input_idx,
+                    c.rg_idx,
+                    c.start_row,
+                    prev.0,
+                    prev.1,
                 );
             }
-            last_rg_per_input[input_idx] = Some(rg_idx);
+            last_position_per_input[c.input_idx] = Some((c.rg_idx, c.start_row + c.num_rows));
         }
     }
     Ok(())
@@ -376,13 +407,22 @@ pub(crate) fn extract_regions_from_metadata(
         // No alignment claim: single region covering each input's only RG.
         // Multi-RG inputs with prefix_len == 0 are rejected earlier; here
         // each input is single-RG (or zero-RG).
+        //
+        // The caller (`run_synthesized_prefix_path`) will split this
+        // region further once it has read the merge order and can see
+        // where the first sort col's value transitions.
         let mut contributing = Vec::new();
         for (idx, state) in decoders_state.iter().enumerate() {
             if state.metadata.num_row_groups() == 0 {
                 continue;
             }
             let rg_meta = state.metadata.row_group(0);
-            contributing.push((idx, 0, rg_meta.num_rows() as usize));
+            contributing.push(RegionContribution {
+                input_idx: idx,
+                rg_idx: 0,
+                start_row: 0,
+                num_rows: rg_meta.num_rows() as usize,
+            });
         }
         if contributing.is_empty() {
             return Ok(Vec::new());
@@ -410,7 +450,7 @@ pub(crate) fn extract_regions_from_metadata(
     // point of region merging). The constraint is **same input, same
     // prefix key, multiple RGs**: producers must ensure prefix
     // transitions align with RG boundaries.
-    let mut by_prefix: BTreeMap<Vec<u8>, Vec<(usize, usize, usize)>> = BTreeMap::new();
+    let mut by_prefix: BTreeMap<Vec<u8>, Vec<RegionContribution>> = BTreeMap::new();
     let prefix_len = input_meta.rg_partition_prefix_len as usize;
 
     for (input_idx, state) in decoders_state.iter().enumerate() {
@@ -442,7 +482,12 @@ pub(crate) fn extract_regions_from_metadata(
             by_prefix
                 .entry(prefix_key)
                 .or_default()
-                .push((input_idx, rg_idx, num_rows));
+                .push(RegionContribution {
+                    input_idx,
+                    rg_idx,
+                    start_row: 0,
+                    num_rows,
+                });
         }
     }
 
@@ -502,6 +547,136 @@ pub(crate) fn assert_unique_rg_prefix_keys(
         }
     }
     Ok(())
+}
+
+/// Synthesize prefix-aligned regions from a global k-way merge order.
+///
+/// Used by the prefix_len=0 path: each input is single-RG and not
+/// prefix-aligned at the producer side, so the engine drains all sort
+/// cols, computes a global merge order, and walks that merge order
+/// here to find prefix-value (first sort column, typically
+/// `metric_name`) transitions. Each run in the merge order has a
+/// constant `sorted_series` (built that way by `compute_merge_order`),
+/// which in turn implies a constant value of every sort col including
+/// the first — so prefix transitions only happen at run boundaries.
+///
+/// For each prefix value we emit one [`Region`] whose `contributing`
+/// records, for each input that participated, a contiguous row range
+/// of that input's RG. The output writer materialises this range as
+/// one output row group, making the produced parquet file prefix-
+/// aligned (the caller sets the output's `rg_partition_prefix_len` to
+/// reflect that — see `streaming_merge_sorted_parquet_files`).
+///
+/// Returns regions in merge-order (which is sort order: the order
+/// matches the merge engine's monotonic consumption of each input's
+/// rows).
+pub(crate) fn synthesize_prefix_regions(
+    global_merge_order: &[MergeRun],
+    aligned_sort_batches: &[RecordBatch],
+    first_sort_col_name: &str,
+) -> Result<Vec<Region>> {
+    if global_merge_order.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Build a per-input row encoding of the first sort column so that
+    // bytewise comparison gives the same answer the merge order's
+    // comparator does. RowConverter handles dictionary / utf8 /
+    // primitive uniformly.
+    let mut rows_per_input: Vec<Option<Rows>> = Vec::with_capacity(aligned_sort_batches.len());
+    for batch in aligned_sort_batches {
+        let rows = match batch.schema().index_of(first_sort_col_name) {
+            Ok(idx) => {
+                let col = batch.column(idx);
+                let conv = RowConverter::new(vec![SortField::new(col.data_type().clone())])
+                    .with_context(|| {
+                        format!("building row converter for prefix col '{first_sort_col_name}'")
+                    })?;
+                let rows = conv.convert_columns(&[Arc::clone(col)]).with_context(|| {
+                    format!("encoding prefix col '{first_sort_col_name}' for region synthesis")
+                })?;
+                Some(rows)
+            }
+            Err(_) => None,
+        };
+        rows_per_input.push(rows);
+    }
+
+    let prefix_bytes_for_run = |run: &MergeRun| -> Result<Vec<u8>> {
+        let rows = rows_per_input[run.input_index].as_ref().ok_or_else(|| {
+            anyhow!(
+                "input {} is missing prefix col '{first_sort_col_name}' — prefix_len=0 synthesis \
+                 requires every input to carry the first sort col",
+                run.input_index,
+            )
+        })?;
+        Ok(rows.row(run.start_row).as_ref().to_vec())
+    };
+
+    let mut regions: Vec<Region> = Vec::new();
+    let mut current_prefix: Option<Vec<u8>> = None;
+    // Per-input (start_row, end_row) accumulated for the current region.
+    let mut current_ranges: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+    let mut current_rg_idx: BTreeMap<usize, usize> = BTreeMap::new();
+
+    let flush = |prefix: Vec<u8>,
+                 ranges: BTreeMap<usize, (usize, usize)>,
+                 rg_indices: &BTreeMap<usize, usize>,
+                 regions: &mut Vec<Region>| {
+        if ranges.is_empty() {
+            return;
+        }
+        let contributing: Vec<RegionContribution> = ranges
+            .into_iter()
+            .map(|(input_idx, (start, end))| RegionContribution {
+                input_idx,
+                rg_idx: *rg_indices
+                    .get(&input_idx)
+                    .expect("rg_idx set when range was opened"),
+                start_row: start,
+                num_rows: end - start,
+            })
+            .collect();
+        regions.push(Region {
+            prefix_key: prefix,
+            contributing,
+        });
+    };
+
+    for run in global_merge_order {
+        let p = prefix_bytes_for_run(run)?;
+        if current_prefix.as_deref() != Some(p.as_slice()) {
+            // Close the prior region (if any) and start a fresh one.
+            if let Some(prev) = current_prefix.take() {
+                flush(
+                    prev,
+                    std::mem::take(&mut current_ranges),
+                    &current_rg_idx,
+                    &mut regions,
+                );
+                current_rg_idx.clear();
+            }
+            current_prefix = Some(p);
+        }
+
+        // Extend the current region's range for this input. The merge
+        // engine ingests each input's rows in increasing row order
+        // within a single RG, so consecutive contributions for the
+        // same input within a region form one contiguous range.
+        let entry = current_ranges
+            .entry(run.input_index)
+            .or_insert((run.start_row, run.start_row));
+        entry.0 = entry.0.min(run.start_row);
+        entry.1 = entry.1.max(run.start_row + run.row_count);
+        current_rg_idx.insert(run.input_index, 0);
+    }
+
+    // Final region.
+    if let Some(prev) = current_prefix.take() {
+        flush(prev, current_ranges, &current_rg_idx, &mut regions);
+    }
+
+    Ok(regions)
 }
 
 /// Assign each region to an output file index.

--- a/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/streaming/region_grouping.rs
@@ -41,11 +41,9 @@
 //! - `Float` / `Double` / `Int96`: rejected with a clear error.
 
 use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail};
 use arrow::array::RecordBatch;
-use arrow::row::{RowConverter, Rows, SortField};
 use parquet::file::metadata::ParquetMetaData;
 
 use super::super::InputMetadata;
@@ -60,10 +58,11 @@ use crate::sort_fields::{is_timestamp_column_name, parse_sort_fields};
 /// A region pairs with **at most one row group per input** — the
 /// property that makes per-region streaming work without
 /// column-chunk-bounded buffering. The `start_row` field on each
-/// contribution allows a single row group to be split across multiple
-/// adjacent regions, which is what the prefix_len=0 synthesis path
-/// does: it slices a single-RG input's data into one synthesized
-/// region per first-sort-col value.
+/// contribution lets a single row group be sliced across multiple
+/// adjacent regions, which is how the engine subdivides a region at
+/// `sorted_series` transitions to honor `num_outputs` when one
+/// region (e.g. a giant single metric with `prefix_len=0`) would
+/// otherwise occupy a single output file.
 #[derive(Debug, Clone)]
 pub(crate) struct Region {
     /// Sort-prefix value identifying this region (e.g., `metric_name`
@@ -79,11 +78,12 @@ pub(crate) struct Region {
 /// group within that input, and the row range within that row group
 /// that belongs to the region.
 ///
-/// For metric-aligned inputs (`rg_partition_prefix_len > 0`) each
+/// For top-level regions from `extract_regions_from_metadata` each
 /// contribution covers a whole RG: `start_row == 0` and
-/// `num_rows == rg.num_rows()`. For inputs that the prefix_len=0
-/// synthesis path slices, multiple regions reference the same
-/// `(input_idx, rg_idx)` with disjoint contiguous row ranges.
+/// `num_rows == rg.num_rows()`. Sub-regions produced by
+/// `split_region_at_sorted_series` reference the same
+/// `(input_idx, rg_idx)` as their parent with disjoint contiguous row
+/// ranges.
 #[derive(Debug, Clone)]
 pub(crate) struct RegionContribution {
     pub(crate) input_idx: usize,
@@ -549,134 +549,145 @@ pub(crate) fn assert_unique_rg_prefix_keys(
     Ok(())
 }
 
-/// Synthesize prefix-aligned regions from a global k-way merge order.
+/// Subdivide a region into a sequence of sub-regions whose cumulative
+/// row counts approach `target_per_output`, splitting only at
+/// `sorted_series` transitions within the region's merge order. A
+/// single `sorted_series` run is never broken — if one run exceeds
+/// the remaining budget, the whole run goes to one output anyway.
 ///
-/// Used by the prefix_len=0 path: each input is single-RG and not
-/// prefix-aligned at the producer side, so the engine drains all sort
-/// cols, computes a global merge order, and walks that merge order
-/// here to find prefix-value (first sort column, typically
-/// `metric_name`) transitions. Each run in the merge order has a
-/// constant `sorted_series` (built that way by `compute_merge_order`),
-/// which in turn implies a constant value of every sort col including
-/// the first — so prefix transitions only happen at run boundaries.
+/// `first_target` is the budget for the FIRST sub-region (typically
+/// the remaining capacity of the current output being filled by the
+/// caller). Subsequent sub-regions target `target_per_output`.
+/// `outputs_remaining` is the number of output files still available;
+/// when it hits 1 we stop splitting and emit the rest as one sub-
+/// region.
 ///
-/// For each prefix value we emit one [`Region`] whose `contributing`
-/// records, for each input that participated, a contiguous row range
-/// of that input's RG. The output writer materialises this range as
-/// one output row group, making the produced parquet file prefix-
-/// aligned (the caller sets the output's `rg_partition_prefix_len` to
-/// reflect that — see `streaming_merge_sorted_parquet_files`).
-///
-/// Returns regions in merge-order (which is sort order: the order
-/// matches the merge engine's monotonic consumption of each input's
-/// rows).
-pub(crate) fn synthesize_prefix_regions(
-    global_merge_order: &[MergeRun],
+/// The returned sub-regions:
+/// - Cover the full input region in sort order.
+/// - Each carries per-input row ranges (`start_row`/`num_rows`) inside the same `(input_idx,
+///   rg_idx)` as the parent — sub-regions of one region all share their parent's RGs.
+/// - Inherit the parent's `prefix_key`; the prefix value is constant across the parent and
+///   therefore across every sub-region.
+pub(crate) fn split_region_at_sorted_series(
+    region: &Region,
+    merge_order: &[MergeRun],
     aligned_sort_batches: &[RecordBatch],
-    first_sort_col_name: &str,
+    first_target: usize,
+    target_per_output: usize,
+    outputs_remaining: usize,
 ) -> Result<Vec<Region>> {
-    if global_merge_order.is_empty() {
+    use arrow::array::BinaryArray;
+
+    use crate::sorted_series::SORTED_SERIES_COLUMN;
+
+    if merge_order.is_empty() {
         return Ok(Vec::new());
     }
-
-    // Build a per-input row encoding of the first sort column so that
-    // bytewise comparison gives the same answer the merge order's
-    // comparator does. RowConverter handles dictionary / utf8 /
-    // primitive uniformly.
-    let mut rows_per_input: Vec<Option<Rows>> = Vec::with_capacity(aligned_sort_batches.len());
-    for batch in aligned_sort_batches {
-        let rows = match batch.schema().index_of(first_sort_col_name) {
-            Ok(idx) => {
-                let col = batch.column(idx);
-                let conv = RowConverter::new(vec![SortField::new(col.data_type().clone())])
-                    .with_context(|| {
-                        format!("building row converter for prefix col '{first_sort_col_name}'")
-                    })?;
-                let rows = conv.convert_columns(&[Arc::clone(col)]).with_context(|| {
-                    format!("encoding prefix col '{first_sort_col_name}' for region synthesis")
-                })?;
-                Some(rows)
-            }
-            Err(_) => None,
-        };
-        rows_per_input.push(rows);
+    if outputs_remaining <= 1 {
+        return Ok(vec![region.clone()]);
     }
 
-    let prefix_bytes_for_run = |run: &MergeRun| -> Result<Vec<u8>> {
-        let rows = rows_per_input[run.input_index].as_ref().ok_or_else(|| {
-            anyhow!(
-                "input {} is missing prefix col '{first_sort_col_name}' — prefix_len=0 synthesis \
-                 requires every input to carry the first sort col",
-                run.input_index,
-            )
-        })?;
-        Ok(rows.row(run.start_row).as_ref().to_vec())
+    // Per-input sorted_series array. compute_merge_order already
+    // requires this column on every input, so a missing-column case
+    // here is a bug rather than a configuration error.
+    let mut ss_arrays: Vec<Option<&BinaryArray>> = Vec::with_capacity(aligned_sort_batches.len());
+    for batch in aligned_sort_batches {
+        match batch.schema().index_of(SORTED_SERIES_COLUMN) {
+            Ok(idx) => {
+                let arr = batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .ok_or_else(|| anyhow!("`{SORTED_SERIES_COLUMN}` must be Binary-typed"))?;
+                ss_arrays.push(Some(arr));
+            }
+            Err(_) => ss_arrays.push(None),
+        }
+    }
+
+    let ss_at = |run_idx: usize| -> Option<&[u8]> {
+        let run = &merge_order[run_idx];
+        ss_arrays[run.input_index].map(|a| a.value(run.start_row))
     };
 
-    let mut regions: Vec<Region> = Vec::new();
-    let mut current_prefix: Option<Vec<u8>> = None;
-    // Per-input (start_row, end_row) accumulated for the current region.
-    let mut current_ranges: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
-    let mut current_rg_idx: BTreeMap<usize, usize> = BTreeMap::new();
+    // Walk runs, splitting before a run whose preceding sorted_series
+    // transition crosses the current target. We can only split at run
+    // boundaries (a run has constant sorted_series internally), so
+    // breaking inside a run is impossible — a giant single-series run
+    // simply lands in one output regardless of size.
+    let mut splits: Vec<std::ops::Range<usize>> = Vec::new();
+    let mut current_start: usize = 0;
+    let mut accumulated: usize = 0;
+    let mut current_target = first_target;
+    let mut outputs_left = outputs_remaining;
 
-    let flush = |prefix: Vec<u8>,
-                 ranges: BTreeMap<usize, (usize, usize)>,
-                 rg_indices: &BTreeMap<usize, usize>,
-                 regions: &mut Vec<Region>| {
-        if ranges.is_empty() {
-            return;
+    for (run_idx, run) in merge_order.iter().enumerate() {
+        if run_idx > 0 && outputs_left > 1 && accumulated >= current_target {
+            let prev_ss = ss_at(run_idx - 1);
+            let curr_ss = ss_at(run_idx);
+            let at_transition = match (prev_ss, curr_ss) {
+                (Some(a), Some(b)) => a != b,
+                _ => true,
+            };
+            if at_transition {
+                splits.push(current_start..run_idx);
+                current_start = run_idx;
+                accumulated = 0;
+                outputs_left -= 1;
+                current_target = target_per_output;
+            }
+        }
+        accumulated += run.row_count;
+    }
+    splits.push(current_start..merge_order.len());
+
+    // Build each sub-region's contributing list from the runs in its
+    // range. Within a sub-region, each input's rows are contiguous
+    // (the merge engine consumes rows in increasing input-row order
+    // and the parent region's contributions are themselves
+    // contiguous), so a `(min_run.start_row, sum_row_count)` range
+    // captures the full slice.
+    let rg_for_input: std::collections::HashMap<usize, usize> = region
+        .contributing
+        .iter()
+        .map(|c| (c.input_idx, c.rg_idx))
+        .collect();
+    let parent_start_row: std::collections::HashMap<usize, usize> = region
+        .contributing
+        .iter()
+        .map(|c| (c.input_idx, c.start_row))
+        .collect();
+
+    let mut sub_regions: Vec<Region> = Vec::with_capacity(splits.len());
+    for range in splits {
+        let mut ranges: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+        for run in &merge_order[range.clone()] {
+            let entry = ranges
+                .entry(run.input_index)
+                .or_insert((run.start_row, run.start_row));
+            entry.0 = entry.0.min(run.start_row);
+            entry.1 = entry.1.max(run.start_row + run.row_count);
         }
         let contributing: Vec<RegionContribution> = ranges
             .into_iter()
             .map(|(input_idx, (start, end))| RegionContribution {
                 input_idx,
-                rg_idx: *rg_indices
-                    .get(&input_idx)
-                    .expect("rg_idx set when range was opened"),
-                start_row: start,
+                rg_idx: *rg_for_input.get(&input_idx).expect("rg_idx from parent"),
+                // The merge order's run.start_row is local to the
+                // aligned sort batch (which itself is the drained
+                // contribution); add the parent's start_row to get
+                // the absolute row inside the RG.
+                start_row: parent_start_row.get(&input_idx).copied().unwrap_or(0) + start,
                 num_rows: end - start,
             })
             .collect();
-        regions.push(Region {
-            prefix_key: prefix,
+        sub_regions.push(Region {
+            prefix_key: region.prefix_key.clone(),
             contributing,
         });
-    };
-
-    for run in global_merge_order {
-        let p = prefix_bytes_for_run(run)?;
-        if current_prefix.as_deref() != Some(p.as_slice()) {
-            // Close the prior region (if any) and start a fresh one.
-            if let Some(prev) = current_prefix.take() {
-                flush(
-                    prev,
-                    std::mem::take(&mut current_ranges),
-                    &current_rg_idx,
-                    &mut regions,
-                );
-                current_rg_idx.clear();
-            }
-            current_prefix = Some(p);
-        }
-
-        // Extend the current region's range for this input. The merge
-        // engine ingests each input's rows in increasing row order
-        // within a single RG, so consecutive contributions for the
-        // same input within a region form one contiguous range.
-        let entry = current_ranges
-            .entry(run.input_index)
-            .or_insert((run.start_row, run.start_row));
-        entry.0 = entry.0.min(run.start_row);
-        entry.1 = entry.1.max(run.start_row + run.row_count);
-        current_rg_idx.insert(run.input_index, 0);
     }
 
-    // Final region.
-    if let Some(prev) = current_prefix.take() {
-        flush(prev, current_ranges, &current_rg_idx, &mut regions);
-    }
-
-    Ok(regions)
+    Ok(sub_regions)
 }
 
 /// Assign each region to an output file index.

--- a/quickwit/quickwit-parquet-engine/src/merge/writer.rs
+++ b/quickwit/quickwit-parquet-engine/src/merge/writer.rs
@@ -169,6 +169,7 @@ pub fn write_merge_outputs(
             path: output_path,
             num_rows: sorted_batch.num_rows(),
             num_row_groups: written.num_row_groups,
+            output_rg_partition_prefix_len: output_prefix_len,
             size_bytes: written.size_bytes,
             row_keys_proto,
             zonemap_regexes,

--- a/quickwit/quickwit-parquet-engine/src/storage/legacy_adapter.rs
+++ b/quickwit/quickwit-parquet-engine/src/storage/legacy_adapter.rs
@@ -28,11 +28,22 @@
 //!
 //! [`LegacyInputAdapter`] handles that case by buffering the whole
 //! file, decoding it through Arrow, concatenating into a single
-//! [`RecordBatch`], and re-encoding it as a **single-row-group**
-//! parquet stream that [`StreamingParquetReader`] can serve. The
-//! original file is already sorted (legacy files were written sorted);
-//! consolidating row groups preserves the order automatically — the
-//! adapter does NOT re-sort.
+//! [`RecordBatch`], and re-encoding it as a prefix-aligned multi-row-
+//! group parquet stream that [`StreamingParquetReader`] can serve.
+//! The adapter splits the consolidated batch at first-sort-col
+//! transitions (typically `metric_name`) and declares
+//! `qh.rg_partition_prefix_len = 1` on the re-encoded file so the
+//! merge engine's prefix-aware fast path can consume it. The original
+//! file is already sorted (legacy files were written sorted), so
+//! consolidating then re-splitting preserves order automatically —
+//! the adapter does NOT re-sort.
+//!
+//! When the original file lacks a `qh.sort_fields` KV or its first
+//! sort column can't be resolved in the schema, the adapter falls
+//! back to a single-row-group re-encode without claiming any prefix
+//! alignment. That route is still valid as input to the merge engine
+//! — it just goes through the engine's `prefix_len = 0` sub-region
+//! splitting path instead of the fast prefix-aligned path.
 //!
 //! Costs: one full-file decode + one full-file re-encode per legacy
 //! input, per merge. This is acceptable because legacy files age out
@@ -52,6 +63,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
+use arrow::row::{RowConverter, SortField};
 use async_trait::async_trait;
 use bytes::Bytes;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -66,7 +78,10 @@ use super::streaming_reader::{
     ColumnPageStream, Page, ParquetReadError, RemoteByteSource, StreamingParquetReader,
 };
 use super::streaming_writer::StreamingParquetWriter;
-use super::writer::ParquetWriteError;
+use super::writer::{
+    PARQUET_META_RG_PARTITION_PREFIX_LEN, PARQUET_META_SORT_FIELDS, ParquetWriteError,
+};
+use crate::sort_fields::{is_timestamp_column_name, parse_sort_fields};
 
 /// Errors from the legacy input adapter.
 ///
@@ -147,7 +162,7 @@ impl LegacyInputAdapter {
         }
 
         let buffered = source.get_slice(&path, 0..file_size).await?;
-        let reencoded_bytes = reencode_as_single_row_group(buffered)?;
+        let reencoded_bytes = reencode_prefix_aligned(buffered)?;
         let reencoded_source: Arc<dyn RemoteByteSource> = Arc::new(InMemoryByteSource {
             bytes: Bytes::from(reencoded_bytes),
         });
@@ -176,10 +191,25 @@ impl ColumnPageStream for LegacyInputAdapter {
 }
 
 /// Decode `bytes` into a single concatenated [`RecordBatch`], then
-/// re-encode it as a single-row-group parquet stream that preserves
-/// the original file's `key_value_metadata` and `sorting_columns`.
-fn reencode_as_single_row_group(bytes: Bytes) -> Result<Vec<u8>, LegacyAdapterError> {
-    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes.clone())
+/// re-encode it as a prefix-aligned multi-row-group parquet stream:
+/// one output row group per distinct value of the first sort column
+/// (typically `metric_name`), with `qh.rg_partition_prefix_len = 1`
+/// stamped into the file's KV metadata. The streaming merge engine
+/// can then consume it through its prefix-aware fast path.
+///
+/// Falls back to a single-row-group encode (preserving the original
+/// `qh.rg_partition_prefix_len`, which is typically `0` for legacy
+/// files) when the first sort column can't be resolved:
+/// - The original file has no `qh.sort_fields` KV.
+/// - The sort-fields string parses but is empty.
+/// - The first sort column is missing from the arrow schema.
+/// - The consolidated batch is zero rows.
+///
+/// The single-RG fallback is still a valid input to the merge engine
+/// — it just routes through the engine's `prefix_len = 0` sub-region
+/// splitting path.
+fn reencode_prefix_aligned(bytes: Bytes) -> Result<Vec<u8>, LegacyAdapterError> {
+    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
         .map_err(LegacyAdapterError::ParquetDecode)?;
 
     let arrow_schema = builder.schema().clone();
@@ -201,14 +231,129 @@ fn reencode_as_single_row_group(bytes: Bytes) -> Result<Vec<u8>, LegacyAdapterEr
     let consolidated_batch = arrow::compute::concat_batches(&arrow_schema, &decoded_batches)
         .map_err(LegacyAdapterError::ArrowDecode)?;
 
-    let props = build_writer_properties(
-        &arrow_schema,
-        original_sorting_cols.unwrap_or_default(),
-        original_kv,
-        consolidated_batch.num_rows(),
-    );
+    let prefix_col_idx = resolve_first_sort_col(original_kv.as_ref(), &arrow_schema);
 
-    write_single_row_group(arrow_schema, props, consolidated_batch)
+    match prefix_col_idx {
+        Some(col_idx) if consolidated_batch.num_rows() > 0 => {
+            let slices = compute_prefix_value_slices(&consolidated_batch, col_idx)?;
+            let kv_with_prefix = inject_prefix_len_kv(original_kv, 1);
+            let props = build_writer_properties(
+                &arrow_schema,
+                original_sorting_cols.unwrap_or_default(),
+                Some(kv_with_prefix),
+                consolidated_batch.num_rows(),
+            );
+            write_multi_row_group(arrow_schema, props, consolidated_batch, &slices)
+        }
+        _ => {
+            // No sort_fields KV / first col missing / empty input —
+            // fall back to single-RG without claiming any prefix
+            // alignment. The merge engine's prefix_len=0 path will
+            // handle it via sorted_series-based output splitting.
+            let props = build_writer_properties(
+                &arrow_schema,
+                original_sorting_cols.unwrap_or_default(),
+                original_kv,
+                consolidated_batch.num_rows(),
+            );
+            write_single_row_group(arrow_schema, props, consolidated_batch)
+        }
+    }
+}
+
+/// Resolve the first sort column from `qh.sort_fields` and return its
+/// index in `arrow_schema`. Returns `None` when the KV is absent, the
+/// string parses to an empty sort schema, or the column isn't in the
+/// schema. Honors the `timestamp` / `timestamp_secs` alias.
+fn resolve_first_sort_col(
+    kv: Option<&Vec<KeyValue>>,
+    arrow_schema: &arrow::datatypes::Schema,
+) -> Option<usize> {
+    let sort_fields_str = kv?
+        .iter()
+        .find(|k| k.key == PARQUET_META_SORT_FIELDS)?
+        .value
+        .as_deref()?;
+    let parsed = parse_sort_fields(sort_fields_str).ok()?;
+    let first = parsed.column.first()?;
+    let name = if is_timestamp_column_name(&first.name)
+        && arrow_schema.index_of("timestamp_secs").is_ok()
+    {
+        "timestamp_secs"
+    } else {
+        first.name.as_str()
+    };
+    arrow_schema.index_of(name).ok()
+}
+
+/// Walk the prefix column row-by-row and produce `(start, len)`
+/// slices, one per distinct value run. Uses the arrow row converter
+/// so dictionary / utf8 / primitive types are all handled uniformly.
+fn compute_prefix_value_slices(
+    batch: &RecordBatch,
+    prefix_col_idx: usize,
+) -> Result<Vec<(usize, usize)>, LegacyAdapterError> {
+    let col = Arc::clone(batch.column(prefix_col_idx));
+    let converter = RowConverter::new(vec![SortField::new(col.data_type().clone())])
+        .map_err(LegacyAdapterError::ArrowDecode)?;
+    let rows = converter
+        .convert_columns(&[col])
+        .map_err(LegacyAdapterError::ArrowDecode)?;
+    let n = rows.num_rows();
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    let mut slices = Vec::new();
+    let mut start = 0;
+    for i in 1..n {
+        if rows.row(i) != rows.row(i - 1) {
+            slices.push((start, i - start));
+            start = i;
+        }
+    }
+    slices.push((start, n - start));
+    Ok(slices)
+}
+
+/// Inject (or replace) the `qh.rg_partition_prefix_len` KV entry on
+/// the re-encoded file. Legacy files omit this key entirely; the
+/// re-encoded output advertises the synthesized prefix alignment so
+/// the merge engine's reader picks the fast path.
+fn inject_prefix_len_kv(original: Option<Vec<KeyValue>>, prefix_len: u32) -> Vec<KeyValue> {
+    let mut kvs = original.unwrap_or_default();
+    kvs.retain(|k| k.key != PARQUET_META_RG_PARTITION_PREFIX_LEN);
+    kvs.push(KeyValue::new(
+        PARQUET_META_RG_PARTITION_PREFIX_LEN.to_string(),
+        prefix_len.to_string(),
+    ));
+    kvs
+}
+
+/// Write `batch` to a multi-row-group parquet stream: one RG per
+/// `(start, len)` slice in `slices`. Slices are emitted in order, so
+/// the sort order observed by readers matches the order of the
+/// consolidated batch.
+fn write_multi_row_group(
+    arrow_schema: arrow::datatypes::SchemaRef,
+    props: WriterProperties,
+    batch: RecordBatch,
+    slices: &[(usize, usize)],
+) -> Result<Vec<u8>, LegacyAdapterError> {
+    let mut out: Vec<u8> = Vec::new();
+    let mut writer = StreamingParquetWriter::try_new(&mut out, arrow_schema, props)?;
+    for &(start, len) in slices {
+        if len == 0 {
+            continue;
+        }
+        let mut row_group = writer.start_row_group()?;
+        for col_idx in 0..batch.num_columns() {
+            let slice = batch.column(col_idx).slice(start, len);
+            row_group.write_next_column(&slice)?;
+        }
+        row_group.finish()?;
+    }
+    writer.close()?;
+    Ok(out)
 }
 
 /// Read sorting columns from row group 0 of `metadata`, if present.
@@ -534,6 +679,86 @@ mod tests {
 
     fn dummy_path() -> PathBuf {
         PathBuf::from("legacy_test.parquet")
+    }
+
+    /// Build a multi-RG fixture whose rows are sorted by `metric_name`
+    /// (so consolidating them produces a batch with contiguous
+    /// metric_name runs, which is what the legacy adapter expects on
+    /// real legacy files). `metrics` is `(name, rows_per_metric)` in
+    /// the order they should appear; the writer rolls a new RG every
+    /// `rows_per_rg` so the multi-RG structure is exercised
+    /// independently of the metric_name partitioning.
+    fn write_sorted_multi_rg_legacy_file(
+        metrics: &[(&str, usize)],
+        sort_fields_value: &str,
+        rows_per_rg: usize,
+    ) -> Bytes {
+        let dict_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("metric_name", dict_type.clone(), false),
+            Field::new("metric_type", DataType::UInt8, false),
+            Field::new("timestamp_secs", DataType::UInt64, false),
+            Field::new("value", DataType::Float64, false),
+            Field::new("timeseries_id", DataType::Int64, false),
+            Field::new("service", dict_type, true),
+        ]));
+
+        let total: usize = metrics.iter().map(|(_, n)| *n).sum();
+        let metric_names_vec: Vec<&str> = metrics.iter().map(|(name, _)| *name).collect();
+        let mut metric_keys: Vec<i32> = Vec::with_capacity(total);
+        let mut tsids: Vec<i64> = Vec::with_capacity(total);
+        let mut timestamps: Vec<u64> = Vec::with_capacity(total);
+        let mut values: Vec<f64> = Vec::with_capacity(total);
+        let mut row_idx: u64 = 0;
+        for (metric_idx, (_, count)) in metrics.iter().enumerate() {
+            for _ in 0..*count {
+                metric_keys.push(metric_idx as i32);
+                tsids.push(1000 + row_idx as i64);
+                // -timestamp_secs/V2 in the sort schema means
+                // timestamps DESC within a metric run.
+                timestamps.push(1_700_000_000 + (*count as u64) - (row_idx % *count as u64));
+                values.push(row_idx as f64);
+                row_idx += 1;
+            }
+        }
+        let metric_name: ArrayRef = Arc::new(
+            DictionaryArray::<Int32Type>::try_new(
+                arrow::array::Int32Array::from(metric_keys),
+                Arc::new(StringArray::from(metric_names_vec)),
+            )
+            .expect("metric dict"),
+        );
+        let metric_type: ArrayRef = Arc::new(UInt8Array::from(vec![0u8; total]));
+        let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+        let value: ArrayRef = Arc::new(Float64Array::from(values));
+        let timeseries_id: ArrayRef = Arc::new(Int64Array::from(tsids));
+        let svc_keys: Vec<Option<i32>> = (0..total as i32).map(|i| Some(i % 3)).collect();
+        let service: ArrayRef = Arc::new(
+            DictionaryArray::<Int32Type>::try_new(
+                arrow::array::Int32Array::from(svc_keys),
+                Arc::new(StringArray::from(vec!["api", "db", "cache"])),
+            )
+            .expect("svc dict"),
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                metric_name,
+                metric_type,
+                timestamp_secs,
+                value,
+                timeseries_id,
+                service,
+            ],
+        )
+        .expect("sorted fixture batch");
+
+        let kvs = vec![KeyValue::new(
+            PARQUET_META_SORT_FIELDS.to_string(),
+            sort_fields_value.to_string(),
+        )];
+        let sorting_cols = default_sorting_cols(&schema);
+        write_multi_rg_file(&[batch], kvs, sorting_cols, rows_per_rg)
     }
 
     fn default_sorting_cols(arrow_schema: &ArrowSchema) -> Vec<SortingColumn> {
@@ -898,7 +1123,7 @@ mod tests {
         );
         let oracle = read_back_to_single_batch(bytes.clone());
 
-        let reencoded = reencode_as_single_row_group(bytes).expect("reencode helper");
+        let reencoded = reencode_prefix_aligned(bytes).expect("reencode helper");
         let reencoded_batch = read_back_to_single_batch(Bytes::from(reencoded));
 
         assert_eq!(reencoded_batch.num_rows(), oracle.num_rows());
@@ -951,5 +1176,138 @@ mod tests {
             let stream: &mut dyn ColumnPageStream = &mut adapter;
             assert!(stream.next_page().await.expect("idempotent EOF").is_none());
         }
+    }
+
+    /// Real legacy files carry `qh.sort_fields` and are written sorted
+    /// by the schema. The adapter must split the consolidated batch
+    /// into one RG per first-sort-col value and stamp the re-encoded
+    /// file with `qh.rg_partition_prefix_len = 1` so the merge engine
+    /// reads it through the prefix-aware fast path. The streaming
+    /// engine's duplicate-prefix invariant verifies on read that each
+    /// RG's metric_name is unique within the file; this test
+    /// indirectly exercises that contract.
+    #[tokio::test]
+    async fn test_legacy_input_with_sort_fields_produces_prefix_aligned_multi_rg() {
+        let metrics = [
+            ("cpu.usage", 40usize),
+            ("memory.used", 40),
+            ("net.bytes", 40),
+        ];
+        // Force multi-RG layout in the input (rows_per_rg=30, smaller
+        // than any metric run) so the fixture proves the adapter
+        // collapses arbitrary input RG boundaries into prefix-aligned
+        // output RG boundaries.
+        let bytes =
+            write_sorted_multi_rg_legacy_file(&metrics, "metric_name|-timestamp_secs/V2", 30);
+        let pre_builder =
+            ParquetRecordBatchReaderBuilder::try_new(bytes.clone()).expect("pre-builder");
+        assert!(
+            pre_builder.metadata().num_row_groups() >= 2,
+            "fixture must produce multi-RG input; got {}",
+            pre_builder.metadata().num_row_groups(),
+        );
+
+        let source = CountingInMemorySource::new(bytes);
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+            .await
+            .expect("adapter open");
+
+        // Three distinct metric_names → three output RGs.
+        assert_eq!(
+            adapter.metadata().num_row_groups(),
+            3,
+            "adapter must emit one RG per distinct first-sort-col value",
+        );
+        let rg_rows: Vec<i64> = (0..adapter.metadata().num_row_groups())
+            .map(|i| adapter.metadata().row_group(i).num_rows())
+            .collect();
+        assert_eq!(rg_rows, vec![40, 40, 40], "row counts per RG");
+
+        // KV must advertise prefix_len = 1.
+        let kv = adapter
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .expect("kv metadata");
+        let prefix_kv = kv
+            .iter()
+            .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+            .and_then(|k| k.value.clone());
+        assert_eq!(
+            prefix_kv.as_deref(),
+            Some("1"),
+            "re-encoded file must declare rg_partition_prefix_len=1",
+        );
+    }
+
+    /// Single-metric legacy file: only one prefix value, so the
+    /// re-encoded file has exactly one RG (vacuously prefix-aligned).
+    /// The `qh.rg_partition_prefix_len = 1` KV is still set so the
+    /// reader's duplicate-prefix check has nothing to validate (one
+    /// RG can never violate the invariant) and the file looks
+    /// identical to a metric-aligned new-format file.
+    #[tokio::test]
+    async fn test_legacy_input_single_metric_yields_one_rg_with_prefix_kv() {
+        let metrics = [("cpu.usage", 90usize)];
+        let bytes =
+            write_sorted_multi_rg_legacy_file(&metrics, "metric_name|-timestamp_secs/V2", 30);
+        let source = CountingInMemorySource::new(bytes);
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+            .await
+            .expect("adapter open");
+
+        assert_eq!(adapter.metadata().num_row_groups(), 1);
+        assert_eq!(adapter.metadata().row_group(0).num_rows(), 90);
+
+        let prefix_kv = adapter
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .and_then(|kvs| {
+                kvs.iter()
+                    .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+                    .and_then(|k| k.value.clone())
+            });
+        assert_eq!(prefix_kv.as_deref(), Some("1"));
+    }
+
+    /// Legacy file without a parseable `qh.sort_fields` KV → the
+    /// adapter cannot determine the prefix column, so it falls back
+    /// to the original single-row-group encode and does NOT stamp
+    /// `qh.rg_partition_prefix_len` on the output. The merge engine
+    /// then routes this input through its prefix_len=0 sub-region
+    /// splitting path.
+    #[tokio::test]
+    async fn test_legacy_input_without_sort_fields_falls_back_to_single_rg() {
+        // Empty KV vec → no qh.sort_fields → fall back.
+        let batch_a = make_metrics_batch(50);
+        let batch_b = make_metrics_batch(50);
+        let arrow_schema = batch_a.schema();
+        let bytes = write_multi_rg_file(
+            &[batch_a, batch_b],
+            Vec::new(),
+            default_sorting_cols(&arrow_schema),
+            50,
+        );
+
+        let source = CountingInMemorySource::new(bytes);
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+            .await
+            .expect("adapter open");
+
+        assert_eq!(adapter.metadata().num_row_groups(), 1);
+        let prefix_kv = adapter
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .and_then(|kvs| {
+                kvs.iter()
+                    .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+                    .and_then(|k| k.value.clone())
+            });
+        assert!(
+            prefix_kv.is_none(),
+            "fallback path must not stamp a prefix_len value; got {prefix_kv:?}",
+        );
     }
 }

--- a/quickwit/quickwit-parquet-engine/src/storage/legacy_adapter.rs
+++ b/quickwit/quickwit-parquet-engine/src/storage/legacy_adapter.rs
@@ -62,7 +62,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use arrow::array::RecordBatch;
+use arrow::array::{ArrayRef, NullArray, RecordBatch};
 use arrow::row::{RowConverter, SortField};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -123,6 +123,24 @@ pub enum LegacyAdapterError {
     /// against pathological inputs.
     #[error("legacy input file is too large to buffer: {actual} bytes exceeds limit {limit}")]
     InputTooLarge { actual: u64, limit: u64 },
+
+    /// The caller asked for `target_prefix_len > 0` but the file does
+    /// not advertise enough sort information to honor the request:
+    /// `qh.sort_fields` is absent, or the sort-fields string declares
+    /// fewer columns than requested. Either case means the file lacks
+    /// a name for one of the first `target_prefix_len` sort columns,
+    /// so the adapter can't claim alignment on a column it can't
+    /// identify. (Prefix columns that are *named* in `qh.sort_fields`
+    /// but missing from the arrow schema are NOT an error — per SS-3
+    /// the adapter treats them as implicitly null at every row, which
+    /// trivially satisfies alignment on that column.) The caller
+    /// should retry with a smaller `target_prefix_len` or pass `0` to
+    /// fall through to the single-row-group re-encode.
+    #[error(
+        "cannot honor target_prefix_len = {target}: {reason} (the legacy file does not advertise \
+         enough sort information to safely synthesize prefix-aligned row groups)"
+    )]
+    PrefixUnresolvable { target: u32, reason: String },
 }
 
 /// 4 GiB upper bound on the input file size we will buffer into RAM.
@@ -143,8 +161,25 @@ pub struct LegacyInputAdapter {
 
 impl LegacyInputAdapter {
     /// Open the legacy file at `path` through `source`, re-encode it
-    /// as a single-row-group parquet stream, and prepare to serve its
-    /// pages.
+    /// into a prefix-aligned parquet stream advertising
+    /// `qh.rg_partition_prefix_len = target_prefix_len`, and prepare
+    /// to serve its pages.
+    ///
+    /// The caller picks `target_prefix_len` based on what the rest of
+    /// the merge plan expects. Typical sources:
+    /// - Match the consensus `rg_partition_prefix_len` of the non-legacy inputs in the same merge
+    ///   (so all inputs end up at one value).
+    /// - Pass `0` when there is no non-legacy input, which produces a single-row-group re-encode
+    ///   and no prefix-alignment claim — the merge engine's `prefix_len = 0` sub-region splitting
+    ///   path handles it.
+    ///
+    /// When `target_prefix_len > 0`, the adapter slices the
+    /// consolidated batch at every transition of the first
+    /// `target_prefix_len` sort columns (composite key, via
+    /// [`RowConverter`]) and emits one output row group per slice.
+    /// Returns an error if the file does not have enough resolvable
+    /// sort columns to honor the request — the caller should either
+    /// retry with a smaller `target_prefix_len` or fall back to `0`.
     ///
     /// Issues exactly one buffered GET against `source` (covering the
     /// whole file). All subsequent reads are served from the in-memory
@@ -152,6 +187,7 @@ impl LegacyInputAdapter {
     pub async fn try_open(
         source: Arc<dyn RemoteByteSource>,
         path: PathBuf,
+        target_prefix_len: u32,
     ) -> Result<Self, LegacyAdapterError> {
         let file_size = source.file_size(&path).await?;
         if file_size > MAX_LEGACY_INPUT_BYTES {
@@ -162,7 +198,7 @@ impl LegacyInputAdapter {
         }
 
         let buffered = source.get_slice(&path, 0..file_size).await?;
-        let reencoded_bytes = reencode_prefix_aligned(buffered)?;
+        let reencoded_bytes = reencode_prefix_aligned(buffered, target_prefix_len)?;
         let reencoded_source: Arc<dyn RemoteByteSource> = Arc::new(InMemoryByteSource {
             bytes: Bytes::from(reencoded_bytes),
         });
@@ -191,24 +227,30 @@ impl ColumnPageStream for LegacyInputAdapter {
 }
 
 /// Decode `bytes` into a single concatenated [`RecordBatch`], then
-/// re-encode it as a prefix-aligned multi-row-group parquet stream:
-/// one output row group per distinct value of the first sort column
-/// (typically `metric_name`), with `qh.rg_partition_prefix_len = 1`
-/// stamped into the file's KV metadata. The streaming merge engine
-/// can then consume it through its prefix-aware fast path.
+/// re-encode it according to `target_prefix_len`:
+/// - `target_prefix_len == 0`: emit a single row group with no prefix alignment claim. The original
+///   `qh.*` KV (which typically omits `qh.rg_partition_prefix_len`) is preserved verbatim. The
+///   merge engine's `prefix_len = 0` sub-region splitting path consumes this without further
+///   plumbing.
+/// - `target_prefix_len > 0`: slice the consolidated batch at every transition of the first
+///   `target_prefix_len` sort columns (composite key, via [`RowConverter`]) and emit one row group
+///   per distinct composite value. Stamp the output's KV with `qh.rg_partition_prefix_len =
+///   target_prefix_len` so the merge engine's prefix-aware fast path takes over.
 ///
-/// Falls back to a single-row-group encode (preserving the original
-/// `qh.rg_partition_prefix_len`, which is typically `0` for legacy
-/// files) when the first sort column can't be resolved:
-/// - The original file has no `qh.sort_fields` KV.
-/// - The sort-fields string parses but is empty.
-/// - The first sort column is missing from the arrow schema.
-/// - The consolidated batch is zero rows.
+/// When `target_prefix_len > 0` and the requested alignment cannot be
+/// honored — `qh.sort_fields` is absent, the sort-fields string
+/// declares fewer columns than requested, or one of the first N
+/// columns is missing from the arrow schema — returns
+/// [`LegacyAdapterError::PrefixUnresolvable`]. The caller can retry
+/// with a smaller `target_prefix_len` or fall back to `0`.
 ///
-/// The single-RG fallback is still a valid input to the merge engine
-/// — it just routes through the engine's `prefix_len = 0` sub-region
-/// splitting path.
-fn reencode_prefix_aligned(bytes: Bytes) -> Result<Vec<u8>, LegacyAdapterError> {
+/// The zero-rows-but-`target_prefix_len > 0` case is degenerate but
+/// still stamps the KV: an empty file vacuously satisfies any prefix
+/// alignment claim.
+fn reencode_prefix_aligned(
+    bytes: Bytes,
+    target_prefix_len: u32,
+) -> Result<Vec<u8>, LegacyAdapterError> {
     let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
         .map_err(LegacyAdapterError::ParquetDecode)?;
 
@@ -231,87 +273,142 @@ fn reencode_prefix_aligned(bytes: Bytes) -> Result<Vec<u8>, LegacyAdapterError> 
     let consolidated_batch = arrow::compute::concat_batches(&arrow_schema, &decoded_batches)
         .map_err(LegacyAdapterError::ArrowDecode)?;
 
-    let prefix_col_idx = resolve_first_sort_col(original_kv.as_ref(), &arrow_schema);
-
-    match prefix_col_idx {
-        Some(col_idx) if consolidated_batch.num_rows() > 0 => {
-            let slices = compute_prefix_value_slices(&consolidated_batch, col_idx)?;
-            let kv_with_prefix = inject_prefix_len_kv(original_kv, 1);
-            let props = build_writer_properties(
-                &arrow_schema,
-                original_sorting_cols.unwrap_or_default(),
-                Some(kv_with_prefix),
-                consolidated_batch.num_rows(),
-            );
-            write_multi_row_group(arrow_schema, props, consolidated_batch, &slices)
-        }
-        _ => {
-            // No sort_fields KV / first col missing / empty input —
-            // fall back to single-RG without claiming any prefix
-            // alignment. The merge engine's prefix_len=0 path will
-            // handle it via sorted_series-based output splitting.
-            let props = build_writer_properties(
-                &arrow_schema,
-                original_sorting_cols.unwrap_or_default(),
-                original_kv,
-                consolidated_batch.num_rows(),
-            );
-            write_single_row_group(arrow_schema, props, consolidated_batch)
-        }
+    if target_prefix_len == 0 {
+        // Single-RG passthrough: preserve original KV unchanged.
+        let props = build_writer_properties(
+            &arrow_schema,
+            original_sorting_cols.unwrap_or_default(),
+            original_kv,
+            consolidated_batch.num_rows(),
+        );
+        return write_single_row_group(arrow_schema, props, consolidated_batch);
     }
+
+    let prefix_col_indices =
+        resolve_prefix_sort_cols(original_kv.as_ref(), &arrow_schema, target_prefix_len)?;
+
+    let slices = if consolidated_batch.num_rows() == 0 {
+        Vec::new()
+    } else {
+        compute_prefix_value_slices(&consolidated_batch, &prefix_col_indices)?
+    };
+    let kv_with_prefix = inject_prefix_len_kv(original_kv, target_prefix_len);
+    let props = build_writer_properties(
+        &arrow_schema,
+        original_sorting_cols.unwrap_or_default(),
+        Some(kv_with_prefix),
+        consolidated_batch.num_rows(),
+    );
+    write_multi_row_group(arrow_schema, props, consolidated_batch, &slices)
 }
 
-/// Resolve the first sort column from `qh.sort_fields` and return its
-/// index in `arrow_schema`. Returns `None` when the KV is absent, the
-/// string parses to an empty sort schema, or the column isn't in the
-/// schema. Honors the `timestamp` / `timestamp_secs` alias.
-fn resolve_first_sort_col(
+/// Resolve the first `prefix_len` sort columns from `qh.sort_fields`
+/// to arrow-schema indices. Honors the
+/// `timestamp` / `timestamp_secs` alias the rest of the engine uses.
+///
+/// Returns one entry per requested prefix column: `Some(idx)` if the
+/// column is present in the schema, or `None` if the column is
+/// declared in `qh.sort_fields` but absent from the arrow schema
+/// (treated as implicitly null at every row per SS-3). Returns
+/// [`LegacyAdapterError::PrefixUnresolvable`] only when the file
+/// doesn't advertise enough sort-column *names* (missing/unparseable
+/// `qh.sort_fields`, or declares fewer columns than requested) —
+/// those are cases where we don't even know which column the prefix
+/// alignment is supposed to be on.
+fn resolve_prefix_sort_cols(
     kv: Option<&Vec<KeyValue>>,
     arrow_schema: &arrow::datatypes::Schema,
-) -> Option<usize> {
-    let sort_fields_str = kv?
-        .iter()
-        .find(|k| k.key == PARQUET_META_SORT_FIELDS)?
-        .value
-        .as_deref()?;
-    let parsed = parse_sort_fields(sort_fields_str).ok()?;
-    let first = parsed.column.first()?;
-    let name = if is_timestamp_column_name(&first.name)
-        && arrow_schema.index_of("timestamp_secs").is_ok()
-    {
-        "timestamp_secs"
-    } else {
-        first.name.as_str()
-    };
-    arrow_schema.index_of(name).ok()
+    prefix_len: u32,
+) -> Result<Vec<Option<usize>>, LegacyAdapterError> {
+    debug_assert!(prefix_len > 0);
+    let sort_fields_str = kv
+        .and_then(|kvs| kvs.iter().find(|k| k.key == PARQUET_META_SORT_FIELDS))
+        .and_then(|kv| kv.value.as_deref())
+        .ok_or_else(|| LegacyAdapterError::PrefixUnresolvable {
+            target: prefix_len,
+            reason: format!("{PARQUET_META_SORT_FIELDS} KV is absent"),
+        })?;
+    let parsed =
+        parse_sort_fields(sort_fields_str).map_err(|e| LegacyAdapterError::PrefixUnresolvable {
+            target: prefix_len,
+            reason: format!("{PARQUET_META_SORT_FIELDS} is unparseable: {e}"),
+        })?;
+    let prefix_len_usize = prefix_len as usize;
+    if parsed.column.len() < prefix_len_usize {
+        return Err(LegacyAdapterError::PrefixUnresolvable {
+            target: prefix_len,
+            reason: format!(
+                "{PARQUET_META_SORT_FIELDS} declares only {} sort columns",
+                parsed.column.len(),
+            ),
+        });
+    }
+    let mut indices = Vec::with_capacity(prefix_len_usize);
+    for sf in parsed.column.iter().take(prefix_len_usize) {
+        let resolved = if is_timestamp_column_name(&sf.name)
+            && arrow_schema.index_of("timestamp_secs").is_ok()
+        {
+            "timestamp_secs"
+        } else {
+            sf.name.as_str()
+        };
+        // Missing column → implicit null per SS-3. A column that is
+        // null at every row is constant, which trivially satisfies
+        // alignment on that column. The transition computation
+        // synthesizes a NullArray in its place.
+        indices.push(arrow_schema.index_of(resolved).ok());
+    }
+    Ok(indices)
 }
 
-/// Walk the prefix column row-by-row and produce `(start, len)`
-/// slices, one per distinct value run. Uses the arrow row converter
-/// so dictionary / utf8 / primitive types are all handled uniformly.
+/// Walk the composite prefix value row-by-row over the columns at
+/// `prefix_col_indices` and produce `(start, len)` slices, one per
+/// distinct composite-value run. Uses a single [`RowConverter`] over
+/// all prefix columns so dictionary / utf8 / primitive types are
+/// handled uniformly and N-column equality is a single byte
+/// comparison per row.
+///
+/// An entry of `None` in `prefix_col_indices` represents a prefix
+/// column that is named in `qh.sort_fields` but absent from the
+/// file's arrow schema. Per SS-3 those rows are treated as having
+/// null values, so this function materializes a [`NullArray`] of the
+/// batch's length in that slot. A column that's null at every row is
+/// constant and contributes no transitions to the composite key —
+/// equivalent to skipping it, but kept explicit so the resulting
+/// alignment claim matches the caller's requested `target_prefix_len`.
 fn compute_prefix_value_slices(
     batch: &RecordBatch,
-    prefix_col_idx: usize,
+    prefix_col_indices: &[Option<usize>],
 ) -> Result<Vec<(usize, usize)>, LegacyAdapterError> {
-    let col = Arc::clone(batch.column(prefix_col_idx));
-    let converter = RowConverter::new(vec![SortField::new(col.data_type().clone())])
-        .map_err(LegacyAdapterError::ArrowDecode)?;
+    let n = batch.num_rows();
+    let cols: Vec<ArrayRef> = prefix_col_indices
+        .iter()
+        .map(|idx_opt| match idx_opt {
+            Some(idx) => Arc::clone(batch.column(*idx)),
+            None => Arc::new(NullArray::new(n)) as ArrayRef,
+        })
+        .collect();
+    let sort_fields: Vec<SortField> = cols
+        .iter()
+        .map(|c| SortField::new(c.data_type().clone()))
+        .collect();
+    let converter = RowConverter::new(sort_fields).map_err(LegacyAdapterError::ArrowDecode)?;
     let rows = converter
-        .convert_columns(&[col])
+        .convert_columns(&cols)
         .map_err(LegacyAdapterError::ArrowDecode)?;
-    let n = rows.num_rows();
-    if n == 0 {
+    let n_rows = rows.num_rows();
+    if n_rows == 0 {
         return Ok(Vec::new());
     }
     let mut slices = Vec::new();
     let mut start = 0;
-    for i in 1..n {
+    for i in 1..n_rows {
         if rows.row(i) != rows.row(i - 1) {
             slices.push((start, i - start));
             start = i;
         }
     }
-    slices.push((start, n - start));
+    slices.push((start, n_rows - start));
     Ok(slices)
 }
 
@@ -815,7 +912,7 @@ mod tests {
             1,
         );
         let source = CountingInMemorySource::new(bytes);
-        let adapter = LegacyInputAdapter::try_open(source.clone(), dummy_path())
+        let adapter = LegacyInputAdapter::try_open(source.clone(), dummy_path(), 0)
             .await
             .expect("adapter open");
 
@@ -867,7 +964,7 @@ mod tests {
         assert_eq!(pre_total, 300);
 
         let source = CountingInMemorySource::new(bytes);
-        let mut adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let mut adapter = LegacyInputAdapter::try_open(source, dummy_path(), 0)
             .await
             .expect("adapter open");
 
@@ -914,7 +1011,7 @@ mod tests {
         // file, and assert the consolidated row count + schema match
         // the adapter's metadata.
         let source = CountingInMemorySource::new(bytes);
-        let mut adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let mut adapter = LegacyInputAdapter::try_open(source, dummy_path(), 0)
             .await
             .expect("adapter open");
 
@@ -955,7 +1052,7 @@ mod tests {
             40,
         );
         let source = CountingInMemorySource::new(bytes);
-        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 0)
             .await
             .expect("adapter open");
 
@@ -986,7 +1083,7 @@ mod tests {
         let sorting_cols = default_sorting_cols(&arrow_schema);
         let bytes = write_multi_rg_file(&[batch_a, batch_b], Vec::new(), sorting_cols.clone(), 30);
         let source = CountingInMemorySource::new(bytes);
-        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 0)
             .await
             .expect("adapter open");
 
@@ -1016,7 +1113,7 @@ mod tests {
         let oracle = read_back_to_single_batch(bytes.clone());
 
         let source = CountingInMemorySource::new(bytes);
-        let mut adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let mut adapter = LegacyInputAdapter::try_open(source, dummy_path(), 0)
             .await
             .expect("adapter open");
         // Drain to drive the streaming path.
@@ -1081,7 +1178,7 @@ mod tests {
             file_size: 4096,
         });
 
-        match LegacyInputAdapter::try_open(source, dummy_path()).await {
+        match LegacyInputAdapter::try_open(source, dummy_path(), 0).await {
             Err(LegacyAdapterError::Io(err)) => {
                 assert!(
                     err.to_string().contains("simulated"),
@@ -1123,7 +1220,7 @@ mod tests {
         );
         let oracle = read_back_to_single_batch(bytes.clone());
 
-        let reencoded = reencode_prefix_aligned(bytes).expect("reencode helper");
+        let reencoded = reencode_prefix_aligned(bytes, 0).expect("reencode helper");
         let reencoded_batch = read_back_to_single_batch(Bytes::from(reencoded));
 
         assert_eq!(reencoded_batch.num_rows(), oracle.num_rows());
@@ -1154,7 +1251,7 @@ mod tests {
             80,
         );
         let source = CountingInMemorySource::new(bytes);
-        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 0)
             .await
             .expect("adapter open");
 
@@ -1208,7 +1305,7 @@ mod tests {
         );
 
         let source = CountingInMemorySource::new(bytes);
-        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 1)
             .await
             .expect("adapter open");
 
@@ -1252,7 +1349,7 @@ mod tests {
         let bytes =
             write_sorted_multi_rg_legacy_file(&metrics, "metric_name|-timestamp_secs/V2", 30);
         let source = CountingInMemorySource::new(bytes);
-        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 1)
             .await
             .expect("adapter open");
 
@@ -1271,31 +1368,30 @@ mod tests {
         assert_eq!(prefix_kv.as_deref(), Some("1"));
     }
 
-    /// Legacy file without a parseable `qh.sort_fields` KV → the
-    /// adapter cannot determine the prefix column, so it falls back
-    /// to the original single-row-group encode and does NOT stamp
-    /// `qh.rg_partition_prefix_len` on the output. The merge engine
-    /// then routes this input through its prefix_len=0 sub-region
-    /// splitting path.
+    /// `target_prefix_len = 0`: the adapter consolidates into a
+    /// single row group and does NOT stamp
+    /// `qh.rg_partition_prefix_len`, regardless of what the original
+    /// file's KV says. This is the "all-legacy merge with no non-
+    /// legacy peers" path — the merge engine's `prefix_len = 0`
+    /// sub-region splitting consumes it directly.
     #[tokio::test]
-    async fn test_legacy_input_without_sort_fields_falls_back_to_single_rg() {
-        // Empty KV vec → no qh.sort_fields → fall back.
-        let batch_a = make_metrics_batch(50);
-        let batch_b = make_metrics_batch(50);
-        let arrow_schema = batch_a.schema();
-        let bytes = write_multi_rg_file(
-            &[batch_a, batch_b],
-            Vec::new(),
-            default_sorting_cols(&arrow_schema),
-            50,
-        );
+    async fn test_target_prefix_len_zero_passes_through_as_single_rg() {
+        // Even with a parseable sort_fields KV, target = 0 must not
+        // alter the layout or stamp the prefix KV.
+        let metrics = [("cpu.usage", 50usize), ("memory.used", 50)];
+        let bytes =
+            write_sorted_multi_rg_legacy_file(&metrics, "metric_name|-timestamp_secs/V2", 30);
 
         let source = CountingInMemorySource::new(bytes);
-        let adapter = LegacyInputAdapter::try_open(source, dummy_path())
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 0)
             .await
             .expect("adapter open");
 
-        assert_eq!(adapter.metadata().num_row_groups(), 1);
+        assert_eq!(
+            adapter.metadata().num_row_groups(),
+            1,
+            "target_prefix_len = 0 must consolidate to a single RG",
+        );
         let prefix_kv = adapter
             .metadata()
             .file_metadata()
@@ -1307,7 +1403,272 @@ mod tests {
             });
         assert!(
             prefix_kv.is_none(),
-            "fallback path must not stamp a prefix_len value; got {prefix_kv:?}",
+            "target_prefix_len = 0 must not stamp a prefix_len value; got {prefix_kv:?}",
         );
+    }
+
+    /// `target_prefix_len > 0` on a file with no `qh.sort_fields` KV
+    /// must surface a `PrefixUnresolvable` error rather than silently
+    /// fall through. The caller decides whether to retry at a smaller
+    /// `target_prefix_len` or with `0`.
+    #[tokio::test]
+    async fn test_target_prefix_len_one_without_sort_fields_returns_unresolvable() {
+        // No sort_fields KV → cannot resolve any prefix column.
+        let batch_a = make_metrics_batch(40);
+        let arrow_schema = batch_a.schema();
+        let bytes = write_multi_rg_file(
+            &[batch_a],
+            Vec::new(),
+            default_sorting_cols(&arrow_schema),
+            40,
+        );
+
+        let source = CountingInMemorySource::new(bytes);
+        let result = LegacyInputAdapter::try_open(source, dummy_path(), 1).await;
+        let Err(err) = result else {
+            panic!("missing sort_fields must surface as PrefixUnresolvable, got Ok(...)");
+        };
+        match err {
+            LegacyAdapterError::PrefixUnresolvable { target, reason } => {
+                assert_eq!(target, 1);
+                assert!(
+                    reason.contains("sort_fields"),
+                    "reason should mention sort_fields KV; got: {reason}",
+                );
+            }
+            other => panic!("expected PrefixUnresolvable, got: {other}"),
+        }
+    }
+
+    /// `target_prefix_len > declared sort cols` must also bail with
+    /// `PrefixUnresolvable`. Confirms the caller-driven negotiation
+    /// contract: the adapter never silently advertises a smaller
+    /// alignment than asked for.
+    #[tokio::test]
+    async fn test_target_prefix_len_exceeds_declared_sort_cols_returns_unresolvable() {
+        // Two-col sort schema → ask for prefix_len = 3 → bail.
+        let metrics = [("cpu.usage", 30usize), ("memory.used", 30)];
+        let bytes =
+            write_sorted_multi_rg_legacy_file(&metrics, "metric_name|-timestamp_secs/V2", 30);
+
+        let source = CountingInMemorySource::new(bytes);
+        let result = LegacyInputAdapter::try_open(source, dummy_path(), 3).await;
+        let Err(err) = result else {
+            panic!("prefix_len exceeding declared sort cols must surface as Unresolvable");
+        };
+        match err {
+            LegacyAdapterError::PrefixUnresolvable { target, reason } => {
+                assert_eq!(target, 3);
+                assert!(
+                    reason.contains("declares only"),
+                    "reason should mention sort col count; got: {reason}",
+                );
+            }
+            other => panic!("expected PrefixUnresolvable, got: {other}"),
+        }
+    }
+
+    /// Composite prefix (`target_prefix_len = 2`): each output RG
+    /// carries a unique `(metric_name, service)` tuple. Exercises the
+    /// N > 1 path of `compute_prefix_value_slices` and confirms the
+    /// stamped KV reflects the caller's request.
+    #[tokio::test]
+    async fn test_target_prefix_len_two_splits_by_metric_and_service() {
+        // 4 (metric, service) groups × 20 rows; sorted ascending by
+        // (metric_name, service). Multi-RG input layout (rows_per_rg=25)
+        // forces consolidation before re-splitting.
+        let groups = [
+            ("cpu.usage", "api", 20usize),
+            ("cpu.usage", "db", 20),
+            ("memory.used", "api", 20),
+            ("memory.used", "cache", 20),
+        ];
+        let bytes = write_sorted_composite_legacy_file(
+            &groups,
+            "metric_name|service|-timestamp_secs/V2",
+            25,
+        );
+
+        let source = CountingInMemorySource::new(bytes);
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 2)
+            .await
+            .expect("adapter open with prefix_len=2");
+
+        // 4 distinct (metric_name, service) tuples → 4 output RGs.
+        assert_eq!(
+            adapter.metadata().num_row_groups(),
+            4,
+            "composite prefix must split at (metric, service) transitions",
+        );
+        let rg_rows: Vec<i64> = (0..adapter.metadata().num_row_groups())
+            .map(|i| adapter.metadata().row_group(i).num_rows())
+            .collect();
+        assert_eq!(rg_rows, vec![20, 20, 20, 20]);
+
+        let prefix_kv = adapter
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .and_then(|kvs| {
+                kvs.iter()
+                    .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+                    .and_then(|k| k.value.clone())
+            });
+        assert_eq!(
+            prefix_kv.as_deref(),
+            Some("2"),
+            "stamped prefix_len must match caller's request",
+        );
+    }
+
+    /// SS-3: a sort column named in `qh.sort_fields` but missing from
+    /// the arrow schema is treated as implicitly null at every row.
+    /// Null at every row is constant, so the column trivially
+    /// satisfies any prefix-alignment claim involving it — the
+    /// adapter must NOT bail with `PrefixUnresolvable` in this case.
+    /// Transitions are driven purely by the columns that ARE present.
+    ///
+    /// Fixture: sort_fields declares `metric_name|env|-timestamp_secs`
+    /// but the schema doesn't contain `env`. With prefix_len = 2 the
+    /// adapter must succeed, split only at `metric_name` transitions
+    /// (the null `env` contributes no transitions), and stamp
+    /// `prefix_len = 2` on the output.
+    #[tokio::test]
+    async fn test_missing_prefix_col_treated_as_null_satisfies_alignment() {
+        let metrics = [("cpu.usage", 30usize), ("memory.used", 30)];
+        // Sort schema declares 3 cols; the fixture schema has
+        // metric_name and timestamp_secs but NO `env` column. Per
+        // SS-3 the merge engine treats `env` as null at every row.
+        let bytes =
+            write_sorted_multi_rg_legacy_file(&metrics, "metric_name|env|-timestamp_secs/V2", 30);
+
+        let source = CountingInMemorySource::new(bytes);
+        let adapter = LegacyInputAdapter::try_open(source, dummy_path(), 2)
+            .await
+            .expect("missing-col-as-null must satisfy alignment without erroring");
+
+        // Two metrics × constant null `env` → two output RGs (one per metric).
+        assert_eq!(
+            adapter.metadata().num_row_groups(),
+            2,
+            "missing prefix col (treated as null) contributes no transitions; only metric_name \
+             transitions split RGs",
+        );
+        let rg_rows: Vec<i64> = (0..adapter.metadata().num_row_groups())
+            .map(|i| adapter.metadata().row_group(i).num_rows())
+            .collect();
+        assert_eq!(rg_rows, vec![30, 30]);
+
+        let prefix_kv = adapter
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .and_then(|kvs| {
+                kvs.iter()
+                    .find(|k| k.key == PARQUET_META_RG_PARTITION_PREFIX_LEN)
+                    .and_then(|k| k.value.clone())
+            });
+        assert_eq!(
+            prefix_kv.as_deref(),
+            Some("2"),
+            "stamped prefix_len must match caller's request even when one col is implicitly null",
+        );
+    }
+
+    /// Composite-prefix fixture: rows grouped by `(metric, service)`
+    /// in the order supplied. Used by the prefix_len=2 test to verify
+    /// transitions on the second prefix column trigger RG splits.
+    fn write_sorted_composite_legacy_file(
+        groups: &[(&str, &str, usize)],
+        sort_fields_value: &str,
+        rows_per_rg: usize,
+    ) -> Bytes {
+        let dict_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("metric_name", dict_type.clone(), false),
+            Field::new("metric_type", DataType::UInt8, false),
+            Field::new("timestamp_secs", DataType::UInt64, false),
+            Field::new("value", DataType::Float64, false),
+            Field::new("timeseries_id", DataType::Int64, false),
+            Field::new("service", dict_type, true),
+        ]));
+
+        // Build per-group dictionary index tables for metric_name and
+        // service. Map each distinct value to its key.
+        let mut metric_names_vec: Vec<&str> = Vec::new();
+        let mut service_values_vec: Vec<&str> = Vec::new();
+        for (metric, service, _) in groups {
+            if !metric_names_vec.contains(metric) {
+                metric_names_vec.push(metric);
+            }
+            if !service_values_vec.contains(service) {
+                service_values_vec.push(service);
+            }
+        }
+
+        let total: usize = groups.iter().map(|(_, _, n)| *n).sum();
+        let mut metric_keys: Vec<i32> = Vec::with_capacity(total);
+        let mut svc_keys: Vec<Option<i32>> = Vec::with_capacity(total);
+        let mut tsids: Vec<i64> = Vec::with_capacity(total);
+        let mut timestamps: Vec<u64> = Vec::with_capacity(total);
+        let mut values: Vec<f64> = Vec::with_capacity(total);
+        let mut row_idx: u64 = 0;
+        for (metric, service, count) in groups {
+            let metric_key = metric_names_vec
+                .iter()
+                .position(|m| m == metric)
+                .expect("metric known") as i32;
+            let svc_key = service_values_vec
+                .iter()
+                .position(|s| s == service)
+                .expect("service known") as i32;
+            for _ in 0..*count {
+                metric_keys.push(metric_key);
+                svc_keys.push(Some(svc_key));
+                tsids.push(1000 + row_idx as i64);
+                timestamps.push(1_700_000_000 + (*count as u64) - (row_idx % *count as u64));
+                values.push(row_idx as f64);
+                row_idx += 1;
+            }
+        }
+
+        let metric_name: ArrayRef = Arc::new(
+            DictionaryArray::<Int32Type>::try_new(
+                arrow::array::Int32Array::from(metric_keys),
+                Arc::new(StringArray::from(metric_names_vec)),
+            )
+            .expect("metric dict"),
+        );
+        let service: ArrayRef = Arc::new(
+            DictionaryArray::<Int32Type>::try_new(
+                arrow::array::Int32Array::from(svc_keys),
+                Arc::new(StringArray::from(service_values_vec)),
+            )
+            .expect("svc dict"),
+        );
+        let metric_type: ArrayRef = Arc::new(UInt8Array::from(vec![0u8; total]));
+        let timestamp_secs: ArrayRef = Arc::new(UInt64Array::from(timestamps));
+        let value: ArrayRef = Arc::new(Float64Array::from(values));
+        let timeseries_id: ArrayRef = Arc::new(Int64Array::from(tsids));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                metric_name,
+                metric_type,
+                timestamp_secs,
+                value,
+                timeseries_id,
+                service,
+            ],
+        )
+        .expect("composite fixture batch");
+
+        let kvs = vec![KeyValue::new(
+            PARQUET_META_SORT_FIELDS.to_string(),
+            sort_fields_value.to_string(),
+        )];
+        let sorting_cols = default_sorting_cols(&schema);
+        write_multi_rg_file(&[batch], kvs, sorting_cols, rows_per_rg)
     }
 }

--- a/quickwit/quickwit-parquet-engine/src/storage/legacy_adapter.rs
+++ b/quickwit/quickwit-parquet-engine/src/storage/legacy_adapter.rs
@@ -57,6 +57,7 @@
 // deprecated items at module scope keeps that lookup direct.
 #![allow(deprecated)]
 
+use std::collections::HashMap;
 use std::io;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -141,6 +142,26 @@ pub enum LegacyAdapterError {
          enough sort information to safely synthesize prefix-aligned row groups)"
     )]
     PrefixUnresolvable { target: u32, reason: String },
+
+    /// The legacy file's rows are not sorted by its declared sort schema
+    /// (SS-1 violation): two row regions in the file carry the same
+    /// composite prefix value with other prefix values in between. The
+    /// adapter walks rows in physical order and emits one RG per
+    /// prefix-value run, so an unsorted input produces multiple RGs
+    /// sharing a prefix key — which violates PA-3 (per-input uniqueness).
+    /// Bail upfront instead of producing a file the downstream merge
+    /// engine will reject mid-merge.
+    #[error(
+        "legacy input is not sorted by its declared sort schema: rows at offset {first_offset} \
+         and offset {second_offset} share composite prefix value (target_prefix_len = {target}). \
+         The adapter relies on the file being sorted per SS-1; an unsorted file would synthesize \
+         multiple row groups with the same prefix key (PA-3 violation)."
+    )]
+    InputNotSorted {
+        target: u32,
+        first_offset: usize,
+        second_offset: usize,
+    },
 }
 
 /// 4 GiB upper bound on the input file size we will buffer into RAM.
@@ -290,7 +311,7 @@ fn reencode_prefix_aligned(
     let slices = if consolidated_batch.num_rows() == 0 {
         Vec::new()
     } else {
-        compute_prefix_value_slices(&consolidated_batch, &prefix_col_indices)?
+        compute_prefix_value_slices(&consolidated_batch, &prefix_col_indices, target_prefix_len)?
     };
     let kv_with_prefix = inject_prefix_len_kv(original_kv, target_prefix_len);
     let props = build_writer_properties(
@@ -376,9 +397,19 @@ fn resolve_prefix_sort_cols(
 /// constant and contributes no transitions to the composite key —
 /// equivalent to skipping it, but kept explicit so the resulting
 /// alignment claim matches the caller's requested `target_prefix_len`.
+///
+/// Detects SS-1 violations (unsorted input) up-front: each emitted
+/// slice's composite prefix-value bytes must be unique. If two
+/// non-adjacent slices carry the same prefix value (e.g., rows
+/// `[A,A,B,B,A,A]`), the input is not sorted by its declared sort
+/// schema, so we'd synthesize a file with two RGs sharing the prefix
+/// — a PA-3 violation the downstream merge engine would reject
+/// mid-merge. Bailing here with `InputNotSorted` keeps that bad file
+/// from ever landing on disk.
 fn compute_prefix_value_slices(
     batch: &RecordBatch,
     prefix_col_indices: &[Option<usize>],
+    target_prefix_len: u32,
 ) -> Result<Vec<(usize, usize)>, LegacyAdapterError> {
     let n = batch.num_rows();
     let cols: Vec<ArrayRef> = prefix_col_indices
@@ -400,15 +431,35 @@ fn compute_prefix_value_slices(
     if n_rows == 0 {
         return Ok(Vec::new());
     }
+    // Track each emitted slice's starting prefix-value bytes; any
+    // repeat signals SS-1 violation on the input.
+    let mut seen: HashMap<Vec<u8>, usize> = HashMap::new();
     let mut slices = Vec::new();
     let mut start = 0;
+    let record_slice = |slices: &mut Vec<(usize, usize)>,
+                        seen: &mut HashMap<Vec<u8>, usize>,
+                        slice_start: usize,
+                        slice_len: usize|
+     -> Result<(), LegacyAdapterError> {
+        let key = rows.row(slice_start).as_ref().to_vec();
+        if let Some(&first_offset) = seen.get(&key) {
+            return Err(LegacyAdapterError::InputNotSorted {
+                target: target_prefix_len,
+                first_offset,
+                second_offset: slice_start,
+            });
+        }
+        seen.insert(key, slice_start);
+        slices.push((slice_start, slice_len));
+        Ok(())
+    };
     for i in 1..n_rows {
         if rows.row(i) != rows.row(i - 1) {
-            slices.push((start, i - start));
+            record_slice(&mut slices, &mut seen, start, i - start)?;
             start = i;
         }
     }
-    slices.push((start, n_rows - start));
+    record_slice(&mut slices, &mut seen, start, n_rows - start)?;
     Ok(slices)
 }
 
@@ -1335,6 +1386,19 @@ mod tests {
             Some("1"),
             "re-encoded file must declare rg_partition_prefix_len=1",
         );
+
+        // F9 chunk-level verification: the count + KV checks above
+        // would still pass if `compute_prefix_value_slices` had an
+        // off-by-one in its boundary detection. PA-1 + PA-3 on chunk
+        // statistics nail down that each RG's metric_name column is
+        // actually constant and no two RGs share a value.
+        crate::merge::streaming::region_grouping::assert_unique_rg_prefix_keys(
+            adapter.metadata(),
+            "metric_name|-timestamp_secs/V2",
+            1,
+            "test_legacy_input_with_sort_fields_produces_prefix_aligned_multi_rg adapter output",
+        )
+        .expect("adapter output must satisfy PA-1 + PA-3 on metric_name");
     }
 
     /// Single-metric legacy file: only one prefix value, so the
@@ -1519,6 +1583,19 @@ mod tests {
             Some("2"),
             "stamped prefix_len must match caller's request",
         );
+
+        // F9 chunk-level verification: a `compute_prefix_value_slices`
+        // bug splitting on only the first prefix col (or off by one)
+        // would still yield 4 RGs of [20,20,20,20] but with the wrong
+        // CONTENTS. PA-1 + PA-3 on the composite (metric, service)
+        // composite key verifies content alignment directly.
+        crate::merge::streaming::region_grouping::assert_unique_rg_prefix_keys(
+            adapter.metadata(),
+            "metric_name|service|-timestamp_secs/V2",
+            2,
+            "test_target_prefix_len_two_splits_by_metric_and_service adapter output",
+        )
+        .expect("composite prefix output must satisfy PA-1 + PA-3");
     }
 
     /// SS-3: a sort column named in `qh.sort_fields` but missing from
@@ -1573,6 +1650,77 @@ mod tests {
             Some("2"),
             "stamped prefix_len must match caller's request even when one col is implicitly null",
         );
+
+        // F10 + F12 chunk-level verification: SS-3 is now honored on
+        // BOTH sides — `find_prefix_parquet_col_indices` returns
+        // `Option<PrefixColumn>` (None for "named in sort schema but
+        // missing from parquet schema"), and
+        // `extract_rg_composite_prefix_key` emits a constant null
+        // marker for those slots. So the adapter's output (which
+        // stamps prefix_len = 2 but omits `env` from the schema)
+        // passes the unified PA-1 + PA-3 verifier: each RG's
+        // metric_name min == max, and the constant null contribution
+        // for `env` makes RG composite keys differ only by
+        // metric_name.
+        crate::merge::streaming::region_grouping::assert_unique_rg_prefix_keys(
+            adapter.metadata(),
+            "metric_name|env|-timestamp_secs/V2",
+            2,
+            "test_missing_prefix_col_treated_as_null_satisfies_alignment adapter output",
+        )
+        .expect("SS-3 null col must satisfy PA-1 + PA-3 (null is constant across all RGs)");
+    }
+
+    /// F8 regression: an unsorted legacy input (rows
+    /// `[A,A,B,B,A,A]` on `metric_name`) violates SS-1. Walking
+    /// row-by-row to find prefix transitions would emit three slices —
+    /// `A`, `B`, `A` — and synthesize a file with two RGs sharing the
+    /// prefix value `A`, violating PA-3. The downstream streaming
+    /// merge engine would catch this later, but only once the bad
+    /// file had been built and possibly archived. The adapter must
+    /// bail upfront with `InputNotSorted` so no PA-3-violating file
+    /// ever lands on disk.
+    #[tokio::test]
+    async fn test_unsorted_legacy_input_rejected_by_adapter() {
+        // metric_name in row order: cpu.usage, memory.used, cpu.usage.
+        // That's an SS-1 violation under sort schema `metric_name ASC`.
+        let bad_metrics = [
+            ("cpu.usage", 20usize),
+            ("memory.used", 20),
+            ("cpu.usage", 20),
+        ];
+        let bytes =
+            write_sorted_multi_rg_legacy_file(&bad_metrics, "metric_name|-timestamp_secs/V2", 20);
+
+        let source = CountingInMemorySource::new(bytes);
+        let result = LegacyInputAdapter::try_open(source, dummy_path(), 1).await;
+        let Err(err) = result else {
+            panic!(
+                "unsorted legacy input must surface as InputNotSorted, got Ok(...) — the adapter \
+                 would have written a PA-3-violating file"
+            );
+        };
+        match err {
+            LegacyAdapterError::InputNotSorted {
+                target,
+                first_offset,
+                second_offset,
+            } => {
+                assert_eq!(target, 1);
+                // First `cpu.usage` run is at offset 0; second is at
+                // offset 40 (after the 20-row `cpu.usage` then 20-row
+                // `memory.used` runs).
+                assert_eq!(
+                    first_offset, 0,
+                    "first duplicate prefix offset should point at the first cpu.usage run",
+                );
+                assert_eq!(
+                    second_offset, 40,
+                    "second duplicate prefix offset should point at the second cpu.usage run",
+                );
+            }
+            other => panic!("expected InputNotSorted, got: {other}"),
+        }
     }
 
     /// Composite-prefix fixture: rows grouped by `(metric, service)`

--- a/quickwit/quickwit-parquet-engine/src/storage/streaming_writer.rs
+++ b/quickwit/quickwit-parquet-engine/src/storage/streaming_writer.rs
@@ -153,6 +153,16 @@ impl<W: Write + Send> StreamingParquetWriter<W> {
         })
     }
 
+    /// Append a `KeyValue` entry to the file's footer metadata. Useful
+    /// when the value can only be computed after all row groups have
+    /// been written (e.g., per-output `qh.row_keys` / `qh.zonemap_regexes`
+    /// in the streaming merge, which derive from the rows that
+    /// physically land in this output file). Must be called before
+    /// [`Self::close`] flushes the footer.
+    pub(crate) fn append_key_value_metadata(&mut self, kv: parquet::file::metadata::KeyValue) {
+        self.file_writer.append_key_value_metadata(kv);
+    }
+
     /// Close the file and return its metadata.
     pub(crate) fn close(self) -> Result<ParquetMetaData, ParquetWriteError> {
         Ok(self.file_writer.close()?)

--- a/quickwit/quickwit-parquet-engine/src/storage/writer.rs
+++ b/quickwit/quickwit-parquet-engine/src/storage/writer.rs
@@ -533,6 +533,8 @@ impl ParquetWriter {
         writer.write(&prepared.sorted_batch)?;
         let bytes = writer.into_inner()?.into_inner();
 
+        assert_indexing_prefix_alignment(&bytes, split_metadata, &self.sort_fields_string)?;
+
         debug!(bytes_written = bytes.len(), "completed write to bytes");
         Ok((bytes, (prepared.row_keys_proto, prepared.zonemap_regexes)))
     }
@@ -555,12 +557,88 @@ impl ParquetWriter {
         writer.write(&prepared.sorted_batch)?;
 
         let bytes_written = writer.into_inner()?.metadata()?.len();
+        assert_indexing_prefix_alignment_on_file(path, split_metadata, &self.sort_fields_string)?;
         debug!(bytes_written, "completed write to file");
         Ok((
             bytes_written,
             (prepared.row_keys_proto, prepared.zonemap_regexes),
         ))
     }
+}
+
+/// Verify the just-written parquet bytes have no two row groups
+/// sharing the same composite prefix key. No-op when split metadata
+/// is absent or `rg_partition_prefix_len == 0` (no alignment claim).
+///
+/// Mirrors the read-path check in
+/// `merge::streaming::region_grouping::extract_regions_from_metadata`
+/// and the merge-output check in `streaming::output::finalize_output`
+/// — see `assert_unique_rg_prefix_keys` for the rationale.
+fn assert_indexing_prefix_alignment(
+    bytes: &[u8],
+    split_metadata: Option<&ParquetSplitMetadata>,
+    fallback_sort_fields: &str,
+) -> Result<(), ParquetWriteError> {
+    let Some(meta) = split_metadata else {
+        return Ok(());
+    };
+    if meta.rg_partition_prefix_len == 0 {
+        return Ok(());
+    }
+    let sort_fields = if meta.sort_fields.is_empty() {
+        fallback_sort_fields
+    } else {
+        meta.sort_fields.as_str()
+    };
+    let bytes_owned = bytes::Bytes::copy_from_slice(bytes);
+    let reader = parquet::file::reader::SerializedFileReader::new(bytes_owned).map_err(|e| {
+        ParquetWriteError::SchemaValidation(format!(
+            "post-write prefix alignment re-parse failed: {e}"
+        ))
+    })?;
+    use parquet::file::reader::FileReader;
+    crate::merge::streaming::region_grouping::assert_unique_rg_prefix_keys(
+        reader.metadata(),
+        sort_fields,
+        meta.rg_partition_prefix_len,
+        "indexing write_to_bytes",
+    )
+    .map_err(|e| ParquetWriteError::SchemaValidation(e.to_string()))
+}
+
+/// File-backed counterpart to `assert_indexing_prefix_alignment` —
+/// re-opens the just-written file and verifies the same invariant.
+fn assert_indexing_prefix_alignment_on_file(
+    path: &Path,
+    split_metadata: Option<&ParquetSplitMetadata>,
+    fallback_sort_fields: &str,
+) -> Result<(), ParquetWriteError> {
+    let Some(meta) = split_metadata else {
+        return Ok(());
+    };
+    if meta.rg_partition_prefix_len == 0 {
+        return Ok(());
+    }
+    let sort_fields = if meta.sort_fields.is_empty() {
+        fallback_sort_fields
+    } else {
+        meta.sort_fields.as_str()
+    };
+    let file = File::open(path)?;
+    let reader = parquet::file::reader::SerializedFileReader::new(file).map_err(|e| {
+        ParquetWriteError::SchemaValidation(format!(
+            "post-write prefix alignment re-open failed for {}: {e}",
+            path.display()
+        ))
+    })?;
+    use parquet::file::reader::FileReader;
+    crate::merge::streaming::region_grouping::assert_unique_rg_prefix_keys(
+        reader.metadata(),
+        sort_fields,
+        meta.rg_partition_prefix_len,
+        &format!("indexing write_to_file {}", path.display()),
+    )
+    .map_err(|e| ParquetWriteError::SchemaValidation(e.to_string()))
 }
 
 /// Parse a sort fields string and resolve column names to physical `ParquetField`s.
@@ -1498,5 +1576,104 @@ mod tests {
         );
 
         std::fs::remove_file(&path).ok();
+    }
+
+    /// Indexing-path strong invariant: when the writer is asked to
+    /// emit a file with `rg_partition_prefix_len > 0`, no two row
+    /// groups may share the same composite prefix key. Forcing a
+    /// small row_group_size on a batch where every row has the same
+    /// metric_name produces multi-RG output with all RGs sharing the
+    /// prefix value — and `write_to_bytes` must reject the result
+    /// rather than land a corrupt file. Mirrors the merge-read-side
+    /// check in `extract_regions_from_metadata`.
+    #[test]
+    fn test_write_to_bytes_rejects_duplicate_rg_prefix_when_claimed_aligned() {
+        use crate::split::{ParquetSplitId, TimeRange};
+
+        let config = ParquetWriterConfig::default().with_row_group_size(3);
+        let writer = ParquetWriter::new(config, &TableConfig::default()).unwrap();
+
+        // 9 rows of cpu.usage at 3 rows per RG → 3 RGs, all with the
+        // same metric_name. Claiming rg_partition_prefix_len = 1 makes
+        // every RG share the prefix key, which must fail.
+        let batch = create_test_batch_with_tags(9, &["service", "env"]);
+        let split_metadata = ParquetSplitMetadata::metrics_builder()
+            .split_id(ParquetSplitId::new("dup-prefix-rejection-test"))
+            .index_uid("test-index:00000000000000000000000000")
+            .time_range(TimeRange::new(100, 200))
+            .sort_fields("metric_name|service|env|timeseries_id|timestamp_secs/V2")
+            .rg_partition_prefix_len(1)
+            .build();
+
+        let err = writer
+            .write_to_bytes(&batch, Some(&split_metadata))
+            .expect_err("must reject duplicate prefix RGs at indexing write");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("shares a prefix key with an earlier row group"),
+            "expected duplicate-prefix error, got: {msg}",
+        );
+        assert!(
+            msg.contains("indexing"),
+            "error should mention the indexing context, got: {msg}",
+        );
+    }
+
+    /// File-backed counterpart: `write_to_file_with_metadata` must
+    /// fire the same check. The output file exists on disk by the
+    /// time we re-parse, but the writer surfaces the violation rather
+    /// than reporting success.
+    #[test]
+    fn test_write_to_file_rejects_duplicate_rg_prefix_when_claimed_aligned() {
+        use crate::split::{ParquetSplitId, TimeRange};
+
+        let config = ParquetWriterConfig::default().with_row_group_size(3);
+        let writer = ParquetWriter::new(config, &TableConfig::default()).unwrap();
+
+        let batch = create_test_batch_with_tags(9, &["service", "env"]);
+        let split_metadata = ParquetSplitMetadata::metrics_builder()
+            .split_id(ParquetSplitId::new("dup-prefix-rejection-file-test"))
+            .index_uid("test-index:00000000000000000000000000")
+            .time_range(TimeRange::new(100, 200))
+            .sort_fields("metric_name|service|env|timeseries_id|timestamp_secs/V2")
+            .rg_partition_prefix_len(1)
+            .build();
+
+        let temp_dir = std::env::temp_dir();
+        let path = temp_dir.join("test_dup_prefix_rejection.parquet");
+        let err = writer
+            .write_to_file_with_metadata(&batch, &path, Some(&split_metadata))
+            .expect_err("must reject duplicate prefix RGs at indexing write_to_file");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("shares a prefix key with an earlier row group"),
+            "expected duplicate-prefix error, got: {msg}",
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Companion to the duplicate-rejection tests: a single-RG file
+    /// vacuously satisfies any prefix_len claim. The writer must
+    /// accept it without raising the duplicate-prefix error.
+    #[test]
+    fn test_write_to_bytes_accepts_single_rg_with_prefix_len_one() {
+        use crate::split::{ParquetSplitId, TimeRange};
+
+        let config = ParquetWriterConfig::default();
+        let writer = ParquetWriter::new(config, &TableConfig::default()).unwrap();
+
+        let batch = create_test_batch_with_tags(20, &["service", "env"]);
+        let split_metadata = ParquetSplitMetadata::metrics_builder()
+            .split_id(ParquetSplitId::new("single-rg-test"))
+            .index_uid("test-index:00000000000000000000000000")
+            .time_range(TimeRange::new(100, 200))
+            .sort_fields("metric_name|service|env|timeseries_id|timestamp_secs/V2")
+            .rg_partition_prefix_len(1)
+            .build();
+
+        writer
+            .write_to_bytes(&batch, Some(&split_metadata))
+            .expect("single-RG must pass the prefix-alignment check");
     }
 }


### PR DESCRIPTION
## Summary
Restructures PR-6b.2's flat phase 0 → phase 3 into a **per-merge-region** loop. Unlocks multi-RG metric-aligned input support and produces multi-RG output naturally — one output row group per merge region (typically one per `metric_name` when `rg_partition_prefix_len == 1`).

## Architectural insight

Sort-prefix alignment (`prefix_len >= 1`) guarantees that any merge region has AT MOST one row group per input. That single invariant unlocks the restructure: phase 0 no longer has to span all RGs upfront (which would force either column-chunk buffering or a second body GET); it drains one RG's sort cols per input per region as we go.

## Pipeline

1. **Pre-compute regions** from RG metadata. For `prefix_len >= 1`, read each RG's `metric_name` column-chunk min stat (must equal max — verifies metric-alignment). Group RGs across inputs by prefix_key. Sort regions by prefix_key.

   For `prefix_len == 0` (single-RG inputs only, validated earlier), one region covers everything — behaviour matches PR-6b.2 for today's single-RG inputs.

2. **Assign regions to output files** by cumulative row count. Caller's `num_outputs` is preserved. Each output file gets a contiguous slice of the region list, so output files have non-overlapping key ranges.

3. **Per-region processing**: for each region in order, advance contributing inputs' decoders through their RGs (drain sort cols of *that* RG, then stream body cols via the existing page-bounded `BodyColOutputPageAssembler`). Each region becomes one output RG in the current writer; when the assignment moves to a new output file, close the previous writer and open a new one.

The streaming body-col mechanism from PR-6b.2 (`arrow::compute::interleave` + `handle.block_on`-driven decoder) is unchanged; it just runs over smaller row ranges (one region instead of one whole output).

## Single-RG-input restriction lifted

PR-6b.2's check that rejected any multi-RG input is replaced with: reject only `prefix_len == 0` AND multi-RG (those still need PR-5's `LegacyMultiRGAdapter`). Multi-RG metric-aligned inputs are now accepted natively.

## Per-output schema simplification

PR-6b.2 optimised the per-output schema based on per-output sort col data (drop all-null cols, re-dict-encode low-cardinality strings). With per-region streaming we don't know each region's content until we drain it, so PR-6c.2 declares the writer's schema as the full union schema and leaves output strings as Utf8. Per-output dict re-encoding can be reintroduced later by tracking cardinality during the streaming pass.

## Tests

- **All 9 PR-6b.2 tests still pass** (single-RG input regression — behaviour preserved).
- **New** `test_multi_rg_metric_aligned_input_produces_multi_rg_output`: feeds a 2-RG metric-aligned input (`prefix_len = 1`, RG 0 = cpu.usage, RG 1 = memory.used); the streaming engine accepts it and produces a 2-RG output (one RG per metric_name region).
- Renamed `test_multi_rg_input_rejected` → `test_legacy_multi_rg_input_rejected` to reflect the new rejection scope (only `prefix_len == 0` multi-RG is rejected; metric-aligned is accepted).

10/10 streaming tests pass. 442/442 crate tests pass. Clippy, doc, machete, fmt all clean.

## What changed

**Added:**
- `Region` struct + `extract_regions_from_metadata` + `assign_regions_to_output_files` (region pre-computation; reads parquet column chunk statistics).
- `OutputAccumulator` — gathers per-output static metadata (row_keys, zonemap, metric_names, time_range, service names) across the regions assigned to each output file. Computed at `finalize_output` time.
- `open_output_writer_for_streaming`, `process_region`, `build_sorting_columns_from_schema`, `finalize_output`.

**Removed (PR-6b.2 multi-output-parallel helpers — no longer needed):**
- `write_streaming_outputs`, `write_all_columns`, `write_sort_col_for_all_outputs`, `write_body_col_for_all_outputs`, `build_parent_union_schema`, `writer_states_index_view`.
- Old `OutputWriterStorage` struct, `PerOutputStatic`, `build_per_output_static`, `derive_output_schema`, `open_output_writer`, `finalize_output_writer`.

**Kept:**
- `BodyColOutputPageAssembler` and its iterator (the page-bounded body col fan-out — still the streaming core).
- `collect_service_names_from_page`, `build_full_union_schema_from_arrow_schemas`.

## Follow-ups deferred

1. **File-size cap with sort-key-boundary splits** — when an output file's cumulative bytes-written approach a threshold, close at the next region boundary and open a new file. Adds extra splits beyond caller's N. Easy add on top of this PR's structure.
2. **Per-output schema optimisation** — track region body-col cardinality during the streaming pass; reintroduce per-output dict encoding and all-null drops.
3. **Mid-region splits at sorted_series transitions** — for finer-grained M:N control when callers want more outputs than there are metric_name regions.

## Stack

Base: `gtt/streaming-merge-engine-merger` (PR-6b.2 #6409).

PR-7 (TBD) wires `ParquetMergeExecutor` to the streaming engine and deletes `ParquetMergeSplitDownloader`.