### PR TITLE
Remove native-tls from transitive dependencies

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -179,7 +179,6 @@ const-oid,https://github.com/RustCrypto/formats,Apache-2.0 OR MIT,RustCrypto Dev
 const-oid,https://github.com/RustCrypto/formats/tree/master/const-oid,Apache-2.0 OR MIT,RustCrypto Developers
 const-random,https://github.com/tkaitchuck/constrandom,MIT OR Apache-2.0,Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
 const-random-macro,https://github.com/tkaitchuck/constrandom,MIT OR Apache-2.0,Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
-const_fn,https://github.com/taiki-e/const_fn,Apache-2.0 OR MIT,The const_fn Authors
 const_format,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 const_format_proc_macros,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 constant_time_eq,https://github.com/cesarb/constant_time_eq,CC0-1.0 OR MIT-0 OR Apache-2.0,Cesar Eduardo Barros <cesarb@cesarb.eti.br>
@@ -380,7 +379,6 @@ hybrid-array,https://github.com/RustCrypto/hybrid-array,MIT OR Apache-2.0,RustCr
 hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>
 hyper-rustls,https://github.com/rustls/hyper-rustls,Apache-2.0 OR ISC OR MIT,The hyper-rustls Authors
 hyper-timeout,https://github.com/hjr3/hyper-timeout,MIT OR Apache-2.0,Herman J. Radtke III <herman@hermanradtke.com>
-hyper-tls,https://github.com/hyperium/hyper-tls,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 hyper-util,https://github.com/hyperium/hyper-util,MIT,Sean McArthur <sean@seanmonstar.com>
 iana-time-zone,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,"Andrew Straw <strawman@astraw.com>, René Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>"
 iana-time-zone-haiku,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,René Kijewski <crates.io@k6i.de>
@@ -492,7 +490,6 @@ mrecordlog,https://github.com/quickwit-oss/mrecordlog,MIT,The mrecordlog Authors
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
 murmur3,https://github.com/stusmall/murmur3,MIT OR Apache-2.0,Stu Small <stuart.alan.small@gmail.com>
 murmurhash32,https://github.com/quickwit-inc/murmurhash32,MIT,Paul Masurel <paul.masurel@gmail.com>
-native-tls,https://github.com/rust-native-tls/rust-native-tls,MIT OR Apache-2.0,Steven Fackler <sfackler@gmail.com>
 new_debug_unreachable,https://github.com/mbrubeck/rust-debug-unreachable,MIT,"Matt Brubeck <mbrubeck@limpet.net>, Jonathan Reem <jonathan.reem@gmail.com>"
 new_string_template,https://github.com/hasezoey/new_string_template,MIT,hasezoey <hasezoey@gmail.com>
 nibble_vec,https://github.com/michaelsproul/rust_nibble_vec,MIT,Michael Sproul <micsproul@gmail.com>
@@ -519,7 +516,6 @@ num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Pro
 num_cpus,https://github.com/seanmonstar/num_cpus,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 num_enum,https://github.com/illicitonion/num_enum,BSD-3-Clause OR MIT OR Apache-2.0,"Daniel Wagner-Hall <dawagner@gmail.com>, Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>, Vincent Esche <regexident@gmail.com>"
 num_enum_derive,https://github.com/illicitonion/num_enum,BSD-3-Clause OR MIT OR Apache-2.0,"Daniel Wagner-Hall <dawagner@gmail.com>, Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>, Vincent Esche <regexident@gmail.com>"
-num_threads,https://github.com/jhpratt/num_threads,MIT OR Apache-2.0,Jacob Pratt <open-source@jhpratt.dev>
 numfmt,https://github.com/kurtlawrence/numfmt,MIT,Kurt Lawrence <kurtlawrence.info>
 oauth2,https://github.com/ramosbugs/oauth2-rs,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Florin Lipan <florinlipan@gmail.com>, David A. Ramos <ramos@cs.stanford.edu>"
 objc2-core-foundation,https://github.com/madsmtm/objc2,Zlib OR Apache-2.0 OR MIT,The objc2-core-foundation Authors
@@ -853,7 +849,6 @@ tinyvec_macros,https://github.com/Soveu/tinyvec_macros,MIT OR Apache-2.0 OR Zlib
 tokio,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-macros,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-metrics,https://github.com/tokio-rs/tokio-metrics,MIT,Tokio Contributors <team@tokio.rs>
-tokio-native-tls,https://github.com/tokio-rs/tls,MIT,Tokio Contributors <team@tokio.rs>
 tokio-retry2,https://github.com/naomijub/tokio-retry,MIT,"Julia Naomi <jnboeira@outlook.com>, Sam Rijs <srijs@airpost.net>"
 tokio-rustls,https://github.com/rustls/tokio-rustls,MIT OR Apache-2.0,The tokio-rustls Authors
 tokio-stream,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
@@ -891,7 +886,6 @@ typetag,https://github.com/dtolnay/typetag,MIT OR Apache-2.0,David Tolnay <dtoln
 typetag-impl,https://github.com/dtolnay/typetag,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 typify-impl,https://github.com/oxidecomputer/typify,Apache-2.0,The typify-impl Authors
 typify-macro,https://github.com/oxidecomputer/typify,Apache-2.0,The typify-macro Authors
-tz-rs,https://github.com/x-hgg-x/tz-rs,MIT OR Apache-2.0,x-hgg-x
 ua-parser,https://github.com/ua-parser/uap-rust,Apache-2.0,The ua-parser Authors
 ucd-trie,https://github.com/BurntSushi/ucd-generate,MIT OR Apache-2.0,Andrew Gallant <jamslam@gmail.com>
 ulid,https://github.com/dylanhart/ulid-rs,MIT,dylanhart <dylan96hart@gmail.com>

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1363,7 +1363,6 @@ dependencies = [
  "serde",
  "time",
  "tracing",
- "tz-rs",
  "url",
  "uuid",
 ]
@@ -2322,12 +2321,6 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "const_format"
@@ -5135,22 +5128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6401,23 +6378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a"
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6656,15 +6616,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -8312,7 +8263,6 @@ dependencies = [
  "log",
  "lz4",
  "murmur3",
- "native-tls",
  "nom 7.1.3",
  "oauth2 5.0.0",
  "openidconnect",
@@ -8322,14 +8272,16 @@ dependencies = [
  "prost-derive 0.13.5",
  "rand 0.8.6",
  "regex",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "snap",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "url",
  "uuid",
+ "webpki-roots 1.0.7",
  "zstd",
 ]
 
@@ -10081,12 +10033,10 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls 0.27.9",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -10098,7 +10048,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
@@ -12152,9 +12101,7 @@ dependencies = [
  "deranged",
  "itoa",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -12282,16 +12229,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -12815,15 +12752,6 @@ dependencies = [
  "serde_tokenstream",
  "syn 2.0.117",
  "typify-impl",
-]
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -139,10 +139,10 @@ futures-util = { version = "0.3", default-features = false }
 glob = "0.3"
 # We can't directly update google-cloud-auth to 1.3 and google-cloud-gax to 1.4, because the latest version
 # of google-cloud-pubsub is "0.30" which explicitly depends on: google-cloud-auth ^0.17 and google-cloud-gax ^0.19.
-google-cloud-auth = "0.17.2"
+google-cloud-auth = { version = "0.17.2", default-features = false, features = ["rustls-tls"] }
 google-cloud-gax = "0.19.2"
 google-cloud-googleapis = { version = "0.16", features = ["pubsub"] }
-google-cloud-pubsub = "0.30"
+google-cloud-pubsub = { version = "0.30", default-features = false, features = ["auth", "rustls-tls"] }
 governor = "0.10.4"
 heck = "0.5"
 hex = "0.4"
@@ -213,7 +213,7 @@ prost-types = "0.14"
 pulsar = { version = "6.7", default-features = false, features = [
   "auth-oauth2",
   "compression",
-  "tokio-runtime",
+  "tokio-rustls-runtime",
 ] }
 quanta = "0.12"
 quick_cache = "0.6.21"
@@ -357,7 +357,7 @@ aws-smithy-types = { version = "1.4", features = [
 aws-types = "1.3"
 
 azure_core = { version = "0.21", features = ["hmac_rust", "enable_reqwest_rustls"] }
-azure_identity = { version = "0.21" }
+azure_identity = { version = "0.21", default-features = false, features = ["enable_reqwest_rustls"] }
 azure_storage = { version = "0.21", default-features = false, features = [
   "enable_reqwest_rustls",
 ] }

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.search.rs
@@ -455,7 +455,7 @@ pub struct RootResourceStats {
     /// the first phase (running aggregation, and identifying the doc address of the top-k hits we should return)
     /// and the second phase (fetch documents).
     ///
-    /// If there are no top-k hits, the second phase .
+    /// If there are no top-k hits, the second phase is skipped.
     #[prost(uint64, tag = "8")]
     pub root_wall_time_microsecs: u64,
 }

--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -80,6 +80,7 @@ quickwit-common = { workspace = true, features = ["testsuite"] }
 azure = [
   "azure_core",
   "azure_identity",
+  "azure_identity/enable_reqwest_rustls",
   "azure_storage",
   "azure_storage_blobs",
   "azure_core/hmac_rust",


### PR DESCRIPTION
## Summary

Switch all crates to rustls-only TLS backends, eliminating `native-tls`, `hyper-tls`, `tokio-native-tls`, and related packages from the dependency tree.

Three packages were pulling in `native-tls` via their default features:
- `azure_identity`: default enables `enable_reqwest` → `reqwest/default-tls`; switched to `default-features = false, features = ["enable_reqwest_rustls"]`
- `google-cloud-auth`: default enables `default-tls` → `reqwest/default-tls`; switched to `default-features = false, features = ["rustls-tls"]`
- `pulsar`: `tokio-runtime` feature hardcodes `native-tls`; switched to `tokio-rustls-runtime`

`google-cloud-pubsub` is also tightened to `default-features = false, features = ["auth", "rustls-tls"]` for consistency.

Net result: 75 fewer entries in `Cargo.lock`, no native-tls/OpenSSL dependency at all when building with `--all-features`.

Also fixes an incomplete comment in the generated `quickwit.search.rs` proto code.

## Test plan

- [x] `cargo check --all-features` passes
- [x] `cargo tree --all-features -i native-tls` returns no matches
- [ ] `cargo nextest run --all-features` (CI)