### PR TITLE
ci: allow GHSA-2f9f-gq7v-9h6m (thrift 0.17 excessive allocation)

### DIFF
--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -20,4 +20,11 @@ jobs:
         with:
           # GHSA-c38w-74pg-36hr, GHSA-4grx-2x9w-596c: minor vuln on the rsa crate, used for google storage.
           # GHSA-cq8v-f236-94qc: rand 0.8.6 unsound with custom logger + rand::rng(), not affected (log feature disabled, transitive dep from fail/sqlx).
-          allow-ghsas: GHSA-c38w-74pg-36hr,GHSA-4grx-2x9w-596c,GHSA-cq8v-f236-94qc
+          # GHSA-2f9f-gq7v-9h6m: thrift 0.17 excessive-allocation on untrusted input. Already a transitive
+          #   dep via parquet on main; PR-4 (streaming Parquet reader) adds it as a direct dep for
+          #   `parquet::format::PageHeader::read_from_in_protocol`. Inputs are parquet files we wrote to
+          #   our own object store (trusted source). Defense-in-depth: the streaming reader caps each
+          #   Thrift parse buffer at `max_page_header_bytes` (1 MiB default) BEFORE handing bytes to
+          #   thrift, so the outer buffer thrift can read from is bounded regardless of any inner
+          #   length prefix. No newer thrift release fixes this — 0.17.0 is the latest on crates.io.
+          allow-ghsas: GHSA-c38w-74pg-36hr,GHSA-4grx-2x9w-596c,GHSA-cq8v-f236-94qc,GHSA-2f9f-gq7v-9h6m


### PR DESCRIPTION
## Summary
- Adds `GHSA-2f9f-gq7v-9h6m` to the `dependency-review-action` allow-list.
- The advisory is a moderate-severity excessive-allocation issue in Apache Thrift 0.17 on untrusted-input length fields.

## Why this is safe for our use
- thrift is **already a transitive dep on main** via `parquet`. PR #6386 (streaming Parquet reader) adds it as a direct dep so it can call `parquet::format::PageHeader::read_from_in_protocol` for streaming page-header parsing — making the existing exposure newly visible to the dep-review action, not introducing it.
- Inputs are parquet files we wrote to our own object store (compactor reads), not network-received untrusted bytes.
- **Defense in depth**: the streaming reader caps each Thrift parse buffer at `max_page_header_bytes` (1 MiB default) **before** handing bytes to thrift, so the outer buffer the parser can read from is bounded regardless of any inner length prefix.
- **No upstream fix**: thrift 0.17.0 is the latest version on crates.io, and parquet 58 is pinned to `thrift = "^0.17"`. Upgrading isn't an option.

## Why this is needed now
PR #6386's `dependency-review` check currently fails because thrift went from "transitive only" to "transitive + direct" in PR-4's diff, and the dep-review action flags newly-introduced packages. Same pattern as the three existing entries (rsa crate, rand crate) — each is a documented advisory we're consciously accepting with a justification.

## Test plan
- [x] No code change other than the workflow allow-list addition + comment
- The fix only takes effect once this lands on main (since `pull_request` workflows run from the base branch's workflow file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)