### PR TITLE
Add range check to `parse_timestamp_float`

### DIFF
--- a/quickwit/quickwit-datetime/src/date_time_parsing.rs
+++ b/quickwit/quickwit-datetime/src/date_time_parsing.rs
@@ -27,6 +27,14 @@ const MIN_TIMESTAMP_SECONDS: i64 = 72_057_595;
 // Maximum supported timestamp value in seconds (16 Mar 2242 12:56:31 GMT).
 const MAX_TIMESTAMP_SECONDS: i64 = 8_589_934_591;
 
+/// Builds the error returned when a Unix timestamp falls outside the range Quickwit supports.
+fn unsupported_timestamp_error(timestamp: impl std::fmt::Display) -> String {
+    format!(
+        "failed to parse unix timestamp `{timestamp}`. Quickwit only supports timestamp values \
+         ranging from `13 Apr 1972 23:59:55` to `16 Mar 2242 12:56:31`"
+    )
+}
+
 pub fn parse_date_time_str(
     date_time_str: &str,
     date_time_formats: &[DateTimeInputFormat],
@@ -75,6 +83,12 @@ pub fn parse_timestamp_float(
                 .map(|date_time_format| date_time_format.as_str())
                 .join("`, `")
         ));
+    }
+    // We apply the same range check as the integer path (`parse_timestamp`) to reject out-of-range
+    // values instead of silently wrapping them when casting the `u128` nanoseconds to `i64`
+    // below.
+    if !(MIN_TIMESTAMP_SECONDS as f64..=MAX_TIMESTAMP_SECONDS as f64).contains(&timestamp) {
+        return Err(unsupported_timestamp_error(timestamp));
     }
     let duration_since_epoch = Duration::try_from_secs_f64(timestamp)
         .map_err(|error| format!("failed to parse datetime `{timestamp}`: {error}"))?;
@@ -167,10 +181,7 @@ pub fn parse_timestamp(timestamp: i64) -> Result<TantivyDateTime, String> {
         MIN_TIMESTAMP_NANOS..=MAX_TIMESTAMP_NANOS => {
             Ok(TantivyDateTime::from_timestamp_nanos(timestamp))
         }
-        _ => Err(format!(
-            "failed to parse unix timestamp `{timestamp}`. Quickwit only support timestamp values \
-             ranging from `13 Apr 1972 23:59:55` to `16 Mar 2242 12:56:31`"
-        )),
+        _ => Err(unsupported_timestamp_error(timestamp)),
     }
 }
 
@@ -385,6 +396,15 @@ mod tests {
                 "failed to parse datetime `1668730394917.01` using the following formats: \
                  `iso8601`, `rfc2822`"
             );
+        }
+        {
+            // Out-of-range float values used to silently wrap when casting `u128` nanoseconds to
+            // `i64`. They must now be rejected, just like the integer path does.
+            let error = parse_timestamp_float(9e18, &[DateTimeInputFormat::Timestamp]).unwrap_err();
+            assert!(error.contains("failed to parse unix timestamp"), "{error}");
+
+            let error = parse_timestamp_float(-1.0, &[DateTimeInputFormat::Timestamp]).unwrap_err();
+            assert!(error.contains("failed to parse unix timestamp"), "{error}");
         }
     }
 


### PR DESCRIPTION
### Description
Add range check to `parse_timestamp_float` to reject out-of-range values instead of silently wrapping when casting.

### How was this PR tested?
Added unit tests.
