### PR TITLE
retry S3 dispatch failures with TransientError kind

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -8437,6 +8437,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "aws-smithy-async",
+ "aws-smithy-types",
  "futures",
  "quickwit-common",
  "tokio",

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -17,6 +17,7 @@ aws-sdk-kinesis = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true }
 aws-sdk-sqs = { workspace = true, optional = true }
 aws-smithy-async = { workspace = true }
+aws-smithy-types = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
 

--- a/quickwit/quickwit-aws/src/error.rs
+++ b/quickwit/quickwit-aws/src/error.rs
@@ -39,7 +39,14 @@ where E: AwsRetryable
             SdkError::DispatchFailure(failure) => {
                 failure.is_io()
                     || failure.is_timeout()
-                    || matches!(failure.as_other(), Some(ErrorKind::TransientError))
+                    || matches!(
+                        failure.as_other(),
+                        Some(
+                            ErrorKind::TransientError
+                                | ErrorKind::ThrottlingError
+                                | ErrorKind::ServerError
+                        )
+                    )
             }
             SdkError::ResponseError(_) => true,
             SdkError::ServiceError(error) => error.err().is_retryable(),

--- a/quickwit/quickwit-aws/src/error.rs
+++ b/quickwit/quickwit-aws/src/error.rs
@@ -16,6 +16,7 @@
 
 use aws_runtime::retries::classifiers::{THROTTLING_ERRORS, TRANSIENT_ERRORS};
 use aws_sdk_s3::error::SdkError;
+use aws_smithy_types::retry::ErrorKind;
 use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadError;
 use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadError;
 use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadError;
@@ -35,7 +36,11 @@ where E: AwsRetryable
         match self {
             SdkError::ConstructionFailure(_) => false,
             SdkError::TimeoutError(_) => true,
-            SdkError::DispatchFailure(failure) => failure.is_io() || failure.is_timeout(),
+            SdkError::DispatchFailure(failure) => {
+                failure.is_io()
+                    || failure.is_timeout()
+                    || matches!(failure.as_other(), Some(ErrorKind::TransientError))
+            }
             SdkError::ResponseError(_) => true,
             SdkError::ServiceError(error) => error.err().is_retryable(),
             _ => false,

--- a/quickwit/quickwit-aws/src/error.rs
+++ b/quickwit/quickwit-aws/src/error.rs
@@ -16,7 +16,6 @@
 
 use aws_runtime::retries::classifiers::{THROTTLING_ERRORS, TRANSIENT_ERRORS};
 use aws_sdk_s3::error::SdkError;
-use aws_smithy_types::retry::ErrorKind;
 use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadError;
 use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadError;
 use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadError;
@@ -26,6 +25,7 @@ use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::operation::put_object::PutObjectError;
 use aws_sdk_s3::operation::upload_part::UploadPartError;
+use aws_smithy_types::retry::ErrorKind;
 
 use crate::retry::AwsRetryable;
 


### PR DESCRIPTION
## Problem

On a large cluster, still observing 22 "failed to upload split" logs on transient s3 errors for which we should retry.

Pattern of logs:

```
failed uploading key *.split in bucket s3://indexes/indexes/datadog  Caused by:     0: storage error(kind=Internal, source=dispatch failure: other: client error (SendRequest): connection closed before message completed (DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(Some(TransientError)), source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(IncompleteMessage)), connection: Unknown } })))     1: dispatch failure: other: client error (SendRequest): connection closed before message completed (DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(Some(TransientError)), source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(IncompleteMessage)), connection: Unknown } }))

```

## What this PR does

`DispatchFailure` errors with `kind: Other(Some(TransientError))` are now classified as retryable

## Test plan

- [ ] Existing unit tests pass
- [ ] Integration tests with S3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)