### PR TITLE
refactor: box large oneof variants to drop clippy allows

### DIFF
--- a/quickwit/quickwit-lambda-server/src/handler.rs
+++ b/quickwit/quickwit-lambda-server/src/handler.rs
@@ -167,7 +167,7 @@ async fn lambda_leaf_search(
                 num_successes += 1;
                 split_results.push(LambdaSingleSplitResult {
                     split_id,
-                    outcome: Some(Outcome::Response(response)),
+                    outcome: Some(Outcome::Response(Box::new(response))),
                 });
             }
             Ok((split_id, Err(error_msg))) => {

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -204,7 +204,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut prost_config = prost_build::Config::default();
     prost_config
         .file_descriptor_set_path("src/codegen/quickwit/search_descriptor.bin")
-        .protoc_arg("--experimental_allow_proto3_optional");
+        .protoc_arg("--experimental_allow_proto3_optional")
+        // Box the large `LeafSearchResponse` variant so the oneof stays small
+        // (the `Error` variant only carries a `String`).
+        .boxed("LambdaSingleSplitResult.outcome.response");
 
     tonic_prost_build::configure()
         .enum_attribute(".", "#[serde(rename_all=\"snake_case\")]")
@@ -216,12 +219,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("SortByValue", "#[derive(Ord, PartialOrd)]")
         .type_attribute("SearchRequest", "#[derive(Hash, Eq)]")
         .type_attribute("PartialHit", "#[derive(Hash, Eq)]")
-        // The `Response` variant carries a `LeafSearchResponse` which now
-        // embeds `LeafResourceStats`.
-        .type_attribute(
-            "LambdaSingleSplitResult.outcome",
-            "#[allow(clippy::large_enum_variant)]",
-        )
         .out_dir("src/codegen/quickwit")
         .compile_with_config(
             prost_config,

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -610,13 +610,12 @@ pub struct LambdaSingleSplitResult {
 /// Nested message and enum types in `LambdaSingleSplitResult`.
 pub mod lambda_single_split_result {
     #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
-    #[allow(clippy::large_enum_variant)]
     #[serde(rename_all = "snake_case")]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Outcome {
         /// On success, the leaf search response for this split.
         #[prost(message, tag = "2")]
-        Response(super::LeafSearchResponse),
+        Response(::prost::alloc::boxed::Box<super::LeafSearchResponse>),
         /// On failure, the error message.
         #[prost(string, tag = "3")]
         Error(::prost::alloc::string::String),

--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -466,10 +466,9 @@ fn get_score_extractor(
     })
 }
 
-#[allow(clippy::large_enum_variant)]
 enum AggregationSegmentCollectors {
     FindTraceIdsSegmentCollector(Box<FindTraceIdsSegmentCollector>),
-    TantivyAggregationSegmentCollector(AggregationSegmentCollector),
+    TantivyAggregationSegmentCollector(Box<AggregationSegmentCollector>),
 }
 
 /// Quickwit collector working at the scale of the segment.
@@ -781,14 +780,14 @@ impl Collector for QuickwitCollector {
                 ))
             }
             Some(QuickwitAggregations::TantivyAggregations(aggs)) => Some(
-                AggregationSegmentCollectors::TantivyAggregationSegmentCollector(
+                AggregationSegmentCollectors::TantivyAggregationSegmentCollector(Box::new(
                     AggregationSegmentCollector::from_agg_req_and_reader(
                         aggs,
                         segment_reader,
                         segment_ord,
                         &self.agg_context_params,
                     )?,
-                ),
+                )),
             ),
             None => None,
         };

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -1533,6 +1533,7 @@ async fn run_offloaded_search_tasks(
                 for split_result in split_results {
                     match split_result.outcome {
                         Some(Outcome::Response(response)) => {
+                            let response = *response;
                             if let Some((split_info, single_split_search_req)) =
                                 split_lookup.remove(&split_result.split_id)
                             {


### PR DESCRIPTION
## Summary

- Replace `#[allow(clippy::large_enum_variant)]` on the generated `LambdaSingleSplitResult.outcome` oneof with `prost_build::Config::boxed("LambdaSingleSplitResult.outcome.response")`. The large `LeafSearchResponse` variant is now wrapped in `Box<T>` while the small `Error(String)` variant stays inline.
- Drop the `#[allow(clippy::large_enum_variant)]` on `AggregationSegmentCollectors` in `quickwit-search/src/collector.rs` by boxing the `TantivyAggregationSegmentCollector` variant for symmetry with the already-boxed `FindTraceIdsSegmentCollector`.
- Update call sites: `Box::new(response)` on the producer in `quickwit-lambda-server` and a deref `let response = *response;` on the consumer in `quickwit-search/src/leaf.rs`.

After this change there are no remaining `clippy::large_enum_variant` suppressions in the repo.

## Test plan

- [ ] `cargo build -p quickwit-proto -p quickwit-search -p quickwit-lambda-server` (done locally)
- [ ] `cargo clippy -p quickwit-search -p quickwit-proto -p quickwit-lambda-server --all-features --tests` passes with no warnings (done locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)