### PR TITLE
Add compatible metric service labels

### DIFF
--- a/quickwit/quickwit-common/src/tower/metrics.rs
+++ b/quickwit/quickwit-common/src/tower/metrics.rs
@@ -102,7 +102,10 @@ pub struct GrpcMetricsLayer {
 
 impl GrpcMetricsLayer {
     pub fn new(subsystem: &'static str, kind: &'static str) -> Self {
-        let labels = labels!("service" => subsystem, "kind" => kind);
+        // `service` is kept for backward compatibility with existing consumers. Prefer
+        // `grpc_service` for new consumers.
+        // TODO: Remove `service` in a future breaking release.
+        let labels = labels!("service" => subsystem, "grpc_service" => subsystem, "kind" => kind);
         Self {
             requests_total: counter!(parent: GRPC_REQUESTS_TOTAL, labels: [labels]),
             requests_in_flight: gauge!(parent: GRPC_REQUESTS_IN_FLIGHT, labels: [labels]),

--- a/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/logs.rs
@@ -243,7 +243,8 @@ impl OtlpGrpcLogsService {
         let num_bytes = doc_batch.num_bytes() as u64;
         self.store_logs(index_id.clone(), doc_batch).await?;
 
-        let labels = label_values!(OTLP_GRPC_LABEL_NAMES => "logs", index_id, "grpc", "protobuf");
+        let labels =
+            label_values!(OTLP_GRPC_LABEL_NAMES => "logs", "logs", index_id, "grpc", "protobuf");
         counter!(parent: INGESTED_LOG_RECORDS_TOTAL, labels: [labels]).inc_by(num_log_records);
         counter!(parent: INGESTED_BYTES_TOTAL, labels: [labels]).inc_by(num_bytes);
 
@@ -316,8 +317,9 @@ impl OtlpGrpcLogsService {
     ) -> Result<ExportLogsServiceResponse, Status> {
         let start = std::time::Instant::now();
 
-        let labels =
-            label_values!(OTLP_GRPC_LABEL_NAMES => "logs", index_id.clone(), "grpc", "protobuf");
+        let labels = label_values!(
+            OTLP_GRPC_LABEL_NAMES => "logs", "logs", index_id.clone(), "grpc", "protobuf"
+        );
         counter!(parent: REQUESTS_TOTAL, labels: [labels]).inc();
         let (export_res, is_error) = match self.export_inner(request, index_id.clone()).await {
             ok @ Ok(_) => (ok, "false"),
@@ -327,7 +329,9 @@ impl OtlpGrpcLogsService {
             }
         };
         let elapsed = start.elapsed().as_secs_f64();
-        let error_labels = label_values!(OTLP_GRPC_ERROR_LABEL_NAMES => "logs", index_id, "grpc", "protobuf", is_error);
+        let error_labels = label_values!(
+            OTLP_GRPC_ERROR_LABEL_NAMES => "logs", "logs", index_id, "grpc", "protobuf", is_error
+        );
         histogram!(parent: REQUEST_DURATION_SECONDS, labels: [error_labels]).observe(elapsed);
 
         export_res

--- a/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/metrics.rs
@@ -17,10 +17,14 @@ use quickwit_metrics::{
     LabelNames, LazyCounter, LazyHistogram, label_names, lazy_counter, lazy_histogram,
 };
 
-pub(crate) const OTLP_GRPC_LABEL_NAMES: LabelNames<4> =
-    label_names!("service", "index", "transport", "format");
-pub(crate) const OTLP_GRPC_ERROR_LABEL_NAMES: LabelNames<5> =
-    label_names!("service", "index", "transport", "format", "error");
+// `service` is kept for backward compatibility with existing consumers. Prefer `signal` for new
+// consumers. For trace traffic, `service` remains singular (`trace`) while `signal` uses the
+// plural OTLP signal name (`traces`).
+// TODO: Remove `service` in a future breaking release.
+pub(crate) const OTLP_GRPC_LABEL_NAMES: LabelNames<5> =
+    label_names!("service", "signal", "index", "transport", "format");
+pub(crate) const OTLP_GRPC_ERROR_LABEL_NAMES: LabelNames<6> =
+    label_names!("service", "signal", "index", "transport", "format", "error");
 
 pub(crate) static REQUESTS_TOTAL: LazyCounter = lazy_counter!(
         name: "requests_total",

--- a/quickwit/quickwit-opentelemetry/src/otlp/otel_metrics.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/otel_metrics.rs
@@ -239,8 +239,9 @@ impl OtlpGrpcMetricsService {
         let num_bytes = doc_batch.num_bytes() as u64;
         self.store_metrics(index_id.clone(), doc_batch).await?;
 
-        let labels =
-            label_values!(OTLP_GRPC_LABEL_NAMES => "metrics", index_id, "grpc", "protobuf");
+        let labels = label_values!(
+            OTLP_GRPC_LABEL_NAMES => "metrics", "metrics", index_id, "grpc", "protobuf"
+        );
         counter!(parent: INGESTED_DATA_POINTS_TOTAL, labels: [labels])
             .inc_by(num_data_points - num_parse_errors);
         counter!(parent: INGESTED_BYTES_TOTAL, labels: [labels]).inc_by(num_bytes);
@@ -332,8 +333,9 @@ impl OtlpGrpcMetricsService {
     ) -> Result<ExportMetricsServiceResponse, Status> {
         let start = std::time::Instant::now();
 
-        let labels =
-            label_values!(OTLP_GRPC_LABEL_NAMES => "metrics", index_id.clone(), "grpc", "protobuf");
+        let labels = label_values!(
+            OTLP_GRPC_LABEL_NAMES => "metrics", "metrics", index_id.clone(), "grpc", "protobuf"
+        );
         counter!(parent: REQUESTS_TOTAL, labels: [labels]).inc();
 
         let (export_res, is_error) = match self.export_inner(request, index_id.clone()).await {
@@ -346,7 +348,7 @@ impl OtlpGrpcMetricsService {
 
         let elapsed = start.elapsed().as_secs_f64();
         let error_labels = label_values!(
-            OTLP_GRPC_ERROR_LABEL_NAMES => "metrics", index_id, "grpc", "protobuf", is_error
+            OTLP_GRPC_ERROR_LABEL_NAMES => "metrics", "metrics", index_id, "grpc", "protobuf", is_error
         );
         histogram!(parent: REQUEST_DURATION_SECONDS, labels: [error_labels]).observe(elapsed);
 

--- a/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
+++ b/quickwit/quickwit-opentelemetry/src/otlp/traces.rs
@@ -705,7 +705,8 @@ impl OtlpGrpcTracesService {
         let num_bytes = doc_batch.num_bytes() as u64;
         self.store_spans(index_id.clone(), doc_batch).await?;
 
-        let labels = label_values!(OTLP_GRPC_LABEL_NAMES => "trace", index_id, "grpc", "protobuf");
+        let labels =
+            label_values!(OTLP_GRPC_LABEL_NAMES => "trace", "traces", index_id, "grpc", "protobuf");
         counter!(parent: INGESTED_SPANS_TOTAL, labels: [labels]).inc_by(num_spans);
         counter!(parent: INGESTED_BYTES_TOTAL, labels: [labels]).inc_by(num_bytes);
 
@@ -778,8 +779,9 @@ impl OtlpGrpcTracesService {
     ) -> Result<ExportTraceServiceResponse, Status> {
         let start = std::time::Instant::now();
 
-        let labels =
-            label_values!(OTLP_GRPC_LABEL_NAMES => "trace", index_id.clone(), "grpc", "protobuf");
+        let labels = label_values!(
+            OTLP_GRPC_LABEL_NAMES => "trace", "traces", index_id.clone(), "grpc", "protobuf"
+        );
         counter!(parent: REQUESTS_TOTAL, labels: [labels]).inc();
         let (export_res, is_error) = match self.export_inner(request, index_id.clone()).await {
             ok @ Ok(_) => (ok, "false"),
@@ -789,7 +791,9 @@ impl OtlpGrpcTracesService {
             }
         };
         let elapsed = start.elapsed().as_secs_f64();
-        let error_labels = label_values!(OTLP_GRPC_ERROR_LABEL_NAMES => "trace", index_id, "grpc", "protobuf", is_error);
+        let error_labels = label_values!(
+            OTLP_GRPC_ERROR_LABEL_NAMES => "trace", "traces", index_id, "grpc", "protobuf", is_error
+        );
         histogram!(parent: REQUEST_DURATION_SECONDS, labels: [error_labels]).observe(elapsed);
 
         export_res


### PR DESCRIPTION
## Summary
The current `service` label conflicts with the `service.name` label set by the OTLP exporter when ingesting telemetry into Datadog, since Datadog internally converts `service.name` to `service`.

To maintain backward compatibility, we preserve the original `service` label for now, but have added new, more appropriate labels: `grpc_service` and `signal`.