### PR TITLE
Race condition bugfix in the dnscache.

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -8395,6 +8395,7 @@ dependencies = [
  "mini-moka",
  "quickwit-common",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -8395,7 +8395,6 @@ dependencies = [
  "mini-moka",
  "quickwit-common",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -23,6 +23,7 @@ aws-smithy-types = { workspace = true }
 futures = { workspace = true }
 mini-moka = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 quickwit-common = { workspace = true }
 

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -23,9 +23,15 @@ aws-smithy-types = { workspace = true }
 futures = { workspace = true }
 mini-moka = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 quickwit-common = { workspace = true }
 
 [features]
 kinesis = ["aws-sdk-kinesis"]
 sqs = ["aws-sdk-sqs"]
+
+[package.metadata.cargo-machete]
+# tracing is only referenced from inside quickwit_common's rate_limited_* macros
+# (via an absolute `::tracing::` path), so it doesn't show up textually in this crate.
+ignored = ["tracing"]

--- a/quickwit/quickwit-aws/Cargo.toml
+++ b/quickwit/quickwit-aws/Cargo.toml
@@ -23,7 +23,6 @@ aws-smithy-types = { workspace = true }
 futures = { workspace = true }
 mini-moka = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
 
 quickwit-common = { workspace = true }
 

--- a/quickwit/quickwit-aws/src/dns.rs
+++ b/quickwit/quickwit-aws/src/dns.rs
@@ -136,7 +136,7 @@ impl ResolveDns for CachingDnsResolver {
         let dns_entry_opt: Option<Arc<DnsEntry>> = cache.get(&host);
         // First insertion CAN trigger several DNS call, but this is not a problem.
         let dns_entry: Arc<DnsEntry> = if let Some(dns_entry) = dns_entry_opt {
-            dns_entry.clone()
+            dns_entry
         } else {
             let dns_entry = Arc::new(DnsEntry::new());
             cache.insert(host.clone(), dns_entry.clone());

--- a/quickwit/quickwit-aws/src/dns.rs
+++ b/quickwit/quickwit-aws/src/dns.rs
@@ -23,53 +23,147 @@
 //! `/etc/hosts`, mDNS, LDAP, etc), but keeps an in-memory cache of the
 //! results so repeated lookups for the same host don't each pay for a
 //! blocking `getaddrinfo` call.
+//!
+//! Cached entries never expire outright: once a host has been resolved at
+//! least once, lookups always return the cached (possibly stale) addresses
+//! immediately. Entries older than [`DNS_REFRESH_COOLDOWN`] instead trigger a
+//! background refresh that updates the cache in place once it completes, so
+//! callers are never blocked waiting on a fresh `getaddrinfo` call for a
+//! host they already have an answer for.
 
 use std::net::IpAddr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
 
 use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, ResolveDnsError};
 use mini_moka::sync::Cache;
+use tokio::sync::watch;
 
-/// TTL applied to cached lookups.
-const DNS_CACHE_TTL: Duration = Duration::from_mins(1);
+// We refresh once every 5 seconds. S3's DNS varies very rapidly.
+const DNS_REFRESH_COOLDOWN: Duration = Duration::from_secs(5);
+
+// On the first call, we do not have any answer to give back,
+// so we wait up to DNS_TIMEOUT seconds for an entry to have been populated
+// by the background task.
+const DNS_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Maximum number of cached hostnames.
+/// In practise this cache should only a few entries to connect to s3's endpoints.
 const DNS_CACHE_SIZE: u64 = 1_024;
+
+// An instant expressed as duration elapsed from a reference time, expressed in millisecs.
+type IInstant = u64;
+
+fn now() -> IInstant {
+    static REFERENCE_TIME: LazyLock<Instant> = LazyLock::new(|| Instant::now());
+    Instant::now().duration_since(*REFERENCE_TIME).as_millis() as u64
+}
+
+/// A cached DNS entry.
+#[derive(Debug)]
+struct DnsEntry {
+    ip_addresses_rx: watch::Receiver<Vec<IpAddr>>,
+    ip_addresses_tx: watch::Sender<Vec<IpAddr>>,
+    next_resolve_attempt: AtomicU64,
+}
+
+impl DnsEntry {
+    fn new() -> Self {
+        let (ip_addresses_tx, ip_addresses_rx) = tokio::sync::watch::channel(Vec::new());
+        DnsEntry {
+            ip_addresses_rx,
+            ip_addresses_tx,
+            next_resolve_attempt: AtomicU64::new(0u64),
+        }
+    }
+
+    fn should_resolve(&self) -> bool {
+        let next_resolve_attempt: u64 = self.next_resolve_attempt.load(Ordering::Relaxed);
+        let now = now();
+        if now >= next_resolve_attempt {
+            // Our current entry is stale. Let's see if we want to trigger
+            // the refresh by atomically updating the next_resolve_attempt instant.
+            //
+            // Relaxed suffices on both arms: this CAS only elects a single winner.
+            self.next_resolve_attempt
+                .compare_exchange(
+                    next_resolve_attempt,
+                    now + DNS_REFRESH_COOLDOWN.as_millis() as u64,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+        } else {
+            false
+        }
+    }
+}
 
 /// A [`ResolveDns`] implementation that caches `getaddrinfo` lookups.
 #[derive(Debug, Clone)]
 pub struct CachingDnsResolver {
-    cache: Arc<Cache<String, Vec<IpAddr>>>,
+    cache: Arc<Cache<String, Arc<DnsEntry>>>,
 }
 
 impl Default for CachingDnsResolver {
     fn default() -> Self {
-        let cache = Cache::builder()
-            .max_capacity(DNS_CACHE_SIZE)
-            .time_to_live(DNS_CACHE_TTL)
-            .build();
+        let cache = Cache::builder().max_capacity(DNS_CACHE_SIZE).build();
         CachingDnsResolver {
             cache: Arc::new(cache),
         }
     }
 }
 
+fn spawn_refresh_dns(ips_tx: tokio::sync::watch::Sender<Vec<IpAddr>>, host: String) {
+    tokio::task::spawn(async move {
+        let Ok(socket_addrs) = tokio::net::lookup_host((host.as_str(), 0)).await else {
+            quickwit_common::rate_limited_error!(limit_per_min = 10, %host, "failed to refresh DNS");
+            return;
+        };
+        let ips: Vec<IpAddr> = socket_addrs.map(|socket_addr| socket_addr.ip()).collect();
+        if ips.is_empty() {
+            return;
+        }
+        let _ = ips_tx.send(ips);
+    });
+}
+
 impl ResolveDns for CachingDnsResolver {
-    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a> {
+    fn resolve_dns<'a>(&'a self, host: &'a str) -> DnsFuture<'a> {
         let cache = self.cache.clone();
-        let host = name.to_string();
+        let host = host.to_string();
+        let dns_entry_opt: Option<Arc<DnsEntry>> = cache.get(&host);
+        // First insertion CAN trigger several DNS call, but this is not a problem.
+        let dns_entry: Arc<DnsEntry> = if let Some(dns_entry) = dns_entry_opt {
+            dns_entry.clone()
+        } else {
+            let dns_entry = Arc::new(DnsEntry::new());
+            cache.insert(host.clone(), dns_entry.clone());
+            dns_entry
+        };
+        if dns_entry.should_resolve() {
+            spawn_refresh_dns(dns_entry.ip_addresses_tx.clone(), host.clone());
+        }
         DnsFuture::new(async move {
-            if let Some(ip_addresses) = cache.get(&host) {
-                return Ok(ip_addresses);
+            {
+                // Happy path! If we have ips, we return directly.
+                let ips_view = dns_entry.ip_addresses_rx.borrow();
+                if !ips_view.is_empty() {
+                    return Ok(ips_view.clone());
+                }
             }
-            let socket_addrs = tokio::net::lookup_host((host.as_str(), 0))
-                .await
-                .map_err(ResolveDnsError::new)?;
-            let ip_addresses: Vec<IpAddr> =
-                socket_addrs.map(|socket_addr| socket_addr.ip()).collect();
-            cache.insert(host, ip_addresses.clone());
-            Ok(ip_addresses)
+            let mut ip_addresses_rx = dns_entry.ip_addresses_rx.clone();
+            let ips: Vec<IpAddr> = tokio::time::timeout(DNS_TIMEOUT, async move {
+                ip_addresses_rx
+                    .wait_for(|ips| !ips.is_empty())
+                    .await
+                    .map_err(ResolveDnsError::new)
+                    .map(|res| res.clone())
+            })
+            .await
+            .map_err(ResolveDnsError::new)??;
+            Ok(ips)
         })
     }
 }

--- a/quickwit/quickwit-aws/src/dns.rs
+++ b/quickwit/quickwit-aws/src/dns.rs
@@ -49,14 +49,14 @@ const DNS_REFRESH_COOLDOWN: Duration = Duration::from_secs(5);
 const DNS_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Maximum number of cached hostnames.
-/// In practise this cache should only a few entries to connect to s3's endpoints.
+/// In practise this cache should only contain a few entries to connect to s3's endpoints.
 const DNS_CACHE_SIZE: u64 = 1_024;
 
 // An instant expressed as duration elapsed from a reference time, expressed in millisecs.
 type IInstant = u64;
 
 fn now() -> IInstant {
-    static REFERENCE_TIME: LazyLock<Instant> = LazyLock::new(|| Instant::now());
+    static REFERENCE_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
     Instant::now().duration_since(*REFERENCE_TIME).as_millis() as u64
 }
 

--- a/quickwit/quickwit-metastore/src/metastore/postgres/utils.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/utils.rs
@@ -207,10 +207,16 @@ pub(super) fn append_query_filters_and_order_by(sql: &mut SelectStatement, query
         // ceiling and keeps parse-time O(1) in the exclude size. The `$1` is
         // postgres' placeholder; sea-query substitutes it with the next bind
         // slot at build time.
-        let excluded_split_ids: Vec<Value> = query
+        let mut excluded_split_ids: Vec<String> = query
             .excluded_split_ids
             .into_iter()
-            .map(|split_id| Value::String(Some(Box::new(split_id.to_string()))))
+            .map(|split_id| split_id.to_string())
+            .collect();
+        // HashSet iteration order is randomized; keep query rendering deterministic.
+        excluded_split_ids.sort_unstable();
+        let excluded_split_ids: Vec<Value> = excluded_split_ids
+            .into_iter()
+            .map(|split_id| Value::String(Some(Box::new(split_id))))
             .collect();
         let excluded_array = Value::Array(ArrayType::String, Some(Box::new(excluded_split_ids)));
         sql.cond_where(Expr::cust_with_values(


### PR DESCRIPTION
I ended up not using hickory for the cache
in order to support all of the libc subtleties (resolv.conf)

Unfortunately, upon expiration, and until the dns entry is updated, all new connection create triggers a DNS update.

Because our DNS is slightly slow, this was causing a significantly inflated (and confusing) number of DNS calls.

The hickory approach on this was to block all callers.

I am not fond of this solution either: it would synchronize GET for no reason at all, and our TTL is pretty arbitrary. There is no need to pay for DNS latency at all.

This PR chooses to run DNS refresh asynchronously when the TTL is expired and the entry is stale.
