### PR TITLE
fix(storage): emit delete metric for the Azure blob backend

### DIFF
--- a/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/azure_blob_storage.rs
@@ -34,6 +34,7 @@ use quickwit_common::retry::{RetryParams, Retryable, retry};
 use quickwit_common::uri::Uri;
 use quickwit_common::{chunk_range, ignore_error_kind, into_u64_range};
 use quickwit_config::{AzureStorageConfig, StorageBackend};
+use quickwit_metrics::HistogramTimer;
 use regex::Regex;
 use tantivy::directory::OwnedBytes;
 use thiserror::Error;
@@ -382,6 +383,10 @@ impl Storage for AzureBlobStorage {
 
     #[instrument(name = "storage.azure.delete", level = "debug", skip(self))]
     async fn delete(&self, path: &Path) -> StorageResult<()> {
+        // The Azure SDK has no batch delete, so bulk_delete also funnels through
+        // here one blob at a time.
+        crate::metrics::OBJECT_STORAGE_DELETE_REQUESTS_TOTAL.inc();
+        let _timer = HistogramTimer::new(&crate::metrics::OBJECT_STORAGE_DELETE_REQUEST_DURATION);
         let blob_name = self.blob_name(path);
         let delete_res: Result<_, StorageError> = self
             .container_client


### PR DESCRIPTION
### Description

The S3 (`s3_compatible_storage`) and GCS (`opendal_storage`) backends both increment `object_storage_requests_total{action="delete_object"}` (via `OBJECT_STORAGE_DELETE_REQUESTS_TOTAL` / `OBJECT_STORAGE_BULK_DELETE_REQUESTS_TOTAL`) when deleting objects. The Azure blob backend does not, so object-storage delete activity is invisible in metrics for Azure-backed deployments.

This adds the counter increment (and the request-duration histogram timer) to `AzureBlobStorage::delete`, matching the other two backends. The Azure backend has no batch-delete API, so `bulk_delete` already calls `delete` one blob at a time — incrementing in `delete` therefore covers both single and bulk deletes with no other changes.

Diff is +7 lines in `quickwit-storage/src/object_storage/azure_blob_storage.rs` (one import + the increment/timer in `delete`).

### How was this PR tested?

`cargo check -p quickwit-storage --features azure` passes. The change mirrors the existing pattern already used in `s3_compatible_storage.rs` and `opendal_storage/base.rs`, so no behavior changes beyond metric emission.