### PR TITLE
Update indexer pool on all node updates; Fix is_indexed for empty shards

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -8953,6 +8953,7 @@ dependencies = [
  "quickwit-cli",
  "quickwit-common",
  "quickwit-config",
+ "quickwit-control-plane",
  "quickwit-datafusion",
  "quickwit-indexing",
  "quickwit-ingest",

--- a/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/fetch.rs
@@ -204,7 +204,7 @@ impl FetchStreamTask {
                         index_uid=%self.index_uid,
                         source_id=%self.source_id,
                         shard_id=%self.shard_id,
-                        to_position_inclusive=%to_position_inclusive,
+                        %to_position_inclusive,
                         "fetch stream reached end of shard"
                     );
                     let eof_position = to_position_inclusive.as_eof();

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -3755,7 +3755,10 @@ mod tests {
                 .await;
         }
 
-        assert_eq!(*status_rx.borrow_and_update(), IngesterStatus::Decommissioning);
+        assert_eq!(
+            *status_rx.borrow_and_update(),
+            IngesterStatus::Decommissioning
+        );
 
         event_broker.publish(ShardPositionsUpdate {
             source_uid: SourceUid {

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -3666,7 +3666,13 @@ mod tests {
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
 
-        let shard = IngesterShard::new_solo(index_uid, source_id, ShardId::from(1)).build();
+        // Give the shard un-indexed data (replication position ahead of truncation) so that, once
+        // closed, it is not immediately `is_indexed`. This keeps the ingester in `Decommissioning`
+        // long enough for the test to observe that state. An empty shard would now fast-path
+        // straight to `Decommissioned` (nothing to index).
+        let shard = IngesterShard::new_solo(index_uid, source_id, ShardId::from(1))
+            .with_replication_position_inclusive(Position::offset(12u64))
+            .build();
         let queue_id = shard.queue_id();
 
         state_guard.shards.insert(queue_id.clone(), shard);

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -1279,8 +1279,6 @@ impl EventSubscriber<ShardPositionsUpdate> for WeakIngesterState {
                     .await;
             }
         }
-        // Gossip-driven deletion is the only way an empty shard is retired, so re-check here or a
-        // decommissioning ingester whose last shard is empty would never reach `Decommissioned`.
         state_guard.check_decommissioning_status().await;
     }
 }
@@ -3320,7 +3318,6 @@ mod tests {
             )
             .await
             .unwrap();
-        // An empty shard only reaches EOF once closed, and `is_indexed` requires a closed shard.
         state_guard.shards.get_mut(&queue_id).unwrap().close();
         drop(state_guard);
 
@@ -3341,7 +3338,6 @@ mod tests {
         let state_guard = ingester.state.lock_fully("test").await.unwrap();
         let shard = state_guard.shards.get(&queue_id).unwrap();
         shard.assert_truncation_position(Position::Beginning.as_eof());
-        assert!(shard.is_indexed());
         assert!(state_guard.mrecordlog.queue_exists(&queue_id));
         state_guard.mrecordlog.assert_records_eq(&queue_id, .., &[]);
     }
@@ -3714,8 +3710,6 @@ mod tests {
         let index_uid = IndexUid::for_test("test-index", 0);
         let source_id = SourceId::from("test-source");
 
-        // Give the shard un-indexed data (replication position ahead of truncation) so that, once
-        // closed, it is not immediately `is_indexed`.
         let shard = IngesterShard::new_solo(index_uid, source_id, ShardId::from(1))
             .with_replication_position_inclusive(Position::offset(12u64))
             .build();
@@ -3781,13 +3775,16 @@ mod tests {
 
         let shard = state_guard.shards.get_mut(&queue_id).unwrap();
         shard.truncation_position_inclusive = Position::Beginning.as_eof();
+        state_guard.check_decommissioning_status().await;
+        assert_eq!(state_guard.status(), IngesterStatus::Decommissioning);
 
+        state_guard.shards.remove(&queue_id);
         state_guard.check_decommissioning_status().await;
         assert_eq!(state_guard.status(), IngesterStatus::Decommissioned);
     }
 
     #[tokio::test]
-    async fn test_decommission_completes_when_empty_shard_retired_via_gossip() {
+    async fn test_decommission_completes_when_empty_shard_deleted_via_gossip() {
         let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
 
         let event_broker = EventBroker::default();
@@ -3831,7 +3828,7 @@ mod tests {
             }
         })
         .await
-        .expect("ingester should reach Decommissioned once its empty shard is retired via gossip");
+        .expect("ingester should reach Decommissioned once its empty shard is deleted via gossip");
 
         let state_guard = ingester.state.lock_fully("test").await.unwrap();
         assert!(!state_guard.shards.contains_key(&queue_id));

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -160,16 +160,6 @@ impl Ingester {
         Ok(ingester)
     }
 
-    /// Checks whether the ingester is fully decommissioned and updates its status accordingly.
-    async fn check_decommissioning_status(&self, state: &mut InnerIngesterState) {
-        if state.status() != IngesterStatus::Decommissioning {
-            return;
-        }
-        if state.shards.values().all(|shard| shard.is_indexed()) {
-            state.set_status(IngesterStatus::Decommissioned).await;
-        }
-    }
-
     /// Initializes a primary shard by creating a queue in the write-ahead log and inserting a new
     /// [`IngesterShard`] into the ingester state. If replication is enabled, this method will
     /// also:
@@ -1039,7 +1029,7 @@ impl Ingester {
         let wal_usage = state_guard.mrecordlog.resource_usage();
         report_wal_usage(wal_usage);
 
-        self.check_decommissioning_status(&mut state_guard).await;
+        state_guard.check_decommissioning_status().await;
         let truncate_response = TruncateShardsResponse {};
         Ok(truncate_response)
     }
@@ -1199,7 +1189,7 @@ impl IngesterService for Ingester {
                 .delete_shard(&queue_id, "control-plane-retain-shards-rpc")
                 .await;
         }
-        self.check_decommissioning_status(&mut state_guard).await;
+        state_guard.check_decommissioning_status().await;
         Ok(RetainShardsResponse {})
     }
 
@@ -1258,9 +1248,7 @@ impl IngesterService for Ingester {
             for shard in state_guard.shards.values_mut() {
                 shard.close();
             }
-            self_clone
-                .check_decommissioning_status(&mut state_guard)
-                .await;
+            state_guard.check_decommissioning_status().await;
         });
         Ok(DecommissionResponse {})
     }
@@ -1291,6 +1279,9 @@ impl EventSubscriber<ShardPositionsUpdate> for WeakIngesterState {
                     .await;
             }
         }
+        // Gossip-driven deletion is the only way an empty shard is retired, so re-check here or a
+        // decommissioning ingester whose last shard is empty would never reach `Decommissioned`.
+        state_guard.check_decommissioning_status().await;
     }
 }
 
@@ -3705,17 +3696,13 @@ mod tests {
         let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
         let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
 
-        ingester
-            .check_decommissioning_status(&mut state_guard)
-            .await;
+        state_guard.check_decommissioning_status().await;
         assert_eq!(state_guard.status(), IngesterStatus::Ready);
 
         state_guard
             .set_status(IngesterStatus::Decommissioning)
             .await;
-        ingester
-            .check_decommissioning_status(&mut state_guard)
-            .await;
+        state_guard.check_decommissioning_status().await;
         assert_eq!(state_guard.status(), IngesterStatus::Decommissioned);
 
         state_guard
@@ -3732,18 +3719,62 @@ mod tests {
         let queue_id = solo_shard.queue_id();
 
         state_guard.shards.insert(queue_id.clone(), solo_shard);
-        ingester
-            .check_decommissioning_status(&mut state_guard)
-            .await;
+        state_guard.check_decommissioning_status().await;
         assert_eq!(state_guard.status(), IngesterStatus::Decommissioning);
 
         let shard = state_guard.shards.get_mut(&queue_id).unwrap();
         shard.truncation_position_inclusive = Position::Beginning.as_eof();
 
-        ingester
-            .check_decommissioning_status(&mut state_guard)
-            .await;
+        state_guard.check_decommissioning_status().await;
         assert_eq!(state_guard.status(), IngesterStatus::Decommissioned);
+    }
+
+    #[tokio::test]
+    async fn test_decommission_completes_when_empty_shard_retired_via_gossip() {
+        let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
+
+        let event_broker = EventBroker::default();
+        ingester.subscribe(&event_broker);
+
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let source_id = SourceId::from("test-source");
+        let shard_id = ShardId::from(1);
+        let queue_id = queue_id(&index_uid, &source_id, &shard_id);
+
+        let empty_shard =
+            IngesterShard::new_solo(index_uid.clone(), source_id.clone(), shard_id.clone())
+                .with_state(ShardState::Closed)
+                .build();
+
+        let mut status_rx = ingester.state.status_rx.clone();
+        {
+            let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
+            state_guard.shards.insert(queue_id.clone(), empty_shard);
+            state_guard
+                .set_status(IngesterStatus::Decommissioning)
+                .await;
+        }
+
+        assert_eq!(*status_rx.borrow_and_update(), IngesterStatus::Decommissioning);
+
+        event_broker.publish(ShardPositionsUpdate {
+            source_uid: SourceUid {
+                index_uid: index_uid.clone(),
+                source_id: source_id.clone(),
+            },
+            updated_shard_positions: vec![(shard_id, Position::Beginning.as_eof())],
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while *status_rx.borrow_and_update() != IngesterStatus::Decommissioned {
+                status_rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("ingester should reach Decommissioned once its empty shard is retired via gossip");
+
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
+        assert!(!state_guard.shards.contains_key(&queue_id));
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -3667,9 +3667,7 @@ mod tests {
         let source_id = SourceId::from("test-source");
 
         // Give the shard un-indexed data (replication position ahead of truncation) so that, once
-        // closed, it is not immediately `is_indexed`. This keeps the ingester in `Decommissioning`
-        // long enough for the test to observe that state. An empty shard would now fast-path
-        // straight to `Decommissioned` (nothing to index).
+        // closed, it is not immediately `is_indexed`.
         let shard = IngesterShard::new_solo(index_uid, source_id, ShardId::from(1))
             .with_replication_position_inclusive(Position::offset(12u64))
             .build();

--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -3290,6 +3290,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_ingester_truncate_empty_shard_to_eof() {
+        let (ingester_ctx, ingester) = IngesterForTest::default().build().await;
+
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let source_id = SourceId::from("test-source");
+        let queue_id = queue_id(&index_uid, &source_id, &ShardId::from(1));
+
+        let doc_mapping_uid = DocMappingUid::random();
+        let doc_mapping_json = format!(r#"{{ "doc_mapping_uid": "{doc_mapping_uid}" }}"#);
+        let shard = Shard {
+            index_uid: Some(index_uid.clone()),
+            source_id: source_id.clone(),
+            shard_id: Some(ShardId::from(1)),
+            shard_state: ShardState::Open as i32,
+            doc_mapping_uid: Some(doc_mapping_uid),
+            ..Default::default()
+        };
+
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
+        ingester
+            .init_primary_shard(
+                &mut state_guard.inner,
+                &mut state_guard.mrecordlog,
+                shard,
+                &doc_mapping_json,
+                Instant::now(),
+                true,
+            )
+            .await
+            .unwrap();
+        // An empty shard only reaches EOF once closed, and `is_indexed` requires a closed shard.
+        state_guard.shards.get_mut(&queue_id).unwrap().close();
+        drop(state_guard);
+
+        let truncate_shards_request = TruncateShardsRequest {
+            ingester_id: ingester_ctx.node_id.to_string(),
+            subrequests: vec![TruncateShardsSubrequest {
+                index_uid: Some(index_uid.clone()),
+                source_id: source_id.clone(),
+                shard_id: Some(ShardId::from(1)),
+                truncate_up_to_position_inclusive: Some(Position::Beginning.as_eof()),
+            }],
+        };
+        ingester
+            .truncate_shards(truncate_shards_request.clone())
+            .await
+            .unwrap();
+
+        let state_guard = ingester.state.lock_fully("test").await.unwrap();
+        let shard = state_guard.shards.get(&queue_id).unwrap();
+        shard.assert_truncation_position(Position::Beginning.as_eof());
+        assert!(shard.is_indexed());
+        assert!(state_guard.mrecordlog.queue_exists(&queue_id));
+        state_guard.mrecordlog.assert_records_eq(&queue_id, .., &[]);
+    }
+
+    #[tokio::test]
     async fn test_ingester_truncate_shards_deletes_dangling_shards() {
         let (ingester_ctx, ingester) = IngesterForTest::default().build().await;
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -447,4 +447,45 @@ mod tests {
         );
         assert!(!solo_shard.is_advertisable);
     }
+
+    #[test]
+    fn test_is_indexed() {
+        let new_solo_shard = || {
+            IngesterShard::new_solo(
+                IndexUid::for_test("test-index", 0),
+                SourceId::from("test-source"),
+                ShardId::from(1),
+            )
+        };
+
+        // An empty shard (replication and truncation both at `Beginning`) has no un-indexed data,
+        // so once it is closed it must be considered indexed. Otherwise an empty replacement shard
+        // opened during a rebalance would block the ingester's decommission forever.
+        assert!(!new_solo_shard().build().is_indexed());
+        assert!(
+            new_solo_shard()
+                .with_state(ShardState::Closed)
+                .build()
+                .is_indexed()
+        );
+
+        // A closed shard with records that have not been fully consumed is not indexed.
+        assert!(
+            !new_solo_shard()
+                .with_state(ShardState::Closed)
+                .with_replication_position_inclusive(Position::offset(5u64))
+                .build()
+                .is_indexed()
+        );
+
+        // A closed shard whose records have all been consumed is indexed.
+        assert!(
+            new_solo_shard()
+                .with_state(ShardState::Closed)
+                .with_replication_position_inclusive(Position::offset(5u64))
+                .with_truncation_position_inclusive(Position::offset(5u64))
+                .build()
+                .is_indexed()
+        );
+    }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -268,14 +268,7 @@ impl IngesterShard {
     }
 
     pub fn is_indexed(&self) -> bool {
-        // Closed and either truncated up to EOF, or empty (no record was ever written, so the
-        // replication position is still at the beginning). The empty case matters for empty
-        // replacement shards opened during a rebalance: they never reach an EOF truncation and
-        // would otherwise block the ingester's decommission forever. A non-empty shard must still
-        // reach an EOF truncation, so a node does not quit before committing the shard's EOF.
-        self.shard_state.is_closed()
-            && (self.truncation_position_inclusive.is_eof()
-                || self.replication_position_inclusive == Position::Beginning)
+        self.shard_state.is_closed() && self.truncation_position_inclusive.is_eof()
     }
 
     pub fn is_replica(&self) -> bool {
@@ -462,17 +455,14 @@ mod tests {
         };
 
         // An empty shard (replication and truncation both at `Beginning`) has no un-indexed data,
-        // so once it is closed it must be considered indexed. Otherwise an empty replacement shard
-        // opened during a rebalance would block the ingester's decommission forever.
+        // but we have to wait for EOF to be gossipped or the shard will be orphaned on decommission
         assert!(!new_solo_shard().build().is_indexed());
         assert!(
-            new_solo_shard()
+            !new_solo_shard()
                 .with_state(ShardState::Closed)
                 .build()
                 .is_indexed()
         );
-
-        // A closed shard with records that have not been fully consumed is not indexed.
         assert!(
             !new_solo_shard()
                 .with_state(ShardState::Closed)
@@ -480,9 +470,6 @@ mod tests {
                 .build()
                 .is_indexed()
         );
-
-        // A non-empty closed shard is only indexed once it has been truncated up to EOF;
-        // consuming all of its records is not enough — the EOF must be committed.
         assert!(
             !new_solo_shard()
                 .with_state(ShardState::Closed)

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -268,7 +268,11 @@ impl IngesterShard {
     }
 
     pub fn is_indexed(&self) -> bool {
-        self.shard_state.is_closed() && self.truncation_position_inclusive.is_eof()
+        // A shard is fully indexed once it is closed and all of its written records have been
+        // consumed, i.e. the truncation position has caught up to the last written (replication)
+        // position.
+        self.shard_state.is_closed()
+            && self.truncation_position_inclusive >= self.replication_position_inclusive
     }
 
     pub fn is_replica(&self) -> bool {

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -268,11 +268,14 @@ impl IngesterShard {
     }
 
     pub fn is_indexed(&self) -> bool {
-        // A shard is fully indexed once it is closed and all of its written records have been
-        // consumed, i.e. the truncation position has caught up to the last written (replication)
-        // position.
+        // Closed and either truncated up to EOF, or empty (no record was ever written, so the
+        // replication position is still at the beginning). The empty case matters for empty
+        // replacement shards opened during a rebalance: they never reach an EOF truncation and
+        // would otherwise block the ingester's decommission forever. A non-empty shard must still
+        // reach an EOF truncation, so a node does not quit before committing the shard's EOF.
         self.shard_state.is_closed()
-            && self.truncation_position_inclusive >= self.replication_position_inclusive
+            && (self.truncation_position_inclusive.is_eof()
+                || self.replication_position_inclusive == Position::Beginning)
     }
 
     pub fn is_replica(&self) -> bool {
@@ -478,12 +481,21 @@ mod tests {
                 .is_indexed()
         );
 
-        // A closed shard whose records have all been consumed is indexed.
+        // A non-empty closed shard is only indexed once it has been truncated up to EOF;
+        // consuming all of its records is not enough — the EOF must be committed.
+        assert!(
+            !new_solo_shard()
+                .with_state(ShardState::Closed)
+                .with_replication_position_inclusive(Position::offset(5u64))
+                .with_truncation_position_inclusive(Position::offset(5u64))
+                .build()
+                .is_indexed()
+        );
         assert!(
             new_solo_shard()
                 .with_state(ShardState::Closed)
                 .with_replication_position_inclusive(Position::offset(5u64))
-                .with_truncation_position_inclusive(Position::offset(5u64))
+                .with_truncation_position_inclusive(Position::offset(5u64).as_eof())
                 .build()
                 .is_indexed()
         );

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -267,10 +267,6 @@ impl IngesterShard {
         now.duration_since(self.last_write_instant) >= idle_timeout
     }
 
-    pub fn is_indexed(&self) -> bool {
-        self.shard_state.is_closed() && self.truncation_position_inclusive.is_eof()
-    }
-
     pub fn is_replica(&self) -> bool {
         matches!(self.shard_type, IngesterShardType::Replica { .. })
     }
@@ -442,49 +438,5 @@ mod tests {
             Position::Beginning
         );
         assert!(!solo_shard.is_advertisable);
-    }
-
-    #[test]
-    fn test_is_indexed() {
-        let new_solo_shard = || {
-            IngesterShard::new_solo(
-                IndexUid::for_test("test-index", 0),
-                SourceId::from("test-source"),
-                ShardId::from(1),
-            )
-        };
-
-        // An empty shard (replication and truncation both at `Beginning`) has no un-indexed data,
-        // but we have to wait for EOF to be gossipped or the shard will be orphaned on decommission
-        assert!(!new_solo_shard().build().is_indexed());
-        assert!(
-            !new_solo_shard()
-                .with_state(ShardState::Closed)
-                .build()
-                .is_indexed()
-        );
-        assert!(
-            !new_solo_shard()
-                .with_state(ShardState::Closed)
-                .with_replication_position_inclusive(Position::offset(5u64))
-                .build()
-                .is_indexed()
-        );
-        assert!(
-            !new_solo_shard()
-                .with_state(ShardState::Closed)
-                .with_replication_position_inclusive(Position::offset(5u64))
-                .with_truncation_position_inclusive(Position::offset(5u64))
-                .build()
-                .is_indexed()
-        );
-        assert!(
-            new_solo_shard()
-                .with_state(ShardState::Closed)
-                .with_replication_position_inclusive(Position::offset(5u64))
-                .with_truncation_position_inclusive(Position::offset(5u64).as_eof())
-                .build()
-                .is_indexed()
-        );
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -87,7 +87,7 @@ impl InnerIngesterState {
         if self.status() != IngesterStatus::Decommissioning {
             return;
         }
-        if self.shards.values().all(|shard| shard.is_indexed()) {
+        if self.shards.is_empty() {
             self.set_status(IngesterStatus::Decommissioned).await;
         }
     }
@@ -605,11 +605,7 @@ impl FullyLockedIngesterState<'_> {
             "truncated shard `{queue_id}` at {truncate_up_to_position_inclusive} initiated via \
              `{initiator}`"
         );
-        self.inner
-            .shards
-            .get_mut(queue_id)
-            .expect("shard was present above and is only removed on the missing-queue path")
-            .truncation_position_inclusive = truncate_up_to_position_inclusive;
+        shard.truncation_position_inclusive = truncate_up_to_position_inclusive;
     }
 
     /// Deletes and truncates the shards as directed by the `advise_reset_shards_response` returned
@@ -1119,7 +1115,6 @@ mod tests {
             shard_01.truncation_position_inclusive,
             Position::Beginning.as_eof()
         );
-        assert!(shard_01.is_indexed());
         assert!(state_guard.mrecordlog.queue_exists(&queue_id_01));
         assert_eq!(
             state_guard
@@ -1135,7 +1130,6 @@ mod tests {
             .await;
         let shard_02 = state_guard.shards.get(&queue_id_02).unwrap();
         assert_eq!(shard_02.truncation_position_inclusive, Position::eof(1u64));
-        assert!(shard_02.is_indexed());
         state_guard
             .mrecordlog
             .assert_records_eq(&queue_id_02, .., &[]);

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -82,6 +82,16 @@ impl InnerIngesterState {
             .await;
     }
 
+    /// Checks whether the ingester is fully decommissioned and updates its status accordingly.
+    pub async fn check_decommissioning_status(&mut self) {
+        if self.status() != IngesterStatus::Decommissioning {
+            return;
+        }
+        if self.shards.values().all(|shard| shard.is_indexed()) {
+            self.set_status(IngesterStatus::Decommissioned).await;
+        }
+    }
+
     /// Returns the shard with the most available permits for this index and source.
     pub fn find_most_capacity_shard_mut(
         &mut self,

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -576,32 +576,40 @@ impl FullyLockedIngesterState<'_> {
         truncate_up_to_position_inclusive: Position,
         initiator: &'static str,
     ) {
-        if let Some(truncate_up_to_offset_inclusive) = truncate_up_to_position_inclusive.as_u64()
-            && let Some(shard) = self.inner.shards.get_mut(queue_id)
-            && shard.truncation_position_inclusive < truncate_up_to_position_inclusive
-        {
+        let Some(shard) = self.inner.shards.get_mut(queue_id) else {
+            return;
+        };
+        if shard.truncation_position_inclusive >= truncate_up_to_position_inclusive {
+            return;
+        }
+        if let Some(truncate_up_to_offset_inclusive) = truncate_up_to_position_inclusive.as_u64() {
             match self
                 .mrecordlog
                 .truncate(queue_id, truncate_up_to_offset_inclusive)
                 .await
             {
-                Ok(_) => {
-                    info!(
-                        "truncated shard `{queue_id}` at {truncate_up_to_position_inclusive} \
-                         initiated via `{initiator}`"
-                    );
-                    shard.truncation_position_inclusive = truncate_up_to_position_inclusive;
-                }
+                Ok(_) => {}
                 Err(TruncateError::MissingQueue(_)) => {
                     error!("failed to truncate shard `{queue_id}`: WAL queue not found");
                     self.shards.remove(queue_id);
                     info!("deleted dangling shard `{queue_id}`");
+                    return;
                 }
                 Err(TruncateError::IoError(io_error)) => {
                     error!("failed to truncate shard `{queue_id}`: {io_error}");
+                    return;
                 }
-            };
+            }
         }
+        info!(
+            "truncated shard `{queue_id}` at {truncate_up_to_position_inclusive} initiated via \
+             `{initiator}`"
+        );
+        self.inner
+            .shards
+            .get_mut(queue_id)
+            .expect("shard was present above and is only removed on the missing-queue path")
+            .truncation_position_inclusive = truncate_up_to_position_inclusive;
     }
 
     /// Deletes and truncates the shards as directed by the `advise_reset_shards_response` returned
@@ -1055,5 +1063,90 @@ mod tests {
         let mut source_b_ids = closed_shards[1].shard_ids.clone();
         source_b_ids.sort();
         assert_eq!(source_b_ids, vec![ShardId::from(5), ShardId::from(6)]);
+    }
+
+    #[tokio::test]
+    async fn test_truncate_shard() {
+        let cluster = test_cluster().await;
+        let (_temp_dir, state) = IngesterState::for_test(cluster).await;
+
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let source_id = SourceId::from("test-source");
+        // Shard 1 is empty (never written): its EOF is `Eof(None)`, with no WAL offset.
+        let queue_id_01 = queue_id(&index_uid, &source_id, &ShardId::from(1));
+        // Shard 2 holds two records: its EOF is `Eof(Some(1))`.
+        let queue_id_02 = queue_id(&index_uid, &source_id, &ShardId::from(2));
+
+        let mut state_guard = state.lock_fully("test").await.unwrap();
+
+        state_guard
+            .mrecordlog
+            .create_queue(&queue_id_01)
+            .await
+            .unwrap();
+        state_guard
+            .mrecordlog
+            .create_queue(&queue_id_02)
+            .await
+            .unwrap();
+        state_guard
+            .mrecordlog
+            .append_records(
+                &queue_id_02,
+                None,
+                [&b"test-doc-foo"[..], &b"test-doc-bar"[..]].into_iter(),
+            )
+            .await
+            .unwrap();
+
+        let shard_01 =
+            IngesterShard::new_solo(index_uid.clone(), source_id.clone(), ShardId::from(1))
+                .with_state(ShardState::Closed)
+                .build();
+        state_guard.shards.insert(queue_id_01.clone(), shard_01);
+        let shard_02 =
+            IngesterShard::new_solo(index_uid.clone(), source_id.clone(), ShardId::from(2))
+                .with_state(ShardState::Closed)
+                .with_replication_position_inclusive(Position::offset(1u64))
+                .build();
+        state_guard.shards.insert(queue_id_02.clone(), shard_02);
+
+        state_guard
+            .truncate_shard(&queue_id_01, Position::Beginning.as_eof(), "test")
+            .await;
+        let shard_01 = state_guard.shards.get(&queue_id_01).unwrap();
+        assert_eq!(
+            shard_01.truncation_position_inclusive,
+            Position::Beginning.as_eof()
+        );
+        assert!(shard_01.is_indexed());
+        assert!(state_guard.mrecordlog.queue_exists(&queue_id_01));
+        assert_eq!(
+            state_guard
+                .shards
+                .get(&queue_id_01)
+                .unwrap()
+                .truncation_position_inclusive,
+            Position::Beginning.as_eof()
+        );
+
+        state_guard
+            .truncate_shard(&queue_id_02, Position::eof(1u64), "test")
+            .await;
+        let shard_02 = state_guard.shards.get(&queue_id_02).unwrap();
+        assert_eq!(shard_02.truncation_position_inclusive, Position::eof(1u64));
+        assert!(shard_02.is_indexed());
+        state_guard
+            .mrecordlog
+            .assert_records_eq(&queue_id_02, .., &[]);
+
+        assert_eq!(
+            state_guard
+                .shards
+                .get(&queue_id_02)
+                .unwrap()
+                .truncation_position_inclusive,
+            Position::eof(1u64)
+        );
     }
 }

--- a/quickwit/quickwit-integration-tests/Cargo.toml
+++ b/quickwit/quickwit-integration-tests/Cargo.toml
@@ -69,6 +69,7 @@ quickwit-actors = { workspace = true, features = ["testsuite"] }
 quickwit-cli = { workspace = true }
 quickwit-common = { workspace = true, features = ["testsuite"] }
 quickwit-config = { workspace = true, features = ["testsuite"] }
+quickwit-control-plane = { workspace = true, features = ["testsuite"] }
 quickwit-indexing = { workspace = true, features = ["testsuite"] }
 quickwit-ingest = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1185,10 +1185,6 @@ async fn test_retiring_indexer_receives_empty_plan() {
     .expect("retiring indexer should be sent an empty plan and shut down its indexing pipelines");
 }
 
-/// Experiment: with two indexers each owning a shard, decommission one and await its FULL graceful
-/// shutdown. This is the condition that stalled in the integration harness. With the control-plane
-/// `testsuite` fast-timing feature enabled, this should complete quickly if the stall was purely
-/// the 30s production reconciliation interval; if it still stalls, there is a real residual.
 #[tokio::test]
 async fn test_retiring_indexer_decommissions_gracefully() {
     quickwit_common::setup_logging_for_tests();
@@ -1268,8 +1264,8 @@ async fn test_retiring_indexer_decommissions_gracefully() {
                 Err(_) => false,
             }
         },
-        Duration::from_secs(20),
         Duration::from_millis(200),
+        Duration::from_millis(1),
     )
     .await
     .expect("the indexer we are about to retire should be indexing a shard");
@@ -1280,18 +1276,16 @@ async fn test_retiring_indexer_decommissions_gracefully() {
                 Err(_) => false,
             }
         },
-        Duration::from_secs(20),
         Duration::from_millis(200),
+        Duration::from_millis(1),
     )
     .await
     .expect("the surviving indexer should also be indexing a shard");
 
-    // Decommission the retiring node and AWAIT its full graceful shutdown. The surviving indexer
-    // must drain the reassigned shard so the retiring ingester reaches `is_indexed`.
     let shutdown_handle = sandbox
         .remove_node(&retiring_node_id)
         .expect("the retiring node should be in the sandbox");
-    tokio::time::timeout(Duration::from_secs(30), shutdown_handle.shutdown())
+    tokio::time::timeout(Duration::from_secs(5), shutdown_handle.shutdown())
         .await
         .expect("graceful decommission of the retiring indexer timed out")
         .expect("retiring indexer shutdown returned an error");
@@ -1315,14 +1309,14 @@ async fn test_retiring_indexer_decommissions_gracefully() {
                 Err(_) => false,
             }
         },
-        Duration::from_secs(15),
-        Duration::from_millis(500),
+        Duration::from_secs(3),
+        Duration::from_millis(200),
     )
     .await
     .expect("all 6 documents should be searchable after decommission");
 
     // Clean shutdown of the remaining nodes (also exercises decommissioning the last indexer).
-    tokio::time::timeout(Duration::from_secs(30), sandbox.shutdown())
+    tokio::time::timeout(Duration::from_secs(3), sandbox.shutdown())
         .await
         .expect("cluster shutdown timed out")
         .expect("cluster shutdown failed");

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1143,8 +1143,8 @@ async fn test_retiring_indexer_receives_empty_plan() {
                 Err(_) => false,
             }
         },
-        Duration::from_secs(1),
         Duration::from_millis(100),
+        Duration::from_millis(1),
     )
     .await
     .expect("the indexer we are about to retire should be indexing a shard");
@@ -1155,8 +1155,8 @@ async fn test_retiring_indexer_receives_empty_plan() {
                 Err(_) => false,
             }
         },
-        Duration::from_secs(2),
         Duration::from_millis(100),
+        Duration::from_millis(1),
     )
     .await
     .expect("the surviving indexer should also be indexing a shard");
@@ -1178,8 +1178,8 @@ async fn test_retiring_indexer_receives_empty_plan() {
                 Err(_) => false,
             }
         },
-        Duration::from_secs(15),
         Duration::from_millis(100),
+        Duration::from_millis(1),
     )
     .await
     .expect("retiring indexer should be sent an empty plan and shut down its indexing pipelines");

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1178,7 +1178,7 @@ async fn test_retiring_indexer_receives_empty_plan() {
                 Err(_) => false,
             }
         },
-        Duration::from_secs(2),
+        Duration::from_secs(15),
         Duration::from_millis(100),
     )
     .await

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1185,6 +1185,149 @@ async fn test_retiring_indexer_receives_empty_plan() {
     .expect("retiring indexer should be sent an empty plan and shut down its indexing pipelines");
 }
 
+/// Experiment: with two indexers each owning a shard, decommission one and await its FULL graceful
+/// shutdown. This is the condition that stalled in the integration harness. With the control-plane
+/// `testsuite` fast-timing feature enabled, this should complete quickly if the stall was purely
+/// the 30s production reconciliation interval; if it still stalls, there is a real residual.
+#[tokio::test]
+async fn test_retiring_indexer_decommissions_gracefully() {
+    quickwit_common::setup_logging_for_tests();
+    let mut sandbox = ClusterSandboxBuilder::default()
+        .add_node([QuickwitService::Indexer])
+        .add_node([QuickwitService::Indexer])
+        .add_node([
+            QuickwitService::ControlPlane,
+            QuickwitService::Searcher,
+            QuickwitService::Metastore,
+            QuickwitService::Janitor,
+        ])
+        .build_and_start()
+        .await;
+    let index_id = "test_retiring_indexer_decommissions_gracefully";
+
+    sandbox
+        .rest_client(QuickwitService::Indexer)
+        .indexes()
+        .create(
+            format!(
+                r#"
+            version: 0.8
+            index_id: {index_id}
+            doc_mapping:
+              field_mappings:
+              - name: body
+                type: text
+            indexing_settings:
+              commit_timeout_secs: 1
+            ingest_settings:
+              min_shards: 2
+            "#
+            ),
+            ConfigFormat::Yaml,
+            false,
+        )
+        .await
+        .unwrap();
+
+    for i in 0..6 {
+        ingest(
+            &sandbox.rest_client(QuickwitService::Indexer),
+            index_id,
+            ingest_json!({ "body": format!("doc-{i}") }),
+            CommitType::Auto,
+        )
+        .await
+        .unwrap();
+    }
+
+    let indexer_node_ids: Vec<_> = sandbox
+        .node_configs
+        .iter()
+        .filter(|(_, services)| services.contains(&QuickwitService::Indexer))
+        .map(|(config, _)| config.node_id.clone())
+        .collect();
+    assert_eq!(
+        indexer_node_ids.len(),
+        2,
+        "expected exactly two indexer nodes"
+    );
+    let retiring_node_id = indexer_node_ids[0].clone();
+    let surviving_node_id = indexer_node_ids[1].clone();
+    let retiring_client = sandbox
+        .rest_client_for_node(&retiring_node_id)
+        .expect("the retiring node should have a REST client");
+    let surviving_client = sandbox
+        .rest_client_for_node(&surviving_node_id)
+        .expect("the surviving node should have a REST client");
+
+    // Precondition: each indexer is indexing a shard.
+    wait_until_predicate(
+        || async {
+            match retiring_client.node_stats().indexing().await {
+                Ok(counters) => counters.num_running_pipelines >= 1,
+                Err(_) => false,
+            }
+        },
+        Duration::from_secs(20),
+        Duration::from_millis(200),
+    )
+    .await
+    .expect("the indexer we are about to retire should be indexing a shard");
+    wait_until_predicate(
+        || async {
+            match surviving_client.node_stats().indexing().await {
+                Ok(counters) => counters.num_running_pipelines >= 1,
+                Err(_) => false,
+            }
+        },
+        Duration::from_secs(20),
+        Duration::from_millis(200),
+    )
+    .await
+    .expect("the surviving indexer should also be indexing a shard");
+
+    // Decommission the retiring node and AWAIT its full graceful shutdown. The surviving indexer
+    // must drain the reassigned shard so the retiring ingester reaches `is_indexed`.
+    let shutdown_handle = sandbox
+        .remove_node(&retiring_node_id)
+        .expect("the retiring node should be in the sandbox");
+    tokio::time::timeout(Duration::from_secs(30), shutdown_handle.shutdown())
+        .await
+        .expect("graceful decommission of the retiring indexer timed out")
+        .expect("retiring indexer shutdown returned an error");
+
+    // No data lost: all 6 docs remain searchable after the decommission.
+    wait_until_predicate(
+        || async {
+            match sandbox
+                .rest_client(QuickwitService::Searcher)
+                .search(
+                    index_id,
+                    quickwit_serve::SearchRequestQueryString {
+                        query: "*".to_string(),
+                        max_hits: 10,
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                Ok(resp) => resp.num_hits == 6,
+                Err(_) => false,
+            }
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(500),
+    )
+    .await
+    .expect("all 6 documents should be searchable after decommission");
+
+    // Clean shutdown of the remaining nodes (also exercises decommissioning the last indexer).
+    tokio::time::timeout(Duration::from_secs(30), sandbox.shutdown())
+        .await
+        .expect("cluster shutdown timed out")
+        .expect("cluster shutdown failed");
+}
+
 /// Verifies that after deleting an index and recreating it with the same name,
 /// ingest works correctly once the capacity broadcast has propagated (>2 broadcast
 /// cycles). Uses 2 ingesters to exercise the Chitchat broadcast path.

--- a/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/ingest_v2_tests.rs
@@ -1143,8 +1143,8 @@ async fn test_retiring_indexer_receives_empty_plan() {
                 Err(_) => false,
             }
         },
-        Duration::from_millis(100),
-        Duration::from_millis(1),
+        Duration::from_secs(1),
+        Duration::from_millis(25),
     )
     .await
     .expect("the indexer we are about to retire should be indexing a shard");
@@ -1155,8 +1155,8 @@ async fn test_retiring_indexer_receives_empty_plan() {
                 Err(_) => false,
             }
         },
-        Duration::from_millis(100),
-        Duration::from_millis(1),
+        Duration::from_secs(1),
+        Duration::from_millis(25),
     )
     .await
     .expect("the surviving indexer should also be indexing a shard");
@@ -1178,8 +1178,8 @@ async fn test_retiring_indexer_receives_empty_plan() {
                 Err(_) => false,
             }
         },
-        Duration::from_millis(100),
-        Duration::from_millis(1),
+        Duration::from_secs(1),
+        Duration::from_millis(25),
     )
     .await
     .expect("retiring indexer should be sent an empty plan and shut down its indexing pipelines");
@@ -1264,8 +1264,8 @@ async fn test_retiring_indexer_decommissions_gracefully() {
                 Err(_) => false,
             }
         },
-        Duration::from_millis(200),
-        Duration::from_millis(1),
+        Duration::from_secs(1),
+        Duration::from_millis(25),
     )
     .await
     .expect("the indexer we are about to retire should be indexing a shard");
@@ -1276,8 +1276,8 @@ async fn test_retiring_indexer_decommissions_gracefully() {
                 Err(_) => false,
             }
         },
-        Duration::from_millis(200),
-        Duration::from_millis(1),
+        Duration::from_secs(1),
+        Duration::from_millis(25),
     )
     .await
     .expect("the surviving indexer should also be indexing a shard");

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1556,8 +1556,10 @@ mod tests {
     use quickwit_common::{ServiceStream, assert_eventually};
     use quickwit_config::SearcherConfig;
     use quickwit_metastore::{IndexMetadata, metastore_for_test};
+    use quickwit_proto::indexing::IndexingTask;
     use quickwit_proto::ingest::ingester::{MockIngesterService, ObservationMessage};
     use quickwit_proto::metastore::{ListIndexesMetadataResponse, MockMetastoreService};
+    use quickwit_proto::types::{IndexUid, PipelineUid};
     use quickwit_search::Job;
     use tokio::sync::watch;
     use tonic::transport::{Channel, Server};
@@ -1700,57 +1702,103 @@ mod tests {
             node_config.grpc_config.max_message_size,
         );
 
-        // adding a indexer node refreshes the indexer pool
-        let new_indexer_node = ClusterNode::for_test(
-            "test-indexer-node",
-            1,
-            true,
-            &["indexer"],
-            &[],
-            IngesterStatus::Ready,
-        )
-        .await;
+        let node_id = NodeId::from_str("test-indexer-node");
+        // Distinct pipeline UIDs so the two tasks are stored under distinct chitchat keys.
+        let make_task = |source_id: &str, pipeline_uid: u128| IndexingTask {
+            index_uid: Some(IndexUid::for_test("test-index", 0)),
+            source_id: source_id.to_string(),
+            pipeline_uid: Some(PipelineUid::for_test(pipeline_uid)),
+            shard_ids: Vec::new(),
+            params_fingerprint: 0,
+        };
+        let build_node = async |tasks: &[IndexingTask], status: IngesterStatus| {
+            ClusterNode::for_test("test-indexer-node", 1, true, &["indexer"], tasks, status).await
+        };
+        // Reads the pool entry's sorted source IDs, or an empty vec if the node is absent.
+        let pool_source_ids = || {
+            let Some(entry) = indexer_pool.get(&node_id) else {
+                return Vec::new();
+            };
+            let mut source_ids: Vec<String> = entry
+                .indexing_tasks
+                .iter()
+                .map(|task| task.source_id.clone())
+                .collect();
+            source_ids.sort();
+            source_ids
+        };
+
+        let indexing_tasks = vec![make_task("source-1", 1), make_task("source-2", 2)];
+
+        // A node first joins ready with no assigned plan.
+        let ready_no_plan = build_node(&[], IngesterStatus::Ready).await;
         cluster_change_stream_tx
-            .send(ClusterChange::Add(new_indexer_node.clone()))
+            .send(ClusterChange::Add(ready_no_plan.clone()))
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(1)).await;
+        assert_eventually!(indexer_pool.len() == 1);
+        {
+            let entry = indexer_pool
+                .get(&node_id)
+                .expect("indexer node should be in the pool");
+            assert_eq!(entry.ingester_status, IngesterStatus::Ready);
+            assert!(entry.indexing_tasks.is_empty());
+        }
 
-        assert_eq!(indexer_pool.len(), 1);
-
-        // changing the ingester status of an indexer node refreshes the indexer pool
-        let updated_indexer_node = ClusterNode::for_test(
-            "test-indexer-node",
-            1,
-            true,
-            &["indexer"],
-            &[],
-            IngesterStatus::Retiring,
-        )
-        .await;
+        // The control plane assigns it an indexing plan: the new plan must be reflected.
+        let ready_with_plan = build_node(&indexing_tasks, IngesterStatus::Ready).await;
         cluster_change_stream_tx
             .send(ClusterChange::Update {
-                previous: new_indexer_node.clone(),
-                updated: updated_indexer_node.clone(),
+                previous: ready_no_plan,
+                updated: ready_with_plan.clone(),
             })
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(1)).await;
+        assert_eventually!(pool_source_ids() == ["source-1", "source-2"]);
+        {
+            let entry = indexer_pool
+                .get(&node_id)
+                .expect("indexer node should be in the pool");
+            assert_eq!(entry.ingester_status, IngesterStatus::Ready);
+            assert_eq!(indexer_pool.len(), 1);
+        }
 
-        assert_eq!(indexer_pool.len(), 1);
-        assert_eq!(
-            indexer_pool
-                .get(&NodeId::from_str("test-indexer-node"))
-                .expect("indexer node should be in the pool")
-                .ingester_status,
-            IngesterStatus::Retiring
-        );
-
-        // removing an indexer node refreshes the indexer pool
+        // The node begins retiring while still owning its plan: the status change is applied and
+        // the plan is preserved.
+        let retiring_with_plan = build_node(&indexing_tasks, IngesterStatus::Retiring).await;
         cluster_change_stream_tx
-            .send(ClusterChange::Remove(new_indexer_node))
+            .send(ClusterChange::Update {
+                previous: ready_with_plan,
+                updated: retiring_with_plan.clone(),
+            })
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(1)).await;
+        assert_eventually!(matches!(
+            indexer_pool.get(&node_id),
+            Some(entry) if entry.ingester_status == IngesterStatus::Retiring
+        ));
+        assert_eq!(pool_source_ids(), ["source-1", "source-2"]);
+        assert_eq!(indexer_pool.len(), 1);
 
-        assert!(indexer_pool.is_empty());
+        // The node transitions to decommissioning and sheds its plan: both the status and the
+        // now-empty plan must be reflected.
+        let decommissioning_no_plan = build_node(&[], IngesterStatus::Decommissioning).await;
+        cluster_change_stream_tx
+            .send(ClusterChange::Update {
+                previous: retiring_with_plan,
+                updated: decommissioning_no_plan.clone(),
+            })
+            .unwrap();
+        assert_eventually!(matches!(
+            indexer_pool.get(&node_id),
+            Some(entry)
+                if entry.ingester_status == IngesterStatus::Decommissioning
+                    && entry.indexing_tasks.is_empty()
+        ));
+        assert_eq!(indexer_pool.len(), 1);
+
+        // Removing the node clears the pool.
+        cluster_change_stream_tx
+            .send(ClusterChange::Remove(decommissioning_no_plan))
+            .unwrap();
+        assert_eventually!(indexer_pool.is_empty());
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1703,13 +1703,13 @@ mod tests {
         );
 
         let node_id = NodeId::from_str("test-indexer-node");
-        let task = IndexingTask {
+        let plan = [IndexingTask {
             index_uid: Some(IndexUid::for_test("test-index", 0)),
             source_id: "test-source".to_string(),
             pipeline_uid: Some(PipelineUid::for_test(1)),
             shard_ids: Vec::new(),
             params_fingerprint: 0,
-        };
+        }];
         let build_node = async |tasks: &[IndexingTask], status: IngesterStatus| {
             ClusterNode::for_test("test-indexer-node", 1, true, &["indexer"], tasks, status).await
         };
@@ -1736,14 +1736,14 @@ mod tests {
         }
 
         // The control plane assigns it an indexing plan: the new plan must be reflected exactly.
-        let ready_with_plan = build_node(&[task.clone()], IngesterStatus::Ready).await;
+        let ready_with_plan = build_node(&plan, IngesterStatus::Ready).await;
         cluster_change_stream_tx
             .send(ClusterChange::Update {
                 previous: ready_no_plan,
                 updated: ready_with_plan.clone(),
             })
             .unwrap();
-        assert_eventually!(pool_tasks() == [task.clone()]);
+        assert_eventually!(pool_tasks() == plan);
         assert_eq!(
             indexer_pool
                 .get(&node_id)
@@ -1755,7 +1755,7 @@ mod tests {
 
         // The node begins retiring while still owning its plan: the status change is applied and
         // the plan is preserved.
-        let retiring_with_plan = build_node(&[task.clone()], IngesterStatus::Retiring).await;
+        let retiring_with_plan = build_node(&plan, IngesterStatus::Retiring).await;
         cluster_change_stream_tx
             .send(ClusterChange::Update {
                 previous: ready_with_plan,
@@ -1766,7 +1766,7 @@ mod tests {
             indexer_pool.get(&node_id),
             Some(entry) if entry.ingester_status == IngesterStatus::Retiring
         ));
-        assert_eq!(pool_tasks(), [task.clone()]);
+        assert_eq!(pool_tasks(), plan);
         assert_eq!(indexer_pool.len(), 1);
 
         // The node transitions to decommissioning and sheds its plan: both the status and the

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1320,10 +1320,7 @@ fn setup_indexer_pool(
                     );
                     Some(change)
                 }
-                ClusterChange::Update { previous, updated }
-                    if updated.is_indexer()
-                        && previous.ingester_status != updated.ingester_status =>
-                {
+                ClusterChange::Update { updated, .. } if updated.is_indexer() => {
                     let change = build_indexer_insert_change(
                         &updated,
                         indexing_service_clone_opt,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1703,32 +1703,23 @@ mod tests {
         );
 
         let node_id = NodeId::from_str("test-indexer-node");
-        // Distinct pipeline UIDs so the two tasks are stored under distinct chitchat keys.
-        let make_task = |source_id: &str, pipeline_uid: u128| IndexingTask {
+        let task = IndexingTask {
             index_uid: Some(IndexUid::for_test("test-index", 0)),
-            source_id: source_id.to_string(),
-            pipeline_uid: Some(PipelineUid::for_test(pipeline_uid)),
+            source_id: "test-source".to_string(),
+            pipeline_uid: Some(PipelineUid::for_test(1)),
             shard_ids: Vec::new(),
             params_fingerprint: 0,
         };
         let build_node = async |tasks: &[IndexingTask], status: IngesterStatus| {
             ClusterNode::for_test("test-indexer-node", 1, true, &["indexer"], tasks, status).await
         };
-        // Reads the pool entry's sorted source IDs, or an empty vec if the node is absent.
-        let pool_source_ids = || {
-            let Some(entry) = indexer_pool.get(&node_id) else {
-                return Vec::new();
-            };
-            let mut source_ids: Vec<String> = entry
-                .indexing_tasks
-                .iter()
-                .map(|task| task.source_id.clone())
-                .collect();
-            source_ids.sort();
-            source_ids
+        // Reads the pool entry's indexing tasks, or an empty vec if the node is absent.
+        let pool_tasks = || {
+            indexer_pool
+                .get(&node_id)
+                .map(|entry| entry.indexing_tasks.clone())
+                .unwrap_or_default()
         };
-
-        let indexing_tasks = vec![make_task("source-1", 1), make_task("source-2", 2)];
 
         // A node first joins ready with no assigned plan.
         let ready_no_plan = build_node(&[], IngesterStatus::Ready).await;
@@ -1744,26 +1735,27 @@ mod tests {
             assert!(entry.indexing_tasks.is_empty());
         }
 
-        // The control plane assigns it an indexing plan: the new plan must be reflected.
-        let ready_with_plan = build_node(&indexing_tasks, IngesterStatus::Ready).await;
+        // The control plane assigns it an indexing plan: the new plan must be reflected exactly.
+        let ready_with_plan = build_node(&[task.clone()], IngesterStatus::Ready).await;
         cluster_change_stream_tx
             .send(ClusterChange::Update {
                 previous: ready_no_plan,
                 updated: ready_with_plan.clone(),
             })
             .unwrap();
-        assert_eventually!(pool_source_ids() == ["source-1", "source-2"]);
-        {
-            let entry = indexer_pool
+        assert_eventually!(pool_tasks() == [task.clone()]);
+        assert_eq!(
+            indexer_pool
                 .get(&node_id)
-                .expect("indexer node should be in the pool");
-            assert_eq!(entry.ingester_status, IngesterStatus::Ready);
-            assert_eq!(indexer_pool.len(), 1);
-        }
+                .expect("indexer node should be in the pool")
+                .ingester_status,
+            IngesterStatus::Ready
+        );
+        assert_eq!(indexer_pool.len(), 1);
 
         // The node begins retiring while still owning its plan: the status change is applied and
         // the plan is preserved.
-        let retiring_with_plan = build_node(&indexing_tasks, IngesterStatus::Retiring).await;
+        let retiring_with_plan = build_node(&[task.clone()], IngesterStatus::Retiring).await;
         cluster_change_stream_tx
             .send(ClusterChange::Update {
                 previous: ready_with_plan,
@@ -1774,7 +1766,7 @@ mod tests {
             indexer_pool.get(&node_id),
             Some(entry) if entry.ingester_status == IngesterStatus::Retiring
         ));
-        assert_eq!(pool_source_ids(), ["source-1", "source-2"]);
+        assert_eq!(pool_tasks(), [task.clone()]);
         assert_eq!(indexer_pool.len(), 1);
 
         // The node transitions to decommissioning and sheds its plan: both the status and the


### PR DESCRIPTION
### Description

Fixes two bugs:

1. https://github.com/quickwit-oss/quickwit/pull/6185 made it so that cluster updates only fire when ingester status changes. This made it so that the reported indexing plan coming from indexers wasn't being updated. Specifically, this appeared when a node was decommissioned, its shards got reassigned, and the new indexer the shards got reassigned finished indexing the shard, and deleted it; in these cases, the control plane running plan loop would see that it wasn't up to date and fire a bunch of reapply plan requests. 
    * Fixed by updating on all indexer changes, as before

2. `is_indexed` is broken for empty shards as of https://github.com/quickwit-oss/quickwit/pull/6504 - `self.truncation_position_inclusive.is_eof()` can't hit because it's necessarily `Position::Beginning`.
    * Fixed by checking the truncation and replication position in is_indexed instead.
    
### How was this PR tested?
Unit tested and integration tested.

I ran a test on a local cluster with all services on one node, and then one service per node with multiple indexers; the test decommissioned one node at a time the way a deployment would, and eventually closed the last one too. In these tests, the number of searchable docs was the same as the number acked on ingest. I also set min shards to be higher than the number of indexers and sent less docs than the number of shards to confirm that empty shards truncate and delete gracefully; everything worked as intended in the test.