### PR TITLE
fix(config): set MD5 checksums for DigitalOcean and GCS flavors since they don't support CRC32C, and explicitly set CRC32C for MinIO

### DIFF
--- a/quickwit/quickwit-config/src/storage_config.rs
+++ b/quickwit/quickwit-config/src/storage_config.rs
@@ -370,20 +370,26 @@ impl S3StorageConfig {
             Some(StorageBackendFlavor::DigitalOcean) => {
                 self.force_path_style_access = true;
                 self.disable_multi_object_delete = true;
+                // doesn't support CRC32C
+                self.checksum_algorithm = ChecksumAlgorithm::Md5;
             }
             Some(StorageBackendFlavor::Garage) => {
                 self.region = Some("garage".to_string());
                 self.force_path_style_access = true;
+                self.checksum_algorithm = ChecksumAlgorithm::Crc32c;
             }
             Some(StorageBackendFlavor::Gcs) => {
                 self.disable_multi_object_delete = true;
                 self.disable_multipart_upload = true;
                 // doesnt support CRC32C via the S3 SDK
-                self.checksum_algorithm = ChecksumAlgorithm::Disabled;
+                // Quickwit comes with a "native" GCS client that supports CRC32C
+                // when compiled with the GCS feature flag.
+                self.checksum_algorithm = ChecksumAlgorithm::Md5;
             }
             Some(StorageBackendFlavor::MinIO) => {
                 self.region = Some("minio".to_string());
                 self.force_path_style_access = true;
+                self.checksum_algorithm = ChecksumAlgorithm::Crc32c;
             }
             _ => {}
         }
@@ -704,40 +710,55 @@ mod tests {
             let s3_storage_config_yaml = r#"
                 flavor: digital_ocean
             "#;
-            let s3_storage_config: S3StorageConfig =
+            let mut s3_storage_config: S3StorageConfig =
                 serde_yaml::from_str(s3_storage_config_yaml).unwrap();
-
+            s3_storage_config.apply_flavor();
             assert_eq!(
                 s3_storage_config.flavor,
                 Some(StorageBackendFlavor::DigitalOcean)
             );
+            assert!(!s3_storage_config.disable_checksums);
+            assert_eq!(s3_storage_config.checksum_algorithm, ChecksumAlgorithm::Md5);
         }
         {
             let s3_storage_config_yaml = r#"
                 flavor: garage
             "#;
-            let s3_storage_config: S3StorageConfig =
+            let mut s3_storage_config: S3StorageConfig =
                 serde_yaml::from_str(s3_storage_config_yaml).unwrap();
+            s3_storage_config.apply_flavor();
 
             assert_eq!(s3_storage_config.flavor, Some(StorageBackendFlavor::Garage));
+            assert!(!s3_storage_config.disable_checksums);
+            assert_eq!(
+                s3_storage_config.checksum_algorithm,
+                ChecksumAlgorithm::Crc32c
+            );
         }
         {
             let s3_storage_config_yaml = r#"
                 flavor: gcs
             "#;
-            let s3_storage_config: S3StorageConfig =
+            let mut s3_storage_config: S3StorageConfig =
                 serde_yaml::from_str(s3_storage_config_yaml).unwrap();
-
+            s3_storage_config.apply_flavor();
             assert_eq!(s3_storage_config.flavor, Some(StorageBackendFlavor::Gcs));
+            assert!(!s3_storage_config.disable_checksums);
+            assert_eq!(s3_storage_config.checksum_algorithm, ChecksumAlgorithm::Md5);
         }
         {
             let s3_storage_config_yaml = r#"
                 flavor: minio
             "#;
-            let s3_storage_config: S3StorageConfig =
+            let mut s3_storage_config: S3StorageConfig =
                 serde_yaml::from_str(s3_storage_config_yaml).unwrap();
-
+            s3_storage_config.apply_flavor();
             assert_eq!(s3_storage_config.flavor, Some(StorageBackendFlavor::MinIO));
+            assert!(!s3_storage_config.disable_checksums);
+            assert_eq!(
+                s3_storage_config.checksum_algorithm,
+                ChecksumAlgorithm::Crc32c
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- DigitalOcean does not support CRC32C: explicitly set `Md5` now that `Crc32c` is the default
- GCS was previously `Disabled` (which predated the CRC32C default); switch to `Md5` since it also lacks CRC32C S3 SDK support
- MinIO: explicitly set `Crc32c` for clarity (previously fell through to the new default)
- Add checksum-related assertions to the per-flavor serde tests

Follows up on #6442 which made CRC32C the default checksum algorithm.

## Test plan
- [ ] `cargo nextest run -p quickwit-config` passes
- [ ] Clippy and fmt clean