### PR TITLE
Bump tantivy to 6b8bd7b

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -7117,7 +7117,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -11795,7 +11795,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -11834,7 +11834,7 @@ dependencies = [
  "tantivy-columnar",
  "tantivy-common",
  "tantivy-fst",
- "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd)",
+ "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b)",
  "tantivy-sstable",
  "tantivy-stacker",
  "tantivy-tokenizer-api",
@@ -11850,7 +11850,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "bitpacking",
 ]
@@ -11858,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -11873,7 +11873,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11909,7 +11909,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -11921,7 +11921,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -11934,7 +11934,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -11943,7 +11943,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=1e859fd#1e859fd78d71986a7d53bc096b0fd27bfa91aec2"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -417,7 +417,7 @@ quickwit-serve = { path = "quickwit-serve" }
 quickwit-storage = { path = "quickwit-storage" }
 quickwit-transport = { path = "quickwit-transport" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "1e859fd", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "6b8bd7b", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",

--- a/quickwit/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexer.rs
@@ -544,6 +544,7 @@ impl Indexer {
             compression_level: Some(indexing_settings.docstore_compression_level),
         });
         let index_settings = IndexSettings {
+            sort_by_field: None,
             docstore_blocksize: indexing_settings.docstore_blocksize,
             docstore_compression,
             docstore_compress_dedicated_thread: true,


### PR DESCRIPTION
Updates tantivy dependency to the latest commit on main (`6b8bd7b`).

Tantivy re-added `sort_by_field: Option<IndexSortByField>` to `IndexSettings`; set to `None` in the indexer since Quickwit does not use index sorting.

Verified with `cargo check --all-features --tests`, `make fmt`, and `make update-licenses` (no license changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)