### PR TITLE
Update OpenTelemetry metrics dependencies

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -870,6 +870,7 @@ tonic-health,https://github.com/hyperium/tonic,MIT,James Nugent <james@jen20.com
 tonic-prost,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
 tonic-prost-build,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
 tonic-reflection,https://github.com/hyperium/tonic,MIT,"James Nugent <james@jen20.com>, Samani G. Gikandi <samani@gojulas.com>"
+tonic-types,https://github.com/hyperium/tonic,MIT,"Lucio Franco <luciofranco14@gmail.com>, Rafael Lemos <flemos.rafael.dev@gmail.com>"
 tower,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
 tower-http,https://github.com/tower-rs/tower-http,MIT,Tower Maintainers <team@tower-rs.com>
 tower-layer,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -6198,9 +6198,8 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-otel"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b8984fa38406b80c094943c0ba90e53d5fff0aea051ff9fac96cf6940993c8"
+version = "0.3.2"
+source = "git+https://github.com/shuheiktgw/metrics?rev=238329060a300f653accf968cca831ac44a8d409#238329060a300f653accf968cca831ac44a8d409"
 dependencies = [
  "metrics",
  "metrics-util",
@@ -7000,9 +6999,8 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+version = "0.32.0"
+source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=7cf7d697626a591394d75c1a7efddcb55198caa6#7cf7d697626a591394d75c1a7efddcb55198caa6"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -7014,9 +7012,8 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+version = "0.32.0"
+source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=7cf7d697626a591394d75c1a7efddcb55198caa6#7cf7d697626a591394d75c1a7efddcb55198caa6"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -7026,22 +7023,20 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+version = "0.32.0"
+source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=7cf7d697626a591394d75c1a7efddcb55198caa6#7cf7d697626a591394d75c1a7efddcb55198caa6"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+version = "0.32.0"
+source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=7cf7d697626a591394d75c1a7efddcb55198caa6#7cf7d697626a591394d75c1a7efddcb55198caa6"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -7049,19 +7044,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.6",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+version = "0.32.0"
+source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=7cf7d697626a591394d75c1a7efddcb55198caa6#7cf7d697626a591394d75c1a7efddcb55198caa6"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
@@ -7069,22 +7063,21 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.14.3",
  "serde",
- "serde_json",
  "tonic 0.14.6",
  "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+version = "0.32.1"
+source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=7cf7d697626a591394d75c1a7efddcb55198caa6#7cf7d697626a591394d75c1a7efddcb55198caa6"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -10054,7 +10047,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.14",
@@ -10102,6 +10094,7 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
@@ -10438,7 +10431,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12512,6 +12505,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.6",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12631,9 +12635,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -170,7 +170,7 @@ lru = "0.18"
 matches = "0.1"
 md5 = "0.8"
 metrics = "0.24"
-metrics-exporter-otel = "0.3"
+metrics-exporter-otel = "0.3.2"
 metrics-exporter-prometheus = { version = "0.18", default-features = false }
 metrics-util = "0.20"
 mime_guess = "2.0"
@@ -183,10 +183,10 @@ numfmt = "1.2"
 oneshot = { version = "0.2", features = ["async", "std"] }
 openssl = { version = "0.10", default-features = false }
 openssl-probe = "0.2"
-opentelemetry = "0.31"
-opentelemetry-appender-tracing = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-json"] }
+opentelemetry = "0.32"
+opentelemetry-appender-tracing = "0.32"
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "http-json"] }
 ouroboros = "0.18"
 parquet = { version = "58", default-features = false, features = ["arrow", "experimental", "snap", "variant_experimental", "zstd"] }
 percent-encoding = "2.3"
@@ -308,7 +308,7 @@ tower-http = { version = "0.6", features = [
   "trace",
 ] }
 tracing = "0.1"
-tracing-opentelemetry = "0.32"
+tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "json",
@@ -416,7 +416,21 @@ tantivy-fst = "0.5"
 encoding_rs = "=0.8.35"
 
 [patch.crates-io]
+# Keep OpenTelemetry on the SDK fix from
+# https://github.com/open-telemetry/opentelemetry-rust/pull/3541.
+#
+metrics-exporter-otel = { git = "https://github.com/shuheiktgw/metrics", rev = "238329060a300f653accf968cca831ac44a8d409" }
+opentelemetry = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "7cf7d697626a591394d75c1a7efddcb55198caa6" }
+opentelemetry-appender-tracing = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "7cf7d697626a591394d75c1a7efddcb55198caa6" }
+opentelemetry-http = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "7cf7d697626a591394d75c1a7efddcb55198caa6" }
+opentelemetry-otlp = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "7cf7d697626a591394d75c1a7efddcb55198caa6" }
+opentelemetry-proto = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "7cf7d697626a591394d75c1a7efddcb55198caa6" }
+opentelemetry_sdk = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "7cf7d697626a591394d75c1a7efddcb55198caa6" }
 sasl2-sys = { git = "https://github.com/quickwit-oss/rust-sasl/", rev = "085a4c7" }
+
+[patch."https://github.com/shuheiktgw/metrics"]
+metrics = "0.24.6"
+metrics-util = "0.20.4"
 
 ## this patched version of tracing helps better understand what happens inside futures (when are
 ## they polled, how long does poll take...)


### PR DESCRIPTION
## Summary

This PR aims to solve the same problem as https://github.com/quickwit-oss/quickwit/pull/6465, but with a different approach. Instead of reimplementing the libraries ourselves, we are opening PRs to fix the issues upstream and patching them on our side until those PRs are merged and released.

* Update the OpenTelemetry crates to 0.32 and patch them with the SDK fix from https://github.com/open-telemetry/opentelemetry-rust/pull/3545.
* Use metrics-exporter-otel 0.3.2 and patch it with the fix from https://github.com/palindrom615/metrics-exporter-otel/pull/2 so that we can use OpenTelemetry 0.32.
