### PR TITLE
chore(deps): bump tantivy to 46b3fb9 (main)

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -3531,8 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "datasketches"
-version = "0.2.0"
-source = "git+https://github.com/fulmicoton-dd/datasketches-rust?rev=7635fb8#7635fb86993b874bfca3ac4d294daa7b869d65d3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 
 [[package]]
 name = "dbl"
@@ -7103,7 +7104,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -11709,7 +11710,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -11748,7 +11749,7 @@ dependencies = [
  "tantivy-columnar",
  "tantivy-common",
  "tantivy-fst",
- "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b)",
+ "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9)",
  "tantivy-sstable",
  "tantivy-stacker",
  "tantivy-tokenizer-api",
@@ -11764,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "bitpacking",
 ]
@@ -11772,7 +11773,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -11787,7 +11788,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11823,7 +11824,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -11835,7 +11836,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -11848,7 +11849,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -11857,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=edfb02b#edfb02b47e4b061ab25d96e26792e84d3af78ef0"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=46b3fb9#46b3fb9ed394343db77aaf02e421272044818c0a"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -400,7 +400,7 @@ quickwit-search = { path = "quickwit-search" }
 quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "edfb02b", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "46b3fb9", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",


### PR DESCRIPTION
## Summary

- Bumps tantivy to the latest `main` rev (`46b3fb9`)
- Pulls in the fix for HLL4 aux-array compact flag compatibility between Rust and Java (datasketches-rust fix merged in tantivy)

## Test plan

- [ ] CI green