### PR TITLE
Serialize mrecords into WAL using Protobuf

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -8903,6 +8903,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "bytesize",
+ "criterion",
  "fail",
  "futures",
  "http 1.4.0",

--- a/quickwit/quickwit-indexing/src/source/ingest/mod.rs
+++ b/quickwit/quickwit-indexing/src/source/ingest/mod.rs
@@ -1527,6 +1527,109 @@ mod tests {
         assert_eq!(shard.status, IndexingStatus::Active);
     }
 
+    // Drives the source with an `MRecordBatch` whose records are encoded with the v1
+    // (`HeaderVersion::V1`, protobuf) format, asserting they are decoded and flow through to the
+    // emitted `RawDocBatch` exactly like v0 records. This exercises the read path end to end while
+    // the write path still emits v0.
+    #[tokio::test]
+    async fn test_ingest_source_emit_batches_mrecord_v1() {
+        use quickwit_ingest::MRecord;
+
+        let pipeline_id = IndexingPipelineId {
+            node_id: NodeId::from_str("test-node"),
+            index_uid: IndexUid::for_test("test-index", 0),
+            source_id: "test-source".to_string(),
+            pipeline_uid: PipelineUid::default(),
+        };
+        let source_config = SourceConfig::for_test("test-source", SourceParams::Ingest);
+        let mock_metastore = MockMetastoreService::new();
+        let ingester_pool = IngesterPool::default();
+        let event_broker = EventBroker::default();
+
+        let source_runtime = SourceRuntime {
+            pipeline_id,
+            source_config,
+            metastore: MetastoreServiceClient::from_mock(mock_metastore),
+            ingester_pool: ingester_pool.clone(),
+            queues_dir_path: PathBuf::from("./queues"),
+            storage_resolver: StorageResolver::for_test(),
+            event_broker,
+            indexing_setting: IndexingSettings::default(),
+        };
+        let retry_params = RetryParams::for_test();
+        let mut source = IngestSource::try_new(source_runtime, retry_params)
+            .await
+            .unwrap();
+
+        let universe = Universe::with_accelerated_time();
+        let (source_mailbox, _source_inbox) = universe.create_test_mailbox::<SourceActor>();
+        let (doc_processor_mailbox, doc_processor_inbox) =
+            universe.create_test_mailbox::<DocProcessor>();
+        let source_sink = SourceSink::from(doc_processor_mailbox.clone());
+        let (observable_state_tx, _observable_state_rx) = watch::channel(serde_json::Value::Null);
+        let ctx: SourceContext =
+            ActorContext::for_test(&universe, source_mailbox, observable_state_tx);
+
+        source.assigned_shards.insert(
+            ShardId::from(1),
+            AssignedShard {
+                leader_id: NodeId::from_str("test-ingester-0"),
+                follower_id_opt: None,
+                partition_id: 1u64.into(),
+                current_position_inclusive: Position::offset(11u64),
+                status: IndexingStatus::Active,
+            },
+        );
+
+        // Build a batch of v1-encoded records: a `Doc` followed by a `Commit`.
+        let encoded_mrecords = [
+            MRecord::Doc("test-doc-v1".into()).encode_v1(),
+            MRecord::Commit.encode_v1(),
+        ];
+        let mut mrecord_buffer: Vec<u8> = Vec::new();
+        let mut mrecord_lengths: Vec<u32> = Vec::new();
+        for encoded_mrecord in &encoded_mrecords {
+            mrecord_lengths.push(encoded_mrecord.len() as u32);
+            mrecord_buffer.extend_from_slice(encoded_mrecord);
+        }
+        let mrecord_batch = Some(MRecordBatch {
+            mrecord_buffer: mrecord_buffer.into(),
+            mrecord_lengths,
+        });
+
+        let fetch_message_tx = source.fetch_stream.fetch_message_tx();
+        let fetch_payload = FetchPayload {
+            index_uid: Some(IndexUid::for_test("test-index", 0)),
+            source_id: "test-source".into(),
+            shard_id: Some(ShardId::from(1)),
+            mrecord_batch,
+            from_position_exclusive: Some(Position::offset(11u64)),
+            to_position_inclusive: Some(Position::offset(13u64)),
+        };
+        let batch_size = fetch_payload.estimate_size();
+        let fetch_message = FetchMessage::new_payload(fetch_payload);
+        let in_flight_value =
+            InFlightValue::new(fetch_message, batch_size, &IN_FLIGHT_FETCH_STREAM);
+        fetch_message_tx.send(Ok(in_flight_value)).await.unwrap();
+
+        source.emit_batches(&source_sink, &ctx).await.unwrap();
+        let doc_batch = doc_processor_inbox
+            .recv_typed_message::<RawDocBatch>()
+            .await
+            .unwrap();
+
+        // The v1 `Doc` is decoded into a document, and the v1 `Commit` forces a commit.
+        assert_eq!(doc_batch.docs.len(), 1);
+        assert_eq!(doc_batch.docs[0], "test-doc-v1");
+        assert!(doc_batch.force_commit);
+
+        let partition_deltas = doc_batch.checkpoint_delta.iter().collect::<Vec<_>>();
+        assert_eq!(partition_deltas.len(), 1);
+        assert_eq!(partition_deltas[0].0, 1u64.into());
+        assert_eq!(partition_deltas[0].1.from, Position::offset(11u64));
+        assert_eq!(partition_deltas[0].1.to, Position::offset(13u64));
+    }
+
     #[tokio::test]
     async fn test_ingest_source_emit_batches_shard_not_found() {
         let pipeline_id = IndexingPipelineId {

--- a/quickwit/quickwit-ingest/Cargo.toml
+++ b/quickwit/quickwit-ingest/Cargo.toml
@@ -45,7 +45,9 @@ quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }
 quickwit-proto = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 mockall = { workspace = true }
+mrecordlog = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 tempfile = { workspace = true }
@@ -55,6 +57,10 @@ quickwit-actors = { workspace = true, features = ["testsuite"] }
 quickwit-cluster = { workspace = true, features = ["testsuite"] }
 quickwit-common = { workspace = true, features = ["testsuite"] }
 quickwit-proto = { workspace = true, features = ["testsuite"] }
+
+[[bench]]
+name = "mrecord_bench"
+harness = false
 
 [build-dependencies]
 quickwit-codegen = { workspace = true }

--- a/quickwit/quickwit-ingest/benches/mrecord_bench.rs
+++ b/quickwit/quickwit-ingest/benches/mrecord_bench.rs
@@ -1,0 +1,184 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Before/after benchmark for the `MRecord` on-disk format: the legacy v0 raw encoding
+//! (`MRecord::encode`) versus the extensible v1 protobuf encoding (`MRecord::encode_v1`).
+//!
+//! Three groups:
+//! - `mrecord_encode` / `mrecord_decode`: per-record codec microbenchmarks (CPU only).
+//! - `mrecord_append_batch`: a batch of documents encoded and appended to a real WAL, mirroring the
+//!   write path (`append_non_empty_doc_batch`) at its production granularity.
+//!
+//! Run with: `cargo bench -p quickwit-ingest --bench mrecord_bench`
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use bytes::{BufMut, Bytes};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use mrecordlog::MultiRecordLog;
+use quickwit_ingest::MRecord;
+
+/// Representative document sizes (bytes): a small log line up to a large structured event.
+const DOC_SIZES: [usize; 4] = [128, 1_024, 8_192, 65_536];
+
+fn make_doc(size: usize) -> Bytes {
+    Bytes::from(vec![b'x'; size])
+}
+
+/// Encodes a `Doc` and drains the result into a reused buffer, modelling the cost of producing the
+/// bytes handed to the WAL plus the single copy the WAL performs on append. This is the fair
+/// apples-to-apples comparison: v0 builds a header+doc chain that is copied once into the sink,
+/// whereas v1 allocates and copies into its own buffer first and is then copied into the sink.
+fn bench_encode(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("mrecord_encode");
+    let mut sink: Vec<u8> = Vec::with_capacity(128 * 1_024);
+
+    for doc_size in DOC_SIZES {
+        let doc = make_doc(doc_size);
+        group.throughput(Throughput::Bytes(doc_size as u64));
+
+        group.bench_with_input(BenchmarkId::new("v0", doc_size), &doc, |bencher, doc| {
+            bencher.iter(|| {
+                let mut encoded = MRecord::Doc(doc.clone()).encode();
+                sink.clear();
+                sink.put(&mut encoded);
+                black_box(&sink);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("v1", doc_size), &doc, |bencher, doc| {
+            bencher.iter(|| {
+                let encoded = MRecord::Doc(doc.clone()).encode_v1();
+                sink.clear();
+                sink.put_slice(&encoded);
+                black_box(&sink);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Decodes a previously encoded `Doc`. Both formats extract the document zero-copy from a `Bytes`
+/// buffer, so this guards against a decode regression in the new format.
+fn bench_decode(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("mrecord_decode");
+
+    for doc_size in DOC_SIZES {
+        let doc = make_doc(doc_size);
+        group.throughput(Throughput::Bytes(doc_size as u64));
+
+        let mut v0_buf: Vec<u8> = Vec::new();
+        v0_buf.put(MRecord::Doc(doc.clone()).encode());
+        let v0_bytes = Bytes::from(v0_buf);
+        group.bench_with_input(
+            BenchmarkId::new("v0", doc_size),
+            &v0_bytes,
+            |bencher, bytes| {
+                bencher.iter(|| black_box(MRecord::decode(bytes.clone())));
+            },
+        );
+
+        let v1_bytes = MRecord::Doc(doc.clone()).encode_v1();
+        group.bench_with_input(
+            BenchmarkId::new("v1", doc_size),
+            &v1_bytes,
+            |bencher, bytes| {
+                bencher.iter(|| black_box(MRecord::decode(bytes.clone())));
+            },
+        );
+    }
+    group.finish();
+}
+
+const BENCH_QUEUE: &str = "bench-queue";
+
+/// Number of documents per appended batch and their (cycled) sizes in bytes, chosen to resemble a
+/// mixed observability workload rather than a single uniform size.
+const BATCH_NUM_DOCS: usize = 1_000;
+const BATCH_DOC_SIZES: [usize; 5] = [100, 250, 500, 1_000, 2_000];
+
+/// Builds the batch of documents and returns it alongside the total payload size in bytes (used for
+/// throughput).
+fn make_batch() -> (Vec<Bytes>, u64) {
+    let mut docs = Vec::with_capacity(BATCH_NUM_DOCS);
+    let mut total_bytes = 0u64;
+    for index in 0..BATCH_NUM_DOCS {
+        let doc_size = BATCH_DOC_SIZES[index % BATCH_DOC_SIZES.len()];
+        total_bytes += doc_size as u64;
+        docs.push(make_doc(doc_size));
+    }
+    (docs, total_bytes)
+}
+
+/// Opens a fresh WAL backed by a temporary directory, using the same persist policy as production
+/// (`PersistPolicy::Always(PersistAction::Flush)`, the default of `MultiRecordLog::open`). The
+/// returned `TempDir` must be kept alive for the lifetime of the WAL.
+fn open_bench_wal() -> (tempfile::TempDir, MultiRecordLog) {
+    let tempdir = tempfile::tempdir().expect("failed to create temp dir");
+    let mut wal = MultiRecordLog::open(tempdir.path()).expect("failed to open WAL");
+    wal.create_queue(BENCH_QUEUE)
+        .expect("failed to create queue");
+    (tempdir, wal)
+}
+
+/// Encodes a batch of documents and appends it to a real WAL, mirroring the write path. Only the
+/// encode + append is timed; opening the WAL and tearing it down happen outside the measured region
+/// (which also avoids accumulating open files or disk usage across iterations).
+fn bench_append_batch(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("mrecord_append_batch");
+    let (docs, total_bytes) = make_batch();
+    group.throughput(Throughput::Bytes(total_bytes));
+    // The WAL is re-created (untimed) on every iteration, so keep the iteration count modest.
+    group.sample_size(20);
+
+    group.bench_function("v0", |bencher| {
+        bencher.iter_custom(|iters| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iters {
+                let (_tempdir, mut wal) = open_bench_wal();
+                let start = Instant::now();
+                let encoded_mrecords = docs.iter().map(|doc| MRecord::Doc(doc.clone()).encode());
+                let outcome = wal
+                    .append_records(BENCH_QUEUE, None, encoded_mrecords)
+                    .expect("failed to append records");
+                elapsed += start.elapsed();
+                black_box(outcome);
+            }
+            elapsed
+        });
+    });
+
+    group.bench_function("v1", |bencher| {
+        bencher.iter_custom(|iters| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iters {
+                let (_tempdir, mut wal) = open_bench_wal();
+                let start = Instant::now();
+                let encoded_mrecords = docs.iter().map(|doc| MRecord::Doc(doc.clone()).encode_v1());
+                let outcome = wal
+                    .append_records(BENCH_QUEUE, None, encoded_mrecords)
+                    .expect("failed to append records");
+                elapsed += start.elapsed();
+                black_box(outcome);
+            }
+            elapsed
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_encode, bench_decode, bench_append_batch);
+criterion_main!(benches);

--- a/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/metrics.rs
@@ -72,6 +72,22 @@ pub(super) static INGEST_RESULT_SHARD_NOT_FOUND: LazyCounter =
 pub(super) static INGEST_RESULT_UNAVAILABLE: LazyCounter =
     lazy_counter!(parent: INGEST_RESULT_TOTAL, "result" => "unavailable");
 
+static SKIPPED_MRECORDS_TOTAL: LazyCounter = lazy_counter!(
+        name: "skipped_mrecords_total",
+        description: "Number of mrecords skipped during decoding, by reason (e.g. an unknown \
+                      header version or record type written by a newer binary).",
+        subsystem: "ingest",
+);
+
+pub(super) static SKIPPED_MRECORDS_UNKNOWN_HEADER_VERSION: LazyCounter =
+    lazy_counter!(parent: SKIPPED_MRECORDS_TOTAL, "reason" => "unknown_header_version");
+
+pub(super) static SKIPPED_MRECORDS_UNKNOWN_RECORD_TYPE: LazyCounter =
+    lazy_counter!(parent: SKIPPED_MRECORDS_TOTAL, "reason" => "unknown_record_type");
+
+pub(super) static SKIPPED_MRECORDS_MALFORMED: LazyCounter =
+    lazy_counter!(parent: SKIPPED_MRECORDS_TOTAL, "reason" => "malformed");
+
 pub(super) static INGEST_ATTEMPTS: LazyCounter = lazy_counter!(
         name: "ingest_attempts",
         description: "Number of routing attempts by AZ locality",

--- a/quickwit/quickwit-ingest/src/ingest_v2/mrecord.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mrecord.rs
@@ -12,19 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::{Buf, Bytes};
-use quickwit_proto::ingest::MRecordBatch;
-use tracing::warn;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use prost::Message as _;
+use quickwit_proto::ingest::{CommitMRecord, DocMRecord, MRecordBatch, MRecordV1, m_record_v1};
 
-/// The first byte of a [`MRecord`] is the version of the record header.
-#[derive(Debug)]
+use super::metrics::{
+    SKIPPED_MRECORDS_MALFORMED, SKIPPED_MRECORDS_UNKNOWN_HEADER_VERSION,
+    SKIPPED_MRECORDS_UNKNOWN_RECORD_TYPE,
+};
+
+/// The first byte of an encoded [`MRecord`] is the version of the record header. It selects how the
+/// remaining bytes are interpreted, which makes the on-disk format forward and backward compatible:
+/// an older binary that does not know a header version skips the record instead of misreading it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum HeaderVersion {
-    /// Version 0, introduced in Quickwit 0.7.0, it uses one byte to encode the record type.
+    /// Version 0, introduced in Quickwit 0.7.0. The header is two bytes: the header version
+    /// followed by one byte encoding the record type (`Doc = 0`, `Commit = 1`). For a `Doc`, the
+    /// remaining bytes are the document verbatim.
     V0 = 0,
+    /// Version 1. The header is a single byte (the header version) followed by a protobuf-encoded
+    /// [`MRecordV1`] message.
+    V1 = 1,
 }
 
-/// Length of the header of a [`MRecord`] in bytes.
+/// Length of the header of a [`HeaderVersion::V0`] [`MRecord`] in bytes.
 pub(super) const MRECORD_HEADER_LEN: usize = 2;
 
 /// `Doc` header v0 composed of the header version and the `Doc = 0` record type.
@@ -39,7 +51,32 @@ pub enum MRecord {
     Commit,
 }
 
+/// Reason an encoded mrecord could not be decoded into a known [`MRecord`]. Each variant maps to a
+/// metric label so a downgrade reading records written by a newer binary is observable rather than
+/// silent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkipReason {
+    /// The buffer is truncated or the protobuf payload failed to decode.
+    Malformed,
+    /// The header version byte is not known to this binary (record written by a newer binary).
+    UnknownHeaderVersion,
+    /// The header version is known but the record type / `mrecord` variant is not (newer binary).
+    UnknownRecordType,
+}
+
+/// Outcome of decoding a single encoded mrecord. Unknown records are reported as [`Self::Skipped`]
+/// instead of being silently dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DecodeOutcome {
+    Decoded(MRecord),
+    Skipped(SkipReason),
+}
+
 impl MRecord {
+    /// Encodes the record using the legacy `HeaderVersion::V0` format. This remains the default
+    /// write format: it is understood by every released binary, so emitting it keeps a rollback
+    /// safe. Switching the write path to [`Self::encode_v1`] must only happen once every binary in
+    /// the rollback window can decode v1.
     pub fn encode(&self) -> impl Buf + use<> {
         match &self {
             Self::Doc(doc) => DOC_HEADER_V0.chain(doc.clone()),
@@ -47,30 +84,77 @@ impl MRecord {
         }
     }
 
-    pub fn decode(mut buf: impl Buf) -> Option<Self> {
-        if buf.remaining() < 2 {
-            return None;
-        }
+    /// Encodes the record using the extensible `HeaderVersion::V1` format (a protobuf
+    /// `MRecordV1` payload). Not yet used by the write path; see [`Self::encode`].
+    pub fn encode_v1(&self) -> Bytes {
+        let mrecord = match self {
+            Self::Doc(doc) => m_record_v1::Mrecord::Doc(DocMRecord { doc: doc.clone() }),
+            Self::Commit => m_record_v1::Mrecord::Commit(CommitMRecord {}),
+        };
+        let mrecord_v1 = MRecordV1 {
+            mrecord: Some(mrecord),
+        };
+        let mut buf = BytesMut::with_capacity(1 + mrecord_v1.encoded_len());
+        buf.put_u8(HeaderVersion::V1 as u8);
+        // Encoding a prost message into a `BytesMut` cannot fail: it only errors on insufficient
+        // capacity, and `BytesMut` grows on demand.
+        mrecord_v1
+            .encode(&mut buf)
+            .expect("encoding an mrecord into a `BytesMut` should never fail");
+        buf.freeze()
+    }
 
+    pub fn decode(buf: impl Buf) -> Option<Self> {
+        match Self::decode_inner(buf) {
+            DecodeOutcome::Decoded(mrecord) => Some(mrecord),
+            DecodeOutcome::Skipped(_) => None,
+        }
+    }
+
+    fn decode_inner(mut buf: impl Buf) -> DecodeOutcome {
+        if buf.remaining() < 1 {
+            return DecodeOutcome::Skipped(SkipReason::Malformed);
+        }
         let header_version = buf.get_u8();
 
-        if header_version != HeaderVersion::V0 as u8 {
-            warn!("unknown mrecord header version `{header_version}`");
-            return None;
+        if header_version == HeaderVersion::V0 as u8 {
+            Self::decode_v0(buf)
+        } else if header_version == HeaderVersion::V1 as u8 {
+            Self::decode_v1(buf)
+        } else {
+            DecodeOutcome::Skipped(SkipReason::UnknownHeaderVersion)
         }
+    }
 
-        let mrecord = match buf.get_u8() {
+    fn decode_v0(mut buf: impl Buf) -> DecodeOutcome {
+        if buf.remaining() < 1 {
+            return DecodeOutcome::Skipped(SkipReason::Malformed);
+        }
+        match buf.get_u8() {
             0 => {
                 let doc = buf.copy_to_bytes(buf.remaining());
-                Self::Doc(doc)
+                DecodeOutcome::Decoded(Self::Doc(doc))
             }
-            1 => Self::Commit,
-            other => {
-                warn!("unknown mrecord type `{other}`");
-                return None;
-            }
+            1 => DecodeOutcome::Decoded(Self::Commit),
+            _ => DecodeOutcome::Skipped(SkipReason::UnknownRecordType),
+        }
+    }
+
+    fn decode_v1(buf: impl Buf) -> DecodeOutcome {
+        let mrecord_v1 = match MRecordV1::decode(buf) {
+            Ok(mrecord_v1) => mrecord_v1,
+            Err(_) => return DecodeOutcome::Skipped(SkipReason::Malformed),
         };
-        Some(mrecord)
+        match mrecord_v1.mrecord {
+            Some(m_record_v1::Mrecord::Doc(DocMRecord { doc })) => {
+                DecodeOutcome::Decoded(Self::Doc(doc))
+            }
+            Some(m_record_v1::Mrecord::Commit(CommitMRecord {})) => {
+                DecodeOutcome::Decoded(Self::Commit)
+            }
+            // An `mrecord` variant written by a newer binary that this one does not know.
+            None => DecodeOutcome::Skipped(SkipReason::UnknownRecordType),
+        }
     }
 
     #[cfg(any(test, feature = "testsuite"))]
@@ -80,7 +164,44 @@ impl MRecord {
 }
 
 pub fn decoded_mrecords(mrecord_batch: &MRecordBatch) -> impl Iterator<Item = MRecord> + '_ {
-    mrecord_batch.encoded_mrecords().flat_map(MRecord::decode)
+    mrecord_batch
+        .encoded_mrecords()
+        .filter_map(
+            |encoded_mrecord| match MRecord::decode_inner(encoded_mrecord) {
+                DecodeOutcome::Decoded(mrecord) => Some(mrecord),
+                DecodeOutcome::Skipped(reason) => {
+                    on_skipped_mrecord(reason);
+                    None
+                }
+            },
+        )
+}
+
+/// Records a skipped mrecord on its metric and emits a rate-limited warning. A burst of skips
+/// typically means a binary is reading records written by a newer one (e.g. after a downgrade).
+fn on_skipped_mrecord(reason: SkipReason) {
+    match reason {
+        SkipReason::Malformed => {
+            SKIPPED_MRECORDS_MALFORMED.inc();
+            quickwit_common::rate_limited_warn!(limit_per_min = 6, "skipped malformed mrecord");
+        }
+        SkipReason::UnknownHeaderVersion => {
+            SKIPPED_MRECORDS_UNKNOWN_HEADER_VERSION.inc();
+            quickwit_common::rate_limited_warn!(
+                limit_per_min = 6,
+                "skipped mrecord with an unknown header version, it was likely written by a newer \
+                 binary"
+            );
+        }
+        SkipReason::UnknownRecordType => {
+            SKIPPED_MRECORDS_UNKNOWN_RECORD_TYPE.inc();
+            quickwit_common::rate_limited_warn!(
+                limit_per_min = 6,
+                "skipped mrecord with an unknown record type, it was likely written by a newer \
+                 binary"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -89,10 +210,25 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_mrecord() {
-        assert!(MRecord::decode(&b""[..]).is_none());
-        assert!(MRecord::decode(&b"a"[..]).is_none());
-        assert!(MRecord::decode(&[HeaderVersion::V0 as u8][..]).is_none());
-        assert!(MRecord::decode(&[HeaderVersion::V0 as u8, 19u8][..]).is_none());
+        // Truncated buffers.
+        assert_eq!(
+            MRecord::decode_inner(&b""[..]),
+            DecodeOutcome::Skipped(SkipReason::Malformed)
+        );
+        assert_eq!(
+            MRecord::decode_inner(&[HeaderVersion::V0 as u8][..]),
+            DecodeOutcome::Skipped(SkipReason::Malformed)
+        );
+        // Unknown header version (e.g. a record written by a newer binary).
+        assert_eq!(
+            MRecord::decode_inner(&b"a"[..]),
+            DecodeOutcome::Skipped(SkipReason::UnknownHeaderVersion)
+        );
+        // Known v0 header, unknown record type.
+        assert_eq!(
+            MRecord::decode_inner(&[HeaderVersion::V0 as u8, 19u8][..]),
+            DecodeOutcome::Skipped(SkipReason::UnknownRecordType)
+        );
     }
 
     #[test]
@@ -109,5 +245,67 @@ mod tests {
         let encoded_record = record.encode();
         let decoded_record = MRecord::decode(encoded_record).unwrap();
         assert_eq!(record, decoded_record);
+    }
+
+    #[test]
+    fn test_mrecord_doc_roundtrip_v1() {
+        let record = MRecord::new_doc("hello");
+        let encoded_record = record.encode_v1();
+        // First byte selects the v1 format.
+        assert_eq!(encoded_record[0], HeaderVersion::V1 as u8);
+        let decoded_record = MRecord::decode(encoded_record).unwrap();
+        assert_eq!(record, decoded_record);
+    }
+
+    #[test]
+    fn test_mrecord_commit_roundtrip_v1() {
+        let record = MRecord::Commit;
+        let encoded_record = record.encode_v1();
+        assert_eq!(encoded_record[0], HeaderVersion::V1 as u8);
+        let decoded_record = MRecord::decode(encoded_record).unwrap();
+        assert_eq!(record, decoded_record);
+    }
+
+    #[test]
+    fn test_mrecord_v1_forward_compatible_unknown_field() {
+        // A `DocMRecord` written by a newer binary carrying an extra, unknown field (here field 2,
+        // a varint — e.g. a future arrival timestamp). An older binary must still recover the doc.
+        let doc_mrecord_with_unknown_field: &[u8] = &[
+            0x0A, 0x05, b'h', b'e', b'l', b'l', b'o', // field 1 (doc): len-delimited "hello"
+            0x10, 0x2A, // field 2 (unknown): varint 42
+        ];
+        let mut mrecord_v1 = vec![HeaderVersion::V1 as u8];
+        // Wrap it in the `MRecordV1` oneof as field 1 (doc), len-delimited.
+        mrecord_v1.push(0x0A);
+        mrecord_v1.push(doc_mrecord_with_unknown_field.len() as u8);
+        mrecord_v1.extend_from_slice(doc_mrecord_with_unknown_field);
+
+        let decoded_record = MRecord::decode(&mrecord_v1[..]).unwrap();
+        assert_eq!(decoded_record, MRecord::new_doc("hello"));
+    }
+
+    #[test]
+    fn test_mrecord_v1_unknown_variant_is_skipped() {
+        // An `MRecordV1` whose `mrecord` oneof is set to an unknown field number (3), as a newer
+        // binary minting a new record type would produce. An older binary skips it.
+        let mrecord_v1: &[u8] = &[
+            HeaderVersion::V1 as u8,
+            0x1A, // field 3, len-delimited
+            0x00, // length 0
+        ];
+        assert_eq!(
+            MRecord::decode_inner(mrecord_v1),
+            DecodeOutcome::Skipped(SkipReason::UnknownRecordType)
+        );
+    }
+
+    #[test]
+    fn test_mrecord_v1_malformed_payload_is_skipped() {
+        // A v1 header followed by bytes that are not a valid protobuf message.
+        let mrecord_v1: &[u8] = &[HeaderVersion::V1 as u8, 0xFF, 0xFF, 0xFF];
+        assert_eq!(
+            MRecord::decode_inner(mrecord_v1),
+            DecodeOutcome::Skipped(SkipReason::Malformed)
+        );
     }
 }

--- a/quickwit/quickwit-proto/build.rs
+++ b/quickwit/quickwit-proto/build.rs
@@ -136,6 +136,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     prost_config
         .bytes([
             "DocBatchV2.doc_buffer",
+            "DocMRecord.doc",
             "MRecordBatch.mrecord_buffer",
             "Position.position",
         ])

--- a/quickwit/quickwit-proto/protos/quickwit/ingest.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/ingest.proto
@@ -71,6 +71,29 @@ message MRecordBatch {
   repeated uint32 mrecord_lengths = 2;
 }
 
+// Payload of an mrecord encoded with header version 1 (see `MRecord` in
+// `quickwit-ingest`). The first byte of an encoded mrecord is the header
+// version: `0x00` selects the legacy raw encoding, `0x01` is followed by a
+// protobuf-encoded `MRecordV1` message.
+//
+// The format is forward and backward compatible: new fields can be added to
+// the record messages below, and an older binary that does not know a field or
+// a new `mrecord` variant simply ignores it. Adding per-record data (e.g. an
+// arrival timestamp) MUST be done by adding a field to an existing message
+// here, never by introducing a new top-level mrecord type.
+message MRecordV1 {
+  oneof mrecord {
+    DocMRecord doc = 1;
+    CommitMRecord commit = 2;
+  }
+}
+
+message DocMRecord {
+  bytes doc = 1;
+}
+
+message CommitMRecord {}
+
 enum ShardState {
   SHARD_STATE_UNSPECIFIED = 0;
   // The shard is open and accepts write requests.

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.ingest.rs
@@ -33,6 +33,43 @@ pub struct MRecordBatch {
     #[prost(uint32, repeated, tag = "2")]
     pub mrecord_lengths: ::prost::alloc::vec::Vec<u32>,
 }
+/// Payload of an mrecord encoded with header version 1 (see `MRecord` in
+/// `quickwit-ingest`). The first byte of an encoded mrecord is the header
+/// version: `0x00` selects the legacy raw encoding, `0x01` is followed by a
+/// protobuf-encoded `MRecordV1` message.
+///
+/// The format is forward and backward compatible: new fields can be added to
+/// the record messages below, and an older binary that does not know a field or
+/// a new `mrecord` variant simply ignores it. Adding per-record data (e.g. an
+/// arrival timestamp) MUST be done by adding a field to an existing message
+/// here, never by introducing a new top-level mrecord type.
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MRecordV1 {
+    #[prost(oneof = "m_record_v1::Mrecord", tags = "1, 2")]
+    pub mrecord: ::core::option::Option<m_record_v1::Mrecord>,
+}
+/// Nested message and enum types in `MRecordV1`.
+pub mod m_record_v1 {
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    #[serde(rename_all = "snake_case")]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Mrecord {
+        #[prost(message, tag = "1")]
+        Doc(super::DocMRecord),
+        #[prost(message, tag = "2")]
+        Commit(super::CommitMRecord),
+    }
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DocMRecord {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub doc: ::prost::bytes::Bytes,
+}
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CommitMRecord {}
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Shard {


### PR DESCRIPTION
### Description
Serialize mrecords into WAL using Protobuf so we have a backward and forward-compatible way to evolve the mrecords schema. This PR adds the code to write and read the new format but mrecords are still written to the WAL using the legacy format.

### How was this PR tested?
Added unit tests

### Bench
```
mrecord_append_batch/v0 time:   [1.0982 ms 1.1502 ms 1.2107 ms]
                        thrpt:  [606.54 MiB/s 638.41 MiB/s 668.69 MiB/s]

mrecord_append_batch/v1 time:   [1.1707 ms 1.3087 ms 1.4137 ms]
                        thrpt:  [519.45 MiB/s 561.09 MiB/s 627.27 MiB/s]
```