### PR TITLE
Decommission compactors gracefully

### DIFF
--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -62,7 +62,7 @@ pub enum CompactorStatus {
     /// Draining: rejects new tasks (reports zero available slots) while in-flight merges finish.
     Decommissioning,
     /// All in-flight merges have completed; the supervisor can be torn down.
-    Finished,
+    Decommissioned,
 }
 
 /// Manages a pool of `CompactionPipeline`s, each executing a single merge task.
@@ -72,7 +72,6 @@ pub enum CompactorStatus {
 pub struct CompactorSupervisor {
     node_id: NodeId,
     planner_client: CompactionPlannerServiceClient,
-    status: CompactorStatus,
     status_tx: watch::Sender<CompactorStatus>,
     pipelines: Vec<Option<CompactionPipeline>>,
     // Bounds the number of pipelines running Tantivy merge step concurrently. There are 2x as many
@@ -118,7 +117,6 @@ impl CompactorSupervisor {
         CompactorSupervisor {
             node_id,
             planner_client,
-            status: CompactorStatus::Ready,
             status_tx,
             pipelines,
             merge_execution_semaphore,
@@ -136,13 +134,16 @@ impl CompactorSupervisor {
         self.status_tx.subscribe()
     }
 
+    fn status(&self) -> CompactorStatus {
+        *self.status_tx.borrow()
+    }
+
     fn set_status(&mut self, status: CompactorStatus) {
-        self.status = status;
         self.status_tx.send_replace(status);
     }
 
     fn check_decommissioning_status(&mut self) {
-        if self.status != CompactorStatus::Decommissioning {
+        if self.status() != CompactorStatus::Decommissioning {
             return;
         }
         let any_in_progress = self
@@ -151,7 +152,7 @@ impl CompactorSupervisor {
             .flatten()
             .any(|pipeline| matches!(pipeline.status(), PipelineStatus::InProgress));
         if !any_in_progress {
-            self.set_status(CompactorStatus::Finished);
+            self.set_status(CompactorStatus::Decommissioned);
         }
     }
 
@@ -214,7 +215,7 @@ impl CompactorSupervisor {
         assignment: MergeTaskAssignment,
         spawn_ctx: &SpawnContext,
     ) -> anyhow::Result<()> {
-        if self.status != CompactorStatus::Ready {
+        if self.status() != CompactorStatus::Ready {
             info!(
                 task_id = %assignment.task_id,
                 "compactor is decommissioning; dropping assigned merge task, the merge planner will reschedule it"
@@ -301,7 +302,7 @@ impl CompactorSupervisor {
     }
 
     fn available_slots(&self, in_progress_count: usize) -> u32 {
-        if self.status != CompactorStatus::Ready {
+        if self.status() != CompactorStatus::Ready {
             return 0;
         }
         (self.pipelines.len() - in_progress_count) as u32
@@ -384,12 +385,9 @@ impl Handler<CheckPipelineStatuses> for CompactorSupervisor {
         _msg: CheckPipelineStatuses,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        // Once finished decommissioning we stop the loop; the node is about to be torn down.
-        if self.status == CompactorStatus::Finished {
-            return Ok(());
-        }
         self.report_status_and_maybe_finish(ctx).await;
-        if self.status == CompactorStatus::Finished {
+        if self.status() == CompactorStatus::Decommissioned {
+            // We stop the loop; the node is about to be torn down.
             info!("compactor finished draining in-flight merges");
             return Ok(());
         }
@@ -407,7 +405,7 @@ impl Handler<Decommission> for CompactorSupervisor {
         _msg: Decommission,
         _ctx: &ActorContext<Self>,
     ) -> Result<watch::Receiver<CompactorStatus>, ActorExitStatus> {
-        if self.status == CompactorStatus::Ready {
+        if self.status() == CompactorStatus::Ready {
             info!("decommissioning compactor");
             self.set_status(CompactorStatus::Decommissioning);
         }
@@ -415,18 +413,32 @@ impl Handler<Decommission> for CompactorSupervisor {
     }
 }
 
-pub async fn wait_for_compactor_decommission(
-    compactor_mailbox: &Mailbox<CompactorSupervisor>,
-    timeout_after: Duration,
-) -> anyhow::Result<()> {
-    let mut status_rx = compactor_mailbox
+/// Initiates compactor decommission if one is present, returning a receiver to await it.
+pub async fn notify_compactor_decommission(
+    compactor_mailbox_opt: Option<&Mailbox<CompactorSupervisor>>,
+) -> anyhow::Result<Option<watch::Receiver<CompactorStatus>>> {
+    let Some(compactor_mailbox) = compactor_mailbox_opt else {
+        return Ok(None);
+    };
+    let status_rx = compactor_mailbox
         .send_message_with_high_priority(Decommission)
         .context("failed to initiate compactor decommission")?
         .await
         .context("compactor dropped decommission reply")?;
+    Ok(Some(status_rx))
+}
+
+/// Waits for a compactor to finish draining its in-flight merges, if one is present.
+pub async fn wait_for_compactor_decommission(
+    status_rx_opt: Option<watch::Receiver<CompactorStatus>>,
+    timeout_after: Duration,
+) -> anyhow::Result<()> {
+    let Some(mut status_rx) = status_rx_opt else {
+        return Ok(());
+    };
     tokio::time::timeout(
         timeout_after,
-        status_rx.wait_for(|status| *status == CompactorStatus::Finished),
+        status_rx.wait_for(|status| *status == CompactorStatus::Decommissioned),
     )
     .await
     .context("timed out waiting for compactor to finish decommissioning")?
@@ -763,14 +775,14 @@ mod tests {
         let mut supervisor = test_supervisor(2);
         supervisor.set_status(CompactorStatus::Decommissioning);
         supervisor.check_decommissioning_status();
-        assert_eq!(supervisor.status, CompactorStatus::Finished);
+        assert_eq!(supervisor.status(), CompactorStatus::Decommissioned);
     }
 
     #[test]
     fn test_check_decommissioning_status_noop_when_ready() {
         let mut supervisor = test_supervisor(2);
         supervisor.check_decommissioning_status();
-        assert_eq!(supervisor.status, CompactorStatus::Ready);
+        assert_eq!(supervisor.status(), CompactorStatus::Ready);
     }
 
     #[test]
@@ -796,7 +808,7 @@ mod tests {
         supervisor.check_decommissioning_status();
 
         // The in-flight pipeline keeps the supervisor draining and advertising no capacity.
-        assert_eq!(supervisor.status, CompactorStatus::Decommissioning);
+        assert_eq!(supervisor.status(), CompactorStatus::Decommissioning);
         let request = supervisor.build_report_status_request(&statuses);
         assert_eq!(request.available_slots, 0);
         assert_eq!(request.in_progress.len(), 1);
@@ -848,11 +860,12 @@ mod tests {
         let status_rx = supervisor.status_rx();
         let (mailbox, _handle) = universe.spawn_builder().spawn(supervisor);
 
-        wait_for_compactor_decommission(&mailbox, Duration::from_secs(10))
+        let decommission_rx_opt = notify_compactor_decommission(Some(&mailbox)).await.unwrap();
+        wait_for_compactor_decommission(decommission_rx_opt, Duration::from_secs(10))
             .await
             .unwrap();
 
-        assert_eq!(*status_rx.borrow(), CompactorStatus::Finished);
+        assert_eq!(*status_rx.borrow(), CompactorStatus::Decommissioned);
         universe.assert_quit().await;
     }
 }

--- a/quickwit/quickwit-compaction/src/compactor_supervisor.rs
+++ b/quickwit/quickwit-compaction/src/compactor_supervisor.rs
@@ -16,8 +16,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use async_trait::async_trait;
-use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, SpawnContext};
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, SpawnContext};
 use quickwit_common::io::{self, Limiter};
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;
@@ -38,7 +39,7 @@ use quickwit_proto::indexing::MergePipelineId;
 use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_proto::types::NodeId;
 use quickwit_storage::StorageResolver;
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, watch};
 use tracing::{error, info};
 
 use crate::compaction_pipeline::{CompactionPipeline, PipelineStatus, PipelineStatusUpdate};
@@ -50,6 +51,20 @@ const CHECK_PIPELINE_STATUSES_INTERVAL: Duration = Duration::from_secs(1);
 #[derive(Debug)]
 struct CheckPipelineStatuses;
 
+#[derive(Debug)]
+pub struct Decommission;
+
+/// Lifecycle state of a `CompactorSupervisor`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactorStatus {
+    /// Normal operation: accepts and spawns new merge tasks.
+    Ready,
+    /// Draining: rejects new tasks (reports zero available slots) while in-flight merges finish.
+    Decommissioning,
+    /// All in-flight merges have completed; the supervisor can be torn down.
+    Finished,
+}
+
 /// Manages a pool of `CompactionPipeline`s, each executing a single merge task.
 ///
 /// Periodically collects pipeline status updates and forwards them to the
@@ -57,6 +72,8 @@ struct CheckPipelineStatuses;
 pub struct CompactorSupervisor {
     node_id: NodeId,
     planner_client: CompactionPlannerServiceClient,
+    status: CompactorStatus,
+    status_tx: watch::Sender<CompactorStatus>,
     pipelines: Vec<Option<CompactionPipeline>>,
     // Bounds the number of pipelines running Tantivy merge step concurrently. There are 2x as many
     // pipeline slots as permits, so half the pipelines can be doing IO while the other half hold a
@@ -97,9 +114,12 @@ impl CompactorSupervisor {
         let merge_execution_semaphore =
             Arc::new(Semaphore::new(max_concurrent_merge_executions.get()));
         let io_throughput_limiter = max_merge_write_throughput.map(io::limiter);
+        let (status_tx, _status_rx) = watch::channel(CompactorStatus::Ready);
         CompactorSupervisor {
             node_id,
             planner_client,
+            status: CompactorStatus::Ready,
+            status_tx,
             pipelines,
             merge_execution_semaphore,
             io_throughput_limiter,
@@ -109,6 +129,47 @@ impl CompactorSupervisor {
             max_concurrent_split_uploads,
             event_broker,
             compaction_root_directory,
+        }
+    }
+
+    pub fn status_rx(&self) -> watch::Receiver<CompactorStatus> {
+        self.status_tx.subscribe()
+    }
+
+    fn set_status(&mut self, status: CompactorStatus) {
+        self.status = status;
+        self.status_tx.send_replace(status);
+    }
+
+    fn check_decommissioning_status(&mut self) {
+        if self.status != CompactorStatus::Decommissioning {
+            return;
+        }
+        let any_in_progress = self
+            .pipelines
+            .iter()
+            .flatten()
+            .any(|pipeline| matches!(pipeline.status(), PipelineStatus::InProgress));
+        if !any_in_progress {
+            self.set_status(CompactorStatus::Finished);
+        }
+    }
+
+    async fn report_status_and_maybe_finish(&mut self, ctx: &ActorContext<Self>) {
+        let statuses = self.check_pipeline_statuses();
+        let request = self.build_report_status_request(&statuses);
+        match ctx
+            .protect_future(self.planner_client.report_status(request))
+            .await
+        {
+            Ok(response) => {
+                ctx.protect_future(self.process_new_tasks(response.new_tasks, ctx.spawn_ctx()))
+                    .await;
+                self.check_decommissioning_status();
+            }
+            Err(error) => {
+                error!(%error, "failed to report status to compaction planner");
+            }
         }
     }
 
@@ -153,6 +214,13 @@ impl CompactorSupervisor {
         assignment: MergeTaskAssignment,
         spawn_ctx: &SpawnContext,
     ) -> anyhow::Result<()> {
+        if self.status != CompactorStatus::Ready {
+            info!(
+                task_id = %assignment.task_id,
+                "compactor is decommissioning; dropping assigned merge task, the merge planner will reschedule it"
+            );
+            return Ok(());
+        }
         let source_uid_label = source_uid_metrics_label(
             assignment.index_uid.as_ref().unwrap(),
             &assignment.source_id,
@@ -232,6 +300,13 @@ impl CompactorSupervisor {
         ))
     }
 
+    fn available_slots(&self, in_progress_count: usize) -> u32 {
+        if self.status != CompactorStatus::Ready {
+            return 0;
+        }
+        (self.pipelines.len() - in_progress_count) as u32
+    }
+
     fn build_report_status_request(
         &self,
         statuses: &[PipelineStatusUpdate],
@@ -240,7 +315,7 @@ impl CompactorSupervisor {
             .iter()
             .filter(|s| matches!(s.status, PipelineStatus::InProgress))
             .count();
-        let available_slots = (self.pipelines.len() - in_progress_count) as i64;
+        let available_slots = self.available_slots(in_progress_count);
 
         let mut in_progress = Vec::new();
         let mut successes = Vec::new();
@@ -272,7 +347,7 @@ impl CompactorSupervisor {
 
         ReportStatusRequest {
             node_id: self.node_id.to_string(),
-            available_slots: available_slots as u32,
+            available_slots,
             in_progress,
             successes,
             failures,
@@ -309,23 +384,55 @@ impl Handler<CheckPipelineStatuses> for CompactorSupervisor {
         _msg: CheckPipelineStatuses,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        let statuses = self.check_pipeline_statuses();
-        let request = self.build_report_status_request(&statuses);
-        match ctx
-            .protect_future(self.planner_client.report_status(request))
-            .await
-        {
-            Ok(response) => {
-                ctx.protect_future(self.process_new_tasks(response.new_tasks, ctx.spawn_ctx()))
-                    .await;
-            }
-            Err(error) => {
-                error!(%error, "failed to report status to compaction planner");
-            }
+        // Once finished decommissioning we stop the loop; the node is about to be torn down.
+        if self.status == CompactorStatus::Finished {
+            return Ok(());
+        }
+        self.report_status_and_maybe_finish(ctx).await;
+        if self.status == CompactorStatus::Finished {
+            info!("compactor finished draining in-flight merges");
+            return Ok(());
         }
         ctx.schedule_self_msg(CHECK_PIPELINE_STATUSES_INTERVAL, CheckPipelineStatuses);
         Ok(())
     }
+}
+
+#[async_trait]
+impl Handler<Decommission> for CompactorSupervisor {
+    type Reply = watch::Receiver<CompactorStatus>;
+
+    async fn handle(
+        &mut self,
+        _msg: Decommission,
+        _ctx: &ActorContext<Self>,
+    ) -> Result<watch::Receiver<CompactorStatus>, ActorExitStatus> {
+        if self.status == CompactorStatus::Ready {
+            info!("decommissioning compactor");
+            self.set_status(CompactorStatus::Decommissioning);
+        }
+        Ok(self.status_rx())
+    }
+}
+
+pub async fn wait_for_compactor_decommission(
+    compactor_mailbox: &Mailbox<CompactorSupervisor>,
+    timeout_after: Duration,
+) -> anyhow::Result<()> {
+    let mut status_rx = compactor_mailbox
+        .send_message_with_high_priority(Decommission)
+        .context("failed to initiate compactor decommission")?
+        .await
+        .context("compactor dropped decommission reply")?;
+    tokio::time::timeout(
+        timeout_after,
+        status_rx.wait_for(|status| *status == CompactorStatus::Finished),
+    )
+    .await
+    .context("timed out waiting for compactor to finish decommissioning")?
+    .context("compactor status channel closed")?;
+    info!("compactor decommissioned successfully");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -649,5 +756,103 @@ mod tests {
         assert_eq!(request.failures.len(), 1);
         assert_eq!(request.failures[0].task_id, "task-3");
         assert_eq!(request.failures[0].error_message, "boom");
+    }
+
+    #[test]
+    fn test_check_decommissioning_status_finishes_when_idle() {
+        let mut supervisor = test_supervisor(2);
+        supervisor.set_status(CompactorStatus::Decommissioning);
+        supervisor.check_decommissioning_status();
+        assert_eq!(supervisor.status, CompactorStatus::Finished);
+    }
+
+    #[test]
+    fn test_check_decommissioning_status_noop_when_ready() {
+        let mut supervisor = test_supervisor(2);
+        supervisor.check_decommissioning_status();
+        assert_eq!(supervisor.status, CompactorStatus::Ready);
+    }
+
+    #[test]
+    fn test_decommissioning_reports_zero_available_slots() {
+        // 4 merge-executions → 8 free pipeline slots, but decommissioning advertises none.
+        let mut supervisor = test_supervisor(4);
+        supervisor.set_status(CompactorStatus::Decommissioning);
+        let request = supervisor.build_report_status_request(&[]);
+        assert_eq!(request.available_slots, 0);
+    }
+
+    #[tokio::test]
+    async fn test_decommissioning_waits_for_in_flight_merge() {
+        let universe = Universe::new();
+        let mut supervisor = test_supervisor(4);
+
+        let mut pipeline = test_pipeline("task-1", &["s1"]);
+        pipeline.spawn_pipeline(universe.spawn_ctx()).unwrap();
+        supervisor.pipelines[0] = Some(pipeline);
+
+        supervisor.set_status(CompactorStatus::Decommissioning);
+        let statuses = supervisor.check_pipeline_statuses();
+        supervisor.check_decommissioning_status();
+
+        // The in-flight pipeline keeps the supervisor draining and advertising no capacity.
+        assert_eq!(supervisor.status, CompactorStatus::Decommissioning);
+        let request = supervisor.build_report_status_request(&statuses);
+        assert_eq!(request.available_slots, 0);
+        assert_eq!(request.in_progress.len(), 1);
+
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_spawn_task_dropped_while_decommissioning() {
+        let universe = Universe::new();
+        let mut supervisor = test_supervisor(2);
+        supervisor.set_status(CompactorStatus::Decommissioning);
+
+        supervisor
+            .spawn_task(test_assignment("task-1", &["s1"]), universe.spawn_ctx())
+            .await
+            .unwrap();
+
+        assert!(supervisor.pipelines.iter().all(|slot| slot.is_none()));
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_compactor_decommission_drains_when_idle() {
+        let universe = Universe::new();
+
+        let mut mock = MockCompactionPlannerService::new();
+        mock.expect_report_status().returning(|_req| {
+            Ok(quickwit_proto::compaction::ReportStatusResponse {
+                new_tasks: Vec::new(),
+            })
+        });
+        let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
+        let client = CompactionPlannerServiceClient::from_mock(mock);
+        let compactor_config = CompactorConfig {
+            max_concurrent_merge_executions: NonZeroUsize::new(2).unwrap(),
+            ..CompactorConfig::for_test()
+        };
+        let supervisor = CompactorSupervisor::new(
+            NodeId::from_str("test-node"),
+            client,
+            &compactor_config,
+            metastore,
+            StorageResolver::for_test(),
+            Arc::new(IndexingSplitCache::no_caching()),
+            EventBroker::default(),
+            TempDirectory::for_test(),
+        );
+        let status_rx = supervisor.status_rx();
+        let (mailbox, _handle) = universe.spawn_builder().spawn(supervisor);
+
+        wait_for_compactor_decommission(&mailbox, Duration::from_secs(10))
+            .await
+            .unwrap();
+
+        assert_eq!(*status_rx.borrow(), CompactorStatus::Finished);
+        universe.assert_quit().await;
     }
 }

--- a/quickwit/quickwit-compaction/src/lib.rs
+++ b/quickwit/quickwit-compaction/src/lib.rs
@@ -23,7 +23,7 @@ pub type TaskId = String;
 
 use std::sync::Arc;
 
-pub use compactor_supervisor::CompactorSupervisor;
+pub use compactor_supervisor::{CompactorSupervisor, wait_for_compactor_decommission};
 use quickwit_actors::{Mailbox, Universe};
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;

--- a/quickwit/quickwit-compaction/src/lib.rs
+++ b/quickwit/quickwit-compaction/src/lib.rs
@@ -23,7 +23,9 @@ pub type TaskId = String;
 
 use std::sync::Arc;
 
-pub use compactor_supervisor::{CompactorSupervisor, wait_for_compactor_decommission};
+pub use compactor_supervisor::{
+    CompactorSupervisor, notify_compactor_decommission, wait_for_compactor_decommission,
+};
 use quickwit_actors::{Mailbox, Universe};
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::temp_dir::TempDirectory;

--- a/quickwit/quickwit-ingest/src/ingest_v2/helpers.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/helpers.rs
@@ -24,13 +24,6 @@ use tracing::info;
 
 /// Tries to get the current status of an ingester by opening an observation stream
 /// and reading the first message.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The observation stream fails to open
-/// - The stream ends without producing a message
-/// - The stream ends after returning an error
 pub async fn try_get_ingester_status(
     ingester: &impl IngesterService,
 ) -> anyhow::Result<IngesterStatus> {
@@ -49,17 +42,6 @@ pub async fn try_get_ingester_status(
 }
 
 /// Waits for an ingester to reach a specific status by monitoring its observation stream.
-///
-/// This function continuously polls the observation stream until the ingester reaches
-/// the desired status.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The observation stream fails to open
-/// - The stream ends without producing a message
-/// - The stream ends after returning an error
-/// - The timeout is exceeded
 pub async fn wait_for_ingester_status(
     ingester: &impl IngesterService,
     status: IngesterStatus,
@@ -108,36 +90,31 @@ async fn wait_for_ingester_status_inner(
     }
 }
 
-/// Initiates decommission of an ingester and waits for it to complete.
-///
-/// This function sends a decommission request to the ingester and then waits
-/// for it to reach the `Decommissioned` status.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The decommission request fails
-/// - The observation stream fails to open
-/// - The stream ends without producing a message
-/// - The stream ends after returning an error
-/// - The timeout is exceeded
-pub async fn wait_for_ingester_decommission(
-    ingester: &impl IngesterService,
-    timeout_after: Duration,
+/// Initiates decommission of an ingester, if one is present.
+pub async fn notify_ingester_decommission(
+    ingester_opt: Option<&impl IngesterService>,
 ) -> anyhow::Result<()> {
-    let now = Instant::now();
-
+    let Some(ingester) = ingester_opt else {
+        return Ok(());
+    };
     ingester
         .decommission(DecommissionRequest {})
         .await
         .context("failed to initiate ingester decommission")?;
+    Ok(())
+}
 
-    wait_for_ingester_status(
-        ingester,
-        IngesterStatus::Decommissioned,
-        timeout_after.saturating_sub(now.elapsed()),
-    )
-    .await?;
+/// Waits for an ingester to reach the `Decommissioned` status, if one is present.
+pub async fn wait_for_ingester_decommission(
+    ingester_opt: Option<&impl IngesterService>,
+    timeout_after: Duration,
+) -> anyhow::Result<()> {
+    let Some(ingester) = ingester_opt else {
+        return Ok(());
+    };
+    let now = Instant::now();
+
+    wait_for_ingester_status(ingester, IngesterStatus::Decommissioned, timeout_after).await?;
 
     info!(
         "successfully decommissioned ingester in {}",
@@ -229,7 +206,8 @@ mod tests {
             .once()
             .returning(|_| Ok(DecommissionResponse {}));
         let ingester = IngesterServiceClient::from_mock(mock_ingester);
-        wait_for_ingester_decommission(&ingester, Duration::from_secs(1))
+        notify_ingester_decommission(Some(&ingester)).await.unwrap();
+        wait_for_ingester_decommission(Some(&ingester), Duration::from_secs(1))
             .await
             .unwrap();
     }
@@ -266,7 +244,8 @@ mod tests {
             .once()
             .returning(|_| Ok(DecommissionResponse {}));
         let ingester = IngesterServiceClient::from_mock(mock_ingester);
-        wait_for_ingester_decommission(&ingester, Duration::from_secs(1))
+        notify_ingester_decommission(Some(&ingester)).await.unwrap();
+        wait_for_ingester_decommission(Some(&ingester), Duration::from_secs(1))
             .await
             .unwrap();
     }

--- a/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/mod.rs
@@ -58,7 +58,8 @@ use workbench::pending_subrequests;
 
 pub use self::fetch::{FetchStreamError, MultiFetchStream};
 pub use self::helpers::{
-    try_get_ingester_status, wait_for_ingester_decommission, wait_for_ingester_status,
+    notify_ingester_decommission, try_get_ingester_status, wait_for_ingester_decommission,
+    wait_for_ingester_status,
 };
 pub use self::ingester::Ingester;
 use self::mrecord::MRECORD_HEADER_LEN;

--- a/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
+++ b/quickwit/quickwit-integration-tests/src/test_utils/cluster_sandbox.rs
@@ -103,6 +103,7 @@ pub struct ClusterSandboxBuilder {
     temp_dir: TempDir,
     node_configs: Vec<TestNodeConfig>,
     use_legacy_ingest: bool,
+    enable_standalone_compactors: bool,
 }
 
 impl Default for ClusterSandboxBuilder {
@@ -111,6 +112,7 @@ impl Default for ClusterSandboxBuilder {
             temp_dir: tempfile::tempdir().unwrap(),
             node_configs: Vec::new(),
             use_legacy_ingest: false,
+            enable_standalone_compactors: false,
         }
     }
 }
@@ -151,6 +153,13 @@ impl ClusterSandboxBuilder {
         self
     }
 
+    /// Opts every node into the external compactor mode. Required for any node running the
+    /// `Compactor` service, and makes janitor nodes host the compaction planner.
+    pub fn enable_standalone_compactors(mut self) -> Self {
+        self.enable_standalone_compactors = true;
+        self
+    }
+
     /// Builds a list of of [`NodeConfig`] from the node definitions added to
     /// builder. For each node, a [`NodeConfig`] is built with the right
     /// parameters such that we will be able to run `quickwit_serve` on them and
@@ -166,7 +175,7 @@ impl ClusterSandboxBuilder {
         let unique_dir_name = new_coolid("test-dir");
         let tcp_listener_resolver = TestTcpListenerResolver::default();
         for (node_idx, node_builder) in self.node_configs.iter().enumerate() {
-            let config = node_builder
+            let mut config = node_builder
                 .build_node_config(
                     node_idx,
                     cluster_id.clone(),
@@ -175,6 +184,7 @@ impl ClusterSandboxBuilder {
                     &tcp_listener_resolver,
                 )
                 .await;
+            config.enable_standalone_compactors = self.enable_standalone_compactors;
             peers.push(config.gossip_advertise_addr.to_string());
             resolved_node_configs.push((config, node_builder.services.clone()));
         }

--- a/quickwit/quickwit-integration-tests/src/tests/compactor_tests.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/compactor_tests.rs
@@ -1,0 +1,58 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use quickwit_actors::ActorExitStatus;
+use quickwit_config::service::QuickwitService;
+
+use crate::test_utils::ClusterSandboxBuilder;
+
+/// A standalone compactor must drain gracefully on shutdown: the decommission path runs to
+/// completion and the supervisor and its pipelines exit cleanly.
+#[tokio::test]
+async fn test_standalone_compactor_graceful_decommission() {
+    let mut sandbox = ClusterSandboxBuilder::default()
+        .enable_standalone_compactors()
+        .add_node([
+            QuickwitService::ControlPlane,
+            QuickwitService::Metastore,
+            QuickwitService::Janitor,
+        ])
+        .add_node([QuickwitService::Compactor])
+        .build_and_start()
+        .await;
+
+    sandbox.wait_for_cluster_num_ready_nodes(2).await.unwrap();
+
+    // With no merge in flight the compactor reaches `Finished` immediately, so the shutdown must
+    // return well before the 300s decommission timeout (a regression would block until then).
+    let exit_statuses = tokio::time::timeout(
+        Duration::from_secs(30),
+        sandbox.shutdown_services([QuickwitService::Compactor]),
+    )
+    .await
+    .expect("compactor decommission should not block on the decommission timeout")
+    .unwrap();
+
+    assert_eq!(exit_statuses.len(), 1);
+    for (actor, status) in &exit_statuses[0] {
+        assert!(
+            matches!(status, ActorExitStatus::Success | ActorExitStatus::Quit),
+            "actor `{actor}` exited uncleanly: {status:?}"
+        );
+    }
+
+    sandbox.shutdown().await.unwrap();
+}

--- a/quickwit/quickwit-integration-tests/src/tests/mod.rs
+++ b/quickwit/quickwit-integration-tests/src/tests/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod basic_tests;
+mod compactor_tests;
 mod ingest_v1_tests;
 mod ingest_v2_tests;
 #[cfg(feature = "datafusion")]

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -75,7 +75,9 @@ use quickwit_common::tower::{
 use quickwit_common::uri::Uri;
 use quickwit_common::{get_bool_from_env, spawn_named_task};
 use quickwit_compaction::planner::CompactionPlanner;
-use quickwit_compaction::{CompactorSupervisor, start_compactor_service};
+use quickwit_compaction::{
+    CompactorSupervisor, start_compactor_service, wait_for_compactor_decommission,
+};
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig};
 use quickwit_control_plane::control_plane::{ControlPlane, ControlPlaneEventSubscriber};
@@ -501,10 +503,12 @@ fn start_shard_positions_service(
 ///
 /// Usually called when receiving a SIGTERM signal, e.g. k8s trying to
 /// decomission a pod.
+#[allow(clippy::too_many_arguments)] // Will go away when we remove ingest v1.
 async fn shutdown_signal_handler(
     shutdown_signal: BoxFutureInfaillible<()>,
     universe: Universe,
     ingester_opt: Option<Ingester>,
+    compactor_supervisor_opt: Option<Mailbox<CompactorSupervisor>>,
     grpc_shutdown_trigger_tx: oneshot::Sender<()>,
     rest_shutdown_trigger_tx: oneshot::Sender<()>,
     health_shutdown_trigger_tx_opt: Option<oneshot::Sender<()>>,
@@ -517,6 +521,13 @@ async fn shutdown_signal_handler(
         && let Err(error) = wait_for_ingester_decommission(ingester, Duration::from_secs(300)).await
     {
         error!("failed to decommission ingester gracefully: {:?}", error);
+    }
+    // Let the compactor finish the merges already in flight before tearing down its pipelines.
+    if let Some(compactor_supervisor) = &compactor_supervisor_opt
+        && let Err(error) =
+            wait_for_compactor_decommission(compactor_supervisor, Duration::from_secs(300)).await
+    {
+        error!("failed to decommission compactor gracefully: {:?}", error);
     }
     let actor_exit_statuses = universe.quit().await;
 
@@ -943,7 +954,7 @@ pub async fn serve_quickwit(
         ingest_service,
         ingester_opt: ingester_opt.clone(),
         compaction_service_client_opt,
-        _compactor_supervisor_opt: compactor_supervisor_opt,
+        _compactor_supervisor_opt: compactor_supervisor_opt.clone(),
         janitor_service_opt,
         jaeger_service_opt,
         otlp_logs_service_opt,
@@ -1048,6 +1059,7 @@ pub async fn serve_quickwit(
         shutdown_signal,
         universe,
         ingester_opt,
+        compactor_supervisor_opt,
         grpc_shutdown_trigger_tx,
         rest_shutdown_trigger_tx,
         health_shutdown_trigger_tx_opt,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -76,7 +76,8 @@ use quickwit_common::uri::Uri;
 use quickwit_common::{get_bool_from_env, spawn_named_task};
 use quickwit_compaction::planner::CompactionPlanner;
 use quickwit_compaction::{
-    CompactorSupervisor, start_compactor_service, wait_for_compactor_decommission,
+    CompactorSupervisor, notify_compactor_decommission, start_compactor_service,
+    wait_for_compactor_decommission,
 };
 use quickwit_config::service::QuickwitService;
 use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig};
@@ -88,7 +89,7 @@ use quickwit_indexing::models::ShardPositionsService;
 use quickwit_indexing::{IndexingSplitCache, start_indexing_service};
 use quickwit_ingest::{
     GetMemoryCapacity, IngestRequest, IngestRouter, IngestServiceClient, Ingester, IngesterPool,
-    IngesterPoolEntry, LocalShardsUpdate, get_idle_shard_timeout,
+    IngesterPoolEntry, LocalShardsUpdate, get_idle_shard_timeout, notify_ingester_decommission,
     setup_ingester_capacity_update_listener, setup_local_shards_update_listener,
     start_ingest_api_service, try_get_ingester_status, wait_for_ingester_decommission,
     wait_for_ingester_status,
@@ -515,18 +516,23 @@ async fn shutdown_signal_handler(
     cluster: Cluster,
 ) -> HashMap<String, ActorExitStatus> {
     shutdown_signal.await;
-    // We must decommission the ingester first before terminating the indexing pipelines that
-    // may consume from it. We also need to keep the gRPC server running while doing so.
-    if let Some(ingester) = &ingester_opt
-        && let Err(error) = wait_for_ingester_decommission(ingester, Duration::from_secs(300)).await
-    {
+    if let Err(error) = notify_ingester_decommission(ingester_opt.as_ref()).await {
+        error!("failed to initiate ingester decommission: {:?}", error);
+    }
+    let compactor_status_rx_opt = notify_compactor_decommission(compactor_supervisor_opt.as_ref())
+        .await
+        .unwrap_or_else(|error| {
+            error!("failed to initiate compactor decommission: {:?}", error);
+            None
+        });
+    let (ingester_result, compactor_result) = tokio::join!(
+        wait_for_ingester_decommission(ingester_opt.as_ref(), Duration::from_secs(300)),
+        wait_for_compactor_decommission(compactor_status_rx_opt, Duration::from_secs(300)),
+    );
+    if let Err(error) = ingester_result {
         error!("failed to decommission ingester gracefully: {:?}", error);
     }
-    // Let the compactor finish the merges already in flight before tearing down its pipelines.
-    if let Some(compactor_supervisor) = &compactor_supervisor_opt
-        && let Err(error) =
-            wait_for_compactor_decommission(compactor_supervisor, Duration::from_secs(300)).await
-    {
+    if let Err(error) = compactor_result {
         error!("failed to decommission compactor gracefully: {:?}", error);
     }
     let actor_exit_statuses = universe.quit().await;


### PR DESCRIPTION
### Description

Currently, split compactors immediately terminate on shutdown signal. This gives them a 5 minute grace period, like ingesters, to finish their ongoing merges gracefully before terminating.

Once switched to Decommissioning, the compactor hardcodes its available slots to 0, finishes its ongoing merges, and then goes silently into the night.

### How was this PR tested?

Unit tests. Cluster tests.
