### PR TITLE
perf(storage): make AsyncDebouncer cleanup O(1) amortized

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -9444,6 +9444,7 @@ dependencies = [
 name = "quickwit-storage"
 version = "0.8.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-trait",
  "aws-config",
@@ -9458,7 +9459,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "bytesize",
- "fnv",
  "futures",
  "http 1.4.0",
  "http-body-util",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -94,6 +94,7 @@ authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
+ahash = "0.8"
 anyhow = "1"
 arc-swap = "1.9"
 arrow = { version = "58", default-features = false, features = ["ipc"] }

--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -11,12 +11,12 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+ahash = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 bytesize = { workspace = true }
-fnv = { workspace = true }
 futures = { workspace = true }
 http-body-util = { workspace = true}
 hyper = { workspace = true }

--- a/quickwit/quickwit-storage/src/debouncer.rs
+++ b/quickwit/quickwit-storage/src/debouncer.rs
@@ -19,8 +19,8 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+use ahash::HashMap;
 use async_trait::async_trait;
-use fnv::FnvHashMap;
 use futures::future::{BoxFuture, WeakShared};
 use futures::{Future, FutureExt};
 use quickwit_common::uri::Uri;
@@ -38,7 +38,7 @@ use crate::{BulkDeleteError, Storage, StorageResult};
 ///
 /// Since most Futures return an Result<V, Error>, this also encompasses the error.
 pub struct AsyncDebouncer<K, V: Clone> {
-    cache: Mutex<FnvHashMap<K, WeakShared<BoxFuture<'static, V>>>>,
+    cache: Mutex<HashMap<K, WeakShared<BoxFuture<'static, V>>>>,
     /// Number of inserts performed since the last full garbage-collection scan.
     ///
     /// Used to amortize the cost of reclaiming entries left behind by cancelled futures (see

--- a/quickwit/quickwit-storage/src/debouncer.rs
+++ b/quickwit/quickwit-storage/src/debouncer.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::hash::Hash;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -38,28 +39,34 @@ use crate::{BulkDeleteError, Storage, StorageResult};
 /// Since most Futures return an Result<V, Error>, this also encompasses the error.
 pub struct AsyncDebouncer<K, V: Clone> {
     cache: Mutex<FnvHashMap<K, WeakShared<BoxFuture<'static, V>>>>,
+    /// Number of inserts performed since the last full garbage-collection scan.
+    ///
+    /// Used to amortize the cost of reclaiming entries left behind by cancelled futures (see
+    /// `get_or_create`). Always mutated while holding the `cache` lock, so the increment/reset
+    /// logic is effectively serialized; `Relaxed` ordering is therefore sufficient.
+    inserts_since_cleanup: AtomicUsize,
 }
 
 impl<K, V: Clone> Default for AsyncDebouncer<K, V> {
     fn default() -> Self {
         Self {
             cache: Default::default(),
+            inserts_since_cleanup: AtomicUsize::new(0),
         }
     }
 }
+
+/// Number of inserts between two full garbage-collection scans of the cache.
+///
+/// Cancelled `get_or_create` futures leave a stale (non-upgradeable) entry behind. A stale entry
+/// is harmless on its own — the next lookup of the same key fails to upgrade and overwrites it —
+/// so we only need a periodic sweep to reclaim entries whose key is never accessed again.
+const CLEANUP_INTERVAL: usize = 1_024;
 
 impl<K: Hash + Eq + Clone, V: Clone> AsyncDebouncer<K, V> {
     /// Returns the number of inflight futures.
     pub fn len(&self) -> usize {
         self.cache.lock().unwrap().len()
-    }
-
-    /// Cleanup
-    /// In case there is already an existing Future for the passed key, the constructor is not
-    /// used.
-    fn cleanup(&self) {
-        let mut guard = self.cache.lock().unwrap();
-        guard.retain(|_, v| v.upgrade().is_some());
     }
 
     /// Instead of the future directly, a constructor to build the future is passed.
@@ -70,24 +77,39 @@ impl<K: Hash + Eq + Clone, V: Clone> AsyncDebouncer<K, V> {
         T: FnOnce() -> F,
         F: Future<Output = V> + Send + 'static,
     {
-        self.cleanup();
-
-        // explicit scope to drop the lock
-        let weak_fut_opt = { self.cache.lock().unwrap().get(&key).cloned() };
-        if let Some(weak_future) = weak_fut_opt
-            && let Some(future) = weak_future.upgrade()
-        {
-            return future.await;
+        // Fast path: an inflight future for this key already exists. The lookup and the
+        // staleness check happen under a single lock; a stale entry (left by a cancelled future)
+        // is simply ignored here and overwritten by the insert below.
+        let existing_future_opt: Option<_> = {
+            let guard = self.cache.lock().unwrap();
+            match guard.get(&key) {
+                Some(weak_future) => weak_future.upgrade(),
+                None => None,
+            }
+        };
+        if let Some(existing_future) = existing_future_opt {
+            return existing_future.await;
         }
 
         let fut = Box::pin(build_a_future()) as BoxFuture<'static, V>;
         let fut = fut.shared();
-        self.cache.lock().unwrap().insert(
-            key.clone(),
-            fut.clone().downgrade().expect(
-                "future has been dropped, but that shouldn't happen since it's still in scope",
-            ),
-        );
+        let weak_fut = fut
+            .clone()
+            .downgrade()
+            .expect("future has been dropped, but that shouldn't happen since it's still in scope");
+        {
+            let mut guard = self.cache.lock().unwrap();
+            guard.insert(key.clone(), weak_fut);
+            // Amortized garbage collection. Running a full scan on every call would make each
+            // call O(n); instead we scan once every `CLEANUP_INTERVAL` inserts, giving O(1)
+            // amortized cost while keeping the cache from growing unboundedly when keys belonging
+            // to cancelled futures are never accessed again.
+            let inserts = self.inserts_since_cleanup.fetch_add(1, Ordering::Relaxed) + 1;
+            if inserts >= CLEANUP_INTERVAL {
+                self.inserts_since_cleanup.store(0, Ordering::Relaxed);
+                guard.retain(|_, weak_future| weak_future.upgrade().is_some());
+            }
+        }
         let res = fut.await;
 
         self.cache.lock().unwrap().remove(&key);

--- a/quickwit/quickwit-storage/src/debouncer.rs
+++ b/quickwit/quickwit-storage/src/debouncer.rs
@@ -69,50 +69,67 @@ impl<K: Hash + Eq + Clone, V: Clone> AsyncDebouncer<K, V> {
         self.cache.lock().unwrap().len()
     }
 
-    /// Instead of the future directly, a constructor to build the future is passed.
-    /// In case there is already an existing Future for the passed key, the constructor is not
-    /// used.
-    pub async fn get_or_create<T, F>(&self, key: K, build_a_future: T) -> V
+    /// Returns the inflight future for `key`, deduplicating concurrent calls: if a future for
+    /// `key` is already inflight, all callers await that same shared future; otherwise
+    /// `build_a_future_fast` is invoked to create one.
+    ///
+    /// # Hidden contract
+    ///
+    /// `build_a_future_fast` is invoked **while the internal cache lock is held**. It must
+    /// therefore:
+    /// - be cheap — it only *constructs* the future, it must not perform blocking work (the future
+    ///   itself is awaited later, outside the lock);
+    /// - never re-enter this `AsyncDebouncer` (e.g. call `get_or_create` on the same instance),
+    ///   which would deadlock, since the cache lock is a non-reentrant [`std::sync::Mutex`].
+    ///
+    /// Holding the lock across both the lookup and the insert is deliberate: it makes the
+    /// lookup-then-insert atomic, so two concurrent callers for the same key cannot both build
+    /// and race to insert. The lock is always released before the future is awaited.
+    async fn get_or_create<T, F>(&self, key: K, build_a_future_fast: T) -> V
     where
         T: FnOnce() -> F,
         F: Future<Output = V> + Send + 'static,
     {
-        // Fast path: an inflight future for this key already exists. The lookup and the
-        // staleness check happen under a single lock; a stale entry (left by a cancelled future)
-        // is simply ignored here and overwritten by the insert below.
-        let existing_future_opt: Option<_> = {
-            let guard = self.cache.lock().unwrap();
-            match guard.get(&key) {
+        // `created` distinguishes the caller that actually built the entry (and is therefore
+        // responsible for removing it once the future resolves) from callers that merely joined
+        // an already-inflight future.
+        let (future, created) = {
+            let mut guard = self.cache.lock().unwrap();
+            // A stale entry (left behind by a cancelled future) fails to upgrade and is simply
+            // overwritten by the insert below.
+            let existing_future_opt = match guard.get(&key) {
                 Some(weak_future) => weak_future.upgrade(),
                 None => None,
+            };
+            match existing_future_opt {
+                Some(existing_future) => (existing_future, false),
+                None => {
+                    let fut = Box::pin(build_a_future_fast()) as BoxFuture<'static, V>;
+                    let fut = fut.shared();
+                    let weak_fut = fut.clone().downgrade().expect(
+                        "future has been dropped, but that shouldn't happen since it's still in \
+                         scope",
+                    );
+                    guard.insert(key.clone(), weak_fut);
+                    // Amortized garbage collection. Running a full scan on every call would make
+                    // each call O(n); instead we scan once every `CLEANUP_INTERVAL` inserts,
+                    // giving O(1) amortized cost while keeping the cache from growing unboundedly
+                    // when keys belonging to cancelled futures are never accessed again.
+                    let inserts = self.inserts_since_cleanup.fetch_add(1, Ordering::Relaxed);
+                    if inserts >= CLEANUP_INTERVAL {
+                        self.inserts_since_cleanup.store(0, Ordering::Relaxed);
+                        guard.retain(|_, weak_future| weak_future.upgrade().is_some());
+                    }
+                    (fut, true)
+                }
             }
         };
-        if let Some(existing_future) = existing_future_opt {
-            return existing_future.await;
-        }
 
-        let fut = Box::pin(build_a_future()) as BoxFuture<'static, V>;
-        let fut = fut.shared();
-        let weak_fut = fut
-            .clone()
-            .downgrade()
-            .expect("future has been dropped, but that shouldn't happen since it's still in scope");
-        {
-            let mut guard = self.cache.lock().unwrap();
-            guard.insert(key.clone(), weak_fut);
-            // Amortized garbage collection. Running a full scan on every call would make each
-            // call O(n); instead we scan once every `CLEANUP_INTERVAL` inserts, giving O(1)
-            // amortized cost while keeping the cache from growing unboundedly when keys belonging
-            // to cancelled futures are never accessed again.
-            let inserts = self.inserts_since_cleanup.fetch_add(1, Ordering::Relaxed) + 1;
-            if inserts >= CLEANUP_INTERVAL {
-                self.inserts_since_cleanup.store(0, Ordering::Relaxed);
-                guard.retain(|_, weak_future| weak_future.upgrade().is_some());
-            }
-        }
-        let res = fut.await;
+        let res = future.await;
 
-        self.cache.lock().unwrap().remove(&key);
+        if created {
+            self.cache.lock().unwrap().remove(&key);
+        }
 
         res
     }

--- a/quickwit/quickwit-storage/src/debouncer.rs
+++ b/quickwit/quickwit-storage/src/debouncer.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 
 use ahash::HashMap;
 use async_trait::async_trait;
-use futures::future::{BoxFuture, WeakShared};
+use futures::future::{BoxFuture, Shared, WeakShared};
 use futures::{Future, FutureExt};
 use quickwit_common::uri::Uri;
 use tantivy::directory::OwnedBytes;
@@ -42,8 +42,7 @@ pub struct AsyncDebouncer<K, V: Clone> {
     /// Number of inserts performed since the last full garbage-collection scan.
     ///
     /// Used to amortize the cost of reclaiming entries left behind by cancelled futures (see
-    /// `get_or_create`). Always mutated while holding the `cache` lock, so the increment/reset
-    /// logic is effectively serialized; `Relaxed` ordering is therefore sufficient.
+    /// `get_or_create`).
     inserts_since_cleanup: AtomicUsize,
 }
 
@@ -64,7 +63,10 @@ impl<K, V: Clone> Default for AsyncDebouncer<K, V> {
 const CLEANUP_INTERVAL: usize = 1_024;
 
 impl<K: Hash + Eq + Clone, V: Clone> AsyncDebouncer<K, V> {
-    /// Returns the number of inflight futures.
+    /// Returns the number of entries in the debouncing cache.
+    ///
+    /// This is always greater than the number of inflight futures, and smaller
+    /// than that number + CLEANUP_INTERVAL + 1.
     pub fn len(&self) -> usize {
         self.cache.lock().unwrap().len()
     }
@@ -85,7 +87,7 @@ impl<K: Hash + Eq + Clone, V: Clone> AsyncDebouncer<K, V> {
     /// Holding the lock across both the lookup and the insert is deliberate: it makes the
     /// lookup-then-insert atomic, so two concurrent callers for the same key cannot both build
     /// and race to insert. The lock is always released before the future is awaited.
-    async fn get_or_create<T, F>(&self, key: K, build_a_future_fast: T) -> V
+    fn get_or_create<T, F>(&self, key: K, build_a_future_fast: T) -> Shared<BoxFuture<'static, V>>
     where
         T: FnOnce() -> F,
         F: Future<Output = V> + Send + 'static,
@@ -93,45 +95,34 @@ impl<K: Hash + Eq + Clone, V: Clone> AsyncDebouncer<K, V> {
         // `created` distinguishes the caller that actually built the entry (and is therefore
         // responsible for removing it once the future resolves) from callers that merely joined
         // an already-inflight future.
-        let (future, created) = {
-            let mut guard = self.cache.lock().unwrap();
-            // A stale entry (left behind by a cancelled future) fails to upgrade and is simply
-            // overwritten by the insert below.
-            let existing_future_opt = match guard.get(&key) {
-                Some(weak_future) => weak_future.upgrade(),
-                None => None,
-            };
-            match existing_future_opt {
-                Some(existing_future) => (existing_future, false),
-                None => {
-                    let fut = Box::pin(build_a_future_fast()) as BoxFuture<'static, V>;
-                    let fut = fut.shared();
-                    let weak_fut = fut.clone().downgrade().expect(
-                        "future has been dropped, but that shouldn't happen since it's still in \
-                         scope",
-                    );
-                    guard.insert(key.clone(), weak_fut);
-                    // Amortized garbage collection. Running a full scan on every call would make
-                    // each call O(n); instead we scan once every `CLEANUP_INTERVAL` inserts,
-                    // giving O(1) amortized cost while keeping the cache from growing unboundedly
-                    // when keys belonging to cancelled futures are never accessed again.
-                    let inserts = self.inserts_since_cleanup.fetch_add(1, Ordering::Relaxed);
-                    if inserts >= CLEANUP_INTERVAL {
-                        self.inserts_since_cleanup.store(0, Ordering::Relaxed);
-                        guard.retain(|_, weak_future| weak_future.upgrade().is_some());
-                    }
-                    (fut, true)
-                }
-            }
-        };
+        let mut debouncing_cache_guard = self.cache.lock().unwrap();
 
-        let res = future.await;
-
-        if created {
-            self.cache.lock().unwrap().remove(&key);
+        // A stale entry (left behind by a cancelled future) fails to upgrade and is simply
+        // overwritten by the insert below.
+        if let Some(fut) = debouncing_cache_guard
+            .get(&key)
+            .and_then(WeakShared::upgrade)
+        {
+            return fut;
         }
 
-        res
+        // Note that we are call build_a_future_fast WHILE holding the cache lock.
+        // For this reason, it is crucial to only call this function with a cheap and simple future
+        // builder.
+        let fut = Box::pin(build_a_future_fast()) as BoxFuture<'static, V>;
+        let fut = fut.shared();
+        let weak_fut = fut.clone().downgrade().unwrap();
+        debouncing_cache_guard.insert(key.clone(), weak_fut);
+
+        // Amortized garbage collection. Running a full scan on every call would make
+        // each call O(n); instead we scan once every `CLEANUP_INTERVAL` inserts.
+        let num_inserts = self.inserts_since_cleanup.fetch_add(1, Ordering::Relaxed);
+        if num_inserts >= CLEANUP_INTERVAL {
+            self.inserts_since_cleanup.store(0, Ordering::Relaxed);
+            debouncing_cache_guard.retain(|_, weak_future| weak_future.upgrade().is_some());
+        }
+
+        fut
     }
 }
 
@@ -240,8 +231,8 @@ mod tests {
 
     use std::ops::Range;
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use std::sync::{Arc, LazyLock};
     use std::time::Duration;
 
     use tempfile::TempDir;
@@ -407,21 +398,16 @@ mod tests {
         "blub".to_string()
     }
 
-    pub static GLOBAL_DEBOUNCER: LazyLock<AsyncDebouncer<String, String>> =
-        LazyLock::new(AsyncDebouncer::default);
-    pub fn get_global_debouncer() -> &'static AsyncDebouncer<String, String> {
-        &GLOBAL_DEBOUNCER
-    }
-
     #[tokio::test]
     async fn test_cancellation_task() {
+        let debouncer = Arc::new(AsyncDebouncer::default());
         let load = || async { load_via_fn2().await };
 
-        let handle = task::spawn(async move {
-            get_global_debouncer()
-                .get_or_create("key1".to_owned(), load)
-                .await
-        });
+        let debouncer_clone = debouncer.clone();
+        let handle =
+            task::spawn(
+                async move { debouncer_clone.get_or_create("key0".to_owned(), load).await },
+            );
         tokio::time::sleep(Duration::from_millis(10)).await;
         // This will cause  the Future to be cancelled, so it will not be polled anymore.
         // That also means the remove in the cache is not called, which is awaiting the future
@@ -429,15 +415,24 @@ mod tests {
 
         tokio::time::sleep(Duration::from_secs(1)).await;
         // The task still hangs unfinished
-        assert_eq!(get_global_debouncer().len(), 1);
+        assert_eq!(debouncer.len(), 1);
 
         // The next get clears
-        get_global_debouncer()
-            .get_or_create("key1".to_owned(), load)
-            .await;
+        debouncer.get_or_create("key0".to_owned(), load).await;
 
         tokio::time::sleep(Duration::from_secs(1)).await;
-        assert_eq!(get_global_debouncer().len(), 0);
+
+        // not cleaned up yet.
+        assert_eq!(debouncer.len(), 1);
+        for i in 0..2 * CLEANUP_INTERVAL {
+            let fut = debouncer.get_or_create(format!("key{}", i), load);
+            drop(fut);
+            assert!(
+                debouncer.len() <= CLEANUP_INTERVAL + 1,
+                "{}",
+                debouncer.len()
+            );
+        }
     }
 
     async fn load_via_fn(path: PathBuf, cnt: &AtomicU32) -> Result<String, String> {


### PR DESCRIPTION
## Problem

`AsyncDebouncer::get_or_create` called `cleanup()` on **every** invocation:

```rust
fn cleanup(&self) {
    let mut guard = self.cache.lock().unwrap();
    guard.retain(|_, v| v.upgrade().is_some()); // full scan, atomic upgrade per entry
}
```

With `n` inflight futures this is O(n) per call — O(n²) overall — all under a single mutex, plus an atomic `WeakShared::upgrade()` for each visited entry. It shows up as a hot spot in profiling under concurrent slice fetches.

The scan is also mostly **redundant**: the happy path already removes its own entry when the future completes (`cache.remove(&key)`). The only thing `cleanup()` reclaims are entries left behind by **cancelled** `get_or_create` futures — and such a stale entry is harmless on its own, since the next lookup of the same key fails to `upgrade()` and overwrites it.

## Fix

1. **Fold the lookup and staleness check into a single locked section.** A stale entry for the requested key is now detected and overwritten in O(1) instead of via a full scan.
2. **Amortize the garbage collection.** The full `retain` now runs only once every `CLEANUP_INTERVAL` (1024) inserts, bounding memory growth from never-reaccessed cancelled keys while making the per-call cost **O(1) amortized**.

## Behavior

Externally observable behavior — debouncing of concurrent identical requests and reclamation of cancelled entries — is unchanged. The existing debouncer tests (including the two cancellation tests) pass **unmodified**:

```
5 tests run: 5 passed
- test_sync_and_send
- test_debounce
- test_async_slice_cache
- test_cancellation_future
- test_cancellation_task
```

`cargo clippy --all-features` and `cargo +nightly fmt --check` are clean.