### PR TITLE
aws: use caching DNS resolver for S3 HTTP client to reduce lookup churn

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -285,7 +285,6 @@ ena,https://github.com/rust-lang/ena,MIT OR Apache-2.0,Niko Matsakis <niko@alum.
 encode_unicode,https://github.com/tormol/encode_unicode,Apache-2.0 OR MIT,Torbjørn Birch Moltu <t.b.moltu@lyse.net>
 encoding_rs,https://github.com/hsivonen/encoding_rs,(Apache-2.0 OR MIT) AND BSD-3-Clause,Henri Sivonen <hsivonen@hsivonen.fi>
 endian-type,https://github.com/Lolirofle/endian-type,MIT,Lolirofle <lolipopple@hotmail.com>
-enum-as-inner,https://github.com/bluejekyll/enum-as-inner,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
 enum-iterator,https://github.com/stephaneyfx/enum-iterator,0BSD,Stephane Raux <stephaneyfx@gmail.com>
 enum-iterator-derive,https://github.com/stephaneyfx/enum-iterator,0BSD,Stephane Raux <stephaneyfx@gmail.com>
 env_filter,https://github.com/rust-cli/env_logger,MIT OR Apache-2.0,The env_filter Authors
@@ -363,8 +362,6 @@ heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,Without Boats <woboats@gmail.com>
 hermit-abi,https://github.com/hermit-os/hermit-rs,MIT OR Apache-2.0,Stefan Lankes
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
-hickory-proto,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
-hickory-resolver,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 hkdf,https://github.com/RustCrypto/KDFs,MIT OR Apache-2.0,RustCrypto Developers
 hmac,https://github.com/RustCrypto/MACs,MIT OR Apache-2.0,RustCrypto Developers
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
@@ -409,7 +406,6 @@ inout,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developer
 instant,https://github.com/sebcrozet/instant,BSD-3-Clause,sebcrozet <developer@crozet.re>
 integer-encoding,https://github.com/dermesser/integer-encoding-rs,MIT,Lewin Bormann <lbo@spheniscida.de>
 inventory,https://github.com/dtolnay/inventory,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
-ipconfig,https://github.com/liranringel/ipconfig,MIT OR Apache-2.0,Liran Ringel <liranringel@gmail.com>
 ipcrypt-rs,https://github.com/jedisct1/rust-ipcrypt2,ISC,Frank Denis <github@pureftpd.org>
 ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@krisprice.nz>
 ipnetwork,https://github.com/achanda/ipnetwork,MIT OR Apache-2.0,"Abhishek Chanda <abhishek.becs@gmail.com>, Linus Färnstrand <faern@faern.net>"
@@ -463,7 +459,6 @@ lock_api,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antr
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 loom,https://github.com/tokio-rs/loom,MIT,Carl Lerche <me@carllerche.com>
 lru,https://github.com/jeromefroe/lru-rs,MIT,Jerome Froelich <jeromefroelic@hotmail.com>
-lru-cache,https://github.com/contain-rs/lru-cache,MIT OR Apache-2.0,Stepan Koltsov <stepan.koltsov@gmail.com>
 lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin Saunders <ben.e.saunders@gmail.com>
 lz4,https://github.com/10xGenomics/lz4-rs,MIT,"Jens Heyens <jens.heyens@ewetel.net>, Artem V. Navrotskiy <bozaro@buzzsoft.ru>, Patrick Marks <pmarks@gmail.com>"
 lz4-sys,https://github.com/10xGenomics/lz4-rs,MIT,"Jens Heyens <jens.heyens@ewetel.net>, Artem V. Navrotskiy <bozaro@buzzsoft.ru>, Patrick Marks <pmarks@gmail.com>"
@@ -692,7 +687,6 @@ reqsign-google,https://github.com/apache/opendal-reqsign,Apache-2.0,The reqsign-
 reqwest,https://github.com/seanmonstar/reqwest,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 reqwest-middleware,https://github.com/TrueLayer/reqwest-middleware,MIT OR Apache-2.0,Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>
 reqwest-retry,https://github.com/TrueLayer/reqwest-middleware,MIT OR Apache-2.0,Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>
-resolv-conf,https://github.com/hickory-dns/resolv-conf,MIT OR Apache-2.0,The resolv-conf Authors
 retry-policies,https://github.com/TrueLayer/retry-policies,MIT OR Apache-2.0,Luca Palmieri <lpalmieri@truelayer.com>
 rfc6979,https://github.com/RustCrypto/signatures/tree/master/rfc6979,Apache-2.0 OR MIT,RustCrypto Developers
 rgb,https://github.com/kornelski/rust-rgb,MIT,"Kornel Lesiński <kornel@geekhood.net>, James Forster <james.forsterer@gmail.com>"
@@ -950,7 +944,6 @@ web-time,https://github.com/daxpedda/web-time,MIT OR Apache-2.0,The web-time Aut
 webpki-root-certs,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-root-certs Authors
 webpki-roots,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-roots Authors
 whoami,https://github.com/ardaku/whoami,Apache-2.0 OR BSL-1.0 OR MIT,The whoami Authors
-widestring,https://github.com/VoidStarKat/widestring-rs,MIT OR Apache-2.0,The widestring Authors
 winapi,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-util,https://github.com/BurntSushi/winapi-util,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
@@ -963,7 +956,6 @@ windows-implement,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The 
 windows-interface,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-interface Authors
 windows-link,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-link Authors
 windows-numerics,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-numerics Authors
-windows-registry,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-registry Authors
 windows-result,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-result Authors
 windows-strings,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-strings Authors
 windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -285,6 +285,7 @@ ena,https://github.com/rust-lang/ena,MIT OR Apache-2.0,Niko Matsakis <niko@alum.
 encode_unicode,https://github.com/tormol/encode_unicode,Apache-2.0 OR MIT,Torbjørn Birch Moltu <t.b.moltu@lyse.net>
 encoding_rs,https://github.com/hsivonen/encoding_rs,(Apache-2.0 OR MIT) AND BSD-3-Clause,Henri Sivonen <hsivonen@hsivonen.fi>
 endian-type,https://github.com/Lolirofle/endian-type,MIT,Lolirofle <lolipopple@hotmail.com>
+enum-as-inner,https://github.com/bluejekyll/enum-as-inner,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
 enum-iterator,https://github.com/stephaneyfx/enum-iterator,0BSD,Stephane Raux <stephaneyfx@gmail.com>
 enum-iterator-derive,https://github.com/stephaneyfx/enum-iterator,0BSD,Stephane Raux <stephaneyfx@gmail.com>
 env_filter,https://github.com/rust-cli/env_logger,MIT OR Apache-2.0,The env_filter Authors
@@ -362,6 +363,8 @@ heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,Without Boats <woboats@gmail.com>
 hermit-abi,https://github.com/hermit-os/hermit-rs,MIT OR Apache-2.0,Stefan Lankes
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
+hickory-proto,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
+hickory-resolver,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 hkdf,https://github.com/RustCrypto/KDFs,MIT OR Apache-2.0,RustCrypto Developers
 hmac,https://github.com/RustCrypto/MACs,MIT OR Apache-2.0,RustCrypto Developers
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
@@ -406,6 +409,7 @@ inout,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developer
 instant,https://github.com/sebcrozet/instant,BSD-3-Clause,sebcrozet <developer@crozet.re>
 integer-encoding,https://github.com/dermesser/integer-encoding-rs,MIT,Lewin Bormann <lbo@spheniscida.de>
 inventory,https://github.com/dtolnay/inventory,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+ipconfig,https://github.com/liranringel/ipconfig,MIT OR Apache-2.0,Liran Ringel <liranringel@gmail.com>
 ipcrypt-rs,https://github.com/jedisct1/rust-ipcrypt2,ISC,Frank Denis <github@pureftpd.org>
 ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@krisprice.nz>
 ipnetwork,https://github.com/achanda/ipnetwork,MIT OR Apache-2.0,"Abhishek Chanda <abhishek.becs@gmail.com>, Linus Färnstrand <faern@faern.net>"
@@ -459,6 +463,7 @@ lock_api,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antr
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 loom,https://github.com/tokio-rs/loom,MIT,Carl Lerche <me@carllerche.com>
 lru,https://github.com/jeromefroe/lru-rs,MIT,Jerome Froelich <jeromefroelic@hotmail.com>
+lru-cache,https://github.com/contain-rs/lru-cache,MIT OR Apache-2.0,Stepan Koltsov <stepan.koltsov@gmail.com>
 lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin Saunders <ben.e.saunders@gmail.com>
 lz4,https://github.com/10xGenomics/lz4-rs,MIT,"Jens Heyens <jens.heyens@ewetel.net>, Artem V. Navrotskiy <bozaro@buzzsoft.ru>, Patrick Marks <pmarks@gmail.com>"
 lz4-sys,https://github.com/10xGenomics/lz4-rs,MIT,"Jens Heyens <jens.heyens@ewetel.net>, Artem V. Navrotskiy <bozaro@buzzsoft.ru>, Patrick Marks <pmarks@gmail.com>"
@@ -687,6 +692,7 @@ reqsign-google,https://github.com/apache/opendal-reqsign,Apache-2.0,The reqsign-
 reqwest,https://github.com/seanmonstar/reqwest,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 reqwest-middleware,https://github.com/TrueLayer/reqwest-middleware,MIT OR Apache-2.0,Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>
 reqwest-retry,https://github.com/TrueLayer/reqwest-middleware,MIT OR Apache-2.0,Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>
+resolv-conf,https://github.com/hickory-dns/resolv-conf,MIT OR Apache-2.0,The resolv-conf Authors
 retry-policies,https://github.com/TrueLayer/retry-policies,MIT OR Apache-2.0,Luca Palmieri <lpalmieri@truelayer.com>
 rfc6979,https://github.com/RustCrypto/signatures/tree/master/rfc6979,Apache-2.0 OR MIT,RustCrypto Developers
 rgb,https://github.com/kornelski/rust-rgb,MIT,"Kornel Lesiński <kornel@geekhood.net>, James Forster <james.forsterer@gmail.com>"
@@ -944,6 +950,7 @@ web-time,https://github.com/daxpedda/web-time,MIT OR Apache-2.0,The web-time Aut
 webpki-root-certs,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-root-certs Authors
 webpki-roots,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-roots Authors
 whoami,https://github.com/ardaku/whoami,Apache-2.0 OR BSL-1.0 OR MIT,The whoami Authors
+widestring,https://github.com/VoidStarKat/widestring-rs,MIT OR Apache-2.0,The widestring Authors
 winapi,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-util,https://github.com/BurntSushi/winapi-util,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
@@ -956,6 +963,7 @@ windows-implement,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The 
 windows-interface,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-interface Authors
 windows-link,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-link Authors
 windows-numerics,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-numerics Authors
+windows-registry,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-registry Authors
 windows-result,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-result Authors
 windows-strings,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-strings Authors
 windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2361,16 +2361,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -2483,12 +2473,6 @@ dependencies = [
  "cast",
  "itertools 0.13.0",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cron"
@@ -4889,76 +4873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "hickory-proto",
- "idna",
- "ipnet",
- "jni",
- "rand 0.10.2",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni",
- "once_cell",
- "prefix-trie",
- "rand 0.10.2",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipconfig",
- "ipnet",
- "jni",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot",
- "rand 0.10.2",
- "resolv-conf",
- "smallvec",
- "system-configuration",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,19 +5424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2 0.6.3",
- "widestring",
- "windows-registry",
- "windows-result",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipcrypt-rs"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5536,9 +5437,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ipnetwork"
@@ -6481,12 +6379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a"
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6855,10 +6747,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -8015,17 +7903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8214,7 +8091,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8234,7 +8111,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8505,7 +8382,6 @@ dependencies = [
 name = "quickwit-aws"
 version = "0.8.0"
 dependencies = [
- "anyhow",
  "aws-config",
  "aws-runtime",
  "aws-sdk-kinesis",
@@ -8516,10 +8392,9 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "futures",
- "hickory-resolver",
+ "mini-moka",
  "quickwit-common",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -10292,12 +10167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
 name = "retry-policies"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10555,7 +10424,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -10838,7 +10707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -11394,7 +11263,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11922,27 +11791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tabled"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12137,7 +11985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -13628,12 +13476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13745,17 +13587,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -2361,6 +2361,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -2473,6 +2483,12 @@ dependencies = [
  "cast",
  "itertools 0.13.0",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cron"
@@ -4873,6 +4889,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.2",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5424,6 +5510,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipcrypt-rs"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5437,6 +5536,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -6379,6 +6481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a"
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6747,6 +6855,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -7903,6 +8015,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8091,7 +8214,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8111,7 +8234,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8382,16 +8505,21 @@ dependencies = [
 name = "quickwit-aws"
 version = "0.8.0"
 dependencies = [
+ "anyhow",
  "aws-config",
  "aws-runtime",
  "aws-sdk-kinesis",
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "aws-smithy-async",
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "futures",
+ "hickory-resolver",
  "quickwit-common",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -10164,6 +10292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "retry-policies"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10421,7 +10555,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -10704,7 +10838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -11260,7 +11394,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11788,6 +11922,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tabled"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11982,7 +12137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -13473,6 +13628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13584,6 +13745,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -148,6 +148,10 @@ google-cloud-pubsub = { version = "0.30", default-features = false, features = [
 governor = "0.10.4"
 heck = "0.5"
 hex = "0.4"
+hickory-resolver = { version = "0.26", default-features = false, features = [
+  "system-config",
+  "tokio",
+] }
 home = "0.5"
 hostname = "0.4"
 http = "1.4"
@@ -362,8 +366,12 @@ aws-sdk-lambda = "1"
 aws-sdk-sqs = "1.98"
 aws-smithy-async = "1.2"
 aws-smithy-mocks = "0.2"
-aws-smithy-http-client = { version = "1.1", features = ["default-client"] }
+aws-smithy-http-client = { version = "1.1", features = [
+  "default-client",
+  "rustls-aws-lc",
+] }
 aws-smithy-runtime = "1.11"
+aws-smithy-runtime-api = "1.8"
 aws-smithy-types = { version = "1.4", features = [
   "byte-stream-poll-next",
   "http-body-1-x",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -148,10 +148,6 @@ google-cloud-pubsub = { version = "0.30", default-features = false, features = [
 governor = "0.10.4"
 heck = "0.5"
 hex = "0.4"
-hickory-resolver = { version = "0.26", default-features = false, features = [
-  "system-config",
-  "tokio",
-] }
 home = "0.5"
 hostname = "0.4"
 http = "1.4"

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -11,7 +11,6 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
 aws-config = { workspace = true }
 aws-runtime = { workspace = true }
 aws-sdk-kinesis = { workspace = true, optional = true }
@@ -22,9 +21,8 @@ aws-smithy-http-client = { workspace = true }
 aws-smithy-runtime-api = { workspace = true }
 aws-smithy-types = { workspace = true }
 futures = { workspace = true }
-hickory-resolver = { workspace = true }
+mini-moka = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
 
 quickwit-common = { workspace = true }
 

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -11,15 +11,20 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 aws-config = { workspace = true }
 aws-runtime = { workspace = true }
 aws-sdk-kinesis = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true }
 aws-sdk-sqs = { workspace = true, optional = true }
 aws-smithy-async = { workspace = true }
+aws-smithy-http-client = { workspace = true }
+aws-smithy-runtime-api = { workspace = true }
 aws-smithy-types = { workspace = true }
 futures = { workspace = true }
+hickory-resolver = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 quickwit-common = { workspace = true }
 

--- a/quickwit/quickwit-aws/src/dns.rs
+++ b/quickwit/quickwit-aws/src/dns.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 use anyhow::Context as _;
 use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, ResolveDnsError};
 use hickory_resolver::TokioResolver;
+use quickwit_common::rate_limited_warn;
 
 /// Minimum TTL enforced on positive DNS responses.
 ///
@@ -49,7 +50,7 @@ pub struct HickoryDnsResolver {
 impl HickoryDnsResolver {
     /// Builds a resolver from the host's DNS configuration (`/etc/resolv.conf`
     /// on Unix), overriding the cache options so short-TTL records are still
-    /// cached for at least `DNS_CACHE_MIN_TTL` seconds.
+    /// cached for at least `DNS_CACHE_MIN_TTL`.
     pub fn from_system_conf() -> anyhow::Result<Self> {
         let mut builder =
             TokioResolver::builder_tokio().context("failed to read system DNS configuration")?;
@@ -71,18 +72,35 @@ impl ResolveDns for HickoryDnsResolver {
         // owning is simpler and side-steps lifetime coupling).
         let host = name.to_string();
         DnsFuture::new(async move {
-            let lookup = resolver
-                .lookup_ip(host)
+            if let Ok(lookup) = resolver.lookup_ip(host.clone()).await {
+                let ip_addresses: Vec<IpAddr> = lookup.iter().collect();
+                if !ip_addresses.is_empty() {
+                    return Ok(ip_addresses);
+                }
+            }
+            // Hickory only speaks the DNS protocol (plus `/etc/hosts`), so it
+            // misses hostnames resolved through other NSS sources (mDNS, LDAP,
+            // custom `nsswitch.conf` plugins, etc). Fall back to the OS
+            // resolver (`getaddrinfo`) for those.
+            rate_limited_warn!(
+                limit_per_min = 1,
+                "hickory dns resolver could not resolve {host}, falling back to the os resolver"
+            );
+            let socket_addrs = tokio::net::lookup_host((host.as_str(), 0))
                 .await
                 .map_err(ResolveDnsError::new)?;
-            let ip_addresses: Vec<IpAddr> = lookup.iter().collect();
-            Ok(ip_addresses)
+            Ok(socket_addrs.map(|socket_addr| socket_addr.ip()).collect())
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
+    use hickory_resolver::config::{NameServerConfig, ResolveHosts, ResolverConfig};
+    use hickory_resolver::net::runtime::TokioRuntimeProvider;
+
     use super::*;
 
     #[tokio::test]
@@ -95,6 +113,44 @@ mod tests {
             .resolve_dns("localhost")
             .await
             .expect("localhost should resolve");
+        assert!(
+            ip_addresses
+                .iter()
+                .any(|ip_address| ip_address.is_loopback()),
+            "expected a loopback address, got {ip_addresses:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hickory_dns_resolver_falls_back_to_os_resolver() {
+        // Points the Hickory resolver at a non-routable name server and disables its
+        // `/etc/hosts` lookup, so it can never resolve anything itself. `localhost`
+        // must still resolve through the OS resolver fallback.
+        let mut builder = TokioResolver::builder_with_config(
+            ResolverConfig::from_parts(
+                None,
+                vec![],
+                vec![NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(
+                    203, 0, 113, 1,
+                )))],
+            ),
+            TokioRuntimeProvider::default(),
+        );
+        let options = builder.options_mut();
+        options.timeout = Duration::from_millis(200);
+        options.attempts = 1;
+        options.use_hosts_file = ResolveHosts::Never;
+        let resolver = HickoryDnsResolver {
+            resolver: Arc::new(
+                builder
+                    .build()
+                    .expect("resolver should build from explicit configuration"),
+            ),
+        };
+        let ip_addresses = resolver
+            .resolve_dns("localhost")
+            .await
+            .expect("localhost should resolve via the os resolver fallback");
         assert!(
             ip_addresses
                 .iter()

--- a/quickwit/quickwit-aws/src/dns.rs
+++ b/quickwit/quickwit-aws/src/dns.rs
@@ -1,0 +1,105 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Caching DNS resolver used by the AWS/S3 HTTP client.
+//!
+//! The AWS SDK's default HTTP client performs a blocking `getaddrinfo`
+//! lookup on every new connection without any caching.
+//!
+//! [`HickoryDnsResolver`] wraps a Hickory resolver, which keeps an in-memory
+//! cache keyed by hostname and honors record TTLs.
+
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, ResolveDnsError};
+use hickory_resolver::TokioResolver;
+
+/// Minimum TTL enforced on positive DNS responses, in seconds.
+///
+/// S3 endpoints advertise TTLs of only a few seconds. Without a floor, the
+/// Hickory cache would expire almost immediately and provide little benefit.
+const DNS_CACHE_MIN_TTL: Duration = Duration::from_secs(60);
+
+/// Maximum number of cached records.
+const DNS_CACHE_SIZE: u64 = 1_024;
+
+/// A [`ResolveDns`] implementation backed by a caching Hickory resolver.
+#[derive(Debug, Clone)]
+pub struct HickoryDnsResolver {
+    // `TokioResolver` is internally reference-counted and cheap to clone,
+    // but the `Arc` makes the shared-cache contract explicit: every clone of
+    // this resolver hits the same DNS cache.
+    resolver: Arc<TokioResolver>,
+}
+
+impl HickoryDnsResolver {
+    /// Builds a resolver from the host's DNS configuration (`/etc/resolv.conf`
+    /// on Unix), overriding the cache options so short-TTL records are still
+    /// cached for at least `DNS_CACHE_MIN_TTL` seconds.
+    pub fn from_system_conf() -> anyhow::Result<Self> {
+        let mut builder =
+            TokioResolver::builder_tokio().context("failed to read system DNS configuration")?;
+        let options = builder.options_mut();
+        options.positive_min_ttl = Some(DNS_CACHE_MIN_TTL);
+        options.cache_size = DNS_CACHE_SIZE;
+        let resolver = builder.build().context("failed to build DNS resolver")?;
+        Ok(HickoryDnsResolver {
+            resolver: Arc::new(resolver),
+        })
+    }
+}
+
+impl ResolveDns for HickoryDnsResolver {
+    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a> {
+        let resolver = self.resolver.clone();
+        // The lookup takes ownership of the host name so the returned future is
+        // `'static` and does not borrow from `name` (the trait allows `'a`, but
+        // owning is simpler and side-steps lifetime coupling).
+        let host = name.to_string();
+        DnsFuture::new(async move {
+            let lookup = resolver
+                .lookup_ip(host)
+                .await
+                .map_err(ResolveDnsError::new)?;
+            let ip_addresses: Vec<IpAddr> = lookup.iter().collect();
+            Ok(ip_addresses)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_hickory_dns_resolver_resolves_localhost() {
+        // `localhost` resolves from `/etc/hosts` (Hickory reads it by default),
+        // so this test does not depend on any network name server.
+        let resolver = HickoryDnsResolver::from_system_conf()
+            .expect("resolver should build from system configuration");
+        let ip_addresses = resolver
+            .resolve_dns("localhost")
+            .await
+            .expect("localhost should resolve");
+        assert!(
+            ip_addresses
+                .iter()
+                .any(|ip_address| ip_address.is_loopback()),
+            "expected a loopback address, got {ip_addresses:?}"
+        );
+    }
+}

--- a/quickwit/quickwit-aws/src/dns.rs
+++ b/quickwit/quickwit-aws/src/dns.rs
@@ -28,11 +28,11 @@ use anyhow::Context as _;
 use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, ResolveDnsError};
 use hickory_resolver::TokioResolver;
 
-/// Minimum TTL enforced on positive DNS responses, in seconds.
+/// Minimum TTL enforced on positive DNS responses.
 ///
 /// S3 endpoints advertise TTLs of only a few seconds. Without a floor, the
 /// Hickory cache would expire almost immediately and provide little benefit.
-const DNS_CACHE_MIN_TTL: Duration = Duration::from_secs(60);
+const DNS_CACHE_MIN_TTL: Duration = Duration::from_mins(1);
 
 /// Maximum number of cached records.
 const DNS_CACHE_SIZE: u64 = 1_024;

--- a/quickwit/quickwit-aws/src/dns.rs
+++ b/quickwit/quickwit-aws/src/dns.rs
@@ -17,98 +17,70 @@
 //! The AWS SDK's default HTTP client performs a blocking `getaddrinfo`
 //! lookup on every new connection without any caching.
 //!
-//! [`HickoryDnsResolver`] wraps a Hickory resolver, which keeps an in-memory
-//! cache keyed by hostname and honors record TTLs.
+//! [`CachingDnsResolver`] resolves names the same way (via
+//! [`tokio::net::lookup_host`], which goes through `getaddrinfo` and
+//! therefore honors every NSS source configured on the host: DNS,
+//! `/etc/hosts`, mDNS, LDAP, etc), but keeps an in-memory cache of the
+//! results so repeated lookups for the same host don't each pay for a
+//! blocking `getaddrinfo` call.
 
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context as _;
 use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, ResolveDnsError};
-use hickory_resolver::TokioResolver;
-use quickwit_common::rate_limited_warn;
+use mini_moka::sync::Cache;
 
-/// Minimum TTL enforced on positive DNS responses.
-///
-/// S3 endpoints advertise TTLs of only a few seconds. Without a floor, the
-/// Hickory cache would expire almost immediately and provide little benefit.
-const DNS_CACHE_MIN_TTL: Duration = Duration::from_mins(1);
+/// TTL applied to cached lookups.
+const DNS_CACHE_TTL: Duration = Duration::from_mins(1);
 
-/// Maximum number of cached records.
+/// Maximum number of cached hostnames.
 const DNS_CACHE_SIZE: u64 = 1_024;
 
-/// A [`ResolveDns`] implementation backed by a caching Hickory resolver.
+/// A [`ResolveDns`] implementation that caches `getaddrinfo` lookups.
 #[derive(Debug, Clone)]
-pub struct HickoryDnsResolver {
-    // `TokioResolver` is internally reference-counted and cheap to clone,
-    // but the `Arc` makes the shared-cache contract explicit: every clone of
-    // this resolver hits the same DNS cache.
-    resolver: Arc<TokioResolver>,
+pub struct CachingDnsResolver {
+    cache: Arc<Cache<String, Vec<IpAddr>>>,
 }
 
-impl HickoryDnsResolver {
-    /// Builds a resolver from the host's DNS configuration (`/etc/resolv.conf`
-    /// on Unix), overriding the cache options so short-TTL records are still
-    /// cached for at least `DNS_CACHE_MIN_TTL`.
-    pub fn from_system_conf() -> anyhow::Result<Self> {
-        let mut builder =
-            TokioResolver::builder_tokio().context("failed to read system DNS configuration")?;
-        let options = builder.options_mut();
-        options.positive_min_ttl = Some(DNS_CACHE_MIN_TTL);
-        options.cache_size = DNS_CACHE_SIZE;
-        let resolver = builder.build().context("failed to build DNS resolver")?;
-        Ok(HickoryDnsResolver {
-            resolver: Arc::new(resolver),
-        })
+impl Default for CachingDnsResolver {
+    fn default() -> Self {
+        let cache = Cache::builder()
+            .max_capacity(DNS_CACHE_SIZE)
+            .time_to_live(DNS_CACHE_TTL)
+            .build();
+        CachingDnsResolver {
+            cache: Arc::new(cache),
+        }
     }
 }
 
-impl ResolveDns for HickoryDnsResolver {
+impl ResolveDns for CachingDnsResolver {
     fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a> {
-        let resolver = self.resolver.clone();
-        // The lookup takes ownership of the host name so the returned future is
-        // `'static` and does not borrow from `name` (the trait allows `'a`, but
-        // owning is simpler and side-steps lifetime coupling).
+        let cache = self.cache.clone();
         let host = name.to_string();
         DnsFuture::new(async move {
-            if let Ok(lookup) = resolver.lookup_ip(host.clone()).await {
-                let ip_addresses: Vec<IpAddr> = lookup.iter().collect();
-                if !ip_addresses.is_empty() {
-                    return Ok(ip_addresses);
-                }
+            if let Some(ip_addresses) = cache.get(&host) {
+                return Ok(ip_addresses);
             }
-            // Hickory only speaks the DNS protocol (plus `/etc/hosts`), so it
-            // misses hostnames resolved through other NSS sources (mDNS, LDAP,
-            // custom `nsswitch.conf` plugins, etc). Fall back to the OS
-            // resolver (`getaddrinfo`) for those.
-            rate_limited_warn!(
-                limit_per_min = 1,
-                "hickory dns resolver could not resolve {host}, falling back to the os resolver"
-            );
             let socket_addrs = tokio::net::lookup_host((host.as_str(), 0))
                 .await
                 .map_err(ResolveDnsError::new)?;
-            Ok(socket_addrs.map(|socket_addr| socket_addr.ip()).collect())
+            let ip_addresses: Vec<IpAddr> =
+                socket_addrs.map(|socket_addr| socket_addr.ip()).collect();
+            cache.insert(host, ip_addresses.clone());
+            Ok(ip_addresses)
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
-
-    use hickory_resolver::config::{NameServerConfig, ResolveHosts, ResolverConfig};
-    use hickory_resolver::net::runtime::TokioRuntimeProvider;
-
     use super::*;
 
     #[tokio::test]
-    async fn test_hickory_dns_resolver_resolves_localhost() {
-        // `localhost` resolves from `/etc/hosts` (Hickory reads it by default),
-        // so this test does not depend on any network name server.
-        let resolver = HickoryDnsResolver::from_system_conf()
-            .expect("resolver should build from system configuration");
+    async fn test_caching_dns_resolver_resolves_localhost() {
+        let resolver = CachingDnsResolver::default();
         let ip_addresses = resolver
             .resolve_dns("localhost")
             .await
@@ -122,40 +94,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hickory_dns_resolver_falls_back_to_os_resolver() {
-        // Points the Hickory resolver at a non-routable name server and disables its
-        // `/etc/hosts` lookup, so it can never resolve anything itself. `localhost`
-        // must still resolve through the OS resolver fallback.
-        let mut builder = TokioResolver::builder_with_config(
-            ResolverConfig::from_parts(
-                None,
-                vec![],
-                vec![NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(
-                    203, 0, 113, 1,
-                )))],
-            ),
-            TokioRuntimeProvider::default(),
-        );
-        let options = builder.options_mut();
-        options.timeout = Duration::from_millis(200);
-        options.attempts = 1;
-        options.use_hosts_file = ResolveHosts::Never;
-        let resolver = HickoryDnsResolver {
-            resolver: Arc::new(
-                builder
-                    .build()
-                    .expect("resolver should build from explicit configuration"),
-            ),
-        };
-        let ip_addresses = resolver
+    async fn test_caching_dns_resolver_caches_lookups() {
+        let resolver = CachingDnsResolver::default();
+        let first = resolver
             .resolve_dns("localhost")
             .await
-            .expect("localhost should resolve via the os resolver fallback");
-        assert!(
-            ip_addresses
-                .iter()
-                .any(|ip_address| ip_address.is_loopback()),
-            "expected a loopback address, got {ip_addresses:?}"
-        );
+            .expect("localhost should resolve");
+        assert!(resolver.cache.get(&"localhost".to_string()).is_some());
+        let second = resolver
+            .resolve_dns("localhost")
+            .await
+            .expect("localhost should resolve from cache");
+        assert_eq!(first, second);
     }
 }

--- a/quickwit/quickwit-aws/src/lib.rs
+++ b/quickwit/quickwit-aws/src/lib.rs
@@ -42,7 +42,7 @@ fn build_http_client() -> SharedHttpClient {
         Ok(resolver) => builder.build_with_resolver(resolver),
         Err(error) => {
             warn!(
-                error=%error,
+                %error,
                 "failed to initialize caching DNS resolver, falling back to the default resolver"
             );
             builder.build_https()

--- a/quickwit/quickwit-aws/src/lib.rs
+++ b/quickwit/quickwit-aws/src/lib.rs
@@ -16,13 +16,13 @@ use aws_config::retry::RetryConfig;
 use aws_config::stalled_stream_protection::StalledStreamProtectionConfig;
 use aws_config::{BehaviorVersion, Region};
 pub use aws_smithy_async::rt::sleep::TokioSleep;
+use aws_smithy_http_client::proxy::ProxyConfig;
 use aws_smithy_http_client::tls::rustls_provider::CryptoMode;
-use aws_smithy_http_client::{Builder as HttpClientBuilder, tls};
+use aws_smithy_http_client::{Builder as HttpClientBuilder, Connector, tls};
 use aws_smithy_runtime_api::client::http::SharedHttpClient;
 use tokio::sync::OnceCell;
-use tracing::warn;
 
-use crate::dns::HickoryDnsResolver;
+use crate::dns::CachingDnsResolver;
 
 pub mod dns;
 pub mod error;
@@ -32,22 +32,21 @@ pub const DEFAULT_AWS_REGION: Region = Region::from_static("us-east-1");
 
 /// Builds the HTTP client used by all AWS SDK clients.
 ///
-/// This mirrors the SDK default (Rustls + aws-lc-rs crypto) but swaps the
-/// default `getaddrinfo`-based DNS resolver for a caching Hickory resolver, see
-/// [`HickoryDnsResolver`]. If the system DNS configuration cannot be read we log
-/// a warning and fall back to the SDK's default resolver rather than failing.
+/// This mirrors `aws-smithy-runtime`'s `default_https_client()` (Rustls +
+/// aws-lc-rs crypto, proxy settings read from the environment,
+/// but wraps the default `getaddrinfo`-based DNS resolver with a cache, see [`CachingDnsResolver`].
 fn build_http_client() -> SharedHttpClient {
-    let builder = HttpClientBuilder::new().tls_provider(tls::Provider::Rustls(CryptoMode::AwsLc));
-    match HickoryDnsResolver::from_system_conf() {
-        Ok(resolver) => builder.build_with_resolver(resolver),
-        Err(error) => {
-            warn!(
-                %error,
-                "failed to initialize caching DNS resolver, falling back to the default resolver"
-            );
-            builder.build_https()
+    HttpClientBuilder::new().build_with_connector_fn(move |settings, runtime_components| {
+        let mut conn_builder =
+            Connector::builder().tls_provider(tls::Provider::Rustls(CryptoMode::AwsLc));
+        conn_builder.set_connector_settings(settings.cloned());
+        if let Some(components) = runtime_components {
+            conn_builder.set_sleep_impl(components.sleep_impl());
         }
-    }
+        // Handling `HTTP_PROXY`/`HTTPS_PROXY`/ `NO_PROXY`
+        conn_builder.set_proxy_config(Some(ProxyConfig::from_env()));
+        conn_builder.build_with_resolver(CachingDnsResolver::default())
+    })
 }
 
 /// Initialises and returns the AWS config.

--- a/quickwit/quickwit-aws/src/lib.rs
+++ b/quickwit/quickwit-aws/src/lib.rs
@@ -16,12 +16,39 @@ use aws_config::retry::RetryConfig;
 use aws_config::stalled_stream_protection::StalledStreamProtectionConfig;
 use aws_config::{BehaviorVersion, Region};
 pub use aws_smithy_async::rt::sleep::TokioSleep;
+use aws_smithy_http_client::tls::rustls_provider::CryptoMode;
+use aws_smithy_http_client::{Builder as HttpClientBuilder, tls};
+use aws_smithy_runtime_api::client::http::SharedHttpClient;
 use tokio::sync::OnceCell;
+use tracing::warn;
 
+use crate::dns::HickoryDnsResolver;
+
+pub mod dns;
 pub mod error;
 pub mod retry;
 
 pub const DEFAULT_AWS_REGION: Region = Region::from_static("us-east-1");
+
+/// Builds the HTTP client used by all AWS SDK clients.
+///
+/// This mirrors the SDK default (Rustls + aws-lc-rs crypto) but swaps the
+/// default `getaddrinfo`-based DNS resolver for a caching Hickory resolver, see
+/// [`HickoryDnsResolver`]. If the system DNS configuration cannot be read we log
+/// a warning and fall back to the SDK's default resolver rather than failing.
+fn build_http_client() -> SharedHttpClient {
+    let builder = HttpClientBuilder::new().tls_provider(tls::Provider::Rustls(CryptoMode::AwsLc));
+    match HickoryDnsResolver::from_system_conf() {
+        Ok(resolver) => builder.build_with_resolver(resolver),
+        Err(error) => {
+            warn!(
+                error=%error,
+                "failed to initialize caching DNS resolver, falling back to the default resolver"
+            );
+            builder.build_https()
+        }
+    }
+}
 
 /// Initialises and returns the AWS config.
 pub async fn get_aws_config() -> &'static aws_config::SdkConfig {
@@ -30,6 +57,7 @@ pub async fn get_aws_config() -> &'static aws_config::SdkConfig {
     SDK_CONFIG
         .get_or_init(|| async {
             aws_config::defaults(aws_behavior_version())
+                .http_client(build_http_client())
                 .stalled_stream_protection(StalledStreamProtectionConfig::enabled().build())
                 // Currently handle this ourselves so probably best for now to leave it as is.
                 .retry_config(RetryConfig::disabled())


### PR DESCRIPTION
## Summary
- The AWS SDK's default HTTP client resolves DNS via hyper's uncached `GaiResolver`, causing redundant blocking `getaddrinfo` lookups under high connection churn (e.g. many concurrent S3 range requests).
- Adds a `HickoryDnsResolver` in `quickwit-aws` backed by a caching Hickory resolver, with a configurable minimum TTL floor (`QW_S3_DNS_CACHE_MIN_TTL_SECS`, default 60s) so short-TTL S3 records are still cached long enough to absorb bursts.
- Falls back to the SDK's default resolver if the system DNS config can't be read.

## Test plan
- [x] `bash scripts/check_license_headers.sh`
- [x] `cargo clippy --workspace --all-features --tests`
- [x] `cargo +nightly fmt --all -- --check`
- [x] Unit test resolving `localhost` via the new resolver