### PR TITLE
Only update indexer pool on material changes

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -394,10 +394,16 @@ impl IndexingScheduler {
     }
 
     fn select_available_indexers_for_scheduling(&self) -> Vec<IndexerNodeInfo> {
-        let (ready, not_ready): (Vec<IndexerNodeInfo>, Vec<IndexerNodeInfo>) = self
+        let (ready, retiring): (Vec<IndexerNodeInfo>, Vec<IndexerNodeInfo>) = self
             .indexer_pool
             .values()
             .into_iter()
+            .filter(|indexer| {
+                matches!(
+                    indexer.ingester_status,
+                    IngesterStatus::Ready | IngesterStatus::Retiring
+                )
+            })
             .partition(|indexer| indexer.ingester_status == IngesterStatus::Ready);
 
         if ready.is_empty() {
@@ -406,7 +412,7 @@ impl IndexingScheduler {
             warn!(
                 "no ready indexer available, falling back to retiring indexers for shard draining"
             );
-            not_ready
+            retiring
         } else {
             ready
         }
@@ -1180,8 +1186,18 @@ mod tests {
         let indexer_pool = IndexerPool::default();
         let retiring_1 = mock_indexer_node_info("indexer-retiring-1", IngesterStatus::Retiring);
         let retiring_2 = mock_indexer_node_info("indexer-retiring-2", IngesterStatus::Retiring);
+        let decommissioned_1 =
+            mock_indexer_node_info("indexer-decommissioned-1", IngesterStatus::Decommissioned);
+        let decommissioning_1 =
+            mock_indexer_node_info("indexer-decommissioning-1", IngesterStatus::Decommissioning);
+        let initializing_1 =
+            mock_indexer_node_info("indexer-initializing-1", IngesterStatus::Initializing);
+
         indexer_pool.insert(retiring_1.node_id.clone(), retiring_1);
         indexer_pool.insert(retiring_2.node_id.clone(), retiring_2);
+        indexer_pool.insert(decommissioned_1.node_id.clone(), decommissioned_1);
+        indexer_pool.insert(decommissioning_1.node_id.clone(), decommissioning_1);
+        indexer_pool.insert(initializing_1.node_id.clone(), initializing_1);
 
         let scheduler = IndexingScheduler::new(
             "test-cluster".to_string(),

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1320,7 +1320,9 @@ fn setup_indexer_pool(
                     );
                     Some(change)
                 }
-                ClusterChange::Update { updated, .. } if updated.is_indexer() => {
+                ClusterChange::Update { previous, updated }
+                    if updated.is_indexer() && indexer_node_changed(&previous, &updated) =>
+                {
                     let change = build_indexer_insert_change(
                         &updated,
                         indexing_service_clone_opt,
@@ -1337,6 +1339,13 @@ fn setup_indexer_pool(
         })
     });
     indexer_pool.listen_for_changes(indexer_change_stream);
+}
+
+/// Only update the indexer pool when a change meaningful to indexing occurs.
+fn indexer_node_changed(previous: &ClusterNode, updated: &ClusterNode) -> bool {
+    previous.ingester_status != updated.ingester_status
+        || previous.indexing_cpu_capacity != updated.indexing_cpu_capacity
+        || previous.indexing_tasks != updated.indexing_tasks
 }
 
 fn build_indexer_insert_change(
@@ -1791,6 +1800,35 @@ mod tests {
             .send(ClusterChange::Remove(decommissioning_no_plan))
             .unwrap();
         assert_eventually!(indexer_pool.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_indexer_node_changed() {
+        let plan = [IndexingTask {
+            index_uid: Some(IndexUid::for_test("test-index", 0)),
+            source_id: "test-source".to_string(),
+            pipeline_uid: Some(PipelineUid::for_test(1)),
+            shard_ids: Vec::new(),
+            params_fingerprint: 0,
+        }];
+        let build_node = async |tasks: &[IndexingTask], status: IngesterStatus| {
+            ClusterNode::for_test("test-indexer-node", 1, true, &["indexer"], tasks, status).await
+        };
+        let ready_with_plan = build_node(&plan, IngesterStatus::Ready).await;
+
+        // An update that touches none of the tracked fields is skipped. `indexing_cpu_capacity` is
+        // not exercised here because `ClusterNode::for_test` cannot set it; it follows the same
+        // comparison as the other two fields.
+        let unchanged = build_node(&plan, IngesterStatus::Ready).await;
+        assert!(!indexer_node_changed(&ready_with_plan, &unchanged));
+
+        // A change to the ingester status is material.
+        let retiring_with_plan = build_node(&plan, IngesterStatus::Retiring).await;
+        assert!(indexer_node_changed(&ready_with_plan, &retiring_with_plan));
+
+        // A change to the indexing plan is material.
+        let ready_without_plan = build_node(&[], IngesterStatus::Ready).await;
+        assert!(indexer_node_changed(&ready_with_plan, &ready_without_plan));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

Only update indexer pool on material changes: indexer tasks, ingester status, or CPU capacity.

### How was this PR tested?
Unit tests.
