### PR TITLE
fix(cli): correct merge command description

### DIFF
--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -154,7 +154,7 @@ pub fn build_tool_command() -> Command {
         .subcommand(
             Command::new("merge")
                 .display_order(10)
-                .about("Merges all the splits for a given Node ID, index ID, source ID.")
+                .about("Runs available merge operations for a given index ID and source ID.")
                 .args(&[
                     arg!(--index <INDEX> "ID of the target index.")
                         .display_order(1)


### PR DESCRIPTION
The current description says the merge command 'Merges all the splits' which is misleading since it doesn't actually merge everything into a single split.

Looking at the implementation, the command spawns a merge pipeline that runs available merge operations according to the configured merge policy, then exits when there are no more ongoing merges.

Updated the description to reflect this behavior.

Closes #3805