### PR TITLE
feat(search): expose CPU thread count and root phase wall times in re…

### DIFF
--- a/quickwit/quickwit-common/src/thread_pool/with_priority.rs
+++ b/quickwit/quickwit-common/src/thread_pool/with_priority.rs
@@ -158,6 +158,10 @@ impl ThreadPoolWithPriority {
         }
     }
 
+    pub fn num_threads(&self) -> usize {
+        self.inner.max_running_tasks
+    }
+
     /// Schedules a cpu intensive function with a normal priority.
     /// If the result future is dropped before it is scheduled on the
     /// underlying thread pool, the task will be cancelled.

--- a/quickwit/quickwit-proto/protos/quickwit/search.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/search.proto
@@ -466,6 +466,9 @@ message LeafResourceStats {
     // across leaves) it is the count of leaves where lambda was the
     // bottleneck. Voluntarily a uint64 (not a bool) for summability.
     uint64 lambda_bottleneck = 14;
+
+    /// Number of CPU threads available in the search pool.
+    uint64 search_pool_cpu_threads = 15;
 }
 
 // Resource statistics for a root search.
@@ -488,6 +491,19 @@ message RootResourceStats {
     // distinguishing "one straggler" from "all leaves comparably slow"
     // without computing it from `leaf_resources_worst` / `leaf_resources_sum`.
     repeated uint64 leaf_wall_times_microsecs = 6;
+
+    // The first phase identifies the partial hits, runs aggregate.
+    // When running a top-k request, a second phase is required to fetch the documents.
+    //
+    // This includes getting the results from leaf searchers and merging them.
+    uint64 root_first_phase_wall_time_microsecs = 7;
+
+    // Overall wall time for the root search. This includes both
+    // the first phase (running aggregation, and identifying the doc address of the top-k hits we should return)
+    // and the second phase (fetch documents).
+    //
+    // If there are no top-k hits, the second phase is skipped.
+    uint64 root_wall_time_microsecs = 8;
 }
 
 // LeafRequestRef references data in LeafSearchRequest to deduplicate data.

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -413,6 +413,9 @@ pub struct LeafResourceStats {
     /// bottleneck. Voluntarily a uint64 (not a bool) for summability.
     #[prost(uint64, tag = "14")]
     pub lambda_bottleneck: u64,
+    /// / Number of CPU threads available in the search pool.
+    #[prost(uint64, tag = "15")]
+    pub search_pool_cpu_threads: u64,
 }
 /// Resource statistics for a root search.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -442,6 +445,19 @@ pub struct RootResourceStats {
     /// without computing it from `leaf_resources_worst` / `leaf_resources_sum`.
     #[prost(uint64, repeated, tag = "6")]
     pub leaf_wall_times_microsecs: ::prost::alloc::vec::Vec<u64>,
+    /// The first phase identifies the partial hits, runs aggregate.
+    /// When running a top-k request, a second phase is required to fetch the documents.
+    ///
+    /// This includes getting the results from leaf searchers and merging them.
+    #[prost(uint64, tag = "7")]
+    pub root_first_phase_wall_time_microsecs: u64,
+    /// Overall wall time for the root search. This includes both
+    /// the first phase (running aggregation, and identifying the doc address of the top-k hits we should return)
+    /// and the second phase (fetch documents).
+    ///
+    /// If there are no top-k hits, the second phase .
+    #[prost(uint64, tag = "8")]
+    pub root_wall_time_microsecs: u64,
 }
 /// LeafRequestRef references data in LeafSearchRequest to deduplicate data.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -1520,10 +1520,12 @@ pub async fn multi_index_leaf_search(
         .await
         .context("failed to merge split search responses")??;
     let wall_time_microsecs = leaf_start.elapsed().as_micros() as u64;
-    leaf_search_response
+    let search_pool_cpu_threads = crate::search_thread_pool().num_threads() as u64;
+    let resource_stats = leaf_search_response
         .resource_stats
-        .get_or_insert_with(LeafResourceStats::default)
-        .wall_time_microsecs = wall_time_microsecs;
+        .get_or_insert_with(LeafResourceStats::default);
+    resource_stats.wall_time_microsecs = wall_time_microsecs;
+    resource_stats.search_pool_cpu_threads = search_pool_cpu_threads;
     Ok(leaf_search_response)
 }
 

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -398,6 +398,7 @@ pub(crate) fn add_leaf_stats(acc: &mut LeafResourceStats, other: &LeafResourceSt
     acc.localexec_num_splits += other.localexec_num_splits;
     acc.localexec_num_docs += other.localexec_num_docs;
     acc.wall_time_microsecs += other.wall_time_microsecs;
+    acc.search_pool_cpu_threads += other.search_pool_cpu_threads;
     acc.min_wait_for_search_permit_microsecs = min_opt(
         acc.min_wait_for_search_permit_microsecs,
         other.min_wait_for_search_permit_microsecs,
@@ -562,6 +563,7 @@ mod stats_merge_tests {
             min_wait_for_search_permit_microsecs: Some(100),
             min_wait_for_cpu_pool_microsecs: Some(2_000),
             wall_time_microsecs: 100_000_000,
+            search_pool_cpu_threads: 8,
         };
         let other = LeafResourceStats {
             partial_result_cache_num_splits: 2,
@@ -578,6 +580,7 @@ mod stats_merge_tests {
             min_wait_for_search_permit_microsecs: Some(50),
             min_wait_for_cpu_pool_microsecs: Some(1_000),
             wall_time_microsecs: 200_000_000,
+            search_pool_cpu_threads: 16,
         };
 
         add_leaf_stats(&mut acc, &other);
@@ -595,6 +598,7 @@ mod stats_merge_tests {
         assert_eq!(acc.localexec_num_docs, 30_000_000);
         // `wall_time_microsecs` is summed post-refactor, not maxed.
         assert_eq!(acc.wall_time_microsecs, 300_000_000);
+        assert_eq!(acc.search_pool_cpu_threads, 24);
 
         // `min_wait_for_*_microsecs` is MIN, not sum — the exception to the
         // extensive-sum rule.

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -742,6 +742,8 @@ fn is_top_5pct_memory_intensive(num_bytes: u64, split_num_docs: u64) -> bool {
 ///
 /// `leaf_resources_worst` is the leaf with the largest `wall_time_microsecs`.
 /// `leaf_resources_sum` is a field-wise sum of every leaf's stats.
+///
+/// Root specific stats are left as 0 and will be filled in within the root phase.
 fn compute_root_resource_stats(
     leaf_responses: &[LeafSearchResponse],
     leaf_num_calls: u64,
@@ -780,6 +782,8 @@ fn compute_root_resource_stats(
         leaf_num_calls_including_retries,
         num_failed_splits,
         leaf_wall_times_microsecs,
+        root_first_phase_wall_time_microsecs: 0u64,
+        root_wall_time_microsecs: 0u64,
     })
 }
 
@@ -1056,7 +1060,8 @@ async fn root_search_aux(
     cluster_client: &ClusterClient,
 ) -> crate::Result<SearchResponse> {
     debug!(split_metadatas = ?PrettySample::new(&split_metadatas, 5));
-    let (first_phase_result, scroll_key_and_start_offset_opt, root_resource_stats): (
+    let start = Instant::now();
+    let (first_phase_result, scroll_key_and_start_offset_opt, mut root_resource_stats_opt): (
         LeafSearchResponse,
         Option<ScrollKeyAndStartOffset>,
         Option<RootResourceStats>,
@@ -1068,6 +1073,11 @@ async fn root_search_aux(
         cluster_client,
     )
     .await?;
+
+    if let Some(root_resource_stats) = root_resource_stats_opt.as_mut() {
+        root_resource_stats.root_first_phase_wall_time_microsecs =
+            start.elapsed().as_micros() as u64;
+    }
 
     let hits = fetch_docs_phase(
         indexes_metas_for_leaf_search,
@@ -1088,6 +1098,10 @@ async fn root_search_aux(
         aggregation_result_postcard_opt = None;
     }
 
+    if let Some(root_resource_stats) = root_resource_stats_opt.as_mut() {
+        root_resource_stats.root_wall_time_microsecs = start.elapsed().as_micros() as u64;
+    }
+
     Ok(SearchResponse {
         aggregation_postcard: aggregation_result_postcard_opt,
         num_hits: first_phase_result.num_hits,
@@ -1099,7 +1113,7 @@ async fn root_search_aux(
             .map(ToString::to_string),
         failed_splits: first_phase_result.failed_splits,
         num_successful_splits: first_phase_result.num_successful_splits,
-        resource_stats: root_resource_stats,
+        resource_stats: root_resource_stats_opt,
     })
 }
 


### PR DESCRIPTION
…source stats

Adds `search_pool_cpu_threads` to `LeafResourceStats` so callers can see the size of the search thread pool, and adds `root_first_phase_wall_time_microsecs` and `root_wall_time_microsecs` to `RootResourceStats` to track end-to-end root search latency broken down by phase.
