### PR TITLE
make errors from stalled stream protection retryable

### DIFF
--- a/quickwit/quickwit-aws/src/error.rs
+++ b/quickwit/quickwit-aws/src/error.rs
@@ -35,7 +35,7 @@ where E: AwsRetryable
         match self {
             SdkError::ConstructionFailure(_) => false,
             SdkError::TimeoutError(_) => true,
-            SdkError::DispatchFailure(_) => false,
+            SdkError::DispatchFailure(failure) => failure.is_io() || failure.is_timeout(),
             SdkError::ResponseError(_) => true,
             SdkError::ServiceError(error) => error.err().is_retryable(),
             _ => false,

--- a/quickwit/quickwit-lambda-client/src/invoker.rs
+++ b/quickwit/quickwit-lambda-client/src/invoker.rs
@@ -89,7 +89,7 @@ fn invoke_error_to_lambda_error(error: SdkError<InvokeError>) -> LambdaInvokeErr
 
     let is_timeout = match &error {
         SdkError::TimeoutError(_) => true,
-        SdkError::DispatchFailure(failure) => failure.is_timeout(),
+        SdkError::DispatchFailure(failure) => failure.is_io() || failure.is_timeout(),
         SdkError::ServiceError(service_error) => matches!(
             service_error.err(),
             InvokeError::EfsMountTimeoutException(_) | InvokeError::SnapStartTimeoutException(_)


### PR DESCRIPTION
### Description

make errors such as this one retryable:
```
uploader: quickwit_indexing::actors::uploader: Failed to upload split. Killing! cause=failed uploading key 01KTP7CAYTHC9DBP7YMBRBVHXM.split in bucket s3://test-bucket/indexes/test-index

Caused by:
    0: storage error(kind=Timeout, source=dispatch failure: timeout: minimum throughput was specified at 1 B/s, but throughput of 0 B/s was observed (DispatchFailure(DispatchFailure { source: ConnectorError { kind: Timeout, source: ThroughputBelowMinimum { expected: Throughput { bytes_read: 1, per_time_elapsed: 1s }, actual: Throughput { bytes_read: 0, per_time_elapsed: 1s } }, connection: Unknown } })))
    1: dispatch failure: timeout: minimum throughput was specified at 1 B/s, but throughput of 0 B/s was observed (DispatchFailure(DispatchFailure { source: ConnectorError { kind: Timeout, source: ThroughputBelowMinimum { expected: Throughput { bytes_read: 1, per_time_elapsed: 1s }, actual: Throughput { bytes_read: 0, per_time_elapsed: 1s } }, connection: Unknown } })) split_id="01KTP7CAYTHC9DBP7YMBRBVHXM"
```
this should save indexing/merging pipeline from dying for transient network issues