### PR TITLE
Ensure all indexers broadcast standalone compactors before starting m…

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -8621,6 +8621,7 @@ dependencies = [
  "async-trait",
  "itertools 0.14.0",
  "quickwit-actors",
+ "quickwit-cluster",
  "quickwit-common",
  "quickwit-config",
  "quickwit-doc-mapper",

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -1012,6 +1012,7 @@ async fn create_empty_cluster(config: &NodeConfig) -> anyhow::Result<Cluster> {
         indexing_cpu_capacity: CpuCapacity::zero(),
         ingester_status: IngesterStatus::default(),
         availability_zone: None,
+        enable_standalone_compactors: false,
     };
     let channel_factory = ChannelFactory::for_grpc(&config.grpc_config)?;
     let cluster = Cluster::join(

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -42,7 +42,7 @@ use crate::grpc_gossip::spawn_catchup_callback_task;
 use crate::member::{
     AVAILABILITY_ZONE_KEY, ClusterMember, ENABLED_SERVICES_KEY, GRPC_ADVERTISE_ADDR_KEY,
     NodeStateExt, PIPELINE_METRICS_PREFIX, READINESS_KEY, READINESS_VALUE_NOT_READY,
-    READINESS_VALUE_READY,
+    READINESS_VALUE_READY, STANDALONE_COMPACTORS_KEY,
 };
 use crate::metrics::spawn_metrics_task;
 use crate::{ClusterChangeStream, ClusterNode};
@@ -224,6 +224,10 @@ impl Cluster {
         if let Some(az) = &self_node.availability_zone {
             initial_key_values.push((AVAILABILITY_ZONE_KEY.to_string(), az.clone()));
         }
+        initial_key_values.push((
+            STANDALONE_COMPACTORS_KEY.to_string(),
+            self_node.enable_standalone_compactors.to_string(),
+        ));
         let chitchat_handle =
             spawn_chitchat(chitchat_config, initial_key_values, transport).await?;
 
@@ -271,6 +275,16 @@ impl Cluster {
             .live_nodes
             .values()
             .filter(|node| node.is_ready)
+            .cloned()
+            .collect()
+    }
+
+    pub async fn live_nodes(&self) -> Vec<ClusterNode> {
+        self.inner
+            .read()
+            .await
+            .live_nodes
+            .values()
             .cloned()
             .collect()
     }
@@ -337,6 +351,12 @@ impl Cluster {
         };
         self.set_self_key_value(READINESS_KEY, readiness_value)
             .await
+    }
+
+    #[cfg(any(test, feature = "testsuite"))]
+    pub async fn set_self_enable_standalone_compactors(&self, enable: bool) {
+        self.set_self_key_value(STANDALONE_COMPACTORS_KEY, enable)
+            .await;
     }
 
     /// Sets a key-value pair on the cluster node's state.
@@ -716,6 +736,7 @@ pub async fn create_cluster_for_test_with_id(
         indexing_cpu_capacity: PIPELINE_FULL_CAPACITY,
         ingester_status: IngesterStatus::default(),
         availability_zone: None,
+        enable_standalone_compactors: false,
     };
     let failure_detector_config = create_failure_detector_config_for_test();
     let cluster = Cluster::join(

--- a/quickwit/quickwit-cluster/src/grpc_service.rs
+++ b/quickwit/quickwit-cluster/src/grpc_service.rs
@@ -123,7 +123,9 @@ impl ClusterService for Cluster {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::member::{ENABLED_SERVICES_KEY, GRPC_ADVERTISE_ADDR_KEY, READINESS_KEY};
+    use crate::member::{
+        ENABLED_SERVICES_KEY, GRPC_ADVERTISE_ADDR_KEY, READINESS_KEY, STANDALONE_COMPACTORS_KEY,
+    };
     use crate::{ChitchatTransport, create_cluster_for_test};
 
     #[tokio::test]
@@ -161,7 +163,7 @@ mod tests {
             .key_values
             .sort_unstable_by(|left, right| left.key.cmp(&right.key));
 
-        assert_eq!(node_state.key_values.len(), 4);
+        assert_eq!(node_state.key_values.len(), 5);
         assert_eq!(node_state.key_values[0].key, ENABLED_SERVICES_KEY);
         assert_eq!(node_state.key_values[0].value, "indexer");
 
@@ -172,5 +174,8 @@ mod tests {
 
         assert_eq!(node_state.key_values[3].key, READINESS_KEY);
         assert_eq!(node_state.key_values[3].value, "READY");
+
+        assert_eq!(node_state.key_values[4].key, STANDALONE_COMPACTORS_KEY);
+        assert_eq!(node_state.key_values[4].value, "false");
     }
 }

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -130,6 +130,7 @@ pub async fn start_cluster_service(node_config: &NodeConfig) -> anyhow::Result<C
         indexing_cpu_capacity,
         ingester_status: IngesterStatus::default(),
         availability_zone: node_config.availability_zone.clone(),
+        enable_standalone_compactors: node_config.enable_standalone_compactors,
     };
     let failure_detector_config = FailureDetectorConfig {
         dead_node_grace_period: Duration::from_secs(2 * 60 * 60), // 2 hours

--- a/quickwit/quickwit-cluster/src/member.rs
+++ b/quickwit/quickwit-cluster/src/member.rs
@@ -40,6 +40,8 @@ pub(crate) const READINESS_VALUE_NOT_READY: &str = "NOT_READY";
 
 pub(crate) const AVAILABILITY_ZONE_KEY: &str = "availability_zone";
 
+pub(crate) const STANDALONE_COMPACTORS_KEY: &str = "standalone_compactors";
+
 pub const INDEXING_CPU_CAPACITY_KEY: &str = "indexing_cpu_capacity";
 
 pub(crate) trait NodeStateExt {
@@ -52,6 +54,8 @@ pub(crate) trait NodeStateExt {
     fn ingester_status(&self) -> IngesterStatus;
 
     fn availability_zone(&self) -> Option<String>;
+
+    fn enable_standalone_compactors(&self) -> bool;
 }
 
 impl NodeStateExt for NodeState {
@@ -92,6 +96,13 @@ impl NodeStateExt for NodeState {
     fn availability_zone(&self) -> Option<String> {
         self.get(AVAILABILITY_ZONE_KEY).map(|az| az.to_string())
     }
+
+    fn enable_standalone_compactors(&self) -> bool {
+        match self.get(STANDALONE_COMPACTORS_KEY) {
+            Some(value) => value == "true",
+            None => false,
+        }
+    }
 }
 
 /// Cluster member.
@@ -125,6 +136,8 @@ pub struct ClusterMember {
     pub is_ready: bool,
     /// Availability zone the node is running in, if enabled.
     pub availability_zone: Option<String>,
+    /// Whether the node was started with standalone compactors enabled.
+    pub enable_standalone_compactors: bool,
 }
 
 impl ClusterMember {
@@ -194,6 +207,7 @@ pub(crate) fn build_cluster_member(
     let indexing_cpu_capacity = parse_indexing_cpu_capacity(node_state);
     let ingester_status = node_state.ingester_status();
     let availability_zone = node_state.availability_zone();
+    let enable_standalone_compactors = node_state.enable_standalone_compactors();
 
     let member = ClusterMember {
         node_id: NodeId::from_arc_str(chitchat_id.node_id.clone()),
@@ -206,6 +220,7 @@ pub(crate) fn build_cluster_member(
         indexing_cpu_capacity,
         ingester_status,
         availability_zone,
+        enable_standalone_compactors,
     };
     Ok(member)
 }
@@ -243,11 +258,25 @@ mod tests {
     use chitchat::NodeState;
     use quickwit_proto::ingest::ingester::IngesterStatus;
 
-    use super::NodeStateExt;
+    use super::{NodeStateExt, STANDALONE_COMPACTORS_KEY};
 
     #[test]
     fn test_ingester_status_defaults_to_ready_when_key_absent() {
         let node_state = NodeState::for_test();
         assert_eq!(node_state.ingester_status(), IngesterStatus::Ready);
+    }
+
+    #[test]
+    fn test_enable_standalone_compactors_parsing() {
+        let absent = NodeState::for_test();
+        assert!(!absent.enable_standalone_compactors());
+
+        let mut enabled = NodeState::for_test();
+        enabled.set(STANDALONE_COMPACTORS_KEY, "true");
+        assert!(enabled.enable_standalone_compactors());
+
+        let mut disabled = NodeState::for_test();
+        disabled.set(STANDALONE_COMPACTORS_KEY, "false");
+        assert!(!disabled.enable_standalone_compactors());
     }
 }

--- a/quickwit/quickwit-cluster/src/node.rs
+++ b/quickwit/quickwit-cluster/src/node.rs
@@ -109,6 +109,10 @@ impl ClusterNode {
     pub fn availability_zone(&self) -> Option<&str> {
         self.inner.member.availability_zone.as_deref()
     }
+
+    pub fn enable_standalone_compactors(&self) -> bool {
+        self.inner.member.enable_standalone_compactors
+    }
 }
 
 impl std::ops::Deref for ClusterNode {

--- a/quickwit/quickwit-compaction/Cargo.toml
+++ b/quickwit/quickwit-compaction/Cargo.toml
@@ -14,6 +14,7 @@ license.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 quickwit-actors = { workspace = true }
+quickwit-cluster = { workspace = true }
 quickwit-common = { workspace = true }
 quickwit-config = { workspace = true }
 quickwit-doc-mapper = { workspace = true }
@@ -31,6 +32,7 @@ itertools = "0.14.0"
 
 [dev-dependencies]
 quickwit-actors = { workspace = true, features = ["testsuite"] }
+quickwit-cluster = { workspace = true, features = ["testsuite"] }
 quickwit-doc-mapper = { workspace = true, features = ["testsuite"] }
 quickwit-metastore = { workspace = true, features = ["testsuite"] }
 quickwit-proto = { workspace = true, features = ["testsuite"] }

--- a/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_planner.rs
@@ -19,6 +19,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler};
+use quickwit_cluster::Cluster;
+use quickwit_common::rate_limited_tracing::rate_limited_info;
 use quickwit_metastore::{
     ListSplitsQuery, ListSplitsRequestExt, MetastoreServiceStreamSplitsExt, Split, SplitState,
 };
@@ -52,6 +54,7 @@ pub struct CompactionPlanner {
     state: CompactionState,
     index_config_metastore: IndexConfigMetastore,
     metastore: MetastoreServiceClient,
+    cluster: Cluster,
 }
 
 const SCAN_AND_PLAN_INTERVAL: Duration = Duration::from_secs(5);
@@ -61,6 +64,9 @@ const INITIAL_SCAN_AND_PLAN_INTERVAL: Duration = SCAN_AND_PLAN_INTERVAL.saturati
 
 #[derive(Debug)]
 struct ScanAndPlan;
+
+#[derive(Debug)]
+struct AwaitIndexersMigrated;
 
 #[async_trait]
 impl Actor for CompactionPlanner {
@@ -74,10 +80,11 @@ impl Actor for CompactionPlanner {
 
     async fn initialize(&mut self, ctx: &ActorContext<Self>) -> Result<(), ActorExitStatus> {
         info!(
-            "compaction planner starting, scanning metastore for immature splits in {} seconds",
+            "compaction planner initializing, waiting for indexers to hand off compaction in {} \
+             seconds",
             INITIAL_SCAN_AND_PLAN_INTERVAL.as_secs()
         );
-        ctx.schedule_self_msg(INITIAL_SCAN_AND_PLAN_INTERVAL, ScanAndPlan);
+        ctx.schedule_self_msg(INITIAL_SCAN_AND_PLAN_INTERVAL, AwaitIndexersMigrated);
         Ok(())
     }
 }
@@ -101,6 +108,32 @@ impl Handler<ScanAndPlan> for CompactionPlanner {
 }
 
 #[async_trait]
+impl Handler<AwaitIndexersMigrated> for CompactionPlanner {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: AwaitIndexersMigrated,
+        ctx: &ActorContext<Self>,
+    ) -> Result<(), ActorExitStatus> {
+        if self.all_indexers_migrated().await {
+            info!(
+                "all indexers report standalone compactors enabled, starting compaction scan loop"
+            );
+            ctx.send_self_message(ScanAndPlan).await?;
+        } else {
+            rate_limited_info!(
+                limit_per_min = 6,
+                "waiting for indexers to report standalone compactors enabled before planning \
+                 merges"
+            );
+            ctx.schedule_self_msg(SCAN_AND_PLAN_INTERVAL, AwaitIndexersMigrated);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
 impl Handler<ReportStatusRequest> for CompactionPlanner {
     type Reply = CompactionResult<ReportStatusResponse>;
 
@@ -119,12 +152,22 @@ impl Handler<ReportStatusRequest> for CompactionPlanner {
 }
 
 impl CompactionPlanner {
-    pub fn new(metastore: MetastoreServiceClient) -> Self {
+    pub fn new(metastore: MetastoreServiceClient, cluster: Cluster) -> Self {
         CompactionPlanner {
             state: CompactionState::new(),
             index_config_metastore: IndexConfigMetastore::new(metastore.clone()),
             metastore,
+            cluster,
         }
+    }
+
+    async fn all_indexers_migrated(&self) -> bool {
+        self.cluster
+            .live_nodes()
+            .await
+            .iter()
+            .filter(|node| node.is_indexer())
+            .all(|node| node.enable_standalone_compactors())
     }
 
     async fn ingest_splits(&mut self, splits: Vec<Split>) {
@@ -211,6 +254,7 @@ impl CompactionPlanner {
                 .iter()
                 .map(|s| s.split_id().to_string())
                 .collect();
+
             self.state
                 .record_assignment(task_id, split_ids, node_id.clone());
 
@@ -263,7 +307,9 @@ mod tests {
     use std::ops::Bound;
     use std::time::Duration;
 
+    use quickwit_cluster::{ChitchatTransport, create_cluster_for_test};
     use quickwit_common::ServiceStream;
+    use quickwit_common::test_utils::wait_until_predicate;
     use quickwit_config::IndexingSettings;
     use quickwit_config::merge_policy_config::{
         ConstWriteAmplificationMergePolicyConfig, MergePolicyConfig,
@@ -325,6 +371,15 @@ mod tests {
         IndexMetadataResponse::try_from_index_metadata(index_metadata).unwrap()
     }
 
+    async fn test_cluster() -> Cluster {
+        use quickwit_cluster::{ChitchatTransport, create_cluster_for_test};
+
+        let transport = ChitchatTransport::default();
+        create_cluster_for_test(Vec::new(), &["janitor"], &transport, true)
+            .await
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn test_scan_metastore_query_shape_and_passthrough() {
         let index_uid = IndexUid::for_test("test-index", 0);
@@ -361,7 +416,10 @@ mod tests {
             Ok(ServiceStream::from(vec![Ok(response)]))
         });
 
-        let planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
         let result = planner.scan_metastore().await.unwrap();
 
         assert_eq!(result.len(), 2);
@@ -387,7 +445,10 @@ mod tests {
             Ok(ServiceStream::from(vec![Ok(response)]))
         });
 
-        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let mut planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
         planner.state.track_split(SplitMetadata {
             split_id: "tracked".to_string(),
             index_uid: index_uid.clone(),
@@ -416,7 +477,10 @@ mod tests {
         mock.expect_index_metadata()
             .returning(move |_| Ok(response.clone()));
 
-        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let mut planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
 
         // Pre-populate: "in-flight" is already being compacted.
         planner.state.track_split(SplitMetadata {
@@ -451,7 +515,10 @@ mod tests {
             })
         });
 
-        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let mut planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
         assert!(planner.scan_and_plan().await.is_err());
     }
 
@@ -468,7 +535,10 @@ mod tests {
             })
         });
 
-        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let mut planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
         planner.ingest_splits(splits).await;
 
         assert!(!planner.state.is_split_tracked("orphan"));
@@ -494,7 +564,10 @@ mod tests {
         mock.expect_index_metadata()
             .returning(move |_| Ok(index_metadata_response.clone()));
 
-        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let mut planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
         planner.scan_and_plan().await.unwrap();
 
         assert!(planner.state.is_split_tracked("s1"));
@@ -525,7 +598,10 @@ mod tests {
         mock.expect_index_metadata()
             .returning(move |_| Ok(index_metadata_response.clone()));
 
-        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let mut planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
         let node_id = NodeId::from_str("worker-1");
 
         planner.scan_and_plan().await.unwrap();
@@ -567,7 +643,10 @@ mod tests {
             )]))
         });
 
-        let mut planner = CompactionPlanner::new(MetastoreServiceClient::from_mock(mock));
+        let mut planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(mock),
+            test_cluster().await,
+        );
 
         let splits: Vec<Split> = split_ids
             .iter()
@@ -642,5 +721,73 @@ mod tests {
         let assignments = planner.assign_tasks(&node_id, 10);
         assert_eq!(assignments.len(), 1);
         assert_eq!(assignments[0].splits_metadata_json.len(), 2);
+    }
+
+    async fn migrated_indexer(seeds: Vec<String>, transport: &ChitchatTransport) -> Cluster {
+        let cluster = create_cluster_for_test(seeds, &["indexer"], transport, true)
+            .await
+            .unwrap();
+        cluster.set_self_enable_standalone_compactors(true).await;
+        cluster
+    }
+
+    async fn wait_for_indexer_count(cluster: &Cluster, expected: usize) {
+        let cluster = cluster.clone();
+        wait_until_predicate(
+            move || {
+                let cluster = cluster.clone();
+                async move {
+                    cluster
+                        .live_nodes()
+                        .await
+                        .iter()
+                        .filter(|node| node.is_indexer())
+                        .count()
+                        == expected
+                }
+            },
+            Duration::from_secs(10),
+            Duration::from_millis(100),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_gate_opens_only_after_indexer_rollout() {
+        let transport = ChitchatTransport::default();
+        let janitor_cluster = create_cluster_for_test(Vec::new(), &["janitor"], &transport, true)
+            .await
+            .unwrap();
+        let seeds = vec![janitor_cluster.gossip_listen_addr.to_string()];
+        let planner = CompactionPlanner::new(
+            MetastoreServiceClient::from_mock(MockMetastoreService::new()),
+            janitor_cluster.clone(),
+        );
+
+        assert!(planner.all_indexers_migrated().await);
+
+        let old_indexer_1 = create_cluster_for_test(seeds.clone(), &["indexer"], &transport, true)
+            .await
+            .unwrap();
+        let old_indexer_2 = create_cluster_for_test(seeds.clone(), &["indexer"], &transport, true)
+            .await
+            .unwrap();
+        wait_for_indexer_count(&janitor_cluster, 2).await;
+        assert!(!planner.all_indexers_migrated().await);
+
+        let new_indexer_1 = migrated_indexer(seeds.clone(), &transport).await;
+        wait_for_indexer_count(&janitor_cluster, 3).await;
+        assert!(!planner.all_indexers_migrated().await);
+
+        let new_indexer_2 = migrated_indexer(seeds.clone(), &transport).await;
+        drop(old_indexer_1);
+        drop(old_indexer_2);
+
+        wait_for_indexer_count(&janitor_cluster, 2).await;
+        assert!(planner.all_indexers_migrated().await);
+
+        drop(new_indexer_1);
+        drop(new_indexer_2);
     }
 }

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -393,7 +393,7 @@ impl IndexingService {
             self.max_concurrent_split_uploads
         };
         let max_concurrent_split_uploads_merge =
-            self.max_concurrent_split_uploads - max_concurrent_split_uploads_index;
+            (self.max_concurrent_split_uploads - max_concurrent_split_uploads_index).max(1);
 
         let pipeline_params = IndexingPipelineParams {
             pipeline_id: indexing_pipeline_id.clone(),

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -303,7 +303,7 @@ async fn get_compaction_planner_client_if_needed(
         return Ok((None, None));
     }
     if is_janitor {
-        let planner = CompactionPlanner::new(metastore_client.clone());
+        let planner = CompactionPlanner::new(metastore_client.clone(), cluster.clone());
         let (mailbox, handle) = universe.spawn_builder().spawn(planner);
         info!("compaction planner actor started on janitor node");
         return Ok((


### PR DESCRIPTION
### Description

When initially turning on `enableStandaloneCompactors`, the janitor running the merge planner and the compactors come online basically immediately and start performing merges. Indexers take a long time (minutes) to decommission, and deploy one by one. That means that we can end up with a split brain situation where there's merge pipelines running on the old indexers, and compactors from the new deploy are up and running. They then end up with a bunch of publish failures.

This addresses that by adding a standalone compactors value to ClusterMember, so that the merge planner can await for all indexers to show that they have standalone compactors enabled. This necessarily means that no merge pipelines are running on those indexers, so that starting standalone compaction is safe.


### How was this PR tested?

Unit tests, local cluster.
