### PR TITLE
Fix shard ownership bug when decommissioning indexer

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -431,13 +431,25 @@ impl IndexingScheduler {
                 .indexer(indexer.node_id.as_str())
                 .unwrap_or(&[])
                 .to_vec();
-            // We don't want to block on a slow indexer so we apply this change asynchronously
+            // We don't want to block on a slow indexer so we apply this change asynchronously.
+            // Bound the apply only for retiring/decommissioning indexers, so a slow or unreachable
+            // draining node can't hold the change-notification guard; ready indexers get no
+            // timeout.
+            let apply_deadline = matches!(
+                indexer.ingester_status,
+                IngesterStatus::Retiring | IngesterStatus::Decommissioning
+            )
+            .then_some(APPLY_INDEXING_PLAN_TIMEOUT);
             let notify_on_drop = notify_on_drop.clone();
             tokio::spawn(async move {
                 let client = indexer.client.clone();
                 let apply_plan_fut =
                     client.apply_indexing_plan(ApplyIndexingPlanRequest { indexing_tasks });
-                match tokio::time::timeout(APPLY_INDEXING_PLAN_TIMEOUT, apply_plan_fut).await {
+                let apply_result = match apply_deadline {
+                    Some(timeout) => tokio::time::timeout(timeout, apply_plan_fut).await,
+                    None => Ok(apply_plan_fut.await),
+                };
+                match apply_result {
                     Ok(Ok(_)) => {}
                     Ok(Err(error)) => {
                         warn!(
@@ -1316,6 +1328,76 @@ mod tests {
             indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
             ingester_status: status,
         }
+    }
+
+    // An `IndexingService` whose apply RPC never returns, so the spawned apply task can only
+    // finish if a timeout cancels it.
+    #[derive(Debug)]
+    struct HangingIndexingService;
+
+    #[async_trait::async_trait]
+    impl IndexingService for HangingIndexingService {
+        async fn apply_indexing_plan(
+            &self,
+            _request: ApplyIndexingPlanRequest,
+        ) -> quickwit_proto::indexing::IndexingResult<ApplyIndexingPlanResponse> {
+            std::future::pending().await
+        }
+    }
+
+    fn hanging_indexer_node_info(status: IngesterStatus) -> IndexerNodeInfo {
+        let client = IndexingServiceClient::tower().build(HangingIndexingService);
+        IndexerNodeInfo {
+            node_id: NodeId::from_str("indexer"),
+            generation_id: 0,
+            client,
+            indexing_tasks: Vec::new(),
+            indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
+            ingester_status: status,
+        }
+    }
+
+    // Applies a plan to a single indexer whose apply RPC hangs forever, then reports whether the
+    // apply task finished within `observe` — i.e. whether a timeout cancelled it.
+    async fn hanging_apply_is_cancelled_within(status: IngesterStatus, observe: Duration) -> bool {
+        let indexer_pool = IndexerPool::default();
+        let indexer = hanging_indexer_node_info(status);
+        indexer_pool.insert(indexer.node_id.clone(), indexer);
+        let mut scheduler = IndexingScheduler::new(
+            "test-cluster".to_string(),
+            NodeId::from_str("control-plane"),
+            indexer_pool,
+        );
+        let physical_plan = PhysicalIndexingPlan::with_indexer_ids(&[]);
+        let waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        let notify_on_drop = scheduler.next_rebuild_tracker.start_rebuild();
+        scheduler.apply_physical_indexing_plan(physical_plan, Some(notify_on_drop));
+        // The waiter resolves only once the spawned apply task drops its `notify_on_drop`, which
+        // for a hanging RPC happens only if a timeout fires.
+        tokio::time::timeout(observe, waiter).await.is_ok()
+    }
+
+    #[tokio::test]
+    async fn test_apply_plan_times_out_only_for_draining_indexers() {
+        // A ready indexer is unbounded: the hanging apply is never cancelled, so its task never
+        // finishes (a wrongly-applied timeout would fire well within 500ms and flip this).
+        assert!(
+            !hanging_apply_is_cancelled_within(IngesterStatus::Ready, Duration::from_millis(500))
+                .await
+        );
+        // Retiring/decommissioning indexers are bounded, so the hanging apply is cancelled and the
+        // task finishes (resolves in ~APPLY_INDEXING_PLAN_TIMEOUT, far within the window).
+        assert!(
+            hanging_apply_is_cancelled_within(IngesterStatus::Retiring, Duration::from_secs(5))
+                .await
+        );
+        assert!(
+            hanging_apply_is_cancelled_within(
+                IngesterStatus::Decommissioning,
+                Duration::from_secs(5)
+            )
+            .await
+        );
     }
 
     fn kafka_source_params_for_test() -> SourceParams {

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -342,7 +342,7 @@ impl IndexingScheduler {
                 return;
             }
         }
-        self.apply_physical_indexing_plan(&indexers, new_physical_plan, Some(notify_on_drop));
+        self.apply_physical_indexing_plan(new_physical_plan, Some(notify_on_drop));
         self.state.num_schedule_indexing_plan += 1;
     }
 
@@ -383,7 +383,7 @@ impl IndexingScheduler {
         } else if !indexing_plans_diff.has_same_tasks() {
             // Some nodes may have not received their tasks, apply it again.
             info!(plans_diff=?indexing_plans_diff, "running tasks and last applied tasks differ: reapply last plan");
-            self.apply_physical_indexing_plan(&indexers, last_applied_plan.clone(), None);
+            self.apply_physical_indexing_plan(last_applied_plan.clone(), None);
         }
     }
 
@@ -408,40 +408,38 @@ impl IndexingScheduler {
 
     fn apply_physical_indexing_plan(
         &mut self,
-        indexers: &[IndexerNodeInfo],
         new_physical_plan: PhysicalIndexingPlan,
         notify_on_drop: Option<Arc<NotifyChangeOnDrop>>,
     ) {
         debug!(new_physical_plan=?new_physical_plan, "apply physical indexing plan");
         APPLY_PLAN_TOTAL.inc();
-        for (node_id, indexing_tasks) in new_physical_plan.indexing_tasks_per_indexer() {
+        // The indexing plan needs to be sent to every reachable indexer in the pool, including not
+        // ready ones, so that any indexer that previously was part of a plan but no longer is can
+        // gracefully shut down its pipelines, such as in the decommissioning case.
+        for indexer in self.indexer_pool.values() {
+            let indexing_tasks = new_physical_plan
+                .indexer(indexer.node_id.as_str())
+                .unwrap_or(&[])
+                .to_vec();
             // We don't want to block on a slow indexer so we apply this change asynchronously
             // TODO not blocking is cool, but we need to make sure there is not accumulation
             // possible here.
             let notify_on_drop = notify_on_drop.clone();
-            tokio::spawn({
-                let indexer = indexers
-                    .iter()
-                    .find(|indexer| indexer.node_id == node_id.as_str())
-                    .expect("This should never happen as the plan was built from these indexers.")
-                    .clone();
-                let indexing_tasks = indexing_tasks.clone();
-                async move {
-                    if let Err(error) = indexer
-                        .client
-                        .clone()
-                        .apply_indexing_plan(ApplyIndexingPlanRequest { indexing_tasks })
-                        .await
-                    {
-                        warn!(
-                            %error,
-                            node_id=%indexer.node_id,
-                            generation_id=indexer.generation_id,
-                            "failed to apply indexing plan to indexer"
-                        );
-                    }
-                    drop(notify_on_drop);
+            tokio::spawn(async move {
+                if let Err(error) = indexer
+                    .client
+                    .clone()
+                    .apply_indexing_plan(ApplyIndexingPlanRequest { indexing_tasks })
+                    .await
+                {
+                    warn!(
+                        %error,
+                        node_id=%indexer.node_id,
+                        generation_id=indexer.generation_id,
+                        "failed to apply indexing plan to indexer"
+                    );
                 }
+                drop(notify_on_drop);
             });
         }
         self.state.num_applied_physical_indexing_plan += 1;
@@ -1106,7 +1104,9 @@ mod tests {
     }
 
     use quickwit_config::SourceInputFormat;
-    use quickwit_proto::indexing::{CpuCapacity, IndexingServiceClient, MockIndexingService, mcpu};
+    use quickwit_proto::indexing::{
+        ApplyIndexingPlanResponse, CpuCapacity, IndexingServiceClient, MockIndexingService, mcpu,
+    };
     use quickwit_proto::ingest::{Shard, ShardState};
 
     fn mock_indexer_node_info(node_id: &str, status: IngesterStatus) -> IndexerNodeInfo {
@@ -1180,6 +1180,72 @@ mod tests {
         );
         let selected = scheduler.select_available_indexers_for_scheduling();
         assert!(selected.is_empty());
+    }
+
+    // Builds an `IndexerNodeInfo` whose client asserts the exact `ApplyIndexingPlanRequest` it
+    // receives (via `withf`) and that it is called exactly once (via `times(1)`, verified on drop).
+    fn asserting_indexer_node_info(
+        node_id: &str,
+        status: IngesterStatus,
+        expect_empty_plan: bool,
+    ) -> IndexerNodeInfo {
+        let mut mock_indexer = MockIndexingService::new();
+        mock_indexer
+            .expect_apply_indexing_plan()
+            .times(1)
+            .withf(move |request| request.indexing_tasks.is_empty() == expect_empty_plan)
+            .returning(|_| Ok(ApplyIndexingPlanResponse {}));
+        let client = IndexingServiceClient::from_mock(mock_indexer);
+        IndexerNodeInfo {
+            node_id: NodeId::from_str(node_id),
+            generation_id: 0,
+            client,
+            indexing_tasks: Vec::new(),
+            indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
+            ingester_status: status,
+        }
+    }
+
+    // A node the planner dropped from the plan (e.g. a retiring indexer) must still receive an
+    // empty plan so it shuts down its now-orphaned pipelines, while nodes in the plan receive
+    // their tasks. See `apply_physical_indexing_plan`.
+    #[tokio::test]
+    async fn test_apply_plan_sends_empty_plan_to_dropped_indexer() {
+        let indexer_pool = IndexerPool::default();
+        // In the plan: receives its task.
+        let ready_indexer =
+            asserting_indexer_node_info("indexer-ready", IngesterStatus::Ready, false);
+        // Dropped from the plan (retiring): must receive an empty plan.
+        let retiring_indexer =
+            asserting_indexer_node_info("indexer-retiring", IngesterStatus::Retiring, true);
+        indexer_pool.insert(ready_indexer.node_id.clone(), ready_indexer);
+        indexer_pool.insert(retiring_indexer.node_id.clone(), retiring_indexer);
+
+        let mut scheduler = IndexingScheduler::new(
+            "test-cluster".to_string(),
+            NodeId::from_str("control-plane"),
+            indexer_pool,
+        );
+
+        let index_uid = IndexUid::from_str("index-1:11111111111111111111111111").unwrap();
+        let task = IndexingTask {
+            pipeline_uid: Some(PipelineUid::for_test(1u128)),
+            index_uid: Some(index_uid),
+            source_id: "source-1".to_string(),
+            shard_ids: Vec::new(),
+            params_fingerprint: 0,
+        };
+        let mut physical_plan =
+            PhysicalIndexingPlan::with_indexer_ids(&["indexer-ready".to_string()]);
+        physical_plan.add_indexing_task("indexer-ready", task);
+
+        // `apply_physical_indexing_plan` dispatches the RPCs on spawned tasks; the rebuild waiter
+        // resolves once every spawned task has dropped its `notify_on_drop` clone, i.e. after all
+        // `apply_indexing_plan` calls have completed.
+        let waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        let notify_on_drop = scheduler.next_rebuild_tracker.start_rebuild();
+        scheduler.apply_physical_indexing_plan(physical_plan, Some(notify_on_drop));
+        waiter.await;
     }
 
     fn kafka_source_params_for_test() -> SourceParams {

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -52,6 +52,12 @@ pub(crate) const MIN_DURATION_BETWEEN_SCHEDULING: Duration =
         Duration::from_secs(30)
     };
 
+pub(crate) const APPLY_INDEXING_PLAN_TIMEOUT: Duration = if cfg!(any(test, feature = "testsuite")) {
+    Duration::from_millis(10)
+} else {
+    Duration::from_secs(2)
+};
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct IndexingSchedulerState {
     pub num_applied_physical_indexing_plan: usize,
@@ -413,31 +419,41 @@ impl IndexingScheduler {
     ) {
         debug!(new_physical_plan=?new_physical_plan, "apply physical indexing plan");
         APPLY_PLAN_TOTAL.inc();
-        // The indexing plan needs to be sent to every reachable indexer in the pool, including not
-        // ready ones, so that any indexer that previously was part of a plan but no longer is can
-        // gracefully shut down its pipelines, such as in the decommissioning case.
-        for indexer in self.indexer_pool.values() {
+        // Retiring and decommissioning indexers still receive the plan so they can gracefully shut
+        // down dropped pipelines; other states (initializing, decommissioned, failed) are skipped.
+        for indexer in self.indexer_pool.values().into_iter().filter(|indexer| {
+            matches!(
+                indexer.ingester_status,
+                IngesterStatus::Ready | IngesterStatus::Retiring | IngesterStatus::Decommissioning
+            )
+        }) {
             let indexing_tasks = new_physical_plan
                 .indexer(indexer.node_id.as_str())
                 .unwrap_or(&[])
                 .to_vec();
             // We don't want to block on a slow indexer so we apply this change asynchronously
-            // TODO not blocking is cool, but we need to make sure there is not accumulation
-            // possible here.
             let notify_on_drop = notify_on_drop.clone();
             tokio::spawn(async move {
-                if let Err(error) = indexer
-                    .client
-                    .clone()
-                    .apply_indexing_plan(ApplyIndexingPlanRequest { indexing_tasks })
-                    .await
-                {
-                    warn!(
-                        %error,
-                        node_id=%indexer.node_id,
-                        generation_id=indexer.generation_id,
-                        "failed to apply indexing plan to indexer"
-                    );
+                let client = indexer.client.clone();
+                let apply_plan_fut =
+                    client.apply_indexing_plan(ApplyIndexingPlanRequest { indexing_tasks });
+                match tokio::time::timeout(APPLY_INDEXING_PLAN_TIMEOUT, apply_plan_fut).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(error)) => {
+                        warn!(
+                            %error,
+                            node_id=%indexer.node_id,
+                            generation_id=indexer.generation_id,
+                            "failed to apply indexing plan to indexer"
+                        );
+                    }
+                    Err(_elapsed) => {
+                        warn!(
+                            node_id=%indexer.node_id,
+                            generation_id=indexer.generation_id,
+                            "timed out applying indexing plan to indexer"
+                        );
+                    }
                 }
                 drop(notify_on_drop);
             });
@@ -1182,37 +1198,50 @@ mod tests {
         assert!(selected.is_empty());
     }
 
-    // Builds an `IndexerNodeInfo` whose client asserts the exact `ApplyIndexingPlanRequest` it
-    // receives (via `withf`) and that it is called exactly once (via `times(1)`, verified on drop).
-    fn asserting_indexer_node_info(
-        node_id: &str,
-        status: IngesterStatus,
-        expect_empty_plan: bool,
-    ) -> IndexerNodeInfo {
-        let mut mock_indexer = MockIndexingService::new();
-        mock_indexer
-            .expect_apply_indexing_plan()
-            .times(1)
-            .withf(move |request| request.indexing_tasks.is_empty() == expect_empty_plan)
-            .returning(|_| Ok(ApplyIndexingPlanResponse {}));
-        let client = IndexingServiceClient::from_mock(mock_indexer);
-        IndexerNodeInfo {
-            node_id: NodeId::from_str(node_id),
-            generation_id: 0,
-            client,
-            indexing_tasks: Vec::new(),
-            indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
-            ingester_status: status,
+    // Only ready, retiring, and decommissioning indexers receive a plan; indexers in any other
+    // state must be skipped entirely. See `apply_physical_indexing_plan`.
+    #[tokio::test]
+    async fn test_apply_plan_skips_non_eligible_indexers() {
+        let indexer_pool = IndexerPool::default();
+        let eligible_indexers = [
+            asserting_indexer_node_info("indexer-ready", IngesterStatus::Ready, true),
+            asserting_indexer_node_info("indexer-retiring", IngesterStatus::Retiring, true),
+            asserting_indexer_node_info(
+                "indexer-decommissioning",
+                IngesterStatus::Decommissioning,
+                true,
+            ),
+        ];
+        let skipped_indexers = [
+            never_applied_indexer_node_info("indexer-unspecified", IngesterStatus::Unspecified),
+            never_applied_indexer_node_info("indexer-initializing", IngesterStatus::Initializing),
+            never_applied_indexer_node_info(
+                "indexer-decommissioned",
+                IngesterStatus::Decommissioned,
+            ),
+            never_applied_indexer_node_info("indexer-failed", IngesterStatus::Failed),
+        ];
+        for indexer in eligible_indexers.into_iter().chain(skipped_indexers) {
+            indexer_pool.insert(indexer.node_id.clone(), indexer);
         }
+
+        let mut scheduler = IndexingScheduler::new(
+            "test-cluster".to_string(),
+            NodeId::from_str("control-plane"),
+            indexer_pool,
+        );
+        let physical_plan = PhysicalIndexingPlan::with_indexer_ids(&[]);
+        let waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        let notify_on_drop = scheduler.next_rebuild_tracker.start_rebuild();
+        scheduler.apply_physical_indexing_plan(physical_plan, Some(notify_on_drop));
+        waiter.await;
     }
 
     // A node the planner dropped from the plan (e.g. a retiring indexer) must still receive an
-    // empty plan so it shuts down its now-orphaned pipelines, while nodes in the plan receive
-    // their tasks. See `apply_physical_indexing_plan`.
+    // empty plan so it shuts down its now-orphaned pipelines.
     #[tokio::test]
     async fn test_apply_plan_sends_empty_plan_to_dropped_indexer() {
         let indexer_pool = IndexerPool::default();
-        // In the plan: receives its task.
         let ready_indexer =
             asserting_indexer_node_info("indexer-ready", IngesterStatus::Ready, false);
         // Dropped from the plan (retiring): must receive an empty plan.
@@ -1246,6 +1275,47 @@ mod tests {
         let notify_on_drop = scheduler.next_rebuild_tracker.start_rebuild();
         scheduler.apply_physical_indexing_plan(physical_plan, Some(notify_on_drop));
         waiter.await;
+    }
+
+    // Builds an `IndexerNodeInfo` whose client asserts the exact `ApplyIndexingPlanRequest` it
+    // receives (via `withf`) and that it is called exactly once (via `times(1)`, verified on drop).
+    fn asserting_indexer_node_info(
+        node_id: &str,
+        status: IngesterStatus,
+        expect_empty_plan: bool,
+    ) -> IndexerNodeInfo {
+        let mut mock_indexer = MockIndexingService::new();
+        mock_indexer
+            .expect_apply_indexing_plan()
+            .times(1)
+            .withf(move |request| request.indexing_tasks.is_empty() == expect_empty_plan)
+            .returning(|_| Ok(ApplyIndexingPlanResponse {}));
+        let client = IndexingServiceClient::from_mock(mock_indexer);
+        IndexerNodeInfo {
+            node_id: NodeId::from_str(node_id),
+            generation_id: 0,
+            client,
+            indexing_tasks: Vec::new(),
+            indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
+            ingester_status: status,
+        }
+    }
+
+    // Builds an `IndexerNodeInfo` whose client asserts it is never asked to apply a plan (via
+    // `never()`, verified on drop). The shared mock is `Arc`-cloned across the client, so a wrong
+    // call from a spawned task is seen when the pool's copy drops on the main thread.
+    fn never_applied_indexer_node_info(node_id: &str, status: IngesterStatus) -> IndexerNodeInfo {
+        let mut mock_indexer = MockIndexingService::new();
+        mock_indexer.expect_apply_indexing_plan().never();
+        let client = IndexingServiceClient::from_mock(mock_indexer);
+        IndexerNodeInfo {
+            node_id: NodeId::from_str(node_id),
+            generation_id: 0,
+            client,
+            indexing_tasks: Vec::new(),
+            indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
+            ingester_status: status,
+        }
     }
 
     fn kafka_source_params_for_test() -> SourceParams {

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -204,7 +204,7 @@ impl FetchStreamTask {
                         index_uid=%self.index_uid,
                         source_id=%self.source_id,
                         shard_id=%self.shard_id,
-                        to_position_inclusive=%self.from_position_inclusive - 1,
+                        to_position_inclusive=%to_position_inclusive,
                         "fetch stream reached end of shard"
                     );
                     let eof_position = to_position_inclusive.as_eof();

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -376,6 +376,28 @@ impl ClusterSandbox {
         .build()
     }
 
+    /// Returns a client targeting the node with the given id specifically, or `None` if no such
+    /// node exists. Unlike [`Self::rest_client`], which returns a client for an arbitrary node
+    /// running a service, this pins the client to a known node — e.g. to keep querying a specific
+    /// node while it is being decommissioned.
+    pub fn rest_client_for_node(&self, node_id: &NodeId) -> Option<QuickwitClient> {
+        let node_config = self
+            .node_configs
+            .iter()
+            .find(|(config, _)| &config.node_id == node_id)?
+            .0
+            .clone();
+        let (ca_cert, identity) = Self::tls_parts(&node_config);
+        let client = QuickwitClientBuilder::new(transport_url(
+            node_config.rest_config.listen_addr,
+            ca_cert.is_some(),
+        ))
+        .set_tls_ca(ca_cert)
+        .set_tls_identity(identity)
+        .build();
+        Some(client)
+    }
+
     /// A client configured to ingest documents and return detailed parse failures.
     pub fn detailed_ingest_client(&self) -> QuickwitClient {
         let node_config = self.find_node_for_service(QuickwitService::Indexer);
@@ -674,6 +696,18 @@ impl ClusterSandbox {
             .unwrap_or_else(|| panic!("no node with service {service:?}"));
         self.node_configs.remove(idx);
         self.node_shutdown_handles.remove(idx)
+    }
+
+    /// Remove the node with the given id from the sandbox and return its shutdown handle, or
+    /// `None` if no such node exists. After this call, `rest_client` and other lookup methods
+    /// skip the removed node, so callers can trigger its shutdown independently.
+    pub fn remove_node(&mut self, node_id: &NodeId) -> Option<NodeShutdownHandle> {
+        let idx = self
+            .node_shutdown_handles
+            .iter()
+            .position(|handle| &handle.node_id == node_id)?;
+        self.node_configs.remove(idx);
+        Some(self.node_shutdown_handles.remove(idx))
     }
 }
 

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1055,6 +1055,132 @@ async fn test_graceful_shutdown_no_data_loss() {
         .unwrap();
 }
 
+/// Regression test for the decommissioning orphaned-pipeline bug. Two indexers each own a shard;
+/// shutting one down must produce a new indexing plan that excludes the retiring indexer but is
+/// still *sent* to it, so it sheds its now-unassigned indexing pipelines instead of orphan-running
+/// them (which previously crash-looped on invalid publish tokens).
+///
+/// We assert the retiring node's indexing pipelines are shut down (`num_running_pipelines == 0`)
+/// while it is still alive. We do not assert full graceful-decommission completion: draining the
+/// reassigned shard on the surviving indexer is a separate concern.
+#[tokio::test]
+async fn test_retiring_indexer_receives_empty_plan() {
+    let mut sandbox = ClusterSandboxBuilder::default()
+        .add_node([QuickwitService::Indexer])
+        .add_node([QuickwitService::Indexer])
+        .add_node([
+            QuickwitService::ControlPlane,
+            QuickwitService::Searcher,
+            QuickwitService::Metastore,
+            QuickwitService::Janitor,
+        ])
+        .build_and_start()
+        .await;
+    let index_id = "test_retiring_indexer_receives_empty_plan";
+
+    // `min_shards: 2` so that, with two indexers, each indexer is assigned a shard to index.
+    sandbox
+        .rest_client(QuickwitService::Indexer)
+        .indexes()
+        .create(
+            format!(
+                r#"
+            version: 0.8
+            index_id: {index_id}
+            doc_mapping:
+              field_mappings:
+              - name: body
+                type: text
+            indexing_settings:
+              commit_timeout_secs: 1
+            ingest_settings:
+              min_shards: 2
+            "#
+            ),
+            ConfigFormat::Yaml,
+            false,
+        )
+        .await
+        .unwrap();
+
+    for i in 0..6 {
+        ingest(
+            &sandbox.rest_client(QuickwitService::Indexer),
+            index_id,
+            ingest_json!({ "body": format!("doc-{i}") }),
+            CommitType::Auto,
+        )
+        .await
+        .unwrap();
+    }
+
+    // Identify the two indexers by id so we never query or shut down the wrong node.
+    let indexer_node_ids: Vec<_> = sandbox
+        .node_configs
+        .iter()
+        .filter(|(_, services)| services.contains(&QuickwitService::Indexer))
+        .map(|(config, _)| config.node_id.clone())
+        .collect();
+    assert_eq!(indexer_node_ids.len(), 2, "expected exactly two indexer nodes");
+    let retiring_node_id = indexer_node_ids[0].clone();
+    let surviving_node_id = indexer_node_ids[1].clone();
+    let retiring_client = sandbox
+        .rest_client_for_node(&retiring_node_id)
+        .expect("the retiring node should have a REST client");
+    let surviving_client = sandbox
+        .rest_client_for_node(&surviving_node_id)
+        .expect("the surviving node should have a REST client");
+
+    // Precondition: each indexer is indexing a shard.
+    wait_until_predicate(
+        || async {
+            match retiring_client.node_stats().indexing().await {
+                Ok(counters) => counters.num_running_pipelines >= 1,
+                Err(_) => false,
+            }
+        },
+        Duration::from_secs(1),
+        Duration::from_millis(100),
+    )
+    .await
+    .expect("the indexer we are about to retire should be indexing a shard");
+    wait_until_predicate(
+        || async {
+            match surviving_client.node_stats().indexing().await {
+                Ok(counters) => counters.num_running_pipelines >= 1,
+                Err(_) => false,
+            }
+        },
+        Duration::from_secs(2),
+        Duration::from_millis(100),
+    )
+    .await
+    .expect("the surviving indexer should also be indexing a shard");
+
+    // Trigger the retiring node's decommission in the background. We only assert that it is told
+    // to shed its plan; we deliberately do not await full decommission.
+    let shutdown_handle = sandbox
+        .remove_node(&retiring_node_id)
+        .expect("the retiring node should be in the sandbox");
+    tokio::spawn(shutdown_handle.shutdown());
+
+    // The fix: the new plan excludes the retiring node but is still sent to it, so it shuts down
+    // its indexing pipelines (`num_running_pipelines` excludes merge pipelines) while still alive.
+    // Without the fix the orphaned pipeline keeps running and this never reaches 0.
+    wait_until_predicate(
+        || async {
+            match retiring_client.node_stats().indexing().await {
+                Ok(counters) => counters.num_running_pipelines == 0,
+                Err(_) => false,
+            }
+        },
+        Duration::from_secs(2),
+        Duration::from_millis(100),
+    )
+    .await
+    .expect("retiring indexer should be sent an empty plan and shut down its indexing pipelines");
+}
+
 /// Verifies that after deleting an index and recreating it with the same name,
 /// ingest works correctly once the capacity broadcast has propagated (>2 broadcast
 /// cycles). Uses 2 ingesters to exercise the Chitchat broadcast path.

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1122,9 +1122,9 @@ async fn test_retiring_indexer_receives_empty_plan() {
         .map(|(config, _)| config.node_id.clone())
         .collect();
     assert_eq!(
-       indexer_node_ids.len(),
+        indexer_node_ids.len(),
         2,
-       "expected exactly two indexer nodes"
+        "expected exactly two indexer nodes"
     );
     let retiring_node_id = indexer_node_ids[0].clone();
     let surviving_node_id = indexer_node_ids[1].clone();

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1121,7 +1121,11 @@ async fn test_retiring_indexer_receives_empty_plan() {
         .filter(|(_, services)| services.contains(&QuickwitService::Indexer))
         .map(|(config, _)| config.node_id.clone())
         .collect();
-    assert_eq!(indexer_node_ids.len(), 2, "expected exactly two indexer nodes");
+    assert_eq!(
+       indexer_node_ids.len(),
+        2,
+       "expected exactly two indexer nodes"
+    );
     let retiring_node_id = indexer_node_ids[0].clone();
     let surviving_node_id = indexer_node_ids[1].clone();
     let retiring_client = sandbox


### PR DESCRIPTION
### Description
Indexing plan broadcast bug when an indexer retires causes crash loop of multiple indexers trying to acquire and index one shard, which slows down indexing and decommissioning dramatically and crashes indexing pipelines (but doesnt corrupt data or cause any data loss).

### In detail
When an ingester signals that it’s entering the retiring state, it’s IngesterStatus is no longer Ready, excluding it from being included in the next indexing plan: https://github.com/quickwit-oss/quickwit/blob/f3880d52dfeff1f4c3795e0e046be1dc1f89b433/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs#L390 

The indexers used to build the plan are the ones then iterated over to send the new indexing plan to: https://github.com/quickwit-oss/quickwit/blob/f3880d52dfeff1f4c3795e0e046be1dc1f89b433/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs#L417 

The problem with this is that the decommissioning indexers are never notified of the new plan (since they’re not in the new plan). The new indexing plan reassigns the shards from this indexer to a different one, which calls AcquireShard with its own publish token, which updates the metastore. It then fetches and indexes the shard and publishes a split.

Since the decommissioning indexer doesn’t know that it’s supposed to stop indexing the shard, it continues indexing the shard as well, and tries to publish a split, but fails because the publish token is different. This triggers the killswitch and the pipeline restarts. This is where the bug is: since it never receives the new indexing plan, the IndexingService still has this shard in its assigned shards - this causes it to call AcquireShard itself, with a new publish token. So now it’s the owner of the shard. The new indexer tries to publish its next split, and now it fails with the same publish token problem, and it restarts and reacquires the shard for itself.

This ping pong happens until either the shard is completely indexed and reaches EOF, or until the decommissioning timeout is hit and the decommissioning indexer is force killed, at which point the new indexer takes over and continues indexing the shard as intended. 

Luckily the publish token works completely as intended and prevents us from having contention or corrupted data. It just means decommissioning takes forever and indexing is much slower.

Fix: Send the new indexing plan to all nodes in the ingester pool, not just the nodes in the plan

### Tests
Added unit test, added integration test.

There’s two additional future improvements that could aid here:

AcquireShards should be based on the most recent indexing plan

Currently, all of a retiring indexer’s shards are indexed on other indexers, and the retiring indexer sits idle. The indexing plan could be modified so that a decommissioning indexer is allowed to index its (and only its) local shards.