### PR TITLE
Light solution to the problem that prevents us from running on locals…

### DIFF
--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -88,9 +88,6 @@ const DEFAULT_QUICKWIT_CONFIG: &str = r#"
     rest:
         listen_port: #rest_listen_port
     grpc_listen_port: #grpc_listen_port
-    storage:
-        s3:
-            checksum_algorithm: disabled
 "#;
 
 const LOGS_JSON_DOCS: &str = r#"{"event": "foo", "level": "info", "ts": 72057597, "device": "rpi", "city": "tokio"}

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -158,9 +158,12 @@ pub async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
     s3_config.set_stalled_stream_protection(Some(stalled_stream_protection));
     s3_config.set_timeout_config(aws_config.timeout_config().cloned());
 
+    // We always disable response checksum. We mostly do range request anyway.
+    // Somehow, localstack keeps returning the full checksum on range request, which
+    // causes error.
+    s3_config.set_response_checksum_validation(Some(ResponseChecksumValidation::WhenRequired));
     if s3_storage_config.checksum_algorithm.is_disabled() {
         s3_config.set_request_checksum_calculation(Some(RequestChecksumCalculation::WhenRequired));
-        s3_config.set_response_checksum_validation(Some(ResponseChecksumValidation::WhenRequired));
     }
 
     if let Some(endpoint) = s3_storage_config.endpoint() {

--- a/quickwit/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit/quickwit-storage/src/storage_resolver.rs
@@ -17,7 +17,9 @@ use std::fmt;
 use std::sync::{Arc, LazyLock};
 
 use quickwit_common::uri::{Protocol, Uri};
-use quickwit_config::{StorageBackend, StorageConfigs};
+use quickwit_config::{
+    ChecksumAlgorithm, S3StorageConfig, StorageBackend, StorageConfig, StorageConfigs,
+};
 
 #[cfg(feature = "azure")]
 use crate::AzureBlobStorageFactory;
@@ -77,7 +79,13 @@ impl StorageResolver {
     /// resolver will not work.
     pub fn unconfigured() -> Self {
         static STORAGE_RESOLVER: LazyLock<StorageResolver> = LazyLock::new(|| {
-            let storage_configs = StorageConfigs::default();
+            // We default to the md5 checksum, as the way we compute crc32c
+            // is causing us to emit a checksum header and a trailer,
+            // which is not supported by localstack.
+            let storage_configs = StorageConfigs::new(vec![StorageConfig::S3(S3StorageConfig {
+                checksum_algorithm: ChecksumAlgorithm::Md5,
+                ..Default::default()
+            })]);
             StorageResolver::configured(&storage_configs)
         });
         STORAGE_RESOLVER.clone()


### PR DESCRIPTION
…tack.

On the crc32 path today, the sdk ends up producing a header AND a trailer checksum, which is not supported by localstack.

We force the use of md5 in tests for this reason. We also disable checksum on response.