### PR TITLE
feat(search): add gauge for warmup memory bytes currently in flight

### DIFF
--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -30,7 +30,7 @@ use quickwit_common::pretty::PrettySample;
 use quickwit_common::uri::Uri;
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_doc_mapper::{Automaton, DocMapper, FastFieldWarmupInfo, TermRange, WarmupInfo};
-use quickwit_metrics::HistogramTimer;
+use quickwit_metrics::{GaugeGuard, HistogramTimer};
 use quickwit_proto::search::lambda_single_split_result::Outcome;
 use quickwit_proto::search::{
     CountHits, LeafResourceStats, LeafSearchRequest, LeafSearchResponse, PartialHit, SearchRequest,
@@ -59,7 +59,7 @@ use crate::collector::{IncrementalCollector, make_collector_for_split, make_merg
 use crate::leaf_cache::LeafSearchCache;
 use crate::metrics::{
     LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES, LEAF_SEARCH_SPLIT_DURATION_SECS,
-    SPLIT_SEARCH_OUTCOME_TOTAL, SplitSearchOutcomeCounters,
+    LEAF_SEARCH_WARMUP_ONGOING_NUM_BYTES, SPLIT_SEARCH_OUTCOME_TOTAL, SplitSearchOutcomeCounters,
 };
 use crate::root::is_metadata_count_request_with_ast;
 use crate::search_permit_provider::{
@@ -723,6 +723,10 @@ async fn leaf_search_single_split(
         );
     }
     LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES.observe(warmup_size.as_u64() as f64);
+    let _warmup_bytes_guard = GaugeGuard::new(
+        &LEAF_SEARCH_WARMUP_ONGOING_NUM_BYTES,
+        warmup_size.as_u64() as f64,
+    );
     search_permit.update_memory_usage(warmup_size);
     search_permit.free_warmup_slot();
 

--- a/quickwit/quickwit-search/src/metrics.rs
+++ b/quickwit/quickwit-search/src/metrics.rs
@@ -233,6 +233,12 @@ pub(crate) static LEAF_SEARCH_SINGLE_SPLIT_WARMUP_NUM_BYTES: LazyHistogram = laz
     buckets: pseudo_exponential_bytes_buckets(),
 );
 
+pub(crate) static LEAF_SEARCH_WARMUP_ONGOING_NUM_BYTES: LazyGauge = lazy_gauge!(
+    name: "leaf_search_warmup_ongoing_num_bytes",
+    description: "Total bytes currently held in warmup caches across all in-flight split searches.",
+    subsystem: "search",
+);
+
 pub(crate) static JOB_ASSIGNED_TOTAL: LazyCounter = lazy_counter!(
         name: "job_assigned_total",
         description: "Number of job assigned to searchers, per affinity rank.",


### PR DESCRIPTION
## Summary
- Adds `leaf_search_warmup_ongoing_num_bytes` gauge to `quickwit-search` metrics
- Tracks total bytes currently held in warmup caches across all in-flight split searches
- Uses a `WarmupBytesGuard` RAII struct to ensure the gauge is decremented on all exit paths (normal return, early return for `ProvablyEmpty`, and error paths via `?`)

## Motivation
The existing `leaf_search_single_split_warmup_num_bytes` histogram records per-split warmup sizes after the fact. This gauge provides a real-time view of memory pressure from ongoing warmups, useful for dashboards and alerting.

## Test plan
- [ ] Compile check: `cargo check -p quickwit-search`
- [ ] Clippy: `cargo clippy --workspace --all-features --tests`
- [ ] Verify metric appears in `/api/v1/metrics` after running a search