### PR TITLE
Use metrics-opentelemetry for OTLP metrics

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -193,7 +193,6 @@ crc-catalog,https://github.com/akhilles/crc-catalog,MIT OR Apache-2.0,Akhil Vela
 crc-fast,https://github.com/awesomized/crc-fast-rust,MIT OR Apache-2.0,Don MacAskill
 crc32fast,https://github.com/srijs/rust-crc32fast,MIT OR Apache-2.0,"Sam Rijs <srijs@airpost.net>, Alex Crichton <alex@alexcrichton.com>"
 criterion-plot,https://github.com/criterion-rs/criterion.rs,Apache-2.0 OR MIT,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
-critical-section,https://github.com/rust-embedded/critical-section,MIT OR Apache-2.0,The critical-section Authors
 cron,https://github.com/zslayton/cron,MIT OR Apache-2.0,Zack Slayton <zack.slayton@gmail.com>
 crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-channel Authors
 crossbeam-deque,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-deque Authors
@@ -475,8 +474,8 @@ measure_time,https://github.com/PSeitz/rust_measure_time,MIT,Pascal Seitz <pasca
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
 memmap2,https://github.com/RazrFalcon/memmap2-rs,MIT OR Apache-2.0,"Dan Burkert <dan@danburkert.com>, Yevhenii Reizner <razrfalcon@gmail.com>, The Contributors"
 metrics,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
-metrics-exporter-otel,https://github.com/palindrom615/metrics,MIT,Whoemoon Jang <palindrom615@gmail.com>
 metrics-exporter-prometheus,https://github.com/metrics-rs/metrics,MIT AND Apache-2.0,Toby Lawrence <toby@nuclearfurnace.com>
+metrics-opentelemetry,https://github.com/DoumanAsh/metrics-opentelemetry,BSL-1.0,The metrics-opentelemetry Authors
 metrics-util,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 mime_guess,https://github.com/abonander/mime_guess,MIT,Austin Bonander <austin.bonander@gmail.com>

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2481,12 +2481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "cron"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6197,18 +6191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-exporter-otel"
-version = "0.3.2"
-source = "git+https://github.com/shuheiktgw/metrics-exporter-otel?rev=b4032665307007ac03ac132fd60850d8c8b7af19#b4032665307007ac03ac132fd60850d8c8b7af19"
-dependencies = [
- "metrics",
- "metrics-util",
- "opentelemetry",
- "portable-atomic",
- "scc",
-]
-
-[[package]]
 name = "metrics-exporter-prometheus"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6227,6 +6209,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "metrics-opentelemetry"
+version = "0.24032.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df39cbce71be50bf6c438f95940f166991a3845a53dcf68c77f08270cf4e327e"
+dependencies = [
+ "metrics",
+ "opentelemetry",
+ "parking_lot",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -7000,7 +6994,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.32.0"
-source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=4279a0115915cdb0a18259d933f58a287b9188eb#4279a0115915cdb0a18259d933f58a287b9188eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -7013,7 +7008,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry-appender-tracing"
 version = "0.32.0"
-source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=4279a0115915cdb0a18259d933f58a287b9188eb#4279a0115915cdb0a18259d933f58a287b9188eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -7024,7 +7020,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry-http"
 version = "0.32.0"
-source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=4279a0115915cdb0a18259d933f58a287b9188eb#4279a0115915cdb0a18259d933f58a287b9188eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7036,7 +7033,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.32.0"
-source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=4279a0115915cdb0a18259d933f58a287b9188eb#4279a0115915cdb0a18259d933f58a287b9188eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -7055,7 +7053,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.32.0"
-source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=4279a0115915cdb0a18259d933f58a287b9188eb#4279a0115915cdb0a18259d933f58a287b9188eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
@@ -7070,7 +7069,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.32.1"
-source = "git+https://github.com/shuheiktgw/opentelemetry-rust?rev=4279a0115915cdb0a18259d933f58a287b9188eb#4279a0115915cdb0a18259d933f58a287b9188eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -7845,9 +7845,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-dependencies = [
- "critical-section",
-]
 
 [[package]]
 name = "portable-atomic-util"
@@ -9500,8 +9497,8 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "metrics",
- "metrics-exporter-otel",
  "metrics-exporter-prometheus",
+ "metrics-opentelemetry",
  "metrics-util",
  "opentelemetry",
  "opentelemetry-appender-tracing",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -170,7 +170,7 @@ lru = "0.18"
 matches = "0.1"
 md5 = "0.8"
 metrics = "0.24"
-metrics-exporter-otel = "0.3.2"
+metrics-opentelemetry = "=0.24032.8"
 metrics-exporter-prometheus = { version = "0.18", default-features = false }
 metrics-util = "0.20"
 mime_guess = "2.0"
@@ -417,13 +417,6 @@ encoding_rs = "=0.8.35"
 
 [patch.crates-io]
 sasl2-sys = { git = "https://github.com/quickwit-oss/rust-sasl/", rev = "085a4c7" }
-metrics-exporter-otel = { git = "https://github.com/shuheiktgw/metrics-exporter-otel", rev = "b4032665307007ac03ac132fd60850d8c8b7af19" }
-opentelemetry = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "4279a0115915cdb0a18259d933f58a287b9188eb" }
-opentelemetry-appender-tracing = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "4279a0115915cdb0a18259d933f58a287b9188eb" }
-opentelemetry-http = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "4279a0115915cdb0a18259d933f58a287b9188eb" }
-opentelemetry-otlp = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "4279a0115915cdb0a18259d933f58a287b9188eb" }
-opentelemetry-proto = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "4279a0115915cdb0a18259d933f58a287b9188eb" }
-opentelemetry_sdk = { git = "https://github.com/shuheiktgw/opentelemetry-rust", rev = "4279a0115915cdb0a18259d933f58a287b9188eb" }
 
 ## this patched version of tracing helps better understand what happens inside futures (when are
 ## they polled, how long does poll take...)

--- a/quickwit/deny.toml
+++ b/quickwit/deny.toml
@@ -57,6 +57,7 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "bzip2-1.0.6",
     "CC0-1.0",
     "CDLA-Permissive-2.0",

--- a/quickwit/quickwit-telemetry-exporters/Cargo.toml
+++ b/quickwit/quickwit-telemetry-exporters/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 metrics = { workspace = true }
-metrics-exporter-otel = { workspace = true }
+metrics-opentelemetry = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 metrics-util = { workspace = true }
 opentelemetry = { workspace = true }

--- a/quickwit/quickwit-telemetry-exporters/src/otlp/metrics.rs
+++ b/quickwit/quickwit-telemetry-exporters/src/otlp/metrics.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use anyhow::Context;
-use metrics_exporter_otel::OpenTelemetryRecorder;
+use metrics_opentelemetry::{OpenTelemetryMetrics, OpenTelemetryRecorder};
 use opentelemetry::metrics::MeterProvider;
 use opentelemetry_otlp::{MetricExporter, Protocol as OtlpWireProtocol, WithExportConfig};
 use opentelemetry_sdk::metrics::{SdkMeterProvider, Temporality};
@@ -58,9 +58,10 @@ pub(crate) fn build_recorder(
         .build();
     let meter = metrics_provider.meter("quickwit");
 
-    let recorder = OpenTelemetryRecorder::new(meter);
+    let otel_metrics = OpenTelemetryMetrics::new(meter);
+    let recorder = OpenTelemetryRecorder::new(otel_metrics);
     for (name, buckets) in quickwit_metrics::histogram_buckets() {
-        recorder.set_histogram_bounds(&metrics::KeyName::from(name), buckets);
+        recorder.set_histogram_bounds(std::iter::once(metrics::KeyName::from(name)), &buckets);
     }
     Ok((recorder, metrics_provider))
 }


### PR DESCRIPTION
## Summary
This PR replaces the forked `metrics-exporter-otel` recorder with `metrics-opentelemetry`. We previously couldn’t use this library because it didn’t provide an API for setting histogram boundaries, but recent changes have added support for that. The library also supports OTel 0.3.2 and handles attributes sorting and deduplication internally ([ref](https://github.com/DoumanAsh/metrics-opentelemetry/commit/872dd5b615cd5fd00b7d0648ac4aafb280cbc6d5)), which means we can remove the forks from our dependencies entirely.

For now, I’ve audited the current version and would like to pin it strictly to minimize supply chain risk.