### PR TITLE
search: attribute permit-wait latency to the blocking resource

### DIFF
--- a/quickwit/quickwit-common/src/tracing_utils.rs
+++ b/quickwit/quickwit-common/src/tracing_utils.rs
@@ -90,6 +90,15 @@ pub fn set_current_span_parent_from_metadata(metadata: &MetadataMap) {
     let _ = Span::current().set_parent(parent_context);
 }
 
+/// Records an attribute on the currently-active span's OpenTelemetry span.
+///
+/// Unlike a `tracing` field (`#[instrument(fields(...))]` or `Span::record`), this does
+/// not propagate to log events, so it can carry verbose values (e.g. a query AST)
+/// without bloating logs. No-op when no OpenTelemetry layer is installed.
+pub fn record_current_span_attribute(key: &'static str, value: impl Into<opentelemetry::Value>) {
+    Span::current().set_attribute(key, value);
+}
+
 /// Tonic interceptor that injects the active span's W3C trace context into
 /// the outgoing gRPC metadata. Drop-in replacement for the legacy
 /// `quickwit_proto::SpanContextInterceptor`.

--- a/quickwit/quickwit-search/src/fetch_docs.rs
+++ b/quickwit/quickwit-search/src/fetch_docs.rs
@@ -28,7 +28,7 @@ use tantivy::schema::document::CompactDocValue;
 use tantivy::schema::{Document as DocumentTrait, Field, TantivyDocument, Value};
 use tantivy::snippet::SnippetGenerator;
 use tantivy::{ReloadPolicy, Score, Searcher, Term};
-use tracing::{Instrument, error};
+use tracing::{Instrument, error, instrument};
 
 use crate::leaf::open_index_with_caches;
 use crate::service::SearcherContext;
@@ -153,6 +153,7 @@ struct Document {
 }
 
 /// Fetching docs from a specific split.
+#[instrument(skip_all, fields(split_id = split.split_id, num_docs = global_doc_addrs.len()))]
 async fn fetch_docs_in_split(
     searcher_context: Arc<SearcherContext>,
     mut global_doc_addrs: Vec<GlobalDocAddress>,

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -67,7 +67,7 @@ use crate::metrics::{
 };
 use crate::root::is_metadata_count_request_with_ast;
 use crate::search_permit_provider::{
-    SearchPermit, SearchPermitFuture, compute_initial_memory_allocation,
+    BlockReasonHandle, SearchPermit, SearchPermitFuture, compute_initial_memory_allocation,
 };
 use crate::service::{SearcherContext, deserialize_doc_mapper};
 use crate::{QuickwitAggregations, SearchError};
@@ -2047,6 +2047,42 @@ pub async fn single_doc_mapping_leaf_search(
     Ok(leaf_search_response)
 }
 
+/// Records the permit block reason onto the `acquire_leaf_split_search_permit`
+/// span when the wait ends.
+///
+/// Implemented as a drop guard (rather than reading after `.await`) so the reason is
+/// recorded even when the wait future is cancelled before the permit is granted — the
+/// long waits that hit a search deadline are exactly the ones that never get granted.
+struct WaitBlockReasonRecorder {
+    wait_span: Span,
+    block_reason: BlockReasonHandle,
+    started_at: Instant,
+}
+
+impl WaitBlockReasonRecorder {
+    fn new(wait_span: Span, block_reason: BlockReasonHandle) -> Self {
+        Self {
+            wait_span,
+            block_reason,
+            started_at: Instant::now(),
+        }
+    }
+}
+
+impl Drop for WaitBlockReasonRecorder {
+    fn drop(&mut self) {
+        // Skip near-instant grants: a sub-millisecond wait isn't worth attributing and
+        // keeps the span uncluttered.
+        const MIN_WAIT_FOR_BLOCK_ATTRIBUTION: Duration = Duration::from_millis(1);
+        if self.started_at.elapsed() < MIN_WAIT_FOR_BLOCK_ATTRIBUTION {
+            return;
+        }
+        if let Some(block_reason) = self.block_reason.get() {
+            self.wait_span.record("blocked_on", block_reason.as_str());
+        }
+    }
+}
+
 async fn run_local_search_tasks(
     local_search_tasks: Vec<LocalSearchTask>,
     index_storage: Arc<dyn Storage + 'static>,
@@ -2069,7 +2105,18 @@ async fn run_local_search_tasks(
             split_id = split.split_id,
             num_docs = split.num_docs
         );
-        let wait_span = info_span!(parent: &split_span, "acquire_leaf_split_search_permit");
+        let wait_span = info_span!(
+            parent: &split_span,
+            "acquire_leaf_split_search_permit",
+            blocked_on = tracing::field::Empty
+        );
+        // Records the block reason on `wait_span` when the wait ends — whether the permit
+        // is granted or the wait is cancelled on a search deadline (the important, long
+        // waits are exactly the ones that get cancelled before being granted).
+        let _block_reason_recorder = WaitBlockReasonRecorder::new(
+            wait_span.clone(),
+            search_permit_future.block_reason_handle(),
+        );
         let leaf_split_search_permit = search_permit_future.instrument(wait_span).await;
 
         // We run simplify search request again: as we push split into the merge collector,

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -300,7 +300,6 @@ async fn run_cancellable(
 ///
 /// Returns whether the query is provably empty in this split (i.e. `on_absent` fired and
 /// warmup was short-circuited).
-#[instrument(skip_all)]
 pub(crate) async fn warmup(
     searcher: &Searcher,
     warmup_info: &WarmupInfo,
@@ -746,6 +745,11 @@ async fn leaf_search_single_split(
     warmup_info.simplify();
 
     let warmup_start = Instant::now();
+    // Baseline the counters so the warmup span attributes exclude bytes fetched while
+    // opening the index (e.g. the split footer on a cold cache), which land in these same
+    // counters before warmup begins.
+    let cache_bytes_before_warmup = byte_range_cache.get_num_bytes();
+    let downloaded_bytes_before_warmup = download_counters.snapshot().0;
     leaf_search_state_guard.set_state(SplitSearchState::WarmUp);
     // Negative cache: a split is provably empty for this query if any required term has
     // previously been proven absent here. Absence is an immutable, query- and
@@ -779,7 +783,35 @@ async fn leaf_search_single_split(
                 HitSet::empty(),
             );
         };
-        warmup(&searcher, &warmup_info, &record_absence).await?
+        // `warmup_mb` is warmed into the byte-range cache during warmup; `downloaded_mb` is
+        // the subset actually fetched from object storage (cache hits excluded). Both are
+        // deltas since `warmup_start`, so index-open reads are not attributed here, and are
+        // recorded after warmup, before the search adds to either.
+        const BYTES_PER_MB: f64 = 1_000_000.0;
+        let warmup_span = info_span!(
+            "warmup",
+            warmup_mb = tracing::field::Empty,
+            downloaded_mb = tracing::field::Empty
+        );
+        let provably_empty = warmup(&searcher, &warmup_info, &record_absence)
+            .instrument(warmup_span.clone())
+            .await?;
+        warmup_span.record(
+            "warmup_mb",
+            byte_range_cache
+                .get_num_bytes()
+                .saturating_sub(cache_bytes_before_warmup) as f64
+                / BYTES_PER_MB,
+        );
+        warmup_span.record(
+            "downloaded_mb",
+            download_counters
+                .snapshot()
+                .0
+                .saturating_sub(downloaded_bytes_before_warmup) as f64
+                / BYTES_PER_MB,
+        );
+        provably_empty
     };
     let warmup_end = Instant::now();
     let warmup_duration: Duration = warmup_end.duration_since(warmup_start);

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -2037,7 +2037,7 @@ async fn run_local_search_tasks(
             split_id = split.split_id,
             num_docs = split.num_docs
         );
-        let wait_span = info_span!(parent: &split_span, "waiting_for_leaf_search_split_semaphore");
+        let wait_span = info_span!(parent: &split_span, "acquire_leaf_split_search_permit");
         let leaf_split_search_permit = search_permit_future.instrument(wait_span).await;
 
         // We run simplify search request again: as we push split into the merge collector,

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -841,7 +841,10 @@ async fn leaf_search_single_split(
     }
 
     let split_num_docs = split.num_docs;
-    let span = info_span!("tantivy_search");
+    // Spans the CPU-pool queue wait: created here (right after warmup) and closed when the
+    // closure starts executing on a pool thread. `tantivy_search` is created inside the
+    // closure so it covers only the CPU execution, not this wait.
+    let cpu_wait_span = info_span!("waiting_for_cpu_pool");
 
     let split_clone = split.clone();
 
@@ -852,9 +855,12 @@ async fn leaf_search_single_split(
     let search_request_and_result: Option<(SearchRequest, LeafSearchResponse)> =
         crate::search_thread_pool()
             .run_cpu_intensive(move || {
+                // The CPU-pool queue wait ends as this closure starts executing.
+                drop(cpu_wait_span);
                 leaf_search_state_guard.set_state(SplitSearchState::Cpu);
                 let cpu_start = Instant::now();
                 let cpu_thread_pool_wait_microsecs = cpu_start.duration_since(warmup_end);
+                let span = info_span!("tantivy_search");
                 let _span_guard = span.enter();
                 // Our search execution has been scheduled, let's check if we can improve the
                 // request based on the results of the preceding searches
@@ -1545,7 +1551,7 @@ pub async fn multi_index_leaf_search(
         let searcher_context = searcher_context.clone();
         let search_request = search_request.clone();
 
-        leaf_request_futures.spawn({
+        leaf_request_futures.spawn(
             async move {
                 let storage = storage_resolver.resolve(&index_uri).await?;
                 single_doc_mapping_leaf_search(
@@ -1555,10 +1561,10 @@ pub async fn multi_index_leaf_search(
                     leaf_search_request_ref.split_offsets,
                     doc_mapper,
                 )
-                .in_current_span()
                 .await
             }
-        });
+            .instrument(Span::current()),
+        );
     }
 
     // Creates a collector which merges responses into one
@@ -1723,12 +1729,15 @@ async fn run_offloaded_search_tasks(
             }],
         };
         let invoker = lambda_invoker.clone();
-        lambda_tasks_joinset.spawn(async move {
-            (
-                batch_split_ids,
-                invoker.invoke_leaf_search(leaf_request).await,
-            )
-        });
+        lambda_tasks_joinset.spawn(
+            async move {
+                (
+                    batch_split_ids,
+                    invoker.invoke_leaf_search(leaf_request).await,
+                )
+            }
+            .in_current_span(),
+        );
     }
 
     while let Some(join_res) = lambda_tasks_joinset.join_next().await {
@@ -2021,9 +2030,15 @@ async fn run_local_search_tasks(
         search_permit_future,
     } in local_search_tasks
     {
-        let leaf_split_search_permit = search_permit_future
-            .instrument(info_span!("waiting_for_leaf_search_split_semaphore"))
-            .await;
+        // Per-split span covering both the permit wait and the search, so each split is a
+        // single subtree (wait + warmup + tantivy) rather than flat siblings.
+        let split_span = info_span!(
+            "leaf_search_single_split_wrapper",
+            split_id = split.split_id,
+            num_docs = split.num_docs
+        );
+        let wait_span = info_span!(parent: &split_span, "waiting_for_leaf_search_split_semaphore");
+        let leaf_split_search_permit = search_permit_future.instrument(wait_span).await;
 
         // We run simplify search request again: as we push split into the merge collector,
         // we may have discovered that we won't find any better candidates for top hits in this
@@ -2045,7 +2060,7 @@ async fn run_local_search_tasks(
                 split.clone(),
                 leaf_split_search_permit,
             )
-            .in_current_span(),
+            .instrument(split_span),
         );
         task_id_to_split_id_map.insert(handle.id(), split_id);
     }
@@ -2174,7 +2189,6 @@ struct LeafSearchContext {
     split_filter: Arc<RwLock<CanSplitDoBetter>>,
 }
 
-#[instrument(skip_all, fields(split_id = split.split_id, num_docs = split.num_docs))]
 async fn leaf_search_single_split_wrapper(
     request: SearchRequest,
     ctx: Arc<LeafSearchContext>,

--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -188,6 +188,7 @@ pub async fn list_all_splits(
 }
 
 /// Extract the list of relevant splits for a given request.
+#[tracing::instrument(skip_all, fields(num_indexes = index_uids.len()))]
 pub async fn list_relevant_splits(
     index_uids: Vec<IndexUid>,
     start_timestamp: Option<i64>,

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -1312,8 +1312,9 @@ pub async fn root_search(
     let num_docs: usize = split_metadatas.iter().map(|split| split.num_docs).sum();
     let num_splits = split_metadatas.len();
 
-    // It would have been nice to add those in the context of the trace span,
-    // but with our current logging setting, it makes logs too verbose.
+    // These would bloat the logs if added as tracing span fields (they propagate to
+    // every log event in the span), so they go on a one-shot `info!` for logs and, via
+    // `record_current_span_attribute`, on the OpenTelemetry span only for the trace.
     info!(
         query_ast = search_request.query_ast.as_str(),
         agg = search_request.aggregation_request(),
@@ -1323,6 +1324,24 @@ pub async fn root_search(
         num_splits = num_splits,
         "root_search"
     );
+    quickwit_common::tracing_utils::record_current_span_attribute(
+        "query_ast",
+        search_request.query_ast.clone(),
+    );
+    quickwit_common::tracing_utils::record_current_span_attribute("num_docs", num_docs as i64);
+    quickwit_common::tracing_utils::record_current_span_attribute("num_splits", num_splits as i64);
+    if let Some(start_timestamp) = search_request.start_timestamp {
+        quickwit_common::tracing_utils::record_current_span_attribute(
+            "start_timestamp",
+            start_timestamp,
+        );
+    }
+    if let Some(end_timestamp) = search_request.end_timestamp {
+        quickwit_common::tracing_utils::record_current_span_attribute(
+            "end_timestamp",
+            end_timestamp,
+        );
+    }
 
     if let Some(max_total_split_searches) = searcher_context.searcher_config.max_splits_per_search
         && max_total_split_searches < num_splits

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -789,7 +789,7 @@ fn compute_root_resource_stats(
 
 /// If this method fails for some splits, a partial search response is returned, with the list of
 /// faulty splits in the failed_splits field.
-#[instrument(level = "debug", skip_all)]
+#[instrument(skip_all)]
 pub(crate) async fn search_partial_hits_phase(
     searcher_context: &SearcherContext,
     indexes_metas_for_leaf_search: &IndexesMetasForLeafSearch,
@@ -1249,6 +1249,7 @@ async fn refine_and_list_matches(
 }
 
 /// Fetches the list of splits and their metadata from the metastore
+#[instrument(skip_all)]
 async fn plan_splits_for_root_search(
     search_request: &mut SearchRequest,
     metastore: &mut MetastoreServiceClient,

--- a/quickwit/quickwit-search/src/search_permit_provider.rs
+++ b/quickwit/quickwit-search/src/search_permit_provider.rs
@@ -17,7 +17,7 @@ use std::collections::binary_heap::PeekMut;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
@@ -56,6 +56,66 @@ pub(crate) struct SplitSearchTaskMetadata {
     /// Estimated cost of this task, in the same arbitrary unit as [`Job::cost()`].
     /// Used to report the current load of this node to the job placer.
     pub job_cost: usize,
+}
+
+/// Why the head of the permit queue could not be granted.
+///
+/// The actor writes it into the shared [`BlockReasonHandle`] each time it fails to serve
+/// the head, so any waiter can read it whether its permit is eventually granted or the
+/// wait is cancelled (e.g. on a search deadline). This is what lets us attribute the
+/// acquisition latency to the binding resource.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PermitBlockReason {
+    /// All concurrent warmup/download slots were in use.
+    WarmupSlots,
+    /// The memory budget could not fit the request's estimated allocation.
+    MemoryBudget,
+}
+
+impl PermitBlockReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PermitBlockReason::WarmupSlots => "warmup_slots",
+            PermitBlockReason::MemoryBudget => "memory_budget",
+        }
+    }
+
+    fn to_code(self) -> u8 {
+        match self {
+            PermitBlockReason::WarmupSlots => 1,
+            PermitBlockReason::MemoryBudget => 2,
+        }
+    }
+
+    fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(PermitBlockReason::WarmupSlots),
+            2 => Some(PermitBlockReason::MemoryBudget),
+            _ => None,
+        }
+    }
+}
+
+/// Shared cell recording the resource currently blocking the head of the permit queue.
+///
+/// A single instance is shared by the actor (which writes it) and every
+/// [`SearchPermitFuture`] (which reads it). Because permits are served in order, whatever
+/// blocks the head effectively blocks every waiter, so a queue-level reason is correct for
+/// a waiter at any position — including one cancelled deep in the queue before it ever
+/// reaches the head. Uses an atomic so it can be read after the wait future is dropped on
+/// cancellation.
+#[derive(Clone, Default)]
+pub struct BlockReasonHandle(Arc<AtomicU8>);
+
+impl BlockReasonHandle {
+    fn set(&self, reason: PermitBlockReason) {
+        self.0.store(reason.to_code(), Ordering::Relaxed);
+    }
+
+    /// The resource currently blocking the queue, or `None` if it isn't blocked.
+    pub fn get(&self) -> Option<PermitBlockReason> {
+        PermitBlockReason::from_code(self.0.load(Ordering::Relaxed))
+    }
 }
 
 pub enum SearchPermitMessage {
@@ -116,6 +176,7 @@ impl SearchPermitProvider {
             permits_requests: BinaryHeap::new(),
             total_memory_allocated: 0u64,
             total_job_cost: total_job_cost.clone(),
+            block_reason: BlockReasonHandle::default(),
         };
         let actor_join_handle = Arc::new(tokio::spawn(actor.run()));
         Self {
@@ -209,6 +270,9 @@ struct SearchPermitActor {
     /// Only the actor mutates it, so [`Ordering::Relaxed`] is sufficient.
     total_job_cost: Arc<AtomicUsize>,
     permits_requests: BinaryHeap<LeafPermitRequest>,
+    /// Shared with every [`SearchPermitFuture`]; set to the resource blocking the head of
+    /// the queue each time it can't be served.
+    block_reason: BlockReasonHandle,
 }
 
 struct SingleSplitPermitRequest {
@@ -253,6 +317,7 @@ impl LeafPermitRequest {
     // `task_metadata` must not be empty.
     fn from_task_metadata(
         task_metadata: Vec<SplitSearchTaskMetadata>,
+        block_reason: BlockReasonHandle,
     ) -> (Self, Vec<SearchPermitFuture>) {
         assert!(!task_metadata.is_empty(), "task_metadata must not be empty");
         // Stamped on every `SingleSplitPermitRequest` we're about to enqueue.
@@ -272,7 +337,10 @@ impl LeafPermitRequest {
                 job_cost: meta.job_cost,
                 requested_at,
             });
-            permits.push(SearchPermitFuture(rx));
+            permits.push(SearchPermitFuture {
+                receiver: rx,
+                block_reason: block_reason.clone(),
+            });
         }
         (
             LeafPermitRequest {
@@ -338,7 +406,7 @@ impl SearchPermitActor {
                 SEARCHER_NODE_LOAD.set(new_load as f64);
 
                 let (leaf_permit_request, permit_futures) =
-                    LeafPermitRequest::from_task_metadata(task_metadata);
+                    LeafPermitRequest::from_task_metadata(task_metadata, self.block_reason.clone());
                 self.permits_requests.push(leaf_permit_request);
                 self.assign_available_permits();
                 let _ = permit_sender.send(permit_futures);
@@ -374,12 +442,25 @@ impl SearchPermitActor {
     }
 
     fn pop_next_request_if_serviceable(&mut self) -> Option<SingleSplitPermitRequest> {
-        if self.num_warmup_slots_available == 0 {
+        // Nothing is waiting, so there is no block to attribute (avoids leaving a stale
+        // reason set once the queue drains and slots/memory are exhausted).
+        if self.permits_requests.is_empty() {
             return None;
         }
-        let available_memory = self
+        if self.num_warmup_slots_available == 0 {
+            self.block_reason.set(PermitBlockReason::WarmupSlots);
+            return None;
+        }
+        let available_memory = match self
             .total_memory_budget
-            .checked_sub(self.total_memory_allocated)?;
+            .checked_sub(self.total_memory_allocated)
+        {
+            Some(available_memory) => available_memory,
+            None => {
+                self.block_reason.set(PermitBlockReason::MemoryBudget);
+                return None;
+            }
+        };
         let mut peeked = self.permits_requests.peek_mut()?;
 
         assert!(
@@ -392,6 +473,8 @@ impl SearchPermitActor {
             }
             return Some(permit_request);
         }
+        // The head request needs more memory than is currently available.
+        self.block_reason.set(PermitBlockReason::MemoryBudget);
         None
     }
 
@@ -510,13 +593,25 @@ impl Drop for SearchPermit {
     }
 }
 
-pub struct SearchPermitFuture(oneshot::Receiver<SearchPermit>);
+pub struct SearchPermitFuture {
+    receiver: oneshot::Receiver<SearchPermit>,
+    block_reason: BlockReasonHandle,
+}
+
+impl SearchPermitFuture {
+    /// Handle to the reason this permit is blocked on. Readable at any time, including
+    /// after this future is dropped on cancellation, so the waiter can attribute the
+    /// wait even when the permit is never granted.
+    pub fn block_reason_handle(&self) -> BlockReasonHandle {
+        self.block_reason.clone()
+    }
+}
 
 impl Future for SearchPermitFuture {
     type Output = SearchPermit;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let receiver = Pin::new(&mut self.get_mut().0);
+        let receiver = Pin::new(&mut self.get_mut().receiver);
         match receiver.poll(cx) {
             Poll::Ready(Ok(search_permit)) => Poll::Ready(search_permit),
             Poll::Ready(Err(_)) => panic!(
@@ -835,6 +930,52 @@ mod tests {
         permits.drain(0..1);
         let next_blocked_permit_fut = remaining_permit_futs.next().unwrap();
         permits.push(try_get(next_blocked_permit_fut).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_permit_block_reason_warmup_slots() {
+        // A single warmup slot with ample memory: once a second request is queued, the
+        // queue can only be blocked on the warmup slot. The reason is queue-level and
+        // shared by every waiter's handle, readable without being granted a permit.
+        let permit_provider = SearchPermitProvider::new(1, ByteSize::mb(1000));
+        let first_fut = permit_provider
+            .get_permits(make_splits(10, 1))
+            .await
+            .into_iter()
+            .next()
+            .unwrap();
+        // First was granted immediately; nothing is blocked yet.
+        assert_eq!(first_fut.block_reason_handle().get(), None);
+        let second_fut = permit_provider
+            .get_permits(make_splits(10, 1))
+            .await
+            .into_iter()
+            .next()
+            .unwrap();
+        // Second can't get the single slot: the queue is now blocked on warmup slots.
+        assert_eq!(
+            second_fut.block_reason_handle().get(),
+            Some(PermitBlockReason::WarmupSlots)
+        );
+        // Draining still works: freeing the slot lets the second request through.
+        let first_permit = first_fut.await;
+        drop(first_permit);
+        let _second_permit = second_fut.await;
+    }
+
+    #[tokio::test]
+    async fn test_permit_block_reason_memory_budget() {
+        // Ample slots but tight memory (100MB / 10MB = 10 permits): the 11th request can
+        // only be blocked on the memory budget.
+        let permit_provider = SearchPermitProvider::new(100, ByteSize::mb(100));
+        let permit_futs = permit_provider.get_permits(make_splits(10, 11)).await;
+        assert_eq!(permit_futs.len(), 11);
+        // The 11th can't fit, so the queue is blocked on memory. The reason is queue-level
+        // and shared, so any waiter's handle reports it — even one deep in the queue.
+        assert_eq!(
+            permit_futs[10].block_reason_handle().get(),
+            Some(PermitBlockReason::MemoryBudget)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
`acquire_leaf_split_search_permit` (renamed from `waiting_for_leaf_search_split_semaphore` in #6620) was a bare timer, so a long wait couldn't be attributed to the two things a split-search permit can block on: warmup/download slots or the memory budget.

The actor now tracks the resource blocking the head of the queue in a shared `BlockReasonHandle` (an atomic). Because permits are served in order, whatever blocks the head blocks every waiter, so this queue-level reason is correct for a waiter at any position. Each `SearchPermitFuture` reads the handle, and a drop guard (`WaitBlockReasonRecorder`) on the wait span records `blocked_on` when the wait ends — granted **or** cancelled — gated on the wait being long (≥1ms) so instant grants stay unlabeled. Attributing on the wait side (not from the granted permit) is what lets the long, deadline-cancelled waits — the ones we care about — carry a reason even though they never get a permit.

Stacked on #6588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
