### PR TITLE
Update lambda artifact to def4e26e9

### DIFF
--- a/quickwit/quickwit-lambda-client/build.rs
+++ b/quickwit/quickwit-lambda-client/build.rs
@@ -27,11 +27,11 @@ use sha2::{Digest, Sha256};
 
 /// URL to download the pre-built Lambda zip from GitHub releases.
 /// This should be updated when a new Lambda binary is released.
-const LAMBDA_ZIP_URL: &str = "https://github.com/quickwit-oss/quickwit/releases/download/lambda-11587c00/quickwit-aws-lambda--aarch64.zip";
+const LAMBDA_ZIP_URL: &str = "https://github.com/quickwit-oss/quickwit/releases/download/def4e26e9/quickwit-aws-lambda-def4e26e9-aarch64.zip";
 
 /// Expected SHA256 hash of the Lambda zip artifact.
 /// Must be updated alongside LAMBDA_ZIP_URL when a new Lambda binary is released.
-const LAMBDA_ZIP_SHA256: &str = "c8159220962bf5b6c1f5d485b44b8e548f668ab4ffe5f93accd0279bbd619ad6";
+const LAMBDA_ZIP_SHA256: &str = "c6c7c6cb92ef9629b27b8697eb59f6e4259822771d00a3b727ca88c048a724de";
 
 /// AWS Lambda direct upload limit is 50MB.
 /// Larger artifacts must be uploaded via S3.


### PR DESCRIPTION
Updates \`quickwit-lambda-client/build.rs\` to point to the new lambda artifact
built from commit def4e26e9.

- Release: https://github.com/quickwit-oss/quickwit/releases/tag/def4e26e9