### PR TITLE
Add update-lambda skill and fix lambda- release tag prefix

### DIFF
--- a/.claude/skills/update-lambda/SKILL.md
+++ b/.claude/skills/update-lambda/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: update-lambda
+description: Trigger a new lambda release, update build.rs with the new artifact URL and SHA256, and open a PR
+disable-model-invocation: true
+---
+
+# Update Lambda Artifact
+
+This skill triggers the `Release Lambda binary` GitHub Actions workflow by pushing a
+`lambda-<commit>` tag, waits for the artifact to be published, then updates
+`quickwit-lambda-client/build.rs` with the new URL and SHA256 hash, and opens a PR.
+
+## Step 1: Verify we are on main
+
+Run: `git branch --show-current`
+
+If not on `main`, abort and ask the user to switch branches first.
+
+## Step 2: Pull latest main
+
+Run: `git pull origin main`
+
+This ensures the lambda tag points to the latest code.
+
+## Step 3: Get the commit short hash
+
+Run: `git rev-parse --short HEAD`
+
+Save this as `COMMIT_HASH` (e.g. `dd6442e`). The tag that will be pushed is
+`lambda-{COMMIT_HASH}`.
+
+## Step 4: Check the tag does not already exist
+
+Run:
+```bash
+git tag --list "lambda-{COMMIT_HASH}"
+```
+
+If the tag already exists locally or on the remote, skip straight to Step 6 to check
+whether the corresponding release already exists. Do not push a duplicate tag.
+
+## Step 5: Push the tag to trigger the workflow
+
+```bash
+git tag lambda-{COMMIT_HASH}
+git push origin lambda-{COMMIT_HASH}
+```
+
+This triggers the `Release Lambda binary` GitHub Actions workflow
+(`.github/workflows/publish_lambda.yaml`).
+
+After pushing, wait ~10 seconds for GitHub to register the workflow run before polling.
+
+## Step 6: Wait for the workflow run to complete
+
+Poll the workflow runs until the one for this tag completes:
+
+```bash
+gh run list --repo quickwit-oss/quickwit \
+  --workflow=publish_lambda.yaml \
+  --limit 10 \
+  --json headBranch,status,conclusion,databaseId,url
+```
+
+Look for the run where `headBranch` equals `lambda-{COMMIT_HASH}`.
+
+- If `status` is `completed` and `conclusion` is `success`: proceed to Step 7.
+- If `status` is `completed` and `conclusion` is not `success`: abort and report
+  the failure URL to the user.
+- If no matching run is found or `status` is still in-progress: wait 30 seconds and
+  retry. The build typically takes 15–20 minutes.
+
+## Step 7: Fetch the draft release asset info
+
+Once the workflow succeeds:
+
+```bash
+gh release view lambda-{COMMIT_HASH} \
+  --repo quickwit-oss/quickwit \
+  --json assets,isDraft
+```
+
+From the first element of `assets`, extract:
+- `url`: the download URL
+- `digest`: the SHA256 in `sha256:<hex>` format — strip the `sha256:` prefix to get
+  the bare hex string.
+
+Abort if the release has no assets or is not found.
+
+## Step 8: Publish the draft release
+
+The release is created as a draft by the workflow. Make it publicly accessible so
+`build.rs` can download the artifact:
+
+```bash
+gh release edit lambda-{COMMIT_HASH} \
+  --repo quickwit-oss/quickwit \
+  --draft=false
+```
+
+## Step 9: Update build.rs
+
+Edit `quickwit/quickwit-lambda-client/build.rs` and update the two constants:
+
+```rust
+const LAMBDA_ZIP_URL: &str = "<new URL from Step 7>";
+const LAMBDA_ZIP_SHA256: &str = "<bare SHA256 hex from Step 7>";
+```
+
+These are the only two lines that should change.
+
+## Step 10: Create a working branch
+
+Get the git username: `git config user.name | tr ' ' '-' | tr '[:upper:]' '[:lower:]'`
+
+Create and checkout a new branch:
+```
+git checkout -b {username}/update-lambda-{COMMIT_HASH}
+```
+
+## Step 11: Commit the changes
+
+Stage the modified file and commit:
+```bash
+git add quickwit/quickwit-lambda-client/build.rs
+git commit -m "Update lambda artifact to {COMMIT_HASH}"
+```
+
+## Step 12: Push and open a PR
+
+```bash
+git push origin {username}/update-lambda-{COMMIT_HASH}
+
+gh pr create \
+  --repo quickwit-oss/quickwit \
+  --title "Update lambda artifact to {COMMIT_HASH}" \
+  --body "$(cat <<'EOF'
+Updates `quickwit-lambda-client/build.rs` to point to the new lambda artifact
+built from commit {COMMIT_HASH}.
+
+- Release: https://github.com/quickwit-oss/quickwit/releases/tag/lambda-{COMMIT_HASH}
+EOF
+)"
+```
+
+Report the PR URL to the user.

--- a/.github/workflows/publish_lambda.yaml
+++ b/.github/workflows/publish_lambda.yaml
@@ -75,4 +75,4 @@ jobs:
           file: quickwit-aws-lambda-${{ env.ASSET_VERSION }}-aarch64.zip
           overwrite: true
           draft: true
-          tag_name: ${{ env.ASSET_VERSION }}
+          tag_name: lambda-${{ env.ASSET_VERSION }}

--- a/quickwit/quickwit-lambda-client/README.md
+++ b/quickwit/quickwit-lambda-client/README.md
@@ -11,39 +11,66 @@ allowing Quickwit to auto-deploy the function at startup.
 
 ## Release Process
 
-### 1. Tag the release
+### Automated (recommended)
+
+Use the `/update-lambda` Claude Code skill from the repo root:
+
+```
+/update-lambda
+```
+
+This skill automates the full process end-to-end:
+1. Creates and pushes a `lambda-<commit>` tag, triggering the `publish_lambda.yaml` workflow
+2. Polls until the cross-compilation build completes (~15–20 min)
+3. Publishes the draft GitHub release
+4. Updates `LAMBDA_ZIP_URL` and `LAMBDA_ZIP_SHA256` in `build.rs`
+5. Opens a PR with the artifact bump
+
+### Manual fallback
+
+**1. Tag the release**
 
 Push a tag with the `lambda-` prefix:
 
 ```bash
-git tag lambda-v0.8.0
-git push origin lambda-v0.8.0
+git tag lambda-<commit>
+git push origin lambda-<commit>
 ```
 
 This triggers the `publish_lambda.yaml` GitHub Action which:
 - Cross-compiles the Lambda binary for ARM64
-- Creates a zip file named `quickwit-aws-lambda-v0.8.0-aarch64.zip`
-- Uploads it as a **draft** GitHub release
+- Creates a zip named `quickwit-aws-lambda-<commit>-aarch64.zip`
+- Uploads it as a **draft** GitHub release tagged `lambda-<commit>`
 
-### 2. Publish the release
+**2. Publish the release**
 
-Go to GitHub releases and manually publish the draft release to make the
-artifact URL publicly accessible.
+Make the artifact URL publicly accessible:
 
-### 3. Update the embedded Lambda URL
-
-Update `LAMBDA_ZIP_URL` in `quickwit-lambda-client/build.rs` to point to the
-new release:
-
-```rust
-const LAMBDA_ZIP_URL: &str = "https://github.com/quickwit-oss/quickwit/releases/download/lambda-v0.8.0/quickwit-aws-lambda-v0.8.0-aarch64.zip";
+```bash
+gh release edit lambda-<commit> --repo quickwit-oss/quickwit --draft=false
 ```
 
-### 4. Versioning
+**3. Update the embedded Lambda URL**
+
+Get the SHA256 from the release metadata (no download needed):
+
+```bash
+gh release view lambda-<commit> --repo quickwit-oss/quickwit \
+  --json assets --jq '.assets[0] | {url, digest}'
+```
+
+Update both constants in `quickwit-lambda-client/build.rs`:
+
+```rust
+const LAMBDA_ZIP_URL: &str = "https://github.com/quickwit-oss/quickwit/releases/download/lambda-<commit>/quickwit-aws-lambda-<commit>-aarch64.zip";
+const LAMBDA_ZIP_SHA256: &str = "<hex from digest field, strip sha256: prefix>";
+```
+
+### Versioning
 
 The Lambda client uses content-based versioning:
-- An MD5 hash of the Lambda zip is computed at build time
-- This hash is embedded in the Lambda function description as `quickwit:{version}-{hash_short}`
+- The SHA256 of the Lambda zip is computed at build time
+- The first 8 hex chars are embedded in the Lambda function description as `quickwit:{version}-{hash_short}`
 - When Quickwit starts, it checks if a matching version exists before deploying
 
 This ensures that:


### PR DESCRIPTION
## Summary

- **`publish_lambda.yaml`**: fixes the GitHub release tag to keep the `lambda-` prefix (`tag_name: lambda-${{ env.ASSET_VERSION }}`). Without this, automated runs produce releases named `<hash>` instead of `lambda-<hash>`.
- **`.claude/skills/update-lambda/SKILL.md`**: new Claude Code skill (`/update-lambda`) that automates the full lambda release process end-to-end: push tag → wait for CI → publish release → update `build.rs` → open PR.
- **`quickwit-lambda-client/README.md`**: documents both the automated (`/update-lambda`) and manual release paths.