### PR TITLE
feat(search): expose CPU thread count and root phase wall times in resource stats

### DIFF
--- a/quickwit/quickwit-common/src/thread_pool/README.md
+++ b/quickwit/quickwit-common/src/thread_pool/README.md
@@ -1,0 +1,29 @@
+# Thread Pool Implementations
+
+This module has two Rayon-backed executors for CPU work.
+
+## `simple.rs`
+
+`SimpleThreadPool` is the default small-task executor behind
+`quickwit_common::thread_pool::run_cpu_intensive`.
+
+It submits work directly to Rayon and keeps only the original cancellation
+check: if the caller drops the returned future before Rayon starts executing
+the closure, the closure is skipped. This implementation has the smallest
+bookkeeping overhead and is meant for short CPU tasks such as decompression,
+checksum computation, and small serialization work.
+
+The `SimpleThreadPool` type is private. Callers should use the re-exported
+`run_cpu_intensive` function for ordinary work. The module also exposes the
+underlying Rayon pool for integration points, such as Tantivy executors, that
+need a Rayon handle instead of a future-returning submission API.
+
+## `with_priority.rs`
+
+`ThreadPoolWithPriority` adds a Quickwit-owned queue in front of Rayon. It
+keeps pending work outside Rayon until a worker slot is available, then
+schedules high-priority tasks before normal-priority tasks.
+
+This is useful when a long queue of normal work can delay latency-sensitive
+follow-up work. The search thread pool uses this implementation so final result
+merges can jump ahead of queued split-search CPU tasks.

--- a/quickwit/quickwit-common/src/thread_pool/mod.rs
+++ b/quickwit/quickwit-common/src/thread_pool/mod.rs
@@ -1,0 +1,31 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+mod simple;
+pub mod with_priority;
+
+pub use simple::{get_underlying_rayon_thread_pool, run_cpu_intensive};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Panicked;
+
+impl fmt::Display for Panicked {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "scheduled task panicked")
+    }
+}
+
+impl std::error::Error for Panicked {}

--- a/quickwit/quickwit-common/src/thread_pool/simple.rs
+++ b/quickwit/quickwit-common/src/thread_pool/simple.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
 use std::sync::Arc;
 
 use futures::{Future, TryFutureExt};
 use quickwit_metrics::{Gauge, GaugeGuard, LazyGauge, gauge, labels, lazy_gauge};
 use tokio::sync::oneshot;
 use tracing::error;
+
+use super::Panicked;
 
 static THREAD_POOL_ONGOING_TASKS: LazyGauge = lazy_gauge!(
     name: "ongoing_tasks",
@@ -37,14 +38,14 @@ static THREAD_POOL_PENDING_TASKS: LazyGauge = lazy_gauge!(
 /// tokio::spawn_blocking should only used for IO-bound tasks, as it has not limit on its
 /// thread count.
 #[derive(Clone)]
-pub struct ThreadPool {
+struct SimpleThreadPool {
     thread_pool: Arc<rayon::ThreadPool>,
     ongoing_tasks: Gauge,
     pending_tasks: Gauge,
 }
 
-impl ThreadPool {
-    pub fn new(name: &'static str, num_threads_opt: Option<usize>) -> ThreadPool {
+impl SimpleThreadPool {
+    fn new(name: &'static str, num_threads_opt: Option<usize>) -> SimpleThreadPool {
         let mut rayon_pool_builder = rayon::ThreadPoolBuilder::new()
             .thread_name(move |thread_id| format!("quickwit-{name}-{thread_id}"))
             .panic_handler(move |_my_panic| {
@@ -59,15 +60,11 @@ impl ThreadPool {
         let labels = labels!("pool" => name);
         let ongoing_tasks = gauge!(parent: THREAD_POOL_ONGOING_TASKS, labels: [labels]);
         let pending_tasks = gauge!(parent: THREAD_POOL_PENDING_TASKS, labels: [labels]);
-        ThreadPool {
+        SimpleThreadPool {
             thread_pool: Arc::new(thread_pool),
             ongoing_tasks,
             pending_tasks,
         }
-    }
-
-    pub fn get_underlying_rayon_thread_pool(&self) -> Arc<rayon::ThreadPool> {
-        self.thread_pool.clone()
     }
 
     /// Function similar to `tokio::spawn_blocking`.
@@ -85,7 +82,7 @@ impl ThreadPool {
     ///
     /// This is nice because it makes work that has been scheduled
     /// but is not running yet "cancellable".
-    pub fn run_cpu_intensive<F, R>(
+    fn run_cpu_intensive<F, R>(
         &self,
         cpu_intensive_fn: F,
     ) -> impl Future<Output = Result<R, Panicked>>
@@ -111,6 +108,15 @@ impl ThreadPool {
     }
 }
 
+fn small_task_executor() -> &'static SimpleThreadPool {
+    static SMALL_TASK_EXECUTOR: std::sync::LazyLock<SimpleThreadPool> =
+        std::sync::LazyLock::new(|| {
+            let num_threads: usize = (crate::num_cpus() / 3).max(2);
+            SimpleThreadPool::new("small_tasks", Some(num_threads))
+        });
+    &SMALL_TASK_EXECUTOR
+}
+
 /// Run a small (<200ms) CPU-intensive task on a dedicated thread pool with a few threads.
 ///
 /// When running blocking io (or side-effects in general), prefer using `tokio::spawn_blocking`
@@ -124,23 +130,12 @@ where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
 {
-    static SMALL_TASK_EXECUTOR: std::sync::LazyLock<ThreadPool> = std::sync::LazyLock::new(|| {
-        let num_threads: usize = (crate::num_cpus() / 3).max(2);
-        ThreadPool::new("small_tasks", Some(num_threads))
-    });
-    SMALL_TASK_EXECUTOR.run_cpu_intensive(cpu_intensive_fn)
+    small_task_executor().run_cpu_intensive(cpu_intensive_fn)
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Panicked;
-
-impl fmt::Display for Panicked {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "scheduled task panicked")
-    }
+pub fn get_underlying_rayon_thread_pool() -> Arc<rayon::ThreadPool> {
+    small_task_executor().thread_pool.clone()
 }
-
-impl std::error::Error for Panicked {}
 
 #[cfg(test)]
 mod tests {

--- a/quickwit/quickwit-common/src/thread_pool/with_priority.rs
+++ b/quickwit/quickwit-common/src/thread_pool/with_priority.rs
@@ -185,6 +185,11 @@ impl ThreadPoolWithPriority {
     ///
     /// This is nice because it makes work that has been scheduled
     /// but is not running yet "cancellable".
+    /// Returns the number of threads in the underlying rayon thread pool.
+    pub fn num_threads(&self) -> usize {
+        self.inner.max_running_tasks
+    }
+
     pub fn run_cpu_intensive<F, R>(
         &self,
         cpu_intensive_fn: F,

--- a/quickwit/quickwit-common/src/thread_pool/with_priority.rs
+++ b/quickwit/quickwit-common/src/thread_pool/with_priority.rs
@@ -1,0 +1,392 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use futures::{Future, TryFutureExt};
+use quickwit_metrics::{Gauge, GaugeGuard, LazyGauge, gauge, labels, lazy_gauge};
+use tokio::sync::oneshot;
+use tracing::error;
+
+use super::Panicked;
+
+static THREAD_POOL_ONGOING_TASKS: LazyGauge = lazy_gauge!(
+    name: "ongoing_tasks",
+    description: "number of tasks being currently processed by threads in the thread pool",
+    subsystem: "thread_pool",
+);
+
+static THREAD_POOL_PENDING_TASKS: LazyGauge = lazy_gauge!(
+    name: "pending_tasks",
+    description: "number of tasks waiting in the queue before being processed by the thread pool",
+    subsystem: "thread_pool",
+);
+
+/// An executor backed by a thread pool to run CPU-intensive tasks.
+///
+/// tokio::spawn_blocking should only used for IO-bound tasks, as it has not limit on its
+/// thread count.
+#[derive(Clone)]
+pub struct ThreadPoolWithPriority {
+    inner: Arc<ThreadPoolInner>,
+}
+
+struct ThreadPoolInner {
+    thread_pool: Arc<rayon::ThreadPool>,
+    max_running_tasks: usize,
+    num_running_tasks: AtomicUsize,
+    state: Mutex<State>,
+    ongoing_tasks: Gauge,
+    pending_tasks: Gauge,
+}
+
+struct State {
+    high_priority_tasks: VecDeque<Box<dyn RunnableTask>>,
+    normal_priority_tasks: VecDeque<Box<dyn RunnableTask>>,
+}
+
+impl State {
+    fn pop_next_task(&mut self) -> Option<Box<dyn RunnableTask>> {
+        self.high_priority_tasks
+            .pop_front()
+            .or_else(|| self.normal_priority_tasks.pop_front())
+    }
+}
+
+struct QueuedTask<F, R> {
+    cpu_intensive_fn: F,
+    tx: oneshot::Sender<R>,
+    span: tracing::Span,
+    pending_tasks_guard: GaugeGuard,
+}
+
+trait RunnableTask: Send {
+    fn is_cancelled(&self) -> bool;
+
+    fn run(self: Box<Self>, ongoing_tasks: Gauge);
+}
+
+impl<F, R> RunnableTask for QueuedTask<F, R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    fn is_cancelled(&self) -> bool {
+        self.tx.is_closed()
+    }
+
+    fn run(self: Box<Self>, ongoing_tasks: Gauge) {
+        let QueuedTask {
+            cpu_intensive_fn,
+            tx,
+            span,
+            pending_tasks_guard,
+        } = *self;
+        drop(pending_tasks_guard);
+        if tx.is_closed() {
+            return;
+        }
+        let _guard = span.enter();
+        let _ongoing_task_guard = GaugeGuard::new(&ongoing_tasks, 1.0);
+        let result = cpu_intensive_fn();
+        let _ = tx.send(result);
+    }
+}
+
+/// A claimed execution slot in the thread pool.
+///
+/// Dropping this permit decrements the running-task count and re-triggers scheduling so the
+/// next queued task can fill the freed slot.
+struct Permit(Arc<ThreadPoolInner>);
+
+impl Permit {
+    fn new(thread_pool_inner: Arc<ThreadPoolInner>) -> Self {
+        thread_pool_inner
+            .num_running_tasks
+            .fetch_add(1, Ordering::AcqRel);
+        Self(thread_pool_inner)
+    }
+}
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        let prev = self.0.num_running_tasks.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(prev > 0, "dropped more permits than were acquired");
+        ThreadPoolInner::schedule(&self.0);
+    }
+}
+
+/// The priority of a task submitted to a [`ThreadPoolWithPriority`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Priority {
+    /// The default priority.
+    Normal,
+    /// A high-priority task is scheduled before normal-priority tasks that are still pending.
+    High,
+}
+
+impl ThreadPoolWithPriority {
+    pub fn new(name: &'static str, num_threads_opt: Option<usize>) -> ThreadPoolWithPriority {
+        let mut rayon_pool_builder = rayon::ThreadPoolBuilder::new()
+            .thread_name(move |thread_id| format!("quickwit-{name}-{thread_id}"))
+            .panic_handler(move |_my_panic| {
+                error!("task running in the quickwit {name} thread pool panicked");
+            });
+        if let Some(num_threads) = num_threads_opt {
+            rayon_pool_builder = rayon_pool_builder.num_threads(num_threads);
+        }
+        let thread_pool = rayon_pool_builder
+            .build()
+            .expect("failed to spawn thread pool");
+        let max_running_tasks = thread_pool.current_num_threads();
+        let labels = labels!("pool" => name);
+        let ongoing_tasks = gauge!(parent: THREAD_POOL_ONGOING_TASKS, labels: [labels]);
+        let pending_tasks = gauge!(parent: THREAD_POOL_PENDING_TASKS, labels: [labels]);
+        ThreadPoolWithPriority {
+            inner: Arc::new(ThreadPoolInner {
+                thread_pool: Arc::new(thread_pool),
+                max_running_tasks,
+                num_running_tasks: AtomicUsize::new(0),
+                state: Mutex::new(State {
+                    high_priority_tasks: VecDeque::new(),
+                    normal_priority_tasks: VecDeque::new(),
+                }),
+                ongoing_tasks,
+                pending_tasks,
+            }),
+        }
+    }
+
+    /// Function similar to `tokio::spawn_blocking`.
+    ///
+    /// Here are two important differences however:
+    ///
+    /// 1) The task runs on a rayon thread pool managed by Quickwit. This pool is specifically used
+    ///    only to run CPU-intensive work and is configured to contain `num_cpus` cores.
+    ///
+    /// 2) Before the task is effectively scheduled, we check that the spawner is still interested
+    ///    in its result.
+    ///
+    /// It is therefore required to `await` the result of this
+    /// function to get any work done.
+    ///
+    /// This is nice because it makes work that has been scheduled
+    /// but is not running yet "cancellable".
+    pub fn run_cpu_intensive<F, R>(
+        &self,
+        cpu_intensive_fn: F,
+    ) -> impl Future<Output = Result<R, Panicked>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.run_cpu_intensive_with_priority(Priority::Normal, cpu_intensive_fn)
+    }
+
+    /// Function similar to [`Self::run_cpu_intensive`], but with explicit priority.
+    pub fn run_cpu_intensive_with_priority<F, R>(
+        &self,
+        priority: Priority,
+        cpu_intensive_fn: F,
+    ) -> impl Future<Output = Result<R, Panicked>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let span = tracing::Span::current();
+        let pending_tasks_guard = GaugeGuard::new(&self.inner.pending_tasks, 1.0);
+        let (tx, rx) = oneshot::channel();
+        let task = QueuedTask {
+            cpu_intensive_fn,
+            tx,
+            span,
+            pending_tasks_guard,
+        };
+        self.inner.enqueue(priority, Box::new(task));
+        ThreadPoolInner::schedule(&self.inner);
+        rx.map_err(|_| Panicked)
+    }
+}
+
+impl ThreadPoolInner {
+    fn enqueue(&self, priority: Priority, task: Box<dyn RunnableTask>) {
+        let mut state = self.state.lock().unwrap();
+        match priority {
+            Priority::Normal => state.normal_priority_tasks.push_back(task),
+            Priority::High => state.high_priority_tasks.push_back(task),
+        }
+    }
+
+    fn schedule(inner: &Arc<Self>) {
+        // Fast path: skip lock acquisition entirely when already at capacity.
+        if inner.num_running_tasks.load(Ordering::Acquire) >= inner.max_running_tasks {
+            return;
+        }
+        let mut state = inner.state.lock().unwrap();
+        while inner.num_running_tasks.load(Ordering::Acquire) < inner.max_running_tasks {
+            let Some(task) = state.pop_next_task() else {
+                return;
+            };
+            if task.is_cancelled() {
+                continue;
+            }
+            let permit = Permit::new(inner.clone());
+            let ongoing_tasks = inner.ongoing_tasks.clone();
+            inner.thread_pool.spawn(move || {
+                task.run(ongoing_tasks);
+                // We explicitly drop here to force the move of the permit into the closure.
+                drop(permit);
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_run_cpu_intensive() {
+        let thread_pool = ThreadPoolWithPriority::new("priority_basic_test", Some(1));
+        assert_eq!(thread_pool.run_cpu_intensive(|| 1).await, Ok(1));
+    }
+
+    #[tokio::test]
+    async fn test_run_cpu_intensive_panicks() {
+        let thread_pool = ThreadPoolWithPriority::new("priority_panic_basic_test", Some(1));
+        assert!(thread_pool.run_cpu_intensive(|| panic!("")).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_run_cpu_intensive_panicks_do_not_shrink_thread_pool() {
+        let thread_pool = ThreadPoolWithPriority::new("priority_repeated_panic_test", Some(1));
+        for _ in 0..100 {
+            assert!(thread_pool.run_cpu_intensive(|| panic!("")).await.is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_cpu_intensive_abort() {
+        let thread_pool = ThreadPoolWithPriority::new("priority_abort_test", Some(1));
+        let counter: Arc<AtomicU64> = Default::default();
+        let mut futures = Vec::new();
+        for _ in 0..1_000 {
+            let counter_clone = counter.clone();
+            let fut = thread_pool.run_cpu_intensive(move || {
+                std::thread::sleep(Duration::from_millis(5));
+                counter_clone.fetch_add(1, Ordering::SeqCst)
+            });
+            futures.push(tokio::time::timeout(Duration::from_millis(1), fut));
+        }
+        futures::future::join_all(futures).await;
+        assert!(counter.load(Ordering::SeqCst) < 100);
+    }
+
+    #[tokio::test]
+    async fn test_run_cpu_intensive_high_priority_runs_before_pending_normal_priority_tasks() {
+        let thread_pool = ThreadPoolWithPriority::new("priority_order_test", Some(1));
+        let execution_order: Arc<std::sync::Mutex<Vec<u64>>> = Default::default();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let first_task = thread_pool.run_cpu_intensive(move || {
+            let _ = started_tx.send(());
+            release_rx.recv().unwrap();
+        });
+        started_rx.await.unwrap();
+
+        let execution_order_clone = execution_order.clone();
+        let normal_task_1 =
+            thread_pool.run_cpu_intensive_with_priority(Priority::Normal, move || {
+                execution_order_clone.lock().unwrap().push(1);
+            });
+
+        let execution_order_clone = execution_order.clone();
+        let normal_task_2 =
+            thread_pool.run_cpu_intensive_with_priority(Priority::Normal, move || {
+                execution_order_clone.lock().unwrap().push(2);
+            });
+
+        let execution_order_clone = execution_order.clone();
+        let high_priority_task =
+            thread_pool.run_cpu_intensive_with_priority(Priority::High, move || {
+                execution_order_clone.lock().unwrap().push(0);
+            });
+
+        release_tx.send(()).unwrap();
+        first_task.await.unwrap();
+        high_priority_task.await.unwrap();
+        normal_task_1.await.unwrap();
+        normal_task_2.await.unwrap();
+
+        assert_eq!(*execution_order.lock().unwrap(), vec![0, 1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_run_cpu_intensive_with_priority_skips_cancelled_pending_task() {
+        let thread_pool = ThreadPoolWithPriority::new("priority_cancellation_test", Some(1));
+        let counter: Arc<AtomicU64> = Default::default();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let first_task = thread_pool.run_cpu_intensive(move || {
+            let _ = started_tx.send(());
+            release_rx.recv().unwrap();
+        });
+        started_rx.await.unwrap();
+
+        let counter_clone = counter.clone();
+        let cancelled_task =
+            thread_pool.run_cpu_intensive_with_priority(Priority::High, move || {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            });
+        drop(cancelled_task);
+
+        let counter_clone = counter.clone();
+        let normal_task = thread_pool.run_cpu_intensive(move || {
+            counter_clone.fetch_add(10, Ordering::SeqCst);
+        });
+
+        release_tx.send(()).unwrap();
+        first_task.await.unwrap();
+        normal_task.await.unwrap();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+    }
+
+    #[tokio::test]
+    async fn test_run_cpu_intensive_panic_releases_scheduler_slot() {
+        let thread_pool = ThreadPoolWithPriority::new("priority_panic_test", Some(1));
+        assert!(
+            thread_pool
+                .run_cpu_intensive_with_priority(Priority::High, || panic!("expected panic"))
+                .await
+                .is_err()
+        );
+
+        let result =
+            tokio::time::timeout(Duration::from_secs(1), thread_pool.run_cpu_intensive(|| 1))
+                .await
+                .unwrap();
+        assert_eq!(result, Ok(1));
+    }
+}

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -99,7 +99,6 @@ message GetKVResponse {
   optional bytes payload = 1;
 }
 
-
 message ReportSplit {
   // Split id (ULID format `01HAV29D4XY3D462FS3D8K5Q2H`)
   string split_id = 2;
@@ -188,16 +187,16 @@ message ListFieldsEntry {
 }
 
 enum ListFieldsType {
-    STR = 0;
-    U64 = 1;
-    I64 = 2;
-    F64 = 3;
-    BOOL = 4;
-    DATE = 5;
-    FACET = 6;
-    BYTES = 7;
-    IP_ADDR = 8;
-    JSON = 9;
+  STR = 0;
+  U64 = 1;
+  I64 = 2;
+  F64 = 3;
+  BOOL = 4;
+  DATE = 5;
+  FACET = 6;
+  BYTES = 7;
+  IP_ADDR = 8;
+  JSON = 9;
 }
 
 // -- Search -------------------
@@ -379,30 +378,30 @@ message LeafSearchRequest {
 //
 // All fields are extensive (sum across splits is meaningful) except where noted.
 message SplitResourceStats {
-    // Number of documents in the split.
-    uint64 split_num_docs = 1;
-    // Bytes resident in the warmup short-lived cache after warmup
-    // (measure of input data the search needed to process).
-    uint64 input_memory_bytes = 2;
-    // Bytes downloaded from storage during the request, as measured
-    // by a request-scoped storage wrapper.
-    uint64 download_num_bytes = 3;
-    // Number of storage GET requests issued during the request.
-    uint64 download_num_requests = 4;
-    // Number of documents matched by the query in this split (we always count).
-    uint64 matched_num_docs = 5;
+  // Number of documents in the split.
+  uint64 split_num_docs = 1;
+  // Bytes resident in the warmup short-lived cache after warmup
+  // (measure of input data the search needed to process).
+  uint64 input_memory_bytes = 2;
+  // Bytes downloaded from storage during the request, as measured
+  // by a request-scoped storage wrapper.
+  uint64 download_num_bytes = 3;
+  // Number of storage GET requests issued during the request.
+  uint64 download_num_requests = 4;
+  // Number of documents matched by the query in this split (we always count).
+  uint64 matched_num_docs = 5;
 
-    // Time the split spent waiting to acquire its search permit.
-    uint64 wait_for_search_permit_microsecs = 6;
-    // Time spent in the warmup phase (downloading and indexing data into caches).
-    uint64 warmup_microsecs = 7;
-    // Time the split spent waiting for a slot on the CPU pool after warmup.
-    uint64 wait_for_cpu_pool_microsecs = 8;
-    // CPU time spent in the search itself (predicate matching + collection +
-    // per-segment harvest), as measured around the tantivy search call.
-    // Excludes any cross-split finalize work performed outside the single-split
-    // search.
-    uint64 cpu_search_microsecs = 9;
+  // Time the split spent waiting to acquire its search permit.
+  uint64 wait_for_search_permit_microsecs = 6;
+  // Time spent in the warmup phase (downloading and indexing data into caches).
+  uint64 warmup_microsecs = 7;
+  // Time the split spent waiting for a slot on the CPU pool after warmup.
+  uint64 wait_for_cpu_pool_microsecs = 8;
+  // CPU time spent in the search itself (predicate matching + collection +
+  // per-segment harvest), as measured around the tantivy search call.
+  // Excludes any cross-split finalize work performed outside the single-split
+  // search.
+  uint64 cpu_search_microsecs = 9;
 }
 
 // Resource statistics for a single leaf-search call (over one or more splits).
@@ -420,74 +419,90 @@ message SplitResourceStats {
 // are also exceptions — they are merged with `min` rather than `sum` (see
 // their per-field doc below).
 message LeafResourceStats {
-    // Number of splits whose results came from the partial result cache.
-    uint64 partial_result_cache_num_splits = 1;
-    // Sum of `split.num_docs` across cache-hit splits.
-    uint64 partial_result_cache_num_docs = 2;
+  // Number of splits whose results came from the partial result cache.
+  uint64 partial_result_cache_num_splits = 1;
+  // Sum of `split.num_docs` across cache-hit splits.
+  uint64 partial_result_cache_num_docs = 2;
 
-    // Number of splits executed locally (excluding cache hits and lambda).
-    uint64 localexec_num_splits = 3;
-    // Sum of `split.num_docs` across locally-executed splits.
-    uint64 localexec_num_docs = 4;
-    // The worst single-split contribution, ranked by `warmup + cpu_search`
-    // (intentionally excludes the queueing phases `wait_for_search_permit`
-    // and `wait_for_cpu_pool` so the ranking reflects "how much work this
-    // split actually did").
-    SplitResourceStats split_resources_worst = 5;
-    // Field-wise sum of `SplitResourceStats` across all locally-executed splits.
-    // If you want to compute averages, divide by localexec_num_splits.
-    SplitResourceStats split_resources_sum = 6;
-    // Minimum `wait_for_search_permit_microsecs` across the locally-executed
-    // splits represented by this stats record. Useful to detect a busy leaf:
-    // if even the luckiest split waited long, the node was already saturated
-    // before this query arrived. Splits that did not execute locally (cache
-    // hits, lambda-dispatched) do NOT contribute — they leave the field unset.
-    //
-    // Aggregation is MIN everywhere (not extensive sum like most fields).
-    // `add_leaf_stats` takes the min of two `Option<u64>` with
-    // `min(None, x) = x`.
-    optional uint64 min_wait_for_search_permit_microsecs = 7;
-    // Same as above, but for `wait_for_cpu_pool_microsecs`.
-    optional uint64 min_wait_for_cpu_pool_microsecs = 8;
-    // Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
-    uint64 wall_time_microsecs = 9;
+  // Number of splits executed locally (excluding cache hits and lambda).
+  uint64 localexec_num_splits = 3;
+  // Sum of `split.num_docs` across locally-executed splits.
+  uint64 localexec_num_docs = 4;
+  // The worst single-split contribution, ranked by `warmup + cpu_search`
+  // (intentionally excludes the queueing phases `wait_for_search_permit`
+  // and `wait_for_cpu_pool` so the ranking reflects "how much work this
+  // split actually did").
+  SplitResourceStats split_resources_worst = 5;
+  // Field-wise sum of `SplitResourceStats` across all locally-executed splits.
+  // If you want to compute averages, divide by localexec_num_splits.
+  SplitResourceStats split_resources_sum = 6;
+  // Minimum `wait_for_search_permit_microsecs` across the locally-executed
+  // splits represented by this stats record. Useful to detect a busy leaf:
+  // if even the luckiest split waited long, the node was already saturated
+  // before this query arrived. Splits that did not execute locally (cache
+  // hits, lambda-dispatched) do NOT contribute — they leave the field unset.
+  //
+  // Aggregation is MIN everywhere (not extensive sum like most fields).
+  // `add_leaf_stats` takes the min of two `Option<u64>` with
+  // `min(None, x) = x`.
+  optional uint64 min_wait_for_search_permit_microsecs = 7;
+  // Same as above, but for `wait_for_cpu_pool_microsecs`.
+  optional uint64 min_wait_for_cpu_pool_microsecs = 8;
+  // Wall-clock duration of the leaf search (set in `multi_index_leaf_search`).
+  uint64 wall_time_microsecs = 9;
 
-    // Number of splits dispatched to lambda (offloaded execution).
-    uint64 lambda_num_splits = 10;
-    // Sum of `split.num_docs` across lambda-dispatched splits.
-    uint64 lambda_num_docs = 11;
-    // Number of lambda-dispatched splits that succeeded.
-    uint64 lambda_success_num_splits = 12;
-    // Sum of `split.num_docs` across successful lambda-dispatched splits.
-    uint64 lambda_success_num_docs = 13;
-    // At the source (a single leaf call) this is 1 if the offloaded path
-    // finished after the local path (lambda was the bottleneck), 0 otherwise.
-    // Forced to 0 when `lambda_num_splits == 0`. At aggregate levels (merged
-    // across leaves) it is the count of leaves where lambda was the
-    // bottleneck. Voluntarily a uint64 (not a bool) for summability.
-    uint64 lambda_bottleneck = 14;
+  // Number of splits dispatched to lambda (offloaded execution).
+  uint64 lambda_num_splits = 10;
+  // Sum of `split.num_docs` across lambda-dispatched splits.
+  uint64 lambda_num_docs = 11;
+  // Number of lambda-dispatched splits that succeeded.
+  uint64 lambda_success_num_splits = 12;
+  // Sum of `split.num_docs` across successful lambda-dispatched splits.
+  uint64 lambda_success_num_docs = 13;
+  // At the source (a single leaf call) this is 1 if the offloaded path
+  // finished after the local path (lambda was the bottleneck), 0 otherwise.
+  // Forced to 0 when `lambda_num_splits == 0`. At aggregate levels (merged
+  // across leaves) it is the count of leaves where lambda was the
+  // bottleneck. Voluntarily a uint64 (not a bool) for summability.
+  uint64 lambda_bottleneck = 14;
+
+  /// Number of CPU threads available in the search pool.
+  uint64 search_pool_cpu_threads = 15;
 }
 
 // Resource statistics for a root search.
 message RootResourceStats {
-    // The leaf with the largest `wall_time_microsecs`.
-    LeafResourceStats leaf_resources_worst = 1;
-    // Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
-    // it is not strictly extensive — the sum still gives a useful view of total leaf time.
-    // If you want to compute averages, divide by leaf_num_calls: failed leaf attempts
-    // usually do not come with proper counters.
-    LeafResourceStats leaf_resources_sum = 2;
-    // Number of leaf calls excluding retries.
-    uint64 leaf_num_calls = 3;
-    // Number of leaf calls, including retries.
-    uint64 leaf_num_calls_including_retries = 4;
-    // Number of failed splits across all leaves.
-    uint64 num_failed_splits = 5;
-    // Per-leaf `wall_time_microsecs`, one entry per leaf that contributed
-    // stats, sorted in descending order (largest first). Useful for
-    // distinguishing "one straggler" from "all leaves comparably slow"
-    // without computing it from `leaf_resources_worst` / `leaf_resources_sum`.
-    repeated uint64 leaf_wall_times_microsecs = 6;
+  // The leaf with the largest `wall_time_microsecs`.
+  LeafResourceStats leaf_resources_worst = 1;
+  // Field-wise sum of all leaf stats. `wall_time_microsecs` is summed even though
+  // it is not strictly extensive — the sum still gives a useful view of total leaf time.
+  // If you want to compute averages, divide by leaf_num_calls: failed leaf attempts
+  // usually do not come with proper counters.
+  LeafResourceStats leaf_resources_sum = 2;
+  // Number of leaf calls excluding retries.
+  uint64 leaf_num_calls = 3;
+  // Number of leaf calls, including retries.
+  uint64 leaf_num_calls_including_retries = 4;
+  // Number of failed splits across all leaves.
+  uint64 num_failed_splits = 5;
+  // Per-leaf `wall_time_microsecs`, one entry per leaf that contributed
+  // stats, sorted in descending order (largest first). Useful for
+  // distinguishing "one straggler" from "all leaves comparably slow"
+  // without computing it from `leaf_resources_worst` / `leaf_resources_sum`.
+  repeated uint64 leaf_wall_times_microsecs = 6;
+
+  // The first phase identifies the partial hits, runs aggregate.
+  // When running a top-k request, a second phase is required to fetch the documents.
+  //
+  // This includes getting the results from leaf searchers and merging them.
+  uint64 root_first_phase_wall_time_microsecs = 7;
+
+  // Overall wall time for the root search. This includes both
+  // the first phase (running aggregation, and identifying the doc address of the top-k hits we should return)
+  // and the second phase (fetch documents).
+  //
+  // If there are no top-k hits, the second phase .
+  uint64 root_wall_time_microsecs = 8;
 }
 
 // LeafRequestRef references data in LeafSearchRequest to deduplicate data.
@@ -552,7 +567,6 @@ message Hit {
   string index_id = 4;
 }
 
-
 // A partial hit, is a hit for which we have not fetch the content yet.
 // Instead, it holds a document_uri which is enough information to
 // go and fetch the actual document data, by performing a `get_doc(...)`
@@ -588,10 +602,10 @@ message PartialHit {
 
 message SortByValue {
   oneof sort_value {
-  uint64 u64 = 1;
-  int64 i64 = 2;
-  double f64 = 3;
-  bool boolean = 4;
+    uint64 u64 = 1;
+    int64 i64 = 2;
+    double f64 = 3;
+    bool boolean = 4;
   }
   // Room for eventual future sorted key types.
   reserved 5 to 20;

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -413,6 +413,9 @@ pub struct LeafResourceStats {
     /// bottleneck. Voluntarily a uint64 (not a bool) for summability.
     #[prost(uint64, tag = "14")]
     pub lambda_bottleneck: u64,
+    /// / Number of CPU threads available in the search pool.
+    #[prost(uint64, tag = "15")]
+    pub search_pool_cpu_threads: u64,
 }
 /// Resource statistics for a root search.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -442,6 +445,19 @@ pub struct RootResourceStats {
     /// without computing it from `leaf_resources_worst` / `leaf_resources_sum`.
     #[prost(uint64, repeated, tag = "6")]
     pub leaf_wall_times_microsecs: ::prost::alloc::vec::Vec<u64>,
+    /// The first phase identifies the partial hits, runs aggregate.
+    /// When running a top-k request, a second phase is required to fetch the documents.
+    ///
+    /// This includes getting the results from leaf searchers and merging them.
+    #[prost(uint64, tag = "7")]
+    pub root_first_phase_wall_time_microsecs: u64,
+    /// Overall wall time for the root search. This includes both
+    /// the first phase (running aggregation, and identifying the doc address of the top-k hits we should return)
+    /// and the second phase (fetch documents).
+    ///
+    /// If there are no top-k hits, the second phase .
+    #[prost(uint64, tag = "8")]
+    pub root_wall_time_microsecs: u64,
 }
 /// LeafRequestRef references data in LeafSearchRequest to deduplicate data.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -175,9 +175,7 @@ async fn fetch_docs_in_split(
     .context("open-index-for-split")?;
     // we add an executor here, we could add it in open_index_with_caches, though we should verify
     // the side-effect before
-    let tantivy_executor = crate::search_thread_pool()
-        .get_underlying_rayon_thread_pool()
-        .into();
+    let tantivy_executor = quickwit_common::thread_pool::get_underlying_rayon_thread_pool().into();
     index.set_executor(tantivy_executor);
     let index_reader = index
         .reader_builder()

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -1516,10 +1516,12 @@ pub async fn multi_index_leaf_search(
         .await
         .context("failed to merge split search responses")??;
     let wall_time_microsecs = leaf_start.elapsed().as_micros() as u64;
-    leaf_search_response
+    let search_pool_cpu_threads = crate::search_thread_pool().num_threads() as u64;
+    let resource_stats = leaf_search_response
         .resource_stats
-        .get_or_insert_with(LeafResourceStats::default)
-        .wall_time_microsecs = wall_time_microsecs;
+        .get_or_insert_with(LeafResourceStats::default);
+    resource_stats.wall_time_microsecs = wall_time_microsecs;
+    resource_stats.search_pool_cpu_threads = search_pool_cpu_threads;
     Ok(leaf_search_response)
 }
 

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -27,6 +27,7 @@ use anyhow::Context;
 use bytesize::ByteSize;
 use futures::future::try_join_all;
 use quickwit_common::pretty::PrettySample;
+use quickwit_common::thread_pool::with_priority::Priority;
 use quickwit_common::uri::Uri;
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_doc_mapper::{Automaton, DocMapper, FastFieldWarmupInfo, TermRange, WarmupInfo};
@@ -1506,7 +1507,7 @@ pub async fn multi_index_leaf_search(
     }
 
     let mut leaf_search_response: LeafSearchResponse = crate::search_thread_pool()
-        .run_cpu_intensive(|| {
+        .run_cpu_intensive_with_priority(Priority::High, || {
             incremental_merge_collector
                 .finalize()
                 .map_err(SearchError::from)
@@ -1911,7 +1912,9 @@ pub async fn single_doc_mapping_leaf_search(
 
     let leaf_search_response_result: tantivy::Result<LeafSearchResponse> =
         crate::search_thread_pool()
-            .run_cpu_intensive(|| incremental_merge_collector.finalize())
+            .run_cpu_intensive_with_priority(Priority::High, || {
+                incremental_merge_collector.finalize()
+            })
             .instrument(info_span!("incremental_merge_intermediate"))
             .await
             .context("failed to merge split search responses: thread panicked")?;

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -46,7 +46,7 @@ mod search_permit_provider;
 mod tests;
 
 pub use collector::QuickwitAggregations;
-use quickwit_common::thread_pool::ThreadPool;
+use quickwit_common::thread_pool::with_priority::ThreadPoolWithPriority;
 use quickwit_common::tower::Pool;
 use quickwit_doc_mapper::DocMapper;
 use quickwit_proto::metastore::{
@@ -96,9 +96,9 @@ pub use crate::service::{MockSearchService, SearchService, SearchServiceImpl};
 /// A pool of searcher clients identified by their gRPC socket address.
 pub type SearcherPool = Pool<SocketAddr, SearchServiceClient>;
 
-fn search_thread_pool() -> &'static ThreadPool {
-    static SEARCH_THREAD_POOL: LazyLock<ThreadPool> =
-        LazyLock::new(|| ThreadPool::new("search", None));
+fn search_thread_pool() -> &'static ThreadPoolWithPriority {
+    static SEARCH_THREAD_POOL: LazyLock<ThreadPoolWithPriority> =
+        LazyLock::new(|| ThreadPoolWithPriority::new("search", None));
     &SEARCH_THREAD_POOL
 }
 

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -398,6 +398,7 @@ pub(crate) fn add_leaf_stats(acc: &mut LeafResourceStats, other: &LeafResourceSt
     acc.localexec_num_splits += other.localexec_num_splits;
     acc.localexec_num_docs += other.localexec_num_docs;
     acc.wall_time_microsecs += other.wall_time_microsecs;
+    acc.search_pool_cpu_threads += other.search_pool_cpu_threads;
     acc.min_wait_for_search_permit_microsecs = min_opt(
         acc.min_wait_for_search_permit_microsecs,
         other.min_wait_for_search_permit_microsecs,
@@ -562,6 +563,7 @@ mod stats_merge_tests {
             min_wait_for_search_permit_microsecs: Some(100),
             min_wait_for_cpu_pool_microsecs: Some(2_000),
             wall_time_microsecs: 100_000_000,
+            search_pool_cpu_threads: 8,
         };
         let other = LeafResourceStats {
             partial_result_cache_num_splits: 2,
@@ -578,6 +580,7 @@ mod stats_merge_tests {
             min_wait_for_search_permit_microsecs: Some(50),
             min_wait_for_cpu_pool_microsecs: Some(1_000),
             wall_time_microsecs: 200_000_000,
+            search_pool_cpu_threads: 16,
         };
 
         add_leaf_stats(&mut acc, &other);
@@ -595,6 +598,7 @@ mod stats_merge_tests {
         assert_eq!(acc.localexec_num_docs, 30_000_000);
         // `wall_time_microsecs` is summed post-refactor, not maxed.
         assert_eq!(acc.wall_time_microsecs, 300_000_000);
+        assert_eq!(acc.search_pool_cpu_threads, 24);
 
         // `min_wait_for_*_microsecs` is MIN, not sum — the exception to the
         // extensive-sum rule.

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -22,6 +22,7 @@ use futures::future::try_join_all;
 use itertools::Itertools;
 use quickwit_common::pretty::PrettySample;
 use quickwit_common::shared_consts;
+use quickwit_common::thread_pool::with_priority::Priority;
 use quickwit_common::uri::Uri;
 use quickwit_config::build_doc_mapper;
 use quickwit_doc_mapper::DYNAMIC_FIELD_NAME;
@@ -836,15 +837,15 @@ pub(crate) async fn search_partial_hits_phase(
     let merge_collector =
         make_merge_collector(search_request, searcher_context.get_aggregation_limits())?;
 
-    // Merging is a cpu-bound task.
-    // It should be executed by Tokio's blocking threads.
+    // Merging is a cpu-bound task. Prioritize it over queued split searches to avoid delaying the
+    // final response once all leaf responses are available.
 
     // Wrap into result for merge_fruits
     let leaf_search_results: Vec<tantivy::Result<LeafSearchResponse>> =
         leaf_search_responses.into_iter().map(Ok).collect_vec();
     let span = info_span!("merge_fruits");
     let leaf_search_response = crate::search_thread_pool()
-        .run_cpu_intensive(move || {
+        .run_cpu_intensive_with_priority(Priority::High, move || {
             let _span_guard = span.enter();
             merge_collector.merge_fruits(leaf_search_results)
         })

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -742,6 +742,8 @@ fn is_top_5pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
 ///
 /// `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
 /// `leaf_resources_sum` is a field-wise sum of every leaf's stats.
+///
+/// Root specific stats are left as 0 and will be filled in within the root phase.
 fn compute_root_resource_stats(
     leaf_responses: &[LeafSearchResponse],
     leaf_num_calls: u64,
@@ -780,6 +782,8 @@ fn compute_root_resource_stats(
         leaf_num_calls_including_retries,
         num_failed_splits,
         leaf_wall_times_microsecs,
+        root_first_phase_wall_time_microsecs: 0u64,
+        root_wall_time_microsecs: 0u64,
     })
 }
 
@@ -1056,7 +1060,8 @@ async fn root_search_aux(
     cluster_client: &ClusterClient,
 ) -> crate::Result<SearchResponse> {
     debug!(split_metadatas = ?PrettySample::new(&split_metadatas, 5));
-    let (first_phase_result, scroll_key_and_start_offset_opt, root_resource_stats): (
+    let start = Instant::now();
+    let (first_phase_result, scroll_key_and_start_offset_opt, mut root_resource_stats_opt): (
         LeafSearchResponse,
         Option<ScrollKeyAndStartOffset>,
         Option<RootResourceStats>,
@@ -1068,6 +1073,11 @@ async fn root_search_aux(
         cluster_client,
     )
     .await?;
+
+    if let Some(root_resource_stats) = root_resource_stats_opt.as_mut() {
+        root_resource_stats.root_first_phase_wall_time_microsecs =
+            start.elapsed().as_micros() as u64;
+    }
 
     let hits = fetch_docs_phase(
         indexes_metas_for_leaf_search,
@@ -1088,6 +1098,10 @@ async fn root_search_aux(
         aggregation_result_postcard_opt = None;
     }
 
+    if let Some(root_resource_stats) = root_resource_stats_opt.as_mut() {
+        root_resource_stats.root_wall_time_microsecs = start.elapsed().as_micros() as u64;
+    }
+
     Ok(SearchResponse {
         aggregation_postcard: aggregation_result_postcard_opt,
         num_hits: first_phase_result.num_hits,
@@ -1099,7 +1113,7 @@ async fn root_search_aux(
             .map(ToString::to_string),
         failed_splits: first_phase_result.failed_splits,
         num_successful_splits: first_phase_result.num_successful_splits,
-        resource_stats: root_resource_stats,
+        resource_stats: root_resource_stats_opt,
     })
 }
 


### PR DESCRIPTION
## Summary

- Adds `search_pool_cpu_threads` to `LeafResourceStats` so callers can observe the size of the search thread pool on each leaf node
- Adds `root_first_phase_wall_time_microsecs` and `root_wall_time_microsecs` to `RootResourceStats` to track end-to-end root search latency broken down by phase (identification vs. fetch)
- Adds `num_threads()` accessor to `ThreadPoolWithPriority`

## Test plan

- [ ] Existing stats merge tests updated to cover `search_pool_cpu_threads` accumulation
- [ ] Manual: verify resource stats fields appear in search responses