### PR TITLE
Refactoring of the code maintaining ClusterNodes

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -199,7 +199,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1528,7 +1528,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1959,15 +1959,13 @@ dependencies = [
 
 [[package]]
 name = "chitchat"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25c92757b21f67dbef0518f9359b6c9af187ffbbbbcb9ea73a45034d135100d"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "itertools 0.14.0",
- "lru 0.16.4",
+ "lru 0.17.0",
  "rand 0.10.1",
  "serde",
  "tokio",
@@ -2163,7 +2161,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4026,7 +4024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5163,7 +5161,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5473,7 +5471,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5529,7 +5527,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5984,6 +5982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -6450,7 +6457,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7067,7 +7074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9463,7 +9470,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9500,7 +9507,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10279,7 +10286,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10626,7 +10633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11178,7 +11185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11460,7 +11467,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11874,7 +11881,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11883,7 +11890,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13384,7 +13391,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1960,6 +1960,8 @@ dependencies = [
 [[package]]
 name = "chitchat"
 version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d05384b0f3f305c5a379b1ec8e716cae107a66eae27e46b120f0a91b7f5ef"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -109,7 +109,7 @@ bitpacking = "0.9.3"
 bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytestring = "1.5"
-chitchat = { path = "/Users/paul.masurel/git/chitchat/chitchat" }
+chitchat = "0.11.0"
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -109,7 +109,7 @@ bitpacking = "0.9.3"
 bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytestring = "1.5"
-chitchat = "0.10.1"
+chitchat = { path = "/Users/paul.masurel/git/chitchat/chitchat" }
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",

--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -184,7 +184,7 @@ async fn compute_cluster_change_events_on_added(
         "node `{}` has {verb} the cluster",
         new_chitchat_id.node_id,
     );
-    let new_node_id: NodeId = new_node.node_id().to_owned();
+    let new_node_id: NodeId = new_node.node_id.clone();
     previous_nodes.insert(new_node_id, new_node.clone());
 
     if new_node.is_ready() {
@@ -484,7 +484,7 @@ pub(crate) mod tests {
 
             let node = previous_nodes.get(&*new_chitchat_id.node_id).unwrap();
 
-            assert_eq!(node.chitchat_id(), &new_chitchat_id);
+            assert_eq!(node.chitchat_id(), new_chitchat_id);
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(!node.is_self_node());
             assert!(!node.is_ready());
@@ -513,7 +513,7 @@ pub(crate) mod tests {
             let ClusterChange::Add(node) = &events[0] else {
                 panic!("expected `ClusterChange::Add` event, got `{:?}`", events[0]);
             };
-            assert_eq!(node.chitchat_id(), &new_chitchat_id);
+            assert_eq!(node.chitchat_id(), new_chitchat_id);
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(!node.is_self_node());
             assert!(node.is_ready());
@@ -540,12 +540,12 @@ pub(crate) mod tests {
                     events[0]
                 );
             };
-            assert_eq!(removed_node.chitchat_id(), &new_chitchat_id);
+            assert_eq!(removed_node.chitchat_id(), new_chitchat_id);
 
             let ClusterChange::Add(rejoined_node) = &events[1] else {
                 panic!("expected `ClusterChange::Add` event, got `{:?}`", events[1]);
             };
-            assert_eq!(rejoined_node.chitchat_id(), &rejoined_chitchat_id);
+            assert_eq!(rejoined_node.chitchat_id(), rejoined_chitchat_id);
             assert_eq!(
                 previous_nodes.get(&*rejoined_chitchat_id.node_id).unwrap(),
                 rejoined_node
@@ -591,7 +591,7 @@ pub(crate) mod tests {
             let ClusterChange::Add(node) = &events[0] else {
                 panic!("expected `ClusterChange::Add` event, got `{:?}`", events[0]);
             };
-            assert_eq!(node.chitchat_id(), &new_chitchat_id);
+            assert_eq!(node.chitchat_id(), new_chitchat_id);
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(node.is_self_node());
             assert!(node.is_ready());
@@ -642,7 +642,7 @@ pub(crate) mod tests {
             let ClusterChange::Add(node) = event else {
                 panic!("expected `ClusterChange::Add` event, got `{event:?}`");
             };
-            assert_eq!(node.chitchat_id(), &updated_chitchat_id);
+            assert_eq!(node.chitchat_id(), updated_chitchat_id);
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(node.is_ready());
             assert!(!node.is_self_node());
@@ -690,7 +690,7 @@ pub(crate) mod tests {
             let ClusterChange::Update { updated, .. } = event else {
                 panic!("expected `ClusterChange::Remove` event, got `{event:?}`");
             };
-            assert_eq!(updated.chitchat_id(), &updated_chitchat_id);
+            assert_eq!(updated.chitchat_id(), updated_chitchat_id);
             assert_eq!(updated.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(!updated.is_self_node());
             assert!(updated.is_ready());
@@ -737,7 +737,7 @@ pub(crate) mod tests {
             let ClusterChange::Remove(node) = event else {
                 panic!("expected `ClusterChange::Remove` event, got `{event:?}`");
             };
-            assert_eq!(node.chitchat_id(), &updated_chitchat_id);
+            assert_eq!(node.chitchat_id(), updated_chitchat_id);
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(!node.is_self_node());
             assert!(!node.is_ready());
@@ -857,7 +857,7 @@ pub(crate) mod tests {
             let ClusterChange::Remove(node) = event else {
                 panic!("expected `ClusterChange::Remove` event, got `{event:?}`");
             };
-            assert_eq!(node.chitchat_id(), &removed_chitchat_id);
+            assert_eq!(node.chitchat_id(), removed_chitchat_id);
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(!node.is_self_node());
             assert!(node.is_ready());

--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -142,7 +142,7 @@ async fn compute_cluster_change_events_on_added(
     client_grpc_config: ClientGrpcConfig,
 ) -> Vec<ClusterChange> {
     let is_self_node = self_chitchat_id == new_chitchat_id;
-    let new_node_id = NodeId::from(new_chitchat_id.node_id.clone());
+    let new_node_id = NodeId::from_arc_str(new_chitchat_id.node_id.clone());
     let maybe_previous_node_entry = previous_nodes.entry(new_node_id);
 
     let mut events = Vec::new();
@@ -227,7 +227,7 @@ async fn compute_cluster_change_events_on_updated(
         previous_channel,
         is_self_node,
     )?;
-    let updated_node_id: NodeId = NodeId::from(updated_node.chitchat_id().node_id.clone());
+    let updated_node_id: NodeId = updated_node.node_id.clone();
     previous_nodes.insert(updated_node_id, updated_node.clone());
 
     if !previous_node.is_ready && updated_node.is_ready {
@@ -262,7 +262,7 @@ fn compute_cluster_change_events_on_removed(
     removed_chitchat_id: &ChitchatId,
     previous_nodes: &mut BTreeMap<NodeId, ClusterNode>,
 ) -> Option<ClusterChange> {
-    let removed_node_id: NodeId = NodeId::from(removed_chitchat_id.node_id.clone());
+    let removed_node_id: NodeId = NodeId::from_arc_str(removed_chitchat_id.node_id.clone());
 
     if let Entry::Occupied(previous_node_entry) = previous_nodes.entry(removed_node_id) {
         let previous_node_ref = previous_node_entry.get();
@@ -609,7 +609,7 @@ pub(crate) mod tests {
             let port = 1235;
             let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
             let updated_chitchat_id = ChitchatId::for_local_test(port);
-            let updated_node_id: NodeId = updated_chitchat_id.node_id.clone().into();
+            let updated_node_id = NodeId::from_arc_str(updated_chitchat_id.node_id.clone());
             let previous_node_state = NodeStateBuilder::default()
                 .with_grpc_advertise_addr(grpc_advertise_addr)
                 .with_readiness(false)
@@ -656,7 +656,7 @@ pub(crate) mod tests {
             let port = 1235;
             let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
             let updated_chitchat_id = ChitchatId::for_local_test(port);
-            let updated_node_id: NodeId = updated_chitchat_id.node_id.clone().into();
+            let updated_node_id = NodeId::from_arc_str(updated_chitchat_id.node_id.clone());
             let previous_node_state = NodeStateBuilder::default()
                 .with_grpc_advertise_addr(grpc_advertise_addr)
                 .with_readiness(true)
@@ -704,7 +704,7 @@ pub(crate) mod tests {
             let port = 1235;
             let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
             let updated_chitchat_id = ChitchatId::for_local_test(port);
-            let updated_node_id: NodeId = updated_chitchat_id.node_id.clone().into();
+            let updated_node_id = NodeId::from_arc_str(updated_chitchat_id.node_id.clone());
             let previous_node_state = NodeStateBuilder::default()
                 .with_grpc_advertise_addr(grpc_advertise_addr)
                 .with_readiness(true)
@@ -751,7 +751,7 @@ pub(crate) mod tests {
             let port = 1235;
             let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
             let updated_chitchat_id = ChitchatId::for_local_test(port);
-            let updated_node_id: NodeId = updated_chitchat_id.node_id.clone().into();
+            let updated_node_id = NodeId::from_arc_str(updated_chitchat_id.node_id.clone());
             let mut previous_chitchat_id = updated_chitchat_id.clone();
             previous_chitchat_id.generation_id += 1;
             let previous_node_state = NodeStateBuilder::default()
@@ -809,7 +809,7 @@ pub(crate) mod tests {
             let port = 1235;
             let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
             let removed_chitchat_id = ChitchatId::for_local_test(port);
-            let removed_node_id: NodeId = removed_chitchat_id.node_id.clone().into();
+            let removed_node_id = NodeId::from_arc_str(removed_chitchat_id.node_id.clone());
             let previous_node_state = NodeStateBuilder::default()
                 .with_grpc_advertise_addr(grpc_advertise_addr)
                 .with_readiness(false)
@@ -835,7 +835,7 @@ pub(crate) mod tests {
             let port = 1235;
             let grpc_advertise_addr: SocketAddr = ([127, 0, 0, 1], port + 1).into();
             let removed_chitchat_id = ChitchatId::for_local_test(port);
-            let removed_node_id: NodeId = removed_chitchat_id.node_id.clone().into();
+            let removed_node_id = NodeId::from_arc_str(removed_chitchat_id.node_id.clone());
             let removed_node_state = NodeStateBuilder::default()
                 .with_grpc_advertise_addr(grpc_advertise_addr)
                 .with_readiness(true)
@@ -872,7 +872,7 @@ pub(crate) mod tests {
 
             let mut rejoined_chitchat_id = removed_chitchat_id.clone();
             rejoined_chitchat_id.generation_id += 1;
-            let rejoined_node_id: NodeId = rejoined_chitchat_id.node_id.clone().into();
+            let rejoined_node_id = NodeId::from_arc_str(rejoined_chitchat_id.node_id.clone());
             let rejoined_node_state = NodeStateBuilder::default()
                 .with_grpc_advertise_addr(grpc_advertise_addr)
                 .with_readiness(true)
@@ -903,7 +903,7 @@ pub(crate) mod tests {
         let cluster_id = "test-cluster".to_string();
         let self_port = 1234;
         let self_chitchat_id = ChitchatId::for_local_test(self_port);
-        let self_node_id: NodeId = self_chitchat_id.node_id.clone().into();
+        let self_node_id = NodeId::from_arc_str(self_chitchat_id.node_id.clone());
         {
             let mut previous_nodes = BTreeMap::default();
             let previous_node_states = BTreeMap::default();

--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -163,7 +163,7 @@ async fn compute_cluster_change_events_on_added(
         let previous_node = previous_node_entry.remove();
         verb = "rejoined";
 
-        if previous_node.is_ready() {
+        if previous_node.is_ready {
             events.push(ClusterChange::Remove(previous_node));
         }
     }
@@ -187,7 +187,7 @@ async fn compute_cluster_change_events_on_added(
     let new_node_id: NodeId = new_node.node_id.clone();
     previous_nodes.insert(new_node_id, new_node.clone());
 
-    if new_node.is_ready() {
+    if new_node.is_ready {
         info!(
             node_id=%new_chitchat_id.node_id,
             generation_id=%new_chitchat_id.generation_id,
@@ -230,7 +230,7 @@ async fn compute_cluster_change_events_on_updated(
     let updated_node_id: NodeId = NodeId::from(updated_node.chitchat_id().node_id.clone());
     previous_nodes.insert(updated_node_id, updated_node.clone());
 
-    if !previous_node.is_ready() && updated_node.is_ready() {
+    if !previous_node.is_ready && updated_node.is_ready {
         warmup_channel(updated_node.channel()).await;
 
         info!(
@@ -240,7 +240,7 @@ async fn compute_cluster_change_events_on_updated(
             updated_chitchat_id.node_id
         );
         Some(ClusterChange::Add(updated_node))
-    } else if previous_node.is_ready() && !updated_node.is_ready() {
+    } else if previous_node.is_ready && !updated_node.is_ready {
         info!(
             node_id=%updated_chitchat_id.node_id,
             generation_id=%updated_chitchat_id.generation_id,
@@ -248,7 +248,7 @@ async fn compute_cluster_change_events_on_updated(
             updated_chitchat_id.node_id
         );
         Some(ClusterChange::Remove(updated_node))
-    } else if previous_node.is_ready() && updated_node.is_ready() {
+    } else if previous_node.is_ready && updated_node.is_ready {
         Some(ClusterChange::Update {
             previous: previous_node,
             updated: updated_node,
@@ -276,7 +276,7 @@ fn compute_cluster_change_events_on_removed(
             );
             let previous_node = previous_node_entry.remove();
 
-            if previous_node.is_ready() {
+            if previous_node.is_ready {
                 return Some(ClusterChange::Remove(previous_node));
             }
         }
@@ -485,9 +485,9 @@ pub(crate) mod tests {
             let node = previous_nodes.get(&*new_chitchat_id.node_id).unwrap();
 
             assert_eq!(node.chitchat_id(), new_chitchat_id);
-            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert_eq!(node.grpc_advertise_addr, grpc_advertise_addr);
             assert!(!node.is_self_node());
-            assert!(!node.is_ready());
+            assert!(!node.is_ready);
         }
         {
             // New node joins the cluster and is ready.
@@ -514,9 +514,9 @@ pub(crate) mod tests {
                 panic!("expected `ClusterChange::Add` event, got `{:?}`", events[0]);
             };
             assert_eq!(node.chitchat_id(), new_chitchat_id);
-            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert_eq!(node.grpc_advertise_addr, grpc_advertise_addr);
             assert!(!node.is_self_node());
-            assert!(node.is_ready());
+            assert!(node.is_ready);
             assert_eq!(previous_nodes.get(&*new_chitchat_id.node_id).unwrap(), node);
 
             // Node rejoins with same node ID but newer generation ID.
@@ -592,9 +592,9 @@ pub(crate) mod tests {
                 panic!("expected `ClusterChange::Add` event, got `{:?}`", events[0]);
             };
             assert_eq!(node.chitchat_id(), new_chitchat_id);
-            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert_eq!(node.grpc_advertise_addr, grpc_advertise_addr);
             assert!(node.is_self_node());
-            assert!(node.is_ready());
+            assert!(node.is_ready);
             assert_eq!(previous_nodes.get(&*new_chitchat_id.node_id).unwrap(), node);
         }
     }
@@ -643,8 +643,8 @@ pub(crate) mod tests {
                 panic!("expected `ClusterChange::Add` event, got `{event:?}`");
             };
             assert_eq!(node.chitchat_id(), updated_chitchat_id);
-            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
-            assert!(node.is_ready());
+            assert_eq!(node.grpc_advertise_addr, grpc_advertise_addr);
+            assert!(node.is_ready);
             assert!(!node.is_self_node());
             assert_eq!(
                 previous_nodes.get(&*updated_chitchat_id.node_id).unwrap(),
@@ -691,9 +691,9 @@ pub(crate) mod tests {
                 panic!("expected `ClusterChange::Remove` event, got `{event:?}`");
             };
             assert_eq!(updated.chitchat_id(), updated_chitchat_id);
-            assert_eq!(updated.grpc_advertise_addr(), grpc_advertise_addr);
+            assert_eq!(updated.grpc_advertise_addr, grpc_advertise_addr);
             assert!(!updated.is_self_node());
-            assert!(updated.is_ready());
+            assert!(updated.is_ready);
             assert_eq!(
                 previous_nodes.get(&*updated_chitchat_id.node_id).unwrap(),
                 &updated
@@ -738,9 +738,9 @@ pub(crate) mod tests {
                 panic!("expected `ClusterChange::Remove` event, got `{event:?}`");
             };
             assert_eq!(node.chitchat_id(), updated_chitchat_id);
-            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert_eq!(node.grpc_advertise_addr, grpc_advertise_addr);
             assert!(!node.is_self_node());
-            assert!(!node.is_ready());
+            assert!(!node.is_ready);
             assert_eq!(
                 previous_nodes.get(&*updated_chitchat_id.node_id).unwrap(),
                 &node
@@ -858,9 +858,9 @@ pub(crate) mod tests {
                 panic!("expected `ClusterChange::Remove` event, got `{event:?}`");
             };
             assert_eq!(node.chitchat_id(), removed_chitchat_id);
-            assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
+            assert_eq!(node.grpc_advertise_addr, grpc_advertise_addr);
             assert!(!node.is_self_node());
-            assert!(node.is_ready());
+            assert!(node.is_ready);
             assert!(!previous_nodes.contains_key(&*removed_chitchat_id.node_id));
         }
         {

--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -142,7 +142,7 @@ async fn compute_cluster_change_events_on_added(
     client_grpc_config: ClientGrpcConfig,
 ) -> Vec<ClusterChange> {
     let is_self_node = self_chitchat_id == new_chitchat_id;
-    let new_node_id: NodeId = new_chitchat_id.node_id.clone().into();
+    let new_node_id = NodeId::from(new_chitchat_id.node_id.clone());
     let maybe_previous_node_entry = previous_nodes.entry(new_node_id);
 
     let mut events = Vec::new();
@@ -184,7 +184,7 @@ async fn compute_cluster_change_events_on_added(
         "node `{}` has {verb} the cluster",
         new_chitchat_id.node_id,
     );
-    let new_node_id: NodeId = new_node.node_id().into();
+    let new_node_id: NodeId = new_node.node_id().to_owned();
     previous_nodes.insert(new_node_id, new_node.clone());
 
     if new_node.is_ready() {
@@ -207,7 +207,7 @@ async fn compute_cluster_change_events_on_updated(
     updated_node_state: &NodeState,
     previous_nodes: &mut BTreeMap<NodeId, ClusterNode>,
 ) -> Option<ClusterChange> {
-    let previous_node = previous_nodes.get(&updated_chitchat_id.node_id)?.clone();
+    let previous_node = previous_nodes.get(&*updated_chitchat_id.node_id)?.clone();
 
     if previous_node.chitchat_id().generation_id > updated_chitchat_id.generation_id {
         warn!(
@@ -220,14 +220,14 @@ async fn compute_cluster_change_events_on_updated(
     }
     let previous_channel = previous_node.channel();
     let is_self_node = self_chitchat_id == updated_chitchat_id;
-    let updated_node = try_new_node_with_channel(
+    let updated_node: ClusterNode = try_new_node_with_channel(
         cluster_id,
         updated_chitchat_id,
         updated_node_state,
         previous_channel,
         is_self_node,
     )?;
-    let updated_node_id: NodeId = updated_node.chitchat_id().node_id.clone().into();
+    let updated_node_id: NodeId = NodeId::from(updated_node.chitchat_id().node_id.clone());
     previous_nodes.insert(updated_node_id, updated_node.clone());
 
     if !previous_node.is_ready() && updated_node.is_ready() {
@@ -262,7 +262,7 @@ fn compute_cluster_change_events_on_removed(
     removed_chitchat_id: &ChitchatId,
     previous_nodes: &mut BTreeMap<NodeId, ClusterNode>,
 ) -> Option<ClusterChange> {
-    let removed_node_id: NodeId = removed_chitchat_id.node_id.clone().into();
+    let removed_node_id: NodeId = NodeId::from(removed_chitchat_id.node_id.clone());
 
     if let Entry::Occupied(previous_node_entry) = previous_nodes.entry(removed_node_id) {
         let previous_node_ref = previous_node_entry.get();
@@ -482,7 +482,7 @@ pub(crate) mod tests {
             .await;
             assert!(events.is_empty());
 
-            let node = previous_nodes.get(&new_chitchat_id.node_id).unwrap();
+            let node = previous_nodes.get(&*new_chitchat_id.node_id).unwrap();
 
             assert_eq!(node.chitchat_id(), &new_chitchat_id);
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
@@ -517,7 +517,7 @@ pub(crate) mod tests {
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(!node.is_self_node());
             assert!(node.is_ready());
-            assert_eq!(previous_nodes.get(&new_chitchat_id.node_id).unwrap(), node);
+            assert_eq!(previous_nodes.get(&*new_chitchat_id.node_id).unwrap(), node);
 
             // Node rejoins with same node ID but newer generation ID.
             let mut rejoined_chitchat_id = ChitchatId::for_local_test(port);
@@ -547,7 +547,7 @@ pub(crate) mod tests {
             };
             assert_eq!(rejoined_node.chitchat_id(), &rejoined_chitchat_id);
             assert_eq!(
-                previous_nodes.get(&rejoined_chitchat_id.node_id).unwrap(),
+                previous_nodes.get(&*rejoined_chitchat_id.node_id).unwrap(),
                 rejoined_node
             );
 
@@ -563,7 +563,7 @@ pub(crate) mod tests {
             .await;
             assert!(events.is_empty());
             assert_eq!(
-                previous_nodes.get(&rejoined_chitchat_id.node_id).unwrap(),
+                previous_nodes.get(&*rejoined_chitchat_id.node_id).unwrap(),
                 rejoined_node
             );
         }
@@ -595,7 +595,7 @@ pub(crate) mod tests {
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(node.is_self_node());
             assert!(node.is_ready());
-            assert_eq!(previous_nodes.get(&new_chitchat_id.node_id).unwrap(), node);
+            assert_eq!(previous_nodes.get(&*new_chitchat_id.node_id).unwrap(), node);
         }
     }
 
@@ -647,7 +647,7 @@ pub(crate) mod tests {
             assert!(node.is_ready());
             assert!(!node.is_self_node());
             assert_eq!(
-                previous_nodes.get(&updated_chitchat_id.node_id).unwrap(),
+                previous_nodes.get(&*updated_chitchat_id.node_id).unwrap(),
                 &node
             );
         }
@@ -695,7 +695,7 @@ pub(crate) mod tests {
             assert!(!updated.is_self_node());
             assert!(updated.is_ready());
             assert_eq!(
-                previous_nodes.get(&updated_chitchat_id.node_id).unwrap(),
+                previous_nodes.get(&*updated_chitchat_id.node_id).unwrap(),
                 &updated
             );
         }
@@ -742,7 +742,7 @@ pub(crate) mod tests {
             assert!(!node.is_self_node());
             assert!(!node.is_ready());
             assert_eq!(
-                previous_nodes.get(&updated_chitchat_id.node_id).unwrap(),
+                previous_nodes.get(&*updated_chitchat_id.node_id).unwrap(),
                 &node
             );
         }
@@ -786,7 +786,7 @@ pub(crate) mod tests {
             assert!(event_opt.is_none());
 
             assert_eq!(
-                previous_nodes.get(&updated_chitchat_id.node_id).unwrap(),
+                previous_nodes.get(&*updated_chitchat_id.node_id).unwrap(),
                 &previous_node
             );
         }
@@ -828,7 +828,7 @@ pub(crate) mod tests {
             let event_opt =
                 compute_cluster_change_events_on_removed(&removed_chitchat_id, &mut previous_nodes);
             assert!(event_opt.is_none());
-            assert!(!previous_nodes.contains_key(&removed_chitchat_id.node_id));
+            assert!(!previous_nodes.contains_key(&*removed_chitchat_id.node_id));
         }
         {
             // Node leaves the cluster in ready state.
@@ -861,7 +861,7 @@ pub(crate) mod tests {
             assert_eq!(node.grpc_advertise_addr(), grpc_advertise_addr);
             assert!(!node.is_self_node());
             assert!(node.is_ready());
-            assert!(!previous_nodes.contains_key(&removed_chitchat_id.node_id));
+            assert!(!previous_nodes.contains_key(&*removed_chitchat_id.node_id));
         }
         {
             // Node leaves the cluster in ready state but in the meantime it has rejoined the

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(any(test, feature = "testsuite"))]
 use anyhow::Context;
 use chitchat::transport::Transport;
 use chitchat::{
@@ -31,6 +32,7 @@ use quickwit_proto::indexing::{IndexingPipelineId, IndexingTask, PipelineMetrics
 use quickwit_proto::types::{NodeId, NodeIdRef, PipelineUid, ShardId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock, mpsc, watch};
+#[cfg(any(test, feature = "testsuite"))]
 use tokio::time::timeout;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::WatchStream;
@@ -213,11 +215,12 @@ impl Cluster {
     }
 
     /// Deprecated: this is going away soon.
+    #[cfg(any(test, feature = "testsuite"))]
     pub async fn ready_members(&self) -> Vec<ClusterMember> {
         self.inner.read().await.ready_members_rx.borrow().clone()
     }
 
-    /// Deprecated: this is going away soon.
+    #[cfg(any(test, feature = "testsuite"))]
     async fn ready_members_watcher(&self) -> WatchStream<Vec<ClusterMember>> {
         WatchStream::new(self.inner.read().await.ready_members_rx.clone())
     }
@@ -330,6 +333,7 @@ impl Cluster {
     }
 
     /// Waits until the predicate holds true for the set of ready members.
+    #[cfg(any(test, feature = "testsuite"))]
     pub async fn wait_for_ready_members<F>(
         &self,
         mut predicate: F,

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -373,7 +373,7 @@ impl Cluster {
 
         ClusterSnapshot {
             cluster_id: self.cluster_id.clone(),
-            self_node_id: self.self_chitchat_id.node_id.clone(),
+            self_node_id: self.self_chitchat_id.node_id.to_string(),
             ready_nodes,
             live_nodes,
             dead_nodes,

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -29,7 +29,7 @@ use chitchat::{
 use itertools::Itertools;
 use quickwit_common::tower::ClientGrpcConfig;
 use quickwit_proto::indexing::{IndexingPipelineId, IndexingTask, PipelineMetrics};
-use quickwit_proto::types::{NodeId, NodeIdRef, PipelineUid, ShardId};
+use quickwit_proto::types::{NodeId, PipelineUid, ShardId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock, mpsc, watch};
 #[cfg(any(test, feature = "testsuite"))]
@@ -99,9 +99,9 @@ impl Cluster {
 
     /// Waits until the predicate holds true for the set of ready members.
     ///
-    /// Subscribes to `change_stream()`, which first emits `Add` events for all currently-ready
-    /// nodes (under the write lock, so no change can slip through), then future change events.
-    /// The local map is updated on each event and the predicate is checked after each update.
+    /// Uses `change_stream_with_initial()` to obtain the current ready set atomically alongside
+    /// the subscription, so the predicate is evaluated on the full initial set before any future
+    /// change event arrives.
     pub async fn wait_for_ready_members<F>(
         &self,
         mut predicate: F,
@@ -110,8 +110,15 @@ impl Cluster {
     where
         F: FnMut(&[ClusterMember]) -> bool,
     {
-        let mut change_stream = self.change_stream();
-        let mut ready_members: BTreeMap<NodeId, ClusterMember> = BTreeMap::new();
+        let (initial_nodes, mut change_stream) = self.change_stream_with_initial().await;
+        let mut ready_members: BTreeMap<NodeId, ClusterMember> = initial_nodes
+            .into_iter()
+            .map(|node| (node.node_id.clone(), node.member().clone()))
+            .collect();
+        let members: Vec<ClusterMember> = ready_members.values().cloned().collect();
+        if predicate(&members) {
+            return Ok(());
+        }
         timeout(timeout_after, async move {
             while let Some(change) = change_stream.next().await {
                 match change {
@@ -146,8 +153,8 @@ impl Cluster {
         &self.self_chitchat_id
     }
 
-    pub fn self_node_id(&self) -> &NodeIdRef {
-        NodeIdRef::from_str(&self.self_chitchat_id.node_id)
+    pub fn self_node_id(&self) -> NodeId {
+        NodeId::from_arc_str(self.self_chitchat_id.node_id.clone())
     }
 
     pub fn gossip_listen_addr(&self) -> SocketAddr {
@@ -271,6 +278,9 @@ impl Cluster {
     }
 
     /// Returns a stream of changes affecting the set of ready nodes in the cluster.
+    ///
+    /// Replays currently-ready nodes as `Add` events before future changes, under the write lock,
+    /// so no change can slip through unobserved.
     pub fn change_stream(&self) -> ClusterChangeStream {
         let (change_stream, change_stream_tx) = ClusterChangeStream::new_unbounded();
         let inner = self.inner.clone();
@@ -288,6 +298,25 @@ impl Cluster {
         };
         tokio::spawn(future);
         change_stream
+    }
+
+    /// Returns the current snapshot of ready nodes and a stream of future changes.
+    ///
+    /// Unlike `change_stream()`, the initial ready set is returned as a `Vec` rather than replayed
+    /// as individual `Add` events. The write lock is held for the duration of the snapshot so the
+    /// returned pair is consistent: no change event can arrive between the snapshot and the first
+    /// stream item.
+    pub async fn change_stream_with_initial(&self) -> (Vec<ClusterNode>, ClusterChangeStream) {
+        let (change_stream, change_stream_tx) = ClusterChangeStream::new_unbounded();
+        let mut inner = self.inner.write().await;
+        let initial_nodes: Vec<ClusterNode> = inner
+            .live_nodes
+            .values()
+            .filter(|node| node.is_ready)
+            .cloned()
+            .collect();
+        inner.change_stream_subscribers.push(change_stream_tx);
+        (initial_nodes, change_stream)
     }
 
     /// Returns whether the self node is ready.

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -35,7 +35,6 @@ use tokio::sync::{Mutex, RwLock, mpsc, watch};
 #[cfg(any(test, feature = "testsuite"))]
 use tokio::time::timeout;
 use tokio_stream::StreamExt;
-use tokio_stream::wrappers::WatchStream;
 use tracing::{info, warn};
 
 use crate::change::{ClusterChange, ClusterChangeStreamFactory, compute_cluster_change_events};
@@ -43,7 +42,7 @@ use crate::grpc_gossip::spawn_catchup_callback_task;
 use crate::member::{
     AVAILABILITY_ZONE_KEY, ClusterMember, ENABLED_SERVICES_KEY, GRPC_ADVERTISE_ADDR_KEY,
     NodeStateExt, PIPELINE_METRICS_PREFIX, READINESS_KEY, READINESS_VALUE_NOT_READY,
-    READINESS_VALUE_READY, build_cluster_member,
+    READINESS_VALUE_READY,
 };
 use crate::metrics::spawn_metrics_task;
 use crate::{ClusterChangeStream, ClusterNode};
@@ -90,16 +89,19 @@ impl Debug for Cluster {
 
 #[cfg(any(test, feature = "testsuite"))]
 impl Cluster {
-    /// Deprecated: this is going away soon.
     pub async fn ready_members(&self) -> Vec<ClusterMember> {
-        self.inner.read().await.ready_members_rx.borrow().clone()
-    }
-
-    async fn ready_members_watcher(&self) -> WatchStream<Vec<ClusterMember>> {
-        WatchStream::new(self.inner.read().await.ready_members_rx.clone())
+        self.ready_nodes()
+            .await
+            .into_iter()
+            .map(|node: ClusterNode| node.member().clone())
+            .collect()
     }
 
     /// Waits until the predicate holds true for the set of ready members.
+    ///
+    /// Subscribes to `change_stream()`, which first emits `Add` events for all currently-ready
+    /// nodes (under the write lock, so no change can slip through), then future change events.
+    /// The local map is updated on each event and the predicate is checked after each update.
     pub async fn wait_for_ready_members<F>(
         &self,
         mut predicate: F,
@@ -108,13 +110,27 @@ impl Cluster {
     where
         F: FnMut(&[ClusterMember]) -> bool,
     {
-        timeout(
-            timeout_after,
-            self.ready_members_watcher()
-                .await
-                .skip_while(|members| !predicate(members))
-                .next(),
-        )
+        let mut change_stream = self.change_stream();
+        let mut ready_members: BTreeMap<NodeId, ClusterMember> = BTreeMap::new();
+        timeout(timeout_after, async move {
+            while let Some(change) = change_stream.next().await {
+                match change {
+                    ClusterChange::Add(node) => {
+                        ready_members.insert(node.node_id.clone(), (*node).clone());
+                    }
+                    ClusterChange::Update { updated, .. } => {
+                        ready_members.insert(updated.node_id.clone(), (*updated).clone());
+                    }
+                    ClusterChange::Remove(node) => {
+                        ready_members.remove(&node.node_id);
+                    }
+                }
+                let members: Vec<ClusterMember> = ready_members.values().cloned().collect();
+                if predicate(&members) {
+                    return;
+                }
+            }
+        })
         .await
         .context("deadline has passed before predicate held true")?;
         Ok(())
@@ -209,9 +225,6 @@ impl Cluster {
         let chitchat = chitchat_handle.chitchat();
         let chitchat_guard = chitchat.lock().await;
         let live_nodes_rx = chitchat_guard.live_nodes_watcher();
-        let live_nodes_stream = chitchat_guard.live_nodes_watch_stream();
-        let (ready_members_tx, ready_members_rx) = watch::channel(Vec::new());
-        spawn_ready_members_task(cluster_id.clone(), live_nodes_stream, ready_members_tx);
         drop(chitchat_guard);
 
         let weak_chitchat = Arc::downgrade(&chitchat);
@@ -233,7 +246,6 @@ impl Cluster {
             chitchat_handle,
             live_nodes: BTreeMap::new(),
             change_stream_subscribers: Vec::new(),
-            ready_members_rx,
         };
         let cluster = Cluster {
             cluster_id,
@@ -460,42 +472,6 @@ impl ClusterChangeStreamFactory for Cluster {
     }
 }
 
-/// Deprecated: this is going away soon.
-fn spawn_ready_members_task(
-    cluster_id: String,
-    mut live_nodes_stream: WatchStream<BTreeMap<ChitchatId, NodeState>>,
-    ready_members_tx: watch::Sender<Vec<ClusterMember>>,
-) {
-    let fut = async move {
-        while let Some(new_live_nodes) = live_nodes_stream.next().await {
-            let mut new_ready_members = Vec::with_capacity(new_live_nodes.len());
-
-            for (chitchat_id, node_state) in new_live_nodes {
-                let member = match build_cluster_member(chitchat_id, &node_state) {
-                    Ok(member) => member,
-                    Err(error) => {
-                        warn!(
-                            cluster_id=%cluster_id,
-                            error=?error,
-                            "Failed to build cluster member from Chitchat node state."
-                        );
-                        continue;
-                    }
-                };
-                if member.is_ready {
-                    new_ready_members.push(member);
-                }
-            }
-            if *ready_members_tx.borrow() != new_ready_members
-                && ready_members_tx.send(new_ready_members).is_err()
-            {
-                break;
-            }
-        }
-    };
-    tokio::spawn(fut);
-}
-
 /// Parses indexing tasks from the chitchat node state.
 pub fn parse_indexing_tasks(node_state: &NodeState) -> Vec<IndexingTask> {
     node_state
@@ -628,7 +604,6 @@ struct InnerCluster {
     chitchat_handle: ChitchatHandle,
     live_nodes: BTreeMap<NodeId, ClusterNode>,
     change_stream_subscribers: Vec<mpsc::UnboundedSender<ClusterChange>>,
-    ready_members_rx: watch::Receiver<Vec<ClusterMember>>,
 }
 
 // Not used within the code, used for documentation.
@@ -797,10 +772,10 @@ mod tests {
             .await
             .unwrap();
 
-        let mut ready_members_watcher = node.ready_members_watcher().await;
-        let ready_members = ready_members_watcher.next().await.unwrap();
+        // Node starts not-ready: subscribe before any readiness change so we don't miss events.
+        let mut change_stream = node.change_stream();
 
-        assert!(ready_members.is_empty());
+        assert!(node.ready_nodes().await.is_empty());
         assert!(!node.is_self_node_ready().await);
 
         let cluster_snapshot = node.snapshot().await;
@@ -819,8 +794,8 @@ mod tests {
 
         node.set_self_node_readiness(true).await;
 
-        let ready_members = ready_members_watcher.next().await.unwrap();
-        assert_eq!(ready_members.len(), 1);
+        let change = change_stream.next().await.unwrap();
+        assert!(matches!(change, ClusterChange::Add(_)));
         assert!(node.is_self_node_ready().await);
 
         let cluster_snapshot = node.snapshot().await;
@@ -839,8 +814,8 @@ mod tests {
 
         node.set_self_node_readiness(false).await;
 
-        let ready_members = ready_members_watcher.next().await.unwrap();
-        assert!(ready_members.is_empty());
+        let change = change_stream.next().await.unwrap();
+        assert!(matches!(change, ClusterChange::Remove(_)));
         assert!(!node.is_self_node_ready().await);
 
         let cluster_snapshot = node.snapshot().await;

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -88,6 +88,39 @@ impl Debug for Cluster {
     }
 }
 
+#[cfg(any(test, feature = "testsuite"))]
+impl Cluster {
+    /// Deprecated: this is going away soon.
+    pub async fn ready_members(&self) -> Vec<ClusterMember> {
+        self.inner.read().await.ready_members_rx.borrow().clone()
+    }
+
+    async fn ready_members_watcher(&self) -> WatchStream<Vec<ClusterMember>> {
+        WatchStream::new(self.inner.read().await.ready_members_rx.clone())
+    }
+
+    /// Waits until the predicate holds true for the set of ready members.
+    pub async fn wait_for_ready_members<F>(
+        &self,
+        mut predicate: F,
+        timeout_after: Duration,
+    ) -> anyhow::Result<()>
+    where
+        F: FnMut(&[ClusterMember]) -> bool,
+    {
+        timeout(
+            timeout_after,
+            self.ready_members_watcher()
+                .await
+                .skip_while(|members| !predicate(members))
+                .next(),
+        )
+        .await
+        .context("deadline has passed before predicate held true")?;
+        Ok(())
+    }
+}
+
 impl Cluster {
     pub fn cluster_id(&self) -> &str {
         &self.cluster_id
@@ -214,17 +247,6 @@ impl Cluster {
         Ok(cluster)
     }
 
-    /// Deprecated: this is going away soon.
-    #[cfg(any(test, feature = "testsuite"))]
-    pub async fn ready_members(&self) -> Vec<ClusterMember> {
-        self.inner.read().await.ready_members_rx.borrow().clone()
-    }
-
-    #[cfg(any(test, feature = "testsuite"))]
-    async fn ready_members_watcher(&self) -> WatchStream<Vec<ClusterMember>> {
-        WatchStream::new(self.inner.read().await.ready_members_rx.clone())
-    }
-
     pub async fn ready_nodes(&self) -> Vec<ClusterNode> {
         self.inner
             .write()
@@ -330,28 +352,6 @@ impl Cluster {
             .lock()
             .await
             .subscribe_event(key_prefix, callback)
-    }
-
-    /// Waits until the predicate holds true for the set of ready members.
-    #[cfg(any(test, feature = "testsuite"))]
-    pub async fn wait_for_ready_members<F>(
-        &self,
-        mut predicate: F,
-        timeout_after: Duration,
-    ) -> anyhow::Result<()>
-    where
-        F: FnMut(&[ClusterMember]) -> bool,
-    {
-        timeout(
-            timeout_after,
-            self.ready_members_watcher()
-                .await
-                .skip_while(|members| !predicate(members))
-                .next(),
-        )
-        .await
-        .context("deadline has passed before predicate held true")?;
-        Ok(())
     }
 
     /// Returns a snapshot of the cluster state, including the underlying Chitchat state.

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -253,7 +253,7 @@ impl Cluster {
             .await
             .live_nodes
             .values()
-            .filter(|node| node.is_ready())
+            .filter(|node| node.is_ready)
             .cloned()
             .collect()
     }
@@ -266,7 +266,7 @@ impl Cluster {
         let future = async move {
             let mut inner = inner.write().await;
             for node in inner.live_nodes.values() {
-                if node.is_ready() {
+                if node.is_ready {
                     change_stream_tx
                         .send(ClusterChange::Add(node.clone()))
                         .expect("receiver end of the channel should be open");

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -730,7 +730,7 @@ pub async fn create_cluster_for_test(
 
     static GOSSIP_ADVERTISE_PORT_SEQUENCE: AtomicU16 = AtomicU16::new(1u16);
     let gossip_advertise_port = GOSSIP_ADVERTISE_PORT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    let node_id: NodeId = format!("node-{gossip_advertise_port}").into();
+    let node_id: NodeId = NodeId::from_str(&format!("node-{gossip_advertise_port}"));
 
     let enabled_services = enabled_services
         .iter()
@@ -1170,7 +1170,7 @@ mod tests {
         let transport = ChannelTransport::default();
 
         let cluster1a = create_cluster_for_test_with_id(
-            "node-11".into(),
+            NodeId::from_str("node-11"),
             11,
             "cluster1".to_string(),
             Vec::new(),
@@ -1180,7 +1180,7 @@ mod tests {
         )
         .await?;
         let cluster2a = create_cluster_for_test_with_id(
-            "node-21".into(),
+            NodeId::from_str("node-21"),
             21,
             "cluster2".to_string(),
             vec![cluster1a.gossip_listen_addr.to_string()],
@@ -1190,7 +1190,7 @@ mod tests {
         )
         .await?;
         let cluster1b = create_cluster_for_test_with_id(
-            "node-12".into(),
+            NodeId::from_str("node-12"),
             12,
             "cluster1".to_string(),
             vec![
@@ -1203,7 +1203,7 @@ mod tests {
         )
         .await?;
         let cluster2b = create_cluster_for_test_with_id(
-            "node-22".into(),
+            NodeId::from_str("node-22"),
             22,
             "cluster2".to_string(),
             vec![

--- a/quickwit/quickwit-cluster/src/grpc_gossip.rs
+++ b/quickwit/quickwit-cluster/src/grpc_gossip.rs
@@ -117,7 +117,7 @@ async fn perform_grpc_gossip_rounds<ClusterServiceClientFactory, Fut>(
                 .chitchat_id
                 .expect("`chitchat_id` should be a required field");
             let chitchat_id = ChitchatId {
-                node_id: Arc::from(proto_chitchat_id.node_id.as_str()),
+                node_id: Arc::<str>::from(proto_chitchat_id.node_id),
                 generation_id: proto_chitchat_id.generation_id,
                 gossip_advertise_addr: proto_chitchat_id
                     .gossip_advertise_addr

--- a/quickwit/quickwit-cluster/src/grpc_gossip.rs
+++ b/quickwit/quickwit-cluster/src/grpc_gossip.rs
@@ -117,7 +117,7 @@ async fn perform_grpc_gossip_rounds<ClusterServiceClientFactory, Fut>(
                 .chitchat_id
                 .expect("`chitchat_id` should be a required field");
             let chitchat_id = ChitchatId {
-                node_id: proto_chitchat_id.node_id.clone(),
+                node_id: Arc::from(proto_chitchat_id.node_id.as_str()),
                 generation_id: proto_chitchat_id.generation_id,
                 gossip_advertise_addr: proto_chitchat_id
                     .gossip_advertise_addr
@@ -195,7 +195,7 @@ fn select_gossip_candidates(
         })
         .sample(&mut rand::rng(), MAX_GOSSIP_PEERS)
         .into_iter()
-        .map(|(node_id, grpc_addr)| (node_id.clone(), grpc_addr))
+        .map(|(node_id, grpc_addr)| (node_id.to_string(), grpc_addr))
         .unzip()
 }
 
@@ -338,7 +338,7 @@ mod tests {
 
         let chitchat_mutex_guard = chitchat.lock().await;
         let chitchat_id = ChitchatId {
-            node_id: "node-4".to_string(),
+            node_id: Arc::from("node-4"),
             generation_id: 0,
             gossip_advertise_addr: "127.0.0.1:14000".parse().unwrap(),
         };

--- a/quickwit/quickwit-cluster/src/grpc_service.rs
+++ b/quickwit/quickwit-cluster/src/grpc_service.rs
@@ -72,7 +72,7 @@ impl ClusterService for Cluster {
 
         for (chitchat_id, node_state) in chitchat_guard.node_states() {
             let proto_chitchat_id = ProtoChitchatId {
-                node_id: chitchat_id.node_id.clone(),
+                node_id: chitchat_id.node_id.to_string(),
                 generation_id: chitchat_id.generation_id,
                 gossip_advertise_addr: chitchat_id.gossip_advertise_addr.to_string(),
             };

--- a/quickwit/quickwit-cluster/src/member.rs
+++ b/quickwit/quickwit-cluster/src/member.rs
@@ -130,7 +130,7 @@ pub struct ClusterMember {
 impl ClusterMember {
     pub fn chitchat_id(&self) -> ChitchatId {
         ChitchatId::new(
-            self.node_id.clone().into(),
+            self.node_id.clone(),
             self.generation_id.as_u64(),
             self.gossip_advertise_addr,
         )
@@ -180,7 +180,7 @@ pub(crate) fn build_cluster_member(
     let availability_zone = node_state.availability_zone();
 
     let member = ClusterMember {
-        node_id: chitchat_id.node_id.into(),
+        node_id: NodeId::from(chitchat_id.node_id.clone()),
         generation_id: chitchat_id.generation_id.into(),
         is_ready,
         enabled_services,

--- a/quickwit/quickwit-cluster/src/member.rs
+++ b/quickwit/quickwit-cluster/src/member.rs
@@ -196,7 +196,7 @@ pub(crate) fn build_cluster_member(
     let availability_zone = node_state.availability_zone();
 
     let member = ClusterMember {
-        node_id: NodeId::from(chitchat_id.node_id.clone()),
+        node_id: NodeId::from_arc_str(chitchat_id.node_id.clone()),
         generation_id: chitchat_id.generation_id.into(),
         is_ready,
         enabled_services,

--- a/quickwit/quickwit-cluster/src/member.rs
+++ b/quickwit/quickwit-cluster/src/member.rs
@@ -135,6 +135,22 @@ impl ClusterMember {
             self.gossip_advertise_addr,
         )
     }
+
+    pub fn is_service_enabled(&self, service: QuickwitService) -> bool {
+        self.enabled_services.contains(&service)
+    }
+
+    pub fn is_indexer(&self) -> bool {
+        self.is_service_enabled(QuickwitService::Indexer)
+    }
+
+    pub fn is_ingester(&self) -> bool {
+        self.is_service_enabled(QuickwitService::Indexer)
+    }
+
+    pub fn is_searcher(&self) -> bool {
+        self.is_service_enabled(QuickwitService::Searcher)
+    }
 }
 
 impl From<ClusterMember> for ChitchatId {

--- a/quickwit/quickwit-cluster/src/node.rs
+++ b/quickwit/quickwit-cluster/src/node.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
 use std::fmt::Debug;
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use chitchat::{ChitchatId, NodeState};
 use quickwit_config::service::QuickwitService;
-use quickwit_proto::indexing::{CpuCapacity, IndexingTask};
+#[cfg(any(test, feature = "testsuite"))]
+use quickwit_proto::indexing::IndexingTask;
+#[cfg(any(test, feature = "testsuite"))]
 use quickwit_proto::ingest::ingester::IngesterStatus;
 use tonic::transport::Channel;
 
@@ -80,49 +80,24 @@ impl ClusterNode {
         self.inner.channel.clone()
     }
 
-    pub fn enabled_services(&self) -> &HashSet<QuickwitService> {
-        &self.inner.member.enabled_services
+    pub fn member(&self) -> &ClusterMember {
+        &self.inner.member
+    }
+
+    pub fn is_service_enabled(&self, service: QuickwitService) -> bool {
+        self.enabled_services.contains(&service)
     }
 
     pub fn is_indexer(&self) -> bool {
-        self.inner
-            .member
-            .enabled_services
-            .contains(&QuickwitService::Indexer)
+        self.is_service_enabled(QuickwitService::Indexer)
     }
 
     pub fn is_ingester(&self) -> bool {
-        self.inner
-            .member
-            .enabled_services
-            .contains(&QuickwitService::Indexer)
+        self.is_service_enabled(QuickwitService::Indexer)
     }
 
     pub fn is_searcher(&self) -> bool {
-        self.inner
-            .member
-            .enabled_services
-            .contains(&QuickwitService::Searcher)
-    }
-
-    pub fn grpc_advertise_addr(&self) -> SocketAddr {
-        self.inner.member.grpc_advertise_addr
-    }
-
-    pub fn indexing_tasks(&self) -> &[IndexingTask] {
-        &self.inner.member.indexing_tasks
-    }
-
-    pub fn indexing_capacity(&self) -> CpuCapacity {
-        self.inner.member.indexing_cpu_capacity
-    }
-
-    pub fn ingester_status(&self) -> IngesterStatus {
-        self.inner.member.ingester_status
-    }
-
-    pub fn is_ready(&self) -> bool {
-        self.inner.member.is_ready
+        self.is_service_enabled(QuickwitService::Searcher)
     }
 
     pub fn is_self_node(&self) -> bool {
@@ -138,7 +113,7 @@ impl std::ops::Deref for ClusterNode {
     type Target = ClusterMember;
 
     fn deref(&self) -> &ClusterMember {
-        &self.inner.member
+        self.member()
     }
 }
 

--- a/quickwit/quickwit-cluster/src/node.rs
+++ b/quickwit/quickwit-cluster/src/node.rs
@@ -21,10 +21,9 @@ use chitchat::{ChitchatId, NodeState};
 use quickwit_config::service::QuickwitService;
 use quickwit_proto::indexing::{CpuCapacity, IndexingTask};
 use quickwit_proto::ingest::ingester::IngesterStatus;
-use quickwit_proto::types::NodeIdRef;
 use tonic::transport::Channel;
 
-use crate::member::build_cluster_member;
+use crate::member::{ClusterMember, build_cluster_member};
 
 #[derive(Clone)]
 pub struct ClusterNode {
@@ -39,23 +38,15 @@ impl ClusterNode {
         channel: Channel,
         is_self_node: bool,
     ) -> anyhow::Result<Self> {
-        let member = build_cluster_member(chitchat_id.clone(), node_state)?;
+        let member = build_cluster_member(chitchat_id, node_state)?;
         let inner = InnerNode {
-            chitchat_id,
+            member,
             channel,
-            enabled_services: member.enabled_services,
-            grpc_advertise_addr: member.grpc_advertise_addr,
-            indexing_tasks: member.indexing_tasks,
-            indexing_capacity: member.indexing_cpu_capacity,
-            ingester_status: member.ingester_status,
-            is_ready: member.is_ready,
             is_self_node,
-            availability_zone: member.availability_zone,
         };
-        let node = ClusterNode {
+        Ok(ClusterNode {
             inner: Arc::new(inner),
-        };
-        Ok(node)
+        })
     }
 
     #[cfg(any(test, feature = "testsuite"))]
@@ -85,58 +76,53 @@ impl ClusterNode {
         Self::try_new(chitchat_id, &node_state, channel, is_self_node).unwrap()
     }
 
-    pub fn chitchat_id(&self) -> &ChitchatId {
-        &self.inner.chitchat_id
-    }
-
-    pub fn node_id(&self) -> &NodeIdRef {
-        NodeIdRef::from_str(&self.inner.chitchat_id.node_id)
-    }
-
     pub fn channel(&self) -> Channel {
         self.inner.channel.clone()
     }
 
     pub fn enabled_services(&self) -> &HashSet<QuickwitService> {
-        &self.inner.enabled_services
+        &self.inner.member.enabled_services
     }
 
     pub fn is_indexer(&self) -> bool {
         self.inner
+            .member
             .enabled_services
             .contains(&QuickwitService::Indexer)
     }
 
     pub fn is_ingester(&self) -> bool {
         self.inner
+            .member
             .enabled_services
             .contains(&QuickwitService::Indexer)
     }
 
     pub fn is_searcher(&self) -> bool {
         self.inner
+            .member
             .enabled_services
             .contains(&QuickwitService::Searcher)
     }
 
     pub fn grpc_advertise_addr(&self) -> SocketAddr {
-        self.inner.grpc_advertise_addr
+        self.inner.member.grpc_advertise_addr
     }
 
     pub fn indexing_tasks(&self) -> &[IndexingTask] {
-        &self.inner.indexing_tasks
+        &self.inner.member.indexing_tasks
     }
 
     pub fn indexing_capacity(&self) -> CpuCapacity {
-        self.inner.indexing_capacity
+        self.inner.member.indexing_cpu_capacity
     }
 
     pub fn ingester_status(&self) -> IngesterStatus {
-        self.inner.ingester_status
+        self.inner.member.ingester_status
     }
 
     pub fn is_ready(&self) -> bool {
-        self.inner.is_ready
+        self.inner.member.is_ready
     }
 
     pub fn is_self_node(&self) -> bool {
@@ -144,16 +130,24 @@ impl ClusterNode {
     }
 
     pub fn availability_zone(&self) -> Option<&str> {
-        self.inner.availability_zone.as_deref()
+        self.inner.member.availability_zone.as_deref()
+    }
+}
+
+impl std::ops::Deref for ClusterNode {
+    type Target = ClusterMember;
+
+    fn deref(&self) -> &ClusterMember {
+        &self.inner.member
     }
 }
 
 impl Debug for ClusterNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Node")
-            .field("node_id", &self.inner.chitchat_id.node_id)
-            .field("enabled_services", &self.inner.enabled_services)
-            .field("is_ready", &self.inner.is_ready)
+            .field("node_id", &self.inner.member.node_id)
+            .field("enabled_services", &self.inner.member.enabled_services)
+            .field("is_ready", &self.inner.member.is_ready)
             .finish()
     }
 }
@@ -161,25 +155,13 @@ impl Debug for ClusterNode {
 #[cfg(test)]
 impl PartialEq for ClusterNode {
     fn eq(&self, other: &Self) -> bool {
-        self.inner.chitchat_id == other.inner.chitchat_id
-            && self.inner.enabled_services == other.inner.enabled_services
-            && self.inner.grpc_advertise_addr == other.inner.grpc_advertise_addr
-            && self.inner.indexing_tasks == other.inner.indexing_tasks
-            && self.inner.is_ready == other.inner.is_ready
+        self.inner.member == other.inner.member
             && self.inner.is_self_node == other.inner.is_self_node
-            && self.inner.availability_zone == other.inner.availability_zone
     }
 }
 
 struct InnerNode {
-    chitchat_id: ChitchatId,
+    member: ClusterMember,
     channel: Channel,
-    enabled_services: HashSet<QuickwitService>,
-    grpc_advertise_addr: SocketAddr,
-    indexing_tasks: Vec<IndexingTask>,
-    indexing_capacity: CpuCapacity,
-    ingester_status: IngesterStatus,
-    is_ready: bool,
     is_self_node: bool,
-    availability_zone: Option<String>,
 }

--- a/quickwit/quickwit-cluster/src/node.rs
+++ b/quickwit/quickwit-cluster/src/node.rs
@@ -75,7 +75,7 @@ impl ClusterNode {
 
         let gossip_advertise_addr = ([127, 0, 0, 1], port).into();
         let grpc_advertise_addr = ([127, 0, 0, 1], port + 1).into();
-        let chitchat_id = ChitchatId::new(node_id.to_string(), 0, gossip_advertise_addr);
+        let chitchat_id = ChitchatId::new(node_id, 0, gossip_advertise_addr);
         let channel = make_channel(grpc_advertise_addr, ClientGrpcConfig::default()).await;
         let mut node_state = NodeState::for_test();
         node_state.set(ENABLED_SERVICES_KEY, enabled_services.join(","));

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -766,7 +766,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(config.cluster_id, DEFAULT_CLUSTER_ID);
-        assert_eq!(config.node_id, get_short_hostname().unwrap());
+        assert_eq!(config.node_id.as_str(), get_short_hostname().unwrap());
         assert_eq!(config.availability_zone, None);
         assert_eq!(
             config.enabled_services,

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -223,7 +223,10 @@ impl NodeConfigBuilder {
         mut self,
         env_vars: &HashMap<String, String>,
     ) -> anyhow::Result<NodeConfig> {
-        let node_id = self.node_id.resolve(env_vars).map(NodeId::new)?;
+        let node_id = self
+            .node_id
+            .resolve(env_vars)
+            .map(|node_id_str| NodeId::from_str(&node_id_str))?;
         let availability_zone = self.availability_zone.resolve_optional(env_vars)?;
 
         let enabled_services = self
@@ -476,7 +479,7 @@ pub fn node_config_for_tests_from_ports(
     rest_listen_port: u16,
     grpc_listen_port: u16,
 ) -> NodeConfig {
-    let node_id = NodeId::new(default_node_id().unwrap());
+    let node_id = NodeId::from_str(&default_node_id().unwrap());
     let enabled_services = QuickwitService::supported_services();
     let availability_zone = Some(String::from("az-1"));
     let listen_address = Host::default();

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -1136,7 +1136,7 @@ async fn watcher_indexers(
                 info!(
                     "indexer `{}` with status `{}` joined the cluster: rebalancing shards and \
                      rebuilding indexing plan",
-                    node.node_id(),
+                    node.node_id,
                     node.ingester_status().as_json_str_name()
                 );
                 trigger_rebalance = true;
@@ -1145,7 +1145,7 @@ async fn watcher_indexers(
                 info!(
                     "indexer `{}` left the cluster: rebalancing shards and rebuilding indexing \
                      plan",
-                    node.node_id()
+                    node.node_id
                 );
                 trigger_rebalance = true
             }
@@ -1157,7 +1157,7 @@ async fn watcher_indexers(
                     info!(
                         "indexer `{}` status changed to `{}`: rebalancing shards and rebuilding \
                          indexing plan",
-                        updated.node_id(),
+                        updated.node_id,
                         updated.ingester_status().as_json_str_name()
                     );
                     trigger_rebalance = true;

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -1924,8 +1924,8 @@ mod tests {
         assert_eq!(indexing_tasks[0].shard_ids, [ShardId::from(17)]);
 
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
-        let shard = &control_plane_debug_info["shard_table"]["test-index-0:00000000000000000000000000"]
-            ["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]
+            ["test-index-0:00000000000000000000000000"]["test-ingester"][0];
         assert_eq!(shard["shard_id"], "00000000000000000017");
         assert_eq!(shard["publish_position_inclusive"], "00000000000000001000");
 
@@ -2029,8 +2029,8 @@ mod tests {
             MetastoreServiceClient::from_mock(mock_metastore),
         );
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
-        let shard = &control_plane_debug_info["shard_table"]["test-index:00000000000000000000000000"]
-            ["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]
+            ["test-index:00000000000000000000000000"]["test-ingester"][0];
         assert_eq!(shard["shard_id"], "00000000000000000017");
         assert_eq!(shard["publish_position_inclusive"], "00000000000000001234");
 
@@ -2746,8 +2746,8 @@ mod tests {
         control_plane_mailbox.ask(callback).await.unwrap();
 
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
-        let shard = &control_plane_debug_info["shard_table"]["test-index:00000000000000000000000000"]
-            ["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]
+            ["test-index:00000000000000000000000000"]["test-ingester"][0];
         assert_eq!(shard["shard_id"], "00000000000000000000");
         assert_eq!(shard["shard_state"], "closed");
 
@@ -2886,8 +2886,8 @@ mod tests {
             control_plane_debug_info["physical_indexing_plan"][0]["node_id"],
             "test-ingester"
         );
-        let shard = &control_plane_debug_info["shard_table"]["test-index:00000000000000000000000000"]
-            ["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]
+            ["test-index:00000000000000000000000000"]["test-ingester"][0];
         assert_eq!(shard["index_uid"], "test-index:00000000000000000000000000");
         assert_eq!(shard["source_id"], INGEST_V2_SOURCE_ID);
         assert_eq!(shard["shard_id"], "00000000000000000000");

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -1214,7 +1214,7 @@ mod tests {
     #[tokio::test]
     async fn test_control_plane_create_index() {
         let universe = Universe::with_accelerated_time();
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id: NodeId = NodeId::from_str("test-node");
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
 
@@ -1270,7 +1270,7 @@ mod tests {
     #[tokio::test]
     async fn test_control_plane_delete_index() {
         let universe = Universe::with_accelerated_time();
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id: NodeId = NodeId::from_str("test-node");
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
 
@@ -1312,7 +1312,7 @@ mod tests {
     #[tokio::test]
     async fn test_control_plane_add_source() {
         let universe = Universe::with_accelerated_time();
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id: NodeId = NodeId::from_str("test-node");
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
 
@@ -1375,7 +1375,7 @@ mod tests {
     async fn test_control_plane_update_source() {
         let universe = Universe::with_accelerated_time();
         let pipelines_after_update = 3;
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id: NodeId = NodeId::from_str("test-node");
         let indexer_pool = IndexerPool::default();
         let mut mock_indexer = MockIndexingService::new();
         // call when starting the cp
@@ -1473,7 +1473,7 @@ mod tests {
     #[tokio::test]
     async fn test_control_plane_toggle_source() {
         let universe = Universe::with_accelerated_time();
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id: NodeId = NodeId::from_str("test-node");
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
 
@@ -1551,7 +1551,7 @@ mod tests {
     #[tokio::test]
     async fn test_control_plane_delete_source() {
         let universe = Universe::with_accelerated_time();
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id: NodeId = NodeId::from_str("test-node");
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
 
@@ -1598,7 +1598,7 @@ mod tests {
     #[tokio::test]
     async fn test_control_plane_get_or_create_open_shards() {
         let universe = Universe::with_accelerated_time();
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id: NodeId = NodeId::from_str("test-node");
         let indexer_pool = IndexerPool::default();
 
         let ingester_pool = IngesterPool::default();
@@ -1678,7 +1678,7 @@ mod tests {
     #[tokio::test]
     async fn test_control_plane_supervision_reload_from_metastore() {
         let universe = Universe::default();
-        let node_id = NodeId::new("test_node".to_string());
+        let node_id = NodeId::from_str("test_node");
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
         let mut mock_metastore = MockMetastoreService::new();
@@ -1814,12 +1814,12 @@ mod tests {
     #[tokio::test]
     async fn test_delete_shard_on_eof() {
         let universe = Universe::with_accelerated_time();
-        let node_id = NodeId::new("test-control-plane".to_string());
+        let node_id = NodeId::from_str("test-control-plane");
         let indexer_pool = IndexerPool::default();
         let (client_mailbox, client_inbox) = universe.create_test_mailbox();
         let client = IndexingServiceClient::from_mailbox::<IndexingService>(client_mailbox);
         let indexer_node_info = IndexerNodeInfo {
-            node_id: NodeId::new("test-indexer".to_string()),
+            node_id: NodeId::from_str("test-indexer"),
             generation_id: 0,
             client,
             indexing_tasks: Vec::new(),
@@ -1924,8 +1924,8 @@ mod tests {
         assert_eq!(indexing_tasks[0].shard_ids, [ShardId::from(17)]);
 
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
-        let shard = &control_plane_debug_info["shard_table"]
-            ["test-index-0:00000000000000000000000000"]["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]["test-index-0:00000000000000000000000000"]
+            ["test-ingester"][0];
         assert_eq!(shard["shard_id"], "00000000000000000017");
         assert_eq!(shard["publish_position_inclusive"], "00000000000000001000");
 
@@ -1963,12 +1963,12 @@ mod tests {
     #[tokio::test]
     async fn test_fill_shard_table_position_from_metastore_on_startup() {
         let universe = Universe::with_accelerated_time();
-        let node_id = NodeId::new("test-control-plane".to_string());
+        let node_id = NodeId::from_str("test-control-plane");
         let indexer_pool = IndexerPool::default();
         let (client_mailbox, _client_inbox) = universe.create_test_mailbox();
         let client = IndexingServiceClient::from_mailbox::<IndexingService>(client_mailbox);
         let indexer_node_info = IndexerNodeInfo {
-            node_id: NodeId::new("test-indexer".to_string()),
+            node_id: NodeId::from_str("test-indexer"),
             generation_id: 0,
             client,
             indexing_tasks: Vec::new(),
@@ -2029,8 +2029,8 @@ mod tests {
             MetastoreServiceClient::from_mock(mock_metastore),
         );
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
-        let shard = &control_plane_debug_info["shard_table"]
-            ["test-index:00000000000000000000000000"]["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]["test-index:00000000000000000000000000"]
+            ["test-ingester"][0];
         assert_eq!(shard["shard_id"], "00000000000000000017");
         assert_eq!(shard["publish_position_inclusive"], "00000000000000001234");
 
@@ -2041,12 +2041,12 @@ mod tests {
     async fn test_delete_non_existing_shard() {
         quickwit_common::setup_logging_for_tests();
         let universe = Universe::default();
-        let node_id = NodeId::new("test-control-plane".to_string());
+        let node_id = NodeId::from_str("test-control-plane");
         let indexer_pool = IndexerPool::default();
         let (client_mailbox, _client_inbox) = universe.create_test_mailbox();
         let client = IndexingServiceClient::from_mailbox::<IndexingService>(client_mailbox);
         let indexer_node_info = IndexerNodeInfo {
-            node_id: NodeId::new("test-indexer".to_string()),
+            node_id: NodeId::from_str("test-indexer"),
             generation_id: 0,
             client,
             indexing_tasks: Vec::new(),
@@ -2134,7 +2134,7 @@ mod tests {
     async fn test_delete_index() {
         quickwit_common::setup_logging_for_tests();
         let universe = Universe::default();
-        let node_id = NodeId::new("test-control-plane".to_string());
+        let node_id = NodeId::from_str("test-control-plane");
         let indexer_pool = IndexerPool::default();
 
         let ingester_pool = IngesterPool::default();
@@ -2220,7 +2220,7 @@ mod tests {
             });
         let ingester =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester));
-        ingester_pool.insert("node1".into(), ingester);
+        ingester_pool.insert(NodeId::from_str("node1"), ingester);
 
         let cluster_config = ClusterConfig::for_test();
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
@@ -2249,7 +2249,7 @@ mod tests {
     async fn test_delete_source() {
         quickwit_common::setup_logging_for_tests();
         let universe = Universe::default();
-        let node_id = NodeId::new("test-control-plane".to_string());
+        let node_id = NodeId::from_str("test-control-plane");
         let indexer_pool = IndexerPool::default();
 
         let ingester_pool = IngesterPool::default();
@@ -2267,7 +2267,7 @@ mod tests {
             });
         let ingester =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester));
-        ingester_pool.insert("node1".into(), ingester);
+        ingester_pool.insert(NodeId::from_str("node1"), ingester);
 
         let mut index_0 = IndexMetadata::for_test("test-index-0", "ram:///test-index-0");
         let index_uid_clone = index_0.index_uid.clone();
@@ -2350,7 +2350,7 @@ mod tests {
         let mut cluster_config = ClusterConfig::for_test();
         cluster_config.auto_create_indexes = true;
 
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
@@ -2552,7 +2552,7 @@ mod tests {
         let universe = Universe::with_accelerated_time();
 
         let cluster_config = ClusterConfig::for_test();
-        let node_id = NodeId::from("test-control-plane");
+        let node_id = NodeId::from_str("test-control-plane");
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
 
         let indexer_pool = IndexerPool::default();
@@ -2620,12 +2620,12 @@ mod tests {
         let universe = Universe::with_accelerated_time();
 
         let cluster_config = ClusterConfig::for_test();
-        let node_id = NodeId::from("test-control-plane");
+        let node_id = NodeId::from_str("test-control-plane");
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
 
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
-        let ingester_id = NodeId::from("test-ingester");
+        let ingester_id = NodeId::from_str("test-ingester");
         let mut mock_ingester = MockIngesterService::new();
         mock_ingester
             .expect_retain_shards()
@@ -2746,8 +2746,8 @@ mod tests {
         control_plane_mailbox.ask(callback).await.unwrap();
 
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
-        let shard = &control_plane_debug_info["shard_table"]
-            ["test-index:00000000000000000000000000"]["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]["test-index:00000000000000000000000000"]
+            ["test-ingester"][0];
         assert_eq!(shard["shard_id"], "00000000000000000000");
         assert_eq!(shard["shard_state"], "closed");
 
@@ -2759,11 +2759,11 @@ mod tests {
         let universe = Universe::with_accelerated_time();
 
         let cluster_config = ClusterConfig::for_test();
-        let node_id = NodeId::from("test-control-plane");
+        let node_id = NodeId::from_str("test-control-plane");
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
 
         let indexer_pool = IndexerPool::default();
-        let ingester_id = NodeId::from("test-ingester");
+        let ingester_id = NodeId::from_str("test-ingester");
 
         let mut mock_indexer = MockIndexingService::new();
         mock_indexer
@@ -2886,8 +2886,8 @@ mod tests {
             control_plane_debug_info["physical_indexing_plan"][0]["node_id"],
             "test-ingester"
         );
-        let shard = &control_plane_debug_info["shard_table"]
-            ["test-index:00000000000000000000000000"]["test-ingester"][0];
+        let shard = &control_plane_debug_info["shard_table"]["test-index:00000000000000000000000000"]
+            ["test-ingester"][0];
         assert_eq!(shard["index_uid"], "test-index:00000000000000000000000000");
         assert_eq!(shard["source_id"], INGEST_V2_SOURCE_ID);
         assert_eq!(shard["shard_id"], "00000000000000000000");

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -1132,12 +1132,12 @@ async fn watcher_indexers(
         // We rebalance shards when either readiness level changes.
         let mut trigger_rebalance = false;
         match cluster_change {
-            ClusterChange::Add(node) if node.is_indexer() && node.ingester_status().is_ready() => {
+            ClusterChange::Add(node) if node.is_indexer() && node.ingester_status.is_ready() => {
                 info!(
                     "indexer `{}` with status `{}` joined the cluster: rebalancing shards and \
                      rebuilding indexing plan",
                     node.node_id,
-                    node.ingester_status().as_json_str_name()
+                    node.ingester_status.as_json_str_name()
                 );
                 trigger_rebalance = true;
             }
@@ -1150,15 +1150,15 @@ async fn watcher_indexers(
                 trigger_rebalance = true
             }
             ClusterChange::Update { previous, updated } if updated.is_indexer() => {
-                let was_ready = previous.ingester_status().is_ready();
-                let is_ready = updated.ingester_status().is_ready();
+                let was_ready = previous.ingester_status.is_ready();
+                let is_ready = updated.ingester_status.is_ready();
 
                 if was_ready ^ is_ready {
                     info!(
                         "indexer `{}` status changed to `{}`: rebalancing shards and rebuilding \
                          indexing plan",
                         updated.node_id,
-                        updated.ingester_status().as_json_str_name()
+                        updated.ingester_status.as_json_str_name()
                     );
                     trigger_rebalance = true;
                 }

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -361,7 +361,7 @@ impl ControlPlane {
             ingesters.insert(ingester_id.clone(), ingester_json);
         }
         for shard in self.model.all_shards() {
-            let ingester_id = NodeId::from(shard.leader_id.clone());
+            let ingester_id = NodeId::from_str(&shard.leader_id);
 
             if let Entry::Vacant(entry) = ingesters.entry(ingester_id.clone()) {
                 let ingester_json = json!({

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -406,7 +406,7 @@ impl IndexingScheduler {
             tokio::spawn({
                 let indexer = indexers
                     .iter()
-                    .find(|indexer| indexer.node_id == *node_id)
+                    .find(|indexer| indexer.node_id == node_id.as_str())
                     .expect("This should never happen as the plan was built from these indexers.")
                     .clone();
                 let indexing_tasks = indexing_tasks.clone();

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/mod.rs
@@ -856,7 +856,7 @@ mod tests {
         let num_indexers = 10;
         let num_shards: usize = 1000;
         let indexers: Vec<NodeId> = (0..num_indexers)
-            .map(|indexer_id| NodeId::new(format!("indexer{indexer_id}")))
+            .map(|indexer_id| NodeId::from_str(&format!("indexer{indexer_id}")))
             .collect();
         let source_uids: Vec<SourceUid> = std::iter::repeat_with(source_id).take(1_000).collect();
         let shard_ids: Vec<ShardId> = (0..num_shards as u64).map(ShardId::from).collect();
@@ -1160,11 +1160,11 @@ mod tests {
             shard2.clone(),
             shard3.clone(),
         ];
-        let node1 = NodeId::new("node1".to_string());
-        let node2 = NodeId::new("node2".to_string());
+        let node1 = NodeId::from_str("node1");
+        let node2 = NodeId::from_str("node2");
         // This node is missing from the capacity map.
         // It should not be assigned any task despite being present in shard locations.
-        let node_missing = NodeId::new("node_missing".to_string());
+        let node_missing = NodeId::from_str("node_missing");
         let mut remaining_num_shards_per_node = HashMap::default();
         remaining_num_shards_per_node
             .insert(node1.as_str().to_string(), NonZeroU32::new(3).unwrap());

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -3619,7 +3619,7 @@ mod tests {
                 status: IngesterStatus::Ready,
                 availability_zone: None,
             };
-            ingester_pool.insert(NodeId::from_str(&ingester_id), ingester);
+            ingester_pool.insert(NodeId::from_str(ingester_id), ingester);
         }
 
         let unavailable_ids: Vec<String> = (0..unavailable_ingester_shards.len())
@@ -3636,7 +3636,7 @@ mod tests {
                 status: IngesterStatus::Retiring,
                 availability_zone: None,
             };
-            ingester_pool.insert(NodeId::from_str(&ingester_id), ingester);
+            ingester_pool.insert(NodeId::from_str(ingester_id), ingester);
         }
 
         let mut shards: Vec<Shard> = Vec::new();
@@ -3777,7 +3777,7 @@ mod tests {
                     status: IngesterStatus::Decommissioned,
                     availability_zone: None,
                 };
-                ingester_pool.insert(NodeId::from_str(&ingester_id), ingester);
+                ingester_pool.insert(NodeId::from_str(ingester_id), ingester);
             }
             model.insert_shards(&index_uid, &source_id, opened_shards);
 

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -1394,7 +1394,7 @@ mod tests {
 
         let ingester_pool = IngesterPool::default();
         ingester_pool.insert(
-            NodeId::from("test-ingester-1"),
+            NodeId::from_str("test-ingester-1"),
             IngesterPoolEntry::ready_with_client(client.clone()),
         );
 
@@ -1425,7 +1425,7 @@ mod tests {
             });
         let ingester = IngesterServiceClient::from_mock(mock_ingester);
         ingester_pool.insert(
-            NodeId::from("test-ingester-2"),
+            NodeId::from_str("test-ingester-2"),
             IngesterPoolEntry::ready_with_client(ingester.clone()),
         );
 
@@ -1614,7 +1614,7 @@ mod tests {
 
         let ingester_pool = IngesterPool::default();
         ingester_pool.insert(
-            NodeId::from("test-ingester-1"),
+            NodeId::from_str("test-ingester-1"),
             IngesterPoolEntry::ready_with_client(client.clone()),
         );
 
@@ -1728,7 +1728,7 @@ mod tests {
         assert!(leader_follower_pairs_opt.is_none());
 
         ingester_pool.insert(
-            NodeId::from("test-ingester-1"),
+            NodeId::from_str("test-ingester-1"),
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::mocked()),
         );
 
@@ -1740,7 +1740,7 @@ mod tests {
         assert!(leader_follower_pairs_opt.is_none());
 
         ingester_pool.insert(
-            "test-ingester-2".into(),
+            NodeId::from_str("test-ingester-2"),
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::mocked()),
         );
 
@@ -1761,13 +1761,13 @@ mod tests {
         if leader_follower_pairs[0].0 == "test-ingester-1" {
             assert_eq!(
                 leader_follower_pairs[0].1,
-                Some(NodeId::from("test-ingester-2"))
+                Some(NodeId::from_str("test-ingester-2"))
             );
         } else {
             assert_eq!(leader_follower_pairs[0].0, "test-ingester-2");
             assert_eq!(
                 leader_follower_pairs[0].1,
-                Some(NodeId::from("test-ingester-1"))
+                Some(NodeId::from_str("test-ingester-1"))
             );
         }
 
@@ -1780,13 +1780,13 @@ mod tests {
             if leader_follower_pair.0 == "test-ingester-1" {
                 assert_eq!(
                     leader_follower_pair.1,
-                    Some(NodeId::from("test-ingester-2"))
+                    Some(NodeId::from_str("test-ingester-2"))
                 );
             } else {
                 assert_eq!(leader_follower_pair.0, "test-ingester-2");
                 assert_eq!(
                     leader_follower_pair.1,
-                    Some(NodeId::from("test-ingester-1"))
+                    Some(NodeId::from_str("test-ingester-1"))
                 );
             }
         }
@@ -1815,19 +1815,19 @@ mod tests {
         assert_eq!(leader_follower_pairs[0].0, "test-ingester-2");
         assert_eq!(
             leader_follower_pairs[0].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
 
         assert_eq!(leader_follower_pairs[1].0, "test-ingester-2");
         assert_eq!(
             leader_follower_pairs[1].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
 
         assert_eq!(leader_follower_pairs[2].0, "test-ingester-2");
         assert_eq!(
             leader_follower_pairs[2].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
 
         let open_shards = vec![
@@ -1858,14 +1858,14 @@ mod tests {
         assert_eq!(leader_follower_pairs[0].0, "test-ingester-2");
         assert_eq!(
             leader_follower_pairs[0].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
 
         ingester_pool.insert(
-            "test-ingester-3".into(),
+            NodeId::from_str("test-ingester-3"),
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::mocked()),
         );
-        let unavailable_leaders = FnvHashSet::from_iter([NodeId::from("test-ingester-2")]);
+        let unavailable_leaders = FnvHashSet::from_iter([NodeId::from_str("test-ingester-2")]);
         let leader_follower_pairs = controller
             .allocate_shards(4, &unavailable_leaders, &model)
             .unwrap();
@@ -1874,25 +1874,25 @@ mod tests {
         assert_eq!(leader_follower_pairs[0].0, "test-ingester-3");
         assert_eq!(
             leader_follower_pairs[0].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
 
         assert_eq!(leader_follower_pairs[1].0, "test-ingester-3");
         assert_eq!(
             leader_follower_pairs[1].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
 
         assert_eq!(leader_follower_pairs[2].0, "test-ingester-3");
         assert_eq!(
             leader_follower_pairs[2].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
 
         assert_eq!(leader_follower_pairs[3].0, "test-ingester-3");
         assert_eq!(
             leader_follower_pairs[3].1,
-            Some(NodeId::from("test-ingester-1"))
+            Some(NodeId::from_str("test-ingester-1"))
         );
     }
 
@@ -1910,7 +1910,7 @@ mod tests {
             1.001,
         );
 
-        let ingester_id_0 = NodeId::from("test-ingester-0");
+        let ingester_id_0 = NodeId::from_str("test-ingester-0");
         let mut mock_ingester_0 = MockIngesterService::new();
         mock_ingester_0
             .expect_init_shards()
@@ -1962,7 +1962,7 @@ mod tests {
             IngesterPoolEntry::ready_with_client(ingester_0),
         );
 
-        let ingester_id_1 = NodeId::from("test-ingester-1");
+        let ingester_id_1 = NodeId::from_str("test-ingester-1");
         let mut mock_ingester_1 = MockIngesterService::new();
         mock_ingester_1
             .expect_init_shards()
@@ -1985,7 +1985,7 @@ mod tests {
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_1));
         ingester_pool.insert(ingester_id_1, ingester_1);
 
-        let ingester_id_2 = NodeId::from("test-ingester-2");
+        let ingester_id_2 = NodeId::from_str("test-ingester-2");
         let mut mock_ingester_2 = MockIngesterService::new();
         mock_ingester_2.expect_init_shards().never();
 
@@ -2202,7 +2202,7 @@ mod tests {
             });
 
         ingester_pool.insert(
-            NodeId::from("test-ingester-1"),
+            NodeId::from_str("test-ingester-1"),
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester)),
         );
         let source_uids: HashMap<SourceUid, usize> = HashMap::from_iter([(source_uid.clone(), 1)]);
@@ -2317,7 +2317,7 @@ mod tests {
             long_term_ingestion_rate: RateMibPerSec(1),
         }]);
         let local_shards_update = LocalShardsUpdate {
-            leader_id: "test-ingester".into(),
+            leader_id: NodeId::from_str("test-ingester"),
             source_uid: source_uid.clone(),
             shard_infos,
         };
@@ -2375,7 +2375,7 @@ mod tests {
             });
         let ingester =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester));
-        ingester_pool.insert("test-ingester".into(), ingester);
+        ingester_pool.insert(NodeId::from_str("test-ingester"), ingester);
 
         let shard_infos = BTreeSet::from_iter([
             ShardInfo {
@@ -2392,7 +2392,7 @@ mod tests {
             },
         ]);
         let local_shards_update = LocalShardsUpdate {
-            leader_id: "test-ingester".into(),
+            leader_id: NodeId::from_str("test-ingester"),
             source_uid: source_uid.clone(),
             shard_infos,
         };
@@ -2417,7 +2417,7 @@ mod tests {
             },
         ]);
         let local_shards_update = LocalShardsUpdate {
-            leader_id: "test-ingester".into(),
+            leader_id: NodeId::from_str("test-ingester"),
             source_uid: source_uid.clone(),
             shard_infos,
         };
@@ -2529,7 +2529,7 @@ mod tests {
 
         let ingester =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester));
-        ingester_pool.insert("test-ingester".into(), ingester);
+        ingester_pool.insert(NodeId::from_str("test-ingester"), ingester);
 
         let shard_infos = BTreeSet::from_iter([ShardInfo {
             shard_id: ShardId::from(1),
@@ -2538,7 +2538,7 @@ mod tests {
             long_term_ingestion_rate: RateMibPerSec(4),
         }]);
         let local_shards_update = LocalShardsUpdate {
-            leader_id: "test-ingester".into(),
+            leader_id: NodeId::from_str("test-ingester"),
             source_uid: source_uid.clone(),
             shard_infos,
         };
@@ -2676,7 +2676,7 @@ mod tests {
             });
         let ingester =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester));
-        ingester_pool.insert("test-ingester".into(), ingester);
+        ingester_pool.insert(NodeId::from_str("test-ingester"), ingester);
 
         // Test failed to open shards.
         controller
@@ -2799,7 +2799,7 @@ mod tests {
             });
         let ingester =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester));
-        ingester_pool.insert("test-ingester".into(), ingester);
+        ingester_pool.insert(NodeId::from_str("test-ingester"), ingester);
 
         // Test failed to close shard.
         controller
@@ -3029,18 +3029,18 @@ mod tests {
                 Ok(RetainShardsResponse {})
             });
         ingester_pool.insert(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_1)),
         );
         ingester_pool.insert(
-            "node-2".into(),
+            NodeId::from_str("node-2"),
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_2)),
         );
         ingester_pool.insert(
-            "node-3".into(),
+            NodeId::from_str("node-3"),
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_3)),
         );
-        let node_id = "node-1".into();
+        let node_id = NodeId::from_str("node-1");
         let wait_handle = controller.sync_with_ingester(&node_id, &model);
         wait_handle.wait().await;
         assert_eq!(count_calls.load(Ordering::Acquire), 1);
@@ -3140,7 +3140,7 @@ mod tests {
         let closed_shards = controller.close_shards(Vec::new()).await;
         assert_eq!(closed_shards.len(), 0);
 
-        let ingester_id_0 = NodeId::from("test-ingester-0");
+        let ingester_id_0 = NodeId::from_str("test-ingester-0");
         let mut mock_ingester_0 = MockIngesterService::new();
         mock_ingester_0
             .expect_close_shards()
@@ -3173,7 +3173,7 @@ mod tests {
             IngesterPoolEntry::ready_with_client(ingester_0),
         );
 
-        let ingester_id_1 = NodeId::from("test-ingester-1");
+        let ingester_id_1 = NodeId::from_str("test-ingester-1");
         let mut mock_ingester_1 = MockIngesterService::new();
         mock_ingester_1
             .expect_close_shards()
@@ -3194,7 +3194,7 @@ mod tests {
             IngesterPoolEntry::ready_with_client(ingester_1),
         );
 
-        let ingester_id_2 = NodeId::from("test-ingester-2");
+        let ingester_id_2 = NodeId::from_str("test-ingester-2");
         let mut mock_ingester_2 = MockIngesterService::new();
         mock_ingester_2.expect_close_shards().never();
 
@@ -3365,7 +3365,7 @@ mod tests {
         ];
         model.insert_shards(&index_uid, &INGEST_V2_SOURCE_ID.to_string(), open_shards);
 
-        let ingester_id_0 = NodeId::from("test-ingester-0");
+        let ingester_id_0 = NodeId::from_str("test-ingester-0");
         let mut mock_ingester_0 = MockIngesterService::new();
         mock_ingester_0
             .expect_close_shards()
@@ -3389,7 +3389,7 @@ mod tests {
             IngesterPoolEntry::ready_with_client(ingester_0),
         );
 
-        let ingester_id_1 = NodeId::from("test-ingester-1");
+        let ingester_id_1 = NodeId::from_str("test-ingester-1");
         let mut mock_ingester_1 = MockIngesterService::new();
         mock_ingester_1.expect_init_shards().return_once(|request| {
             assert_eq!(request.subrequests.len(), 2);
@@ -3515,7 +3515,7 @@ mod tests {
             .map(|i| format!("shard-{i}"))
             .collect();
         for (shard, &shard_count) in shards.into_iter().zip(shard_counts.iter()) {
-            shard_counts_map.insert(NodeId::from(shard), shard_count);
+            shard_counts_map.insert(NodeId::from_str(&shard), shard_count);
         }
         for i in 0..10 {
             test_allocate_shards_aux_aux(&shard_counts_map, i, false);
@@ -3619,7 +3619,7 @@ mod tests {
                 status: IngesterStatus::Ready,
                 availability_zone: None,
             };
-            ingester_pool.insert(NodeId::from(ingester_id.clone()), ingester);
+            ingester_pool.insert(NodeId::from_str(&ingester_id), ingester);
         }
 
         let unavailable_ids: Vec<String> = (0..unavailable_ingester_shards.len())
@@ -3636,7 +3636,7 @@ mod tests {
                 status: IngesterStatus::Retiring,
                 availability_zone: None,
             };
-            ingester_pool.insert(NodeId::from(ingester_id.clone()), ingester);
+            ingester_pool.insert(NodeId::from_str(&ingester_id), ingester);
         }
 
         let mut shards: Vec<Shard> = Vec::new();
@@ -3777,7 +3777,7 @@ mod tests {
                     status: IngesterStatus::Decommissioned,
                     availability_zone: None,
                 };
-                ingester_pool.insert(NodeId::from(ingester_id.clone()), ingester);
+                ingester_pool.insert(NodeId::from_str(&ingester_id), ingester);
             }
             model.insert_shards(&index_uid, &source_id, opened_shards);
 

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -458,7 +458,7 @@ impl IngestController {
         let unavailable_leaders: FnvHashSet<NodeId> = get_open_shards_request
             .unavailable_leaders
             .into_iter()
-            .map(NodeId::from)
+            .map(|id| NodeId::from_str(&id))
             .collect();
 
         // We do a first pass to identify the shards that are missing from the model and need to be
@@ -572,7 +572,7 @@ impl IngestController {
         }
 
         for shard in model.all_shards() {
-            if shard.is_open() && !unavailable_leaders.contains(&shard.leader_id) {
+            if shard.is_open() && !unavailable_leaders.contains(shard.leader_id.as_str()) {
                 for ingest_node in shard.ingesters() {
                     if let Some(shard_count) =
                         per_node_num_open_shards.get_mut(ingest_node.as_str())
@@ -641,7 +641,7 @@ impl IngestController {
                     }
                 })
                 .collect();
-            let Some(leader) = self.ingester_pool.get(&leader_id) else {
+            let Some(leader) = self.ingester_pool.get(leader_id.as_str()) else {
                 warn!("failed to init shards: ingester `{leader_id}` is unavailable");
                 failures.extend(init_shard_failures);
                 continue;
@@ -1210,7 +1210,7 @@ impl IngestController {
                 source_id: shard.source_id,
                 shard_id: shard.shard_id,
             };
-            let leader_id = NodeId::from(shard.leader_id);
+            let leader_id = NodeId::from_str(&shard.leader_id);
             per_leader_shards_to_close
                 .entry(leader_id)
                 .or_default()
@@ -1302,7 +1302,7 @@ fn find_scale_down_candidate(
         .max_by_key(|(_leader_id, shard_entries)| (shard_entries.len(), rng.next_u32()))
         .map(|(leader_id, shard_entries)| {
             (
-                leader_id.clone().into(),
+                NodeId::from_str(leader_id),
                 shard_entries.choose(&mut rng).unwrap().shard_id().clone(),
             )
         })

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -446,7 +446,8 @@ impl ShardTable {
             .shard_entries
             .values()
             .filter(|shard_entry| {
-                shard_entry.shard.is_open() && !unavailable_leaders.contains(&shard_entry.leader_id)
+                shard_entry.shard.is_open()
+                    && !unavailable_leaders.contains(shard_entry.leader_id.as_str())
             })
             .cloned()
             .collect();

--- a/quickwit/quickwit-control-plane/src/model/shard_table.rs
+++ b/quickwit/quickwit-control-plane/src/model/shard_table.rs
@@ -842,7 +842,7 @@ mod tests {
         assert_eq!(open_shards[0].shard, shard_03);
         assert_eq!(open_shards[1].shard, shard_04);
 
-        unavailable_ingesters.insert("test-leader-0".into());
+        unavailable_ingesters.insert(NodeId::from_str("test-leader-0"));
 
         let open_shards = shard_table
             .find_open_shards_sorted(&index_uid, &source_id, &unavailable_ingesters)
@@ -1235,8 +1235,8 @@ mod tests {
         let shard1 = ShardId::from("shard1");
         let shard2 = ShardId::from("shard1");
         let unlisted_shard = ShardId::from("unlisted");
-        let node1 = NodeId::new("node1".to_string());
-        let node2 = NodeId::new("node2".to_string());
+        let node1 = NodeId::from_str("node1");
+        let node2 = NodeId::from_str("node2");
         let mut shard_locations = ShardLocations::default();
         shard_locations.add_location(&shard1, &node1);
         shard_locations.add_location(&shard1, &node2);
@@ -1343,19 +1343,19 @@ mod tests {
         };
         assert_eq!(
             &get_sorted_locations_for_shard(0u64),
-            &[&NodeId::from("indexer1"), &NodeId::from("indexer2")]
+            &[&NodeId::from_str("indexer1"), &NodeId::from_str("indexer2")]
         );
         assert_eq!(
             &get_sorted_locations_for_shard(1u64),
-            &[&NodeId::from("indexer1")]
+            &[&NodeId::from_str("indexer1")]
         );
         assert_eq!(
             &get_sorted_locations_for_shard(2u64),
-            &[&NodeId::from("indexer2")]
+            &[&NodeId::from_str("indexer2")]
         );
         assert_eq!(
             &get_sorted_locations_for_shard(3u64),
-            &[&NodeId::from("indexer1"), &NodeId::from("indexer2")]
+            &[&NodeId::from_str("indexer1"), &NodeId::from_str("indexer2")]
         );
     }
 }

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -73,7 +73,7 @@ pub fn test_indexer_change_stream(
                 ClusterChange::Add(node)
                     if node.enabled_services().contains(&QuickwitService::Indexer) =>
                 {
-                    let node_id = node.node_id().to_owned();
+                    let node_id = node.node_id.clone();
                     let generation_id = node.chitchat_id().generation_id;
                     let indexing_tasks = node.indexing_tasks().to_vec();
                     let client_mailbox = indexing_clients.get(&node_id).unwrap().clone();
@@ -90,7 +90,7 @@ pub fn test_indexer_change_stream(
                     );
                     Some(change)
                 }
-                ClusterChange::Remove(node) => Some(Change::Remove(node.node_id().to_owned())),
+                ClusterChange::Remove(node) => Some(Change::Remove(node.node_id.clone())),
                 _ => None,
             }
         })

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -75,7 +75,7 @@ pub fn test_indexer_change_stream(
                 ClusterChange::Add(node) if node.is_service_enabled(QuickwitService::Indexer) => {
                     let node_id = node.node_id.clone();
                     let generation_id = node.chitchat_id().generation_id;
-                    let indexing_tasks = node.indexing_tasks().to_vec();
+                    let indexing_tasks = node.indexing_tasks.to_vec();
                     let client_mailbox = indexing_clients.get(&node_id).unwrap().clone();
                     let client = IndexingServiceClient::from_mailbox(client_mailbox);
                     let change = Change::Insert(

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -18,7 +18,9 @@ use std::time::Duration;
 use fnv::FnvHashMap;
 use futures::{Stream, StreamExt};
 use quickwit_actors::{Inbox, Mailbox, Observe, Universe};
-use quickwit_cluster::{ChannelTransport, Cluster, ClusterChange, create_cluster_for_test};
+use quickwit_cluster::{
+    ChannelTransport, Cluster, ClusterChange, ClusterMember, create_cluster_for_test,
+};
 use quickwit_common::test_utils::wait_until_predicate;
 use quickwit_common::tower::{Change, Pool};
 use quickwit_config::service::QuickwitService;
@@ -70,9 +72,7 @@ pub fn test_indexer_change_stream(
         let indexing_clients = indexing_clients.clone();
         Box::pin(async move {
             match cluster_change {
-                ClusterChange::Add(node)
-                    if node.enabled_services().contains(&QuickwitService::Indexer) =>
-                {
+                ClusterChange::Add(node) if node.is_service_enabled(QuickwitService::Indexer) => {
                     let node_id = node.node_id.clone();
                     let generation_id = node.chitchat_id().generation_id;
                     let indexing_tasks = node.indexing_tasks().to_vec();
@@ -329,11 +329,7 @@ async fn test_scheduler_scheduling_multiple_indexers() {
 
     cluster
         .wait_for_ready_members(
-            |members| {
-                members
-                    .iter()
-                    .any(|member| member.enabled_services.contains(&QuickwitService::Indexer))
-            },
+            |members| members.iter().any(ClusterMember::is_indexer),
             Duration::from_secs(5),
         )
         .await
@@ -391,13 +387,7 @@ async fn test_scheduler_scheduling_multiple_indexers() {
 
     cluster
         .wait_for_ready_members(
-            |members| {
-                members
-                    .iter()
-                    .filter(|member| member.enabled_services.contains(&QuickwitService::Indexer))
-                    .count()
-                    == 1
-            },
+            |members| members.iter().filter(|member| member.is_indexer()).count() == 1,
             Duration::from_secs(5),
         )
         .await

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -23,7 +23,6 @@ use quickwit_cluster::{
 };
 use quickwit_common::test_utils::wait_until_predicate;
 use quickwit_common::tower::{Change, Pool};
-use quickwit_config::service::QuickwitService;
 use quickwit_config::{
     ClusterConfig, KafkaSourceParams, SourceConfig, SourceInputFormat, SourceParams,
 };
@@ -72,7 +71,7 @@ pub fn test_indexer_change_stream(
         let indexing_clients = indexing_clients.clone();
         Box::pin(async move {
             match cluster_change {
-                ClusterChange::Add(node) if node.is_service_enabled(QuickwitService::Indexer) => {
+                ClusterChange::Add(node) if node.is_indexer() => {
                     let node_id = node.node_id.clone();
                     let generation_id = node.chitchat_id().generation_id;
                     let indexing_tasks = node.indexing_tasks.to_vec();

--- a/quickwit/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit/quickwit-indexing/failpoints/mod.rs
@@ -293,7 +293,7 @@ async fn test_merge_executor_controlled_directory_kill_switch() -> anyhow::Resul
         tantivy_dirs,
     };
     let pipeline_id = MergePipelineId {
-        node_id: NodeId::from("test-node"),
+        node_id: NodeId::from_str("test-node"),
         index_uid: IndexUid::new_with_random_ulid(index_id),
         source_id: "test-source".to_string(),
     };

--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -748,7 +748,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: index_uid.clone(),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
@@ -885,7 +885,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: index_uid.clone(),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
@@ -962,7 +962,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
@@ -1046,7 +1046,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
@@ -1134,7 +1134,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());
@@ -1214,7 +1214,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper: Arc<DocMapper> =
@@ -1314,7 +1314,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper: Arc<DocMapper> =
@@ -1385,7 +1385,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper: Arc<DocMapper> =
@@ -1457,7 +1457,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper: Arc<DocMapper> =
@@ -1522,7 +1522,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper: Arc<DocMapper> =
@@ -1583,7 +1583,7 @@ mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let doc_mapper = Arc::new(default_doc_mapper_for_test());

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -581,7 +581,7 @@ mod tests {
         mut num_fails: usize,
         test_file: &str,
     ) -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::for_test("test-index", 2);
         let pipeline_id = IndexingPipelineId {
             node_id,
@@ -712,7 +712,7 @@ mod tests {
     }
 
     async fn indexing_pipeline_simple(test_file: &str) -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid: IndexUid = IndexUid::for_test("test-index", 1);
         let pipeline_id = IndexingPipelineId {
             node_id,
@@ -819,7 +819,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_pipeline_does_not_stop_on_indexing_pipeline_failure() {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let pipeline_id = IndexingPipelineId {
             node_id,
             index_uid: IndexUid::new_with_random_ulid("test-index"),
@@ -924,7 +924,7 @@ mod tests {
     }
 
     async fn indexing_pipeline_all_failures_handling(test_file: &str) -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid: IndexUid = IndexUid::for_test("test-index", 2);
         let pipeline_id = IndexingPipelineId {
             node_id,

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -1202,7 +1202,7 @@ mod tests {
                 .unwrap();
         let merge_scheduler_mailbox: Mailbox<MergeSchedulerService> = universe.get_or_spawn_one();
         let indexing_server = IndexingService::new(
-            NodeId::from("test-node"),
+            NodeId::from_str("test-node"),
             data_dir_path.to_path_buf(),
             indexer_config,
             num_blocking_threads,
@@ -1719,7 +1719,7 @@ mod tests {
                 .unwrap();
         let merge_scheduler_service = universe.get_or_spawn_one();
         let indexing_server = IndexingService::new(
-            NodeId::from("test-node"),
+            NodeId::from_str("test-node"),
             data_dir_path,
             indexer_config,
             num_blocking_threads,
@@ -1920,7 +1920,7 @@ mod tests {
         let storage_resolver = StorageResolver::unconfigured();
         let merge_scheduler_service: Mailbox<MergeSchedulerService> = universe.get_or_spawn_one();
         let mut indexing_server = IndexingService::new(
-            NodeId::from("test-ingest-api-gc-node"),
+            NodeId::from_str("test-ingest-api-gc-node"),
             data_dir_path,
             indexer_config,
             num_blocking_threads,

--- a/quickwit/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_executor.rs
@@ -458,7 +458,7 @@ impl MergeExecutor {
         };
         let indexed_split = IndexedSplit {
             split_attrs: SplitAttrs {
-                node_id: NodeId::new(split.node_id),
+                node_id: NodeId::from_str(&split.node_id),
                 index_uid: split.index_uid,
                 source_id: split.source_id,
                 doc_mapping_uid: split.doc_mapping_uid,

--- a/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_pipeline.rs
@@ -587,7 +587,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_pipeline_simple() -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = "test-source".to_string();
         let pipeline_id = MergePipelineId {

--- a/quickwit/quickwit-indexing/src/actors/merge_planner.rs
+++ b/quickwit/quickwit-indexing/src/actors/merge_planner.rs
@@ -348,7 +348,7 @@ impl MergePlanner {
 
 /// We can only merge splits with the same (node_id, index_id, source_id).
 fn belongs_to_pipeline(pipeline_id: &MergePipelineId, split: &SplitMetadata) -> bool {
-    pipeline_id.node_id == split.node_id
+    pipeline_id.node_id == split.node_id.as_str()
         && pipeline_id.index_uid == split.index_uid
         && pipeline_id.source_id == split.source_id
 }
@@ -407,7 +407,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_planner_with_stable_custom_merge_policy() -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
         let [doc_mapping_uid1, doc_mapping_uid2] = {
@@ -525,7 +525,7 @@ mod tests {
     #[tokio::test]
     async fn test_merge_planner_spawns_merge_over_existing_splits_on_startup() -> anyhow::Result<()>
     {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
         let doc_mapping_uid = DocMappingUid::random();
@@ -610,7 +610,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_planner_dismiss_splits_from_different_pipeline_id() -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
         let doc_mapping_uid = DocMappingUid::random();
@@ -681,7 +681,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_planner_inherit_mailbox_with_splits_bug_3847() -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
         let doc_mapping_uid = DocMappingUid::random();

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -504,7 +504,7 @@ mod tests {
         }
         let index = index_writer.finalize()?;
 
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
 

--- a/quickwit/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/uploader.rs
@@ -529,7 +529,7 @@ mod tests {
     async fn test_uploader_with_sequencer() -> anyhow::Result<()> {
         quickwit_common::setup_logging_for_tests();
 
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
 
@@ -645,7 +645,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_uploader_with_sequencer_emits_replace() -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
 
@@ -799,7 +799,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_uploader_without_sequencer() -> anyhow::Result<()> {
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::for_test("test-index", 0);
         let index_uid_clone = index_uid.clone();
         let source_id = "test-source".to_string();
@@ -982,7 +982,7 @@ mod tests {
         // we need to keep the handle alive.
         let _subscribe_handle = event_broker.subscribe(report_splits_listener);
 
-        let node_id = NodeId::from("test-node");
+        let node_id = NodeId::from_str("test-node");
         let index_uid = IndexUid::new_with_random_ulid("test-index");
         let source_id = "test-source".to_string();
 

--- a/quickwit/quickwit-indexing/src/merge_policy/mod.rs
+++ b/quickwit/quickwit-indexing/src/merge_policy/mod.rs
@@ -407,7 +407,7 @@ pub mod tests {
         let merged_split_id = new_split_id();
         let tags = merge_tags(splits);
         let pipeline_id = MergePipelineId {
-            node_id: NodeId::from("test_node"),
+            node_id: NodeId::from_str("test_node"),
             index_uid: IndexUid::new_with_random_ulid("test_index"),
             source_id: "test_source".to_string(),
         };
@@ -439,7 +439,7 @@ pub mod tests {
         let pipeline_id = IndexingPipelineId {
             index_uid: IndexUid::new_with_random_ulid("test-index"),
             source_id: "test-source".to_string(),
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             pipeline_uid: PipelineUid::default(),
         };
         let merge_planner = MergePlanner::new(

--- a/quickwit/quickwit-indexing/src/source/ingest/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest/mod.rs
@@ -157,7 +157,7 @@ impl IngestSource {
         source_runtime: SourceRuntime,
         retry_params: RetryParams,
     ) -> anyhow::Result<IngestSource> {
-        let self_node_id: NodeId = source_runtime.node_id().into();
+        let self_node_id: NodeId = source_runtime.node_id().to_owned();
         let client_id = ClientId::new(
             self_node_id.clone(),
             SourceUid {
@@ -349,7 +349,7 @@ impl IngestSource {
                 continue;
             };
             let truncate_shards_request = TruncateShardsRequest {
-                ingester_id: ingester_id.clone().into(),
+                ingester_id: ingester_id.to_string(),
                 subrequests: truncate_subrequests,
             };
             let truncate_future = async move {
@@ -566,8 +566,9 @@ impl Source for IngestSource {
             let index_uid = acquired_shard.index_uid().clone();
             let shard_id = acquired_shard.shard_id().clone();
             let mut current_position_inclusive = acquired_shard.publish_position_inclusive();
-            let leader_id: NodeId = acquired_shard.leader_id.into();
-            let follower_id_opt: Option<NodeId> = acquired_shard.follower_id.map(Into::into);
+            let leader_id: NodeId = NodeId::from_str(&acquired_shard.leader_id);
+            let follower_id_opt: Option<NodeId> =
+                acquired_shard.follower_id.map(|id| NodeId::from_str(&id));
             let source_id: SourceId = acquired_shard.source_id;
             let partition_id = PartitionId::from(shard_id.as_str());
             let from_position_exclusive = current_position_inclusive.clone();

--- a/quickwit/quickwit-indexing/src/source/ingest/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest/mod.rs
@@ -694,7 +694,7 @@ mod tests {
     #[tokio::test]
     async fn test_ingest_source_assign_shards() {
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             index_uid: IndexUid::for_test("test-index", 0),
             source_id: "test-source".to_string(),
             pipeline_uid: PipelineUid::default(),
@@ -930,7 +930,7 @@ mod tests {
 
         let ingester_0 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_0));
-        ingester_pool.insert("test-ingester-0".into(), ingester_0.clone());
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0.clone());
 
         let event_broker = EventBroker::default();
 
@@ -1018,7 +1018,7 @@ mod tests {
 
         let assigned_shard = source.assigned_shards.get(&ShardId::from(1)).unwrap();
         let expected_assigned_shard = AssignedShard {
-            leader_id: "test-ingester-0".into(),
+            leader_id: NodeId::from_str("test-ingester-0"),
             follower_id_opt: None,
             partition_id: 1u64.into(),
             current_position_inclusive: Position::offset(11u64),
@@ -1028,7 +1028,7 @@ mod tests {
 
         let assigned_shard = source.assigned_shards.get(&ShardId::from(2)).unwrap();
         let expected_assigned_shard = AssignedShard {
-            leader_id: "test-ingester-0".into(),
+            leader_id: NodeId::from_str("test-ingester-0"),
             follower_id_opt: None,
             partition_id: 2u64.into(),
             current_position_inclusive: Position::offset(12u64),
@@ -1047,7 +1047,7 @@ mod tests {
         // - emission of a suggest truncate
         // - no stream request is emitted
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             index_uid: IndexUid::for_test("test-index", 0),
             source_id: "test-source".to_string(),
             pipeline_uid: PipelineUid::default(),
@@ -1129,7 +1129,7 @@ mod tests {
 
         let ingester_0 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_0));
-        ingester_pool.insert("test-ingester-0".into(), ingester_0.clone());
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0.clone());
 
         let event_broker = EventBroker::default();
         let (shard_positions_update_tx, mut shard_positions_update_rx) =
@@ -1194,7 +1194,7 @@ mod tests {
         // - emission of a suggest truncate
         // - the stream request emitted does not include the EOF shards
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             index_uid: IndexUid::for_test("test-index", 0),
             source_id: "test-source".to_string(),
             pipeline_uid: PipelineUid::default(),
@@ -1296,7 +1296,7 @@ mod tests {
 
         let ingester_0 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_0));
-        ingester_pool.insert("test-ingester-0".into(), ingester_0.clone());
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0.clone());
 
         let event_broker = EventBroker::default();
         let (shard_positions_update_tx, mut shard_positions_update_rx) =
@@ -1364,7 +1364,7 @@ mod tests {
     #[tokio::test]
     async fn test_ingest_source_emit_batches() {
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             index_uid: IndexUid::for_test("test-index", 0),
             source_id: "test-source".to_string(),
             pipeline_uid: PipelineUid::default(),
@@ -1402,7 +1402,7 @@ mod tests {
         source.assigned_shards.insert(
             ShardId::from(1),
             AssignedShard {
-                leader_id: "test-ingester-0".into(),
+                leader_id: NodeId::from_str("test-ingester-0"),
                 follower_id_opt: None,
                 partition_id: 1u64.into(),
                 current_position_inclusive: Position::offset(11u64),
@@ -1412,7 +1412,7 @@ mod tests {
         source.assigned_shards.insert(
             ShardId::from(2),
             AssignedShard {
-                leader_id: "test-ingester-1".into(),
+                leader_id: NodeId::from_str("test-ingester-1"),
                 follower_id_opt: None,
                 partition_id: 2u64.into(),
                 current_position_inclusive: Position::offset(22u64),
@@ -1530,7 +1530,7 @@ mod tests {
     #[tokio::test]
     async fn test_ingest_source_emit_batches_shard_not_found() {
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             index_uid: IndexUid::for_test("test-index", 0),
             source_id: "test-source".to_string(),
             pipeline_uid: PipelineUid::default(),
@@ -1583,7 +1583,7 @@ mod tests {
 
         let ingester_0 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_0));
-        ingester_pool.insert("test-ingester-0".into(), ingester_0.clone());
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0.clone());
 
         let event_broker = EventBroker::default();
         let source_runtime = SourceRuntime {
@@ -1639,7 +1639,7 @@ mod tests {
     #[tokio::test]
     async fn test_ingest_source_suggest_truncate() {
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             index_uid: IndexUid::for_test("test-index", 0),
             source_id: "test-source".to_string(),
             pipeline_uid: PipelineUid::default(),
@@ -1682,7 +1682,7 @@ mod tests {
             });
         let ingester_0 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_0));
-        ingester_pool.insert("test-ingester-0".into(), ingester_0.clone());
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0.clone());
 
         let mut mock_ingester_1 = MockIngesterService::new();
         mock_ingester_1
@@ -1710,7 +1710,7 @@ mod tests {
             });
         let ingester_1 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_1));
-        ingester_pool.insert("test-ingester-1".into(), ingester_1.clone());
+        ingester_pool.insert(NodeId::from_str("test-ingester-1"), ingester_1.clone());
 
         let mut mock_ingester_3 = MockIngesterService::new();
         mock_ingester_3
@@ -1731,7 +1731,7 @@ mod tests {
             });
         let ingester_3 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_3));
-        ingester_pool.insert("test-ingester-3".into(), ingester_3.clone());
+        ingester_pool.insert(NodeId::from_str("test-ingester-3"), ingester_3.clone());
 
         let event_broker = EventBroker::default();
         let (shard_positions_update_tx, mut shard_positions_update_rx) =
@@ -1767,7 +1767,7 @@ mod tests {
         source.assigned_shards.insert(
             ShardId::from(1),
             AssignedShard {
-                leader_id: "test-ingester-0".into(),
+                leader_id: NodeId::from_str("test-ingester-0"),
                 follower_id_opt: None,
                 partition_id: 1u64.into(),
                 current_position_inclusive: Position::offset(11u64),
@@ -1777,8 +1777,8 @@ mod tests {
         source.assigned_shards.insert(
             ShardId::from(2),
             AssignedShard {
-                leader_id: "test-ingester-0".into(),
-                follower_id_opt: Some("test-ingester-1".into()),
+                leader_id: NodeId::from_str("test-ingester-0"),
+                follower_id_opt: Some(NodeId::from_str("test-ingester-1")),
                 partition_id: 2u64.into(),
                 current_position_inclusive: Position::offset(22u64),
                 status: IndexingStatus::Active,
@@ -1787,8 +1787,8 @@ mod tests {
         source.assigned_shards.insert(
             ShardId::from(3),
             AssignedShard {
-                leader_id: "test-ingester-1".into(),
-                follower_id_opt: Some("test-ingester-0".into()),
+                leader_id: NodeId::from_str("test-ingester-1"),
+                follower_id_opt: Some(NodeId::from_str("test-ingester-0")),
                 partition_id: 3u64.into(),
                 current_position_inclusive: Position::offset(33u64),
                 status: IndexingStatus::Active,
@@ -1797,8 +1797,8 @@ mod tests {
         source.assigned_shards.insert(
             ShardId::from(4),
             AssignedShard {
-                leader_id: "test-ingester-2".into(),
-                follower_id_opt: Some("test-ingester-3".into()),
+                leader_id: NodeId::from_str("test-ingester-2"),
+                follower_id_opt: Some(NodeId::from_str("test-ingester-3")),
                 partition_id: 4u64.into(),
                 current_position_inclusive: Position::offset(44u64),
                 status: IndexingStatus::Active,
@@ -1807,8 +1807,8 @@ mod tests {
         source.assigned_shards.insert(
             ShardId::from(5),
             AssignedShard {
-                leader_id: "test-ingester-2".into(),
-                follower_id_opt: Some("test-ingester-3".into()),
+                leader_id: NodeId::from_str("test-ingester-2"),
+                follower_id_opt: Some(NodeId::from_str("test-ingester-3")),
                 partition_id: 5u64.into(),
                 current_position_inclusive: Position::Beginning,
                 status: IndexingStatus::Active,
@@ -1850,7 +1850,7 @@ mod tests {
         // away. In that case, the ingester should just ignore the assigned shard, as
         // opposed to fail as the metastore does not let it `acquire` the shard.
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
             index_uid: IndexUid::for_test("test-index", 0),
             source_id: "test-source".to_string(),
             pipeline_uid: PipelineUid::default(),

--- a/quickwit/quickwit-indexing/src/source/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/mod.rs
@@ -619,7 +619,7 @@ mod tests {
 
             SourceRuntime {
                 pipeline_id: IndexingPipelineId {
-                    node_id: NodeId::from("test-node"),
+                    node_id: NodeId::from_str("test-node"),
                     index_uid: self.index_uid,
                     source_id: self.source_config.source_id.clone(),
                     pipeline_uid: PipelineUid::for_test(0u128),

--- a/quickwit/quickwit-indexing/src/source/queue_sources/coordinator.rs
+++ b/quickwit/quickwit-indexing/src/source/queue_sources/coordinator.rs
@@ -337,7 +337,7 @@ mod tests {
         shared_state: QueueSharedState,
     ) -> QueueCoordinator {
         let pipeline_id = IndexingPipelineId {
-            node_id: NodeId::from_str("test-node").unwrap(),
+            node_id: NodeId::from_str("test-node"),
             index_uid: shared_state.source_uid.index_uid.clone(),
             source_id: shared_state.source_uid.source_id.clone(),
             pipeline_uid: PipelineUid::random(),

--- a/quickwit/quickwit-indexing/src/test_utils.rs
+++ b/quickwit/quickwit-indexing/src/test_utils.rs
@@ -74,7 +74,7 @@ impl TestSandbox {
         indexing_settings_yaml: &str,
         search_fields: &[&str],
     ) -> anyhow::Result<TestSandbox> {
-        let node_id = NodeId::new(append_random_suffix("test-node"));
+        let node_id = NodeId::from_str(&append_random_suffix("test-node"));
         let transport = ChannelTransport::default();
         let cluster = create_cluster_for_test(Vec::new(), &["indexer"], &transport, true)
             .await

--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast/capacity_score.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast/capacity_score.rs
@@ -182,7 +182,7 @@ pub async fn setup_ingester_capacity_update_listener(
                 warn!("failed to parse ingester capacity `{}`", event.value);
                 return;
             };
-            let node_id: NodeId = event.node.node_id.clone().into();
+            let node_id: NodeId = NodeId::from_str(&event.node.node_id);
             event_broker.publish(IngesterCapacityScoreUpdate {
                 node_id,
                 source_uid,

--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast/local_shards.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast/local_shards.rs
@@ -573,7 +573,7 @@ mod tests {
             index_uid.clone(),
             SourceId::from("test-source"),
             ShardId::from(2),
-            NodeId::from("test-leader"),
+            NodeId::from_str("test-leader"),
         )
         .advertisable()
         .build();

--- a/quickwit/quickwit-ingest/src/ingest_v2/broadcast/local_shards.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/broadcast/local_shards.rs
@@ -386,7 +386,7 @@ pub async fn setup_local_shards_update_listener(
                 warn!("failed to parse shard infos `{}`", event.value);
                 return;
             };
-            let leader_id: NodeId = event.node.node_id.clone().into();
+            let leader_id: NodeId = NodeId::from_str(&event.node.node_id);
 
             let local_shards_update = LocalShardsUpdate {
                 leader_id,

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -1281,25 +1281,25 @@ pub(super) mod tests {
 
     #[test]
     fn test_select_preferred_and_failover_ingesters() {
-        let self_node_id: NodeId = "test-ingester-0".into();
+        let self_node_id = NodeId::from_str("test-ingester-0");
 
         let (preferred, failover) =
-            select_preferred_and_failover_ingesters(&self_node_id, "test-ingester-0".into(), None);
+            select_preferred_and_failover_ingesters(&self_node_id, NodeId::from_str("test-ingester-0"), None);
         assert_eq!(preferred, "test-ingester-0");
         assert!(failover.is_none());
 
         let (preferred, failover) = select_preferred_and_failover_ingesters(
             &self_node_id,
-            "test-ingester-0".into(),
-            Some("test-ingester-1".into()),
+            NodeId::from_str("test-ingester-0"),
+            Some(NodeId::from_str("test-ingester-1")),
         );
         assert_eq!(preferred, "test-ingester-0");
         assert_eq!(failover.unwrap(), "test-ingester-1");
 
         let (preferred, failover) = select_preferred_and_failover_ingesters(
             &self_node_id,
-            "test-ingester-1".into(),
-            Some("test-ingester-0".into()),
+            NodeId::from_str("test-ingester-1"),
+            Some(NodeId::from_str("test-ingester-0")),
         );
         assert_eq!(preferred, "test-ingester-0");
         assert_eq!(failover.unwrap(), "test-ingester-1");
@@ -1313,7 +1313,7 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec!["test-ingester-0".into(), "test-ingester-1".into()];
+        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1334,7 +1334,7 @@ pub(super) mod tests {
             });
         let ingester_1 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_1));
-        ingester_pool.insert("test-ingester-1".into(), ingester_1);
+        ingester_pool.insert(NodeId::from_str("test-ingester-1"), ingester_1);
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
@@ -1411,7 +1411,7 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec!["test-ingester-0".into(), "test-ingester-1".into()];
+        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1451,8 +1451,8 @@ pub(super) mod tests {
         let ingester_1 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_1));
 
-        ingester_pool.insert("test-ingester-0".into(), ingester_0);
-        ingester_pool.insert("test-ingester-1".into(), ingester_1);
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0);
+        ingester_pool.insert(NodeId::from_str("test-ingester-1"), ingester_1);
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
@@ -1529,7 +1529,7 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec!["test-ingester-0".into(), "test-ingester-1".into()];
+        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1568,8 +1568,8 @@ pub(super) mod tests {
         let ingester_1 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_1));
 
-        ingester_pool.insert("test-ingester-0".into(), ingester_0);
-        ingester_pool.insert("test-ingester-1".into(), ingester_1);
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0);
+        ingester_pool.insert(NodeId::from_str("test-ingester-1"), ingester_1);
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
@@ -1649,7 +1649,7 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec!["test-ingester-0".into(), "test-ingester-1".into()];
+        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1671,7 +1671,7 @@ pub(super) mod tests {
             });
         let ingester_0 =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester_0));
-        ingester_pool.insert("test-ingester-0".into(), ingester_0);
+        ingester_pool.insert(NodeId::from_str("test-ingester-0"), ingester_0);
 
         fault_tolerant_fetch_stream(
             client_id,
@@ -1706,7 +1706,7 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec!["test-ingester".into()];
+        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester")];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1761,7 +1761,7 @@ pub(super) mod tests {
         let ingester =
             IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(mock_ingester));
 
-        ingester_pool.insert("test-ingester".into(), ingester);
+        ingester_pool.insert(NodeId::from_str("test-ingester"), ingester);
 
         let fetch_payload = FetchPayload {
             index_uid: Some(index_uid.clone()),
@@ -1876,7 +1876,7 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn test_multi_fetch_stream() {
-        let self_node_id: NodeId = "test-node".into();
+        let self_node_id = NodeId::from_str("test-node");
         let client_id = "test-client".to_string();
         let ingester_pool = IngesterPool::default();
         let retry_params = RetryParams::for_test();

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -1283,8 +1283,11 @@ pub(super) mod tests {
     fn test_select_preferred_and_failover_ingesters() {
         let self_node_id = NodeId::from_str("test-ingester-0");
 
-        let (preferred, failover) =
-            select_preferred_and_failover_ingesters(&self_node_id, NodeId::from_str("test-ingester-0"), None);
+        let (preferred, failover) = select_preferred_and_failover_ingesters(
+            &self_node_id,
+            NodeId::from_str("test-ingester-0"),
+            None,
+        );
         assert_eq!(preferred, "test-ingester-0");
         assert!(failover.is_none());
 
@@ -1313,7 +1316,10 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
+        let ingester_ids: Vec<NodeId> = vec![
+            NodeId::from_str("test-ingester-0"),
+            NodeId::from_str("test-ingester-1"),
+        ];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1411,7 +1417,10 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
+        let ingester_ids: Vec<NodeId> = vec![
+            NodeId::from_str("test-ingester-0"),
+            NodeId::from_str("test-ingester-1"),
+        ];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1529,7 +1538,10 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
+        let ingester_ids: Vec<NodeId> = vec![
+            NodeId::from_str("test-ingester-0"),
+            NodeId::from_str("test-ingester-1"),
+        ];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);
@@ -1649,7 +1661,10 @@ pub(super) mod tests {
         let shard_id = ShardId::from(1);
         let mut from_position_exclusive = Position::offset(0u64);
 
-        let ingester_ids: Vec<NodeId> = vec![NodeId::from_str("test-ingester-0"), NodeId::from_str("test-ingester-1")];
+        let ingester_ids: Vec<NodeId> = vec![
+            NodeId::from_str("test-ingester-0"),
+            NodeId::from_str("test-ingester-1"),
+        ];
         let ingester_pool = IngesterPool::default();
 
         let (fetch_message_tx, mut fetch_stream) = ServiceStream::new_bounded(5);

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -1359,7 +1359,7 @@ mod tests {
             let control_plane = ControlPlaneServiceClient::from_mock(mock_control_plane);
 
             Self {
-                node_id: "test-ingester".into(),
+                node_id: NodeId::from_str("test-ingester"),
                 control_plane,
                 ingester_pool: IngesterPool::default(),
                 disk_capacity: ByteSize::mb(256),
@@ -1373,7 +1373,7 @@ mod tests {
 
     impl IngesterForTest {
         pub fn with_node_id(mut self, node_id: &str) -> Self {
-            self.node_id = node_id.into();
+            self.node_id = NodeId::from_str(node_id);
             self
         }
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -129,7 +129,7 @@ impl Ingester {
         replication_factor: usize,
         idle_shard_timeout: Duration,
     ) -> IngestV2Result<Self> {
-        let self_node_id: NodeId = cluster.self_node_id().into();
+        let self_node_id: NodeId = cluster.self_node_id().to_owned();
         let state = IngesterState::load(
             cluster.clone(),
             wal_dir_path,
@@ -220,8 +220,8 @@ impl Ingester {
         let rate_meter = RateMeter::default();
 
         let primary_shard = if let Some(follower_id) = &shard.follower_id {
-            let leader_id: NodeId = shard.leader_id.clone().into();
-            let follower_id: NodeId = follower_id.clone().into();
+            let leader_id: NodeId = NodeId::from_str(&shard.leader_id);
+            let follower_id: NodeId = NodeId::from_str(&follower_id);
 
             let replication_client = self
                 .init_replication_stream(
@@ -388,8 +388,8 @@ impl Ingester {
             Entry::Vacant(entry) => entry,
         };
         let open_request = OpenReplicationStreamRequest {
-            leader_id: leader_id.clone().into(),
-            follower_id: follower_id.clone().into(),
+            leader_id: leader_id.to_string(),
+            follower_id: follower_id.to_string(),
             replication_seqno: 0,
         };
         let open_message = SynReplicationMessage::new_open_request(open_request);
@@ -868,8 +868,8 @@ impl Ingester {
         if open_replication_stream_request.follower_id != self.self_node_id {
             return Err(IngestV2Error::Internal("routing error".to_string()));
         }
-        let leader_id: NodeId = open_replication_stream_request.leader_id.into();
-        let follower_id: NodeId = open_replication_stream_request.follower_id.into();
+        let leader_id: NodeId = NodeId::from_str(&open_replication_stream_request.leader_id);
+        let follower_id: NodeId = NodeId::from_str(&open_replication_stream_request.follower_id);
 
         let mut state_guard = self.state.lock_partially("open_replication_stream").await?;
         let status = state_guard.status();
@@ -947,7 +947,7 @@ impl Ingester {
         let self_node_id = self.self_node_id.clone();
         let observation_stream = status_stream.map(move |status| {
             let observation_message = ObservationMessage {
-                node_id: self_node_id.clone().into(),
+                node_id: self_node_id.to_string(),
                 status: status as i32,
             };
             Ok(observation_message)

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -129,7 +129,7 @@ impl Ingester {
         replication_factor: usize,
         idle_shard_timeout: Duration,
     ) -> IngestV2Result<Self> {
-        let self_node_id: NodeId = cluster.self_node_id().to_owned();
+        let self_node_id: NodeId = cluster.self_node_id();
         let state = IngesterState::load(
             cluster.clone(),
             wal_dir_path,
@@ -221,7 +221,7 @@ impl Ingester {
 
         let primary_shard = if let Some(follower_id) = &shard.follower_id {
             let leader_id: NodeId = NodeId::from_str(&shard.leader_id);
-            let follower_id: NodeId = NodeId::from_str(&follower_id);
+            let follower_id: NodeId = NodeId::from_str(follower_id);
 
             let replication_client = self
                 .init_replication_stream(

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -365,7 +365,7 @@ mod tests {
             IndexUid::for_test("test-index", 0),
             SourceId::from("test-source"),
             ShardId::from(1),
-            NodeId::from("test-follower"),
+            NodeId::from_str("test-follower"),
         )
         .with_state(ShardState::Closed)
         .with_replication_position_inclusive(Position::offset(42u64))
@@ -396,7 +396,7 @@ mod tests {
             IndexUid::for_test("test-index", 0),
             SourceId::from("test-source"),
             ShardId::from(1),
-            NodeId::from("test-leader"),
+            NodeId::from_str("test-leader"),
         )
         .with_state(ShardState::Closed)
         .with_replication_position_inclusive(Position::offset(42u64))

--- a/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
@@ -345,8 +345,8 @@ impl ReplicationClient {
         commit_type: CommitTypeV2,
     ) -> impl Future<Output = Result<ReplicateResponse, ReplicationError>> + Send + 'static {
         let replicate_request = ReplicateRequest {
-            leader_id: leader_id.into(),
-            follower_id: follower_id.into(),
+            leader_id: leader_id.to_string(),
+            follower_id: follower_id.to_string(),
             subrequests,
             commit_type: commit_type as i32,
             replication_seqno: 0, // replication number are generated further down
@@ -469,7 +469,7 @@ impl ReplicationTask {
         let index_uid = replica_shard.index_uid().clone();
         let shard_id = replica_shard.shard_id().clone();
         let source_id = replica_shard.source_id;
-        let leader_id = NodeId::from(replica_shard.leader_id);
+        let leader_id = NodeId::from_str(&replica_shard.leader_id);
 
         let replica_shard =
             IngesterShard::new_replica(index_uid, source_id, shard_id, leader_id).build();
@@ -703,7 +703,7 @@ impl ReplicationTask {
 
         report_wal_usage(wal_usage);
 
-        let follower_id = self.follower_id.clone().into();
+        let follower_id = self.follower_id.to_string();
 
         let replicate_response = ReplicateResponse {
             follower_id,

--- a/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/replication.rs
@@ -822,8 +822,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replication_stream_task_init() {
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let (syn_replication_stream_tx, mut syn_replication_stream_rx) = mpsc::channel(5);
         let (ack_replication_stream_tx, ack_replication_stream) =
             ServiceStream::new_bounded(SYN_REPLICATION_STREAM_CAPACITY);
@@ -869,8 +869,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replication_stream_task_replicate() {
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let (syn_replication_stream_tx, mut syn_replication_stream_rx) = mpsc::channel(5);
         let (ack_replication_stream_tx, ack_replication_stream) =
             ServiceStream::new_bounded(SYN_REPLICATION_STREAM_CAPACITY);
@@ -995,8 +995,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replication_stream_replicate_errors() {
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let (syn_replication_stream_tx, _syn_replication_stream_rx) = mpsc::channel(5);
         let (_ack_replication_stream_tx, ack_replication_stream) =
             ServiceStream::new_bounded(SYN_REPLICATION_STREAM_CAPACITY);
@@ -1033,8 +1033,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replication_task_happy_path() {
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let cluster = create_cluster_for_test(
             Vec::new(),
             &[QuickwitService::Indexer.as_str()],
@@ -1304,8 +1304,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replication_task_shard_closed() {
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let cluster = create_cluster_for_test(
             Vec::new(),
             &[QuickwitService::Indexer.as_str()],
@@ -1389,8 +1389,8 @@ mod tests {
     #[cfg(not(feature = "failpoints"))]
     #[tokio::test]
     async fn test_replication_task_deletes_dangling_shard() {
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let cluster = create_cluster_for_test(
             Vec::new(),
             &[QuickwitService::Indexer.as_str()],
@@ -1485,8 +1485,8 @@ mod tests {
         let scenario = fail::FailScenario::setup();
         fail::cfg("ingester:append_records", "return").unwrap();
 
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let cluster = create_cluster_for_test(
             Vec::new(),
             &[QuickwitService::Indexer.as_str()],
@@ -1582,8 +1582,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replication_task_resource_exhausted() {
-        let leader_id: NodeId = "test-leader".into();
-        let follower_id: NodeId = "test-follower".into();
+        let leader_id = NodeId::from_str("test-leader");
+        let follower_id = NodeId::from_str("test-follower");
         let cluster = create_cluster_for_test(
             Vec::new(),
             &[QuickwitService::Indexer.as_str()],

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -282,7 +282,7 @@ impl IngestRouter {
         while let Some((persist_summary, persist_result)) = persist_futures.next().await {
             match persist_result {
                 Ok(persist_response) => {
-                    let leader_id = NodeId::from(persist_response.leader_id.clone());
+                    let leader_id = NodeId::from_str(&persist_response.leader_id);
 
                     for persist_success in persist_response.successes {
                         workbench.record_persist_success(persist_success);
@@ -411,7 +411,7 @@ impl IngestRouter {
                 subrequest_ids,
             };
             let persist_request = PersistRequest {
-                leader_id: leader_id.into(),
+                leader_id: leader_id.to_string(),
                 subrequests,
                 commit_type: commit_type as i32,
             };

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -637,7 +637,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_make_get_or_create_open_shard_request() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane: ControlPlaneServiceClient =
             ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
         let ingester_pool = IngesterPool::default();
@@ -729,7 +729,7 @@ mod tests {
         drop(rendezvous_2);
 
         ingester_pool.insert(
-            "test-ingester-0".into(),
+            NodeId::from_str("test-ingester-0"),
             IngesterPoolEntry::mocked_ingester(),
         );
         {
@@ -738,7 +738,7 @@ mod tests {
             // subrequests trigger CP request.
             workbench
                 .unavailable_leaders
-                .insert("test-ingester-0".into());
+                .insert(NodeId::from_str("test-ingester-0"));
             let (get_or_create_open_shard_request_opt, _rendezvous) = router
                 .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
                 .await
@@ -775,7 +775,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_populate_routing_table() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
 
         let index_uid: IndexUid = IndexUid::for_test("test-index-0", 0);
         let index_uid2: IndexUid = IndexUid::for_test("test-index-1", 0);
@@ -942,7 +942,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_batch_persist_records_no_shards_available_empty_routing_table() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let mut mock_control_plane = MockControlPlaneService::new();
         mock_control_plane
             .expect_get_or_create_open_shards()
@@ -987,7 +987,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_batch_persist_records_no_shards_available_unavailable_ingester() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let mut mock_control_plane = MockControlPlaneService::new();
         mock_control_plane
             .expect_get_or_create_open_shards()
@@ -1047,7 +1047,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_process_persist_results_record_persist_successes() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane = ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
         let ingester_pool = IngesterPool::default();
         let replication_factor = 1;
@@ -1071,7 +1071,7 @@ mod tests {
 
         persist_futures.push(async move {
             let persist_summary = PersistRequestSummary {
-                leader_id: "test-ingester-0".into(),
+                leader_id: NodeId::from_str("test-ingester-0"),
                 subrequest_ids: vec![0],
             };
             let persist_result = Ok::<_, IngestV2Error>(PersistResponse {
@@ -1105,7 +1105,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_process_persist_results_record_persist_failures() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane = ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
         let ingester_pool = IngesterPool::default();
         let replication_factor = 1;
@@ -1129,7 +1129,7 @@ mod tests {
 
         persist_futures.push(async move {
             let persist_summary = PersistRequestSummary {
-                leader_id: "test-ingester-0".into(),
+                leader_id: NodeId::from_str("test-ingester-0"),
                 subrequest_ids: vec![0],
             };
             let persist_result = Ok::<_, IngestV2Error>(PersistResponse {
@@ -1162,16 +1162,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_process_persist_results_does_not_remove_unavailable_leaders() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane = ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
 
         let ingester_pool = IngesterPool::default();
         ingester_pool.insert(
-            "test-ingester-0".into(),
+            NodeId::from_str("test-ingester-0"),
             IngesterPoolEntry::mocked_ingester(),
         );
         ingester_pool.insert(
-            "test-ingester-1".into(),
+            NodeId::from_str("test-ingester-1"),
             IngesterPoolEntry::mocked_ingester(),
         );
 
@@ -1203,7 +1203,7 @@ mod tests {
 
         persist_futures.push(async {
             let persist_summary = PersistRequestSummary {
-                leader_id: "test-ingester-0".into(),
+                leader_id: NodeId::from_str("test-ingester-0"),
                 subrequest_ids: vec![0],
             };
             let persist_result =
@@ -1223,12 +1223,12 @@ mod tests {
         assert!(
             !workbench
                 .unavailable_leaders
-                .contains(&NodeId::from("test-ingester-1"))
+                .contains(&NodeId::from_str("test-ingester-1"))
         );
         let persist_futures = FuturesUnordered::new();
         persist_futures.push(async {
             let persist_summary = PersistRequestSummary {
-                leader_id: "test-ingester-1".into(),
+                leader_id: NodeId::from_str("test-ingester-1"),
                 subrequest_ids: vec![1],
             };
             let persist_result =
@@ -1245,7 +1245,7 @@ mod tests {
         assert!(
             workbench
                 .unavailable_leaders
-                .contains(&NodeId::from("test-ingester-1"))
+                .contains(&NodeId::from_str("test-ingester-1"))
         );
 
         let subworkbench = workbench.subworkbenches.get(&1).unwrap();
@@ -1257,7 +1257,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_ingest() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane = ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
         let ingester_pool = IngesterPool::default();
         let router = IngestRouter::new(
@@ -1332,7 +1332,7 @@ mod tests {
                 })
             });
         ingester_pool.insert(
-            "test-ingester-0".into(),
+            NodeId::from_str("test-ingester-0"),
             IngesterPoolEntry {
                 client: IngesterServiceClient::from_mock(mock_ingester_0),
                 status: IngesterStatus::Ready,
@@ -1368,7 +1368,7 @@ mod tests {
                 })
             });
         ingester_pool.insert(
-            "test-ingester-1".into(),
+            NodeId::from_str("test-ingester-1"),
             IngesterPoolEntry {
                 client: IngesterServiceClient::from_mock(mock_ingester_1),
                 availability_zone: None,
@@ -1408,7 +1408,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_ingest_retry() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane = ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
         let ingester_pool = IngesterPool::default();
         let router = IngestRouter::new(
@@ -1489,7 +1489,7 @@ mod tests {
                 })
             });
         ingester_pool.insert(
-            "test-ingester-0".into(),
+            NodeId::from_str("test-ingester-0"),
             IngesterPoolEntry {
                 client: IngesterServiceClient::from_mock(mock_ingester_0),
                 status: IngesterStatus::Ready,
@@ -1515,7 +1515,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_debug_info() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane = ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
         let ingester_pool = IngesterPool::default();
         let replication_factor = 1;
@@ -1572,7 +1572,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_router_returns_rate_limited_failure() {
-        let self_node_id = "test-router".into();
+        let self_node_id = NodeId::from_str("test-router");
         let control_plane = ControlPlaneServiceClient::from_mock(MockControlPlaneService::new());
         let ingester_pool = IngesterPool::default();
         let replication_factor = 1;
@@ -1638,7 +1638,7 @@ mod tests {
         });
         let ingester_0 = IngesterServiceClient::from_mock(mock_ingester_0);
         ingester_pool.insert(
-            "test-ingester-0".into(),
+            NodeId::from_str("test-ingester-0"),
             IngesterPoolEntry {
                 client: ingester_0.clone(),
                 availability_zone: None,
@@ -1669,7 +1669,7 @@ mod tests {
         let event_broker = EventBroker::default();
         let ingester_pool = IngesterPool::default();
         let router = IngestRouter::new(
-            "test-router".into(),
+            NodeId::from_str("test-router"),
             ControlPlaneServiceClient::from_mock(MockControlPlaneService::new()),
             ingester_pool.clone(),
             1,
@@ -1679,7 +1679,7 @@ mod tests {
         router.subscribe();
 
         event_broker.publish(IngesterCapacityScoreUpdate {
-            node_id: "test-ingester-0".into(),
+            node_id: NodeId::from_str("test-ingester-0"),
             source_uid: SourceUid {
                 index_uid: IndexUid::for_test("test-index", 0),
                 source_id: "test-source".to_string(),
@@ -1691,7 +1691,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         ingester_pool.insert(
-            "test-ingester-0".into(),
+            NodeId::from_str("test-ingester-0"),
             IngesterPoolEntry::mocked_ingester(),
         );
         let state_guard = router.state.lock().await;
@@ -1699,13 +1699,13 @@ mod tests {
             .routing_table
             .pick_node("test-index", "test-source", &ingester_pool, &HashSet::new())
             .unwrap();
-        assert_eq!(node.node_id, NodeId::from("test-ingester-0"));
+        assert_eq!(node.node_id, NodeId::from_str("test-ingester-0"));
     }
 
     #[tokio::test]
     async fn test_router_process_persist_results_marks_unavailable_on_persist_failure() {
         let router = IngestRouter::new(
-            "test-router".into(),
+            NodeId::from_str("test-router"),
             ControlPlaneServiceClient::from_mock(MockControlPlaneService::new()),
             IngesterPool::default(),
             1,
@@ -1732,7 +1732,7 @@ mod tests {
         let persist_futures = FuturesUnordered::new();
         persist_futures.push(async {
             let summary = PersistRequestSummary {
-                leader_id: "test-ingester-0".into(),
+                leader_id: NodeId::from_str("test-ingester-0"),
                 subrequest_ids: vec![0],
             };
             let result = Ok::<_, IngestV2Error>(PersistResponse {
@@ -1758,14 +1758,14 @@ mod tests {
         assert!(
             !workbench
                 .unavailable_leaders
-                .contains(&NodeId::from("test-ingester-0"))
+                .contains(&NodeId::from_str("test-ingester-0"))
         );
 
         // NodeUnavailable DOES mark the leader as unavailable.
         let persist_futures = FuturesUnordered::new();
         persist_futures.push(async {
             let summary = PersistRequestSummary {
-                leader_id: "test-ingester-1".into(),
+                leader_id: NodeId::from_str("test-ingester-1"),
                 subrequest_ids: vec![1],
             };
             let result = Ok::<_, IngestV2Error>(PersistResponse {
@@ -1791,7 +1791,7 @@ mod tests {
         assert!(
             workbench
                 .unavailable_leaders
-                .contains(&NodeId::from("test-ingester-1"))
+                .contains(&NodeId::from_str("test-ingester-1"))
         );
     }
 
@@ -1799,7 +1799,7 @@ mod tests {
     async fn test_router_process_persist_results_applies_piggybacked_routing_updates() {
         let ingester_pool = IngesterPool::default();
         let router = IngestRouter::new(
-            "test-router".into(),
+            NodeId::from_str("test-router"),
             ControlPlaneServiceClient::from_mock(MockControlPlaneService::new()),
             ingester_pool.clone(),
             1,
@@ -1817,7 +1817,7 @@ mod tests {
         let persist_futures = FuturesUnordered::new();
         persist_futures.push(async {
             let summary = PersistRequestSummary {
-                leader_id: "test-ingester-0".into(),
+                leader_id: NodeId::from_str("test-ingester-0"),
                 subrequest_ids: vec![0],
             };
             let result = Ok::<_, IngestV2Error>(PersistResponse {
@@ -1841,7 +1841,7 @@ mod tests {
             .await;
 
         ingester_pool.insert(
-            "test-ingester-0".into(),
+            NodeId::from_str("test-ingester-0"),
             IngesterPoolEntry::mocked_ingester(),
         );
         let state_guard = router.state.lock().await;
@@ -1849,6 +1849,6 @@ mod tests {
             .routing_table
             .pick_node("test-index", "test-source", &ingester_pool, &HashSet::new())
             .unwrap();
-        assert_eq!(node.node_id, NodeId::from("test-ingester-0"));
+        assert_eq!(node.node_id, NodeId::from_str("test-ingester-0"));
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
@@ -630,8 +630,14 @@ mod tests {
     fn test_classify_az_locality() {
         let table = RoutingTable::new(Some("az-1".to_string()));
         let pool = IngesterPool::default();
-        pool.insert(NodeId::from_str("node-local"), mocked_ingester(Some("az-1")));
-        pool.insert(NodeId::from_str("node-remote"), mocked_ingester(Some("az-2")));
+        pool.insert(
+            NodeId::from_str("node-local"),
+            mocked_ingester(Some("az-1")),
+        );
+        pool.insert(
+            NodeId::from_str("node-remote"),
+            mocked_ingester(Some("az-2")),
+        );
         pool.insert(NodeId::from_str("node-no-az"), mocked_ingester(None));
 
         assert_eq!(

--- a/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
@@ -322,7 +322,7 @@ mod tests {
 
         // Insert first node.
         table.apply_capacity_update(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             8,
@@ -334,7 +334,7 @@ mod tests {
 
         // Update existing node.
         table.apply_capacity_update(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             4,
@@ -346,7 +346,7 @@ mod tests {
 
         // Add second node.
         table.apply_capacity_update(
-            "node-2".into(),
+            NodeId::from_str("node-2"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             6,
@@ -356,7 +356,7 @@ mod tests {
 
         // Zero shards: node stays in table but becomes ineligible for routing.
         table.apply_capacity_update(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             0,
@@ -402,20 +402,20 @@ mod tests {
         assert!(!table.has_open_nodes("test-index", "test-source", &pool, &HashSet::new()));
 
         // Node is in pool → true.
-        pool.insert("node-1".into(), mocked_ingester(None));
+        pool.insert(NodeId::from_str("node-1"), mocked_ingester(None));
         assert!(table.has_open_nodes("test-index", "test-source", &pool, &HashSet::new()));
 
         // Node is unavailable → false.
-        let unavailable: HashSet<NodeId> = HashSet::from(["node-1".into()]);
+        let unavailable: HashSet<NodeId> = HashSet::from([NodeId::from_str("node-1")]);
         assert!(!table.has_open_nodes("test-index", "test-source", &pool, &unavailable));
 
         // Second node available → true despite first being unavailable.
-        pool.insert("node-2".into(), mocked_ingester(None));
+        pool.insert(NodeId::from_str("node-2"), mocked_ingester(None));
         assert!(table.has_open_nodes("test-index", "test-source", &pool, &unavailable));
 
         // Node with capacity_score=0 is not eligible.
         table.apply_capacity_update(
-            "node-2".into(),
+            NodeId::from_str("node-2"),
             index_uid.clone(),
             "test-source".into(),
             0,
@@ -428,12 +428,12 @@ mod tests {
     fn test_has_open_nodes_requires_cp_seed() {
         let mut table = RoutingTable::default();
         let pool = IngesterPool::default();
-        pool.insert("node-1".into(), mocked_ingester(None));
+        pool.insert(NodeId::from_str("node-1"), mocked_ingester(None));
 
         // Chitchat broadcast populates the entry, but has_open_nodes still returns false
         // because the entry hasn't been seeded from the control plane yet.
         table.apply_capacity_update(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             8,
@@ -464,26 +464,26 @@ mod tests {
         let pool = IngesterPool::default();
 
         table.apply_capacity_update(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             5,
             1,
         );
         table.apply_capacity_update(
-            "node-2".into(),
+            NodeId::from_str("node-2"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             5,
             1,
         );
-        pool.insert("node-1".into(), mocked_ingester(Some("az-1")));
-        pool.insert("node-2".into(), mocked_ingester(Some("az-2")));
+        pool.insert(NodeId::from_str("node-1"), mocked_ingester(Some("az-1")));
+        pool.insert(NodeId::from_str("node-2"), mocked_ingester(Some("az-2")));
 
         let picked = table
             .pick_node("test-index", "test-source", &pool, &HashSet::new())
             .unwrap();
-        assert_eq!(picked.node_id, NodeId::from("node-1"));
+        assert_eq!(picked.node_id, NodeId::from_str("node-1"));
     }
 
     #[test]
@@ -492,18 +492,18 @@ mod tests {
         let pool = IngesterPool::default();
 
         table.apply_capacity_update(
-            "node-2".into(),
+            NodeId::from_str("node-2"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             5,
             1,
         );
-        pool.insert("node-2".into(), mocked_ingester(Some("az-2")));
+        pool.insert(NodeId::from_str("node-2"), mocked_ingester(Some("az-2")));
 
         let picked = table
             .pick_node("test-index", "test-source", &pool, &HashSet::new())
             .unwrap();
-        assert_eq!(picked.node_id, NodeId::from("node-2"));
+        assert_eq!(picked.node_id, NodeId::from_str("node-2"));
     }
 
     #[test]
@@ -512,18 +512,18 @@ mod tests {
         let pool = IngesterPool::default();
 
         table.apply_capacity_update(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             5,
             1,
         );
-        pool.insert("node-1".into(), mocked_ingester(Some("az-1")));
+        pool.insert(NodeId::from_str("node-1"), mocked_ingester(Some("az-1")));
 
         let picked = table
             .pick_node("test-index", "test-source", &pool, &HashSet::new())
             .unwrap();
-        assert_eq!(picked.node_id, NodeId::from("node-1"));
+        assert_eq!(picked.node_id, NodeId::from_str("node-1"));
     }
 
     #[test]
@@ -544,19 +544,19 @@ mod tests {
         // wins when it does, so it should win ~67% of 1000 runs. Asserting > 550
         // is ~7.5 standard deviations from the mean — effectively impossible to flake.
         let high = IngesterNode {
-            node_id: "high".into(),
+            node_id: NodeId::from_str("high"),
             index_uid: IndexUid::for_test("idx", 0),
             capacity_score: 9,
             open_shard_count: 2,
         };
         let mid = IngesterNode {
-            node_id: "mid".into(),
+            node_id: NodeId::from_str("mid"),
             index_uid: IndexUid::for_test("idx", 0),
             capacity_score: 5,
             open_shard_count: 2,
         };
         let low = IngesterNode {
-            node_id: "low".into(),
+            node_id: NodeId::from_str("low"),
             index_uid: IndexUid::for_test("idx", 0),
             capacity_score: 1,
             open_shard_count: 2,
@@ -630,26 +630,26 @@ mod tests {
     fn test_classify_az_locality() {
         let table = RoutingTable::new(Some("az-1".to_string()));
         let pool = IngesterPool::default();
-        pool.insert("node-local".into(), mocked_ingester(Some("az-1")));
-        pool.insert("node-remote".into(), mocked_ingester(Some("az-2")));
-        pool.insert("node-no-az".into(), mocked_ingester(None));
+        pool.insert(NodeId::from_str("node-local"), mocked_ingester(Some("az-1")));
+        pool.insert(NodeId::from_str("node-remote"), mocked_ingester(Some("az-2")));
+        pool.insert(NodeId::from_str("node-no-az"), mocked_ingester(None));
 
         assert_eq!(
-            table.classify_az_locality(&"node-local".into(), &pool),
+            table.classify_az_locality(&NodeId::from_str("node-local"), &pool),
             "same_az"
         );
         assert_eq!(
-            table.classify_az_locality(&"node-remote".into(), &pool),
+            table.classify_az_locality(&NodeId::from_str("node-remote"), &pool),
             "cross_az"
         );
         assert_eq!(
-            table.classify_az_locality(&"node-no-az".into(), &pool),
+            table.classify_az_locality(&NodeId::from_str("node-no-az"), &pool),
             "az_unaware"
         );
 
         let table_no_az = RoutingTable::default();
         assert_eq!(
-            table_no_az.classify_az_locality(&"node-local".into(), &pool),
+            table_no_az.classify_az_locality(&NodeId::from_str("node-local"), &pool),
             "az_unaware"
         );
     }
@@ -661,14 +661,14 @@ mod tests {
 
         // Populate with incarnation 0: two nodes.
         table.apply_capacity_update(
-            "node-1".into(),
+            NodeId::from_str("node-1"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             8,
             3,
         );
         table.apply_capacity_update(
-            "node-2".into(),
+            NodeId::from_str("node-2"),
             IndexUid::for_test("test-index", 0),
             "test-source".into(),
             6,
@@ -680,7 +680,7 @@ mod tests {
 
         // Capacity update with incarnation 1 clears stale nodes.
         table.apply_capacity_update(
-            "node-3".into(),
+            NodeId::from_str("node-3"),
             IndexUid::for_test("test-index", 1),
             "test-source".into(),
             5,

--- a/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
@@ -276,7 +276,7 @@ impl RoutingTable {
             .iter()
             .map(|shard| {
                 let num_open_shards = shard.is_open() as usize;
-                let leader_id = NodeId::from(shard.leader_id.clone());
+                let leader_id = NodeId::from_str(&shard.leader_id);
                 (leader_id, num_open_shards)
             })
             .into_grouping_map()

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -901,7 +901,7 @@ mod tests {
         is_replica: bool,
     ) -> IngesterShard {
         let builder = if is_replica {
-            IngesterShard::new_replica(index_uid, source_id, shard_id, NodeId::from("test-leader"))
+            IngesterShard::new_replica(index_uid, source_id, shard_id, NodeId::from_str("test-leader"))
         } else {
             IngesterShard::new_solo(index_uid, source_id, shard_id)
         };

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -901,7 +901,12 @@ mod tests {
         is_replica: bool,
     ) -> IngesterShard {
         let builder = if is_replica {
-            IngesterShard::new_replica(index_uid, source_id, shard_id, NodeId::from_str("test-leader"))
+            IngesterShard::new_replica(
+                index_uid,
+                source_id,
+                shard_id,
+                NodeId::from_str("test-leader"),
+            )
         } else {
             IngesterShard::new_solo(index_uid, source_id, shard_id)
         };

--- a/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/workbench.rs
@@ -719,7 +719,7 @@ mod tests {
         let mut workbench = IngestWorkbench::new(ingest_subrequests, 1);
 
         let persist_error = IngestV2Error::Timeout("request timed out".to_string());
-        let leader_id = NodeId::from("test-leader");
+        let leader_id = NodeId::from_str("test-leader");
         let persist_summary = PersistRequestSummary {
             leader_id: leader_id.clone(),
             subrequest_ids: vec![0],
@@ -745,7 +745,7 @@ mod tests {
         let mut workbench = IngestWorkbench::new(ingest_subrequests, 1);
 
         let persist_error = IngestV2Error::Unavailable("connection error".to_string());
-        let leader_id = NodeId::from("test-leader");
+        let leader_id = NodeId::from_str("test-leader");
         let persist_summary = PersistRequestSummary {
             leader_id: leader_id.clone(),
             subrequest_ids: vec![0],
@@ -774,7 +774,7 @@ mod tests {
 
         let persist_error = IngestV2Error::Internal("IO error".to_string());
         let persist_summary = PersistRequestSummary {
-            leader_id: NodeId::from("test-leader"),
+            leader_id: NodeId::from_str("test-leader"),
             subrequest_ids: vec![0],
         };
         workbench.record_persist_error(persist_error, persist_summary);

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -78,7 +78,7 @@ impl TestNodeConfig {
         config.enabled_services.clone_from(&self.services);
         config.jaeger_config.enable_endpoint = true;
         config.cluster_id.clone_from(&cluster_id);
-        config.node_id = NodeId::new(format!("test-node-{node_idx}"));
+        config.node_id = NodeId::from_str(&format!("test-node-{node_idx}"));
         let root_data_dir = temp_dir.path().to_path_buf();
         config.data_dir_path = root_data_dir.join(config.node_id.as_str());
         config.metastore_uri =

--- a/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_pipeline.rs
@@ -191,7 +191,7 @@ impl DeleteTaskPipeline {
         let packager = Packager::new("MergePackager", tag_fields, uploader_mailbox);
         let (packager_mailbox, packager_supervisor_handler) = ctx.spawn_actor().supervise(packager);
         let pipeline_id = MergePipelineId {
-            node_id: NodeId::from("unknown"),
+            node_id: NodeId::from_str("unknown"),
             index_uid: self.index_uid.clone(),
             source_id: "unknown".to_string(),
         };

--- a/quickwit/quickwit-metastore/src/tests/list_splits.rs
+++ b/quickwit/quickwit-metastore/src/tests/list_splits.rs
@@ -939,7 +939,7 @@ pub async fn test_metastore_list_splits_by_node_id<
     metastore.stage_splits(stage_splits_request).await.unwrap();
 
     let list_splits_query =
-        ListSplitsQuery::for_index(index_uid.clone()).with_node_id(NodeId::from("test-node-1"));
+        ListSplitsQuery::for_index(index_uid.clone()).with_node_id(NodeId::from_str("test-node-1"));
     let list_splits_request =
         ListSplitsRequest::try_from_list_splits_query(&list_splits_query).unwrap();
 

--- a/quickwit/quickwit-proto/src/types/mod.rs
+++ b/quickwit/quickwit-proto/src/types/mod.rs
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_node_id() {
-        let node_id = NodeId::new("test-node".to_string());
+        let node_id = NodeId::from_str("test-node");
         assert_eq!(node_id.as_str(), "test-node");
         assert_eq!(node_id, NodeIdRef::from_str("test-node"));
     }

--- a/quickwit/quickwit-proto/src/types/mod.rs
+++ b/quickwit/quickwit-proto/src/types/mod.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -94,17 +95,11 @@ impl Display for SourceUid {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct NodeId(String);
+pub struct NodeId(Arc<str>);
 
 impl NodeId {
-    /// Constructs a new [`NodeId`].
-    pub const fn new(node_id: String) -> Self {
-        Self(node_id)
-    }
-
-    /// Takes ownership of the underlying [`String`], consuming `self`.
-    pub fn take(self) -> String {
-        self.0
+    pub fn from_str(node_id: &str) -> Self {
+        Self(Arc::from(node_id))
     }
 }
 
@@ -116,12 +111,6 @@ impl AsRef<NodeIdRef> for NodeId {
 
 impl Borrow<str> for NodeId {
     fn borrow(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Borrow<String> for NodeId {
-    fn borrow(&self) -> &String {
         &self.0
     }
 }
@@ -141,26 +130,38 @@ impl Deref for NodeId {
 }
 
 impl Display for NodeId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl From<Arc<str>> for NodeId {
+    fn from(node_id: Arc<str>) -> Self {
+        Self(node_id)
+    }
+}
+
+impl From<NodeId> for Arc<str> {
+    fn from(node_id: NodeId) -> Self {
+        node_id.0
     }
 }
 
 impl From<&'_ str> for NodeId {
     fn from(node_id: &str) -> Self {
-        Self::new(node_id.to_string())
+        Self(Arc::from(node_id))
     }
 }
 
 impl From<String> for NodeId {
     fn from(node_id: String) -> Self {
-        Self::new(node_id)
+        Self(Arc::from(node_id))
     }
 }
 
 impl From<NodeId> for String {
     fn from(node_id: NodeId) -> Self {
-        node_id.0
+        node_id.0.to_string()
     }
 }
 
@@ -174,7 +175,7 @@ impl FromStr for NodeId {
     type Err = Infallible;
 
     fn from_str(node_id: &str) -> Result<Self, Self::Err> {
-        Ok(NodeId::new(node_id.to_string()))
+        Ok(NodeId(Arc::from(node_id)))
     }
 }
 
@@ -232,12 +233,6 @@ impl Display for NodeIdRef {
     }
 }
 
-impl<'a> From<&'a str> for &'a NodeIdRef {
-    fn from(node_id: &'a str) -> &'a NodeIdRef {
-        NodeIdRef::from_str(node_id)
-    }
-}
-
 impl PartialEq<NodeIdRef> for NodeId {
     fn eq(&self, other: &NodeIdRef) -> bool {
         self.as_str() == other.as_str()
@@ -272,7 +267,7 @@ impl ToOwned for NodeIdRef {
     type Owned = NodeId;
 
     fn to_owned(&self) -> Self::Owned {
-        NodeId(self.0.to_string())
+        NodeId(Arc::from(&self.0))
     }
 }
 

--- a/quickwit/quickwit-proto/src/types/mod.rs
+++ b/quickwit/quickwit-proto/src/types/mod.rs
@@ -96,6 +96,7 @@ impl Display for SourceUid {
 pub struct NodeId(Arc<str>);
 
 impl NodeId {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(node_id: &str) -> Self {
         Self(Arc::from(node_id))
     }

--- a/quickwit/quickwit-proto/src/types/mod.rs
+++ b/quickwit/quickwit-proto/src/types/mod.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
-use std::convert::Infallible;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -101,6 +99,10 @@ impl NodeId {
     pub fn from_str(node_id: &str) -> Self {
         Self(Arc::from(node_id))
     }
+
+    pub fn from_arc_str(node_id: Arc<str>) -> Self {
+        Self(node_id)
+    }
 }
 
 impl AsRef<NodeIdRef> for NodeId {
@@ -135,58 +137,14 @@ impl Display for NodeId {
     }
 }
 
-impl From<Arc<str>> for NodeId {
-    fn from(node_id: Arc<str>) -> Self {
-        Self(node_id)
-    }
-}
-
 impl From<NodeId> for Arc<str> {
     fn from(node_id: NodeId) -> Self {
         node_id.0
     }
 }
 
-impl From<&'_ str> for NodeId {
-    fn from(node_id: &str) -> Self {
-        Self(Arc::from(node_id))
-    }
-}
-
-impl From<String> for NodeId {
-    fn from(node_id: String) -> Self {
-        Self(Arc::from(node_id))
-    }
-}
-
-impl From<NodeId> for String {
-    fn from(node_id: NodeId) -> Self {
-        node_id.0.to_string()
-    }
-}
-
-impl From<&'_ NodeIdRef> for NodeId {
-    fn from(node_id: &NodeIdRef) -> Self {
-        node_id.to_owned()
-    }
-}
-
-impl FromStr for NodeId {
-    type Err = Infallible;
-
-    fn from_str(node_id: &str) -> Result<Self, Self::Err> {
-        Ok(NodeId(Arc::from(node_id)))
-    }
-}
-
 impl PartialEq<&str> for NodeId {
     fn eq(&self, other: &&str) -> bool {
-        self.as_str() == *other
-    }
-}
-
-impl PartialEq<String> for NodeId {
-    fn eq(&self, other: &String) -> bool {
         self.as_str() == *other
     }
 }
@@ -328,7 +286,7 @@ mod tests {
             node_id: NodeId,
         }
         let node = Node {
-            node_id: NodeId::from("test-node"),
+            node_id: NodeId::from_str("test-node"),
         };
         let serialized = serde_json::to_string(&node).unwrap();
         assert_eq!(serialized, r#"{"node_id":"test-node"}"#);

--- a/quickwit/quickwit-serve/src/datafusion_api/setup.rs
+++ b/quickwit/quickwit-serve/src/datafusion_api/setup.rs
@@ -118,12 +118,12 @@ async fn datafusion_worker_changes(
             vec![insert_datafusion_worker(&node, max_message_size)]
         }
         ClusterChange::Remove(node) if node.is_searcher() => {
-            vec![Change::Remove(node.grpc_advertise_addr())]
+            vec![Change::Remove(node.grpc_advertise_addr)]
         }
         ClusterChange::Update { previous, updated } => {
             let mut changes = Vec::new();
             if previous.is_searcher() {
-                changes.push(Change::Remove(previous.grpc_advertise_addr()));
+                changes.push(Change::Remove(previous.grpc_advertise_addr));
             }
             if is_datafusion_worker_node(&updated).await {
                 changes.push(insert_datafusion_worker(&updated, max_message_size));
@@ -173,7 +173,7 @@ fn insert_datafusion_worker(
     node: &ClusterNode,
     max_message_size: ByteSize,
 ) -> Change<SocketAddr, SearchServiceClient> {
-    let grpc_addr = node.grpc_advertise_addr();
+    let grpc_addr = node.grpc_advertise_addr;
     Change::Insert(
         grpc_addr,
         create_search_client_from_grpc_addr(grpc_addr, max_message_size),
@@ -286,7 +286,7 @@ mod tests {
             IngesterStatus::Ready,
         )
         .await;
-        let grpc_addr = node.grpc_advertise_addr();
+        let grpc_addr = node.grpc_advertise_addr;
 
         let changes =
             datafusion_worker_changes(ClusterChange::Remove(node), ByteSize::mib(1)).await;

--- a/quickwit/quickwit-serve/src/developer_api/debug.rs
+++ b/quickwit/quickwit-serve/src/developer_api/debug.rs
@@ -107,7 +107,7 @@ async fn get_node_debug_infos(
         if node_id_patterns.matches(&ready_node.node_id) {
             let node_id = ready_node.node_id.clone();
             let client = DeveloperServiceClient::from_channel(
-                ready_node.grpc_advertise_addr(),
+                ready_node.grpc_advertise_addr,
                 ready_node.channel(),
                 DeveloperApiServer::MAX_GRPC_MESSAGE_SIZE,
                 Some(CompressionEncoding::Zstd),

--- a/quickwit/quickwit-serve/src/developer_api/debug.rs
+++ b/quickwit/quickwit-serve/src/developer_api/debug.rs
@@ -104,8 +104,8 @@ async fn get_node_debug_infos(
     let mut get_debug_info_futures = FuturesUnordered::new();
 
     for ready_node in ready_nodes {
-        if node_id_patterns.matches(ready_node.node_id()) {
-            let node_id = ready_node.node_id().to_owned();
+        if node_id_patterns.matches(&ready_node.node_id) {
+            let node_id = ready_node.node_id.clone();
             let client = DeveloperServiceClient::from_channel(
                 ready_node.grpc_advertise_addr(),
                 ready_node.channel(),

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -236,7 +236,7 @@ async fn balance_channel_for_service(
     let service_change_stream = cluster_change_stream.filter_map(move |cluster_change| {
         Box::pin(async move {
             match cluster_change {
-                ClusterChange::Add(node) if node.enabled_services.contains(&service) => {
+                ClusterChange::Add(node) if node.is_service_enabled(service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
@@ -247,7 +247,7 @@ async fn balance_channel_for_service(
                     );
                     Some(Change::Insert(node.grpc_advertise_addr, node.channel()))
                 }
-                ClusterChange::Remove(node) if node.enabled_services.contains(&service) => {
+                ClusterChange::Remove(node) if node.is_service_enabled(service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1073,7 +1073,7 @@ fn build_ingester_insert_change(
         chitchat_id.node_id,
         node.ingester_status(),
     );
-    let node_id: NodeId = node.node_id().to_owned();
+    let node_id: NodeId = node.node_id.clone();
     let ingester_service = build_ingester_service(
         node,
         ingester_opt,
@@ -1096,7 +1096,7 @@ fn build_ingester_remove_change(node: &ClusterNode) -> Change<NodeId, IngesterPo
         "removing node `{}` from ingester pool",
         chitchat_id.node_id,
     );
-    let node_id: NodeId = node.node_id().to_owned();
+    let node_id: NodeId = node.node_id.clone();
     Change::Remove(node_id)
 }
 
@@ -1290,7 +1290,7 @@ fn build_indexer_insert_change(
         chitchat_id.node_id,
         node.ingester_status()
     );
-    let node_id: NodeId = node.node_id().to_owned();
+    let node_id: NodeId = node.node_id.clone();
     let client = build_indexing_service(node, indexing_service_opt, grpc_max_message_size);
     Change::Insert(
         node_id.clone(),
@@ -1312,7 +1312,7 @@ fn build_indexer_remove_change(node: &ClusterNode) -> Change<NodeId, IndexerNode
         "removing node `{}` from indexer pool",
         chitchat_id.node_id,
     );
-    let node_id: NodeId = node.node_id().to_owned();
+    let node_id: NodeId = node.node_id.clone();
     Change::Remove(node_id)
 }
 

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -239,7 +239,7 @@ async fn balance_channel_for_service(
                 ClusterChange::Add(node) if node.enabled_services().contains(&service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = chitchat_id.node_id,
+                        node_id = %chitchat_id.node_id,
                         generation_id = chitchat_id.generation_id,
                         "adding node `{}` to {} pool",
                         chitchat_id.node_id,
@@ -250,7 +250,7 @@ async fn balance_channel_for_service(
                 ClusterChange::Remove(node) if node.enabled_services().contains(&service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = chitchat_id.node_id,
+                        node_id = %chitchat_id.node_id,
                         generation_id = chitchat_id.generation_id,
                         "removing node `{}` from {} pool",
                         chitchat_id.node_id,
@@ -324,7 +324,7 @@ async fn start_control_plane_if_needed(
         )
         .await?;
 
-        let self_node_id: NodeId = cluster.self_node_id().into();
+        let self_node_id: NodeId = cluster.self_node_id().to_owned();
 
         let control_plane_mailbox = setup_control_plane(
             universe,
@@ -940,7 +940,7 @@ async fn setup_ingest_v2(
     ingester_pool: IngesterPool,
 ) -> anyhow::Result<(IngestRouter, IngestRouterServiceClient, Option<Ingester>)> {
     // Instantiate ingest router.
-    let self_node_id: NodeId = cluster.self_node_id().into();
+    let self_node_id: NodeId = cluster.self_node_id().to_owned();
     let grpc_compression_encoding_opt = node_config.ingest_api_config.grpc_compression_encoding();
     let replication_factor = node_config
         .ingest_api_config
@@ -1067,13 +1067,13 @@ fn build_ingester_insert_change(
 ) -> Change<NodeId, IngesterPoolEntry> {
     let chitchat_id = node.chitchat_id();
     info!(
-        node_id = chitchat_id.node_id,
+        node_id = %chitchat_id.node_id,
         generation_id = chitchat_id.generation_id,
         "adding/updating node `{}` with ingester status `{}` to ingester pool",
         chitchat_id.node_id,
         node.ingester_status(),
     );
-    let node_id: NodeId = node.node_id().into();
+    let node_id: NodeId = node.node_id().to_owned();
     let ingester_service = build_ingester_service(
         node,
         ingester_opt,
@@ -1091,12 +1091,12 @@ fn build_ingester_insert_change(
 fn build_ingester_remove_change(node: &ClusterNode) -> Change<NodeId, IngesterPoolEntry> {
     let chitchat_id = node.chitchat_id();
     info!(
-        node_id = chitchat_id.node_id,
+        node_id = %chitchat_id.node_id,
         generation_id = chitchat_id.generation_id,
         "removing node `{}` from ingester pool",
         chitchat_id.node_id,
     );
-    let node_id: NodeId = node.node_id().into();
+    let node_id: NodeId = node.node_id().to_owned();
     Change::Remove(node_id)
 }
 
@@ -1155,7 +1155,7 @@ async fn setup_searcher(
                 ClusterChange::Add(node) if node.is_searcher() => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = chitchat_id.node_id,
+                        node_id = %chitchat_id.node_id,
                         generation_id = chitchat_id.generation_id,
                         "adding node `{}` to searcher pool",
                         chitchat_id.node_id,
@@ -1179,7 +1179,7 @@ async fn setup_searcher(
                 ClusterChange::Remove(node) if node.is_searcher() => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = chitchat_id.node_id,
+                        node_id = %chitchat_id.node_id,
                         generation_id = chitchat_id.generation_id,
                         "removing node `{}` from searcher pool",
                         chitchat_id.node_id,
@@ -1284,13 +1284,13 @@ fn build_indexer_insert_change(
 ) -> Change<NodeId, IndexerNodeInfo> {
     let chitchat_id = node.chitchat_id();
     info!(
-        node_id = chitchat_id.node_id,
+        node_id = %chitchat_id.node_id,
         generation_id = chitchat_id.generation_id,
         "adding node `{}` with ingester status `{}` to indexer pool",
         chitchat_id.node_id,
         node.ingester_status()
     );
-    let node_id: NodeId = node.node_id().into();
+    let node_id: NodeId = node.node_id().to_owned();
     let client = build_indexing_service(node, indexing_service_opt, grpc_max_message_size);
     Change::Insert(
         node_id.clone(),
@@ -1307,12 +1307,12 @@ fn build_indexer_insert_change(
 fn build_indexer_remove_change(node: &ClusterNode) -> Change<NodeId, IndexerNodeInfo> {
     let chitchat_id = node.chitchat_id();
     info!(
-        node_id = chitchat_id.node_id,
+        node_id = %chitchat_id.node_id,
         generation_id = chitchat_id.generation_id,
         "removing node `{}` from indexer pool",
         chitchat_id.node_id,
     );
-    let node_id: NodeId = node.node_id().into();
+    let node_id: NodeId = node.node_id().to_owned();
     Change::Remove(node_id)
 }
 

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1772,7 +1772,7 @@ mod tests {
 
         assert_eq!(ingester_pool.len(), 1);
         let pool_entry = ingester_pool
-            .get(&NodeId::from("test-ingester-node"))
+            .get(&NodeId::from_str("test-ingester-node"))
             .unwrap();
         assert_eq!(pool_entry.status, IngesterStatus::Initializing);
 
@@ -1796,7 +1796,7 @@ mod tests {
 
         assert_eq!(ingester_pool.len(), 1);
         let pool_entry = ingester_pool
-            .get(&NodeId::from("test-ingester-node"))
+            .get(&NodeId::from_str("test-ingester-node"))
             .unwrap();
         assert_eq!(pool_entry.status, IngesterStatus::Ready);
 
@@ -1821,7 +1821,7 @@ mod tests {
         // The node should still be in the pool with updated status.
         assert_eq!(ingester_pool.len(), 1);
         let pool_entry = ingester_pool
-            .get(&NodeId::from("test-ingester-node"))
+            .get(&NodeId::from_str("test-ingester-node"))
             .unwrap();
         assert_eq!(pool_entry.status, IngesterStatus::Decommissioning);
 

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -236,7 +236,7 @@ async fn balance_channel_for_service(
     let service_change_stream = cluster_change_stream.filter_map(move |cluster_change| {
         Box::pin(async move {
             match cluster_change {
-                ClusterChange::Add(node) if node.enabled_services().contains(&service) => {
+                ClusterChange::Add(node) if node.enabled_services.contains(&service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
@@ -245,9 +245,9 @@ async fn balance_channel_for_service(
                         chitchat_id.node_id,
                         service.as_str().replace('_', " "),
                     );
-                    Some(Change::Insert(node.grpc_advertise_addr(), node.channel()))
+                    Some(Change::Insert(node.grpc_advertise_addr, node.channel()))
                 }
-                ClusterChange::Remove(node) if node.enabled_services().contains(&service) => {
+                ClusterChange::Remove(node) if node.enabled_services.contains(&service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
@@ -256,7 +256,7 @@ async fn balance_channel_for_service(
                         chitchat_id.node_id,
                         service.as_str().replace('_', " "),
                     );
-                    Some(Change::Remove(node.grpc_advertise_addr()))
+                    Some(Change::Remove(node.grpc_advertise_addr))
                 }
                 _ => None,
             }
@@ -1038,7 +1038,7 @@ fn setup_ingester_pool(
                 // unnecessary churn
                 ClusterChange::Update { previous, updated }
                     if updated.is_indexer()
-                        && previous.ingester_status() != updated.ingester_status() =>
+                        && previous.ingester_status != updated.ingester_status =>
                 {
                     let change = build_ingester_insert_change(
                         &updated,
@@ -1071,7 +1071,7 @@ fn build_ingester_insert_change(
         generation_id = chitchat_id.generation_id,
         "adding/updating node `{}` with ingester status `{}` to ingester pool",
         chitchat_id.node_id,
-        node.ingester_status(),
+        node.ingester_status,
     );
     let node_id: NodeId = node.node_id.clone();
     let ingester_service = build_ingester_service(
@@ -1082,7 +1082,7 @@ fn build_ingester_insert_change(
     );
     let pool_entry = IngesterPoolEntry {
         client: ingester_service,
-        status: node.ingester_status(),
+        status: node.ingester_status,
         availability_zone: node.availability_zone().map(|az| az.to_string()),
     };
     Change::Insert(node_id, pool_entry)
@@ -1121,7 +1121,7 @@ fn build_ingester_service(
         .stack_layer(INGEST_GRPC_CLIENT_METRICS_LAYER.clone())
         .stack_layer(TimeoutLayer::new(GRPC_INGESTER_SERVICE_TIMEOUT))
         .build_from_channel(
-            node.grpc_advertise_addr(),
+            node.grpc_advertise_addr,
             node.channel(),
             max_message_size,
             grpc_compression_encoding_opt,
@@ -1160,7 +1160,7 @@ async fn setup_searcher(
                         "adding node `{}` to searcher pool",
                         chitchat_id.node_id,
                     );
-                    let grpc_addr = node.grpc_advertise_addr();
+                    let grpc_addr = node.grpc_advertise_addr;
 
                     if node.is_self_node() {
                         let search_client =
@@ -1184,7 +1184,7 @@ async fn setup_searcher(
                         "removing node `{}` from searcher pool",
                         chitchat_id.node_id,
                     );
-                    Some(Change::Remove(node.grpc_advertise_addr()))
+                    Some(Change::Remove(node.grpc_advertise_addr))
                 }
                 _ => None,
             }
@@ -1288,7 +1288,7 @@ fn build_indexer_insert_change(
         generation_id = chitchat_id.generation_id,
         "adding node `{}` with ingester status `{}` to indexer pool",
         chitchat_id.node_id,
-        node.ingester_status()
+        node.ingester_status
     );
     let node_id: NodeId = node.node_id.clone();
     let client = build_indexing_service(node, indexing_service_opt, grpc_max_message_size);
@@ -1298,8 +1298,8 @@ fn build_indexer_insert_change(
             node_id,
             generation_id: chitchat_id.generation_id,
             client,
-            indexing_tasks: node.indexing_tasks().to_vec(),
-            indexing_capacity: node.indexing_capacity(),
+            indexing_tasks: node.indexing_tasks.to_vec(),
+            indexing_capacity: node.indexing_cpu_capacity,
         },
     )
 }
@@ -1339,7 +1339,7 @@ fn build_indexing_service(
         .stack_layer(INDEXING_GRPC_CLIENT_METRICS_LAYER.clone())
         .stack_layer(TimeoutLayer::new(GRPC_INDEXING_SERVICE_TIMEOUT))
         .build_from_channel(
-            node.grpc_advertise_addr(),
+            node.grpc_advertise_addr,
             node.channel(),
             max_message_size,
             None,


### PR DESCRIPTION
- we now rely on Arc<str> instead of String for NodeId. Chitchat now emits Arc<str>, making cloning cheap
- nesting ClusterMember within ClusterNode. Both struct had a confusing relationship. Now the relationship is clearer. ClusterNode is Member + a channel.
- as a legacy code, we used to maintain a watch channel with the list of ClusterMember. That channel was maintained by own task, generating copies of all members upon cluster modifications. These members were only used in unit test. This PR removes this code that was marked as "to deprecate"