### PR TITLE
feat(search): abort split warmup when a required term is missing

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -9353,6 +9353,7 @@ dependencies = [
  "tantivy-fst",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tower 0.5.3",
  "tracing",
  "ttl_cache",

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/mod.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/mod.rs
@@ -108,6 +108,13 @@ pub struct WarmupInfo {
     pub term_ranges_grouped_by_field: HashMap<Field, HashMap<TermRange, bool>>,
     /// Automatons to warmup
     pub automatons_grouped_by_field: HashMap<Field, HashSet<Automaton>>,
+    /// Terms that must all be present for the query to match any document.
+    ///
+    /// If any of these terms has an empty posting list in a split, the query
+    /// provably matches nothing there, so the leaf search can abort warmup
+    /// early. This is a conservative subset (see
+    /// `quickwit_query::query_ast::required_terms`).
+    pub required_terms: HashSet<Term>,
 }
 
 impl WarmupInfo {
@@ -147,6 +154,10 @@ impl WarmupInfo {
             let sub_map = self.automatons_grouped_by_field.entry(field).or_default();
             sub_map.extend(automatons);
         }
+
+        // Required terms come from the query; a collector's `WarmupInfo` carries
+        // none, so this union simply preserves the query's set.
+        self.required_terms.extend(other.required_terms);
     }
 
     /// Simplify a WarmupInfo, removing some redundant tasks
@@ -677,6 +688,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            ..Default::default()
         };
 
         // merging with default has no impact
@@ -700,6 +712,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            ..Default::default()
         };
         wi_base.merge(wi_2.clone());
 
@@ -789,6 +802,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            ..Default::default()
         };
         let expected = WarmupInfo {
             term_dict_fields: hashset_field(&[1]),
@@ -805,6 +819,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            ..Default::default()
         };
 
         warmup_info.simplify();

--- a/quickwit/quickwit-doc-mapper/src/query_builder.rs
+++ b/quickwit/quickwit-doc-mapper/src/query_builder.rs
@@ -196,7 +196,7 @@ pub(crate) fn build_query(
     }
     .visit(&query_ast);
 
-    let query = query_ast.build_tantivy_query(context)?;
+    let (query, required_terms) = query_ast.build_tantivy_query_and_required_terms(context)?;
 
     let term_set_query_fields = extract_term_set_query_fields(&query_ast, context.schema)?;
     let (term_ranges_grouped_by_field, automatons_grouped_by_field) =
@@ -225,6 +225,7 @@ pub(crate) fn build_query(
         term_ranges_grouped_by_field,
         fast_fields,
         automatons_grouped_by_field,
+        required_terms,
         ..WarmupInfo::default()
     };
 

--- a/quickwit/quickwit-query/src/query_ast/mod.rs
+++ b/quickwit/quickwit-query/src/query_ast/mod.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
+use tantivy::Term;
 use tantivy::query::BoostQuery as TantivyBoostQuery;
 use tantivy::schema::Schema as TantivySchema;
 
@@ -25,6 +28,7 @@ mod full_text_query;
 mod phrase_prefix_query;
 mod range_query;
 mod regex_query;
+mod required_terms;
 mod tantivy_query_ast;
 mod term_query;
 mod term_set_query;
@@ -266,6 +270,25 @@ impl QueryAst {
     ) -> Result<Box<dyn crate::TantivyQuery>, InvalidQuery> {
         let tantivy_query_ast = self.build_tantivy_ast_call(context)?;
         Ok(tantivy_query_ast.simplify().into())
+    }
+
+    /// Like [`Self::build_tantivy_query`], but additionally returns the set of
+    /// *required terms*: terms that must all be present in a split for the query
+    /// to match any document. A leaf search uses this to abort warmup early when
+    /// a required term turns out to have an empty posting list. See
+    /// [`required_terms`] for the contract.
+    pub fn build_tantivy_query_and_required_terms(
+        &self,
+        context: &BuildTantivyAstContext,
+    ) -> Result<(Box<dyn crate::TantivyQuery>, HashSet<Term>), InvalidQuery> {
+        let tantivy_query_ast = self.build_tantivy_ast_call(context)?.simplify();
+        let mut required_terms = HashSet::new();
+        required_terms::collect_required_terms(
+            &tantivy_query_ast,
+            context.schema,
+            &mut required_terms,
+        );
+        Ok((tantivy_query_ast.into(), required_terms))
     }
 }
 

--- a/quickwit/quickwit-query/src/query_ast/required_terms.rs
+++ b/quickwit/quickwit-query/src/query_ast/required_terms.rs
@@ -1,0 +1,194 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Extraction of *required terms*: terms that must all be present in a split for
+//! the query to match any document.
+//!
+//! A leaf search warms up a split by, among other things, loading the posting
+//! list of each query term. [`tantivy`] reports whether each term was actually
+//! found. If a *required* term is missing (empty posting list), the query
+//! provably matches nothing in that split, so the remaining (much more
+//! expensive) warmup downloads can be cancelled.
+//!
+//! The set is a conservative under-approximation: only single-term clauses
+//! combined purely by conjunction (`must` / `filter`) qualify. Anything else
+//! (`should`, `must_not`, ranges, phrases, term sets, terms on non-indexed
+//! fields, ...) is omitted, so a term ends up in the set only when its absence
+//! truly implies the whole query is empty.
+//!
+//! The biggest gap is that a disjunction of terms (e.g. `my_id:(1 OR 2 OR 3)`) is not covered.
+//! For this we would need to build a more complex representation of the required terms, ideally an
+//! AST that can be evaluated against the set of found terms. This is left for future work.
+
+use std::collections::HashSet;
+
+use tantivy::Term;
+use tantivy::query::TermQuery as TantivyTermQuery;
+use tantivy::schema::Schema;
+
+use crate::query_ast::tantivy_query_ast::{TantivyBoolQuery, TantivyQueryAst};
+
+/// Collects the terms that must be present for the (already simplified) query to
+/// match any document. See the module docs for the conservative contract.
+pub(crate) fn collect_required_terms(
+    ast: &TantivyQueryAst,
+    schema: &Schema,
+    required_terms: &mut HashSet<Term>,
+) {
+    match ast {
+        TantivyQueryAst::Leaf(query) => {
+            let Some(term_query) = query.downcast_ref::<TantivyTermQuery>() else {
+                return;
+            };
+            let term = term_query.term();
+            if schema.get_field_entry(term.field()).is_indexed() {
+                required_terms.insert(term.clone());
+            }
+        }
+        TantivyQueryAst::Bool(bool_query) => {
+            collect_required_terms_from_bool(bool_query, schema, required_terms);
+        }
+        TantivyQueryAst::ConstPredicate(_) => {}
+    }
+}
+
+fn collect_required_terms_from_bool(
+    bool_query: &TantivyBoolQuery,
+    schema: &Schema,
+    required_terms: &mut HashSet<Term>,
+) {
+    // Only `must` and `filter` clauses are unconditionally required. `should`
+    // (even with `minimum_should_match`) and `must_not` never make a single term
+    // mandatory, so we do not descend into them.
+    for child in bool_query.must.iter().chain(bool_query.filter.iter()) {
+        collect_required_terms(child, schema, required_terms);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use tantivy::Term;
+    use tantivy::query::TermQuery as TantivyTermQuery;
+    use tantivy::schema::{Field, STORED, Schema, TEXT};
+
+    use super::collect_required_terms;
+    use crate::query_ast::tantivy_query_ast::{TantivyBoolQuery, TantivyQueryAst};
+
+    fn term(field: Field, value: &str) -> Term {
+        Term::from_field_text(field, value)
+    }
+
+    fn term_leaf(field: Field, value: &str) -> TantivyQueryAst {
+        TantivyTermQuery::new(term(field, value), Default::default()).into()
+    }
+
+    fn required(ast: &TantivyQueryAst, schema: &Schema) -> HashSet<Term> {
+        let mut out = HashSet::new();
+        collect_required_terms(ast, schema, &mut out);
+        out
+    }
+
+    #[test]
+    fn test_single_indexed_term_is_required() {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_text_field("f", TEXT);
+        let schema = schema_builder.build();
+
+        assert_eq!(
+            required(&term_leaf(field, "x"), &schema),
+            HashSet::from([term(field, "x")]),
+        );
+    }
+
+    #[test]
+    fn test_term_on_non_indexed_field_is_not_required() {
+        let mut schema_builder = Schema::builder();
+        let stored_only = schema_builder.add_text_field("stored", STORED);
+        let schema = schema_builder.build();
+
+        assert!(required(&term_leaf(stored_only, "x"), &schema).is_empty());
+    }
+
+    #[test]
+    fn test_must_and_filter_are_required() {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_text_field("f", TEXT);
+        let schema = schema_builder.build();
+
+        let ast = TantivyQueryAst::Bool(TantivyBoolQuery {
+            must: vec![term_leaf(field, "a")],
+            filter: vec![term_leaf(field, "b")],
+            ..Default::default()
+        });
+        assert_eq!(
+            required(&ast, &schema),
+            HashSet::from([term(field, "a"), term(field, "b")]),
+        );
+    }
+
+    #[test]
+    fn test_should_and_must_not_are_not_required() {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_text_field("f", TEXT);
+        let schema = schema_builder.build();
+
+        // `must: [a]`, `should: [b]`, `must_not: [c]` -> only `a` is required.
+        let ast = TantivyQueryAst::Bool(TantivyBoolQuery {
+            must: vec![term_leaf(field, "a")],
+            should: vec![term_leaf(field, "b")],
+            must_not: vec![term_leaf(field, "c")],
+            ..Default::default()
+        });
+        assert_eq!(required(&ast, &schema), HashSet::from([term(field, "a")]),);
+
+        // A disjunction alone makes no term required.
+        let ast = TantivyQueryAst::Bool(TantivyBoolQuery {
+            should: vec![term_leaf(field, "a"), term_leaf(field, "b")],
+            ..Default::default()
+        });
+        assert!(required(&ast, &schema).is_empty());
+    }
+
+    #[test]
+    fn test_nested_conjunction_collects_recursively() {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_text_field("f", TEXT);
+        let schema = schema_builder.build();
+
+        // must: [ Bool{ must: [a, b] } ] -> both a and b are required.
+        let ast = TantivyQueryAst::Bool(TantivyBoolQuery {
+            must: vec![TantivyQueryAst::Bool(TantivyBoolQuery {
+                must: vec![term_leaf(field, "a"), term_leaf(field, "b")],
+                ..Default::default()
+            })],
+            ..Default::default()
+        });
+        assert_eq!(
+            required(&ast, &schema),
+            HashSet::from([term(field, "a"), term(field, "b")]),
+        );
+
+        // must: [ Bool{ should: [a, b] } ] -> nothing required (disjunction).
+        let ast = TantivyQueryAst::Bool(TantivyBoolQuery {
+            must: vec![TantivyQueryAst::Bool(TantivyBoolQuery {
+                should: vec![term_leaf(field, "a"), term_leaf(field, "b")],
+                ..Default::default()
+            })],
+            ..Default::default()
+        });
+        assert!(required(&ast, &schema).is_empty());
+    }
+}

--- a/quickwit/quickwit-search/Cargo.toml
+++ b/quickwit/quickwit-search/Cargo.toml
@@ -30,6 +30,7 @@ tantivy = { workspace = true }
 tantivy-fst = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tower = { workspace = true, features = ["timeout"] }
 tracing = { workspace = true }
 ttl_cache = { workspace = true }

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -52,6 +52,7 @@ use tantivy::fastfield::FastFieldReaders;
 use tantivy::schema::Field;
 use tantivy::{DateTime, Index, ReloadPolicy, Searcher, TantivyError, Term};
 use tokio::task::{JoinError, JoinSet};
+use tokio_util::sync::CancellationToken;
 use tracing::*;
 
 use crate::collector::{IncrementalCollector, make_collector_for_split, make_merge_collector};
@@ -254,6 +255,33 @@ pub(crate) async fn open_index_with_caches(
     Ok((index, hot_directory))
 }
 
+/// Outcome of [`warmup`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WarmupOutcome {
+    /// The warmup completed; the split must be searched.
+    Completed,
+    /// A required term has an empty posting list, so the query provably matches
+    /// nothing in this split. The remaining warmup downloads were cancelled.
+    ProvablyEmpty,
+}
+
+/// Runs `fut`, racing it against `cancel`. If cancellation fires first, the
+/// (possibly in-flight) future is dropped — aborting its downloads — and
+/// `Ok(())` is returned. With no token, `fut` simply runs to completion.
+async fn run_cancellable(
+    cancel: Option<&CancellationToken>,
+    fut: impl std::future::Future<Output = anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    let Some(cancel) = cancel else {
+        return fut.await;
+    };
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => Ok(()),
+        result = fut => result,
+    }
+}
+
 /// Tantivy search does not make it possible to fetch data asynchronously during
 /// search.
 ///
@@ -264,32 +292,69 @@ pub(crate) async fn open_index_with_caches(
 /// are position required too), and the collector.
 ///
 /// * `query` - query is used to extract the terms and their fields which will be loaded from the
-/// inverted_index.
+///   inverted_index.
 ///
 /// * `term_dict_field_names` - A list of fields, where the whole dictionary needs to be loaded.
-/// This is e.g. required for term aggregation, since we don't know in advance which terms are going
-/// to be hit.
+///   This is e.g. required for term aggregation, since we don't know in advance which terms are
+///   going to be hit.
 #[instrument(skip_all)]
-pub(crate) async fn warmup(searcher: &Searcher, warmup_info: &WarmupInfo) -> anyhow::Result<()> {
+pub(crate) async fn warmup(
+    searcher: &Searcher,
+    warmup_info: &WarmupInfo,
+) -> anyhow::Result<WarmupOutcome> {
     debug!(warmup_info=?warmup_info);
-    let warm_up_terms_future = warm_up_terms(searcher, &warmup_info.terms_grouped_by_field)
-        .instrument(debug_span!("warm_up_terms"));
-    let warm_up_term_ranges_future =
-        warm_up_term_ranges(searcher, &warmup_info.term_ranges_grouped_by_field)
-            .instrument(debug_span!("warm_up_term_ranges"));
-    let warm_up_term_dict_future =
-        warm_up_term_dict_fields(searcher, &warmup_info.term_dict_fields)
-            .instrument(debug_span!("warm_up_term_dicts"));
-    let warm_up_fastfields_future = warm_up_fastfields(searcher, &warmup_info.fast_fields)
-        .instrument(debug_span!("warm_up_fastfields"));
-    let warm_up_fieldnorms_future = warm_up_fieldnorms(searcher, warmup_info.field_norms)
-        .instrument(debug_span!("warm_up_fieldnorms"));
+
+    // Early-abort optimization: the split's downloads can be cancelled as soon as
+    // a *required* term is found to have an empty posting list, which proves the
+    // query matches nothing here. This conclusion is only sound for the whole
+    // split when there is a single segment (the common case in Quickwit), so we
+    // only arm the token then. `warm_up_terms` fires the token; every other
+    // warmup task observes it through `run_cancellable` and bails.
+    let abort_token: Option<CancellationToken> =
+        if searcher.segment_readers().len() == 1 && !warmup_info.required_terms.is_empty() {
+            Some(CancellationToken::new())
+        } else {
+            None
+        };
+
+    let warm_up_terms_future = warm_up_terms(
+        searcher,
+        &warmup_info.terms_grouped_by_field,
+        &warmup_info.required_terms,
+        abort_token.as_ref(),
+    )
+    .instrument(debug_span!("warm_up_terms"));
+    let warm_up_term_ranges_future = run_cancellable(
+        abort_token.as_ref(),
+        warm_up_term_ranges(searcher, &warmup_info.term_ranges_grouped_by_field),
+    )
+    .instrument(debug_span!("warm_up_term_ranges"));
+    let warm_up_term_dict_future = run_cancellable(
+        abort_token.as_ref(),
+        warm_up_term_dict_fields(searcher, &warmup_info.term_dict_fields),
+    )
+    .instrument(debug_span!("warm_up_term_dicts"));
+    let warm_up_fastfields_future = run_cancellable(
+        abort_token.as_ref(),
+        warm_up_fastfields(searcher, &warmup_info.fast_fields),
+    )
+    .instrument(debug_span!("warm_up_fastfields"));
+    let warm_up_fieldnorms_future = run_cancellable(
+        abort_token.as_ref(),
+        warm_up_fieldnorms(searcher, warmup_info.field_norms),
+    )
+    .instrument(debug_span!("warm_up_fieldnorms"));
     // TODO merge warm_up_postings into warm_up_term_dict_fields
-    let warm_up_postings_future = warm_up_postings(searcher, &warmup_info.term_dict_fields)
-        .instrument(debug_span!("warm_up_postings"));
-    let warm_up_automatons_future =
-        warm_up_automatons(searcher, &warmup_info.automatons_grouped_by_field)
-            .instrument(debug_span!("warm_up_automatons"));
+    let warm_up_postings_future = run_cancellable(
+        abort_token.as_ref(),
+        warm_up_postings(searcher, &warmup_info.term_dict_fields),
+    )
+    .instrument(debug_span!("warm_up_postings"));
+    let warm_up_automatons_future = run_cancellable(
+        abort_token.as_ref(),
+        warm_up_automatons(searcher, &warmup_info.automatons_grouped_by_field),
+    )
+    .instrument(debug_span!("warm_up_automatons"));
 
     tokio::try_join!(
         warm_up_terms_future,
@@ -301,7 +366,15 @@ pub(crate) async fn warmup(searcher: &Searcher, warmup_info: &WarmupInfo) -> any
         warm_up_automatons_future,
     )?;
 
-    Ok(())
+    let provably_empty = match &abort_token {
+        Some(abort_token) => abort_token.is_cancelled(),
+        None => false,
+    };
+    if provably_empty {
+        Ok(WarmupOutcome::ProvablyEmpty)
+    } else {
+        Ok(WarmupOutcome::Completed)
+    }
 }
 
 async fn warm_up_term_dict_fields(
@@ -377,6 +450,8 @@ async fn warm_up_fastfields(
 async fn warm_up_terms(
     searcher: &Searcher,
     terms_grouped_by_field: &HashMap<Field, HashMap<Term, bool>>,
+    required_terms: &HashSet<Term>,
+    abort_token: Option<&CancellationToken>,
 ) -> anyhow::Result<()> {
     let mut warm_up_futures = Vec::new();
     for (field, terms) in terms_grouped_by_field {
@@ -384,13 +459,30 @@ async fn warm_up_terms(
             let inv_idx = segment_reader.inverted_index(*field)?;
             for (term, position_needed) in terms.iter() {
                 let inv_idx_clone = inv_idx.clone();
-                warm_up_futures
-                    .push(async move { inv_idx_clone.warm_postings(term, *position_needed).await });
+                // Only a required term can prove the query empty. When such a
+                // term turns out to have an empty posting list, fire the token so
+                // the rest of the warmup is cancelled.
+                let cancel_on_empty = match abort_token {
+                    Some(abort_token) if required_terms.contains(term) => Some(abort_token),
+                    _ => None,
+                };
+                warm_up_futures.push(async move {
+                    let found = inv_idx_clone.warm_postings(term, *position_needed).await?;
+                    if !found && let Some(abort_token) = cancel_on_empty {
+                        abort_token.cancel();
+                    }
+                    anyhow::Ok(())
+                });
             }
         }
     }
-    try_join_all(warm_up_futures).await?;
-    Ok(())
+    // Race against the token so we also stop loading the *other* terms' postings
+    // once a required term has proven the query empty.
+    run_cancellable(abort_token, async move {
+        try_join_all(warm_up_futures).await?;
+        anyhow::Ok(())
+    })
+    .await
 }
 
 async fn warm_up_term_ranges(
@@ -484,6 +576,36 @@ fn get_leaf_resp_from_count(count: u64) -> LeafSearchResponse {
         num_successful_splits: 1,
         intermediate_aggregation_result: None,
         resource_stats: None,
+    }
+}
+
+/// Wraps a single split's [`SplitResourceStats`] into a [`LeafResourceStats`],
+/// attributing it to either local execution or lambda offload.
+///
+/// Lambda-executed splits do not contribute to `split_resources_sum` /
+/// `split_resources_worst` — those aggregates are reserved for locally-executed
+/// splits. The `lambda_num_*` totals (success + failure) are injected once by the
+/// caller in `run_offloaded_search_tasks`, so only the success counters are set
+/// here.
+fn leaf_resource_stats_for_split(split_stats: SplitResourceStats) -> LeafResourceStats {
+    if quickwit_common::is_running_in_lambda() {
+        LeafResourceStats {
+            lambda_success_num_splits: 1,
+            lambda_success_num_docs: split_stats.split_num_docs,
+            ..Default::default()
+        }
+    } else {
+        LeafResourceStats {
+            localexec_num_splits: 1,
+            localexec_num_docs: split_stats.split_num_docs,
+            split_resources_sum: Some(split_stats),
+            split_resources_worst: Some(split_stats),
+            min_wait_for_search_permit_microsecs: Some(
+                split_stats.wait_for_search_permit_microsecs,
+            ),
+            min_wait_for_cpu_pool_microsecs: Some(split_stats.wait_for_cpu_pool_microsecs),
+            ..Default::default()
+        }
     }
 }
 
@@ -589,7 +711,7 @@ async fn leaf_search_single_split(
 
     let warmup_start = Instant::now();
     leaf_search_state_guard.set_state(SplitSearchState::WarmUp);
-    warmup(&searcher, &warmup_info).await?;
+    let warmup_outcome = warmup(&searcher, &warmup_info).await?;
     let warmup_end = Instant::now();
     let warmup_duration: Duration = warmup_end.duration_since(warmup_start);
     let warmup_size = ByteSize(byte_range_cache.get_num_bytes());
@@ -603,6 +725,42 @@ async fn leaf_search_single_split(
     LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES.observe(warmup_size.as_u64() as f64);
     search_permit.update_memory_usage(warmup_size);
     search_permit.free_warmup_slot();
+
+    if warmup_outcome == WarmupOutcome::ProvablyEmpty {
+        // A required term's posting list was empty, so the query matches no
+        // document in this split. The remaining warmup downloads were aborted;
+        // skip the search and report an empty (but counted) result. This is the
+        // identity for hit and aggregation merging.
+        //
+        // We still report the bytes pulled during the (aborted) warmup and the
+        // time spent queued for the search permit, so resource stats stay
+        // accurate; only the CPU-queue and CPU phases never happened.
+        let (download_num_bytes, download_num_requests) = download_counters.snapshot();
+        let split_stats = SplitResourceStats {
+            split_num_docs: split.num_docs,
+            matched_num_docs: 0,
+            input_memory_bytes: warmup_size.as_u64(),
+            download_num_bytes,
+            download_num_requests,
+            wait_for_search_permit_microsecs: search_permit.wait_for_acquisition().as_micros()
+                as u64,
+            warmup_microsecs: warmup_duration.as_micros() as u64,
+            wait_for_cpu_pool_microsecs: 0,
+            cpu_search_microsecs: 0,
+        };
+        let mut leaf_search_response = get_leaf_resp_from_count(0);
+        leaf_search_response.resource_stats = Some(leaf_resource_stats_for_split(split_stats));
+        // Cache the empty result so repeated identical queries hit the partial
+        // result cache instead of re-opening the split and re-probing the term
+        // every time (matching what the normal search path does).
+        ctx.searcher_context.leaf_search_cache.put(
+            split.clone(),
+            search_request.clone(),
+            leaf_search_response.clone(),
+        );
+        leaf_search_state_guard.set_state(SplitSearchState::PrunedDuringWarmup);
+        return Ok(Some(leaf_search_response));
+    }
 
     let split_num_docs = split.num_docs;
     let span = info_span!("tantivy_search");
@@ -651,39 +809,8 @@ async fn leaf_search_single_split(
                     wait_for_cpu_pool_microsecs: cpu_thread_pool_wait_microsecs.as_micros() as u64,
                     cpu_search_microsecs: cpu_start.elapsed().as_micros() as u64,
                 };
-                let resource_stats = if quickwit_common::is_running_in_lambda() {
-                    // Running inside an AWS Lambda runtime: this split was
-                    // dispatched here via lambda offload. Per the proto
-                    // contract, lambda-executed splits do not contribute
-                    // to `split_resources_worst` / `split_resources_sum` — those
-                    // aggregates are reserved for locally-executed splits.
-                    //
-                    // Only the success counters are set here. The
-                    // `lambda_num_*` totals (success + failure) are
-                    // injected once by the caller in
-                    // `run_offloaded_search_tasks` so they reflect every
-                    // dispatched split, not just the ones that came back.
-                    LeafResourceStats {
-                        lambda_success_num_splits: 1,
-                        lambda_success_num_docs: split_num_docs,
-                        ..Default::default()
-                    }
-                } else {
-                    LeafResourceStats {
-                        localexec_num_splits: 1,
-                        localexec_num_docs: split_num_docs,
-                        split_resources_sum: Some(split_stats),
-                        split_resources_worst: Some(split_stats),
-                        min_wait_for_search_permit_microsecs: Some(
-                            split_stats.wait_for_search_permit_microsecs,
-                        ),
-                        min_wait_for_cpu_pool_microsecs: Some(
-                            split_stats.wait_for_cpu_pool_microsecs,
-                        ),
-                        ..Default::default()
-                    }
-                };
-                leaf_search_response.resource_stats = Some(resource_stats);
+                leaf_search_response.resource_stats =
+                    Some(leaf_resource_stats_for_split(split_stats));
                 leaf_search_state_guard.set_state(SplitSearchState::Success);
                 Result::<_, TantivyError>::Ok(Some((
                     simplified_search_request,
@@ -1908,6 +2035,7 @@ enum SplitSearchState {
     CacheHit,
     PrunedBeforeWarmup,
     WarmUp,
+    PrunedDuringWarmup,
     PrunedAfterWarmup,
     CpuQueue,
     Cpu,
@@ -1921,6 +2049,7 @@ impl SplitSearchState {
             SplitSearchState::CacheHit => counters.cache_hit.inc(),
             SplitSearchState::PrunedBeforeWarmup => counters.pruned_before_warmup.inc(),
             SplitSearchState::WarmUp => counters.cancel_warmup.inc(),
+            SplitSearchState::PrunedDuringWarmup => counters.pruned_during_warmup.inc(),
             SplitSearchState::PrunedAfterWarmup => counters.pruned_after_warmup.inc(),
             SplitSearchState::CpuQueue => counters.cancel_cpu_queue.inc(),
             SplitSearchState::Cpu => counters.cancel_cpu.inc(),
@@ -2585,6 +2714,75 @@ mod tests {
 
         assert!(directory_size_larger > directory_size_smaller + 100);
         assert!(larger_size > smaller_size + 100);
+    }
+
+    /// Builds a single-segment in-RAM searcher with one text field, one document
+    /// per provided value.
+    fn ram_searcher_with_text(field_name: &str, docs: &[&str]) -> (Searcher, Field) {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_text_field(field_name, tantivy::schema::TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer = index.writer(15_000_000).unwrap();
+        for doc_text in docs {
+            let mut doc = TantivyDocument::default();
+            doc.add_text(field, doc_text);
+            index_writer.add_document(doc).unwrap();
+        }
+        index_writer.commit().unwrap();
+        let searcher = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()
+            .unwrap()
+            .searcher();
+        (searcher, field)
+    }
+
+    fn warmup_info_with_required(terms: &[&Term], required: &[&Term]) -> WarmupInfo {
+        let mut terms_grouped_by_field: HashMap<Field, HashMap<Term, bool>> = HashMap::new();
+        for term in terms {
+            terms_grouped_by_field
+                .entry(term.field())
+                .or_default()
+                .insert((*term).clone(), false);
+        }
+        WarmupInfo {
+            terms_grouped_by_field,
+            required_terms: required.iter().map(|term| (*term).clone()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_warmup_aborts_when_required_term_is_missing() {
+        let (searcher, body) = ram_searcher_with_text("body", &["hello world"]);
+        // Single segment: the early-abort optimization is armed.
+        assert_eq!(searcher.segment_readers().len(), 1);
+
+        let present = Term::from_field_text(body, "hello");
+        let missing = Term::from_field_text(body, "missing");
+
+        // A required term with an empty posting list proves the query empty.
+        let warmup_info = warmup_info_with_required(&[&present, &missing], &[&missing]);
+        assert_eq!(
+            warmup(&searcher, &warmup_info).await.unwrap(),
+            WarmupOutcome::ProvablyEmpty
+        );
+
+        // The required term is present: warmup completes normally.
+        let warmup_info = warmup_info_with_required(&[&present], &[&present]);
+        assert_eq!(
+            warmup(&searcher, &warmup_info).await.unwrap(),
+            WarmupOutcome::Completed
+        );
+
+        // A missing term that is not required must not abort.
+        let warmup_info = warmup_info_with_required(&[&present, &missing], &[]);
+        assert_eq!(
+            warmup(&searcher, &warmup_info).await.unwrap(),
+            WarmupOutcome::Completed
+        );
     }
 
     fn nz(n: usize) -> std::num::NonZeroUsize {

--- a/quickwit/quickwit-search/src/metrics.rs
+++ b/quickwit/quickwit-search/src/metrics.rs
@@ -43,6 +43,7 @@ pub struct SplitSearchOutcomeCounters {
     pub cache_hit: Counter,
     pub pruned_before_warmup: Counter,
     pub cancel_warmup: Counter,
+    pub pruned_during_warmup: Counter,
     pub pruned_after_warmup: Counter,
     pub cancel_cpu_queue: Counter,
     pub cancel_cpu: Counter,
@@ -56,6 +57,7 @@ impl Default for SplitSearchOutcomeCounters {
             cache_hit: Counter::local(),
             pruned_before_warmup: Counter::local(),
             cancel_warmup: Counter::local(),
+            pruned_during_warmup: Counter::local(),
             pruned_after_warmup: Counter::local(),
             cancel_cpu_queue: Counter::local(),
             cancel_cpu: Counter::local(),
@@ -70,6 +72,7 @@ impl fmt::Display for SplitSearchOutcomeCounters {
         print_if_not_null("cache_hit", &self.cache_hit, f)?;
         print_if_not_null("pruned_before_warmup", &self.pruned_before_warmup, f)?;
         print_if_not_null("cancel_warmup", &self.cancel_warmup, f)?;
+        print_if_not_null("pruned_during_warmup", &self.pruned_during_warmup, f)?;
         print_if_not_null("pruned_after_warmup", &self.pruned_after_warmup, f)?;
         print_if_not_null("cancel_cpu_queue", &self.cancel_cpu_queue, f)?;
         print_if_not_null("cancel_cpu", &self.cancel_cpu, f)?;
@@ -92,6 +95,7 @@ impl SplitSearchOutcomeCounters {
             cache_hit: counter("cache_hit"),
             pruned_before_warmup: counter("pruned_before_warmup"),
             cancel_warmup: counter("cancel_warmup"),
+            pruned_during_warmup: counter("pruned_during_warmup"),
             pruned_after_warmup: counter("pruned_after_warmup"),
             cancel_cpu_queue: counter("cancel_cpu_queue"),
             cancel_cpu: counter("cancel_cpu"),


### PR DESCRIPTION
Abort split warmup when a required term is missing to not fully download fast fields.

A leaf search warms up a split by downloading term dictionaries, posting lists, fast fields and field norms before running the query. When the query has a term that *must* match (a single-term clause reachable through `must`/`filter` only) and that term's posting list is empty in the split, the query provably matches nothing there — so the rest of the warmup is wasted work. Moreover it downloads fastfields and may put unnecessary pressure on the cache.

This extracts the set of required terms from the query AST and, during warmup, cancels the remaining downloads (fast fields, field norms, other postings) as soon as a required term is found missing, returning an empty result for the split. `warm_postings` already reports term existence, which is used here.

- quickwit-query: `required_terms` extraction + `build_tantivy_query_and_required_terms`.
- quickwit-doc-mapper: `WarmupInfo::required_terms`.
- quickwit-search: race warmup against a `CancellationToken` fired by `warm_up_terms`; abort returns a counted empty response that still reports its (aborted) download volume; new `pruned_empty_term` metric.

# Benchmarks
Comparing: main with ff cache (baseline), main, abort

`list_7d_low_hits` is a single selective term.

We can see the downloaded data is reduced, the number of get requests is unchanged (requests still run in parallel). CPU time is reduced due to reduced IO.

<img width="1341" height="350" alt="Screenshot 2026-06-15 at 11 46 26" src="https://github.com/user-attachments/assets/633881a2-674f-4f05-8c77-25076a88ff4e" />

<img width="1341" height="350" alt="Screenshot 2026-06-15 at 11 45 14" src="https://github.com/user-attachments/assets/887f0034-6de8-4ade-b6ae-33b719d2eb70" />

<img width="1341" height="350" alt="Screenshot 2026-06-15 at 11 48 12" src="https://github.com/user-attachments/assets/bf50d895-927f-4ce7-b037-8ac9f4c38eba" />
