### PR TITLE
Introduce default retry policy to otlp exporters

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -7037,6 +7037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.0",
+ "httpdate",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",

--- a/quickwit/quickwit-telemetry-exporters/Cargo.toml
+++ b/quickwit/quickwit-telemetry-exporters/Cargo.toml
@@ -18,7 +18,7 @@ metrics-exporter-prometheus = { workspace = true }
 metrics-util = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-appender-tracing = { workspace = true }
-opentelemetry-otlp = { workspace = true }
+opentelemetry-otlp = { workspace = true, features = ["experimental-grpc-retry", "experimental-http-retry"] }
 opentelemetry_sdk = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true, features = ["parsing"] }

--- a/quickwit/quickwit-telemetry-exporters/src/otlp/logs.rs
+++ b/quickwit/quickwit-telemetry-exporters/src/otlp/logs.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use anyhow::Context;
-use opentelemetry_otlp::{LogExporter, Protocol as OtlpWireProtocol, WithExportConfig};
+use opentelemetry_otlp::{
+    LogExporter, Protocol as OtlpWireProtocol, WithExportConfig, WithHttpConfig, WithTonicConfig,
+};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 
@@ -22,13 +24,18 @@ use crate::otlp::{OtlpExporterConfig, OtlpProtocol};
 impl OtlpProtocol {
     pub(crate) fn log_exporter(&self) -> anyhow::Result<LogExporter> {
         match self {
-            OtlpProtocol::Grpc => LogExporter::builder().with_tonic().build(),
+            OtlpProtocol::Grpc => LogExporter::builder()
+                .with_tonic()
+                .with_retry_policy(super::RETRY_POLICY)
+                .build(),
             OtlpProtocol::HttpProtobuf => LogExporter::builder()
                 .with_http()
+                .with_retry_policy(super::RETRY_POLICY)
                 .with_protocol(OtlpWireProtocol::HttpBinary)
                 .build(),
             OtlpProtocol::HttpJson => LogExporter::builder()
                 .with_http()
+                .with_retry_policy(super::RETRY_POLICY)
                 .with_protocol(OtlpWireProtocol::HttpJson)
                 .build(),
         }

--- a/quickwit/quickwit-telemetry-exporters/src/otlp/metrics.rs
+++ b/quickwit/quickwit-telemetry-exporters/src/otlp/metrics.rs
@@ -15,7 +15,9 @@
 use anyhow::Context;
 use metrics_opentelemetry::{OpenTelemetryMetrics, OpenTelemetryRecorder};
 use opentelemetry::metrics::MeterProvider;
-use opentelemetry_otlp::{MetricExporter, Protocol as OtlpWireProtocol, WithExportConfig};
+use opentelemetry_otlp::{
+    MetricExporter, Protocol as OtlpWireProtocol, WithExportConfig, WithHttpConfig, WithTonicConfig,
+};
 use opentelemetry_sdk::metrics::{SdkMeterProvider, Temporality};
 
 use crate::otlp::{OtlpExporterConfig, OtlpProtocol, quickwit_resource};
@@ -28,15 +30,18 @@ impl OtlpProtocol {
         match self {
             OtlpProtocol::Grpc => MetricExporter::builder()
                 .with_tonic()
+                .with_retry_policy(super::RETRY_POLICY)
                 .with_temporality(temporality)
                 .build(),
             OtlpProtocol::HttpProtobuf => MetricExporter::builder()
                 .with_http()
+                .with_retry_policy(super::RETRY_POLICY)
                 .with_temporality(temporality)
                 .with_protocol(OtlpWireProtocol::HttpBinary)
                 .build(),
             OtlpProtocol::HttpJson => MetricExporter::builder()
                 .with_http()
+                .with_retry_policy(super::RETRY_POLICY)
                 .with_temporality(temporality)
                 .with_protocol(OtlpWireProtocol::HttpJson)
                 .build(),

--- a/quickwit/quickwit-telemetry-exporters/src/otlp/mod.rs
+++ b/quickwit/quickwit-telemetry-exporters/src/otlp/mod.rs
@@ -18,3 +18,12 @@ pub(crate) mod metrics;
 pub(crate) mod traces;
 
 pub(crate) use config::{OtlpExporterConfig, OtlpProtocol, quickwit_resource};
+use opentelemetry_otlp::retry::RetryPolicy;
+
+//Common retry policy for OTLP exporters
+const RETRY_POLICY: RetryPolicy = RetryPolicy {
+    max_retries: 5,
+    initial_delay_ms: 500,
+    max_delay_ms: 30_000,
+    jitter_ms: 100,
+};

--- a/quickwit/quickwit-telemetry-exporters/src/otlp/traces.rs
+++ b/quickwit/quickwit-telemetry-exporters/src/otlp/traces.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use anyhow::Context;
-use opentelemetry_otlp::{Protocol as OtlpWireProtocol, SpanExporter, WithExportConfig};
+use opentelemetry_otlp::{
+    Protocol as OtlpWireProtocol, SpanExporter, WithExportConfig, WithHttpConfig, WithTonicConfig,
+};
 use opentelemetry_sdk::trace::{BatchConfigBuilder, SdkTracerProvider};
 use opentelemetry_sdk::{Resource, trace};
 
@@ -22,13 +24,18 @@ use crate::otlp::{OtlpExporterConfig, OtlpProtocol};
 impl OtlpProtocol {
     pub(crate) fn span_exporter(&self) -> anyhow::Result<SpanExporter> {
         match self {
-            OtlpProtocol::Grpc => SpanExporter::builder().with_tonic().build(),
+            OtlpProtocol::Grpc => SpanExporter::builder()
+                .with_tonic()
+                .with_retry_policy(super::RETRY_POLICY)
+                .build(),
             OtlpProtocol::HttpProtobuf => SpanExporter::builder()
                 .with_http()
+                .with_retry_policy(super::RETRY_POLICY)
                 .with_protocol(OtlpWireProtocol::HttpBinary)
                 .build(),
             OtlpProtocol::HttpJson => SpanExporter::builder()
                 .with_http()
+                .with_retry_policy(super::RETRY_POLICY)
                 .with_protocol(OtlpWireProtocol::HttpJson)
                 .build(),
         }


### PR DESCRIPTION
### Description

Unfortunately current SDK doesn't retry automatically as it is experimental feature 
This PR just introduces feature of retry mechanism to make sure OTLP export will at least retry before giving up
I recently discovered myself that retry is not builtin with default feature set
So JFYI.

Reference:
https://docs.rs/opentelemetry-otlp/0.32.0/opentelemetry_otlp/#grpc-retry-policy

### How was this PR tested?

It hasn't been tested
