### PR TITLE
Add UnicodeSegmenter tokenizer

### DIFF
--- a/.claude/skills/simple-pr/SKILL.md
+++ b/.claude/skills/simple-pr/SKILL.md
@@ -42,19 +42,42 @@ Create a short, descriptive branch name based on the changes (e.g., `fix-typo-in
 
 Create and checkout the branch: `git checkout -b {username}/{short-descriptive-name}`
 
-## Step 6: Commit changes
+## Step 6: Run pre-PR checks
 
-Commit with the message from step 3:
+Before committing, run these checks and fix any failures:
+
+```bash
+# License headers (every .rs, .proto, .py file needs the Apache 2.0 header)
+bash scripts/check_license_headers.sh
+
+# Clippy (must pass with no warnings)
+cargo clippy --workspace --all-features --tests
+
+# Format check
+cargo +nightly fmt --all -- --check
+```
+
+Fix any issues found before proceeding. For license headers, the correct header for `.rs` files is:
+```
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// ...
+```
+
+## Step 7: Commit changes
+
+Commit with the message from step 4:
 ```
 git commit -m "{commit-message}"
 ```
 
-## Step 7: Push and open a PR
+## Step 8: Push and open a PR
 
 Push the branch and open a PR:
 ```
 git push -u origin {branch-name}
-gh pr create --title "{commit-message-title}" --body "{longer-description-if-needed}"
+gh pr create --draft --title "{commit-message-title}" --body "{longer-description-if-needed}"
 ```
 
 Report the PR URL to the user when complete.

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -9225,6 +9225,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tracing",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -324,6 +324,7 @@ username = "0.2"
 # 1. The `OpenApi` struct structure changed (fields are private), breaking our manual merging logic in openapi.rs
 # in `quickwit-serve`. This code is fundamentally incompatible with version 5.x.
 utoipa = { version = "4.2", features = ["time", "ulid"] }
+unicode-segmentation = "1.12"
 uuid = { version = "1.23", features = ["v4", "serde"] }
 vrl = { version = "0.32", default-features = false, features = [
   "compiler",

--- a/quickwit/quickwit-query/Cargo.toml
+++ b/quickwit/quickwit-query/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 tantivy = { workspace = true }
+unicode-segmentation = { workspace = true }
 tantivy-fst = { workspace = true }
 tracing = { workspace = true }
 time = { workspace = true }

--- a/quickwit/quickwit-query/src/tokenizers/mod.rs
+++ b/quickwit/quickwit-query/src/tokenizers/mod.rs
@@ -15,6 +15,7 @@
 mod chinese_compatible;
 mod code_tokenizer;
 mod tokenizer_manager;
+mod unicode_segmenter_tokenizer;
 
 use std::sync::LazyLock;
 
@@ -26,6 +27,7 @@ use tantivy::tokenizer::{
 use self::chinese_compatible::ChineseTokenizer;
 pub use self::code_tokenizer::CodeTokenizer;
 pub use self::tokenizer_manager::{RAW_TOKENIZER_NAME, TokenizerManager};
+pub use self::unicode_segmenter_tokenizer::UnicodeSegmenterTokenizer;
 
 pub const DEFAULT_REMOVE_TOKEN_LENGTH: usize = 255;
 
@@ -80,6 +82,16 @@ pub fn create_default_quickwit_tokenizer_manager() -> TokenizerManager {
             .build(),
         true,
     );
+    let unicode_segmenter_tokenizer = TextAnalyzer::builder(UnicodeSegmenterTokenizer)
+        .filter(LowerCaser)
+        .filter(RemoveLongFilter::limit(DEFAULT_REMOVE_TOKEN_LENGTH))
+        .build();
+    tokenizer_manager.register(
+        "unicode_segmenter",
+        unicode_segmenter_tokenizer.clone(),
+        true,
+    );
+    tokenizer_manager.register("datadog", unicode_segmenter_tokenizer, true);
     tokenizer_manager
 }
 

--- a/quickwit/quickwit-query/src/tokenizers/unicode_segmenter_tokenizer.rs
+++ b/quickwit/quickwit-query/src/tokenizers/unicode_segmenter_tokenizer.rs
@@ -1,0 +1,106 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Tokenizer based on Unicode word boundaries (Unicode Standard Annex #29).
+///
+/// Splits text into tokens at Unicode word boundaries, preserving words that
+/// contain punctuation internally (e.g. "can't", "32.3"). This makes it
+/// well-suited for log messages and natural language text with mixed content.
+#[derive(Clone, Default)]
+pub struct UnicodeSegmenterTokenizer;
+
+pub struct UnicodeSegmenterTokenStream<'a> {
+    iter: unicode_segmentation::UnicodeWordIndices<'a>,
+    token: Token,
+    position: usize,
+}
+
+impl<'a> TokenStream for UnicodeSegmenterTokenStream<'a> {
+    fn advance(&mut self) -> bool {
+        if let Some((start, word)) = self.iter.next() {
+            let pos = self.position;
+            let end = start + word.len();
+            let token = self.token_mut();
+            token.text.clear();
+            token.text.push_str(word);
+            token.offset_from = start;
+            token.offset_to = end;
+            token.position = pos;
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn token(&self) -> &Token {
+        &self.token
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        &mut self.token
+    }
+}
+
+impl Tokenizer for UnicodeSegmenterTokenizer {
+    type TokenStream<'a> = UnicodeSegmenterTokenStream<'a>;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        UnicodeSegmenterTokenStream {
+            iter: text.unicode_word_indices(),
+            token: Token::default(),
+            position: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unicode_segmenter_tokenizer() {
+        let text = r#"The quick ("brown") fox can't jump 32.3 feet, right?"#;
+        let mut tokenizer = UnicodeSegmenterTokenizer;
+        let mut stream = tokenizer.token_stream(text);
+
+        let mut tokens = Vec::new();
+        while stream.advance() {
+            let token = stream.token().clone();
+            tokens.push((token.offset_from, token.offset_to, token.text));
+        }
+
+        let expected = vec![
+            (0, 3, "The"),
+            (4, 9, "quick"),
+            (12, 17, "brown"),
+            (20, 23, "fox"),
+            (24, 29, "can't"),
+            (30, 34, "jump"),
+            (35, 39, "32.3"),
+            (40, 44, "feet"),
+            (46, 51, "right"),
+        ];
+        assert_eq!(
+            tokens,
+            expected
+                .into_iter()
+                .map(|(start, end, word)| (start, end, word.to_string()))
+                .collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
The hidden goal of this is to unify the lambda binary for quickwit and Datadog BYOC logs.

## Summary

- Add `UnicodeSegmenterTokenizer` based on Unicode word boundaries (UAX #29), using the `unicode-segmentation` crate.
- Registered as both `unicode_segmenter` and `datadog` tokenizers in the default tokenizer manager.

## Test plan

- [ ] `cargo nextest run -p quickwit-query` — unit tests for the new tokenizer
- [ ] `cargo clippy --workspace --all-features --tests`