### PR TITLE
Exclude known split ids; double merge concurrency

### DIFF
--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -224,6 +224,7 @@ sea-query = { version = "0.32" }
 sea-query-binder = { version = "0.7", features = [
   "runtime-tokio-rustls",
   "sqlx-postgres",
+  "postgres-array",
 ] }
 # ^1.0.184 due to serde-rs/serde#2538
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/quickwit/quickwit-compaction/src/compaction_pipeline.rs
+++ b/quickwit/quickwit-compaction/src/compaction_pipeline.rs
@@ -26,11 +26,11 @@ use quickwit_indexing::actors::{
     MergeExecutor, MergeSplitDownloader, Packager, Publisher, Uploader, UploaderType,
 };
 use quickwit_indexing::merge_policy::MergeOperation;
-use quickwit_indexing::metrics::INDEXER_METRICS;
 use quickwit_indexing::{IndexingSplitStore, PublisherType, SplitsUpdateMailbox};
 use quickwit_proto::indexing::MergePipelineId;
 use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_proto::types::{IndexUid, SourceId, SplitId};
+use tokio::sync::Semaphore;
 use tracing::{error, info};
 
 use crate::metrics::COMPACTOR_METRICS;
@@ -105,6 +105,7 @@ pub struct CompactionPipeline {
     io_throughput_limiter: Option<Limiter>,
     max_concurrent_split_uploads: usize,
     event_broker: EventBroker,
+    merge_execution_semaphore: Arc<Semaphore>,
     pipeline_start: Option<Instant>,
 }
 
@@ -123,6 +124,7 @@ impl CompactionPipeline {
         io_throughput_limiter: Option<Limiter>,
         max_concurrent_split_uploads: usize,
         event_broker: EventBroker,
+        merge_execution_semaphore: Arc<Semaphore>,
     ) -> Self {
         CompactionPipeline {
             task_id,
@@ -140,6 +142,7 @@ impl CompactionPipeline {
             io_throughput_limiter,
             max_concurrent_split_uploads,
             event_broker,
+            merge_execution_semaphore,
             pipeline_start: None,
         }
     }
@@ -331,6 +334,7 @@ impl CompactionPipeline {
             self.doc_mapper.clone(),
             merge_executor_io_controls,
             merge_packager_mailbox,
+            Some(self.merge_execution_semaphore.clone()),
         );
         let (merge_executor_mailbox, merge_executor_handle) = spawn_ctx
             .spawn_builder()
@@ -386,6 +390,7 @@ pub(crate) mod tests {
     use quickwit_proto::metastore::{MetastoreServiceClient, MockMetastoreService};
     use quickwit_proto::types::{IndexUid, NodeId};
     use quickwit_storage::RamStorage;
+    use tokio::sync::Semaphore;
 
     use super::{CompactionPipeline, PipelineStatus};
 
@@ -416,6 +421,7 @@ pub(crate) mod tests {
             None,
             2,
             EventBroker::default(),
+            Arc::new(Semaphore::new(2)),
         )
     }
 

--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -35,6 +35,7 @@ use quickwit_proto::indexing::MergePipelineId;
 use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_proto::types::NodeId;
 use quickwit_storage::StorageResolver;
+use tokio::sync::Semaphore;
 use tracing::{error, info};
 
 use crate::compaction_pipeline::{CompactionPipeline, PipelineStatus, PipelineStatusUpdate};
@@ -54,7 +55,10 @@ pub struct CompactorSupervisor {
     node_id: NodeId,
     planner_client: CompactionPlannerServiceClient,
     pipelines: Vec<Option<CompactionPipeline>>,
-
+    // Bounds the number of pipelines running Tantivy merge step concurrently. There are 2x as many
+    // pipeline slots as permits, so half the pipelines can be doing IO while the other half hold a
+    // permit.
+    merge_execution_semaphore: Arc<Semaphore>,
     // Shared resources distributed to pipelines when spawning actor chains.
     io_throughput_limiter: Option<Limiter>,
     metastore: MetastoreServiceClient,
@@ -62,7 +66,6 @@ pub struct CompactorSupervisor {
     split_cache: Arc<IndexingSplitCache>,
     max_concurrent_split_uploads: usize,
     event_broker: EventBroker,
-
     // Scratch directory root (<data_dir>/compaction/).
     compaction_root_directory: TempDirectory,
 }
@@ -72,7 +75,7 @@ impl CompactorSupervisor {
     pub fn new(
         node_id: NodeId,
         planner_client: CompactionPlannerServiceClient,
-        num_pipeline_slots: usize,
+        max_concurrent_merge_executions: usize,
         io_throughput_limiter: Option<Limiter>,
         metastore: MetastoreServiceClient,
         storage_resolver: StorageResolver,
@@ -81,11 +84,14 @@ impl CompactorSupervisor {
         event_broker: EventBroker,
         compaction_root_directory: TempDirectory,
     ) -> Self {
+        let num_pipeline_slots = max_concurrent_merge_executions * 2;
         let pipelines = (0..num_pipeline_slots).map(|_| None).collect();
+        let merge_execution_semaphore = Arc::new(Semaphore::new(max_concurrent_merge_executions));
         CompactorSupervisor {
             node_id,
             planner_client,
             pipelines,
+            merge_execution_semaphore,
             io_throughput_limiter,
             metastore,
             storage_resolver,
@@ -124,8 +130,14 @@ impl CompactorSupervisor {
                 error!(%task_id, %error, "failed to spawn compaction task");
             }
         }
-        let available_slots = self.pipelines.iter().filter(|pipeline_opt| pipeline_opt.is_none()).count();
-        COMPACTOR_METRICS.available_slots.set(available_slots as i64);
+        let available_slots = self
+            .pipelines
+            .iter()
+            .filter(|pipeline_opt| pipeline_opt.is_none())
+            .count();
+        COMPACTOR_METRICS
+            .available_slots
+            .set(available_slots as i64);
     }
 
     async fn spawn_task(
@@ -211,6 +223,7 @@ impl CompactorSupervisor {
             self.io_throughput_limiter.clone(),
             self.max_concurrent_split_uploads,
             self.event_broker.clone(),
+            self.merge_execution_semaphore.clone(),
         ))
     }
 
@@ -324,14 +337,16 @@ mod tests {
     use super::*;
     use crate::compaction_pipeline::tests::test_pipeline;
 
-    fn test_supervisor(num_slots: usize) -> CompactorSupervisor {
+    /// Builds a test supervisor with `max_concurrent_merge_executions` permits
+    /// and `2 * max_concurrent_merge_executions` pipeline slots.
+    fn test_supervisor(max_concurrent_merge_executions: usize) -> CompactorSupervisor {
         let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
         let compaction_client =
             CompactionPlannerServiceClient::from_mock(MockCompactionPlannerService::new());
         CompactorSupervisor::new(
             NodeId::from("test-node"),
             compaction_client,
-            num_slots,
+            max_concurrent_merge_executions,
             None,
             metastore,
             StorageResolver::for_test(),
@@ -374,6 +389,7 @@ mod tests {
     #[tokio::test]
     async fn test_end_to_end_statuses_to_proto() {
         let universe = Universe::new();
+        // 3 merge-executions → 6 pipeline slots
         let mut supervisor = test_supervisor(3);
 
         let mut pipeline = test_pipeline("task-1", &["s1", "s2"]);
@@ -384,8 +400,8 @@ mod tests {
         let request = supervisor.build_report_status_request(&statuses);
 
         assert_eq!(request.node_id, "test-node");
-        // 3 slots, 1 in-progress = 2 available
-        assert_eq!(request.available_slots, 2);
+        // 6 slots, 1 in-progress = 5 available
+        assert_eq!(request.available_slots, 5);
         assert_eq!(request.in_progress.len(), 1);
         assert_eq!(request.in_progress[0].task_id, "task-1");
         assert_eq!(request.in_progress[0].split_ids, vec!["s1", "s2"]);
@@ -396,10 +412,11 @@ mod tests {
 
     #[test]
     fn test_build_report_status_request_empty() {
+        // 4 merge-executions → 8 pipeline slots
         let supervisor = test_supervisor(4);
         let request = supervisor.build_report_status_request(&[]);
         assert_eq!(request.node_id, "test-node");
-        assert_eq!(request.available_slots, 4);
+        assert_eq!(request.available_slots, 8);
         assert!(request.in_progress.is_empty());
         assert!(request.successes.is_empty());
         assert!(request.failures.is_empty());
@@ -499,7 +516,8 @@ mod tests {
     #[tokio::test]
     async fn test_spawn_task_fails_when_all_slots_occupied() {
         let universe = Universe::new();
-        let mut supervisor = test_supervisor(2);
+        // 1 merge-execution → 2 pipeline slots
+        let mut supervisor = test_supervisor(1);
 
         supervisor
             .spawn_task(test_assignment("task-1", &["s1"]), universe.spawn_ctx())
@@ -538,6 +556,7 @@ mod tests {
 
         let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
         let client = CompactionPlannerServiceClient::from_mock(mock);
+        // 3 merge-executions → 6 pipeline slots
         let mut supervisor = CompactorSupervisor::new(
             NodeId::from("test-node"),
             client,
@@ -554,7 +573,7 @@ mod tests {
         // Simulate what the handler does: collect statuses, report, process response.
         let statuses = supervisor.check_pipeline_statuses();
         let request = supervisor.build_report_status_request(&statuses);
-        assert_eq!(request.available_slots, 3);
+        assert_eq!(request.available_slots, 6);
 
         let response = supervisor
             .planner_client
@@ -571,13 +590,14 @@ mod tests {
         assert_eq!(request.in_progress.len(), 1);
         assert_eq!(request.in_progress[0].task_id, "planner-task-1");
         assert_eq!(request.in_progress[0].split_ids.len(), 2);
-        assert_eq!(request.available_slots, 2);
+        assert_eq!(request.available_slots, 5);
 
         universe.assert_quit().await;
     }
 
     #[test]
     fn test_build_report_status_request_mixed_statuses() {
+        // 4 merge-executions → 8 pipeline slots
         let supervisor = test_supervisor(4);
         let statuses = vec![
             PipelineStatusUpdate {
@@ -607,7 +627,8 @@ mod tests {
 
         let request = supervisor.build_report_status_request(&statuses);
 
-        assert_eq!(request.available_slots, 3);
+        // 8 slots, 1 in-progress = 7 available
+        assert_eq!(request.available_slots, 7);
         assert_eq!(request.in_progress.len(), 1);
         assert_eq!(request.in_progress[0].task_id, "task-1");
         assert_eq!(request.in_progress[0].split_ids, vec!["s1", "s2"]);

--- a/quickwit/quickwit-compaction/src/lib.rs
+++ b/quickwit/quickwit-compaction/src/lib.rs
@@ -57,7 +57,7 @@ pub async fn start_compactor_service(
     let supervisor = CompactorSupervisor::new(
         node_id,
         compaction_client,
-        compactor_config.max_concurrent_pipelines.get(),
+        compactor_config.max_concurrent_merge_executions.get(),
         io_throughput_limiter,
         metastore,
         storage_resolver,

--- a/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
@@ -37,10 +37,14 @@ use super::index_config_metastore::{IndexConfigMetastore, IndexEntry};
 use crate::planner::metrics::COMPACTION_PLANNER_METRICS;
 
 /// Cap on splits fetched per tick. Every tick, the planner re-scans the immature published set,
-/// sorted by `maturity_timestamp` ASC  so the most-urgent splits are processed first when a backlog
+/// sorted by `maturity_timestamp` ASC so the most-urgent splits are processed first when a backlog
 /// exists. Splits beyond this cap aren't lost -- they bubble into range as the front of the queue
 /// is merged off.
 const SCAN_PAGE_SIZE: usize = 5_000;
+
+/// Cap on the size of the `excluded_split_ids` list we send to the metastore.
+/// It's a sanity max rather than some invariant.
+const MAX_EXCLUDED_SPLIT_IDS: usize = 50_000;
 
 #[derive(Debug)]
 pub struct CompactionPlanner {
@@ -140,11 +144,13 @@ impl CompactionPlanner {
     }
 
     async fn scan_metastore(&self) -> Result<Vec<Split>> {
+        let excluded_split_ids = self.state.tracked_split_ids(MAX_EXCLUDED_SPLIT_IDS);
         let query = ListSplitsQuery::for_all_indexes()
             .with_split_state(SplitState::Published)
             .retain_immature(OffsetDateTime::now_utc())
             .sort_by_maturity_timestamp()
-            .with_limit(SCAN_PAGE_SIZE);
+            .with_limit(SCAN_PAGE_SIZE)
+            .with_excluded_split_ids(excluded_split_ids);
         let request = ListSplitsRequest::try_from_list_splits_query(&query)?;
         let splits = self
             .metastore
@@ -266,7 +272,7 @@ mod tests {
         IndexMetadata, IndexMetadataResponseExt, ListSplitsRequestExt, ListSplitsResponseExt,
         SortBy, Split, SplitMaturity, SplitMetadata, SplitState,
     };
-    use quickwit_proto::compaction::CompactionSuccess;
+    use quickwit_proto::compaction::{CompactionInProgress, CompactionSuccess};
     use quickwit_proto::metastore::{
         IndexMetadataResponse, ListSplitsResponse, MetastoreError, MockMetastoreService,
     };
@@ -347,6 +353,10 @@ mod tests {
             assert_eq!(query.update_timestamp.start, Bound::Unbounded);
             assert_eq!(query.update_timestamp.end, Bound::Unbounded);
 
+            // No tracked splits → empty exclude list. The non-empty case is
+            // covered by `test_scan_metastore_excludes_tracked_splits`.
+            assert!(query.excluded_split_ids.is_empty());
+
             let response = ListSplitsResponse::try_from_splits(returned_clone.clone()).unwrap();
             Ok(ServiceStream::from(vec![Ok(response)]))
         });
@@ -357,6 +367,43 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].split_metadata.split_id, "a");
         assert_eq!(result[1].split_metadata.split_id, "b");
+    }
+
+    #[tokio::test]
+    async fn test_scan_metastore_excludes_tracked_splits() {
+        let index_uid = IndexUid::for_test("test-index", 0);
+
+        let mut mock = MockMetastoreService::new();
+        mock.expect_list_splits().returning(move |req| {
+            let query = req.deserialize_list_splits_query().unwrap();
+            let mut excluded = query.excluded_split_ids.clone();
+            excluded.sort();
+            assert_eq!(
+                excluded,
+                vec!["in-flight".to_string(), "tracked".to_string()]
+            );
+
+            let response = ListSplitsResponse::try_from_splits(Vec::new()).unwrap();
+            Ok(ServiceStream::from(vec![Ok(response)]))
+        });
+
+        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        planner.state.track_split(SplitMetadata {
+            split_id: "tracked".to_string(),
+            index_uid: index_uid.clone(),
+            ..Default::default()
+        });
+        planner.state.update_heartbeats(
+            &NodeId::from("test-node"),
+            &[CompactionInProgress {
+                task_id: "t-1".to_string(),
+                index_uid: Some(index_uid.clone()),
+                source_id: "src".to_string(),
+                split_ids: vec!["in-flight".to_string()],
+            }],
+        );
+
+        planner.scan_metastore().await.unwrap();
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-compaction/src/planner/compaction_state.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_state.rs
@@ -85,6 +85,22 @@ impl CompactionState {
             || self.in_flight_split_ids.contains(split_id)
     }
 
+    /// All split IDs the planner is currently tracking. Used by the metastore
+    /// scan to exclude already-known splits so each tick returns fresh work.
+    pub fn tracked_split_ids(&self, max_size: usize) -> Vec<SplitId> {
+        let mut out = Vec::with_capacity(
+            (self.needs_compaction_split_ids.len() + self.in_flight_split_ids.len()).min(max_size),
+        );
+        out.extend(
+            self.needs_compaction_split_ids
+                .iter()
+                .chain(self.in_flight_split_ids.iter())
+                .take(max_size)
+                .cloned(),
+        );
+        out
+    }
+
     /// Adds a split to the needs_compaction set.
     pub fn track_split(&mut self, split: SplitMetadata) {
         let split_id = split.split_id().to_string();

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -230,9 +230,10 @@ impl Default for IndexerConfig {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CompactorConfig {
-    /// Maximum number of concurrent merge pipelines. Defaults to CPU count.
-    #[serde(default = "CompactorConfig::default_max_concurrent_pipelines")]
-    pub max_concurrent_pipelines: NonZeroUsize,
+    /// Maximum number of concurrent merges, which hold the CPU for
+    /// a long time. Defaults to `num_cpus - 1`.
+    #[serde(default = "CompactorConfig::default_max_concurrent_merge_executions")]
+    pub max_concurrent_merge_executions: NonZeroUsize,
     /// Maximum number of concurrent split uploads across all pipelines.
     #[serde(default = "CompactorConfig::default_max_concurrent_split_uploads")]
     pub max_concurrent_split_uploads: usize,
@@ -242,8 +243,9 @@ pub struct CompactorConfig {
 }
 
 impl CompactorConfig {
-    fn default_max_concurrent_pipelines() -> NonZeroUsize {
-        NonZeroUsize::new(quickwit_common::num_cpus()).unwrap_or(NonZeroUsize::MIN)
+    fn default_max_concurrent_merge_executions() -> NonZeroUsize {
+        let cpus = quickwit_common::num_cpus().saturating_sub(1);
+        NonZeroUsize::new(cpus).unwrap_or(NonZeroUsize::MIN)
     }
 
     fn default_max_concurrent_split_uploads() -> usize {
@@ -253,7 +255,7 @@ impl CompactorConfig {
     #[cfg(any(test, feature = "testsuite"))]
     pub fn for_test() -> Self {
         CompactorConfig {
-            max_concurrent_pipelines: NonZeroUsize::new(2).unwrap(),
+            max_concurrent_merge_executions: NonZeroUsize::new(2).unwrap(),
             max_concurrent_split_uploads: 4,
             max_merge_write_throughput: None,
         }
@@ -263,7 +265,7 @@ impl CompactorConfig {
 impl Default for CompactorConfig {
     fn default() -> Self {
         Self {
-            max_concurrent_pipelines: Self::default_max_concurrent_pipelines(),
+            max_concurrent_merge_executions: Self::default_max_concurrent_merge_executions(),
             max_concurrent_split_uploads: Self::default_max_concurrent_split_uploads(),
             max_merge_write_throughput: None,
         }

--- a/quickwit/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit/quickwit-indexing/failpoints/mod.rs
@@ -308,6 +308,7 @@ async fn test_merge_executor_controlled_directory_kill_switch() -> anyhow::Resul
         doc_mapper,
         io_controls,
         merge_packager_mailbox,
+        None,
     );
 
     let (merge_executor_mailbox, _merge_executor_handle) =

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -42,6 +42,7 @@ use tantivy::index::SegmentId;
 use tantivy::tokenizer::TokenizerManager;
 use tantivy::{DateTime, Directory, Index, IndexMeta, IndexWriter, SegmentReader};
 use tokio::runtime::Handle;
+use tokio::sync::Semaphore;
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::actors::Packager;
@@ -56,6 +57,9 @@ pub struct MergeExecutor {
     doc_mapper: Arc<DocMapper>,
     io_controls: IoControls,
     merge_packager_mailbox: Mailbox<Packager>,
+    /// Bounds concurrent Tantivy merges across pipelines on this node.
+    /// `None` in the legacy indexing-side merge pipeline.
+    merge_execution_semaphore: Option<Arc<Semaphore>>,
 }
 
 #[async_trait]
@@ -95,6 +99,16 @@ impl Handler<MergeScratch> for MergeExecutor {
             merge_scratch_directory,
             ..
         } = merge_scratch;
+        // On nodes running the split compaction architecture, merge pipelines are ephemeral, and we
+        // need to make sure there aren't too many CPU-bound operations occurring concurrently.
+        let _cpu_permit = match &self.merge_execution_semaphore {
+            Some(semaphore) => Some(
+                ctx.protect_future(semaphore.clone().acquire_owned())
+                    .await
+                    .expect("merge execution semaphore should never be closed"),
+            ),
+            None => None,
+        };
         let indexed_split_opt: Option<IndexedSplit> = match merge_operation.operation_type {
             MergeOperationType::Merge => {
                 let merge_res = self
@@ -311,6 +325,7 @@ impl MergeExecutor {
         doc_mapper: Arc<DocMapper>,
         io_controls: IoControls,
         merge_packager_mailbox: Mailbox<Packager>,
+        merge_execution_semaphore: Option<Arc<Semaphore>>,
     ) -> Self {
         MergeExecutor {
             pipeline_id,
@@ -318,6 +333,7 @@ impl MergeExecutor {
             doc_mapper,
             io_controls,
             merge_packager_mailbox,
+            merge_execution_semaphore,
         }
     }
 
@@ -669,6 +685,7 @@ mod tests {
             test_sandbox.doc_mapper(),
             IoControls::default(),
             merge_packager_mailbox,
+            None,
         );
         let (merge_executor_mailbox, merge_executor_handle) = test_sandbox
             .universe()
@@ -814,6 +831,7 @@ mod tests {
             test_sandbox.doc_mapper(),
             IoControls::default(),
             merge_packager_mailbox,
+            None,
         );
         let (delete_task_executor_mailbox, delete_task_executor_handle) =
             universe.spawn_builder().spawn(delete_task_executor);

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -318,6 +318,7 @@ impl MergePipeline {
             self.params.doc_mapper.clone(),
             merge_executor_io_controls,
             merge_packager_mailbox,
+            None,
         );
         let (merge_executor_mailbox, merge_executor_handle) = ctx
             .spawn_actor()

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -206,6 +206,7 @@ impl DeleteTaskPipeline {
             doc_mapper.clone(),
             delete_executor_io_controls,
             packager_mailbox,
+            None,
         );
         let (delete_executor_mailbox, task_executor_supervisor_handler) =
             ctx.spawn_actor().supervise(delete_executor);

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -1071,6 +1071,14 @@ fn split_query_predicate(split: &&Split, query: &ListSplitsQuery) -> bool {
         }
     }
 
+    if query
+        .excluded_split_ids
+        .iter()
+        .any(|excluded| excluded == &split.split_metadata.split_id)
+    {
+        return false;
+    }
+
     true
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -872,6 +872,10 @@ pub struct ListSplitsQuery {
 
     /// Only return splits whose (index_uid, split_id) are lexicographically after this split
     pub after_split: Option<(IndexUid, SplitId)>,
+
+    /// Exclude any split whose `split_id` appears in this list. Empty means no
+    /// exclusion.
+    pub excluded_split_ids: Vec<SplitId>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -948,6 +952,7 @@ impl ListSplitsQuery {
             mature: Bound::Unbounded,
             sort_by: SortBy::None,
             after_split: None,
+            excluded_split_ids: Vec::new(),
         }
     }
 
@@ -972,6 +977,7 @@ impl ListSplitsQuery {
             mature: Bound::Unbounded,
             sort_by: SortBy::None,
             after_split: None,
+            excluded_split_ids: Vec::new(),
         })
     }
 
@@ -992,6 +998,7 @@ impl ListSplitsQuery {
             mature: Bound::Unbounded,
             sort_by: SortBy::None,
             after_split: None,
+            excluded_split_ids: Vec::new(),
         }
     }
 
@@ -1185,6 +1192,13 @@ impl ListSplitsQuery {
     /// This is only useful if results are sorted by index_uid and split_id.
     pub fn after_split(mut self, split_meta: &SplitMetadata) -> Self {
         self.after_split = Some((split_meta.index_uid.clone(), split_meta.split_id.clone()));
+        self
+    }
+
+    /// Excludes splits whose `split_id` is in the provided list. Used by the
+    /// compaction planner to skip splits it is already tracking locally.
+    pub fn with_excluded_split_ids(mut self, excluded_split_ids: Vec<SplitId>) -> Self {
+        self.excluded_split_ids = excluded_split_ids;
         self
     }
 }

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -868,7 +868,7 @@ impl MetastoreService for PostgresqlMetastore {
         let list_splits_query = request.deserialize_list_splits_query()?;
         let mut sql_query_builder = Query::select();
         sql_query_builder.column(Asterisk).from(Splits::Table);
-        append_query_filters_and_order_by(&mut sql_query_builder, &list_splits_query);
+        append_query_filters_and_order_by(&mut sql_query_builder, list_splits_query);
 
         let (sql_query, values) = sql_query_builder.build_sqlx(PostgresQueryBuilder);
         let pg_split_stream = SplitStream::new(
@@ -2683,7 +2683,7 @@ mod tests {
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let query =
             ListSplitsQuery::for_index(index_uid.clone()).with_split_state(SplitState::Staged);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2697,7 +2697,7 @@ mod tests {
 
         let query =
             ListSplitsQuery::for_index(index_uid.clone()).with_split_state(SplitState::Published);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2711,7 +2711,7 @@ mod tests {
 
         let query = ListSplitsQuery::for_index(index_uid.clone())
             .with_split_states([SplitState::Published, SplitState::MarkedForDeletion]);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2723,7 +2723,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_index(index_uid.clone()).with_update_timestamp_lt(51);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2735,7 +2735,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_index(index_uid.clone()).with_create_timestamp_lte(55);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2749,7 +2749,7 @@ mod tests {
         let maturity_evaluation_datetime = OffsetDateTime::from_unix_timestamp(55).unwrap();
         let query = ListSplitsQuery::for_index(index_uid.clone())
             .retain_mature(maturity_evaluation_datetime);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2763,7 +2763,7 @@ mod tests {
 
         let query = ListSplitsQuery::for_index(index_uid.clone())
             .retain_immature(maturity_evaluation_datetime);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2775,7 +2775,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_index(index_uid.clone()).with_delete_opstamp_gte(4);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2787,7 +2787,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_index(index_uid.clone()).with_time_range_start_gt(45);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2799,7 +2799,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_index(index_uid.clone()).with_time_range_end_lt(45);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2815,7 +2815,7 @@ mod tests {
                 is_present: false,
                 tag: "tag-2".to_string(),
             });
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2828,7 +2828,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_index(index_uid.clone()).with_offset(4);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2841,7 +2841,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_index(index_uid.clone()).sort_by_index_uid();
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2859,7 +2859,7 @@ mod tests {
                 split_id: "my_split".to_string(),
                 ..Default::default()
             });
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2872,7 +2872,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_all_indexes().with_split_state(SplitState::Staged);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2883,7 +2883,7 @@ mod tests {
         let sql = select_statement.column(Asterisk).from(Splits::Table);
 
         let query = ListSplitsQuery::for_all_indexes().with_max_time_range_end(42);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
 
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
@@ -2900,7 +2900,8 @@ mod tests {
         let query = ListSplitsQuery::for_index(index_uid.clone())
             .with_time_range_start_gt(0)
             .with_time_range_end_lt(40);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
+
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2914,7 +2915,7 @@ mod tests {
         let query = ListSplitsQuery::for_index(index_uid.clone())
             .with_time_range_start_gt(45)
             .with_delete_opstamp_gt(0);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2928,7 +2929,7 @@ mod tests {
         let query = ListSplitsQuery::for_index(index_uid.clone())
             .with_update_timestamp_lt(51)
             .with_create_timestamp_lte(63);
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2945,7 +2946,7 @@ mod tests {
                 is_present: true,
                 tag: "tag-1".to_string(),
             });
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
@@ -2960,12 +2961,26 @@ mod tests {
         let query =
             ListSplitsQuery::try_from_index_uids(vec![index_uid.clone(), index_uid_2.clone()])
                 .unwrap();
-        append_query_filters_and_order_by(sql, &query);
+        append_query_filters_and_order_by(sql, query);
         assert_eq!(
             sql.to_string(PostgresQueryBuilder),
             format!(
                 r#"SELECT * FROM "splits" WHERE "index_uid" IN ('{index_uid}', '{index_uid_2}')"#
             )
+        );
+    }
+
+    #[test]
+    fn test_list_splits_query_excluded_split_ids() {
+        let mut select_statement = Query::select();
+        let sql = select_statement.column(Asterisk).from(Splits::Table);
+
+        let query = ListSplitsQuery::for_all_indexes()
+            .with_excluded_split_ids(vec!["s1".to_string(), "s2".to_string()]);
+        append_query_filters_and_order_by(sql, query);
+        assert_eq!(
+            sql.to_string(PostgresQueryBuilder),
+            r#"SELECT * FROM "splits" WHERE split_id <> ALL(ARRAY ['s1','s2']::text[])"#
         );
     }
 

--- a/quickwit/quickwit-metastore/src/metastore/postgres/utils.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/utils.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use quickwit_common::uri::Uri;
 use quickwit_proto::metastore::{MetastoreError, MetastoreResult};
-use sea_query::{Expr, Func, Order, SelectStatement, any};
+use sea_query::{ArrayType, Expr, Func, Order, SelectStatement, Value, any};
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::{ConnectOptions, Postgres};
 use tracing::error;
@@ -96,10 +96,7 @@ pub(super) fn append_range_filters<V: Display>(
     };
 }
 
-pub(super) fn append_query_filters_and_order_by(
-    sql: &mut SelectStatement,
-    query: &ListSplitsQuery,
-) {
+pub(super) fn append_query_filters_and_order_by(sql: &mut SelectStatement, query: ListSplitsQuery) {
     if let Some(index_uids) = &query.index_uids {
         // Note: `ListSplitsQuery` builder enforces a non empty `index_uids` list.
         // TODO we should explore IN VALUES, = ANY and similar constructs in case they perform
@@ -200,6 +197,23 @@ pub(super) fn append_query_filters_and_order_by(
             ])
             .gt(Expr::tuple([Expr::value(index_uid), Expr::value(split_id)])),
         );
+    }
+
+    if !query.excluded_split_ids.is_empty() {
+        // One bind regardless of list length: avoids postgres' 65535 param
+        // ceiling and keeps parse-time O(1) in the exclude size. The `$1` is
+        // postgres' placeholder; sea-query substitutes it with the next bind
+        // slot at build time.
+        let excluded_values: Vec<Value> = query
+            .excluded_split_ids
+            .into_iter()
+            .map(|split_id| Value::String(Some(Box::new(split_id))))
+            .collect();
+        let excluded_array = Value::Array(ArrayType::String, Some(Box::new(excluded_values)));
+        sql.cond_where(Expr::cust_with_values(
+            "split_id <> ALL($1::text[])",
+            [excluded_array],
+        ));
     }
 
     match query.sort_by {

--- a/quickwit/quickwit-storage/src/object_storage/policy.rs
+++ b/quickwit/quickwit-storage/src/object_storage/policy.rs
@@ -67,10 +67,10 @@ impl MultiPartPolicy {
 impl Default for MultiPartPolicy {
     fn default() -> Self {
         MultiPartPolicy {
-            /// We want to balance time spent waiting on uploads while still being careful about
-            /// not hammering S3 Puts, which can be expensive.
-            /// TODO: Dynamic multipart policy.
-            target_part_num_bytes: 512 * 1_024 * 1_024, // 5GB
+            // We want to balance time spent waiting on uploads while still being careful about
+            // not hammering S3 Puts, which can be expensive.
+            // TODO: Dynamic multipart policy.
+            target_part_num_bytes: 512 * 1_024 * 1_024, // 512mib
             multipart_threshold_num_bytes: 128 * 1_024 * 1_024, // 128 MiB
             max_num_parts: 10_000,
             max_object_num_bytes: 5_000_000_000_000u64, // S3 allows up to 5TB objects


### PR DESCRIPTION
### Description

Better utilize resources - semaphore for merge executions, everything else is IO. It allows us to run interleave pipelines better and get more net merges out with less resources. Will make this configurable in a future PR.

Also added the list of tracked splits to exclude from the metastore scan. This is necessary because before, we'd always fetch the 5000 oldest splits that are not yet mature. At a certain point we end up retrieving all of the splits that make up pending L3+ merges, and since those are already tracked, it's keeping us from scanning newer splits that are better candidates to be merged.

### How was this PR tested?

Describe how you tested this PR.
