### PR TITLE
docs(claude): note review-reply threading hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ See `quickwit/CLAUDE.md` for architecture overview, crate descriptions, and buil
 | Recreates futures in `select!` loops | Use `&mut fut` to resume, not recreate — dropping loses data | GAP-002 |
 | Holds locks across await points | Invariant violations on cancel. Use message passing or synchronous critical sections | GAP-002 |
 | Silently swallows unexpected state | If a condition "shouldn't happen," return an error or assert — don't silently return Ok. Skipping optional/missing data is fine; pretending a bug didn't occur is not | Code quality |
+| Replies to PR review comments as standalone inline comments | Use `gh api repos/.../pulls/{pr}/comments/{codex_comment_id}/replies` (or `in_reply_to_id` in the POST body) so the reply is **threaded under** the original review comment. Standalone inline comments at the same line are NOT replies; they show as separate threads. Verify with the GitHub API that `in_reply_to_id` is set on your reply. | Review hygiene |
 
 ## Engineering Priority
 


### PR DESCRIPTION
Adds one entry to the Known Pitfalls table in `CLAUDE.md`.

I'd been replying to Codex review comments by posting **new inline comments at the same line** rather than as **threaded replies under the original**. They look similar in some views but are NOT the same — the reply chain is broken, and the "Resolved conversations" view doesn't roll them up together.

Correct technique with `gh`:
```bash
gh api repos/{owner}/{repo}/pulls/{pr}/comments/{codex_comment_id}/replies --input reply.json
```
or pass `in_reply_to_id` in the POST body to `pulls/{pr}/comments`. Verify via the API that `in_reply_to_id` is set on the new comment.

## Test plan
- [x] Doc-only change, no code paths affected