### PR TITLE
feat: track resource stats across split, leaf and root search

### DIFF
--- a/quickwit/quickwit-common/src/lib.rs
+++ b/quickwit/quickwit-common/src/lib.rs
@@ -81,6 +81,17 @@ pub fn is_true(value: &bool) -> bool {
     *value
 }
 
+/// `true` when the current process is running inside an AWS Lambda runtime.
+///
+/// Detected via the presence of the `AWS_LAMBDA_FUNCTION_NAME` environment
+/// variable, which the Lambda runtime sets automatically. The result is cached
+/// on first access since environment variables are read once at process start.
+pub fn is_running_in_lambda() -> bool {
+    static IS_LAMBDA: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("AWS_LAMBDA_FUNCTION_NAME").is_some());
+    *IS_LAMBDA
+}
+
 pub fn chunk_range(range: Range<usize>, chunk_size: usize) -> impl Iterator<Item = Range<usize>> {
     range.clone().step_by(chunk_size).map(move |block_start| {
         let block_end = (block_start + chunk_size).min(range.end);

--- a/quickwit/quickwit-jaeger/src/lib.rs
+++ b/quickwit/quickwit-jaeger/src/lib.rs
@@ -2723,6 +2723,7 @@ mod tests {
                     scroll_id: None,
                     failed_splits: Vec::new(),
                     num_successful_splits: 1,
+                    resource_stats: None,
                 })
             });
 

--- a/quickwit/quickwit-lambda-client/src/invoker.rs
+++ b/quickwit/quickwit-lambda-client/src/invoker.rs
@@ -170,14 +170,18 @@ impl LambdaLeafSearchInvoker for AwsLambdaInvoker {
         let start = std::time::Instant::now();
         let result = self.invoke_leaf_search_with_retry(request).await;
         let elapsed = start.elapsed().as_secs_f64();
-        let status = if result.is_ok() { "success" } else { "error" };
+        let outcome = match &result {
+            Ok(_) => "success",
+            Err(SearchError::Timeout(_)) => "timeout",
+            Err(_) => "other",
+        };
         LAMBDA_METRICS
             .leaf_search_requests_total
-            .with_label_values([status])
+            .with_label_values([outcome])
             .inc();
         LAMBDA_METRICS
             .leaf_search_duration_seconds
-            .with_label_values([status])
+            .with_label_values([outcome])
             .observe(elapsed);
         result
     }

--- a/quickwit/quickwit-lambda-client/src/metrics.rs
+++ b/quickwit/quickwit-lambda-client/src/metrics.rs
@@ -46,14 +46,14 @@ impl Default for LambdaMetrics {
                 "Total number of Lambda leaf search invocations.",
                 "lambda",
                 &[],
-                ["status"],
+                ["outcome"],
             ),
             leaf_search_duration_seconds: new_histogram_vec(
                 "leaf_search_duration_seconds",
                 "Duration of Lambda leaf search invocations in seconds.",
                 "lambda",
                 &[],
-                ["status"],
+                ["outcome"],
                 duration_buckets(),
             ),
             leaf_search_request_payload_size_bytes: new_histogram(

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -184,6 +184,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
 
     // Search service.
+    //
+    // Unlike the other services above, search goes through `tonic_prost_build` directly
+    // (not through `quickwit_codegen::Codegen`, which emits `cargo:rerun-if-changed` for
+    // every proto it compiles). `prost_build` 0.14 has a TODO acknowledging it does not
+    // emit those directives itself, and `tonic_prost_build` 0.14.5 exposes an
+    // `emit_rerun_if_changed` setter but never forwards it to the underlying `Config`.
+    // Without the explicit hint below, edits to `search.proto` do not retrigger build.rs
+    // (because the other `Codegen` calls have already narrowed cargo's watch list).
+    println!("cargo:rerun-if-changed=protos/quickwit/search.proto");
+
     let mut prost_config = prost_build::Config::default();
     prost_config
         .file_descriptor_set_path("src/codegen/quickwit/search_descriptor.bin")
@@ -199,6 +209,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("SortByValue", "#[derive(Ord, PartialOrd)]")
         .type_attribute("SearchRequest", "#[derive(Hash, Eq)]")
         .type_attribute("PartialHit", "#[derive(Hash, Eq)]")
+        // The `Response` variant carries a `LeafSearchResponse` which now
+        // embeds `LeafResourceStats`.
+        .type_attribute(
+            "LambdaSingleSplitResult.outcome",
+            "#[allow(clippy::large_enum_variant)]",
+        )
         .out_dir("src/codegen/quickwit")
         .compile_with_config(
             prost_config,

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -392,14 +392,13 @@ message SplitResourceStats {
 // If the configuration allows it, leaf nodes can offload part of their computation to
 // lambdas.
 //
-// `split_resources_worsts` / `split_resources_sum` aggregations on
+// `split_resources_worst` / `split_resources_sum` aggregations on
 // `LeafResourceStats` are only computed for locally-executed splits.
 //
 // All numeric fields are extensive (summed when merging across leaves).
-// `split_resources_worsts` is the exception — it is the top-2 worst single-split
-// contributions selected by ranking (largest first), not summed.
-// `lambda_bottleneck` is 0 or 1 at the source and becomes a count of leaves
-// where lambda was the bottleneck once aggregated.
+// `split_resources_worst` is the exception — it is selected by ranking, not
+// summed. `lambda_bottleneck` is 0 or 1 at the source and becomes a count of
+// leaves where lambda was the bottleneck once aggregated.
 // `min_wait_for_search_permit_microsecs` and `min_wait_for_cpu_pool_microsecs`
 // are also exceptions — they are merged with `min` rather than `sum` (see
 // their per-field doc below).
@@ -413,12 +412,11 @@ message LeafResourceStats {
     uint64 localexec_num_splits = 8;
     // Sum of `split.num_docs` across locally-executed splits.
     uint64 localexec_num_docs = 9;
-    // Top-2 worst single-split contributions, ranked by
-    // `warmup + wait_for_cpu_pool + cpu_predicate + cpu_collection + cpu_harvest`
-    // (intentionally excludes `wait_for_search_permit`). Largest first: index
-    // 0 is the absolute worst, index 1 is the second worst (or absent if only
-    // one local split contributed).
-    repeated SplitResourceStats split_resources_worsts = 10;
+    // The worst single-split contribution, ranked by `warmup + cpu_search`
+    // (intentionally excludes the queueing phases `wait_for_search_permit`
+    // and `wait_for_cpu_pool` so the ranking reflects "how much work this
+    // split actually did").
+    SplitResourceStats split_resources_worst = 10;
     // Field-wise sum of `SplitResourceStats` across all locally-executed splits.
     // If you want to compute averages, divide by localexec_num_splits.
     SplitResourceStats split_resources_sum = 11;
@@ -455,12 +453,8 @@ message LeafResourceStats {
 
 // Resource statistics for a root search.
 message RootResourceStats {
-    // Top-2 leaves by `wall_time_microsecs`, largest first: index 0 is the
-    // absolute worst leaf, index 1 is the second worst (or absent if only
-    // one leaf contributed stats). Useful to tell whether a single
-    // straggler dominated a query or whether several leaves were
-    // comparably slow.
-    repeated LeafResourceStats leaf_resources_worsts = 1;
+    // The leaf with the largest `wall_time_microsecs`.
+    LeafResourceStats leaf_resources_worst = 1;
     // Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
     // it is not strictly extensive — the sum still gives a useful view of total leaf time.
     // If you want to compute averages, divide by leaf_num_calls: failed leaf attempts

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -409,17 +409,17 @@ message LeafResourceStats {
     uint64 partial_result_cache_num_docs = 2;
 
     // Number of splits executed locally (excluding cache hits and lambda).
-    uint64 localexec_num_splits = 8;
+    uint64 localexec_num_splits = 3;
     // Sum of `split.num_docs` across locally-executed splits.
-    uint64 localexec_num_docs = 9;
+    uint64 localexec_num_docs = 4;
     // The worst single-split contribution, ranked by `warmup + cpu_search`
     // (intentionally excludes the queueing phases `wait_for_search_permit`
     // and `wait_for_cpu_pool` so the ranking reflects "how much work this
     // split actually did").
-    SplitResourceStats split_resources_worst = 10;
+    SplitResourceStats split_resources_worst = 5;
     // Field-wise sum of `SplitResourceStats` across all locally-executed splits.
     // If you want to compute averages, divide by localexec_num_splits.
-    SplitResourceStats split_resources_sum = 11;
+    SplitResourceStats split_resources_sum = 6;
     // Minimum `wait_for_search_permit_microsecs` across the locally-executed
     // splits represented by this stats record. Useful to detect a busy leaf:
     // if even the luckiest split waited long, the node was already saturated
@@ -429,26 +429,26 @@ message LeafResourceStats {
     // Aggregation is MIN everywhere (not extensive sum like most fields).
     // `add_leaf_stats` takes the min of two `Option<u64>` with
     // `min(None, x) = x`.
-    optional uint64 min_wait_for_search_permit_microsecs = 13;
+    optional uint64 min_wait_for_search_permit_microsecs = 7;
     // Same as above, but for `wait_for_cpu_pool_microsecs`.
-    optional uint64 min_wait_for_cpu_pool_microsecs = 14;
+    optional uint64 min_wait_for_cpu_pool_microsecs = 8;
     // Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
-    uint64 wall_time_microsecs = 12;
+    uint64 wall_time_microsecs = 9;
 
     // Number of splits dispatched to lambda (offloaded execution).
-    uint64 lambda_num_splits = 3;
+    uint64 lambda_num_splits = 10;
     // Sum of `split.num_docs` across lambda-dispatched splits.
-    uint64 lambda_num_docs = 4;
+    uint64 lambda_num_docs = 11;
     // Number of lambda-dispatched splits that succeeded.
-    uint64 lambda_success_num_splits = 5;
+    uint64 lambda_success_num_splits = 12;
     // Sum of `split.num_docs` across successful lambda-dispatched splits.
-    uint64 lambda_success_num_docs = 6;
+    uint64 lambda_success_num_docs = 13;
     // At the source (a single leaf call) this is 1 if the offloaded path
     // finished after the local path (lambda was the bottleneck), 0 otherwise.
     // Forced to 0 when `lambda_num_splits == 0`. At aggregate levels (merged
     // across leaves) it is the count of leaves where lambda was the
     // bottleneck. Voluntarily a uint64 (not a bool) for summability.
-    uint64 lambda_bottleneck = 7;
+    uint64 lambda_bottleneck = 14;
 }
 
 // Resource statistics for a root search.

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -319,6 +319,9 @@ message SearchResponse {
 
   // Total number of successful splits searched.
   uint64 num_successful_splits = 8;
+
+  // Resource statistics for the root search.
+  RootResourceStats resource_stats = 10;
 }
 
 message SearchPlanResponse {
@@ -355,12 +358,98 @@ message LeafSearchRequest {
   repeated string index_uris = 9;
 }
 
-message ResourceStats {
-    uint64 short_lived_cache_num_bytes = 1;
-    uint64 split_num_docs = 2;
-    uint64 warmup_microsecs = 3;
-    uint64 cpu_thread_pool_wait_microsecs = 4;
-    uint64 cpu_microsecs = 5;
+// Per-split resource statistics.
+//
+// All fields are extensive (sum across splits is meaningful) except where noted.
+message SplitResourceStats {
+    // Number of documents in the split.
+    uint64 split_num_docs = 1;
+    // Bytes resident in the warmup short-lived cache after warmup
+    // (measure of input data the search needed to process).
+    uint64 input_memory_bytes = 2;
+    // Bytes downloaded from storage during the request, as measured
+    // by a request-scoped storage wrapper.
+    uint64 download_num_bytes = 3;
+    // Number of storage GET requests issued during the request.
+    uint64 download_num_requests = 4;
+    // Number of documents matched by the query in this split (we always count).
+    uint64 matched_num_docs = 5;
+
+    // Time the split spent waiting to acquire its search permit.
+    uint64 wait_for_search_permit_microsecs = 6;
+    // Time spent in the warmup phase (downloading and indexing data into caches).
+    uint64 warmup_microsecs = 7;
+    // Time the split spent waiting for a slot on the CPU pool after warmup.
+    uint64 wait_for_cpu_pool_microsecs = 8;
+    // CPU time spent in the search itself (predicate matching + collection +
+    // per-segment harvest), as measured around the tantivy search call.
+    // Excludes any cross-split finalize work performed outside the single-split
+    // search.
+    uint64 cpu_search_microsecs = 9;
+}
+
+// Resource statistics for a single leaf-search call (over one or more splits).
+// If the configuration allows it, leaf nodes can offload part of their computation to
+// lambdas.
+//
+// `split_resources_worst` / `split_resources_sum` aggregations on
+// `LeafResourceStats` are only computed for locally-executed splits.
+//
+// All numeric fields are extensive (summed when merging across leaves).
+// `split_resources_worst` is the exception — it is selected by ranking, not
+// summed. `lambda_bottleneck` is 0 or 1 at the source and becomes a count of
+// leaves where lambda was the bottleneck once aggregated.
+message LeafResourceStats {
+    // Number of splits whose results came from the partial result cache.
+    uint64 partial_result_cache_num_splits = 1;
+    // Sum of `split.num_docs` across cache-hit splits.
+    uint64 partial_result_cache_num_docs = 2;
+
+    // Number of splits executed locally (excluding cache hits and lambda).
+    uint64 localexec_num_splits = 8;
+    // Sum of `split.num_docs` across locally-executed splits.
+    uint64 localexec_num_docs = 9;
+    // The worst single-split contribution, ranked by
+    // `warmup + wait_for_cpu_pool + cpu_predicate + cpu_collection + cpu_harvest`
+    // (intentionally excludes `wait_for_search_permit`).
+    SplitResourceStats split_resources_worst = 10;
+    // Field-wise sum of `SplitResourceStats` across all locally-executed splits.
+    // If you want to compute averages, divide by localexec_num_splits.
+    SplitResourceStats split_resources_sum = 11;
+    // Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
+    uint64 wall_time_microsecs = 12;
+
+    // Number of splits dispatched to lambda (offloaded execution).
+    uint64 lambda_num_splits = 3;
+    // Sum of `split.num_docs` across lambda-dispatched splits.
+    uint64 lambda_num_docs = 4;
+    // Number of lambda-dispatched splits that succeeded.
+    uint64 lambda_success_num_splits = 5;
+    // Sum of `split.num_docs` across successful lambda-dispatched splits.
+    uint64 lambda_success_num_docs = 6;
+    // At the source (a single leaf call) this is 1 if the offloaded path
+    // finished after the local path (lambda was the bottleneck), 0 otherwise.
+    // Forced to 0 when `lambda_num_splits == 0`. At aggregate levels (merged
+    // across leaves) it is the count of leaves where lambda was the
+    // bottleneck. Voluntarily a uint64 (not a bool) for summability.
+    uint64 lambda_bottleneck = 7;
+}
+
+// Resource statistics for a root search.
+message RootResourceStats {
+    // The leaf with the largest `wall_time_microsecs`.
+    LeafResourceStats leaf_resources_worst = 1;
+    // Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
+    // it is not strictly extensive — the sum still gives a useful view of total leaf time.
+    // If you want to compute averages, divide by leaf_num_calls: failed leaf attempts
+    // usually do not come with proper counters.
+    LeafResourceStats leaf_resources_sum = 2;
+    // Number of leaf calls excluding retries.
+    uint64 leaf_num_calls = 3;
+    // Number of leaf calls, including retries.
+    uint64 leaf_num_calls_including_retries = 4;
+    // Number of failed splits across all leaves.
+    uint64 num_failed_splits = 5;
 }
 
 // LeafRequestRef references data in LeafSearchRequest to deduplicate data.
@@ -496,7 +585,10 @@ message LeafSearchResponse {
   // postcard serialized intermediate aggregation_result.
   optional bytes intermediate_aggregation_result = 6;
 
-  ResourceStats resource_stats = 8;
+  // [deprecated] ResourceStats resource_stats = 8;
+  reserved 8;
+
+  LeafResourceStats resource_stats = 9;
 }
 
 // The result of searching a single split in a Lambda invocation.

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -466,6 +466,11 @@ message RootResourceStats {
     uint64 leaf_num_calls_including_retries = 4;
     // Number of failed splits across all leaves.
     uint64 num_failed_splits = 5;
+    // Per-leaf `wall_time_microsecs`, one entry per leaf that contributed
+    // stats, sorted in descending order (largest first). Useful for
+    // distinguishing "one straggler" from "all leaves comparably slow"
+    // without computing it from `leaf_resources_worst` / `leaf_resources_sum`.
+    repeated uint64 leaf_wall_times_microsecs = 6;
 }
 
 // LeafRequestRef references data in LeafSearchRequest to deduplicate data.

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -392,13 +392,17 @@ message SplitResourceStats {
 // If the configuration allows it, leaf nodes can offload part of their computation to
 // lambdas.
 //
-// `split_resources_worst` / `split_resources_sum` aggregations on
+// `split_resources_worsts` / `split_resources_sum` aggregations on
 // `LeafResourceStats` are only computed for locally-executed splits.
 //
 // All numeric fields are extensive (summed when merging across leaves).
-// `split_resources_worst` is the exception — it is selected by ranking, not
-// summed. `lambda_bottleneck` is 0 or 1 at the source and becomes a count of
-// leaves where lambda was the bottleneck once aggregated.
+// `split_resources_worsts` is the exception — it is the top-2 worst single-split
+// contributions selected by ranking (largest first), not summed.
+// `lambda_bottleneck` is 0 or 1 at the source and becomes a count of leaves
+// where lambda was the bottleneck once aggregated.
+// `min_wait_for_search_permit_microsecs` and `min_wait_for_cpu_pool_microsecs`
+// are also exceptions — they are merged with `min` rather than `sum` (see
+// their per-field doc below).
 message LeafResourceStats {
     // Number of splits whose results came from the partial result cache.
     uint64 partial_result_cache_num_splits = 1;
@@ -409,13 +413,27 @@ message LeafResourceStats {
     uint64 localexec_num_splits = 8;
     // Sum of `split.num_docs` across locally-executed splits.
     uint64 localexec_num_docs = 9;
-    // The worst single-split contribution, ranked by
+    // Top-2 worst single-split contributions, ranked by
     // `warmup + wait_for_cpu_pool + cpu_predicate + cpu_collection + cpu_harvest`
-    // (intentionally excludes `wait_for_search_permit`).
-    SplitResourceStats split_resources_worst = 10;
+    // (intentionally excludes `wait_for_search_permit`). Largest first: index
+    // 0 is the absolute worst, index 1 is the second worst (or absent if only
+    // one local split contributed).
+    repeated SplitResourceStats split_resources_worsts = 10;
     // Field-wise sum of `SplitResourceStats` across all locally-executed splits.
     // If you want to compute averages, divide by localexec_num_splits.
     SplitResourceStats split_resources_sum = 11;
+    // Minimum `wait_for_search_permit_microsecs` across the locally-executed
+    // splits represented by this stats record. Useful to detect a busy leaf:
+    // if even the luckiest split waited long, the node was already saturated
+    // before this query arrived. Splits that did not execute locally (cache
+    // hits, lambda-dispatched) do NOT contribute — they leave the field unset.
+    //
+    // Aggregation is MIN everywhere (not extensive sum like most fields).
+    // `add_leaf_stats` takes the min of two `Option<u64>` with
+    // `min(None, x) = x`.
+    optional uint64 min_wait_for_search_permit_microsecs = 13;
+    // Same as above, but for `wait_for_cpu_pool_microsecs`.
+    optional uint64 min_wait_for_cpu_pool_microsecs = 14;
     // Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
     uint64 wall_time_microsecs = 12;
 
@@ -437,8 +455,12 @@ message LeafResourceStats {
 
 // Resource statistics for a root search.
 message RootResourceStats {
-    // The leaf with the largest `wall_time_microsecs`.
-    LeafResourceStats leaf_resources_worst = 1;
+    // Top-2 leaves by `wall_time_microsecs`, largest first: index 0 is the
+    // absolute worst leaf, index 1 is the second worst (or absent if only
+    // one leaf contributed stats). Useful to tell whether a single
+    // straggler dominated a query or whether several leaves were
+    // comparably slow.
+    repeated LeafResourceStats leaf_resources_worsts = 1;
     // Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
     // it is not strictly extensive — the sum still gives a useful view of total leaf time.
     // If you want to compute averages, divide by leaf_num_calls: failed leaf attempts

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -327,15 +327,19 @@ pub struct SplitResourceStats {
 /// If the configuration allows it, leaf nodes can offload part of their computation to
 /// lambdas.
 ///
-/// `split_resources_worst` / `split_resources_sum` aggregations on
+/// `split_resources_worsts` / `split_resources_sum` aggregations on
 /// `LeafResourceStats` are only computed for locally-executed splits.
 ///
 /// All numeric fields are extensive (summed when merging across leaves).
-/// `split_resources_worst` is the exception — it is selected by ranking, not
-/// summed. `lambda_bottleneck` is 0 or 1 at the source and becomes a count of
-/// leaves where lambda was the bottleneck once aggregated.
+/// `split_resources_worsts` is the exception — it is the top-2 worst single-split
+/// contributions selected by ranking (largest first), not summed.
+/// `lambda_bottleneck` is 0 or 1 at the source and becomes a count of leaves
+/// where lambda was the bottleneck once aggregated.
+/// `min_wait_for_search_permit_microsecs` and `min_wait_for_cpu_pool_microsecs`
+/// are also exceptions — they are merged with `min` rather than `sum` (see
+/// their per-field doc below).
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeafResourceStats {
     /// Number of splits whose results came from the partial result cache.
     #[prost(uint64, tag = "1")]
@@ -349,15 +353,31 @@ pub struct LeafResourceStats {
     /// Sum of `split.num_docs` across locally-executed splits.
     #[prost(uint64, tag = "9")]
     pub localexec_num_docs: u64,
-    /// The worst single-split contribution, ranked by
+    /// Top-2 worst single-split contributions, ranked by
     /// `warmup + wait_for_cpu_pool + cpu_predicate + cpu_collection + cpu_harvest`
-    /// (intentionally excludes `wait_for_search_permit`).
-    #[prost(message, optional, tag = "10")]
-    pub split_resources_worst: ::core::option::Option<SplitResourceStats>,
+    /// (intentionally excludes `wait_for_search_permit`). Largest first: index
+    /// 0 is the absolute worst, index 1 is the second worst (or absent if only
+    /// one local split contributed).
+    #[prost(message, repeated, tag = "10")]
+    pub split_resources_worsts: ::prost::alloc::vec::Vec<SplitResourceStats>,
     /// Field-wise sum of `SplitResourceStats` across all locally-executed splits.
     /// If you want to compute averages, divide by localexec_num_splits.
     #[prost(message, optional, tag = "11")]
     pub split_resources_sum: ::core::option::Option<SplitResourceStats>,
+    /// Minimum `wait_for_search_permit_microsecs` across the locally-executed
+    /// splits represented by this stats record. Useful to detect a busy leaf:
+    /// if even the luckiest split waited long, the node was already saturated
+    /// before this query arrived. Splits that did not execute locally (cache
+    /// hits, lambda-dispatched) do NOT contribute — they leave the field unset.
+    ///
+    /// Aggregation is MIN everywhere (not extensive sum like most fields).
+    /// `add_leaf_stats` takes the min of two `Option<u64>` with
+    /// `min(None, x) = x`.
+    #[prost(uint64, optional, tag = "13")]
+    pub min_wait_for_search_permit_microsecs: ::core::option::Option<u64>,
+    /// Same as above, but for `wait_for_cpu_pool_microsecs`.
+    #[prost(uint64, optional, tag = "14")]
+    pub min_wait_for_cpu_pool_microsecs: ::core::option::Option<u64>,
     /// Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
     #[prost(uint64, tag = "12")]
     pub wall_time_microsecs: u64,
@@ -383,11 +403,15 @@ pub struct LeafResourceStats {
 }
 /// Resource statistics for a root search.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RootResourceStats {
-    /// The leaf with the largest `wall_time_microsecs`.
-    #[prost(message, optional, tag = "1")]
-    pub leaf_resources_worst: ::core::option::Option<LeafResourceStats>,
+    /// Top-2 leaves by `wall_time_microsecs`, largest first: index 0 is the
+    /// absolute worst leaf, index 1 is the second worst (or absent if only
+    /// one leaf contributed stats). Useful to tell whether a single
+    /// straggler dominated a query or whether several leaves were
+    /// comparably slow.
+    #[prost(message, repeated, tag = "1")]
+    pub leaf_resources_worsts: ::prost::alloc::vec::Vec<LeafResourceStats>,
     /// Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
     /// it is not strictly extensive — the sum still gives a useful view of total leaf time.
     /// If you want to compute averages, divide by leaf_num_calls: failed leaf attempts

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -401,7 +401,7 @@ pub struct LeafResourceStats {
 }
 /// Resource statistics for a root search.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RootResourceStats {
     /// The leaf with the largest `wall_time_microsecs`.
     #[prost(message, optional, tag = "1")]
@@ -421,6 +421,12 @@ pub struct RootResourceStats {
     /// Number of failed splits across all leaves.
     #[prost(uint64, tag = "5")]
     pub num_failed_splits: u64,
+    /// Per-leaf `wall_time_microsecs`, one entry per leaf that contributed
+    /// stats, sorted in descending order (largest first). Useful for
+    /// distinguishing "one straggler" from "all leaves comparably slow"
+    /// without computing it from `leaf_resources_worst` / `leaf_resources_sum`.
+    #[prost(uint64, repeated, tag = "6")]
+    pub leaf_wall_times_microsecs: ::prost::alloc::vec::Vec<u64>,
 }
 /// LeafRequestRef references data in LeafSearchRequest to deduplicate data.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -327,19 +327,18 @@ pub struct SplitResourceStats {
 /// If the configuration allows it, leaf nodes can offload part of their computation to
 /// lambdas.
 ///
-/// `split_resources_worsts` / `split_resources_sum` aggregations on
+/// `split_resources_worst` / `split_resources_sum` aggregations on
 /// `LeafResourceStats` are only computed for locally-executed splits.
 ///
 /// All numeric fields are extensive (summed when merging across leaves).
-/// `split_resources_worsts` is the exception — it is the top-2 worst single-split
-/// contributions selected by ranking (largest first), not summed.
-/// `lambda_bottleneck` is 0 or 1 at the source and becomes a count of leaves
-/// where lambda was the bottleneck once aggregated.
+/// `split_resources_worst` is the exception — it is selected by ranking, not
+/// summed. `lambda_bottleneck` is 0 or 1 at the source and becomes a count of
+/// leaves where lambda was the bottleneck once aggregated.
 /// `min_wait_for_search_permit_microsecs` and `min_wait_for_cpu_pool_microsecs`
 /// are also exceptions — they are merged with `min` rather than `sum` (see
 /// their per-field doc below).
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LeafResourceStats {
     /// Number of splits whose results came from the partial result cache.
     #[prost(uint64, tag = "1")]
@@ -353,13 +352,12 @@ pub struct LeafResourceStats {
     /// Sum of `split.num_docs` across locally-executed splits.
     #[prost(uint64, tag = "9")]
     pub localexec_num_docs: u64,
-    /// Top-2 worst single-split contributions, ranked by
-    /// `warmup + wait_for_cpu_pool + cpu_predicate + cpu_collection + cpu_harvest`
-    /// (intentionally excludes `wait_for_search_permit`). Largest first: index
-    /// 0 is the absolute worst, index 1 is the second worst (or absent if only
-    /// one local split contributed).
-    #[prost(message, repeated, tag = "10")]
-    pub split_resources_worsts: ::prost::alloc::vec::Vec<SplitResourceStats>,
+    /// The worst single-split contribution, ranked by `warmup + cpu_search`
+    /// (intentionally excludes the queueing phases `wait_for_search_permit`
+    /// and `wait_for_cpu_pool` so the ranking reflects "how much work this
+    /// split actually did").
+    #[prost(message, optional, tag = "10")]
+    pub split_resources_worst: ::core::option::Option<SplitResourceStats>,
     /// Field-wise sum of `SplitResourceStats` across all locally-executed splits.
     /// If you want to compute averages, divide by localexec_num_splits.
     #[prost(message, optional, tag = "11")]
@@ -403,15 +401,11 @@ pub struct LeafResourceStats {
 }
 /// Resource statistics for a root search.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RootResourceStats {
-    /// Top-2 leaves by `wall_time_microsecs`, largest first: index 0 is the
-    /// absolute worst leaf, index 1 is the second worst (or absent if only
-    /// one leaf contributed stats). Useful to tell whether a single
-    /// straggler dominated a query or whether several leaves were
-    /// comparably slow.
-    #[prost(message, repeated, tag = "1")]
-    pub leaf_resources_worsts: ::prost::alloc::vec::Vec<LeafResourceStats>,
+    /// The leaf with the largest `wall_time_microsecs`.
+    #[prost(message, optional, tag = "1")]
+    pub leaf_resources_worst: ::core::option::Option<LeafResourceStats>,
     /// Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
     /// it is not strictly extensive — the sum still gives a useful view of total leaf time.
     /// If you want to compute averages, divide by leaf_num_calls: failed leaf attempts

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -347,20 +347,20 @@ pub struct LeafResourceStats {
     #[prost(uint64, tag = "2")]
     pub partial_result_cache_num_docs: u64,
     /// Number of splits executed locally (excluding cache hits and lambda).
-    #[prost(uint64, tag = "8")]
+    #[prost(uint64, tag = "3")]
     pub localexec_num_splits: u64,
     /// Sum of `split.num_docs` across locally-executed splits.
-    #[prost(uint64, tag = "9")]
+    #[prost(uint64, tag = "4")]
     pub localexec_num_docs: u64,
     /// The worst single-split contribution, ranked by `warmup + cpu_search`
     /// (intentionally excludes the queueing phases `wait_for_search_permit`
     /// and `wait_for_cpu_pool` so the ranking reflects "how much work this
     /// split actually did").
-    #[prost(message, optional, tag = "10")]
+    #[prost(message, optional, tag = "5")]
     pub split_resources_worst: ::core::option::Option<SplitResourceStats>,
     /// Field-wise sum of `SplitResourceStats` across all locally-executed splits.
     /// If you want to compute averages, divide by localexec_num_splits.
-    #[prost(message, optional, tag = "11")]
+    #[prost(message, optional, tag = "6")]
     pub split_resources_sum: ::core::option::Option<SplitResourceStats>,
     /// Minimum `wait_for_search_permit_microsecs` across the locally-executed
     /// splits represented by this stats record. Useful to detect a busy leaf:
@@ -371,32 +371,32 @@ pub struct LeafResourceStats {
     /// Aggregation is MIN everywhere (not extensive sum like most fields).
     /// `add_leaf_stats` takes the min of two `Option<u64>` with
     /// `min(None, x) = x`.
-    #[prost(uint64, optional, tag = "13")]
+    #[prost(uint64, optional, tag = "7")]
     pub min_wait_for_search_permit_microsecs: ::core::option::Option<u64>,
     /// Same as above, but for `wait_for_cpu_pool_microsecs`.
-    #[prost(uint64, optional, tag = "14")]
+    #[prost(uint64, optional, tag = "8")]
     pub min_wait_for_cpu_pool_microsecs: ::core::option::Option<u64>,
     /// Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
-    #[prost(uint64, tag = "12")]
+    #[prost(uint64, tag = "9")]
     pub wall_time_microsecs: u64,
     /// Number of splits dispatched to lambda (offloaded execution).
-    #[prost(uint64, tag = "3")]
+    #[prost(uint64, tag = "10")]
     pub lambda_num_splits: u64,
     /// Sum of `split.num_docs` across lambda-dispatched splits.
-    #[prost(uint64, tag = "4")]
+    #[prost(uint64, tag = "11")]
     pub lambda_num_docs: u64,
     /// Number of lambda-dispatched splits that succeeded.
-    #[prost(uint64, tag = "5")]
+    #[prost(uint64, tag = "12")]
     pub lambda_success_num_splits: u64,
     /// Sum of `split.num_docs` across successful lambda-dispatched splits.
-    #[prost(uint64, tag = "6")]
+    #[prost(uint64, tag = "13")]
     pub lambda_success_num_docs: u64,
     /// At the source (a single leaf call) this is 1 if the offloaded path
     /// finished after the local path (lambda was the bottleneck), 0 otherwise.
     /// Forced to 0 when `lambda_num_splits == 0`. At aggregate levels (merged
     /// across leaves) it is the count of leaves where lambda was the
     /// bottleneck. Voluntarily a uint64 (not a bool) for summability.
-    #[prost(uint64, tag = "7")]
+    #[prost(uint64, tag = "14")]
     pub lambda_bottleneck: u64,
 }
 /// Resource statistics for a root search.

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -240,6 +240,9 @@ pub struct SearchResponse {
     /// Total number of successful splits searched.
     #[prost(uint64, tag = "8")]
     pub num_successful_splits: u64,
+    /// Resource statistics for the root search.
+    #[prost(message, optional, tag = "10")]
+    pub resource_stats: ::core::option::Option<RootResourceStats>,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -281,19 +284,125 @@ pub struct LeafSearchRequest {
     #[prost(string, repeated, tag = "9")]
     pub index_uris: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Per-split resource statistics.
+///
+/// All fields are extensive (sum across splits is meaningful) except where noted.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ResourceStats {
+pub struct SplitResourceStats {
+    /// Number of documents in the split.
     #[prost(uint64, tag = "1")]
-    pub short_lived_cache_num_bytes: u64,
-    #[prost(uint64, tag = "2")]
     pub split_num_docs: u64,
+    /// Bytes resident in the warmup short-lived cache after warmup
+    /// (measure of input data the search needed to process).
+    #[prost(uint64, tag = "2")]
+    pub input_memory_bytes: u64,
+    /// Bytes downloaded from storage during the request, as measured
+    /// by a request-scoped storage wrapper.
     #[prost(uint64, tag = "3")]
-    pub warmup_microsecs: u64,
+    pub download_num_bytes: u64,
+    /// Number of storage GET requests issued during the request.
     #[prost(uint64, tag = "4")]
-    pub cpu_thread_pool_wait_microsecs: u64,
+    pub download_num_requests: u64,
+    /// Number of documents matched by the query in this split (we always count).
     #[prost(uint64, tag = "5")]
-    pub cpu_microsecs: u64,
+    pub matched_num_docs: u64,
+    /// Time the split spent waiting to acquire its search permit.
+    #[prost(uint64, tag = "6")]
+    pub wait_for_search_permit_microsecs: u64,
+    /// Time spent in the warmup phase (downloading and indexing data into caches).
+    #[prost(uint64, tag = "7")]
+    pub warmup_microsecs: u64,
+    /// Time the split spent waiting for a slot on the CPU pool after warmup.
+    #[prost(uint64, tag = "8")]
+    pub wait_for_cpu_pool_microsecs: u64,
+    /// CPU time spent in the search itself (predicate matching + collection +
+    /// per-segment harvest), as measured around the tantivy search call.
+    /// Excludes any cross-split finalize work performed outside the single-split
+    /// search.
+    #[prost(uint64, tag = "9")]
+    pub cpu_search_microsecs: u64,
+}
+/// Resource statistics for a single leaf-search call (over one or more splits).
+/// If the configuration allows it, leaf nodes can offload part of their computation to
+/// lambdas.
+///
+/// `split_resources_worst` / `split_resources_sum` aggregations on
+/// `LeafResourceStats` are only computed for locally-executed splits.
+///
+/// All numeric fields are extensive (summed when merging across leaves).
+/// `split_resources_worst` is the exception — it is selected by ranking, not
+/// summed. `lambda_bottleneck` is 0 or 1 at the source and becomes a count of
+/// leaves where lambda was the bottleneck once aggregated.
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct LeafResourceStats {
+    /// Number of splits whose results came from the partial result cache.
+    #[prost(uint64, tag = "1")]
+    pub partial_result_cache_num_splits: u64,
+    /// Sum of `split.num_docs` across cache-hit splits.
+    #[prost(uint64, tag = "2")]
+    pub partial_result_cache_num_docs: u64,
+    /// Number of splits executed locally (excluding cache hits and lambda).
+    #[prost(uint64, tag = "8")]
+    pub localexec_num_splits: u64,
+    /// Sum of `split.num_docs` across locally-executed splits.
+    #[prost(uint64, tag = "9")]
+    pub localexec_num_docs: u64,
+    /// The worst single-split contribution, ranked by
+    /// `warmup + wait_for_cpu_pool + cpu_predicate + cpu_collection + cpu_harvest`
+    /// (intentionally excludes `wait_for_search_permit`).
+    #[prost(message, optional, tag = "10")]
+    pub split_resources_worst: ::core::option::Option<SplitResourceStats>,
+    /// Field-wise sum of `SplitResourceStats` across all locally-executed splits.
+    /// If you want to compute averages, divide by localexec_num_splits.
+    #[prost(message, optional, tag = "11")]
+    pub split_resources_sum: ::core::option::Option<SplitResourceStats>,
+    /// Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
+    #[prost(uint64, tag = "12")]
+    pub wall_time_microsecs: u64,
+    /// Number of splits dispatched to lambda (offloaded execution).
+    #[prost(uint64, tag = "3")]
+    pub lambda_num_splits: u64,
+    /// Sum of `split.num_docs` across lambda-dispatched splits.
+    #[prost(uint64, tag = "4")]
+    pub lambda_num_docs: u64,
+    /// Number of lambda-dispatched splits that succeeded.
+    #[prost(uint64, tag = "5")]
+    pub lambda_success_num_splits: u64,
+    /// Sum of `split.num_docs` across successful lambda-dispatched splits.
+    #[prost(uint64, tag = "6")]
+    pub lambda_success_num_docs: u64,
+    /// At the source (a single leaf call) this is 1 if the offloaded path
+    /// finished after the local path (lambda was the bottleneck), 0 otherwise.
+    /// Forced to 0 when `lambda_num_splits == 0`. At aggregate levels (merged
+    /// across leaves) it is the count of leaves where lambda was the
+    /// bottleneck. Voluntarily a uint64 (not a bool) for summability.
+    #[prost(uint64, tag = "7")]
+    pub lambda_bottleneck: u64,
+}
+/// Resource statistics for a root search.
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RootResourceStats {
+    /// The leaf with the largest `wall_time_microsecs`.
+    #[prost(message, optional, tag = "1")]
+    pub leaf_resources_worst: ::core::option::Option<LeafResourceStats>,
+    /// Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
+    /// it is not strictly extensive — the sum still gives a useful view of total leaf time.
+    /// If you want to compute averages, divide by leaf_num_calls: failed leaf attempts
+    /// usually do not come with proper counters.
+    #[prost(message, optional, tag = "2")]
+    pub leaf_resources_sum: ::core::option::Option<LeafResourceStats>,
+    /// Number of leaf calls excluding retries.
+    #[prost(uint64, tag = "3")]
+    pub leaf_num_calls: u64,
+    /// Number of leaf calls, including retries.
+    #[prost(uint64, tag = "4")]
+    pub leaf_num_calls_including_retries: u64,
+    /// Number of failed splits across all leaves.
+    #[prost(uint64, tag = "5")]
+    pub num_failed_splits: u64,
 }
 /// LeafRequestRef references data in LeafSearchRequest to deduplicate data.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -460,8 +569,8 @@ pub struct LeafSearchResponse {
     pub intermediate_aggregation_result: ::core::option::Option<
         ::prost::alloc::vec::Vec<u8>,
     >,
-    #[prost(message, optional, tag = "8")]
-    pub resource_stats: ::core::option::Option<ResourceStats>,
+    #[prost(message, optional, tag = "9")]
+    pub resource_stats: ::core::option::Option<LeafResourceStats>,
 }
 /// The result of searching a single split in a Lambda invocation.
 /// Each result is tagged with its split_id so that ordering is irrelevant.
@@ -477,6 +586,7 @@ pub struct LambdaSingleSplitResult {
 /// Nested message and enum types in `LambdaSingleSplitResult`.
 pub mod lambda_single_split_result {
     #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    #[allow(clippy::large_enum_variant)]
     #[serde(rename_all = "snake_case")]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Outcome {

--- a/quickwit/quickwit-search/src/cluster_client.rs
+++ b/quickwit/quickwit-search/src/cluster_client.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
 use base64::Engine;
@@ -26,7 +28,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::retry::search::LeafSearchRetryPolicy;
 use crate::retry::{DefaultRetryPolicy, RetryPolicy, retry_client};
-use crate::{SearchJobPlacer, SearchServiceClient, merge_resource_stats_it};
+use crate::{SearchJobPlacer, SearchServiceClient, merge_leaf_stats_it};
 
 /// Maximum number of put requests emitted to perform a replicated given PUT KV.
 const MAX_PUT_KV_ATTEMPTS: usize = 6;
@@ -77,12 +79,17 @@ impl ClusterClient {
     }
 
     /// Leaf search with retry on another node client.
+    ///
+    /// Returns the response and increases `leaf_search_call_count`
+    /// with the number of leaf search calls done (including retries).
     pub async fn leaf_search(
         &self,
         request: LeafSearchRequest,
         mut client: SearchServiceClient,
+        leaf_search_call_count: Arc<AtomicU64>,
     ) -> crate::Result<LeafSearchResponse> {
-        let mut response_res = client.leaf_search(request.clone()).await;
+        leaf_search_call_count.fetch_add(1u64, std::sync::atomic::Ordering::Relaxed);
+        let response_res = client.leaf_search(request.clone()).await;
         let retry_policy = LeafSearchRetryPolicy {};
         // We retry only once.
         let Some(retry_request) = retry_policy.retry_request(request, &response_res) else {
@@ -112,9 +119,9 @@ impl ClusterClient {
             "Leaf search response error: `{:?}`. Retry once to execute {:?} with {:?}",
             response_res, retry_request, client
         );
+        leaf_search_call_count.fetch_add(1u64, std::sync::atomic::Ordering::Relaxed);
         let retry_result = client.leaf_search(retry_request).await;
-        response_res = merge_original_with_retry_leaf_search_results(response_res, retry_result);
-        response_res
+        merge_original_with_retry_leaf_search_results(response_res, retry_result)
     }
 
     /// Leaf search with retry on another node client.
@@ -260,7 +267,7 @@ fn merge_original_with_retry_leaf_search_response(
         (Some(left), None) => Some(left),
         (None, None) => None,
     };
-    let resource_stats = merge_resource_stats_it([
+    let resource_stats = merge_leaf_stats_it([
         &original_response.resource_stats,
         &retry_response.resource_stats,
     ]);
@@ -296,6 +303,7 @@ fn merge_original_with_retry_leaf_search_results(
 mod tests {
     use std::collections::HashSet;
     use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use quickwit_proto::search::{
         LeafRequestRef, PartialHit, SearchRequest, SortValue, SplitIdAndFooterOffsets,
@@ -462,11 +470,13 @@ mod tests {
             .await
             .unwrap();
         let cluster_client = ClusterClient::new(search_job_placer);
+        let call_count: Arc<AtomicU64> = Default::default();
         let leaf_search_response = cluster_client
-            .leaf_search(request, first_client)
+            .leaf_search(request, first_client, call_count.clone())
             .await
             .unwrap();
         assert_eq!(leaf_search_response.num_attempted_splits, 1);
+        assert_eq!(call_count.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -510,10 +520,14 @@ mod tests {
             .assign_job(SearchJob::for_test("split_1", 0), &HashSet::new())
             .await
             .unwrap();
+        let call_count: Arc<AtomicU64> = Default::default();
         let cluster_client = ClusterClient::new(search_job_placer);
-        let result = cluster_client.leaf_search(request, first_client).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().num_hits, 2);
+        let response = cluster_client
+            .leaf_search(request, first_client, call_count.clone())
+            .await
+            .unwrap();
+        assert_eq!(response.num_hits, 2);
+        assert_eq!(call_count.load(Ordering::Relaxed), 2);
     }
 
     #[test]

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use quickwit_common::binary_heap::{SortKeyMapper, TopK};
 use quickwit_doc_mapper::{FastFieldWarmupInfo, WarmupInfo};
 use quickwit_proto::search::{
-    LeafSearchResponse, PartialHit, ResourceStats, SearchRequest, SortByValue, SortOrder,
+    LeafResourceStats, LeafSearchResponse, PartialHit, SearchRequest, SortByValue, SortOrder,
     SortValue, SplitSearchError,
 };
 use quickwit_proto::types::SplitId;
@@ -36,7 +36,7 @@ use tantivy::{DateTime, DocId, Score, SegmentOrdinal, SegmentReader, TantivyErro
 
 use crate::find_trace_ids_collector::{FindTraceIdsCollector, FindTraceIdsSegmentCollector, Span};
 use crate::top_k_collector::{QuickwitSegmentTopKCollector, specialized_top_k_segment_collector};
-use crate::{GlobalDocAddress, merge_resource_stats, merge_resource_stats_it};
+use crate::{GlobalDocAddress, add_leaf_stats, merge_leaf_stats_it};
 
 #[derive(Clone, Debug)]
 pub(crate) enum SortByComponent {
@@ -927,7 +927,7 @@ fn merge_leaf_responses(
     let resource_stats_it = leaf_responses
         .iter()
         .map(|leaf_response| &leaf_response.resource_stats);
-    let merged_resource_stats = merge_resource_stats_it(resource_stats_it);
+    let merged_resource_stats = merge_leaf_stats_it(resource_stats_it);
 
     let merged_intermediate_aggregation_result: Option<Vec<u8>> =
         merge_intermediate_aggregation_result(
@@ -1201,7 +1201,7 @@ pub(crate) struct IncrementalCollector {
     num_attempted_splits: u64,
     num_successful_splits: u64,
     start_offset: usize,
-    resource_stats: Option<ResourceStats>,
+    resource_stats: Option<LeafResourceStats>,
 }
 
 impl IncrementalCollector {
@@ -1238,7 +1238,12 @@ impl IncrementalCollector {
             resource_stats,
         } = leaf_response;
 
-        merge_resource_stats(&resource_stats, &mut self.resource_stats);
+        if let Some(new_stats) = &resource_stats {
+            let acc = self
+                .resource_stats
+                .get_or_insert_with(LeafResourceStats::default);
+            add_leaf_stats(acc, new_stats);
+        }
 
         self.num_hits += num_hits;
         self.top_k_hits.add_entries(partial_hits.into_iter());
@@ -1255,6 +1260,20 @@ impl IncrementalCollector {
     /// Add a failed split to the state
     pub(crate) fn add_failed_split(&mut self, split_error: SplitSearchError) {
         self.failed_splits.push(split_error)
+    }
+
+    /// Add the lambda dispatch totals to the state.
+    ///
+    /// `num_splits` is the total number of splits offloaded to lambda
+    /// (including failures), and `num_docs` is the sum of `num_docs` across
+    /// those splits. Per-split `lambda_success_*` counters are accumulated
+    /// separately via each lambda response's own `resource_stats`.
+    pub(crate) fn add_lambda_totals(&mut self, num_splits: u64, num_docs: u64) {
+        let acc = self
+            .resource_stats
+            .get_or_insert_with(LeafResourceStats::default);
+        acc.lambda_num_splits += num_splits;
+        acc.lambda_num_docs += num_docs;
     }
 
     /// Get the worst top-hit. Can be used to skip splits if they can't possibly do better.
@@ -1299,8 +1318,8 @@ mod tests {
     use std::cmp::Ordering;
 
     use quickwit_proto::search::{
-        LeafSearchResponse, PartialHit, ResourceStats, SearchRequest, SortByValue, SortField,
-        SortOrder, SortValue, SplitSearchError,
+        LeafResourceStats, LeafSearchResponse, PartialHit, SearchRequest, SortByValue, SortField,
+        SortOrder, SortValue, SplitResourceStats, SplitSearchError,
     };
     use tantivy::TantivyDocument;
     use tantivy::aggregation::agg_req::Aggregations;
@@ -1949,8 +1968,16 @@ mod tests {
                     num_attempted_splits: 3,
                     num_successful_splits: 3,
                     intermediate_aggregation_result: None,
-                    resource_stats: Some(ResourceStats {
-                        cpu_microsecs: 100,
+                    resource_stats: Some(LeafResourceStats {
+                        split_resources_sum: Some(SplitResourceStats {
+                            cpu_search_microsecs: 100,
+                            ..Default::default()
+                        }),
+                        split_resources_worst: Some(SplitResourceStats {
+                            cpu_search_microsecs: 100,
+                            ..Default::default()
+                        }),
+                        localexec_num_splits: 1,
                         ..Default::default()
                     }),
                 },
@@ -1971,8 +1998,16 @@ mod tests {
                     num_attempted_splits: 2,
                     num_successful_splits: 1,
                     intermediate_aggregation_result: None,
-                    resource_stats: Some(ResourceStats {
-                        cpu_microsecs: 50,
+                    resource_stats: Some(LeafResourceStats {
+                        split_resources_sum: Some(SplitResourceStats {
+                            cpu_search_microsecs: 50,
+                            ..Default::default()
+                        }),
+                        split_resources_worst: Some(SplitResourceStats {
+                            cpu_search_microsecs: 50,
+                            ..Default::default()
+                        }),
+                        localexec_num_splits: 1,
                         ..Default::default()
                     }),
                 },
@@ -2007,8 +2042,16 @@ mod tests {
                 num_attempted_splits: 5,
                 num_successful_splits: 4,
                 intermediate_aggregation_result: None,
-                resource_stats: Some(ResourceStats {
-                    cpu_microsecs: 150,
+                resource_stats: Some(LeafResourceStats {
+                    split_resources_sum: Some(SplitResourceStats {
+                        cpu_search_microsecs: 150,
+                        ..Default::default()
+                    }),
+                    split_resources_worst: Some(SplitResourceStats {
+                        cpu_search_microsecs: 100,
+                        ..Default::default()
+                    }),
+                    localexec_num_splits: 2,
                     ..Default::default()
                 }),
             }

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -1973,10 +1973,10 @@ mod tests {
                             cpu_search_microsecs: 100,
                             ..Default::default()
                         }),
-                        split_resources_worsts: vec![SplitResourceStats {
+                        split_resources_worst: Some(SplitResourceStats {
                             cpu_search_microsecs: 100,
                             ..Default::default()
-                        }],
+                        }),
                         localexec_num_splits: 1,
                         ..Default::default()
                     }),
@@ -2003,10 +2003,10 @@ mod tests {
                             cpu_search_microsecs: 50,
                             ..Default::default()
                         }),
-                        split_resources_worsts: vec![SplitResourceStats {
+                        split_resources_worst: Some(SplitResourceStats {
                             cpu_search_microsecs: 50,
                             ..Default::default()
-                        }],
+                        }),
                         localexec_num_splits: 1,
                         ..Default::default()
                     }),
@@ -2047,16 +2047,10 @@ mod tests {
                         cpu_search_microsecs: 150,
                         ..Default::default()
                     }),
-                    split_resources_worsts: vec![
-                        SplitResourceStats {
-                            cpu_search_microsecs: 100,
-                            ..Default::default()
-                        },
-                        SplitResourceStats {
-                            cpu_search_microsecs: 50,
-                            ..Default::default()
-                        },
-                    ],
+                    split_resources_worst: Some(SplitResourceStats {
+                        cpu_search_microsecs: 100,
+                        ..Default::default()
+                    }),
                     localexec_num_splits: 2,
                     ..Default::default()
                 }),

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -1973,10 +1973,10 @@ mod tests {
                             cpu_search_microsecs: 100,
                             ..Default::default()
                         }),
-                        split_resources_worst: Some(SplitResourceStats {
+                        split_resources_worsts: vec![SplitResourceStats {
                             cpu_search_microsecs: 100,
                             ..Default::default()
-                        }),
+                        }],
                         localexec_num_splits: 1,
                         ..Default::default()
                     }),
@@ -2003,10 +2003,10 @@ mod tests {
                             cpu_search_microsecs: 50,
                             ..Default::default()
                         }),
-                        split_resources_worst: Some(SplitResourceStats {
+                        split_resources_worsts: vec![SplitResourceStats {
                             cpu_search_microsecs: 50,
                             ..Default::default()
-                        }),
+                        }],
                         localexec_num_splits: 1,
                         ..Default::default()
                     }),
@@ -2047,10 +2047,16 @@ mod tests {
                         cpu_search_microsecs: 150,
                         ..Default::default()
                     }),
-                    split_resources_worst: Some(SplitResourceStats {
-                        cpu_search_microsecs: 100,
-                        ..Default::default()
-                    }),
+                    split_resources_worsts: vec![
+                        SplitResourceStats {
+                            cpu_search_microsecs: 100,
+                            ..Default::default()
+                        },
+                        SplitResourceStats {
+                            cpu_search_microsecs: 50,
+                            ..Default::default()
+                        },
+                    ],
                     localexec_num_splits: 2,
                     ..Default::default()
                 }),

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -649,33 +649,33 @@ async fn leaf_search_single_split(
                     wait_for_cpu_pool_microsecs: cpu_thread_pool_wait_microsecs.as_micros() as u64,
                     cpu_search_microsecs: cpu_start.elapsed().as_micros() as u64,
                 };
-                leaf_search_response.resource_stats =
-                    Some(if quickwit_common::is_running_in_lambda() {
-                        // Running inside an AWS Lambda runtime: this split was
-                        // dispatched here via lambda offload. Per the proto
-                        // contract, lambda-executed splits do not contribute
-                        // to `split_resources_worst` / `split_resources_sum` — those
-                        // aggregates are reserved for locally-executed splits.
-                        //
-                        // Only the success counters are set here. The
-                        // `lambda_num_*` totals (success + failure) are
-                        // injected once by the caller in
-                        // `run_offloaded_search_tasks` so they reflect every
-                        // dispatched split, not just the ones that came back.
-                        LeafResourceStats {
-                            lambda_success_num_splits: 1,
-                            lambda_success_num_docs: split_num_docs,
-                            ..Default::default()
-                        }
-                    } else {
-                        LeafResourceStats {
-                            localexec_num_splits: 1,
-                            localexec_num_docs: split_num_docs,
-                            split_resources_sum: Some(split_stats),
-                            split_resources_worst: Some(split_stats),
-                            ..Default::default()
-                        }
-                    });
+                let resource_stats = if quickwit_common::is_running_in_lambda() {
+                    // Running inside an AWS Lambda runtime: this split was
+                    // dispatched here via lambda offload. Per the proto
+                    // contract, lambda-executed splits do not contribute
+                    // to `split_resources_worst` / `split_resources_sum` — those
+                    // aggregates are reserved for locally-executed splits.
+                    //
+                    // Only the success counters are set here. The
+                    // `lambda_num_*` totals (success + failure) are
+                    // injected once by the caller in
+                    // `run_offloaded_search_tasks` so they reflect every
+                    // dispatched split, not just the ones that came back.
+                    LeafResourceStats {
+                        lambda_success_num_splits: 1,
+                        lambda_success_num_docs: split_num_docs,
+                        ..Default::default()
+                    }
+                } else {
+                    LeafResourceStats {
+                        localexec_num_splits: 1,
+                        localexec_num_docs: split_num_docs,
+                        split_resources_sum: Some(split_stats),
+                        split_resources_worst: Some(split_stats),
+                        ..Default::default()
+                    }
+                };
+                leaf_search_response.resource_stats = Some(resource_stats);
                 leaf_search_state_guard.set_state(SplitSearchState::Success);
                 Result::<_, TantivyError>::Ok(Some((
                     simplified_search_request,
@@ -1742,16 +1742,14 @@ pub async fn single_doc_mapping_leaf_search(
     // local → false). The load after `tokio::join!` therefore observes the
     // value written by whichever future finished last: lambda was the
     // bottleneck iff the offloaded path is the last one to write.
-    let offloaded_is_bottleneck = Arc::new(AtomicBool::new(false));
-    let flag_local_writer = offloaded_is_bottleneck.clone();
-    let flag_offloaded_writer = offloaded_is_bottleneck.clone();
-    let timed_local_fut = async move {
+    let offloaded_is_bottleneck = AtomicBool::new(false);
+    let timed_local_fut = async {
         run_local_search_tasks_fut.await;
-        flag_local_writer.store(false, Ordering::Relaxed);
+        offloaded_is_bottleneck.store(false, Ordering::Relaxed);
     };
-    let timed_offloaded_fut = async move {
+    let timed_offloaded_fut = async {
         let result = run_offloaded_search_tasks_fut.await;
-        flag_offloaded_writer.store(true, Ordering::Relaxed);
+        offloaded_is_bottleneck.store(true, Ordering::Relaxed);
         result
     };
     let (offloaded_res, ()) = tokio::join!(timed_offloaded_fut, timed_local_fut);

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -653,7 +653,7 @@ async fn leaf_search_single_split(
                     // Running inside an AWS Lambda runtime: this split was
                     // dispatched here via lambda offload. Per the proto
                     // contract, lambda-executed splits do not contribute
-                    // to `split_resources_worsts` / `split_resources_sum` — those
+                    // to `split_resources_worst` / `split_resources_sum` — those
                     // aggregates are reserved for locally-executed splits.
                     //
                     // Only the success counters are set here. The
@@ -671,7 +671,7 @@ async fn leaf_search_single_split(
                         localexec_num_splits: 1,
                         localexec_num_docs: split_num_docs,
                         split_resources_sum: Some(split_stats),
-                        split_resources_worsts: vec![split_stats],
+                        split_resources_worst: Some(split_stats),
                         min_wait_for_search_permit_microsecs: Some(
                             split_stats.wait_for_search_permit_microsecs,
                         ),

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -653,7 +653,7 @@ async fn leaf_search_single_split(
                     // Running inside an AWS Lambda runtime: this split was
                     // dispatched here via lambda offload. Per the proto
                     // contract, lambda-executed splits do not contribute
-                    // to `split_resources_worst` / `split_resources_sum` — those
+                    // to `split_resources_worsts` / `split_resources_sum` — those
                     // aggregates are reserved for locally-executed splits.
                     //
                     // Only the success counters are set here. The
@@ -671,7 +671,13 @@ async fn leaf_search_single_split(
                         localexec_num_splits: 1,
                         localexec_num_docs: split_num_docs,
                         split_resources_sum: Some(split_stats),
-                        split_resources_worst: Some(split_stats),
+                        split_resources_worsts: vec![split_stats],
+                        min_wait_for_search_permit_microsecs: Some(
+                            split_stats.wait_for_search_permit_microsecs,
+                        ),
+                        min_wait_for_cpu_pool_microsecs: Some(
+                            split_stats.wait_for_cpu_pool_microsecs,
+                        ),
                         ..Default::default()
                     }
                 };

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -19,6 +19,7 @@ use std::num::NonZeroUsize;
 use std::ops::Bound;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
@@ -31,16 +32,16 @@ use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_doc_mapper::{Automaton, DocMapper, FastFieldWarmupInfo, TermRange, WarmupInfo};
 use quickwit_proto::search::lambda_single_split_result::Outcome;
 use quickwit_proto::search::{
-    CountHits, LeafSearchRequest, LeafSearchResponse, PartialHit, ResourceStats, SearchRequest,
-    SortOrder, SortValue, SplitIdAndFooterOffsets, SplitSearchError,
+    CountHits, LeafResourceStats, LeafSearchRequest, LeafSearchResponse, PartialHit, SearchRequest,
+    SortOrder, SortValue, SplitIdAndFooterOffsets, SplitResourceStats, SplitSearchError,
 };
 use quickwit_query::query_ast::{
     BoolQuery, CacheNode, QueryAst, QueryAstTransformer, RangeQuery, TermQuery,
 };
 use quickwit_query::tokenizers::TokenizerManager;
 use quickwit_storage::{
-    BundleStorage, ByteRangeCache, MemorySizedCache, OwnedBytes, SplitCache, Storage,
-    StorageResolver, TimeoutAndRetryStorage, wrap_storage_with_cache,
+    BundleStorage, ByteRangeCache, CountingStorage, MemorySizedCache, OwnedBytes, SplitCache,
+    Storage, StorageResolver, TimeoutAndRetryStorage, wrap_storage_with_cache,
 };
 use tantivy::aggregation::AggContextParams;
 use tantivy::aggregation::agg_req::{AggregationVariants, Aggregations};
@@ -494,7 +495,6 @@ fn compute_index_size(hot_directory: &HotDirectory) -> ByteSize {
 }
 
 /// Apply a leaf search on a single split.
-#[allow(clippy::too_many_arguments)]
 async fn leaf_search_single_split(
     search_request: SearchRequest,
     ctx: Arc<LeafSearchContext>,
@@ -530,6 +530,11 @@ async fn leaf_search_single_split(
     let split_id = split.split_id.to_string();
     let byte_range_cache =
         ByteRangeCache::with_infinite_capacity(&quickwit_storage::STORAGE_METRICS.shortlived_cache);
+    // Wrap storage at request scope so we observe per-split download volume.
+    // Cache layers (split cache, footer cache, hotcache, byte-range cache) live
+    // ABOVE this wrapper, so reads served from cache do not contribute to the
+    // counters — that is the desired "downloaded from object storage" semantics.
+    let (storage, download_counters) = CountingStorage::instrument_storage(storage);
     let (index, hot_directory) = open_index_with_caches(
         &ctx.searcher_context,
         storage,
@@ -598,13 +603,14 @@ async fn leaf_search_single_split(
     search_permit.free_warmup_slot();
 
     let split_num_docs = split.num_docs;
-
     let span = info_span!("tantivy_search");
 
     let split_clone = split.clone();
 
     let ctx_clone = ctx.clone();
+    let download_counters_clone = download_counters.clone();
     leaf_search_state_guard.set_state(SplitSearchState::CpuQueue);
+    let wait_for_search_permit: Duration = search_permit.wait_for_acquisition();
     let search_request_and_result: Option<(SearchRequest, LeafSearchResponse)> =
         crate::search_thread_pool()
             .run_cpu_intensive(move || {
@@ -630,14 +636,46 @@ async fn leaf_search_single_split(
                     } else {
                         searcher.search(&query, &collector)?
                     };
-                leaf_search_response.resource_stats = Some(ResourceStats {
-                    cpu_microsecs: cpu_start.elapsed().as_micros() as u64,
-                    short_lived_cache_num_bytes: warmup_size.as_u64(),
+                let (download_num_bytes, download_num_requests) =
+                    download_counters_clone.snapshot();
+                let split_stats = SplitResourceStats {
                     split_num_docs,
+                    matched_num_docs: leaf_search_response.num_hits,
+                    input_memory_bytes: warmup_size.as_u64(),
+                    download_num_bytes,
+                    download_num_requests,
+                    wait_for_search_permit_microsecs: wait_for_search_permit.as_micros() as u64,
                     warmup_microsecs: warmup_duration.as_micros() as u64,
-                    cpu_thread_pool_wait_microsecs: cpu_thread_pool_wait_microsecs.as_micros()
-                        as u64,
-                });
+                    wait_for_cpu_pool_microsecs: cpu_thread_pool_wait_microsecs.as_micros() as u64,
+                    cpu_search_microsecs: cpu_start.elapsed().as_micros() as u64,
+                };
+                leaf_search_response.resource_stats =
+                    Some(if quickwit_common::is_running_in_lambda() {
+                        // Running inside an AWS Lambda runtime: this split was
+                        // dispatched here via lambda offload. Per the proto
+                        // contract, lambda-executed splits do not contribute
+                        // to `split_resources_worst` / `split_resources_sum` — those
+                        // aggregates are reserved for locally-executed splits.
+                        //
+                        // Only the success counters are set here. The
+                        // `lambda_num_*` totals (success + failure) are
+                        // injected once by the caller in
+                        // `run_offloaded_search_tasks` so they reflect every
+                        // dispatched split, not just the ones that came back.
+                        LeafResourceStats {
+                            lambda_success_num_splits: 1,
+                            lambda_success_num_docs: split_num_docs,
+                            ..Default::default()
+                        }
+                    } else {
+                        LeafResourceStats {
+                            localexec_num_splits: 1,
+                            localexec_num_docs: split_num_docs,
+                            split_resources_sum: Some(split_stats),
+                            split_resources_worst: Some(split_stats),
+                            ..Default::default()
+                        }
+                    });
                 leaf_search_state_guard.set_state(SplitSearchState::Success);
                 Result::<_, TantivyError>::Ok(Some((
                     simplified_search_request,
@@ -1248,6 +1286,7 @@ pub async fn multi_index_leaf_search(
     leaf_search_request: LeafSearchRequest,
     storage_resolver: StorageResolver,
 ) -> Result<LeafSearchResponse, SearchError> {
+    let leaf_start = Instant::now();
     let search_request: Arc<SearchRequest> = leaf_search_request
         .search_request
         .ok_or_else(|| SearchError::Internal("no search request".to_string()))?
@@ -1331,11 +1370,21 @@ pub async fn multi_index_leaf_search(
         }
     }
 
-    crate::search_thread_pool()
-        .run_cpu_intensive(|| incremental_merge_collector.finalize().map_err(Into::into))
+    let mut leaf_search_response: LeafSearchResponse = crate::search_thread_pool()
+        .run_cpu_intensive(|| {
+            incremental_merge_collector
+                .finalize()
+                .map_err(SearchError::from)
+        })
         .instrument(info_span!("incremental_merge_finalize"))
         .await
-        .context("failed to merge split search responses")?
+        .context("failed to merge split search responses")??;
+    let wall_time_microsecs = leaf_start.elapsed().as_micros() as u64;
+    leaf_search_response
+        .resource_stats
+        .get_or_insert_with(LeafResourceStats::default)
+        .wall_time_microsecs = wall_time_microsecs;
+    Ok(leaf_search_response)
 }
 
 /// Optimizes the search_request based on CanSplitDoBetter
@@ -1427,6 +1476,14 @@ async fn run_offloaded_search_tasks(
             split
         })
         .collect();
+
+    // Totals across every split dispatched to lambda (success + failure).
+    // These land authoritatively in the merged `LeafResourceStats` via a
+    // single synthetic injection at the end of this function. Per-split
+    // success contributions are added inline through each lambda response's
+    // own `resource_stats`.
+    let lambda_num_splits: u64 = splits.len() as u64;
+    let lambda_num_docs: u64 = splits.iter().map(|split| split.num_docs).sum();
 
     let batches: Vec<Vec<SplitIdAndFooterOffsets>> = greedy_batch_split(
         splits,
@@ -1520,6 +1577,15 @@ async fn run_offloaded_search_tasks(
             }
         }
     }
+
+    // Record the dispatch totals (every split offloaded, regardless of
+    // outcome). The per-split lambda responses only contribute to
+    // `lambda_success_*`; this call is the authoritative source for
+    // `lambda_num_*`.
+    incremental_merge_collector
+        .lock()
+        .unwrap()
+        .add_lambda_totals(lambda_num_splits, lambda_num_docs);
 
     Ok(())
 }
@@ -1645,6 +1711,8 @@ pub async fn single_doc_mapping_leaf_search(
         offloaded_search_tasks,
     } = schedule_search_tasks(uncached_splits, &searcher_context).await;
 
+    let has_offloaded_tasks = !offloaded_search_tasks.is_empty();
+
     // Offload splits to Lambda.
     let run_offloaded_search_tasks_fut = run_offloaded_search_tasks(
         &searcher_context,
@@ -1670,9 +1738,31 @@ pub async fn single_doc_mapping_leaf_search(
         leaf_search_context,
     );
 
-    let (offloaded_res, _) =
-        tokio::join!(run_offloaded_search_tasks_fut, run_local_search_tasks_fut);
+    // Each path stores its own outcome on completion (offloaded → true,
+    // local → false). The load after `tokio::join!` therefore observes the
+    // value written by whichever future finished last: lambda was the
+    // bottleneck iff the offloaded path is the last one to write.
+    let offloaded_is_bottleneck = Arc::new(AtomicBool::new(false));
+    let flag_local_writer = offloaded_is_bottleneck.clone();
+    let flag_offloaded_writer = offloaded_is_bottleneck.clone();
+    let timed_local_fut = async move {
+        run_local_search_tasks_fut.await;
+        flag_local_writer.store(false, Ordering::Relaxed);
+    };
+    let timed_offloaded_fut = async move {
+        let result = run_offloaded_search_tasks_fut.await;
+        flag_offloaded_writer.store(true, Ordering::Relaxed);
+        result
+    };
+    let (offloaded_res, ()) = tokio::join!(timed_offloaded_fut, timed_local_fut);
     offloaded_res?;
+
+    // We defensively ensure that lambda bottleneck is set to 0 if there were no lambdas.
+    let lambda_bottleneck: u64 = if has_offloaded_tasks {
+        u64::from(offloaded_is_bottleneck.load(Ordering::Relaxed))
+    } else {
+        0u64
+    };
 
     // we can't use unwrap_or_clone because mutexes aren't Clone
     let incremental_merge_collector = match Arc::try_unwrap(incremental_merge_collector_arc) {
@@ -1687,7 +1777,12 @@ pub async fn single_doc_mapping_leaf_search(
             .await
             .context("failed to merge split search responses: thread panicked")?;
 
-    Ok(leaf_search_response_result?)
+    let mut leaf_search_response = leaf_search_response_result?;
+    leaf_search_response
+        .resource_stats
+        .get_or_insert_default()
+        .lambda_bottleneck = lambda_bottleneck;
+    Ok(leaf_search_response)
 }
 
 async fn run_local_search_tasks(
@@ -1782,6 +1877,9 @@ fn process_partial_result_cache(
             // TODO remove the clone here.
             .get(split.clone(), search_request.clone())
         {
+            // The cached response already carries cache-hit `resource_stats`
+            // (set at write time by `LeafSearchCache::put`), so no per-read
+            // rewrite is needed here.
             let mut split_search_guard = SplitSearchStateGuard::new(split_outcome_counters.clone());
             split_search_guard.set_state(SplitSearchState::CacheHit);
             incremental_merge_collector.add_result(cached_response)?;
@@ -1853,7 +1951,6 @@ struct LeafSearchContext {
     split_filter: Arc<RwLock<CanSplitDoBetter>>,
 }
 
-#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, fields(split_id = split.split_id, num_docs = split.num_docs))]
 async fn leaf_search_single_split_wrapper(
     request: SearchRequest,

--- a/quickwit/quickwit-search/src/leaf_cache.rs
+++ b/quickwit/quickwit-search/src/leaf_cache.rs
@@ -17,7 +17,7 @@ use std::ops::{Bound, RangeBounds};
 use prost::Message;
 use quickwit_config::CacheConfig;
 use quickwit_proto::search::{
-    CountHits, LeafSearchResponse, SearchRequest, SplitIdAndFooterOffsets,
+    CountHits, LeafResourceStats, LeafSearchResponse, SearchRequest, SplitIdAndFooterOffsets,
 };
 use quickwit_proto::types::SplitId;
 use quickwit_storage::{MemorySizedCache, OwnedBytes};
@@ -67,8 +67,15 @@ impl LeafSearchCache {
         &self,
         split_info: SplitIdAndFooterOffsets,
         search_request: SearchRequest,
-        result: LeafSearchResponse,
+        mut result: LeafSearchResponse,
     ) {
+        // We overwrite the original stats so that
+        // we get the right counter on cache hits.
+        result.resource_stats = Some(LeafResourceStats {
+            partial_result_cache_num_splits: 1,
+            partial_result_cache_num_docs: split_info.num_docs,
+            ..Default::default()
+        });
         let key = CacheKey::from_split_meta_and_request(split_info, search_request);
         let encoded_result = result.encode_to_vec();
         self.content.put(key, OwnedBytes::new(encoded_result));
@@ -237,7 +244,7 @@ impl quickwit_query::query_ast::PredicateCache for PredicateCacheImpl {
 mod tests {
     use bytesize::ByteSize;
     use quickwit_proto::search::{
-        LeafSearchResponse, PartialHit, ResourceStats, SearchRequest, SortValue,
+        LeafResourceStats, LeafSearchResponse, PartialHit, SearchRequest, SortValue,
         SplitIdAndFooterOffsets,
     };
 
@@ -303,8 +310,21 @@ mod tests {
 
         assert!(cache.get(split_1.clone(), query_1.clone()).is_none());
 
-        cache.put(split_1.clone(), query_1.clone(), result.clone());
-        assert_eq!(cache.get(split_1.clone(), query_1.clone()).unwrap(), result);
+        // `LeafSearchCache::put` overwrites `resource_stats` with the
+        // cache-hit counters; reads always see those, not the original stats.
+        let expected = LeafSearchResponse {
+            resource_stats: Some(LeafResourceStats {
+                partial_result_cache_num_splits: 1,
+                partial_result_cache_num_docs: split_1.num_docs,
+                ..Default::default()
+            }),
+            ..result.clone()
+        };
+        cache.put(split_1.clone(), query_1.clone(), result);
+        assert_eq!(
+            cache.get(split_1.clone(), query_1.clone()).unwrap(),
+            expected
+        );
         assert!(cache.get(split_2, query_1).is_none());
         assert!(cache.get(split_1, query_2).is_none());
     }
@@ -389,7 +409,7 @@ mod tests {
                 sort_value2: None,
                 split_id: "split_1".to_string(),
             }],
-            resource_stats: Some(ResourceStats::default()),
+            resource_stats: Some(LeafResourceStats::default()),
         };
 
         // for split_1, 1 and 1bis cover different timestamp ranges

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -552,23 +552,6 @@ mod stats_merge_tests {
             wall_time_microsecs: 200_000_000,
         };
 
-        // Destructure on the proto type so a new field forces a compile
-        // error pointing at this test.
-        let LeafResourceStats {
-            partial_result_cache_num_splits: _,
-            partial_result_cache_num_docs: _,
-            lambda_num_splits: _,
-            lambda_num_docs: _,
-            lambda_success_num_splits: _,
-            lambda_success_num_docs: _,
-            lambda_bottleneck: _,
-            localexec_num_splits: _,
-            localexec_num_docs: _,
-            split_resources_worst: _,
-            split_resources_sum: _,
-            wall_time_microsecs: _,
-        } = other;
-
         add_leaf_stats(&mut acc, &other);
 
         assert_eq!(acc.partial_result_cache_num_splits, 3);
@@ -645,7 +628,7 @@ mod stats_merge_tests {
             wall_time_microsecs: 42,
             ..Default::default()
         };
-        let snapshot = acc.clone();
+        let snapshot = acc;
         add_leaf_stats(&mut acc, &LeafResourceStats::default());
         assert_eq!(acc, snapshot);
     }

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -347,7 +347,7 @@ pub fn searcher_pool_for_test(
     )
 }
 
-/// Sum of the per-phase microsecond fields used to rank `split_resources_worst`.
+/// Sum of the per-phase microsecond fields used to rank `split_resources_worsts`.
 /// Intentionally excludes `wait_for_search_permit_microsecs`.
 pub(crate) fn split_phase_sum_microsecs(stats: &SplitResourceStats) -> u64 {
     stats.warmup_microsecs + stats.wait_for_cpu_pool_microsecs + stats.cpu_search_microsecs
@@ -366,12 +366,49 @@ pub(crate) fn add_split_stats(acc: &mut SplitResourceStats, other: &SplitResourc
     acc.cpu_search_microsecs += other.cpu_search_microsecs;
 }
 
+/// Min of two `Option<u64>`, treating `None` as "no contribution":
+/// `min(None, x) = x`, `min(None, None) = None`.
+#[inline]
+pub(crate) fn min_opt(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+    match (left, right) {
+        (None, value) | (value, None) => value,
+        (Some(left), Some(right)) => Some(left.min(right)),
+    }
+}
+
+/// How many entries we keep in the `*_worsts` ranked lists (`split_resources_worsts`,
+/// `leaf_resources_worsts`): the worst and the second worst.
+pub(crate) const NUM_WORST_KEPT: usize = 2;
+
+/// Merge two ranked top-N lists (each already ordered largest-first by `key_fn`)
+/// into a single ranked top-N list, keeping at most `NUM_WORST_KEPT` entries.
+/// Ties are broken by the order in which entries were seen (`acc` first, then `other`).
+pub(crate) fn merge_top_n_by_key<T, K>(acc: &[T], other: &[T], key_fn: impl Fn(&T) -> K) -> Vec<T>
+where
+    T: Clone,
+    K: Ord,
+{
+    let mut merged: Vec<T> = Vec::with_capacity(acc.len() + other.len());
+    merged.extend(acc.iter().cloned());
+    merged.extend(other.iter().cloned());
+    // `sort_by_key` is stable, so equal keys retain `acc`-before-`other` order;
+    // `Reverse` flips ascending into descending so the largest ends up first.
+    merged.sort_by_key(|entry| std::cmp::Reverse(key_fn(entry)));
+    merged.truncate(NUM_WORST_KEPT);
+    merged
+}
+
 /// Merge another `LeafResourceStats` into `acc`.
 ///
-/// Every numeric field is summed. `lambda_bottleneck` is 0 or 1 at the source
-/// (a single leaf call) and becomes a count of leaves where lambda was the
-/// bottleneck once aggregated. `split_resources_worst` is selected by
-/// `split_phase_sum_microsecs`; `split_resources_sum` is field-wise summed.
+/// Every numeric field is summed, with two exceptions:
+/// - `split_resources_worsts` keeps the top-2 worst splits across the inputs, ranked by
+///   `split_phase_sum_microsecs` (largest first). `split_resources_sum` is field-wise summed.
+/// - `min_wait_for_search_permit_microsecs` and `min_wait_for_cpu_pool_microsecs` are merged with
+///   `min_opt` (treating `None` as "no contribution"), so the merged value is the minimum across
+///   every locally-executed split that contributed.
+///
+/// `lambda_bottleneck` is 0 or 1 at the source (a single leaf call) and becomes
+/// a count of leaves where lambda was the bottleneck once aggregated.
 pub(crate) fn add_leaf_stats(acc: &mut LeafResourceStats, other: &LeafResourceStats) {
     acc.partial_result_cache_num_splits += other.partial_result_cache_num_splits;
     acc.partial_result_cache_num_docs += other.partial_result_cache_num_docs;
@@ -383,16 +420,25 @@ pub(crate) fn add_leaf_stats(acc: &mut LeafResourceStats, other: &LeafResourceSt
     acc.localexec_num_splits += other.localexec_num_splits;
     acc.localexec_num_docs += other.localexec_num_docs;
     acc.wall_time_microsecs += other.wall_time_microsecs;
+    acc.min_wait_for_search_permit_microsecs = min_opt(
+        acc.min_wait_for_search_permit_microsecs,
+        other.min_wait_for_search_permit_microsecs,
+    );
+    acc.min_wait_for_cpu_pool_microsecs = min_opt(
+        acc.min_wait_for_cpu_pool_microsecs,
+        other.min_wait_for_cpu_pool_microsecs,
+    );
     if let Some(other_split) = &other.split_resources_sum {
         let acc_split = acc
             .split_resources_sum
             .get_or_insert_with(SplitResourceStats::default);
         add_split_stats(acc_split, other_split);
     }
-    acc.split_resources_worst = [acc.split_resources_worst, other.split_resources_worst]
-        .into_iter()
-        .flatten()
-        .max_by_key(split_phase_sum_microsecs);
+    acc.split_resources_worsts = merge_top_n_by_key(
+        &acc.split_resources_worsts,
+        &other.split_resources_worsts,
+        split_phase_sum_microsecs,
+    );
 }
 
 /// Merge an iterator of `Option<LeafResourceStats>` into a single `Option<LeafResourceStats>`.
@@ -431,7 +477,7 @@ mod stats_merge_tests {
             localexec_num_splits: 1,
             localexec_num_docs: split.split_num_docs,
             split_resources_sum: Some(split),
-            split_resources_worst: Some(split),
+            split_resources_worsts: vec![split],
             ..Default::default()
         }
     }
@@ -505,11 +551,12 @@ mod stats_merge_tests {
         assert_eq!(acc, snapshot);
     }
 
-    /// `add_leaf_stats` is "every numeric field is extensive" post-refactor.
-    /// Adding a new field to the proto without summing it in
-    /// `add_leaf_stats` should fail this test: the
-    /// `let LeafResourceStats { ... } = other;` destructure forces the test
-    /// to be updated whenever a field is added.
+    /// `add_leaf_stats` is "every numeric field is extensive" with the
+    /// exception of `min_wait_for_*_microsecs` (merged with `min_opt`).
+    /// The fully-enumerated `LeafResourceStats { ... }` literal (no
+    /// `..Default::default()`) forces this test to be updated whenever a
+    /// field is added — and the per-field assertions below document each
+    /// field's aggregation behavior.
     #[test]
     fn test_add_leaf_stats_sums_every_field() {
         let split_a = SplitResourceStats {
@@ -533,8 +580,10 @@ mod stats_merge_tests {
             lambda_bottleneck: 0,
             localexec_num_splits: 1_000_000,
             localexec_num_docs: 10_000_000,
-            split_resources_worst: Some(split_a),
+            split_resources_worsts: vec![split_a],
             split_resources_sum: Some(split_a),
+            min_wait_for_search_permit_microsecs: Some(100),
+            min_wait_for_cpu_pool_microsecs: Some(2_000),
             wall_time_microsecs: 100_000_000,
         };
         let other = LeafResourceStats {
@@ -547,8 +596,10 @@ mod stats_merge_tests {
             lambda_bottleneck: 1,
             localexec_num_splits: 2_000_000,
             localexec_num_docs: 20_000_000,
-            split_resources_worst: Some(split_b),
+            split_resources_worsts: vec![split_b],
             split_resources_sum: Some(split_b),
+            min_wait_for_search_permit_microsecs: Some(50),
+            min_wait_for_cpu_pool_microsecs: Some(1_000),
             wall_time_microsecs: 200_000_000,
         };
 
@@ -568,15 +619,46 @@ mod stats_merge_tests {
         // `wall_time_microsecs` is summed post-refactor, not maxed.
         assert_eq!(acc.wall_time_microsecs, 300_000_000);
 
+        // `min_wait_for_*_microsecs` is MIN, not sum — the exception to the
+        // extensive-sum rule.
+        assert_eq!(acc.min_wait_for_search_permit_microsecs, Some(50));
+        assert_eq!(acc.min_wait_for_cpu_pool_microsecs, Some(1_000));
+
         // `split_resources_sum` field-wise sums every contributing split.
         let summed = acc.split_resources_sum.unwrap();
         assert_eq!(summed.split_num_docs, 3);
         assert_eq!(summed.cpu_search_microsecs, 300);
 
-        // `split_resources_worst` is the split with the larger phase-sum:
-        // split_b (cpu_search 200) beats split_a (cpu_search 100).
-        let worst = acc.split_resources_worst.unwrap();
-        assert_eq!(worst.split_num_docs, 2);
+        // `split_resources_worsts` keeps the top-2 worst splits, largest first.
+        // split_b (cpu_search 200) > split_a (cpu_search 100).
+        assert_eq!(acc.split_resources_worsts.len(), 2);
+        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 2);
+        assert_eq!(acc.split_resources_worsts[1].split_num_docs, 1);
+    }
+
+    /// `split_resources_worsts` keeps the top-2 splits across an arbitrary
+    /// number of contributors, ranked by `split_phase_sum_microsecs`.
+    #[test]
+    fn test_add_leaf_stats_split_resources_worsts_keeps_top_2() {
+        // cpu_search values pick the phase-sum ordering: 200 > 100 > 50 > 25.
+        let split_top = split_stats(1, 0, 200);
+        let split_2nd = split_stats(2, 0, 100);
+        let split_3rd = split_stats(3, 0, 50);
+        let split_4th = split_stats(4, 0, 25);
+
+        let mut acc = LeafResourceStats {
+            split_resources_worsts: vec![split_2nd, split_4th],
+            ..Default::default()
+        };
+        let other = LeafResourceStats {
+            split_resources_worsts: vec![split_top, split_3rd],
+            ..Default::default()
+        };
+        add_leaf_stats(&mut acc, &other);
+        assert_eq!(acc.split_resources_worsts.len(), 2);
+        // Largest first, second-largest next.
+        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 1);
+        assert_eq!(acc.split_resources_worsts[1].split_num_docs, 2);
     }
 
     /// When the accumulator already has `split_resources_*` and the other
@@ -588,7 +670,7 @@ mod stats_merge_tests {
         let other = LeafResourceStats {
             localexec_num_splits: 1,
             localexec_num_docs: 7,
-            // No split_resources_sum / split_resources_worst.
+            // No split_resources_sum / split_resources_worsts.
             ..Default::default()
         };
         add_leaf_stats(&mut acc, &other);
@@ -596,7 +678,8 @@ mod stats_merge_tests {
         assert_eq!(acc.localexec_num_docs, 12);
         // Both fields must still point at split_a.
         assert_eq!(acc.split_resources_sum.unwrap().split_num_docs, 5);
-        assert_eq!(acc.split_resources_worst.unwrap().split_num_docs, 5);
+        assert_eq!(acc.split_resources_worsts.len(), 1);
+        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 5);
     }
 
     /// When the accumulator has no `split_resources_*` and the other side
@@ -609,7 +692,8 @@ mod stats_merge_tests {
         add_leaf_stats(&mut acc, &other);
         assert_eq!(acc.localexec_num_splits, 1);
         assert_eq!(acc.split_resources_sum.unwrap().split_num_docs, 9);
-        assert_eq!(acc.split_resources_worst.unwrap().split_num_docs, 9);
+        assert_eq!(acc.split_resources_worsts.len(), 1);
+        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 9);
     }
 
     /// Adding a default `LeafResourceStats` should be an identity operation
@@ -624,13 +708,29 @@ mod stats_merge_tests {
             localexec_num_splits: 1,
             localexec_num_docs: 3,
             split_resources_sum: Some(split),
-            split_resources_worst: Some(split),
+            split_resources_worsts: vec![split],
+            // Set the min fields explicitly so this test verifies that
+            // `min_opt(Some(x), None) = Some(x)` keeps them unchanged.
+            min_wait_for_search_permit_microsecs: Some(7),
+            min_wait_for_cpu_pool_microsecs: Some(11),
             wall_time_microsecs: 42,
             ..Default::default()
         };
-        let snapshot = acc;
+        let snapshot = acc.clone();
         add_leaf_stats(&mut acc, &LeafResourceStats::default());
         assert_eq!(acc, snapshot);
+    }
+
+    #[test]
+    fn test_min_opt() {
+        assert_eq!(min_opt(None, None), None);
+        assert_eq!(min_opt(Some(5), None), Some(5));
+        assert_eq!(min_opt(None, Some(7)), Some(7));
+        assert_eq!(min_opt(Some(5), Some(7)), Some(5));
+        assert_eq!(min_opt(Some(7), Some(5)), Some(5));
+        // 0 is a real value, not a sentinel.
+        assert_eq!(min_opt(Some(0), Some(5)), Some(0));
+        assert_eq!(min_opt(Some(0), None), Some(0));
     }
 
     #[test]

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -70,7 +70,8 @@ use quickwit_metastore::{
     MetastoreServiceStreamSplitsExt, SplitMetadata, SplitState,
 };
 use quickwit_proto::search::{
-    PartialHit, ResourceStats, SearchRequest, SearchResponse, SplitIdAndFooterOffsets,
+    LeafResourceStats, PartialHit, SearchRequest, SearchResponse, SplitIdAndFooterOffsets,
+    SplitResourceStats,
 };
 use quickwit_proto::types::IndexUid;
 use quickwit_storage::StorageResolver;
@@ -346,125 +347,320 @@ pub fn searcher_pool_for_test(
     )
 }
 
-pub(crate) fn merge_resource_stats_it<'a>(
-    stats_it: impl IntoIterator<Item = &'a Option<ResourceStats>>,
-) -> Option<ResourceStats> {
-    let mut acc_stats: Option<ResourceStats> = None;
-    for new_stats in stats_it {
-        merge_resource_stats(new_stats, &mut acc_stats);
-    }
-    acc_stats
+/// Sum of the per-phase microsecond fields used to rank `split_resources_worst`.
+/// Intentionally excludes `wait_for_search_permit_microsecs`.
+pub(crate) fn split_phase_sum_microsecs(stats: &SplitResourceStats) -> u64 {
+    stats.warmup_microsecs + stats.wait_for_cpu_pool_microsecs + stats.cpu_search_microsecs
 }
 
-fn merge_resource_stats(
-    new_stats_opt: &Option<ResourceStats>,
-    stat_accs_opt: &mut Option<ResourceStats>,
-) {
-    if let Some(new_stats) = new_stats_opt {
-        if let Some(stat_accs) = stat_accs_opt {
-            stat_accs.short_lived_cache_num_bytes += new_stats.short_lived_cache_num_bytes;
-            stat_accs.split_num_docs += new_stats.split_num_docs;
-            stat_accs.warmup_microsecs += new_stats.warmup_microsecs;
-            stat_accs.cpu_thread_pool_wait_microsecs += new_stats.cpu_thread_pool_wait_microsecs;
-            stat_accs.cpu_microsecs += new_stats.cpu_microsecs;
-        } else {
-            *stat_accs_opt = Some(*new_stats);
-        }
-    }
+/// Field-wise sum of two `SplitResourceStats` (every field is extensive).
+pub(crate) fn add_split_stats(acc: &mut SplitResourceStats, other: &SplitResourceStats) {
+    acc.split_num_docs += other.split_num_docs;
+    acc.input_memory_bytes += other.input_memory_bytes;
+    acc.download_num_bytes += other.download_num_bytes;
+    acc.download_num_requests += other.download_num_requests;
+    acc.matched_num_docs += other.matched_num_docs;
+    acc.wait_for_search_permit_microsecs += other.wait_for_search_permit_microsecs;
+    acc.warmup_microsecs += other.warmup_microsecs;
+    acc.wait_for_cpu_pool_microsecs += other.wait_for_cpu_pool_microsecs;
+    acc.cpu_search_microsecs += other.cpu_search_microsecs;
 }
+
+/// Merge another `LeafResourceStats` into `acc`.
+///
+/// Every numeric field is summed. `lambda_bottleneck` is 0 or 1 at the source
+/// (a single leaf call) and becomes a count of leaves where lambda was the
+/// bottleneck once aggregated. `split_resources_worst` is selected by
+/// `split_phase_sum_microsecs`; `split_resources_sum` is field-wise summed.
+pub(crate) fn add_leaf_stats(acc: &mut LeafResourceStats, other: &LeafResourceStats) {
+    acc.partial_result_cache_num_splits += other.partial_result_cache_num_splits;
+    acc.partial_result_cache_num_docs += other.partial_result_cache_num_docs;
+    acc.lambda_num_splits += other.lambda_num_splits;
+    acc.lambda_num_docs += other.lambda_num_docs;
+    acc.lambda_success_num_splits += other.lambda_success_num_splits;
+    acc.lambda_success_num_docs += other.lambda_success_num_docs;
+    acc.lambda_bottleneck += other.lambda_bottleneck;
+    acc.localexec_num_splits += other.localexec_num_splits;
+    acc.localexec_num_docs += other.localexec_num_docs;
+    acc.wall_time_microsecs += other.wall_time_microsecs;
+    if let Some(other_split) = &other.split_resources_sum {
+        let acc_split = acc
+            .split_resources_sum
+            .get_or_insert_with(SplitResourceStats::default);
+        add_split_stats(acc_split, other_split);
+    }
+    acc.split_resources_worst = [acc.split_resources_worst, other.split_resources_worst]
+        .into_iter()
+        .flatten()
+        .max_by_key(split_phase_sum_microsecs);
+}
+
+/// Merge an iterator of `Option<LeafResourceStats>` into a single `Option<LeafResourceStats>`.
+///
+/// `None` entries are skipped. The accumulator is materialized lazily on the first
+/// non-`None` entry so a fully-empty iterator still returns `None`.
+pub(crate) fn merge_leaf_stats_it<'a>(
+    stats_it: impl IntoIterator<Item = &'a Option<LeafResourceStats>>,
+) -> Option<LeafResourceStats> {
+    let mut acc: Option<LeafResourceStats> = None;
+    for new_stats in stats_it {
+        let Some(new_stats) = new_stats else {
+            continue;
+        };
+        let acc = acc.get_or_insert_with(LeafResourceStats::default);
+        add_leaf_stats(acc, new_stats);
+    }
+    acc
+}
+
 #[cfg(test)]
 mod stats_merge_tests {
     use super::*;
 
+    fn split_stats(num_docs: u64, warmup: u64, search: u64) -> SplitResourceStats {
+        SplitResourceStats {
+            split_num_docs: num_docs,
+            warmup_microsecs: warmup,
+            cpu_search_microsecs: search,
+            ..Default::default()
+        }
+    }
+
+    fn leaf_stats_one_split(split: SplitResourceStats) -> LeafResourceStats {
+        LeafResourceStats {
+            localexec_num_splits: 1,
+            localexec_num_docs: split.split_num_docs,
+            split_resources_sum: Some(split),
+            split_resources_worst: Some(split),
+            ..Default::default()
+        }
+    }
+
+    /// `add_split_stats` is an "every field is extensive" merger. Adding a
+    /// new field to the proto without summing it in `add_split_stats` should
+    /// fail this test: the `let SplitResourceStats { ... } = other;`
+    /// destructure forces the test to be updated whenever a field is added.
     #[test]
-    fn test_merge_resource_stats() {
-        let mut acc_stats = None;
+    fn test_add_split_stats_sums_every_field() {
+        let mut acc = SplitResourceStats {
+            split_num_docs: 1,
+            input_memory_bytes: 10,
+            download_num_bytes: 100,
+            download_num_requests: 1_000,
+            matched_num_docs: 10_000,
+            wait_for_search_permit_microsecs: 100_000,
+            warmup_microsecs: 1_000_000,
+            wait_for_cpu_pool_microsecs: 10_000_000,
+            cpu_search_microsecs: 100_000_000,
+        };
+        let other = SplitResourceStats {
+            split_num_docs: 2,
+            input_memory_bytes: 20,
+            download_num_bytes: 200,
+            download_num_requests: 2_000,
+            matched_num_docs: 20_000,
+            wait_for_search_permit_microsecs: 200_000,
+            warmup_microsecs: 2_000_000,
+            wait_for_cpu_pool_microsecs: 20_000_000,
+            cpu_search_microsecs: 200_000_000,
+        };
+        // Destructure on the proto type itself so a newly-added field forces
+        // an update to this test (otherwise the assertion below would silently
+        // miss it).
+        let SplitResourceStats {
+            split_num_docs: _,
+            input_memory_bytes: _,
+            download_num_bytes: _,
+            download_num_requests: _,
+            matched_num_docs: _,
+            wait_for_search_permit_microsecs: _,
+            warmup_microsecs: _,
+            wait_for_cpu_pool_microsecs: _,
+            cpu_search_microsecs: _,
+        } = other;
 
-        merge_resource_stats(&None, &mut acc_stats);
+        add_split_stats(&mut acc, &other);
 
-        assert_eq!(acc_stats, None);
-
-        let stats = Some(ResourceStats {
-            short_lived_cache_num_bytes: 100,
-            split_num_docs: 200,
-            warmup_microsecs: 300,
-            cpu_thread_pool_wait_microsecs: 400,
-            cpu_microsecs: 500,
-        });
-
-        merge_resource_stats(&stats, &mut acc_stats);
-
-        assert_eq!(acc_stats, stats);
-
-        let new_stats = Some(ResourceStats {
-            short_lived_cache_num_bytes: 50,
-            split_num_docs: 100,
-            warmup_microsecs: 150,
-            cpu_thread_pool_wait_microsecs: 200,
-            cpu_microsecs: 250,
-        });
-
-        merge_resource_stats(&new_stats, &mut acc_stats);
-
-        let stats_plus_new_stats = Some(ResourceStats {
-            short_lived_cache_num_bytes: 150,
-            split_num_docs: 300,
-            warmup_microsecs: 450,
-            cpu_thread_pool_wait_microsecs: 600,
-            cpu_microsecs: 750,
-        });
-
-        assert_eq!(acc_stats, stats_plus_new_stats);
-
-        merge_resource_stats(&None, &mut acc_stats);
-
-        assert_eq!(acc_stats, stats_plus_new_stats);
+        assert_eq!(acc.split_num_docs, 3);
+        assert_eq!(acc.input_memory_bytes, 30);
+        assert_eq!(acc.download_num_bytes, 300);
+        assert_eq!(acc.download_num_requests, 3_000);
+        assert_eq!(acc.matched_num_docs, 30_000);
+        assert_eq!(acc.wait_for_search_permit_microsecs, 300_000);
+        assert_eq!(acc.warmup_microsecs, 3_000_000);
+        assert_eq!(acc.wait_for_cpu_pool_microsecs, 30_000_000);
+        assert_eq!(acc.cpu_search_microsecs, 300_000_000);
     }
 
     #[test]
-    fn test_merge_resource_stats_it() {
-        let merged_stats = merge_resource_stats_it(Vec::<&Option<ResourceStats>>::new());
-        assert_eq!(merged_stats, None);
+    fn test_add_split_stats_with_zero_is_identity() {
+        let mut acc = SplitResourceStats {
+            split_num_docs: 42,
+            download_num_bytes: 1_024,
+            cpu_search_microsecs: 1_000,
+            ..Default::default()
+        };
+        let snapshot = acc;
+        add_split_stats(&mut acc, &SplitResourceStats::default());
+        assert_eq!(acc, snapshot);
+    }
 
-        let stats1 = Some(ResourceStats {
-            short_lived_cache_num_bytes: 100,
-            split_num_docs: 200,
-            warmup_microsecs: 300,
-            cpu_thread_pool_wait_microsecs: 400,
-            cpu_microsecs: 500,
-        });
+    /// `add_leaf_stats` is "every numeric field is extensive" post-refactor.
+    /// Adding a new field to the proto without summing it in
+    /// `add_leaf_stats` should fail this test: the
+    /// `let LeafResourceStats { ... } = other;` destructure forces the test
+    /// to be updated whenever a field is added.
+    #[test]
+    fn test_add_leaf_stats_sums_every_field() {
+        let split_a = SplitResourceStats {
+            split_num_docs: 1,
+            cpu_search_microsecs: 100,
+            ..Default::default()
+        };
+        let split_b = SplitResourceStats {
+            split_num_docs: 2,
+            cpu_search_microsecs: 200,
+            ..Default::default()
+        };
 
-        let merged_stats = merge_resource_stats_it(vec![&None, &stats1, &None]);
+        let mut acc = LeafResourceStats {
+            partial_result_cache_num_splits: 1,
+            partial_result_cache_num_docs: 10,
+            lambda_num_splits: 100,
+            lambda_num_docs: 1_000,
+            lambda_success_num_splits: 10_000,
+            lambda_success_num_docs: 100_000,
+            lambda_bottleneck: 0,
+            localexec_num_splits: 1_000_000,
+            localexec_num_docs: 10_000_000,
+            split_resources_worst: Some(split_a),
+            split_resources_sum: Some(split_a),
+            wall_time_microsecs: 100_000_000,
+        };
+        let other = LeafResourceStats {
+            partial_result_cache_num_splits: 2,
+            partial_result_cache_num_docs: 20,
+            lambda_num_splits: 200,
+            lambda_num_docs: 2_000,
+            lambda_success_num_splits: 20_000,
+            lambda_success_num_docs: 200_000,
+            lambda_bottleneck: 1,
+            localexec_num_splits: 2_000_000,
+            localexec_num_docs: 20_000_000,
+            split_resources_worst: Some(split_b),
+            split_resources_sum: Some(split_b),
+            wall_time_microsecs: 200_000_000,
+        };
 
-        assert_eq!(merged_stats, stats1);
+        // Destructure on the proto type so a new field forces a compile
+        // error pointing at this test.
+        let LeafResourceStats {
+            partial_result_cache_num_splits: _,
+            partial_result_cache_num_docs: _,
+            lambda_num_splits: _,
+            lambda_num_docs: _,
+            lambda_success_num_splits: _,
+            lambda_success_num_docs: _,
+            lambda_bottleneck: _,
+            localexec_num_splits: _,
+            localexec_num_docs: _,
+            split_resources_worst: _,
+            split_resources_sum: _,
+            wall_time_microsecs: _,
+        } = other;
 
-        let stats2 = Some(ResourceStats {
-            short_lived_cache_num_bytes: 50,
-            split_num_docs: 100,
-            warmup_microsecs: 150,
-            cpu_thread_pool_wait_microsecs: 200,
-            cpu_microsecs: 250,
-        });
+        add_leaf_stats(&mut acc, &other);
 
-        let stats3 = Some(ResourceStats {
-            short_lived_cache_num_bytes: 25,
-            split_num_docs: 50,
-            warmup_microsecs: 75,
-            cpu_thread_pool_wait_microsecs: 100,
-            cpu_microsecs: 125,
-        });
+        assert_eq!(acc.partial_result_cache_num_splits, 3);
+        assert_eq!(acc.partial_result_cache_num_docs, 30);
+        assert_eq!(acc.lambda_num_splits, 300);
+        assert_eq!(acc.lambda_num_docs, 3_000);
+        assert_eq!(acc.lambda_success_num_splits, 30_000);
+        assert_eq!(acc.lambda_success_num_docs, 300_000);
+        // `lambda_bottleneck` is summed post-refactor (a count at aggregate
+        // levels), not maxed.
+        assert_eq!(acc.lambda_bottleneck, 1);
+        assert_eq!(acc.localexec_num_splits, 3_000_000);
+        assert_eq!(acc.localexec_num_docs, 30_000_000);
+        // `wall_time_microsecs` is summed post-refactor, not maxed.
+        assert_eq!(acc.wall_time_microsecs, 300_000_000);
 
-        let merged_stats = merge_resource_stats_it(vec![&stats1, &stats2, &stats3]);
+        // `split_resources_sum` field-wise sums every contributing split.
+        let summed = acc.split_resources_sum.unwrap();
+        assert_eq!(summed.split_num_docs, 3);
+        assert_eq!(summed.cpu_search_microsecs, 300);
 
-        assert_eq!(
-            merged_stats,
-            Some(ResourceStats {
-                short_lived_cache_num_bytes: 175,
-                split_num_docs: 350,
-                warmup_microsecs: 525,
-                cpu_thread_pool_wait_microsecs: 700,
-                cpu_microsecs: 875,
-            })
-        );
+        // `split_resources_worst` is the split with the larger phase-sum:
+        // split_b (cpu_search 200) beats split_a (cpu_search 100).
+        let worst = acc.split_resources_worst.unwrap();
+        assert_eq!(worst.split_num_docs, 2);
+    }
+
+    /// When the accumulator already has `split_resources_*` and the other
+    /// side has none, the accumulator's values must be preserved.
+    #[test]
+    fn test_add_leaf_stats_other_with_no_split_resources_keeps_acc() {
+        let split = split_stats(5, 10, 20);
+        let mut acc = leaf_stats_one_split(split);
+        let other = LeafResourceStats {
+            localexec_num_splits: 1,
+            localexec_num_docs: 7,
+            // No split_resources_sum / split_resources_worst.
+            ..Default::default()
+        };
+        add_leaf_stats(&mut acc, &other);
+        assert_eq!(acc.localexec_num_splits, 2);
+        assert_eq!(acc.localexec_num_docs, 12);
+        // Both fields must still point at split_a.
+        assert_eq!(acc.split_resources_sum.unwrap().split_num_docs, 5);
+        assert_eq!(acc.split_resources_worst.unwrap().split_num_docs, 5);
+    }
+
+    /// When the accumulator has no `split_resources_*` and the other side
+    /// does, the result must adopt the other side's values.
+    #[test]
+    fn test_add_leaf_stats_acc_empty_adopts_other_split_resources() {
+        let mut acc = LeafResourceStats::default();
+        let split = split_stats(9, 11, 13);
+        let other = leaf_stats_one_split(split);
+        add_leaf_stats(&mut acc, &other);
+        assert_eq!(acc.localexec_num_splits, 1);
+        assert_eq!(acc.split_resources_sum.unwrap().split_num_docs, 9);
+        assert_eq!(acc.split_resources_worst.unwrap().split_num_docs, 9);
+    }
+
+    /// Adding a default `LeafResourceStats` should be an identity operation
+    /// on every field.
+    #[test]
+    fn test_add_leaf_stats_with_default_is_identity() {
+        let split = split_stats(3, 4, 5);
+        let mut acc = LeafResourceStats {
+            partial_result_cache_num_splits: 1,
+            lambda_num_splits: 2,
+            lambda_bottleneck: 1,
+            localexec_num_splits: 1,
+            localexec_num_docs: 3,
+            split_resources_sum: Some(split),
+            split_resources_worst: Some(split),
+            wall_time_microsecs: 42,
+            ..Default::default()
+        };
+        let snapshot = acc.clone();
+        add_leaf_stats(&mut acc, &LeafResourceStats::default());
+        assert_eq!(acc, snapshot);
+    }
+
+    #[test]
+    fn test_merge_leaf_stats_it() {
+        let merged = merge_leaf_stats_it(Vec::<&Option<LeafResourceStats>>::new());
+        assert_eq!(merged, None);
+
+        let leaf_a = Some(leaf_stats_one_split(split_stats(10, 1, 2)));
+        let leaf_b = Some(leaf_stats_one_split(split_stats(20, 3, 4)));
+
+        let merged = merge_leaf_stats_it(vec![&None, &leaf_a, &None, &leaf_b]);
+        let merged = merged.unwrap();
+        assert_eq!(merged.localexec_num_splits, 2);
+        assert_eq!(merged.localexec_num_docs, 30);
     }
 }

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -347,10 +347,12 @@ pub fn searcher_pool_for_test(
     )
 }
 
-/// Sum of the per-phase microsecond fields used to rank `split_resources_worsts`.
-/// Intentionally excludes `wait_for_search_permit_microsecs`.
+/// Sum of the per-phase microsecond fields used to rank `split_resources_worst`.
+/// Intentionally excludes the two waiting phases (`wait_for_search_permit_microsecs`
+/// and `wait_for_cpu_pool_microsecs`) so the ranking reflects "how much work this
+/// split actually did" rather than "how long this split queued behind other work".
 pub(crate) fn split_phase_sum_microsecs(stats: &SplitResourceStats) -> u64 {
-    stats.warmup_microsecs + stats.wait_for_cpu_pool_microsecs + stats.cpu_search_microsecs
+    stats.warmup_microsecs + stats.cpu_search_microsecs
 }
 
 /// Field-wise sum of two `SplitResourceStats` (every field is extensive).
@@ -376,33 +378,11 @@ pub(crate) fn min_opt(left: Option<u64>, right: Option<u64>) -> Option<u64> {
     }
 }
 
-/// How many entries we keep in the `*_worsts` ranked lists (`split_resources_worsts`,
-/// `leaf_resources_worsts`): the worst and the second worst.
-pub(crate) const NUM_WORST_KEPT: usize = 2;
-
-/// Merge two ranked top-N lists (each already ordered largest-first by `key_fn`)
-/// into a single ranked top-N list, keeping at most `NUM_WORST_KEPT` entries.
-/// Ties are broken by the order in which entries were seen (`acc` first, then `other`).
-pub(crate) fn merge_top_n_by_key<T, K>(acc: &[T], other: &[T], key_fn: impl Fn(&T) -> K) -> Vec<T>
-where
-    T: Clone,
-    K: Ord,
-{
-    let mut merged: Vec<T> = Vec::with_capacity(acc.len() + other.len());
-    merged.extend(acc.iter().cloned());
-    merged.extend(other.iter().cloned());
-    // `sort_by_key` is stable, so equal keys retain `acc`-before-`other` order;
-    // `Reverse` flips ascending into descending so the largest ends up first.
-    merged.sort_by_key(|entry| std::cmp::Reverse(key_fn(entry)));
-    merged.truncate(NUM_WORST_KEPT);
-    merged
-}
-
 /// Merge another `LeafResourceStats` into `acc`.
 ///
 /// Every numeric field is summed, with two exceptions:
-/// - `split_resources_worsts` keeps the top-2 worst splits across the inputs, ranked by
-///   `split_phase_sum_microsecs` (largest first). `split_resources_sum` is field-wise summed.
+/// - `split_resources_worst` is selected by `split_phase_sum_microsecs`; `split_resources_sum` is
+///   field-wise summed.
 /// - `min_wait_for_search_permit_microsecs` and `min_wait_for_cpu_pool_microsecs` are merged with
 ///   `min_opt` (treating `None` as "no contribution"), so the merged value is the minimum across
 ///   every locally-executed split that contributed.
@@ -434,11 +414,10 @@ pub(crate) fn add_leaf_stats(acc: &mut LeafResourceStats, other: &LeafResourceSt
             .get_or_insert_with(SplitResourceStats::default);
         add_split_stats(acc_split, other_split);
     }
-    acc.split_resources_worsts = merge_top_n_by_key(
-        &acc.split_resources_worsts,
-        &other.split_resources_worsts,
-        split_phase_sum_microsecs,
-    );
+    acc.split_resources_worst = [acc.split_resources_worst, other.split_resources_worst]
+        .into_iter()
+        .flatten()
+        .max_by_key(split_phase_sum_microsecs);
 }
 
 /// Merge an iterator of `Option<LeafResourceStats>` into a single `Option<LeafResourceStats>`.
@@ -477,7 +456,7 @@ mod stats_merge_tests {
             localexec_num_splits: 1,
             localexec_num_docs: split.split_num_docs,
             split_resources_sum: Some(split),
-            split_resources_worsts: vec![split],
+            split_resources_worst: Some(split),
             ..Default::default()
         }
     }
@@ -580,7 +559,7 @@ mod stats_merge_tests {
             lambda_bottleneck: 0,
             localexec_num_splits: 1_000_000,
             localexec_num_docs: 10_000_000,
-            split_resources_worsts: vec![split_a],
+            split_resources_worst: Some(split_a),
             split_resources_sum: Some(split_a),
             min_wait_for_search_permit_microsecs: Some(100),
             min_wait_for_cpu_pool_microsecs: Some(2_000),
@@ -596,7 +575,7 @@ mod stats_merge_tests {
             lambda_bottleneck: 1,
             localexec_num_splits: 2_000_000,
             localexec_num_docs: 20_000_000,
-            split_resources_worsts: vec![split_b],
+            split_resources_worst: Some(split_b),
             split_resources_sum: Some(split_b),
             min_wait_for_search_permit_microsecs: Some(50),
             min_wait_for_cpu_pool_microsecs: Some(1_000),
@@ -629,36 +608,10 @@ mod stats_merge_tests {
         assert_eq!(summed.split_num_docs, 3);
         assert_eq!(summed.cpu_search_microsecs, 300);
 
-        // `split_resources_worsts` keeps the top-2 worst splits, largest first.
-        // split_b (cpu_search 200) > split_a (cpu_search 100).
-        assert_eq!(acc.split_resources_worsts.len(), 2);
-        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 2);
-        assert_eq!(acc.split_resources_worsts[1].split_num_docs, 1);
-    }
-
-    /// `split_resources_worsts` keeps the top-2 splits across an arbitrary
-    /// number of contributors, ranked by `split_phase_sum_microsecs`.
-    #[test]
-    fn test_add_leaf_stats_split_resources_worsts_keeps_top_2() {
-        // cpu_search values pick the phase-sum ordering: 200 > 100 > 50 > 25.
-        let split_top = split_stats(1, 0, 200);
-        let split_2nd = split_stats(2, 0, 100);
-        let split_3rd = split_stats(3, 0, 50);
-        let split_4th = split_stats(4, 0, 25);
-
-        let mut acc = LeafResourceStats {
-            split_resources_worsts: vec![split_2nd, split_4th],
-            ..Default::default()
-        };
-        let other = LeafResourceStats {
-            split_resources_worsts: vec![split_top, split_3rd],
-            ..Default::default()
-        };
-        add_leaf_stats(&mut acc, &other);
-        assert_eq!(acc.split_resources_worsts.len(), 2);
-        // Largest first, second-largest next.
-        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 1);
-        assert_eq!(acc.split_resources_worsts[1].split_num_docs, 2);
+        // `split_resources_worst` is the split with the larger phase-sum:
+        // split_b (cpu_search 200) beats split_a (cpu_search 100).
+        let worst = acc.split_resources_worst.unwrap();
+        assert_eq!(worst.split_num_docs, 2);
     }
 
     /// When the accumulator already has `split_resources_*` and the other
@@ -670,7 +623,7 @@ mod stats_merge_tests {
         let other = LeafResourceStats {
             localexec_num_splits: 1,
             localexec_num_docs: 7,
-            // No split_resources_sum / split_resources_worsts.
+            // No split_resources_sum / split_resources_worst.
             ..Default::default()
         };
         add_leaf_stats(&mut acc, &other);
@@ -678,8 +631,7 @@ mod stats_merge_tests {
         assert_eq!(acc.localexec_num_docs, 12);
         // Both fields must still point at split_a.
         assert_eq!(acc.split_resources_sum.unwrap().split_num_docs, 5);
-        assert_eq!(acc.split_resources_worsts.len(), 1);
-        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 5);
+        assert_eq!(acc.split_resources_worst.unwrap().split_num_docs, 5);
     }
 
     /// When the accumulator has no `split_resources_*` and the other side
@@ -692,8 +644,7 @@ mod stats_merge_tests {
         add_leaf_stats(&mut acc, &other);
         assert_eq!(acc.localexec_num_splits, 1);
         assert_eq!(acc.split_resources_sum.unwrap().split_num_docs, 9);
-        assert_eq!(acc.split_resources_worsts.len(), 1);
-        assert_eq!(acc.split_resources_worsts[0].split_num_docs, 9);
+        assert_eq!(acc.split_resources_worst.unwrap().split_num_docs, 9);
     }
 
     /// Adding a default `LeafResourceStats` should be an identity operation
@@ -708,7 +659,7 @@ mod stats_merge_tests {
             localexec_num_splits: 1,
             localexec_num_docs: 3,
             split_resources_sum: Some(split),
-            split_resources_worsts: vec![split],
+            split_resources_worst: Some(split),
             // Set the min fields explicitly so this test verifies that
             // `min_opt(Some(x), None) = Some(x)` keeps them unchanged.
             min_wait_for_search_permit_microsecs: Some(7),
@@ -716,7 +667,7 @@ mod stats_merge_tests {
             wall_time_microsecs: 42,
             ..Default::default()
         };
-        let snapshot = acc.clone();
+        let snapshot = acc;
         add_leaf_stats(&mut acc, &LeafResourceStats::default());
         assert_eq!(acc, snapshot);
     }

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -761,6 +761,12 @@ fn compute_root_resource_stats(
         .max_by_key(|stats| stats.wall_time_microsecs)
         .cloned();
 
+    let mut leaf_wall_times_microsecs: Vec<u64> = leaf_stats
+        .iter()
+        .map(|stats| stats.wall_time_microsecs)
+        .collect();
+    leaf_wall_times_microsecs.sort_by_key(|time| std::cmp::Reverse(*time));
+
     let mut leaf_resources_sum = LeafResourceStats::default();
     for stats in &leaf_stats {
         crate::add_leaf_stats(&mut leaf_resources_sum, stats);
@@ -772,6 +778,7 @@ fn compute_root_resource_stats(
         leaf_num_calls,
         leaf_num_calls_including_retries,
         num_failed_splits,
+        leaf_wall_times_microsecs,
     })
 }
 
@@ -2994,6 +3001,9 @@ mod tests {
             .expect("worst leaf should be set");
         assert_eq!(worst.wall_time_microsecs, 2_500);
         assert_eq!(worst.localexec_num_docs, 20);
+
+        // `leaf_wall_times_microsecs` lists every leaf's wall time, largest first.
+        assert_eq!(&root_stats.leaf_wall_times_microsecs, &[2_500, 1_000]);
 
         // `leaf_resources_sum` field-wise sums every numeric counter, including
         // `wall_time_microsecs` and `lambda_bottleneck` (post-`add_leaf_stats`

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -739,8 +739,8 @@ fn is_top_5pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
 /// Build a `RootResourceStats` from the per-leaf responses captured before
 /// they are merged.
 ///
-/// `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
-/// `leaf_resources_sum` is a field-wise sum of every leaf's stats.
+/// `leaf_resources_worsts` is the top-2 leaves by `wall_time_microsecs`, largest
+/// first. `leaf_resources_sum` is a field-wise sum of every leaf's stats.
 fn compute_root_resource_stats(
     leaf_responses: &[LeafSearchResponse],
     leaf_num_calls: u64,
@@ -755,11 +755,13 @@ fn compute_root_resource_stats(
         return None;
     }
 
-    let leaf_resources_worst = leaf_stats
-        .iter()
-        .copied()
-        .max_by_key(|stats| stats.wall_time_microsecs)
-        .cloned();
+    // Top-2 leaves by `wall_time_microsecs`, largest first. Sort all candidates
+    // and truncate — leaf counts are small (typically dozens), so this is
+    // simpler than a hand-rolled single-pass top-N selector.
+    let mut leaf_resources_worsts: Vec<LeafResourceStats> =
+        leaf_stats.iter().map(|stats| (*stats).clone()).collect();
+    leaf_resources_worsts.sort_by_key(|stats| std::cmp::Reverse(stats.wall_time_microsecs));
+    leaf_resources_worsts.truncate(crate::NUM_WORST_KEPT);
 
     let mut leaf_resources_sum = LeafResourceStats::default();
     for stats in &leaf_stats {
@@ -767,7 +769,7 @@ fn compute_root_resource_stats(
     }
 
     Some(RootResourceStats {
-        leaf_resources_worst,
+        leaf_resources_worsts,
         leaf_resources_sum: Some(leaf_resources_sum),
         leaf_num_calls,
         leaf_num_calls_including_retries,
@@ -2956,7 +2958,7 @@ mod tests {
                 localexec_num_docs: 10,
                 lambda_bottleneck: 0,
                 split_resources_sum: Some(split_a),
-                split_resources_worst: Some(split_a),
+                split_resources_worsts: vec![split_a],
                 wall_time_microsecs: 1_000,
                 ..Default::default()
             }),
@@ -2968,7 +2970,7 @@ mod tests {
                 localexec_num_docs: 20,
                 lambda_bottleneck: 1,
                 split_resources_sum: Some(split_b),
-                split_resources_worst: Some(split_b),
+                split_resources_worsts: vec![split_b],
                 wall_time_microsecs: 2_500,
                 ..Default::default()
             }),
@@ -2988,12 +2990,15 @@ mod tests {
         assert_eq!(root_stats.leaf_num_calls_including_retries, 3);
         assert_eq!(root_stats.num_failed_splits, 1);
 
-        // `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
-        let worst = root_stats
-            .leaf_resources_worst
-            .expect("worst leaf should be set");
+        // `leaf_resources_worsts` keeps the top-2 leaves by `wall_time_microsecs`,
+        // largest first.
+        assert_eq!(root_stats.leaf_resources_worsts.len(), 2);
+        let worst = &root_stats.leaf_resources_worsts[0];
         assert_eq!(worst.wall_time_microsecs, 2_500);
         assert_eq!(worst.localexec_num_docs, 20);
+        let second_worst = &root_stats.leaf_resources_worsts[1];
+        assert_eq!(second_worst.wall_time_microsecs, 1_000);
+        assert_eq!(second_worst.localexec_num_docs, 10);
 
         // `leaf_resources_sum` field-wise sums every numeric counter, including
         // `wall_time_microsecs` and `lambda_bottleneck` (post-`add_leaf_stats`
@@ -3034,7 +3039,7 @@ mod tests {
                     localexec_num_splits: 1,
                     localexec_num_docs: 7,
                     split_resources_sum: Some(split),
-                    split_resources_worst: Some(split),
+                    split_resources_worsts: vec![split],
                     wall_time_microsecs: 500,
                     ..Default::default()
                 }),
@@ -3094,7 +3099,7 @@ mod tests {
 
         // The two leaves report distinct stats so we can verify that root
         // aggregation produces a meaningful `leaf_resources_sum` and selects
-        // the longer-running leaf as `leaf_resources_worst`.
+        // the longer-running leaf as `leaf_resources_worsts`.
         let split1_stats = SplitResourceStats {
             split_num_docs: 10,
             input_memory_bytes: 1_024,
@@ -3119,7 +3124,7 @@ mod tests {
             localexec_num_splits: 1,
             localexec_num_docs: 10,
             split_resources_sum: Some(split1_stats),
-            split_resources_worst: Some(split1_stats),
+            split_resources_worsts: vec![split1_stats],
             wall_time_microsecs: 1_000,
             ..Default::default()
         };
@@ -3127,7 +3132,7 @@ mod tests {
             localexec_num_splits: 1,
             localexec_num_docs: 20,
             split_resources_sum: Some(split2_stats),
-            split_resources_worst: Some(split2_stats),
+            split_resources_worsts: vec![split2_stats],
             wall_time_microsecs: 2_500,
             ..Default::default()
         };
@@ -3144,7 +3149,7 @@ mod tests {
                     failed_splits: Vec::new(),
                     num_attempted_splits: 1,
                     num_successful_splits: 1,
-                    resource_stats: Some(leaf_stats_1),
+                    resource_stats: Some(leaf_stats_1.clone()),
                     ..Default::default()
                 })
             },
@@ -3165,7 +3170,7 @@ mod tests {
                     failed_splits: Vec::new(),
                     num_attempted_splits: 1,
                     num_successful_splits: 1,
-                    resource_stats: Some(leaf_stats_2),
+                    resource_stats: Some(leaf_stats_2.clone()),
                     ..Default::default()
                 })
             },
@@ -3201,12 +3206,15 @@ mod tests {
         assert_eq!(root_stats.leaf_num_calls_including_retries, 2);
         assert_eq!(root_stats.num_failed_splits, 0);
 
-        // `leaf_resources_worst` is the leaf with the largest wall_time.
-        let worst = root_stats
-            .leaf_resources_worst
-            .expect("leaf_resources_worst should be set");
+        // `leaf_resources_worsts` keeps the top-2 leaves by wall_time, largest
+        // first.
+        assert_eq!(root_stats.leaf_resources_worsts.len(), 2);
+        let worst = &root_stats.leaf_resources_worsts[0];
         assert_eq!(worst.wall_time_microsecs, 2_500);
         assert_eq!(worst.localexec_num_splits, 1);
+        let second_worst = &root_stats.leaf_resources_worsts[1];
+        assert_eq!(second_worst.wall_time_microsecs, 1_000);
+        assert_eq!(second_worst.localexec_num_splits, 1);
 
         // `leaf_resources_sum` field-wise sums every numeric counter across
         // leaves; `wall_time_microsecs` is summed too after the recent

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
@@ -31,9 +31,10 @@ use quickwit_proto::metastore::{
     ListIndexesMetadataRequest, MetastoreService, MetastoreServiceClient,
 };
 use quickwit_proto::search::{
-    FetchDocsRequest, FetchDocsResponse, Hit, LeafHit, LeafRequestRef, LeafSearchRequest,
-    LeafSearchResponse, PartialHit, SearchPlanResponse, SearchRequest, SearchResponse,
-    SnippetRequest, SortDatetimeFormat, SortField, SortValue, SplitIdAndFooterOffsets,
+    FetchDocsRequest, FetchDocsResponse, Hit, LeafHit, LeafRequestRef, LeafResourceStats,
+    LeafSearchRequest, LeafSearchResponse, PartialHit, RootResourceStats, SearchPlanResponse,
+    SearchRequest, SearchResponse, SnippetRequest, SortDatetimeFormat, SortField, SortValue,
+    SplitIdAndFooterOffsets,
 };
 use quickwit_proto::types::{IndexUid, SplitId};
 use quickwit_query::query_ast::{
@@ -569,7 +570,11 @@ async fn search_partial_hits_phase_with_scroll(
     mut search_request: SearchRequest,
     split_metadatas: &[SplitMetadata],
     cluster_client: &ClusterClient,
-) -> crate::Result<(LeafSearchResponse, Option<ScrollKeyAndStartOffset>)> {
+) -> crate::Result<(
+    LeafSearchResponse,
+    Option<ScrollKeyAndStartOffset>,
+    Option<RootResourceStats>,
+)> {
     let scroll_ttl_opt = get_scroll_ttl_duration(&search_request)?;
 
     if let Some(scroll_ttl) = scroll_ttl_opt {
@@ -581,7 +586,7 @@ async fn search_partial_hits_phase_with_scroll(
             .max_hits
             .max(shared_consts::SCROLL_BATCH_LEN as u64);
         search_request.scroll_ttl_secs = None;
-        let mut leaf_search_resp = search_partial_hits_phase(
+        let (mut leaf_search_resp, root_resource_stats) = search_partial_hits_phase(
             searcher_context,
             indexes_metas_for_leaf_search,
             &search_request,
@@ -624,9 +629,13 @@ async fn search_partial_hits_phase_with_scroll(
         cluster_client
             .put_kv(&scroll_key, &payload, scroll_ttl)
             .await;
-        Ok((leaf_search_resp, Some(scroll_key_and_start_offset)))
+        Ok((
+            leaf_search_resp,
+            Some(scroll_key_and_start_offset),
+            root_resource_stats,
+        ))
     } else {
-        let leaf_search_resp = search_partial_hits_phase(
+        let (leaf_search_resp, root_resource_stats) = search_partial_hits_phase(
             searcher_context,
             indexes_metas_for_leaf_search,
             &search_request,
@@ -634,7 +643,7 @@ async fn search_partial_hits_phase_with_scroll(
             cluster_client,
         )
         .await?;
-        Ok((leaf_search_resp, None))
+        Ok((leaf_search_resp, None, root_resource_stats))
     }
 }
 
@@ -727,6 +736,45 @@ fn is_top_5pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
     is_memory_intensive
 }
 
+/// Build a `RootResourceStats` from the per-leaf responses captured before
+/// they are merged.
+///
+/// `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
+/// `leaf_resources_sum` is a field-wise sum of every leaf's stats.
+fn compute_root_resource_stats(
+    leaf_responses: &[LeafSearchResponse],
+    leaf_num_calls: u64,
+    leaf_num_calls_including_retries: u64,
+    num_failed_splits: u64,
+) -> Option<RootResourceStats> {
+    let leaf_stats: Vec<&LeafResourceStats> = leaf_responses
+        .iter()
+        .filter_map(|resp| resp.resource_stats.as_ref())
+        .collect();
+    if leaf_stats.is_empty() {
+        return None;
+    }
+
+    let leaf_resources_worst = leaf_stats
+        .iter()
+        .copied()
+        .max_by_key(|stats| stats.wall_time_microsecs)
+        .cloned();
+
+    let mut leaf_resources_sum = LeafResourceStats::default();
+    for stats in &leaf_stats {
+        crate::add_leaf_stats(&mut leaf_resources_sum, stats);
+    }
+
+    Some(RootResourceStats {
+        leaf_resources_worst,
+        leaf_resources_sum: Some(leaf_resources_sum),
+        leaf_num_calls,
+        leaf_num_calls_including_retries,
+        num_failed_splits,
+    })
+}
+
 /// If this method fails for some splits, a partial search response is returned, with the list of
 /// faulty splits in the failed_splits field.
 #[instrument(level = "debug", skip_all)]
@@ -736,7 +784,11 @@ pub(crate) async fn search_partial_hits_phase(
     search_request: &SearchRequest,
     split_metadatas: &[SplitMetadata],
     cluster_client: &ClusterClient,
-) -> crate::Result<LeafSearchResponse> {
+) -> crate::Result<(LeafSearchResponse, Option<RootResourceStats>)> {
+    // Each entry is (leaf response, number of leaf attempts made to obtain it).
+    // Metadata-count responses are synthesised locally and contribute 0 attempts.
+    let mut leaf_num_calls = 0u64;
+    let leaf_num_calls_including_retries_arc: Arc<AtomicU64> = Default::default();
     let leaf_search_responses: Vec<LeafSearchResponse> =
         if is_metadata_count_request(search_request) {
             get_count_from_metadata(split_metadatas)
@@ -753,10 +805,26 @@ pub(crate) async fn search_partial_hits_phase(
                     indexes_metas_for_leaf_search,
                     client_jobs,
                 )?;
-                leaf_request_tasks.push(cluster_client.leaf_search(leaf_request, client.clone()));
+                leaf_request_tasks.push(cluster_client.leaf_search(
+                    leaf_request,
+                    client.clone(),
+                    leaf_num_calls_including_retries_arc.clone(),
+                ));
             }
+            leaf_num_calls = leaf_request_tasks.len() as u64;
             try_join_all(leaf_request_tasks).await?
         };
+
+    let num_failed_splits: u64 = leaf_search_responses
+        .iter()
+        .map(|resp| resp.failed_splits.len() as u64)
+        .sum();
+    let root_resource_stats = compute_root_resource_stats(
+        &leaf_search_responses,
+        leaf_num_calls,
+        leaf_num_calls_including_retries_arc.load(Ordering::Relaxed),
+        num_failed_splits,
+    );
 
     let merge_collector =
         make_merge_collector(search_request, searcher_context.get_aggregation_limits())?;
@@ -786,16 +854,17 @@ pub(crate) async fn search_partial_hits_phase(
     );
 
     if let Some(resource_stats) = &leaf_search_response.resource_stats
+        && let Some(split_resources_sum) = &resource_stats.split_resources_sum
         && is_top_5pct_memory_intensive(
-            resource_stats.short_lived_cache_num_bytes,
-            resource_stats.split_num_docs,
+            split_resources_sum.input_memory_bytes,
+            split_resources_sum.split_num_docs,
         )
     {
         // We log at most 5 times per minute.
         quickwit_common::rate_limited_info!(
             limit_per_min = 5,
-            split_num_docs = resource_stats.split_num_docs,
-            short_lived_cached_num_bytes = resource_stats.short_lived_cache_num_bytes,
+            split_num_docs = split_resources_sum.split_num_docs,
+            input_memory_bytes = split_resources_sum.input_memory_bytes,
             "memory intensive query"
         );
     }
@@ -804,7 +873,7 @@ pub(crate) async fn search_partial_hits_phase(
         quickwit_common::rate_limited_error!(limit_per_min=6, num_failed_splits = leaf_search_response.failed_splits.len(), failed_splits = ?PrettySample::new(&leaf_search_response.failed_splits, 5), "leaf search response contains failed splits");
     }
 
-    Ok(leaf_search_response)
+    Ok((leaf_search_response, root_resource_stats))
 }
 
 pub(crate) fn get_snippet_request(search_request: &SearchRequest) -> Option<SnippetRequest> {
@@ -979,9 +1048,10 @@ async fn root_search_aux(
     cluster_client: &ClusterClient,
 ) -> crate::Result<SearchResponse> {
     debug!(split_metadatas = ?PrettySample::new(&split_metadatas, 5));
-    let (first_phase_result, scroll_key_and_start_offset_opt): (
+    let (first_phase_result, scroll_key_and_start_offset_opt, root_resource_stats): (
         LeafSearchResponse,
         Option<ScrollKeyAndStartOffset>,
+        Option<RootResourceStats>,
     ) = search_partial_hits_phase_with_scroll(
         searcher_context,
         indexes_metas_for_leaf_search,
@@ -1021,6 +1091,7 @@ async fn root_search_aux(
             .map(ToString::to_string),
         failed_splits: first_phase_result.failed_splits,
         num_successful_splits: first_phase_result.num_successful_splits,
+        resource_stats: root_resource_stats,
     })
 }
 
@@ -2831,6 +2902,332 @@ mod tests {
         .unwrap();
         assert_eq!(search_response.num_hits, 3);
         assert_eq!(search_response.hits.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_compute_root_resource_stats_returns_none_for_empty_input() {
+        assert!(compute_root_resource_stats(&[], 0, 0, 0).is_none());
+    }
+
+    #[test]
+    fn test_compute_root_resource_stats_returns_none_when_no_leaf_carries_stats() {
+        // A leaf without `resource_stats` should be ignored: with every leaf
+        // missing stats, `compute_root_resource_stats` returns `None`. The
+        // scalar counter arguments are still preserved if we ever decide to
+        // emit a stats payload anyway, but per the current contract they are
+        // dropped together with the rest.
+        let responses = vec![
+            LeafSearchResponse {
+                resource_stats: None,
+                ..Default::default()
+            },
+            LeafSearchResponse {
+                resource_stats: None,
+                ..Default::default()
+            },
+        ];
+        assert!(compute_root_resource_stats(&responses, 2, 2, 0).is_none());
+    }
+
+    #[test]
+    fn test_compute_root_resource_stats_aggregates_per_leaf_stats() {
+        use quickwit_proto::search::SplitResourceStats;
+
+        let split_a = SplitResourceStats {
+            split_num_docs: 10,
+            download_num_bytes: 4_096,
+            download_num_requests: 2,
+            warmup_microsecs: 100,
+            cpu_search_microsecs: 200,
+            ..Default::default()
+        };
+        let split_b = SplitResourceStats {
+            split_num_docs: 20,
+            download_num_bytes: 8_192,
+            download_num_requests: 3,
+            warmup_microsecs: 150,
+            cpu_search_microsecs: 350,
+            ..Default::default()
+        };
+        let leaf_a = LeafSearchResponse {
+            resource_stats: Some(LeafResourceStats {
+                localexec_num_splits: 1,
+                localexec_num_docs: 10,
+                lambda_bottleneck: 0,
+                split_resources_sum: Some(split_a),
+                split_resources_worst: Some(split_a),
+                wall_time_microsecs: 1_000,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let leaf_b = LeafSearchResponse {
+            resource_stats: Some(LeafResourceStats {
+                localexec_num_splits: 1,
+                localexec_num_docs: 20,
+                lambda_bottleneck: 1,
+                split_resources_sum: Some(split_b),
+                split_resources_worst: Some(split_b),
+                wall_time_microsecs: 2_500,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let root_stats = compute_root_resource_stats(
+            &[leaf_a, leaf_b],
+            /* leaf_num_calls */ 2,
+            /* including_retries */ 3,
+            /* num_failed_splits */ 1,
+        )
+        .expect("expected `RootResourceStats` to be produced");
+
+        // Scalar fields are passed through verbatim.
+        assert_eq!(root_stats.leaf_num_calls, 2);
+        assert_eq!(root_stats.leaf_num_calls_including_retries, 3);
+        assert_eq!(root_stats.num_failed_splits, 1);
+
+        // `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
+        let worst = root_stats
+            .leaf_resources_worst
+            .expect("worst leaf should be set");
+        assert_eq!(worst.wall_time_microsecs, 2_500);
+        assert_eq!(worst.localexec_num_docs, 20);
+
+        // `leaf_resources_sum` field-wise sums every numeric counter, including
+        // `wall_time_microsecs` and `lambda_bottleneck` (post-`add_leaf_stats`
+        // refactor: everything is extensive).
+        let sum = root_stats.leaf_resources_sum.expect("sum should be set");
+        assert_eq!(sum.localexec_num_splits, 2);
+        assert_eq!(sum.localexec_num_docs, 30);
+        assert_eq!(sum.lambda_bottleneck, 1);
+        assert_eq!(sum.wall_time_microsecs, 3_500);
+
+        // `split_resources_sum` rolls up every contributing split.
+        let split_sum = sum
+            .split_resources_sum
+            .expect("split_resources_sum should be set");
+        assert_eq!(split_sum.split_num_docs, 30);
+        assert_eq!(split_sum.download_num_bytes, 12_288);
+        assert_eq!(split_sum.download_num_requests, 5);
+        assert_eq!(split_sum.warmup_microsecs, 250);
+        assert_eq!(split_sum.cpu_search_microsecs, 550);
+    }
+
+    #[test]
+    fn test_compute_root_resource_stats_skips_leaves_without_stats() {
+        // A mix of stats-bearing and stats-less leaves: the latter are
+        // silently dropped (we cannot synthesize stats we never received).
+        use quickwit_proto::search::SplitResourceStats;
+        let split = SplitResourceStats {
+            split_num_docs: 7,
+            ..Default::default()
+        };
+        let responses = vec![
+            LeafSearchResponse {
+                resource_stats: None,
+                ..Default::default()
+            },
+            LeafSearchResponse {
+                resource_stats: Some(LeafResourceStats {
+                    localexec_num_splits: 1,
+                    localexec_num_docs: 7,
+                    split_resources_sum: Some(split),
+                    split_resources_worst: Some(split),
+                    wall_time_microsecs: 500,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ];
+        let root_stats = compute_root_resource_stats(&responses, 2, 2, 0)
+            .expect("at least one leaf carried stats");
+        let sum = root_stats.leaf_resources_sum.unwrap();
+        assert_eq!(sum.localexec_num_splits, 1);
+        assert_eq!(sum.wall_time_microsecs, 500);
+        // `leaf_num_calls` reflects the call count (passed in by the caller),
+        // not the number of leaves that returned stats.
+        assert_eq!(root_stats.leaf_num_calls, 2);
+    }
+
+    /// End-to-end check that `SearchResponse.resource_stats` is populated by
+    /// `root_search` when the leaf responses carry `LeafResourceStats`. This
+    /// is the same function the gRPC `RootSearch` handler invokes (see
+    /// `service::SearchServiceImpl::root_search`, which is a thin wrapper
+    /// over the free function called here), so it covers the gRPC root code
+    /// path end-to-end with mocked metastore + leaf services.
+    #[tokio::test]
+    async fn test_root_search_populates_resource_stats() -> anyhow::Result<()> {
+        use quickwit_proto::search::{LeafResourceStats, SplitResourceStats};
+
+        let search_request = quickwit_proto::search::SearchRequest {
+            index_id_patterns: vec!["test-index".to_string()],
+            query_ast: qast_json_helper("test", &["body"]),
+            max_hits: 10,
+            ..Default::default()
+        };
+        let mut mock_metastore = MockMetastoreService::new();
+        let index_metadata = IndexMetadata::for_test("test-index", "ram:///test-index");
+        let index_uid = index_metadata.index_uid.clone();
+        mock_metastore
+            .expect_list_indexes_metadata()
+            .returning(move |_index_ids_query| {
+                Ok(ListIndexesMetadataResponse::for_test(vec![
+                    index_metadata.clone(),
+                ]))
+            });
+        mock_metastore
+            .expect_list_splits()
+            .returning(move |_filter| {
+                let splits = vec![
+                    MockSplitBuilder::new("split1")
+                        .with_index_uid(&index_uid)
+                        .build(),
+                    MockSplitBuilder::new("split2")
+                        .with_index_uid(&index_uid)
+                        .build(),
+                ];
+                let splits_response = ListSplitsResponse::try_from_splits(splits).unwrap();
+                Ok(ServiceStream::from(vec![Ok(splits_response)]))
+            });
+
+        // The two leaves report distinct stats so we can verify that root
+        // aggregation produces a meaningful `leaf_resources_sum` and selects
+        // the longer-running leaf as `leaf_resources_worst`.
+        let split1_stats = SplitResourceStats {
+            split_num_docs: 10,
+            input_memory_bytes: 1_024,
+            download_num_bytes: 4_096,
+            download_num_requests: 2,
+            matched_num_docs: 5,
+            warmup_microsecs: 100,
+            cpu_search_microsecs: 200,
+            ..Default::default()
+        };
+        let split2_stats = SplitResourceStats {
+            split_num_docs: 20,
+            input_memory_bytes: 2_048,
+            download_num_bytes: 8_192,
+            download_num_requests: 3,
+            matched_num_docs: 7,
+            warmup_microsecs: 150,
+            cpu_search_microsecs: 350,
+            ..Default::default()
+        };
+        let leaf_stats_1 = LeafResourceStats {
+            localexec_num_splits: 1,
+            localexec_num_docs: 10,
+            split_resources_sum: Some(split1_stats),
+            split_resources_worst: Some(split1_stats),
+            wall_time_microsecs: 1_000,
+            ..Default::default()
+        };
+        let leaf_stats_2 = LeafResourceStats {
+            localexec_num_splits: 1,
+            localexec_num_docs: 20,
+            split_resources_sum: Some(split2_stats),
+            split_resources_worst: Some(split2_stats),
+            wall_time_microsecs: 2_500,
+            ..Default::default()
+        };
+
+        let mut mock_search_service_1 = MockSearchService::new();
+        mock_search_service_1.expect_leaf_search().returning(
+            move |_leaf_search_req: quickwit_proto::search::LeafSearchRequest| {
+                Ok(quickwit_proto::search::LeafSearchResponse {
+                    num_hits: 2,
+                    partial_hits: vec![
+                        mock_partial_hit("split1", 3, 1),
+                        mock_partial_hit("split1", 1, 3),
+                    ],
+                    failed_splits: Vec::new(),
+                    num_attempted_splits: 1,
+                    num_successful_splits: 1,
+                    resource_stats: Some(leaf_stats_1),
+                    ..Default::default()
+                })
+            },
+        );
+        mock_search_service_1.expect_fetch_docs().returning(
+            |fetch_docs_req: quickwit_proto::search::FetchDocsRequest| {
+                Ok(quickwit_proto::search::FetchDocsResponse {
+                    hits: get_doc_for_fetch_req(fetch_docs_req),
+                })
+            },
+        );
+        let mut mock_search_service_2 = MockSearchService::new();
+        mock_search_service_2.expect_leaf_search().returning(
+            move |_leaf_search_req: quickwit_proto::search::LeafSearchRequest| {
+                Ok(quickwit_proto::search::LeafSearchResponse {
+                    num_hits: 1,
+                    partial_hits: vec![mock_partial_hit("split2", 2, 2)],
+                    failed_splits: Vec::new(),
+                    num_attempted_splits: 1,
+                    num_successful_splits: 1,
+                    resource_stats: Some(leaf_stats_2),
+                    ..Default::default()
+                })
+            },
+        );
+        mock_search_service_2.expect_fetch_docs().returning(
+            |fetch_docs_req: quickwit_proto::search::FetchDocsRequest| {
+                Ok(quickwit_proto::search::FetchDocsResponse {
+                    hits: get_doc_for_fetch_req(fetch_docs_req),
+                })
+            },
+        );
+        let searcher_pool = searcher_pool_for_test([
+            ("127.0.0.1:1001", mock_search_service_1),
+            ("127.0.0.1:1002", mock_search_service_2),
+        ]);
+        let search_job_placer = SearchJobPlacer::new(searcher_pool);
+        let cluster_client = ClusterClient::new(search_job_placer.clone());
+
+        let search_response = root_search(
+            &SearcherContext::for_test(),
+            search_request,
+            MetastoreServiceClient::from_mock(mock_metastore),
+            &cluster_client,
+        )
+        .await?;
+
+        assert_eq!(search_response.num_hits, 3);
+
+        let root_stats = search_response
+            .resource_stats
+            .expect("root resource_stats should be populated");
+        assert_eq!(root_stats.leaf_num_calls, 2);
+        assert_eq!(root_stats.leaf_num_calls_including_retries, 2);
+        assert_eq!(root_stats.num_failed_splits, 0);
+
+        // `leaf_resources_worst` is the leaf with the largest wall_time.
+        let worst = root_stats
+            .leaf_resources_worst
+            .expect("leaf_resources_worst should be set");
+        assert_eq!(worst.wall_time_microsecs, 2_500);
+        assert_eq!(worst.localexec_num_splits, 1);
+
+        // `leaf_resources_sum` field-wise sums every numeric counter across
+        // leaves; `wall_time_microsecs` is summed too after the recent
+        // `add_leaf_stats` refactor.
+        let sum = root_stats
+            .leaf_resources_sum
+            .expect("leaf_resources_sum should be set");
+        assert_eq!(sum.localexec_num_splits, 2);
+        assert_eq!(sum.localexec_num_docs, 30);
+        assert_eq!(sum.wall_time_microsecs, 3_500);
+
+        // `split_resources_sum` aggregates per-split contributions across all
+        // local splits in every leaf.
+        let split_sum = sum
+            .split_resources_sum
+            .expect("split_resources_sum should be set");
+        assert_eq!(split_sum.split_num_docs, 30);
+        assert_eq!(split_sum.download_num_bytes, 12_288);
+        assert_eq!(split_sum.download_num_requests, 5);
+        assert_eq!(split_sum.matched_num_docs, 12);
+
         Ok(())
     }
 

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -739,8 +739,8 @@ fn is_top_5pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
 /// Build a `RootResourceStats` from the per-leaf responses captured before
 /// they are merged.
 ///
-/// `leaf_resources_worsts` is the top-2 leaves by `wall_time_microsecs`, largest
-/// first. `leaf_resources_sum` is a field-wise sum of every leaf's stats.
+/// `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
+/// `leaf_resources_sum` is a field-wise sum of every leaf's stats.
 fn compute_root_resource_stats(
     leaf_responses: &[LeafSearchResponse],
     leaf_num_calls: u64,
@@ -755,13 +755,11 @@ fn compute_root_resource_stats(
         return None;
     }
 
-    // Top-2 leaves by `wall_time_microsecs`, largest first. Sort all candidates
-    // and truncate — leaf counts are small (typically dozens), so this is
-    // simpler than a hand-rolled single-pass top-N selector.
-    let mut leaf_resources_worsts: Vec<LeafResourceStats> =
-        leaf_stats.iter().map(|stats| (*stats).clone()).collect();
-    leaf_resources_worsts.sort_by_key(|stats| std::cmp::Reverse(stats.wall_time_microsecs));
-    leaf_resources_worsts.truncate(crate::NUM_WORST_KEPT);
+    let leaf_resources_worst = leaf_stats
+        .iter()
+        .copied()
+        .max_by_key(|stats| stats.wall_time_microsecs)
+        .cloned();
 
     let mut leaf_resources_sum = LeafResourceStats::default();
     for stats in &leaf_stats {
@@ -769,7 +767,7 @@ fn compute_root_resource_stats(
     }
 
     Some(RootResourceStats {
-        leaf_resources_worsts,
+        leaf_resources_worst,
         leaf_resources_sum: Some(leaf_resources_sum),
         leaf_num_calls,
         leaf_num_calls_including_retries,
@@ -2958,7 +2956,7 @@ mod tests {
                 localexec_num_docs: 10,
                 lambda_bottleneck: 0,
                 split_resources_sum: Some(split_a),
-                split_resources_worsts: vec![split_a],
+                split_resources_worst: Some(split_a),
                 wall_time_microsecs: 1_000,
                 ..Default::default()
             }),
@@ -2970,7 +2968,7 @@ mod tests {
                 localexec_num_docs: 20,
                 lambda_bottleneck: 1,
                 split_resources_sum: Some(split_b),
-                split_resources_worsts: vec![split_b],
+                split_resources_worst: Some(split_b),
                 wall_time_microsecs: 2_500,
                 ..Default::default()
             }),
@@ -2990,15 +2988,12 @@ mod tests {
         assert_eq!(root_stats.leaf_num_calls_including_retries, 3);
         assert_eq!(root_stats.num_failed_splits, 1);
 
-        // `leaf_resources_worsts` keeps the top-2 leaves by `wall_time_microsecs`,
-        // largest first.
-        assert_eq!(root_stats.leaf_resources_worsts.len(), 2);
-        let worst = &root_stats.leaf_resources_worsts[0];
+        // `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
+        let worst = root_stats
+            .leaf_resources_worst
+            .expect("worst leaf should be set");
         assert_eq!(worst.wall_time_microsecs, 2_500);
         assert_eq!(worst.localexec_num_docs, 20);
-        let second_worst = &root_stats.leaf_resources_worsts[1];
-        assert_eq!(second_worst.wall_time_microsecs, 1_000);
-        assert_eq!(second_worst.localexec_num_docs, 10);
 
         // `leaf_resources_sum` field-wise sums every numeric counter, including
         // `wall_time_microsecs` and `lambda_bottleneck` (post-`add_leaf_stats`
@@ -3039,7 +3034,7 @@ mod tests {
                     localexec_num_splits: 1,
                     localexec_num_docs: 7,
                     split_resources_sum: Some(split),
-                    split_resources_worsts: vec![split],
+                    split_resources_worst: Some(split),
                     wall_time_microsecs: 500,
                     ..Default::default()
                 }),
@@ -3099,7 +3094,7 @@ mod tests {
 
         // The two leaves report distinct stats so we can verify that root
         // aggregation produces a meaningful `leaf_resources_sum` and selects
-        // the longer-running leaf as `leaf_resources_worsts`.
+        // the longer-running leaf as `leaf_resources_worst`.
         let split1_stats = SplitResourceStats {
             split_num_docs: 10,
             input_memory_bytes: 1_024,
@@ -3124,7 +3119,7 @@ mod tests {
             localexec_num_splits: 1,
             localexec_num_docs: 10,
             split_resources_sum: Some(split1_stats),
-            split_resources_worsts: vec![split1_stats],
+            split_resources_worst: Some(split1_stats),
             wall_time_microsecs: 1_000,
             ..Default::default()
         };
@@ -3132,7 +3127,7 @@ mod tests {
             localexec_num_splits: 1,
             localexec_num_docs: 20,
             split_resources_sum: Some(split2_stats),
-            split_resources_worsts: vec![split2_stats],
+            split_resources_worst: Some(split2_stats),
             wall_time_microsecs: 2_500,
             ..Default::default()
         };
@@ -3149,7 +3144,7 @@ mod tests {
                     failed_splits: Vec::new(),
                     num_attempted_splits: 1,
                     num_successful_splits: 1,
-                    resource_stats: Some(leaf_stats_1.clone()),
+                    resource_stats: Some(leaf_stats_1),
                     ..Default::default()
                 })
             },
@@ -3170,7 +3165,7 @@ mod tests {
                     failed_splits: Vec::new(),
                     num_attempted_splits: 1,
                     num_successful_splits: 1,
-                    resource_stats: Some(leaf_stats_2.clone()),
+                    resource_stats: Some(leaf_stats_2),
                     ..Default::default()
                 })
             },
@@ -3206,15 +3201,12 @@ mod tests {
         assert_eq!(root_stats.leaf_num_calls_including_retries, 2);
         assert_eq!(root_stats.num_failed_splits, 0);
 
-        // `leaf_resources_worsts` keeps the top-2 leaves by wall_time, largest
-        // first.
-        assert_eq!(root_stats.leaf_resources_worsts.len(), 2);
-        let worst = &root_stats.leaf_resources_worsts[0];
+        // `leaf_resources_worst` is the leaf with the largest wall_time.
+        let worst = root_stats
+            .leaf_resources_worst
+            .expect("leaf_resources_worst should be set");
         assert_eq!(worst.wall_time_microsecs, 2_500);
         assert_eq!(worst.localexec_num_splits, 1);
-        let second_worst = &root_stats.leaf_resources_worsts[1];
-        assert_eq!(second_worst.wall_time_microsecs, 1_000);
-        assert_eq!(second_worst.localexec_num_splits, 1);
 
         // `leaf_resources_sum` field-wise sums every numeric counter across
         // leaves; `wall_time_microsecs` is summed too after the recent

--- a/quickwit/quickwit-search/src/scroll_context.rs
+++ b/quickwit/quickwit-search/src/scroll_context.rs
@@ -25,7 +25,9 @@ use base64::prelude::BASE64_STANDARD;
 use quickwit_common::metrics::GaugeGuard;
 use quickwit_common::shared_consts::SCROLL_BATCH_LEN;
 use quickwit_metastore::SplitMetadata;
-use quickwit_proto::search::{LeafSearchResponse, PartialHit, SearchRequest, SplitSearchError};
+use quickwit_proto::search::{
+    LeafSearchResponse, PartialHit, RootResourceStats, SearchRequest, SplitSearchError,
+};
 use quickwit_proto::types::IndexUid;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -99,15 +101,21 @@ impl ScrollContext {
 
     /// Loads in the `ScrollContext` cache all the
     /// hits in range [start_offset..start_offset + SCROLL_BATCH_LEN).
+    ///
+    /// Returns the per-search `RootResourceStats`, if any, so the caller can
+    /// surface them on the scroll response.
     pub async fn load_batch_starting_at(
         &mut self,
         start_offset: u64,
         previous_last_hit: PartialHit,
         cluster_client: &ClusterClient,
         searcher_context: &SearcherContext,
-    ) -> crate::Result<bool> {
+    ) -> crate::Result<Option<RootResourceStats>> {
         self.search_request.search_after = Some(previous_last_hit);
-        let leaf_search_response: LeafSearchResponse = crate::root::search_partial_hits_phase(
+        let (leaf_search_response, root_resource_stats): (
+            LeafSearchResponse,
+            Option<RootResourceStats>,
+        ) = crate::root::search_partial_hits_phase(
             searcher_context,
             &self.indexes_metas_for_leaf_search,
             &self.search_request,
@@ -117,7 +125,7 @@ impl ScrollContext {
         .await?;
         self.cached_partial_hits_start_offset = start_offset;
         self.cached_partial_hits = leaf_search_response.partial_hits;
-        Ok(true)
+        Ok(root_resource_stats)
     }
 }
 

--- a/quickwit/quickwit-search/src/search_permit_provider.rs
+++ b/quickwit/quickwit-search/src/search_permit_provider.rs
@@ -18,6 +18,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
 use bytesize::ByteSize;
 use quickwit_common::metrics::GaugeGuard;
@@ -168,6 +169,7 @@ struct SearchPermitActor {
 struct SingleSplitPermitRequest {
     permit_sender: oneshot::Sender<SearchPermit>,
     permit_size: u64,
+    requested_at: Instant,
 }
 
 struct LeafPermitRequest {
@@ -205,6 +207,10 @@ impl LeafPermitRequest {
     // `permit_sizes` must not be empty.
     fn from_estimated_costs(permit_sizes: Vec<u64>) -> (Self, Vec<SearchPermitFuture>) {
         assert!(!permit_sizes.is_empty(), "permit_sizes must not be empty");
+        // Stamped on every `SingleSplitPermitRequest` we're about to enqueue.
+        // The actor will compute `requested_at.elapsed()` at grant time to
+        // report the permit's acquisition latency.
+        let requested_at = Instant::now();
         let mut permits = Vec::with_capacity(permit_sizes.len());
         let mut single_split_permit_requests = Vec::with_capacity(permit_sizes.len());
         for permit_size in permit_sizes {
@@ -215,6 +221,7 @@ impl LeafPermitRequest {
             single_split_permit_requests.push(SingleSplitPermitRequest {
                 permit_sender: tx,
                 permit_size,
+                requested_at,
             });
             permits.push(SearchPermitFuture(rx));
         }
@@ -345,6 +352,7 @@ impl SearchPermitActor {
                     msg_sender: self.msg_sender.clone(),
                     memory_allocation: permit_request.permit_size,
                     warmup_slot_freed: false,
+                    wait_for_acquisition: permit_request.requested_at.elapsed(),
                 })
                 // if the requester dropped its receiver, we drop the newly
                 // created SearchPermit which releases the resources
@@ -361,9 +369,16 @@ pub struct SearchPermit {
     msg_sender: mpsc::WeakUnboundedSender<SearchPermitMessage>,
     memory_allocation: u64,
     warmup_slot_freed: bool,
+    /// Time the request spent in the permit queue.
+    wait_for_acquisition: Duration,
 }
 
 impl SearchPermit {
+    /// Time spent acquiring this permit (request → grant).
+    pub fn wait_for_acquisition(&self) -> Duration {
+        self.wait_for_acquisition
+    }
+
     /// Update the memory usage attached to this permit.
     ///
     /// This will increase or decrease the available memory in the [`SearchPermitProvider`].

--- a/quickwit/quickwit-search/src/service.rs
+++ b/quickwit/quickwit-search/src/service.rs
@@ -25,8 +25,8 @@ use quickwit_proto::search::{
     FetchDocsRequest, FetchDocsResponse, GetKvRequest, Hit, LeafListFieldsRequest,
     LeafListTermsRequest, LeafListTermsResponse, LeafSearchRequest, LeafSearchResponse,
     ListFieldsRequest, ListFieldsResponse, ListTermsRequest, ListTermsResponse, PutKvRequest,
-    ReportSplitsRequest, ReportSplitsResponse, ScrollRequest, SearchPlanResponse, SearchRequest,
-    SearchResponse, SnippetRequest,
+    ReportSplitsRequest, ReportSplitsResponse, RootResourceStats, ScrollRequest,
+    SearchPlanResponse, SearchRequest, SearchResponse, SnippetRequest,
 };
 use quickwit_storage::{
     MemorySizedCache, QuickwitCache, SplitCache, StorageCache, StorageResolver,
@@ -343,6 +343,7 @@ pub(crate) async fn scroll(
 
     let mut partial_hits = Vec::new();
     let mut scroll_context_modified = false;
+    let mut resource_stats: Option<RootResourceStats> = None;
 
     let cached_results = scroll_context.get_cached_partial_hits(start_doc..end_doc);
     partial_hits.extend_from_slice(cached_results);
@@ -352,7 +353,7 @@ pub(crate) async fn scroll(
             .cloned()
             .unwrap_or_else(|| current_scroll.search_after.clone());
         let cursor = start_doc + partial_hits.len() as u64;
-        scroll_context
+        resource_stats = scroll_context
             .load_batch_starting_at(cursor, search_after, cluster_client, searcher_context)
             .await?;
         partial_hits.extend_from_slice(scroll_context.get_cached_partial_hits(cursor..end_doc));
@@ -394,6 +395,10 @@ pub(crate) async fn scroll(
         aggregation_postcard: None,
         failed_splits: scroll_context.failed_splits,
         num_successful_splits: scroll_context.num_successful_splits,
+        // Populated only when this scroll page triggered an inner
+        // `search_partial_hits_phase`. Pure cache hits (served entirely from
+        // the scroll context) carry `None` because no leaf search ran.
+        resource_stats,
     })
 }
 /// [`SearcherContext`] provides a common set of variables

--- a/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/jaeger_api/rest_handler.rs
@@ -481,6 +481,7 @@ mod tests {
                     scroll_id: None,
                     failed_splits: Vec::new(),
                     num_successful_splits: 1,
+                    resource_stats: None,
                 })
             });
         let mock_search_service = Arc::new(mock_search_service);
@@ -514,6 +515,7 @@ mod tests {
                     scroll_id: None,
                     failed_splits: Vec::new(),
                     num_successful_splits: 1,
+                    resource_stats: None,
                 })
             });
         let mock_search_service = Arc::new(mock_search_service);

--- a/quickwit/quickwit-storage/src/counting_storage.rs
+++ b/quickwit/quickwit-storage/src/counting_storage.rs
@@ -93,36 +93,13 @@ impl Storage for CountingStorage {
         self.inner.put(path, payload).await
     }
 
-    fn copy_to<'life0, 'life1, 'life2, 'async_trait>(
-        &'life0 self,
-        path: &'life1 Path,
-        output: &'life2 mut dyn SendableAsync,
-    ) -> ::core::pin::Pin<
-        Box<
-            dyn ::core::future::Future<Output = StorageResult<()>>
-                + ::core::marker::Send
-                + 'async_trait,
-        >,
-    >
-    where
-        'life0: 'async_trait,
-        'life1: 'async_trait,
-        'life2: 'async_trait,
-        Self: 'async_trait,
-    {
+    async fn copy_to(&self, path: &Path, output: &mut dyn SendableAsync) -> StorageResult<()> {
         // We do not know the final byte count without intercepting the writer,
         // so we conservatively count the request only. `copy_to` is not on the
         // hot path of leaf search (only `get_slice` is), so this approximation
         // is acceptable.
-        let counters = self.counters.clone();
-        let inner_fut = self.inner.copy_to(path, output);
-        Box::pin(async move {
-            let result = inner_fut.await;
-            if result.is_ok() {
-                counters.requests.fetch_add(1, Ordering::Relaxed);
-            }
-            result
-        })
+        self.counters.requests.fetch_add(1, Ordering::Relaxed);
+        self.inner.copy_to(path, output).await
     }
 
     async fn copy_to_file(&self, path: &Path, output_path: &Path) -> StorageResult<u64> {

--- a/quickwit/quickwit-storage/src/counting_storage.rs
+++ b/quickwit/quickwit-storage/src/counting_storage.rs
@@ -1,0 +1,229 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use quickwit_common::uri::Uri;
+use tantivy::directory::OwnedBytes;
+use tokio::io::AsyncRead;
+
+use crate::storage::SendableAsync;
+use crate::{BulkDeleteError, PutPayload, Storage, StorageResult};
+
+/// Per-request download counters tracked by [`CountingStorage`].
+///
+/// `bytes` accumulates the size of every successfully fulfilled read; `requests`
+/// counts each call to a read method. Counters are atomic so a single instance
+/// can be shared across the wrapper clones used internally by lower storage
+/// layers (`HotDirectory`, `BundleStorage`, etc.).
+#[derive(Debug, Default)]
+pub struct DownloadCounters {
+    bytes: AtomicU64,
+    requests: AtomicU64,
+}
+
+impl DownloadCounters {
+    /// Snapshots the current counters as `(bytes, requests)`.
+    pub fn snapshot(&self) -> (u64, u64) {
+        (
+            self.bytes.load(Ordering::Relaxed),
+            self.requests.load(Ordering::Relaxed),
+        )
+    }
+
+    fn record_read(&self, num_bytes: u64) {
+        self.bytes.fetch_add(num_bytes, Ordering::Relaxed);
+        self.requests.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Storage proxy that counts the bytes and number of read requests it serves.
+///
+/// Wrap a base `Storage` with this proxy at the entry point of a request to
+/// observe the per-request download volume. Cached layers (split cache, footer
+/// cache, hotcache, byte-range cache) live BELOW this wrapper, so reads served
+/// from cache do NOT contribute to the counters — that is the desired behavior
+/// for a "downloaded from object storage" measurement.
+///
+/// Write methods (`put`, `delete`, `bulk_delete`) and metadata methods
+/// (`exists`, `file_num_bytes`, `check_connectivity`) are passed through
+/// without counting; we only record reads that materialise data.
+#[derive(Debug)]
+pub struct CountingStorage {
+    inner: Arc<dyn Storage>,
+    counters: Arc<DownloadCounters>,
+}
+
+impl CountingStorage {
+    /// Wrap a storage object to count for download request and downloaded bytes.
+    pub fn instrument_storage(
+        inner: Arc<dyn Storage>,
+    ) -> (Arc<dyn Storage>, Arc<DownloadCounters>) {
+        let counters = Arc::new(DownloadCounters::default());
+        let instrumented_storage = Self {
+            inner,
+            counters: counters.clone(),
+        };
+        (Arc::new(instrumented_storage), counters)
+    }
+}
+
+#[async_trait]
+impl Storage for CountingStorage {
+    async fn check_connectivity(&self) -> anyhow::Result<()> {
+        self.inner.check_connectivity().await
+    }
+
+    async fn put(&self, path: &Path, payload: Box<dyn PutPayload>) -> StorageResult<()> {
+        self.inner.put(path, payload).await
+    }
+
+    fn copy_to<'life0, 'life1, 'life2, 'async_trait>(
+        &'life0 self,
+        path: &'life1 Path,
+        output: &'life2 mut dyn SendableAsync,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn ::core::future::Future<Output = StorageResult<()>>
+                + ::core::marker::Send
+                + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+        Self: 'async_trait,
+    {
+        // We do not know the final byte count without intercepting the writer,
+        // so we conservatively count the request only. `copy_to` is not on the
+        // hot path of leaf search (only `get_slice` is), so this approximation
+        // is acceptable.
+        let counters = self.counters.clone();
+        let inner_fut = self.inner.copy_to(path, output);
+        Box::pin(async move {
+            let result = inner_fut.await;
+            if result.is_ok() {
+                counters.requests.fetch_add(1, Ordering::Relaxed);
+            }
+            result
+        })
+    }
+
+    async fn copy_to_file(&self, path: &Path, output_path: &Path) -> StorageResult<u64> {
+        let num_bytes = self.inner.copy_to_file(path, output_path).await?;
+        self.counters.record_read(num_bytes);
+        Ok(num_bytes)
+    }
+
+    async fn get_slice(&self, path: &Path, range: Range<usize>) -> StorageResult<OwnedBytes> {
+        let bytes = self.inner.get_slice(path, range).await?;
+        self.counters.record_read(bytes.len() as u64);
+        Ok(bytes)
+    }
+
+    async fn get_slice_stream(
+        &self,
+        path: &Path,
+        range: Range<usize>,
+    ) -> StorageResult<Box<dyn AsyncRead + Send + Unpin>> {
+        // We approximate the bytes by the requested range length on success.
+        // The stream may yield fewer bytes if the caller drops it early, but
+        // that is rare and the over-count is bounded by the requested range.
+        let range_len = range.len() as u64;
+        let stream = self.inner.get_slice_stream(path, range).await?;
+        self.counters.record_read(range_len);
+        Ok(stream)
+    }
+
+    async fn get_all(&self, path: &Path) -> StorageResult<OwnedBytes> {
+        let bytes = self.inner.get_all(path).await?;
+        self.counters.record_read(bytes.len() as u64);
+        Ok(bytes)
+    }
+
+    async fn delete(&self, path: &Path) -> StorageResult<()> {
+        self.inner.delete(path).await
+    }
+
+    async fn bulk_delete<'a>(&self, paths: &[&'a Path]) -> Result<(), BulkDeleteError> {
+        self.inner.bulk_delete(paths).await
+    }
+
+    async fn exists(&self, path: &Path) -> StorageResult<bool> {
+        self.inner.exists(path).await
+    }
+
+    async fn file_num_bytes(&self, path: &Path) -> StorageResult<u64> {
+        self.inner.file_num_bytes(path).await
+    }
+
+    fn uri(&self) -> &Uri {
+        self.inner.uri()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RamStorageBuilder;
+
+    #[tokio::test]
+    async fn test_counting_storage_counts_get_slice() {
+        let inner = RamStorageBuilder::default()
+            .put("foo", b"hello world")
+            .build();
+        let (storage, counters) = CountingStorage::instrument_storage(Arc::new(inner));
+
+        let bytes = storage.get_slice(Path::new("foo"), 0..5).await.unwrap();
+        assert_eq!(bytes.as_slice(), b"hello");
+
+        let bytes = storage.get_slice(Path::new("foo"), 6..11).await.unwrap();
+        assert_eq!(bytes.as_slice(), b"world");
+
+        let (download_num_bytes, download_num_requests) = counters.snapshot();
+        assert_eq!(download_num_bytes, 10);
+        assert_eq!(download_num_requests, 2);
+    }
+
+    #[tokio::test]
+    async fn test_counting_storage_counts_get_all() {
+        let inner = RamStorageBuilder::default().put("foo", b"hello").build();
+        let (storage, counters) = CountingStorage::instrument_storage(Arc::new(inner));
+
+        let bytes = storage.get_all(Path::new("foo")).await.unwrap();
+        assert_eq!(bytes.as_slice(), b"hello");
+
+        let (download_num_bytes, download_num_requests) = counters.snapshot();
+        assert_eq!(download_num_bytes, 5);
+        assert_eq!(download_num_requests, 1);
+    }
+
+    #[tokio::test]
+    async fn test_counting_storage_does_not_count_metadata() {
+        let inner = RamStorageBuilder::default().put("foo", b"hello").build();
+        let (storage, counters) = CountingStorage::instrument_storage(Arc::new(inner));
+
+        assert!(storage.exists(Path::new("foo")).await.unwrap());
+        assert_eq!(storage.file_num_bytes(Path::new("foo")).await.unwrap(), 5);
+
+        let (download_num_bytes, download_num_requests) = counters.snapshot();
+        assert_eq!(download_num_bytes, 0);
+        assert_eq!(download_num_requests, 0);
+    }
+}

--- a/quickwit/quickwit-storage/src/lib.rs
+++ b/quickwit/quickwit-storage/src/lib.rs
@@ -26,6 +26,7 @@
 //!
 //! The `BundleStorage` bundles together multiple files into a single file.
 mod cache;
+mod counting_storage;
 mod debouncer;
 mod file_descriptor_cache;
 mod metrics;
@@ -66,6 +67,7 @@ pub use self::cache::MockStorageCache;
 pub use self::cache::{
     ByteRangeCache, MemorySizedCache, QuickwitCache, StorageCache, wrap_storage_with_cache,
 };
+pub use self::counting_storage::{CountingStorage, DownloadCounters};
 pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
 #[cfg(feature = "azure")]
 pub use self::object_storage::{AzureBlobStorage, AzureBlobStorageFactory};


### PR DESCRIPTION
### Description

Introduce a `resource_stats` payload on `LeafSearchResponse` and `SearchResponse` so callers can see how a query spent its budget across the split → leaf → root hierarchy.

#### Proto

Three new messages in `quickwit-proto/protos/quickwit/search.proto`:

- **`SplitResourceStats`** — per-split counters (`split_num_docs`, `matched_num_docs`), input working set (`input_memory_bytes`), storage download (`download_num_bytes`, `download_num_requests`), and per-phase microsecond timings (permit wait, warmup, cpu-pool wait, cpu search).
- **`LeafResourceStats`** — per-leaf counters: partial-result-cache hits, lambda dispatched / lambda-succeeded splits, the lambda-bottleneck signal, locally-executed splits; plus `split_resources_worst` (worst split by phase-sum), `split_resources_sum` (field-wise sum over local splits), and the leaf's `wall_time_microsecs`.
- **`RootResourceStats`** — per-search aggregates: `leaf_resources_worst`, `leaf_resources_sum` (field-wise sums of every leaf), leaf-call counts (excluding and including retries), and failed-split count.

#### Plumbing

- `CountingStorage` (new wrapper in `quickwit-storage`) records downloaded bytes / GET requests per request.
- `leaf_search_single_split` assembles `SplitResourceStats` from the counters and per-phase `Instant`s; it writes to either `localexec_*` or `lambda_success_*` depending on `quickwit_common::is_running_in_lambda` — a process-wide cached bool driven by the `AWS_LAMBDA_FUNCTION_NAME` env var the Lambda runtime sets.
- `run_offloaded_search_tasks` captures the lambda dispatch totals (`lambda_num_splits` / `lambda_num_docs`) and forwards them via a new `IncrementalCollector::add_lambda_totals`. Lambda failure counting stays in the client because transport-level failures cannot be observed by the lambda server.
- `LeafSearchCache::put` rewrites `resource_stats` to the cache-hit shape at write time, so cache reads need no per-read mutation.
- `multi_index_leaf_search` stamps `wall_time_microsecs` on the merged `LeafResourceStats`.
- `lambda_bottleneck` is determined inside `single_doc_mapping_leaf_search` via an `AtomicBool` race between the local and offload futures (last writer wins after `tokio::join!`).
- `ClusterClient::leaf_search` takes an `Arc<AtomicU64>` so the root can count leaf attempts including retries.
- `search_partial_hits_phase` now returns an `Option<RootResourceStats>` alongside the merged response; `compute_root_resource_stats` produces it from the per-leaf responses before they are merged. `root_search_aux` attaches it to `SearchResponse.resource_stats`.
- The gRPC `Scroll` handler surfaces `resource_stats` when a scroll page triggered an inner search (pure cache-hit pages stay `None`).
- `add_leaf_stats` is fully extensive: every numeric field is summed, including `wall_time_microsecs` and `lambda_bottleneck` (the latter becomes a count of leaves where lambda was the bottleneck once aggregated).

#### Lambda outcome metric

`LAMBDA_METRICS.leaf_search_requests_total` / `leaf_search_duration_seconds` now carry an `outcome` label whose value is `success`, `timeout` or `other`. Timeout is detected from SDK / EFS / SnapStart timeout errors.

### How was this PR tested?

- Unit tests on `add_split_stats`, `add_leaf_stats`, `compute_root_resource_stats`, and `CountingStorage`. The "sums every field" tests destructure on the proto types so a new field forces a compile error pointing at the test.
- End-to-end gRPC root test `test_root_search_populates_resource_stats` exercising the same free function the `RootSearch` handler invokes, with mocked metastore and leaf services.
- `cargo nextest run -p quickwit-search` passes locally.
- `cargo nextest run -p quickwit-storage --tests counting_storage` passes locally.
