### PR TITLE
fix(lambda): treat empty LAMBDA_ZIP_PATH as unset in build script

### DIFF
--- a/quickwit/quickwit-lambda-client/build.rs
+++ b/quickwit/quickwit-lambda-client/build.rs
@@ -44,12 +44,17 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     let zip_dest = out_dir.join("lambda_bootstrap.zip");
 
-    let sha256 = if let Ok(local_path) = env::var("LAMBDA_ZIP_PATH") {
-        // CI mode: a pre-built zip is provided via env; skip the remote download.
-        use_local_lambda_zip(Path::new(&local_path), &zip_dest)
-    } else {
-        fetch_lambda_zip(&zip_dest);
-        LAMBDA_ZIP_SHA256.to_string()
+    // Treat LAMBDA_ZIP_PATH="" (set but empty, e.g. from a Dockerfile ARG with no value passed)
+    // the same as unset — fall back to downloading the zip from the remote URL.
+    let sha256 = match env::var("LAMBDA_ZIP_PATH").ok().filter(|p| !p.is_empty()) {
+        Some(local_path) => {
+            // CI mode: a pre-built zip is provided via env; skip the remote download.
+            use_local_lambda_zip(Path::new(&local_path), &zip_dest)
+        }
+        None => {
+            fetch_lambda_zip(&zip_dest);
+            LAMBDA_ZIP_SHA256.to_string()
+        }
     };
 
     // Export first 8 hex chars of the SHA256 as environment variable.


### PR DESCRIPTION
## Summary

The Dockerfile sets `ENV LAMBDA_ZIP_PATH=$LAMBDA_ZIP_PATH` after the `ARG` declaration. When no build arg is passed (e.g. local builds not triggered by a release tag), this results in the env var being set to an empty string rather than being absent.

`env::var("LAMBDA_ZIP_PATH")` returns `Ok("")` in that case, so `build.rs` tried to read a zip file at path `""` and panicked with:

```
failed to read LAMBDA_ZIP_PATH "": No such file or directory (os error 2)
```

Fix by filtering out the empty-string case, treating it the same as unset and falling back to the normal download path from GitHub releases.

## Test plan

- [ ] Local Docker build without `--build-arg LAMBDA_ZIP_PATH` completes successfully (downloads zip from GitHub)
- [ ] CI build with `LAMBDA_ZIP_PATH` set to a valid path still uses the local zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)