### PR TITLE
chore: explicitly set unicode-segmentation version to 1.13

### DIFF
--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -324,7 +324,7 @@ username = "0.2"
 # 1. The `OpenApi` struct structure changed (fields are private), breaking our manual merging logic in openapi.rs
 # in `quickwit-serve`. This code is fundamentally incompatible with version 5.x.
 utoipa = { version = "4.2", features = ["time", "ulid"] }
-unicode-segmentation = "1.12"
+unicode-segmentation = "1.13"
 uuid = { version = "1.23", features = ["v4", "serde"] }
 vrl = { version = "0.32", default-features = false, features = [
   "compiler",


### PR DESCRIPTION
## Description

Bump `unicode-segmentation` from `"1.12"` to `"1.13"` in the workspace `Cargo.toml`.

`Cargo.lock` already resolves to `1.13.2`, so this change only aligns the minimum version specifier -- no actual dependency version change at build time.

### Why

`unicode-segmentation` 1.13.2 introduces an **ASCII fast path** for `unicode_word_indices` and `unicode_words` ([unicode-rs/unicode-segmentation#147](https://github.com/unicode-rs/unicode-segmentation/pull/147)).
Quickwit's `UnicodeSegmenterTokenizer` calls `text.unicode_word_indices()` directly, so this improvement benefits tokenization performance on ASCII-heavy text, which is the common case for most deployments.

Other notable changes in the 1.13.x series:
- Increased `#[inline]` opportunities (15-40% general perf improvement)
- Unicode 17.0.0 support

### How was this PR tested?

Version-only change in `Cargo.toml`. `Cargo.lock` is unchanged, so the resolved dependency is identical to what was already being built.