### PR TITLE
Report unavailable nodes to control-plane

### DIFF
--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -1603,6 +1603,10 @@ mod tests {
         let indexer_pool = IndexerPool::default();
 
         let ingester_pool = IngesterPool::default();
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester"),
+            IngesterPoolEntry::ready_with_client(IngesterServiceClient::mocked()),
+        );
 
         let mut mock_metastore = MockMetastoreService::new();
         let index_uid: IndexUid = IndexUid::for_test("test-index", 0);
@@ -1633,6 +1637,7 @@ mod tests {
                         source_id: INGEST_V2_SOURCE_ID.to_string(),
                         shard_id: Some(ShardId::from(1)),
                         shard_state: ShardState::Open as i32,
+                        leader_id: "test-ingester".to_string(),
                         ..Default::default()
                     }],
                 }];

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -251,9 +251,19 @@ async fn open_shards_on_metastore_and_model(
     Ok(open_shards_response)
 }
 
+/// Returns `true` if the ingester is available, i.e. in the ingester pool and ready to serve
+/// requests.
+fn is_ingester_available_and_ready(ingester_pool: &IngesterPool, ingester_id: &str) -> bool {
+    ingester_pool
+        .get(ingester_id)
+        .map(|ingester| ingester.status.is_ready())
+        .unwrap_or(false)
+}
+
 fn get_open_shard_from_model(
     get_open_shards_subrequest: &GetOrCreateOpenShardsSubrequest,
     model: &ControlPlaneModel,
+    ingester_pool: &IngesterPool,
     unavailable_leaders: &FnvHashSet<NodeId>,
 ) -> Result<Option<GetOrCreateOpenShardsSuccess>, GetOrCreateOpenShardsFailureReason> {
     let Some(index_uid) = model.index_uid(&get_open_shards_subrequest.index_id) else {
@@ -266,20 +276,23 @@ fn get_open_shard_from_model(
     ) else {
         return Err(GetOrCreateOpenShardsFailureReason::SourceNotFound);
     };
-    if open_shard_entries.is_empty() {
-        return Ok(None);
-    }
-    // We already have open shards. Let's return them.
     let open_shards: Vec<Shard> = open_shard_entries
         .into_iter()
+        .filter(|shard_entry| {
+            is_ingester_available_and_ready(ingester_pool, shard_entry.leader_id.as_str())
+        })
         .map(|shard_entry| shard_entry.shard)
         .collect();
-    Ok(Some(GetOrCreateOpenShardsSuccess {
+    if open_shards.is_empty() {
+        return Ok(None);
+    }
+    let success = GetOrCreateOpenShardsSuccess {
         subrequest_id: get_open_shards_subrequest.subrequest_id,
         index_uid: Some(index_uid.clone()),
         source_id: get_open_shards_subrequest.source_id.clone(),
         open_shards,
-    }))
+    };
+    Ok(Some(success))
 }
 
 impl IngestController {
@@ -464,9 +477,12 @@ impl IngestController {
         // We do a first pass to identify the shards that are missing from the model and need to be
         // created.
         for get_open_shards_subrequest in &get_open_shards_request.subrequests {
-            if let Ok(None) =
-                get_open_shard_from_model(get_open_shards_subrequest, model, &unavailable_leaders)
-            {
+            if let Ok(None) = get_open_shard_from_model(
+                get_open_shards_subrequest,
+                model,
+                &self.ingester_pool,
+                &unavailable_leaders,
+            ) {
                 // We did not find any open shard in the model, we will have to create one.
                 // Let's keep track of all of the source that require new shards, so we can batch
                 // create them after this loop.
@@ -513,6 +529,7 @@ impl IngestController {
             match get_open_shard_from_model(
                 &get_open_shards_subrequest,
                 model,
+                &self.ingester_pool,
                 &unavailable_leaders,
             ) {
                 Ok(Some(success)) => {
@@ -1705,6 +1722,72 @@ mod tests {
             .find(|shard| shard.shard_id() == ShardId::from(1))
             .unwrap();
         assert!(shard_1.is_closed());
+    }
+
+    #[test]
+    fn test_get_open_shard_from_model_excludes_ingesters_that_are_not_available_and_ready() {
+        let index_id = "test-index-0";
+        let index_uid = IndexUid::for_test(index_id, 0);
+        let source_id: SourceId = "test-source".to_string();
+
+        let mut model = ControlPlaneModel::default();
+        let mut index_metadata = IndexMetadata::for_test(index_id, "ram://indexes/test-index-0");
+        let mut source_config = SourceConfig::ingest_v2();
+        source_config.source_id = source_id.clone();
+        index_metadata.add_source(source_config).unwrap();
+        model.add_index(index_metadata);
+
+        let shards = vec![Shard {
+            shard_id: Some(ShardId::from(1)),
+            index_uid: Some(index_uid.clone()),
+            source_id: source_id.clone(),
+            leader_id: "test-ingester-0".to_string(),
+            shard_state: ShardState::Open as i32,
+            ..Default::default()
+        }];
+        model.insert_shards(&index_uid, &source_id, shards);
+
+        let subrequest = GetOrCreateOpenShardsSubrequest {
+            subrequest_id: 0,
+            index_id: index_id.to_string(),
+            source_id: source_id.clone(),
+        };
+        let unavailable_leaders = FnvHashSet::default();
+
+        // The leader holding the only open shard is missing from the pool: the shard is excluded
+        // and the control plane will have to create a new one.
+        let ingester_pool = IngesterPool::default();
+        let open_shard_opt =
+            get_open_shard_from_model(&subrequest, &model, &ingester_pool, &unavailable_leaders)
+                .unwrap();
+        assert!(open_shard_opt.is_none());
+
+        // The leader is in the pool but not ready (retiring): the shard is still excluded.
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester-0"),
+            IngesterPoolEntry {
+                client: IngesterServiceClient::mocked(),
+                status: IngesterStatus::Retiring,
+                availability_zone: None,
+            },
+        );
+        let open_shard_opt =
+            get_open_shard_from_model(&subrequest, &model, &ingester_pool, &unavailable_leaders)
+                .unwrap();
+        assert!(open_shard_opt.is_none());
+
+        // The leader is in the pool and ready: the shard is returned.
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester-0"),
+            IngesterPoolEntry::ready_with_client(IngesterServiceClient::mocked()),
+        );
+        let success =
+            get_open_shard_from_model(&subrequest, &model, &ingester_pool, &unavailable_leaders)
+                .unwrap()
+                .unwrap();
+        assert_eq!(success.open_shards.len(), 1);
+        assert_eq!(success.open_shards[0].shard_id(), ShardId::from(1));
+        assert_eq!(success.open_shards[0].leader_id, "test-ingester-0");
     }
 
     #[test]

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -163,12 +163,15 @@ impl IngestRouter {
         ingester_pool: &IngesterPool,
     ) -> DebouncedGetOrCreateOpenShardsRequest {
         let mut debounced_request = DebouncedGetOrCreateOpenShardsRequest::default();
-        let unavailable_leaders: &HashSet<NodeId> = &workbench.unavailable_leaders;
+        // `unavailable_leaders` is populated by the calls to `has_any_routing_candidate` below as
+        // we look for nodes with open shards to route the subrequests to. They are then
+        // reported to the control plane so it can create shards on other nodes.
+        let unavailable_leaders: &mut HashSet<NodeId> = &mut workbench.unavailable_leaders;
 
         let mut state_guard = self.state.lock().await;
 
         for subrequest in pending_subrequests(&workbench.subworkbenches) {
-            if !state_guard.routing_table.has_open_nodes(
+            if !state_guard.routing_table.has_any_routing_candidate(
                 &subrequest.index_id,
                 &subrequest.source_id,
                 ingester_pool,
@@ -708,12 +711,18 @@ mod tests {
         assert_eq!(subrequest.index_id, "test-index-1");
         assert_eq!(subrequest.source_id, "test-source");
 
-        assert!(
-            get_or_create_open_shard_request
-                .unavailable_leaders
-                .is_empty()
+        // `test-ingester-0` holds the only open shard for `test-index-0` but is missing from the
+        // pool, so it is recorded as unavailable while scanning and reported to the control plane.
+        assert_eq!(
+            get_or_create_open_shard_request.unavailable_leaders,
+            ["test-ingester-0"]
         );
-        assert!(workbench.unavailable_leaders.is_empty());
+        assert_eq!(
+            workbench.unavailable_leaders,
+            HashSet::from([NodeId::from_str("test-ingester-0")])
+        );
+
+        workbench.unavailable_leaders.clear();
 
         let (get_or_create_open_shard_request_opt, rendezvous_2) = router
             .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
@@ -734,7 +743,7 @@ mod tests {
         );
         {
             // Ingester-0 is in pool and in table, but marked unavailable on the workbench
-            // (simulating a prior transport error). has_open_nodes returns false → both
+            // (simulating a prior transport error). has_any_routing_candidate returns false → both
             // subrequests trigger CP request.
             workbench
                 .unavailable_leaders
@@ -752,7 +761,7 @@ mod tests {
         }
         {
             // Fresh workbench: ingester-0 is in pool, in table, and NOT unavailable.
-            // has_open_nodes returns true for index-0 → only index-1 triggers request.
+            // has_any_routing_candidate returns true for index-0 → only index-1 triggers request.
             let mut workbench = IngestWorkbench::new(ingest_subrequests, 3);
             let (get_or_create_open_shard_request_opt, _rendezvous) = router
                 .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)

--- a/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
@@ -37,6 +37,30 @@ pub(super) struct IngesterNode {
     pub open_shard_count: usize,
 }
 
+impl IngesterNode {
+    fn is_routing_candidate(
+        &self,
+        ingester_pool: &IngesterPool,
+        unavailable_leaders: &mut HashSet<NodeId>,
+    ) -> bool {
+        if self.capacity_score == 0 || self.open_shard_count == 0 {
+            return false;
+        }
+        if unavailable_leaders.contains(&self.node_id) {
+            return false;
+        }
+        let is_ready = ingester_pool
+            .get(&self.node_id)
+            .map(|ingester| ingester.status.is_ready())
+            .unwrap_or(false);
+
+        if !is_ready {
+            unavailable_leaders.insert(self.node_id.clone());
+        }
+        is_ready
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct RoutingEntry {
     pub index_uid: IndexUid,
@@ -184,12 +208,16 @@ impl RoutingTable {
         per_index
     }
 
-    pub fn has_open_nodes(
+    /// Returns `true` if the entry has at least one routing candidate, i.e. an available node with
+    /// at least one open shard and a capacity score greater than 0. As it scans the entry, it
+    /// records any leader that has open shards but is no longer in the ingester pool or is not
+    /// ready into `unavailable_leaders`, so they can be reported to the control plane.
+    pub fn has_any_routing_candidate(
         &self,
         index_id: &str,
         source_id: &str,
         ingester_pool: &IngesterPool,
-        unavailable_leaders: &HashSet<NodeId>,
+        unavailable_leaders: &mut HashSet<NodeId>,
     ) -> bool {
         let key = (index_id.to_string(), source_id.to_string());
         let Some(entry) = self.table.get(&key) else {
@@ -199,15 +227,14 @@ impl RoutingTable {
         if !entry.seeded_from_cp {
             return false;
         }
-        entry.nodes.values().any(|node| {
-            node.capacity_score > 0
-                && node.open_shard_count > 0
-                && ingester_pool
-                    .get(&node.node_id)
-                    .map(|entry| entry.status.is_ready())
-                    .unwrap_or(false)
-                && !unavailable_leaders.contains(&node.node_id)
-        })
+        // We scan every node (rather than short-circuiting with `any`) so that all unavailable
+        // nodes are recorded and reported to the control plane in a single round.
+        let mut has_any_candidate = false;
+
+        for node in entry.nodes.values() {
+            has_any_candidate |= node.is_routing_candidate(ingester_pool, unavailable_leaders);
+        }
+        has_any_candidate
     }
 
     /// Applies a capacity update from the IngesterCapacityScoreUpdate broadcast. This is the
@@ -315,6 +342,59 @@ mod tests {
         }
     }
 
+    fn ingester_node(
+        node_id: &str,
+        capacity_score: usize,
+        open_shard_count: usize,
+    ) -> IngesterNode {
+        IngesterNode {
+            node_id: NodeId::from_str(node_id),
+            index_uid: IndexUid::for_test("test-index", 0),
+            capacity_score,
+            open_shard_count,
+        }
+    }
+
+    #[test]
+    fn test_ingester_node_is_routing_candidate() {
+        let pool = IngesterPool::default();
+        pool.insert(NodeId::from_str("node-1"), mocked_ingester(None));
+
+        // No capacity or no open shards: not a routing candidate, not reported as unavailable.
+        let mut unavailable_leaders = HashSet::new();
+        assert!(
+            !ingester_node("node-1", 0, 3).is_routing_candidate(&pool, &mut unavailable_leaders)
+        );
+        assert!(
+            !ingester_node("node-1", 5, 0).is_routing_candidate(&pool, &mut unavailable_leaders)
+        );
+        assert!(unavailable_leaders.is_empty());
+
+        // Open shards and a ready leader: open, not reported as unavailable.
+        assert!(
+            ingester_node("node-1", 5, 3).is_routing_candidate(&pool, &mut unavailable_leaders)
+        );
+        assert!(unavailable_leaders.is_empty());
+
+        // Open shards but the leader is missing from the pool: not open, reported as unavailable.
+        assert!(
+            !ingester_node("node-2", 5, 3).is_routing_candidate(&pool, &mut unavailable_leaders)
+        );
+        assert_eq!(
+            unavailable_leaders,
+            HashSet::from([NodeId::from_str("node-2")])
+        );
+
+        // A leader already known to be unavailable is skipped without re-inserting.
+        assert!(
+            !ingester_node("node-2", 5, 3).is_routing_candidate(&pool, &mut unavailable_leaders)
+        );
+        assert_eq!(
+            unavailable_leaders,
+            HashSet::from([NodeId::from_str("node-2")])
+        );
+    }
+
     #[test]
     fn test_apply_capacity_update() {
         let mut table = RoutingTable::default();
@@ -369,15 +449,20 @@ mod tests {
     }
 
     #[test]
-    fn test_has_open_nodes() {
+    fn test_has_any_routing_candidate() {
         let mut table = RoutingTable::default();
         let pool = IngesterPool::default();
         let index_uid = IndexUid::for_test("test-index", 0);
 
         // Empty table.
-        assert!(!table.has_open_nodes("test-index", "test-source", &pool, &HashSet::new()));
+        assert!(!table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut HashSet::new()
+        ));
 
-        // Seed from CP so has_open_nodes can return true.
+        // Seed from CP so has_any_routing_candidate can return true.
         let shards = vec![
             Shard {
                 index_uid: Some(index_uid.clone()),
@@ -398,22 +483,54 @@ mod tests {
         ];
         table.merge_from_shards(index_uid.clone(), "test-source".into(), shards);
 
-        // Node exists but is not in pool.
-        assert!(!table.has_open_nodes("test-index", "test-source", &pool, &HashSet::new()));
+        // Neither node is in the pool: both leaders are recorded as unavailable and reported to
+        // the control plane.
+        let mut unavailable_leaders: HashSet<NodeId> = HashSet::new();
+        assert!(!table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut unavailable_leaders
+        ));
+        assert_eq!(unavailable_leaders.len(), 2);
+        assert!(unavailable_leaders.contains(&NodeId::from_str("node-1")));
+        assert!(unavailable_leaders.contains(&NodeId::from_str("node-2")));
 
-        // Node is in pool → true.
+        // node-1 is in pool → true. node-2 is still missing from the pool and gets recorded.
         pool.insert(NodeId::from_str("node-1"), mocked_ingester(None));
-        assert!(table.has_open_nodes("test-index", "test-source", &pool, &HashSet::new()));
+        let mut unavailable_leaders = HashSet::new();
+        assert!(table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut unavailable_leaders
+        ));
+        assert_eq!(
+            unavailable_leaders,
+            HashSet::from([NodeId::from_str("node-2")])
+        );
 
-        // Node is unavailable → false.
-        let unavailable: HashSet<NodeId> = HashSet::from([NodeId::from_str("node-1")]);
-        assert!(!table.has_open_nodes("test-index", "test-source", &pool, &unavailable));
+        // node-1 is already known to be unavailable, and node-2 is not in the pool → false. The
+        // leader already in the set is left untouched.
+        let mut unavailable_leaders: HashSet<NodeId> = HashSet::from([NodeId::from_str("node-1")]);
+        assert!(!table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut unavailable_leaders
+        ));
 
         // Second node available → true despite first being unavailable.
         pool.insert(NodeId::from_str("node-2"), mocked_ingester(None));
-        assert!(table.has_open_nodes("test-index", "test-source", &pool, &unavailable));
+        let mut unavailable_leaders: HashSet<NodeId> = HashSet::from([NodeId::from_str("node-1")]);
+        assert!(table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut unavailable_leaders
+        ));
 
-        // Node with capacity_score=0 is not eligible.
+        // Node with capacity_score=0 is not eligible and is not reported as unavailable.
         table.apply_capacity_update(
             NodeId::from_str("node-2"),
             index_uid.clone(),
@@ -421,16 +538,26 @@ mod tests {
             0,
             2,
         );
-        assert!(!table.has_open_nodes("test-index", "test-source", &pool, &unavailable));
+        let mut unavailable_leaders: HashSet<NodeId> = HashSet::from([NodeId::from_str("node-1")]);
+        assert!(!table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut unavailable_leaders
+        ));
+        assert_eq!(
+            unavailable_leaders,
+            HashSet::from([NodeId::from_str("node-1")])
+        );
     }
 
     #[test]
-    fn test_has_open_nodes_requires_cp_seed() {
+    fn test_has_any_routing_candidate_requires_cp_seed() {
         let mut table = RoutingTable::default();
         let pool = IngesterPool::default();
         pool.insert(NodeId::from_str("node-1"), mocked_ingester(None));
 
-        // Chitchat broadcast populates the entry, but has_open_nodes still returns false
+        // Chitchat broadcast populates the entry, but has_any_routing_candidate still returns false
         // because the entry hasn't been seeded from the control plane yet.
         table.apply_capacity_update(
             NodeId::from_str("node-1"),
@@ -439,9 +566,14 @@ mod tests {
             8,
             3,
         );
-        assert!(!table.has_open_nodes("test-index", "test-source", &pool, &HashSet::new()));
+        assert!(!table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut HashSet::new()
+        ));
 
-        // After merge_from_shards (CP response), has_open_nodes returns true.
+        // After merge_from_shards (CP response), has_any_routing_candidate returns true.
         let shards = vec![Shard {
             index_uid: Some(IndexUid::for_test("test-index", 0)),
             source_id: "test-source".to_string(),
@@ -455,7 +587,12 @@ mod tests {
             "test-source".into(),
             shards,
         );
-        assert!(table.has_open_nodes("test-index", "test-source", &pool, &HashSet::new()));
+        assert!(table.has_any_routing_candidate(
+            "test-index",
+            "test-source",
+            &pool,
+            &mut HashSet::new()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### Description
Fixes the issue described in #6480 where the router is no longer reporting unavailable nodes to the control plane.

### How was this PR tested?
Added unit tests.
