### PR TITLE
Rate-limit the leaf search memory over-allocation warning to 1/min

### DIFF
--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -717,7 +717,8 @@ async fn leaf_search_single_split(
     let warmup_duration: Duration = warmup_end.duration_since(warmup_start);
     let warmup_size = ByteSize(byte_range_cache.get_num_bytes());
     if warmup_size > search_permit.memory_allocation() {
-        warn!(
+        quickwit_common::rate_limited_warn!(
+            limit_per_min = 1,
             memory_usage = ?warmup_size,
             memory_allocation = ?search_permit.memory_allocation(),
             "current leaf search is consuming more memory than the initial allocation"


### PR DESCRIPTION
## Summary
- Replaces `warn!` with `quickwit_common::rate_limited_warn!(limit_per_min = 1, ...)` in `leaf_search_single_split`
- Prevents log flooding when many splits repeatedly exceed their memory allocation

## Test plan
- [ ] Existing search tests pass