### PR TITLE
Harden recovery from metastore overload

### DIFF
--- a/docs/internals/metastore-overload-recovery.md
+++ b/docs/internals/metastore-overload-recovery.md
@@ -1,0 +1,131 @@
+# Metastore overload and cluster recovery
+
+This document explains how PostgreSQL metastore overload can turn into a prolonged cluster outage, and how the recovery fixes work together.
+
+The initial database contention and the recovery bugs are different problems. Database contention starts the incident. The control-plane, scheduler, and ingest-routing bugs amplify it by preventing the cluster from converging after the database becomes responsive again.
+
+## Trigger and recovery amplifiers
+
+For this incident, telemetry points to PostgreSQL contention as the trigger. The code review identified several independent mechanisms that could prolong recovery; it does not establish that every branch occurred or that they happened in a strict sequence.
+
+```text
+Concurrent metastore work contends in PostgreSQL
+  -> the connection pool fills and requests queue in SQLx
+  -> readiness probes and control-plane operations time out
+     |-> periodic reconciliation can stop after a recoverable error
+     |-> a control-plane restart can leave stale generation-owned work
+     |-> a restarted indexer may not receive an unchanged plan
+     `-> an ingest router may keep selecting a stale source route
+  -> database health returns, but one or more recovery paths remain stuck
+  -> indexing and ingestion stay degraded
+```
+
+## 1. Bound aggregate metastore admission
+
+**Before.** The metastore server configured at least 100 in-flight requests for each generated RPC method, even when the PostgreSQL pool contained only 10 connections. The layer was called “shared,” but cloning `LoadShedLayer` for each method created an independent semaphore for every method.
+
+**Why this prolongs an outage.** A PostgreSQL statement cannot execute until its request acquires a connection. The other requests wait in SQLx's acquisition queue, retain RPC capacity, and time out. If admitted calls contend on the same database lock, they can also hold all connections while making progress one at a time. `check_connectivity` accesses the pool directly and has no priority over this convoy, so repeated acquisition failures make the metastore node report itself as not ready. Retries can keep refilling the queue after the initiating traffic burst has ended.
+
+**Fix.** `LoadShedLayer::new_shared` stores one semaphore shared by all RPC methods. PostgreSQL-backed metastores admit `max(1, max_connections - 1)` unary RPCs in aggregate. Excess requests fail before entering the metastore with `TooManyRequests`; when the pool has at least two connections, one connection remains as best-effort headroom for direct work such as readiness checks.
+
+SQLx `PoolTimedOut` errors are deliberately not converted to `TooManyRequests`. A `TooManyRequests` produced by pre-dispatch load shedding is safely known to have no side effects. A pool acquisition can instead time out after an operation has already produced side effects, so its transaction outcome may be uncertain and the control plane may need to reload state.
+
+**Proof.** `test_shared_load_shed_across_services`, `test_postgres_metastore_admission_matches_connection_pool_capacity`, and `test_metastore_admission_is_shared_across_rpc_methods` prove aggregate cross-method admission, the pool-size mapping, rejection before execution, and permit release.
+
+## 2. Keep periodic reconciliation alive after safe overload rejection
+
+**Before.** `ControlPlanLoop` scheduled its next run only after a completely successful iteration. A `TooManyRequests` emitted by pre-dispatch load shedding was correctly considered recoverable, so the control-plane actor stayed alive, but the handler returned without scheduling another iteration.
+
+**Why this prolongs an outage.** A single transient overload response could silently stop the periodic chain responsible for shard rebalancing and indexing-plan reconciliation. Restoring database capacity did not restart that chain. The cluster then depended on an unrelated event or a later control-plane restart to converge.
+
+**Fix.** The current control-plane generation schedules its next iteration after a recoverable error. Errors with an uncertain transaction outcome still restart the actor so that it reloads authoritative metastore state.
+
+**Proof.** `test_control_plan_loop_continues_after_too_many_requests` verifies that overload rejection does not kill the periodic loop or force an actor respawn.
+
+## 3. Isolate work owned by each control-plane generation
+
+A supervised control plane can restart while reusing the same mailbox. Work started by the old actor must not act on the successor's freshly loaded model.
+
+### Timers and cluster watchers
+
+**Before.** Periodic timers and cluster-change watchers were not tied to an actor generation. Repeated failures could leave multiple watchers sending untagged rebalance messages to the shared mailbox. A watcher blocked on mailbox capacity could survive shutdown.
+
+**Why this prolongs an outage.** One cluster event could trigger duplicate plan rebuilds and shard rebalances, multiplying metastore and indexer traffic during recovery. A timer queued just before shutdown could also run against the successor's state.
+
+**Fix.** Each actor instance receives a monotonically increasing generation and an explicit shutdown signal. Control-loop messages emitted by timers and rebalance messages emitted by watchers carry that generation. Successors discard stale messages, and watchers can cancel even while waiting for mailbox capacity.
+
+**Proof.** `test_control_plane_respawns_do_not_multiply_generation_owned_work` and `test_watch_indexers_cancels_while_rebalance_send_is_backpressured` cover duplicate work and cancellation under backpressure.
+
+### Readiness during restart
+
+**Before.** A generation that failed after becoming ready kept its readiness signal set to `true` until the supervisor created its replacement.
+
+**Why this matters during recovery.** For up to a supervisor heartbeat, the stale signal misrepresented whether an initialized control-plane generation existed. In the current OSS server, this signal is awaited during initial setup and is not wired to ongoing node discovery, so this is a readiness-correctness fix rather than an independent explanation for the outage.
+
+**Fix.** Finalization clears readiness immediately. A replacement generation starts not ready and becomes ready only after initialization finishes.
+
+**Proof.** `test_control_plane_failure_clears_readiness_before_supervisor_respawn` verifies the transition.
+
+### Delayed shard closures
+
+**Before.** A rebalance opens replacement shards, waits for gossip propagation, and closes the old shards asynchronously. That delayed task could survive actor failure and send an untagged callback to the successor.
+
+**Why this prolongs an outage.** The stale task could issue close RPCs selected from the previous generation's model. If its callback crossed the restart boundary, it could also apply those results to the successor's freshly loaded model, setting recovery back and creating more corrective rebalance work.
+
+**Fix.** Delayed close work observes generation shutdown during its delay, RPC phase, and callback delivery. The callback carries its generation, and the handler ignores stale callbacks.
+
+**Proof.** `test_delayed_rebalance_close_is_cancelled_on_generation_shutdown` and `test_control_plane_handles_current_and_ignores_stale_rebalance_shards_callback` cover cancellation and stale-callback rejection.
+
+## 4. Reapply indexing plans to restarted processes
+
+### Detect process generations, not only stable node IDs
+
+**Before.** Scheduler equality considered indexer node IDs and indexing-task contents. An indexer can restart with the same `NodeId` but a new `generation_id`. If gossip still described the same tasks, the scheduler considered the plan unchanged and skipped dispatch.
+
+**Why this prolongs an outage.** The replacement process could miss the current physical plan, including an empty plan used to keep dropped pipelines off a draining node. Pipeline recovery, shard draining, or backlog processing could then stall until an unrelated plan change occurred.
+
+**Fix.** The scheduler records the process generation targeted by the latest dispatch attempt for each eligible indexer. A generation change causes the current plan to be sent again even when its tasks are unchanged. A restarted retiring or decommissioning node that is absent from the plan receives an empty plan.
+
+**Proof.** `test_control_running_plan_reapplies_unchanged_plan_to_new_generation`, `test_rebuild_plan_reapplies_unchanged_plan_to_new_generation`, and `test_rebuild_plan_sends_empty_plan_to_new_generation_of_dropped_retiring_indexer` cover the replay cases.
+
+### Bound every plan-application wait
+
+**Before.** Applying a plan to a draining indexer had an outer timeout, but applying one to a ready indexer had no independent hard deadline. If its client future did not complete or honor the ordinary client timeout, it retained the rebuild completion guard indefinitely.
+
+**Why this prolongs an outage.** Recovery work waiting for plan completion could remain blocked behind one unreachable indexer, even when the rest of the plan was delivered.
+
+**Fix.** Every eligible indexer has a deadline. Ready indexers receive a 35-second deadline, which is longer than the ordinary 30-second client timeout; retiring and decommissioning indexers retain the shorter two-second deadline.
+
+**Proof.** `test_apply_plan_times_out_for_all_eligible_indexers` and `test_ready_indexer_apply_allows_slow_success` prove bounded completion without rejecting a valid slow response.
+
+## 5. Remove stale source routes after `NoShardsAvailable`
+
+**Before.** A `NoShardsAvailable` persist response did not invalidate the route that selected the leader. The router expected a piggybacked routing update to refresh it, but an ingester omits a source for which it has no shard. The stale `(index, source) -> leader` entry therefore remained selectable. Routing bookkeeping also trusted the leader ID echoed in the response instead of the node that received the request.
+
+**Why this prolongs an outage.** Retries repeatedly selected the same leader, received the same failure, and never asked the control plane for a replacement. The loop could continue after the ingester and control plane were otherwise healthy.
+
+**Fix.** The router records a source-scoped tombstone for the actual RPC target. It makes that leader unavailable only for the affected index and source, while preserving healthy sources on the same ingester. The tombstone survives an eventually consistent control-plane response that still advertises the stale shard; an authoritative positive ingester update or a new index incarnation clears it.
+
+**Proof.** `test_no_shards_available_uses_request_leader_and_clears_omitted_stale_entry`, `test_source_unavailable_tombstone_survives_stale_cp_merge`, and `test_no_shards_available_recovers_via_source_scoped_leader_exclusion` cover invalidation, stale updates, and recovery.
+
+## 6. Preserve source-specific exclusions in shard-creation requests
+
+**Before.** `GetOrCreateOpenShardsRequest.unavailable_leaders` applies to the whole request, while `NoShardsAvailable` applies to one source. A single batch could not express “exclude leader A for source A, but keep it eligible for source B.” Zero-capacity leaders were rejected locally but not reported to the control plane, so the control plane could also return the same unusable leader.
+
+**Why this prolongs an outage.** Omitting the failed leader allowed the control plane to return the stale route again. Excluding it globally would disrupt healthy sources. For zero-capacity nodes, local rejection followed by an unchanged control-plane answer formed another no-progress loop.
+
+**Fix.** Node-wide failures remain in a workbench-wide exclusion set, while leaders tombstoned after a source-specific `NoShardsAvailable` stay scoped to that exact index and source. Each subrequest receives the union of those scopes. The debouncer groups subrequests by identical normalized exclusion sets and sends separate control-plane requests. A failure in one group does not prevent later groups from being processed, so unrelated sources can still obtain replacement routes.
+
+Splitting a request could duplicate request-wide closed-shard feedback and amplify control-plane work. The feedback is therefore attached to exactly one generated request.
+
+**Proof.** `test_router_populate_routing_table_debounced_splits_source_exclusions`, `test_debounced_get_or_create_open_shards_request`, `test_ingester_node_is_routing_candidate`, and `test_has_any_routing_candidate` cover request grouping, one-time feedback, source and node scopes, and zero-capacity reporting.
+
+## What these fixes do not guarantee
+
+- The shared PostgreSQL limit provides best-effort headroom, not a reserved connection. Direct pool users bypass it, and streaming RPCs release the admission permit before the returned stream has finished using PostgreSQL.
+- A one-connection pool cannot retain headroom because it must still admit one request.
+- Admission bounds overload but does not fix slow SQL, external database failures, or the underlying database lock contention.
+- Cancelling a delayed shard close cannot undo a close accepted at the exact shutdown boundary. The successor reloads metastore state to reconcile that race.
+- A plan-application timeout releases the rebuild waiter; it does not prove that the indexer applied the plan. Periodic reconciliation can retry while the reported running plan or process generation still differs.
+
+The combined effect is that excess unary metastore RPCs are rejected before joining SQLx's acquisition queue, periodic recovery continues after safe load shedding, the patched generation-owned tasks are fenced across restarts, replacement indexer generations are targeted with the current plan, and routers can request a replacement while excluding a stale source leader.

--- a/quickwit/quickwit-common/src/tower/load_shed.rs
+++ b/quickwit/quickwit-common/src/tower/load_shed.rs
@@ -97,11 +97,17 @@ where F: Future<Output = Result<T, E>>
     }
 }
 
+#[derive(Debug, Clone)]
+enum PermitSource {
+    PerService(usize),
+    Shared(Arc<Semaphore>),
+}
+
 /// Allows at most `max_in_flight_requests` in-flight requests before rejecting new incoming
 /// requests.
 #[derive(Debug, Clone)]
 pub struct LoadShedLayer {
-    max_in_flight_requests: usize,
+    permit_source: PermitSource,
 }
 
 impl LoadShedLayer {
@@ -109,7 +115,18 @@ impl LoadShedLayer {
     /// before rejecting new incoming requests.
     pub fn new(max_in_flight_requests: usize) -> Self {
         Self {
-            max_in_flight_requests,
+            permit_source: PermitSource::PerService(max_in_flight_requests),
+        }
+    }
+
+    /// Creates a new `LoadShedLayer` whose limit is shared by every service built from this layer
+    /// or one of its clones.
+    ///
+    /// This is useful for generated service clients that clone a common layer into one service
+    /// stack per RPC method and need one aggregate in-flight request limit across all methods.
+    pub fn new_shared(max_in_flight_requests: usize) -> Self {
+        Self {
+            permit_source: PermitSource::Shared(Arc::new(Semaphore::new(max_in_flight_requests))),
         }
     }
 }
@@ -118,9 +135,15 @@ impl<S> Layer<S> for LoadShedLayer {
     type Service = LoadShed<S>;
 
     fn layer(&self, service: S) -> Self::Service {
+        let permits = match &self.permit_source {
+            PermitSource::PerService(max_in_flight_requests) => {
+                Arc::new(Semaphore::new(*max_in_flight_requests))
+            }
+            PermitSource::Shared(permits) => permits.clone(),
+        };
         LoadShed {
             inner: service,
-            permits: Arc::new(Semaphore::new(self.max_in_flight_requests)),
+            permits,
             permit_opt: None,
         }
     }
@@ -151,5 +174,37 @@ mod tests {
 
         drop(in_fight_fut);
         service.ready().await.unwrap().call(()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_shared_load_shed_across_services() {
+        #[derive(Debug)]
+        struct MyError;
+
+        impl MakeLoadShedError for MyError {
+            fn make_load_shed_error() -> Self {
+                MyError
+            }
+        }
+
+        let shared_layer = LoadShedLayer::new_shared(1);
+        let mut first_service = ServiceBuilder::new()
+            .layer(shared_layer.clone())
+            .service_fn(|_| async { Ok::<_, MyError>(()) });
+        let mut second_service = ServiceBuilder::new()
+            .layer(shared_layer)
+            .service_fn(|_| async { Ok::<_, MyError>(()) });
+
+        let in_flight_fut = first_service.ready().await.unwrap().call(());
+        second_service.ready().await.unwrap_err();
+
+        drop(in_flight_fut);
+        second_service
+            .ready()
+            .await
+            .unwrap()
+            .call(())
+            .await
+            .unwrap();
     }
 }

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -17,6 +17,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::Formatter;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::Context;
@@ -78,12 +80,16 @@ const PRUNE_SHARDS_DEFAULT_COOLDOWN_PERIOD: Duration = Duration::from_secs(120);
 const REBUILD_PLAN_COOLDOWN_PERIOD: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]
-struct ControlPlanLoop;
+struct ControlPlanLoop {
+    actor_generation: u64,
+}
 
 #[derive(Debug, Default, Clone, Copy)]
 struct RebuildPlan;
 
 pub struct ControlPlane {
+    actor_generation: u64,
+    actor_generation_shutdown_tx: watch::Sender<()>,
     cluster_config: ClusterConfig,
     cluster_change_stream_opt: Option<ClusterChangeStream>,
     // The control plane state is split into to independent functions, that we naturally isolated
@@ -155,8 +161,11 @@ impl ControlPlane {
         info!("starting control plane");
 
         let (readiness_tx, readiness_rx) = watch::channel(false);
+        let next_actor_generation = Arc::new(AtomicU64::new(0));
         let (control_plane_mailbox, control_plane_handle) =
             universe.spawn_builder().supervise_fn(move || {
+                let actor_generation = next_actor_generation.fetch_add(1, Ordering::Relaxed);
+                let (actor_generation_shutdown_tx, _) = watch::channel(());
                 let cluster_id = cluster_config.cluster_id.clone();
                 let replication_factor = cluster_config.replication_factor;
                 let shard_throughput_limit_mib: f32 = cluster_config.shard_throughput_limit.as_u64()
@@ -176,6 +185,8 @@ impl ControlPlane {
                 let _ = readiness_tx.send(false);
 
                 ControlPlane {
+                    actor_generation,
+                    actor_generation_shutdown_tx,
                     cluster_config: cluster_config.clone(),
                     cluster_change_stream_opt: Some(cluster_change_stream_factory.create()),
                     indexing_scheduler,
@@ -231,20 +242,56 @@ impl Actor for ControlPlane {
 
         self.ingest_controller.sync_with_all_ingesters(&self.model);
 
-        ctx.schedule_self_msg(CONTROL_PLAN_LOOP_INTERVAL, ControlPlanLoop);
+        self.schedule_control_plan_loop(ctx);
 
         let weak_mailbox = ctx.mailbox().downgrade();
         let cluster_change_stream = self
             .cluster_change_stream_opt
             .take()
             .expect("`initialize` should be called only once");
-        spawn_watch_indexers_task(weak_mailbox, cluster_change_stream);
+        spawn_watch_indexers_task(
+            weak_mailbox,
+            cluster_change_stream,
+            self.actor_generation,
+            self.actor_generation_shutdown_tx.subscribe(),
+        );
         let _ = self.readiness_tx.send(true);
+        Ok(())
+    }
+
+    async fn finalize(
+        &mut self,
+        _exit_status: &ActorExitStatus,
+        _ctx: &ActorContext<Self>,
+    ) -> anyhow::Result<()> {
+        // The supervisor may take up to one heartbeat to create the successor generation. Stop
+        // advertising this generation as ready as soon as it exits.
+        let _ = self.readiness_tx.send(false);
+        // Explicitly wake generation-owned tasks instead of relying on this sender being dropped
+        // after finalization.
+        let _ = self.actor_generation_shutdown_tx.send(());
         Ok(())
     }
 }
 
 impl ControlPlane {
+    fn schedule_control_plan_loop(&self, ctx: &ActorContext<Self>) {
+        let actor_generation = self.actor_generation;
+        let actor_generation_shutdown_rx = self.actor_generation_shutdown_tx.subscribe();
+        let self_mailbox = ctx.mailbox().clone();
+        let callback = move || {
+            // A supervised actor keeps the same mailbox across respawns. Do not let a timer owned
+            // by an exited generation enqueue work for its successor.
+            if !matches!(actor_generation_shutdown_rx.has_changed(), Ok(false)) {
+                return;
+            }
+            let _ =
+                self_mailbox.send_message_with_high_priority(ControlPlanLoop { actor_generation });
+        };
+        ctx.spawn_ctx()
+            .schedule_event(callback, CONTROL_PLAN_LOOP_INTERVAL);
+    }
+
     async fn auto_create_indexes(
         &mut self,
         subrequests: &[GetOrCreateOpenShardsSubrequest],
@@ -525,21 +572,38 @@ impl Handler<ControlPlanLoop> for ControlPlane {
 
     async fn handle(
         &mut self,
-        _message: ControlPlanLoop,
+        message: ControlPlanLoop,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
+        // A timer may have enqueued its message just before its actor generation exited. Since the
+        // supervisor reuses the inbox, reject such messages in the successor generation.
+        if message.actor_generation != self.actor_generation {
+            return Ok(());
+        }
         if self.disable_control_loop {
             return Ok(());
         }
         if let Err(metastore_error) = self
             .ingest_controller
-            .rebalance_shards(&mut self.model, ctx.mailbox(), ctx.progress())
+            .rebalance_shards(
+                &mut self.model,
+                ctx.mailbox(),
+                ctx.progress(),
+                self.actor_generation,
+                self.actor_generation_shutdown_tx.subscribe(),
+            )
             .await
         {
-            return convert_metastore_error::<()>(metastore_error).map(|_| ());
+            let actor_result = convert_metastore_error::<()>(metastore_error).map(|_| ());
+            if actor_result.is_ok() {
+                // Recoverable errors keep this actor generation alive, so it remains responsible
+                // for scheduling the next control tick.
+                self.schedule_control_plan_loop(ctx);
+            }
+            return actor_result;
         }
         self.indexing_scheduler.control_running_plan(&self.model);
-        ctx.schedule_self_msg(CONTROL_PLAN_LOOP_INTERVAL, ControlPlanLoop);
+        self.schedule_control_plan_loop(ctx);
         Ok(())
     }
 }
@@ -1060,7 +1124,9 @@ fn apply_index_template_match(
 }
 
 #[derive(Debug)]
-struct RebalanceShards;
+struct RebalanceShards {
+    actor_generation: u64,
+}
 
 #[async_trait]
 impl Handler<RebalanceShards> for ControlPlane {
@@ -1068,12 +1134,23 @@ impl Handler<RebalanceShards> for ControlPlane {
 
     async fn handle(
         &mut self,
-        _message: RebalanceShards,
+        message: RebalanceShards,
         ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
+        // Cluster watchers are generation-scoped, but an event may already be queued when its
+        // generation exits. The shared supervised inbox must not deliver it to the successor.
+        if message.actor_generation != self.actor_generation {
+            return Ok(());
+        }
         if let Err(error) = self
             .ingest_controller
-            .rebalance_shards(&mut self.model, ctx.mailbox(), ctx.progress())
+            .rebalance_shards(
+                &mut self.model,
+                ctx.mailbox(),
+                ctx.progress(),
+                self.actor_generation,
+                self.actor_generation_shutdown_tx.subscribe(),
+            )
             .await
         {
             return convert_metastore_error::<()>(error).map(|_| ());
@@ -1092,6 +1169,12 @@ impl Handler<RebalanceShardsCallback> for ControlPlane {
         message: RebalanceShardsCallback,
         _ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
+        // The delayed close may have completed just before its generation shut down and queued this
+        // callback in the mailbox shared with the successor. Never apply that stale result to the
+        // successor's freshly loaded model.
+        if message.actor_generation != self.actor_generation {
+            return Ok(());
+        }
         let num_closed_shards = message.closed_shards.len();
         debug!("closing {num_closed_shards} shards after rebalance");
 
@@ -1113,15 +1196,53 @@ impl Handler<RebalanceShardsCallback> for ControlPlane {
 fn spawn_watch_indexers_task(
     weak_mailbox: WeakMailbox<ControlPlane>,
     cluster_change_stream: ClusterChangeStream,
+    actor_generation: u64,
+    actor_generation_shutdown_rx: watch::Receiver<()>,
 ) {
-    tokio::spawn(watcher_indexers(weak_mailbox, cluster_change_stream));
+    tokio::spawn(watcher_indexers(
+        weak_mailbox,
+        cluster_change_stream,
+        actor_generation,
+        actor_generation_shutdown_rx,
+    ));
 }
 
 async fn watcher_indexers(
     weak_mailbox: WeakMailbox<ControlPlane>,
-    mut cluster_change_stream: ClusterChangeStream,
+    cluster_change_stream: ClusterChangeStream,
+    actor_generation: u64,
+    actor_generation_shutdown_rx: watch::Receiver<()>,
 ) {
-    while let Some(cluster_change) = cluster_change_stream.next().await {
+    watcher_indexers_with_before_send_hook(
+        weak_mailbox,
+        cluster_change_stream,
+        actor_generation,
+        actor_generation_shutdown_rx,
+        || {},
+    )
+    .await;
+}
+
+async fn watcher_indexers_with_before_send_hook<F>(
+    weak_mailbox: WeakMailbox<ControlPlane>,
+    mut cluster_change_stream: ClusterChangeStream,
+    actor_generation: u64,
+    mut actor_generation_shutdown_rx: watch::Receiver<()>,
+    before_send_hook: F,
+) where
+    F: Fn() + Send,
+{
+    loop {
+        let cluster_change_opt = tokio::select! {
+            biased;
+            _ = actor_generation_shutdown_rx.changed() => {
+                return;
+            }
+            cluster_change_opt = cluster_change_stream.next() => cluster_change_opt,
+        };
+        let Some(cluster_change) = cluster_change_opt else {
+            return;
+        };
         let Some(mailbox) = weak_mailbox.upgrade() else {
             return;
         };
@@ -1165,8 +1286,20 @@ async fn watcher_indexers(
             }
             _ => {}
         }
-        if trigger_rebalance && mailbox.send_message(RebalanceShards).await.is_err() {
-            return;
+        if trigger_rebalance {
+            before_send_hook();
+            let send_rebalance_fut = mailbox.send_message(RebalanceShards { actor_generation });
+            tokio::select! {
+                biased;
+                _ = actor_generation_shutdown_rx.changed() => {
+                    return;
+                }
+                send_result = send_rebalance_fut => {
+                    if send_result.is_err() {
+                        return;
+                    }
+                }
+            }
         }
     }
 }
@@ -1174,10 +1307,10 @@ async fn watcher_indexers(
 #[cfg(test)]
 mod tests {
     use std::num::NonZero;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex as StdMutex};
 
     use mockall::Sequence;
-    use quickwit_actors::{AskError, Observe, SupervisorMetrics};
+    use quickwit_actors::{AskError, Observe, QueueCapacity, SupervisorMetrics};
     use quickwit_cluster::{ClusterChangeStreamFactoryForTest, ClusterNode};
     use quickwit_config::{
         CLI_SOURCE_ID, INGEST_V2_SOURCE_ID, IndexConfig, KafkaSourceParams, SourceParams,
@@ -1206,10 +1339,60 @@ mod tests {
         OpenShardSubresponse, OpenShardsResponse, SourceType,
     };
     use quickwit_proto::types::{DocMappingUid, Position};
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, mpsc, oneshot};
 
     use super::*;
     use crate::IndexerNodeInfo;
+
+    /// Unlike `ClusterChangeStreamFactoryForTest`, this factory broadcasts an event to every
+    /// stream it has created. It mirrors the production cluster's subscriber behavior and makes a
+    /// leaked watcher observable after a supervised actor respawn.
+    #[derive(Clone, Default)]
+    struct BroadcastClusterChangeStreamFactory {
+        change_stream_txs: Arc<StdMutex<Vec<mpsc::UnboundedSender<ClusterChange>>>>,
+    }
+
+    impl BroadcastClusterChangeStreamFactory {
+        fn broadcast(&self, cluster_change: ClusterChange) {
+            self.change_stream_txs
+                .lock()
+                .unwrap()
+                .retain(|change_stream_tx| change_stream_tx.send(cluster_change.clone()).is_ok());
+        }
+
+        fn num_subscribers(&self) -> usize {
+            self.change_stream_txs.lock().unwrap().len()
+        }
+    }
+
+    impl ClusterChangeStreamFactory for BroadcastClusterChangeStreamFactory {
+        fn create(&self) -> ClusterChangeStream {
+            let (cluster_change_stream, cluster_change_stream_tx) =
+                ClusterChangeStream::new_unbounded();
+            self.change_stream_txs
+                .lock()
+                .unwrap()
+                .push(cluster_change_stream_tx);
+            cluster_change_stream
+        }
+    }
+
+    #[derive(Debug)]
+    struct EnableControlLoopForTest;
+
+    #[async_trait]
+    impl Handler<EnableControlLoopForTest> for ControlPlane {
+        type Reply = ();
+
+        async fn handle(
+            &mut self,
+            _message: EnableControlLoopForTest,
+            _ctx: &ActorContext<Self>,
+        ) -> Result<Self::Reply, ActorExitStatus> {
+            self.disable_control_loop = false;
+            Ok(())
+        }
+    }
 
     #[tokio::test]
     async fn test_control_plane_create_index() {
@@ -1812,6 +1995,355 @@ mod tests {
                 num_errors: 1,
                 num_kills: 0
             }
+        );
+
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_control_plane_respawns_do_not_multiply_generation_owned_work() {
+        let universe = Universe::default();
+        let node_id = NodeId::from_str("test-control-plane");
+        let indexer_pool = IndexerPool::default();
+        let ingester_pool = IngesterPool::default();
+        let mut mock_metastore = MockMetastoreService::new();
+        mock_metastore
+            .expect_list_indexes_metadata()
+            .times(3) // Initial generation plus two supervised respawns.
+            .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
+        mock_metastore
+            .expect_create_index()
+            .times(2)
+            .returning(|_| {
+                Err(MetastoreError::Connection {
+                    message: "connection lost after request".to_string(),
+                })
+            });
+
+        let cluster_change_stream_factory = BroadcastClusterChangeStreamFactory::default();
+        let disable_control_loop = true;
+        let (control_plane_mailbox, control_plane_handle, mut readiness_rx) =
+            ControlPlane::spawn_inner(
+                &universe,
+                ClusterConfig::for_test(),
+                node_id,
+                cluster_change_stream_factory.clone(),
+                indexer_pool,
+                ingester_pool,
+                MetastoreServiceClient::from_mock(mock_metastore),
+                disable_control_loop,
+            );
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            readiness_rx.wait_for(|readiness| *readiness),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let index_config = IndexConfig::for_test("test-index", "ram:///test-index");
+        let create_index_request =
+            CreateIndexRequest::try_from_index_config(&index_config).unwrap();
+        for expected_num_errors in 1..=2 {
+            let create_index_error: AskError<ControlPlaneError> = control_plane_mailbox
+                .ask_for_res(create_index_request.clone())
+                .await
+                .unwrap_err();
+            assert!(matches!(create_index_error, AskError::ProcessMessageError));
+
+            // The supervisor reuses this mailbox. Waiting for Observe proves that the successor
+            // generation has completed initialization and is serving messages.
+            let control_plane_state = control_plane_mailbox.ask(Observe).await.unwrap();
+            assert!(control_plane_state.readiness);
+            assert_eq!(
+                control_plane_handle
+                    .process_pending_and_observe()
+                    .await
+                    .metrics
+                    .num_errors,
+                expected_num_errors
+            );
+        }
+
+        let indexer_node = ClusterNode::for_test(
+            "test-indexer",
+            1515,
+            false,
+            &["indexer"],
+            &[],
+            IngesterStatus::Ready,
+        )
+        .await;
+        cluster_change_stream_factory.broadcast(ClusterChange::Add(indexer_node));
+        let control_plane_state = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let state = control_plane_mailbox.ask(Observe).await.unwrap();
+                if state.ingest_controller.num_rebalance_shards_ops == 1 {
+                    break state;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("current generation should process the cluster event");
+        assert_eq!(
+            control_plane_state
+                .ingest_controller
+                .num_rebalance_shards_ops,
+            1,
+            "one cluster event must be handled by only the current generation's watcher"
+        );
+
+        // A non-indexer event gives the production-style broadcaster an opportunity to prune
+        // receivers dropped by the two exited generations.
+        let metastore_node = ClusterNode::for_test(
+            "test-metastore",
+            1516,
+            false,
+            &["metastore"],
+            &[],
+            IngesterStatus::Unspecified,
+        )
+        .await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while cluster_change_stream_factory.num_subscribers() != 1 {
+                cluster_change_stream_factory.broadcast(ClusterChange::Add(metastore_node.clone()));
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("exited generations should drop their cluster subscriptions");
+
+        // These are the exact messages that timers from the first two generations could have
+        // queued immediately before exiting. They must not run, or start new periodic chains, in
+        // the third generation.
+        control_plane_mailbox
+            .ask(EnableControlLoopForTest)
+            .await
+            .unwrap();
+        control_plane_mailbox
+            .ask(ControlPlanLoop {
+                actor_generation: 0,
+            })
+            .await
+            .unwrap();
+        control_plane_mailbox
+            .ask(ControlPlanLoop {
+                actor_generation: 1,
+            })
+            .await
+            .unwrap();
+        let control_plane_state = control_plane_mailbox.ask(Observe).await.unwrap();
+        assert_eq!(
+            control_plane_state
+                .ingest_controller
+                .num_rebalance_shards_ops,
+            1,
+            "stale control-loop messages must not execute in a successor generation"
+        );
+
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_control_plane_failure_clears_readiness_before_supervisor_respawn() {
+        let universe = Universe::default();
+        let mut mock_metastore = MockMetastoreService::new();
+        mock_metastore
+            .expect_list_indexes_metadata()
+            .return_once(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
+        mock_metastore.expect_create_index().return_once(|_| {
+            Err(MetastoreError::Connection {
+                message: "connection lost after request".to_string(),
+            })
+        });
+
+        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let (control_plane_mailbox, control_plane_handle, mut readiness_rx) =
+            ControlPlane::spawn_inner(
+                &universe,
+                ClusterConfig::for_test(),
+                NodeId::from_str("test-control-plane"),
+                cluster_change_stream_factory,
+                IndexerPool::default(),
+                IngesterPool::default(),
+                MetastoreServiceClient::from_mock(mock_metastore),
+                true,
+            );
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            readiness_rx.wait_for(|readiness| *readiness),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let index_config = IndexConfig::for_test("test-index", "ram:///test-index");
+        let create_index_request =
+            CreateIndexRequest::try_from_index_config(&index_config).unwrap();
+        let create_index_error: AskError<ControlPlaneError> = control_plane_mailbox
+            .ask_for_res(create_index_request)
+            .await
+            .unwrap_err();
+        assert!(matches!(create_index_error, AskError::ProcessMessageError));
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            readiness_rx.wait_for(|readiness| !*readiness),
+        )
+        .await
+        .expect("failed control-plane generation should immediately clear readiness")
+        .unwrap();
+        assert_eq!(
+            control_plane_handle.observe().await.metrics,
+            SupervisorMetrics::default(),
+            "readiness should clear before the supervisor heartbeat respawns the actor"
+        );
+
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_control_plan_loop_continues_after_too_many_requests() {
+        let universe = Universe::default();
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let retiring_ingester_id = NodeId::from_str("retiring-ingester");
+        let ready_ingester_id = NodeId::from_str("ready-ingester");
+
+        let mut index_metadata = IndexMetadata::for_test("test-index", "ram:///test-index");
+        index_metadata
+            .add_source(SourceConfig::ingest_v2())
+            .unwrap();
+
+        let mut mock_metastore = MockMetastoreService::new();
+        mock_metastore
+            .expect_list_indexes_metadata()
+            .return_once(move |_| {
+                Ok(ListIndexesMetadataResponse::for_test(vec![
+                    index_metadata.clone(),
+                ]))
+            });
+        let index_uid_clone = index_uid.clone();
+        let retiring_ingester_id_clone = retiring_ingester_id.clone();
+        mock_metastore.expect_list_shards().return_once(move |_| {
+            Ok(ListShardsResponse {
+                subresponses: vec![ListShardsSubresponse {
+                    index_uid: Some(index_uid_clone.clone()),
+                    source_id: INGEST_V2_SOURCE_ID.to_string(),
+                    shards: vec![Shard {
+                        index_uid: Some(index_uid_clone.clone()),
+                        source_id: INGEST_V2_SOURCE_ID.to_string(),
+                        shard_id: Some(ShardId::from(1)),
+                        shard_state: ShardState::Open as i32,
+                        leader_id: retiring_ingester_id_clone.to_string(),
+                        ..Default::default()
+                    }],
+                }],
+            })
+        });
+        let mut open_shards_sequence = Sequence::new();
+        mock_metastore
+            .expect_open_shards()
+            .times(1)
+            .in_sequence(&mut open_shards_sequence)
+            .return_once(|_| Err(MetastoreError::TooManyRequests));
+        mock_metastore
+            .expect_open_shards()
+            .times(1)
+            .in_sequence(&mut open_shards_sequence)
+            .return_once(|request| {
+                let subrequest = &request.subrequests[0];
+                Ok(OpenShardsResponse {
+                    subresponses: vec![OpenShardSubresponse {
+                        subrequest_id: subrequest.subrequest_id,
+                        open_shard: Some(Shard {
+                            index_uid: subrequest.index_uid.clone(),
+                            source_id: subrequest.source_id.clone(),
+                            shard_id: subrequest.shard_id.clone(),
+                            leader_id: subrequest.leader_id.clone(),
+                            follower_id: subrequest.follower_id.clone(),
+                            shard_state: ShardState::Open as i32,
+                            ..Default::default()
+                        }),
+                    }],
+                })
+            });
+
+        let mut mock_retiring_ingester = MockIngesterService::new();
+        mock_retiring_ingester
+            .expect_retain_shards()
+            .return_once(|_| Ok(RetainShardsResponse {}));
+        let mut mock_ready_ingester = MockIngesterService::new();
+        mock_ready_ingester
+            .expect_retain_shards()
+            .return_once(|_| Ok(RetainShardsResponse {}));
+        mock_ready_ingester
+            .expect_init_shards()
+            .times(2)
+            .returning(|request| {
+                let shard = request.subrequests[0].shard().clone();
+                Ok(InitShardsResponse {
+                    successes: vec![InitShardSuccess {
+                        subrequest_id: 0,
+                        shard: Some(shard),
+                    }],
+                    failures: Vec::new(),
+                })
+            });
+
+        let ingester_pool = IngesterPool::default();
+        ingester_pool.insert(
+            retiring_ingester_id,
+            IngesterPoolEntry {
+                client: IngesterServiceClient::from_mock(mock_retiring_ingester),
+                status: IngesterStatus::Retiring,
+                availability_zone: None,
+            },
+        );
+        ingester_pool.insert(
+            ready_ingester_id,
+            IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(
+                mock_ready_ingester,
+            )),
+        );
+
+        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let (control_plane_mailbox, control_plane_handle, mut readiness_rx) = ControlPlane::spawn(
+            &universe,
+            ClusterConfig::for_test(),
+            NodeId::from_str("test-control-plane"),
+            cluster_change_stream_factory,
+            IndexerPool::default(),
+            ingester_pool,
+            MetastoreServiceClient::from_mock(mock_metastore),
+        );
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            readiness_rx.wait_for(|readiness| *readiness),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let state = control_plane_mailbox.ask(Observe).await.unwrap();
+                if state.ingest_controller.num_rebalance_shards_ops >= 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("control loop should retry after a recoverable metastore error");
+
+        assert_eq!(
+            control_plane_handle
+                .process_pending_and_observe()
+                .await
+                .metrics,
+            SupervisorMetrics::default(),
+            "TooManyRequests must not respawn the control plane"
         );
 
         universe.assert_quit().await;
@@ -2458,7 +2990,13 @@ mod tests {
 
         let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
         let cluster_change_stream = cluster_change_stream_factory.create();
-        spawn_watch_indexers_task(weak_control_plane_mailbox, cluster_change_stream);
+        let (_actor_generation_shutdown_tx, actor_generation_shutdown_rx) = watch::channel(());
+        spawn_watch_indexers_task(
+            weak_control_plane_mailbox,
+            cluster_change_stream,
+            0,
+            actor_generation_shutdown_rx,
+        );
 
         let cluster_change_stream_tx = cluster_change_stream_factory.change_stream_tx();
 
@@ -2516,14 +3054,14 @@ mod tests {
         cluster_change_stream_tx.send(cluster_change).unwrap();
 
         tokio::time::sleep(Duration::from_millis(1)).await;
-        let RebalanceShards = control_plane_inbox.recv_typed_message().await.unwrap();
+        let RebalanceShards { .. } = control_plane_inbox.recv_typed_message().await.unwrap();
 
         // removing an indexer node triggers a shard rebalancing.
         let cluster_change = ClusterChange::Remove(indexer_node.clone());
         cluster_change_stream_tx.send(cluster_change).unwrap();
 
         tokio::time::sleep(Duration::from_millis(1)).await;
-        let RebalanceShards = control_plane_inbox.recv_typed_message().await.unwrap();
+        let RebalanceShards { .. } = control_plane_inbox.recv_typed_message().await.unwrap();
 
         // a change in IngesterStatus readiness triggers a shard rebalancing.
         let node_ready = ClusterNode::for_test(
@@ -2551,7 +3089,67 @@ mod tests {
         cluster_change_stream_tx.send(cluster_change).unwrap();
 
         tokio::time::sleep(Duration::from_millis(1)).await;
-        let RebalanceShards = control_plane_inbox.recv_typed_message().await.unwrap();
+        let RebalanceShards { .. } = control_plane_inbox.recv_typed_message().await.unwrap();
+
+        universe.assert_quit().await;
+    }
+
+    #[tokio::test]
+    async fn test_watch_indexers_cancels_while_rebalance_send_is_backpressured() {
+        let universe = Universe::default();
+        let (control_plane_mailbox, _control_plane_inbox) =
+            universe.create_mailbox("backpressured-control-plane", QueueCapacity::Bounded(1));
+        control_plane_mailbox
+            .try_send_message(RebalanceShards {
+                actor_generation: 0,
+            })
+            .unwrap();
+
+        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream = cluster_change_stream_factory.create();
+        let cluster_change_stream_tx = cluster_change_stream_factory.change_stream_tx();
+        let (actor_generation_shutdown_tx, actor_generation_shutdown_rx) = watch::channel(());
+        let (before_send_tx, before_send_rx) = oneshot::channel();
+        let before_send_tx_opt = Arc::new(StdMutex::new(Some(before_send_tx)));
+        let before_send_tx_opt_clone = before_send_tx_opt.clone();
+        let watcher_handle = tokio::spawn(watcher_indexers_with_before_send_hook(
+            control_plane_mailbox.downgrade(),
+            cluster_change_stream,
+            0,
+            actor_generation_shutdown_rx,
+            move || {
+                if let Some(before_send_tx) = before_send_tx_opt_clone.lock().unwrap().take() {
+                    let _ = before_send_tx.send(());
+                }
+            },
+        ));
+
+        let indexer_node = ClusterNode::for_test(
+            "test-indexer",
+            1515,
+            false,
+            &["indexer"],
+            &[],
+            IngesterStatus::Ready,
+        )
+        .await;
+        cluster_change_stream_tx
+            .send(ClusterChange::Add(indexer_node))
+            .unwrap();
+        tokio::time::timeout(Duration::from_millis(100), before_send_rx)
+            .await
+            .expect("watcher should consume the cluster event")
+            .unwrap();
+        assert!(
+            !watcher_handle.is_finished(),
+            "watcher should be waiting for mailbox capacity"
+        );
+
+        drop(actor_generation_shutdown_tx);
+        tokio::time::timeout(Duration::from_millis(100), watcher_handle)
+            .await
+            .expect("generation shutdown should cancel a backpressured watcher")
+            .unwrap();
 
         universe.assert_quit().await;
     }
@@ -2625,7 +3223,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_control_plane_handles_rebalance_shards_callback() {
+    async fn test_control_plane_handles_current_and_ignores_stale_rebalance_shards_callback() {
         let universe = Universe::with_accelerated_time();
 
         let cluster_config = ClusterConfig::for_test();
@@ -2747,12 +3345,26 @@ mod tests {
             },
         ];
         let rebalance_lock = Arc::new(Mutex::new(()));
-        let rebalance_guard = rebalance_lock.clone().lock_owned().await;
-        let callback = RebalanceShardsCallback {
-            closed_shards,
-            rebalance_guard,
+        let stale_rebalance_guard = rebalance_lock.clone().lock_owned().await;
+        let stale_callback = RebalanceShardsCallback {
+            actor_generation: 1,
+            closed_shards: closed_shards.clone(),
+            rebalance_guard: stale_rebalance_guard,
         };
-        control_plane_mailbox.ask(callback).await.unwrap();
+        control_plane_mailbox.ask(stale_callback).await.unwrap();
+
+        let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
+        let shard = &control_plane_debug_info["shard_table"]
+            ["test-index:00000000000000000000000000"]["test-ingester"][0];
+        assert_eq!(shard["shard_state"], "open");
+
+        let current_rebalance_guard = rebalance_lock.clone().lock_owned().await;
+        let current_callback = RebalanceShardsCallback {
+            actor_generation: 0,
+            closed_shards,
+            rebalance_guard: current_rebalance_guard,
+        };
+        control_plane_mailbox.ask(current_callback).await.unwrap();
 
         let control_plane_debug_info = control_plane_mailbox.ask(GetDebugInfo).await.unwrap();
         let shard = &control_plane_debug_info["shard_table"]

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -52,17 +52,29 @@ pub(crate) const MIN_DURATION_BETWEEN_SCHEDULING: Duration =
         Duration::from_secs(30)
     };
 
-pub(crate) const APPLY_INDEXING_PLAN_TIMEOUT: Duration = if cfg!(any(test, feature = "testsuite")) {
-    Duration::from_millis(10)
-} else {
-    Duration::from_secs(2)
-};
+// The indexing gRPC client has a 30-second timeout. Keep the Ready deadline above it so ordinary
+// client errors win the race while still bounding clients without a timeout layer.
+pub(crate) const READY_INDEXER_APPLY_PLAN_TIMEOUT: Duration =
+    if cfg!(any(test, feature = "testsuite")) {
+        Duration::from_millis(250)
+    } else {
+        Duration::from_secs(35)
+    };
+
+pub(crate) const DRAINING_INDEXER_APPLY_PLAN_TIMEOUT: Duration =
+    if cfg!(any(test, feature = "testsuite")) {
+        Duration::from_millis(10)
+    } else {
+        Duration::from_secs(2)
+    };
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct IndexingSchedulerState {
     pub num_applied_physical_indexing_plan: usize,
     pub num_schedule_indexing_plan: usize,
     pub last_applied_physical_plan: Option<PhysicalIndexingPlan>,
+    #[serde(skip)]
+    last_dispatched_indexer_generations: FnvHashMap<String, u64>,
     #[serde(skip)]
     pub last_applied_plan_timestamp: Option<Instant>,
 }
@@ -343,8 +355,9 @@ impl IndexingScheduler {
                 last_applied_plan.indexing_tasks_per_indexer(),
                 new_physical_plan.indexing_tasks_per_indexer(),
             );
-            // No need to apply the new plan as it is the same as the old one.
-            if plans_diff.is_empty() {
+            // Task equality is not sufficient: a restarted indexer keeps its stable node ID but
+            // has a new generation and has not received this control-plane dispatch.
+            if plans_diff.is_empty() && self.have_same_indexer_generations() {
                 return;
             }
         }
@@ -383,12 +396,14 @@ impl IndexingScheduler {
             &running_indexing_tasks_by_node_id,
             last_applied_plan.indexing_tasks_per_indexer(),
         );
+        let have_same_indexer_generations = self.have_same_indexer_generations();
         if !indexing_plans_diff.has_same_nodes() {
             info!(plans_diff=?indexing_plans_diff, "running plan and last applied plan node IDs differ: schedule an indexing plan");
             self.rebuild_plan(model);
-        } else if !indexing_plans_diff.has_same_tasks() {
-            // Some nodes may have not received their tasks, apply it again.
-            info!(plans_diff=?indexing_plans_diff, "running tasks and last applied tasks differ: reapply last plan");
+        } else if !indexing_plans_diff.has_same_tasks() || !have_same_indexer_generations {
+            // Some nodes may not have received their tasks, either because their running tasks
+            // differ or because a new process generation replaced the previous one.
+            info!(plans_diff=?indexing_plans_diff, "running plan or indexer generation differs from last applied plan: reapply last plan");
             self.apply_physical_indexing_plan(last_applied_plan.clone(), None);
         }
     }
@@ -418,6 +433,34 @@ impl IndexingScheduler {
         }
     }
 
+    fn indexers_eligible_for_plan_dispatch(&self) -> Vec<IndexerNodeInfo> {
+        self.indexer_pool
+            .values()
+            .into_iter()
+            .filter(|indexer| {
+                matches!(
+                    indexer.ingester_status,
+                    IngesterStatus::Ready
+                        | IngesterStatus::Retiring
+                        | IngesterStatus::Decommissioning
+                )
+            })
+            .collect()
+    }
+
+    fn have_same_indexer_generations(&self) -> bool {
+        let eligible_indexers = self.indexers_eligible_for_plan_dispatch();
+        if self.state.last_dispatched_indexer_generations.len() != eligible_indexers.len() {
+            return false;
+        }
+        eligible_indexers.iter().all(|indexer| {
+            self.state
+                .last_dispatched_indexer_generations
+                .get(indexer.node_id.as_str())
+                == Some(&indexer.generation_id)
+        })
+    }
+
     fn apply_physical_indexing_plan(
         &mut self,
         new_physical_plan: PhysicalIndexingPlan,
@@ -427,34 +470,28 @@ impl IndexingScheduler {
         APPLY_PLAN_TOTAL.inc();
         // Retiring and decommissioning indexers still receive the plan so they can gracefully shut
         // down dropped pipelines; other states (initializing, decommissioned, failed) are skipped.
-        for indexer in self.indexer_pool.values().into_iter().filter(|indexer| {
-            matches!(
-                indexer.ingester_status,
-                IngesterStatus::Ready | IngesterStatus::Retiring | IngesterStatus::Decommissioning
-            )
-        }) {
+        let eligible_indexers = self.indexers_eligible_for_plan_dispatch();
+        let dispatched_indexer_generations: FnvHashMap<String, u64> = eligible_indexers
+            .iter()
+            .map(|indexer| (indexer.node_id.to_string(), indexer.generation_id))
+            .collect();
+        for indexer in eligible_indexers {
             let indexing_tasks = new_physical_plan
                 .indexer(indexer.node_id.as_str())
                 .unwrap_or(&[])
                 .to_vec();
             // We don't want to block on a slow indexer so we apply this change asynchronously.
-            // Bound the apply only for retiring/decommissioning indexers, so a slow or unreachable
-            // draining node can't hold the change-notification guard; ready indexers get no
-            // timeout.
-            let apply_deadline = matches!(
-                indexer.ingester_status,
-                IngesterStatus::Retiring | IngesterStatus::Decommissioning
-            )
-            .then_some(APPLY_INDEXING_PLAN_TIMEOUT);
+            let apply_timeout = if indexer.ingester_status == IngesterStatus::Ready {
+                READY_INDEXER_APPLY_PLAN_TIMEOUT
+            } else {
+                DRAINING_INDEXER_APPLY_PLAN_TIMEOUT
+            };
             let notify_on_drop = notify_on_drop.clone();
             tokio::spawn(async move {
                 let client = indexer.client.clone();
                 let apply_plan_fut =
                     client.apply_indexing_plan(ApplyIndexingPlanRequest { indexing_tasks });
-                let apply_result = match apply_deadline {
-                    Some(timeout) => tokio::time::timeout(timeout, apply_plan_fut).await,
-                    None => Ok(apply_plan_fut.await),
-                };
+                let apply_result = tokio::time::timeout(apply_timeout, apply_plan_fut).await;
                 match apply_result {
                     Ok(Ok(_)) => {}
                     Ok(Err(error)) => {
@@ -478,6 +515,7 @@ impl IndexingScheduler {
         }
         self.state.num_applied_physical_indexing_plan += 1;
         self.state.last_applied_plan_timestamp = Some(Instant::now());
+        self.state.last_dispatched_indexer_generations = dispatched_indexer_generations;
         self.state.last_applied_physical_plan = Some(new_physical_plan);
     }
 }
@@ -1305,6 +1343,133 @@ mod tests {
         waiter.await;
     }
 
+    #[tokio::test]
+    async fn test_control_running_plan_reapplies_unchanged_plan_to_new_generation() {
+        let indexer_pool = IndexerPool::default();
+        let initial_indexer = asserting_indexer_node_info("indexer", IngesterStatus::Ready, false);
+        indexer_pool.insert(initial_indexer.node_id.clone(), initial_indexer);
+
+        let mut scheduler = IndexingScheduler::new(
+            "test-cluster".to_string(),
+            NodeId::from_str("control-plane"),
+            indexer_pool.clone(),
+        );
+        let indexing_task = IndexingTask {
+            pipeline_uid: Some(PipelineUid::for_test(1u128)),
+            index_uid: Some(IndexUid::for_test("index", 1)),
+            source_id: "source".to_string(),
+            shard_ids: Vec::new(),
+            params_fingerprint: 0,
+        };
+        let mut physical_plan = PhysicalIndexingPlan::with_indexer_ids(&["indexer".to_string()]);
+        physical_plan.add_indexing_task("indexer", indexing_task.clone());
+
+        let waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        let notify_on_drop = scheduler.next_rebuild_tracker.start_rebuild();
+        scheduler.apply_physical_indexing_plan(physical_plan, Some(notify_on_drop));
+        waiter.await;
+
+        // The replacement advertises exactly the desired tasks. Comparing tasks and node IDs
+        // alone would therefore miss that this is a fresh process which never received the plan.
+        let plan_applied = Arc::new(tokio::sync::Notify::new());
+        let restarted_indexer = notifying_indexer_node_info(
+            "indexer",
+            1,
+            IngesterStatus::Ready,
+            vec![indexing_task],
+            plan_applied.clone(),
+        );
+        indexer_pool.insert(restarted_indexer.node_id.clone(), restarted_indexer);
+        scheduler.state.last_applied_plan_timestamp = None;
+
+        scheduler.control_running_plan(&ControlPlaneModel::default());
+
+        tokio::time::timeout(Duration::from_secs(1), plan_applied.notified())
+            .await
+            .expect("the restarted indexer should receive the unchanged plan");
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_plan_reapplies_unchanged_plan_to_new_generation() {
+        let indexer_pool = IndexerPool::default();
+        let initial_indexer = asserting_indexer_node_info("indexer", IngesterStatus::Ready, true);
+        indexer_pool.insert(initial_indexer.node_id.clone(), initial_indexer);
+        let mut scheduler = IndexingScheduler::new(
+            "test-cluster".to_string(),
+            NodeId::from_str("control-plane"),
+            indexer_pool.clone(),
+        );
+
+        let initial_apply_waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        scheduler.rebuild_plan(&ControlPlaneModel::default());
+        initial_apply_waiter.await;
+
+        let plan_applied = Arc::new(tokio::sync::Notify::new());
+        let restarted_indexer = notifying_indexer_node_info(
+            "indexer",
+            1,
+            IngesterStatus::Ready,
+            Vec::new(),
+            plan_applied.clone(),
+        );
+        indexer_pool.insert(restarted_indexer.node_id.clone(), restarted_indexer);
+
+        scheduler.rebuild_plan(&ControlPlaneModel::default());
+
+        tokio::time::timeout(Duration::from_secs(1), plan_applied.notified())
+            .await
+            .expect("rebuilding should dispatch an unchanged plan to the new generation");
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_plan_sends_empty_plan_to_new_generation_of_dropped_retiring_indexer() {
+        let indexer_pool = IndexerPool::default();
+        let ready_indexer = asserting_indexer_node_info_with_num_calls(
+            "indexer-ready",
+            IngesterStatus::Ready,
+            true,
+            2,
+        );
+        let retiring_indexer =
+            asserting_indexer_node_info("indexer-retiring", IngesterStatus::Retiring, true);
+        indexer_pool.insert(ready_indexer.node_id.clone(), ready_indexer);
+        indexer_pool.insert(retiring_indexer.node_id.clone(), retiring_indexer);
+        let mut scheduler = IndexingScheduler::new(
+            "test-cluster".to_string(),
+            NodeId::from_str("control-plane"),
+            indexer_pool.clone(),
+        );
+
+        // The retiring indexer is deliberately omitted from the physical plan, but receives an
+        // empty plan so it shuts down pipelines that are no longer assigned to it.
+        let physical_plan = PhysicalIndexingPlan::with_indexer_ids(&["indexer-ready".to_string()]);
+        let initial_apply_waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        let notify_on_drop = scheduler.next_rebuild_tracker.start_rebuild();
+        scheduler.apply_physical_indexing_plan(physical_plan, Some(notify_on_drop));
+        initial_apply_waiter.await;
+
+        let empty_plan_applied = Arc::new(tokio::sync::Notify::new());
+        let restarted_retiring_indexer = notifying_indexer_node_info(
+            "indexer-retiring",
+            1,
+            IngesterStatus::Retiring,
+            Vec::new(),
+            empty_plan_applied.clone(),
+        );
+        indexer_pool.insert(
+            restarted_retiring_indexer.node_id.clone(),
+            restarted_retiring_indexer,
+        );
+
+        let reapply_waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        scheduler.rebuild_plan(&ControlPlaneModel::default());
+
+        tokio::time::timeout(Duration::from_secs(1), empty_plan_applied.notified())
+            .await
+            .expect("the restarted dropped indexer should receive an empty plan");
+        reapply_waiter.await;
+    }
+
     // Builds an `IndexerNodeInfo` whose client asserts the exact `ApplyIndexingPlanRequest` it
     // receives (via `withf`) and that it is called exactly once (via `times(1)`, verified on drop).
     fn asserting_indexer_node_info(
@@ -1312,10 +1477,19 @@ mod tests {
         status: IngesterStatus,
         expect_empty_plan: bool,
     ) -> IndexerNodeInfo {
+        asserting_indexer_node_info_with_num_calls(node_id, status, expect_empty_plan, 1)
+    }
+
+    fn asserting_indexer_node_info_with_num_calls(
+        node_id: &str,
+        status: IngesterStatus,
+        expect_empty_plan: bool,
+        num_calls: usize,
+    ) -> IndexerNodeInfo {
         let mut mock_indexer = MockIndexingService::new();
         mock_indexer
             .expect_apply_indexing_plan()
-            .times(1)
+            .times(num_calls)
             .withf(move |request| request.indexing_tasks.is_empty() == expect_empty_plan)
             .returning(|_| Ok(ApplyIndexingPlanResponse {}));
         let client = IndexingServiceClient::from_mock(mock_indexer);
@@ -1346,6 +1520,34 @@ mod tests {
         }
     }
 
+    fn notifying_indexer_node_info(
+        node_id: &str,
+        generation_id: u64,
+        ingester_status: IngesterStatus,
+        indexing_tasks: Vec<IndexingTask>,
+        plan_applied: Arc<tokio::sync::Notify>,
+    ) -> IndexerNodeInfo {
+        let expected_indexing_tasks = indexing_tasks.clone();
+        let mut mock_indexer = MockIndexingService::new();
+        mock_indexer
+            .expect_apply_indexing_plan()
+            .times(1)
+            .withf(move |request| request.indexing_tasks == expected_indexing_tasks)
+            .returning(move |_| {
+                plan_applied.notify_one();
+                Ok(ApplyIndexingPlanResponse {})
+            });
+        let client = IndexingServiceClient::from_mock(mock_indexer);
+        IndexerNodeInfo {
+            node_id: NodeId::from_str(node_id),
+            generation_id,
+            client,
+            indexing_tasks,
+            indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
+            ingester_status,
+        }
+    }
+
     // An `IndexingService` whose apply RPC never returns, so the spawned apply task can only
     // finish if a timeout cancels it.
     #[derive(Debug)]
@@ -1358,6 +1560,25 @@ mod tests {
             _request: ApplyIndexingPlanRequest,
         ) -> quickwit_proto::indexing::IndexingResult<ApplyIndexingPlanResponse> {
             std::future::pending().await
+        }
+    }
+
+    #[derive(Debug)]
+    struct SlowSuccessfulIndexingService {
+        delay: Duration,
+        apply_completed: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl IndexingService for SlowSuccessfulIndexingService {
+        async fn apply_indexing_plan(
+            &self,
+            _request: ApplyIndexingPlanRequest,
+        ) -> quickwit_proto::indexing::IndexingResult<ApplyIndexingPlanResponse> {
+            tokio::time::sleep(self.delay).await;
+            self.apply_completed
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(ApplyIndexingPlanResponse {})
         }
     }
 
@@ -1394,26 +1615,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_apply_plan_times_out_only_for_draining_indexers() {
-        // A ready indexer is unbounded: the hanging apply is never cancelled, so its task never
-        // finishes (a wrongly-applied timeout would fire well within 500ms and flip this).
+    async fn test_apply_plan_times_out_for_all_eligible_indexers() {
+        // Every eligible indexer is bounded, so one unreachable ready node cannot retain the
+        // change-notification guard indefinitely and stall subsequent rebuilds.
         assert!(
-            !hanging_apply_is_cancelled_within(IngesterStatus::Ready, Duration::from_millis(500))
-                .await
+            hanging_apply_is_cancelled_within(IngesterStatus::Ready, Duration::from_secs(1)).await
         );
-        // Retiring/decommissioning indexers are bounded, so the hanging apply is cancelled and the
-        // task finishes (resolves in ~APPLY_INDEXING_PLAN_TIMEOUT, far within the window).
         assert!(
-            hanging_apply_is_cancelled_within(IngesterStatus::Retiring, Duration::from_secs(5))
+            hanging_apply_is_cancelled_within(IngesterStatus::Retiring, Duration::from_secs(1))
                 .await
         );
         assert!(
             hanging_apply_is_cancelled_within(
                 IngesterStatus::Decommissioning,
-                Duration::from_secs(5)
+                Duration::from_secs(1)
             )
             .await
         );
+    }
+
+    #[tokio::test]
+    async fn test_ready_indexer_apply_allows_slow_success() {
+        let slow_apply_duration = Duration::from_millis(50);
+        assert!(DRAINING_INDEXER_APPLY_PLAN_TIMEOUT < slow_apply_duration);
+        assert!(slow_apply_duration < READY_INDEXER_APPLY_PLAN_TIMEOUT);
+        let apply_completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let client = IndexingServiceClient::tower().build(SlowSuccessfulIndexingService {
+            delay: slow_apply_duration,
+            apply_completed: apply_completed.clone(),
+        });
+        let indexer = IndexerNodeInfo {
+            node_id: NodeId::from_str("indexer"),
+            generation_id: 0,
+            client,
+            indexing_tasks: Vec::new(),
+            indexing_capacity: CpuCapacity::from_cpu_millis(4_000),
+            ingester_status: IngesterStatus::Ready,
+        };
+        let indexer_pool = IndexerPool::default();
+        indexer_pool.insert(indexer.node_id.clone(), indexer);
+        let mut scheduler = IndexingScheduler::new(
+            "test-cluster".to_string(),
+            NodeId::from_str("control-plane"),
+            indexer_pool,
+        );
+
+        let waiter = scheduler.next_rebuild_tracker.next_rebuild_waiter();
+        let notify_on_drop = scheduler.next_rebuild_tracker.start_rebuild();
+        scheduler.apply_physical_indexing_plan(
+            PhysicalIndexingPlan::with_indexer_ids(&[]),
+            Some(notify_on_drop),
+        );
+        waiter.await;
+
+        assert!(apply_completed.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     fn kafka_source_params_for_test() -> SourceParams {

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -51,7 +51,7 @@ use rand::rngs::ThreadRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, RngExt, rng};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, OwnedMutexGuard};
+use tokio::sync::{Mutex, OwnedMutexGuard, watch};
 use tracing::{Level, debug, enabled, error, info, instrument, warn};
 use ulid::Ulid;
 
@@ -1033,6 +1033,8 @@ impl IngestController {
         model: &mut ControlPlaneModel,
         mailbox: &Mailbox<ControlPlane>,
         progress: &Progress,
+        actor_generation: u64,
+        actor_generation_shutdown_rx: watch::Receiver<()>,
     ) -> MetastoreResult<usize> {
         let Ok(rebalance_guard) = self.rebalance_lock.clone().try_lock_owned() else {
             debug!("skipping rebalance: another rebalance is already in progress");
@@ -1095,24 +1097,13 @@ impl IngestController {
         }
         let close_shards_fut = self.close_shards(shards_to_close);
         let mailbox_clone = mailbox.clone();
-
-        let close_shards_and_send_callback_fut = async move {
-            // We wait for a few seconds before closing the shards to give the ingesters some time
-            // to learn about the ones we just opened via gossip.
-            tokio::time::sleep(CLOSE_SHARDS_UPON_REBALANCE_DELAY).await;
-
-            let closed_shards = close_shards_fut.await;
-
-            if closed_shards.is_empty() {
-                return;
-            }
-            let callback = RebalanceShardsCallback {
-                closed_shards,
-                rebalance_guard,
-            };
-            let _ = mailbox_clone.send_message(callback).await;
-        };
-        tokio::spawn(close_shards_and_send_callback_fut);
+        let _delayed_close_handle = spawn_delayed_rebalance_close_task(
+            mailbox_clone,
+            close_shards_fut,
+            rebalance_guard,
+            actor_generation,
+            actor_generation_shutdown_rx,
+        );
 
         if num_opened_shards > 0 {
             info!("rebalance opened {num_opened_shards} new shards");
@@ -1271,6 +1262,53 @@ impl IngestController {
     }
 }
 
+fn spawn_delayed_rebalance_close_task<F>(
+    mailbox: Mailbox<ControlPlane>,
+    close_shards_fut: F,
+    rebalance_guard: OwnedMutexGuard<()>,
+    actor_generation: u64,
+    mut actor_generation_shutdown_rx: watch::Receiver<()>,
+) -> tokio::task::JoinHandle<()>
+where
+    F: Future<Output = Vec<ShardPKey>> + Send + 'static,
+{
+    tokio::spawn(async move {
+        // Give ingesters time to learn about newly opened shards via gossip before closing the old
+        // ones. If the owning control-plane generation exits, its successor will reconcile from
+        // the metastore and decide which shards to close.
+        tokio::select! {
+            biased;
+            _ = actor_generation_shutdown_rx.changed() => {
+                return;
+            }
+            _ = tokio::time::sleep(CLOSE_SHARDS_UPON_REBALANCE_DELAY) => {}
+        }
+
+        let closed_shards = tokio::select! {
+            biased;
+            _ = actor_generation_shutdown_rx.changed() => {
+                return;
+            }
+            closed_shards = close_shards_fut => closed_shards,
+        };
+
+        if closed_shards.is_empty() {
+            return;
+        }
+        let callback = RebalanceShardsCallback {
+            actor_generation,
+            closed_shards,
+            rebalance_guard,
+        };
+        let send_callback_fut = mailbox.send_message(callback);
+        tokio::select! {
+            biased;
+            _ = actor_generation_shutdown_rx.changed() => {}
+            _ = send_callback_fut => {}
+        }
+    })
+}
+
 fn summarize_shard_ids(shard_ids: &[ShardIds]) -> Vec<&str> {
     shard_ids
         .iter()
@@ -1288,6 +1326,8 @@ fn summarize_shard_ids(shard_ids: &[ShardIds]) -> Vec<&str> {
 /// requests to complete, we use a callback to handle the results of those close shards requests.
 #[derive(Debug)]
 pub(crate) struct RebalanceShardsCallback {
+    /// Generation that opened the replacement shards and started the delayed close operation.
+    pub actor_generation: u64,
     pub closed_shards: Vec<ShardPKey>,
     pub rebalance_guard: OwnedMutexGuard<()>,
 }
@@ -1355,6 +1395,45 @@ mod tests {
 
     const TEST_SHARD_THROUGHPUT_LIMIT_MIB: f32 =
         DEFAULT_SHARD_THROUGHPUT_LIMIT.as_u64() as f32 / quickwit_common::shared_consts::MIB as f32;
+
+    #[tokio::test]
+    async fn test_delayed_rebalance_close_is_cancelled_on_generation_shutdown() {
+        let universe = Universe::default();
+        let (control_plane_mailbox, control_plane_inbox) = universe.create_test_mailbox();
+        let rebalance_lock = Arc::new(Mutex::new(()));
+        let rebalance_guard = rebalance_lock.clone().lock_owned().await;
+        let close_shards_poll_count = Arc::new(AtomicUsize::new(0));
+        let close_shards_poll_count_clone = close_shards_poll_count.clone();
+        let close_shards_fut = async move {
+            close_shards_poll_count_clone.fetch_add(1, Ordering::Relaxed);
+            Vec::new()
+        };
+        let (actor_generation_shutdown_tx, actor_generation_shutdown_rx) = watch::channel(());
+        actor_generation_shutdown_tx.send(()).unwrap();
+
+        let delayed_close_handle = spawn_delayed_rebalance_close_task(
+            control_plane_mailbox,
+            close_shards_fut,
+            rebalance_guard,
+            7,
+            actor_generation_shutdown_rx,
+        );
+        delayed_close_handle.await.unwrap();
+
+        assert_eq!(close_shards_poll_count.load(Ordering::Relaxed), 0);
+        assert!(
+            control_plane_inbox
+                .drain_for_test_typed::<RebalanceShardsCallback>()
+                .is_empty()
+        );
+        // Cancellation must release the guard so the successor generation can rebalance.
+        let _successor_rebalance_guard =
+            tokio::time::timeout(Duration::from_millis(10), rebalance_lock.lock())
+                .await
+                .unwrap();
+
+        universe.assert_quit().await;
+    }
 
     #[tokio::test]
     async fn test_ingest_controller_get_or_create_open_shards() {
@@ -3386,9 +3465,16 @@ mod tests {
         let universe = Universe::with_accelerated_time();
         let (control_plane_mailbox, control_plane_inbox) = universe.create_test_mailbox();
         let progress = Progress::default();
+        let (actor_generation_shutdown_tx, _) = watch::channel(());
 
         let num_opened_shards = controller
-            .rebalance_shards(&mut model, &control_plane_mailbox, &progress)
+            .rebalance_shards(
+                &mut model,
+                &control_plane_mailbox,
+                &progress,
+                0,
+                actor_generation_shutdown_tx.subscribe(),
+            )
             .await
             .unwrap();
         assert_eq!(num_opened_shards, 0);
@@ -3516,7 +3602,13 @@ mod tests {
         ingester_pool.insert(ingester_id_1.clone(), ingester_1);
 
         let num_opened_shards = controller
-            .rebalance_shards(&mut model, &control_plane_mailbox, &progress)
+            .rebalance_shards(
+                &mut model,
+                &control_plane_mailbox,
+                &progress,
+                0,
+                actor_generation_shutdown_tx.subscribe(),
+            )
             .await
             .unwrap();
         assert_eq!(num_opened_shards, 1);
@@ -3528,6 +3620,7 @@ mod tests {
         .await
         .unwrap()
         .unwrap();
+        assert_eq!(callback.actor_generation, 0);
         assert_eq!(callback.closed_shards.len(), 1);
     }
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/debouncing.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/debouncing.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use quickwit_proto::control_plane::{
@@ -68,35 +68,46 @@ impl GetOrCreateOpenShardsRequestDebouncer {
 
 #[derive(Default)]
 pub(super) struct DebouncedGetOrCreateOpenShardsRequest {
-    subrequests: Vec<GetOrCreateOpenShardsSubrequest>,
+    subrequests_by_unavailable_leaders: BTreeMap<Vec<String>, Vec<GetOrCreateOpenShardsSubrequest>>,
     pub closed_shards: Vec<ShardIds>,
-    pub unavailable_leaders: Vec<String>,
     rendezvous: Rendezvous,
 }
 
 impl DebouncedGetOrCreateOpenShardsRequest {
     pub fn is_empty(&self) -> bool {
-        self.subrequests.is_empty()
+        self.subrequests_by_unavailable_leaders.is_empty()
     }
 
-    pub fn take(self) -> (Option<GetOrCreateOpenShardsRequest>, Rendezvous) {
-        if self.is_empty() {
-            return (None, self.rendezvous);
-        }
-        let request = GetOrCreateOpenShardsRequest {
-            subrequests: self.subrequests,
-            closed_shards: self.closed_shards,
-            unavailable_leaders: self.unavailable_leaders,
-        };
-        (Some(request), self.rendezvous)
+    pub fn take(self) -> (Vec<GetOrCreateOpenShardsRequest>, Rendezvous) {
+        let mut closed_shards_opt = Some(self.closed_shards);
+        let requests = self
+            .subrequests_by_unavailable_leaders
+            .into_iter()
+            .map(
+                |(unavailable_leaders, subrequests)| GetOrCreateOpenShardsRequest {
+                    subrequests,
+                    // Closed-shard feedback is request-wide. Send it once even when source-specific
+                    // exclusions require splitting the control-plane request.
+                    closed_shards: closed_shards_opt.take().unwrap_or_default(),
+                    unavailable_leaders,
+                },
+            )
+            .collect();
+        (requests, self.rendezvous)
     }
 
     pub fn push_subrequest(
         &mut self,
         subrequest: GetOrCreateOpenShardsSubrequest,
         permit: PermitGuard,
+        mut unavailable_leaders: Vec<String>,
     ) {
-        self.subrequests.push(subrequest);
+        unavailable_leaders.sort_unstable();
+        unavailable_leaders.dedup();
+        self.subrequests_by_unavailable_leaders
+            .entry(unavailable_leaders)
+            .or_default()
+            .push(subrequest);
         self.rendezvous.permits.push(permit);
     }
 
@@ -191,8 +202,8 @@ mod tests {
         let debounced_request = DebouncedGetOrCreateOpenShardsRequest::default();
         assert!(debounced_request.is_empty());
 
-        let (request_opt, rendezvous) = debounced_request.take();
-        assert!(request_opt.is_none());
+        let (requests, rendezvous) = debounced_request.take();
+        assert!(requests.is_empty());
         assert!(rendezvous.is_empty());
 
         let mut debouncer = GetOrCreateOpenShardsRequestDebouncer::default();
@@ -206,6 +217,28 @@ mod tests {
                 ..Default::default()
             },
             permit,
+            Vec::new(),
+        );
+
+        let permit = debouncer.acquire("test-index", "test-source-bar").unwrap();
+        debounced_request.push_subrequest(
+            GetOrCreateOpenShardsSubrequest {
+                index_id: "test-index".to_string(),
+                source_id: "test-source-bar".to_string(),
+                ..Default::default()
+            },
+            permit,
+            vec!["test-node".to_string()],
+        );
+        let permit = debouncer.acquire("test-index", "test-source-baz").unwrap();
+        debounced_request.push_subrequest(
+            GetOrCreateOpenShardsSubrequest {
+                index_id: "test-index".to_string(),
+                source_id: "test-source-baz".to_string(),
+                ..Default::default()
+            },
+            permit,
+            vec!["test-node".to_string(), "test-node".to_string()],
         );
 
         let barrier = debouncer
@@ -213,11 +246,14 @@ mod tests {
             .unwrap_err();
         debounced_request.push_barrier(barrier);
 
-        let (request_opt, rendezvous) = debounced_request.take();
-        let request = request_opt.unwrap();
+        let (requests, rendezvous) = debounced_request.take();
 
-        assert_eq!(request.subrequests.len(), 1);
-        assert_eq!(rendezvous.num_permits(), 1);
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].subrequests.len(), 1);
+        assert!(requests[0].unavailable_leaders.is_empty());
+        assert_eq!(requests[1].subrequests.len(), 2);
+        assert_eq!(requests[1].unavailable_leaders, ["test-node"]);
+        assert_eq!(rendezvous.num_permits(), 3);
         assert_eq!(rendezvous.num_barriers(), 1);
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -35,11 +35,11 @@ use quickwit_proto::ingest::router::{
     IngestFailureReason, IngestRequestV2, IngestResponseV2, IngestRouterService,
 };
 use quickwit_proto::ingest::{CommitTypeV2, IngestV2Error, IngestV2Result, RateLimitingCause};
-use quickwit_proto::types::{NodeId, SubrequestId};
+use quickwit_proto::types::{IndexUid, NodeId, SourceId, SubrequestId};
 use serde_json::{Value as JsonValue, json};
 use tokio::sync::{Mutex, Semaphore};
 use tokio::time::error::Elapsed;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use super::broadcast::IngesterCapacityScoreUpdate;
 use super::debouncing::{
@@ -163,34 +163,55 @@ impl IngestRouter {
         ingester_pool: &IngesterPool,
     ) -> DebouncedGetOrCreateOpenShardsRequest {
         let mut debounced_request = DebouncedGetOrCreateOpenShardsRequest::default();
-        // `unavailable_leaders` is populated by the calls to `has_any_routing_candidate` below as
-        // we look for nodes with open shards to route the subrequests to. They are then
-        // reported to the control plane so it can create shards on other nodes.
-        let unavailable_leaders: &mut HashSet<NodeId> = &mut workbench.unavailable_leaders;
+        let pending_sources: Vec<(SubrequestId, String, SourceId)> =
+            pending_subrequests(&workbench.subworkbenches)
+                .map(|subrequest| {
+                    (
+                        subrequest.subrequest_id,
+                        subrequest.index_id.clone(),
+                        subrequest.source_id.clone(),
+                    )
+                })
+                .collect();
+        let mut acquired_subrequests = Vec::new();
 
         let mut state_guard = self.state.lock().await;
 
-        for subrequest in pending_subrequests(&workbench.subworkbenches) {
-            if !state_guard.routing_table.has_any_routing_candidate(
-                &subrequest.index_id,
-                &subrequest.source_id,
+        for (subrequest_id, index_id, source_id) in pending_sources {
+            let source_unavailable_leaders = state_guard
+                .routing_table
+                .source_unavailable_leaders(&index_id, &source_id);
+            let mut unavailable_leaders = workbench.unavailable_leaders.clone();
+            unavailable_leaders.extend(source_unavailable_leaders.iter().cloned());
+
+            let has_routing_candidate = state_guard.routing_table.has_any_routing_candidate(
+                &index_id,
+                &source_id,
                 ingester_pool,
-                unavailable_leaders,
-            ) {
+                &mut unavailable_leaders,
+            );
+            // `has_any_routing_candidate` adds node-wide failures (zero capacity, missing pool
+            // entry, non-ready status) to its mutable set. Keep those failures across attempts,
+            // but do not promote the source-specific exclusions with which the scan was seeded.
+            workbench.unavailable_leaders.extend(
+                unavailable_leaders
+                    .difference(&source_unavailable_leaders)
+                    .cloned(),
+            );
+
+            if !has_routing_candidate {
                 // No known nodes with open shards for this source. Ask the control
                 // plane to create shards so we have somewhere to route to.
-                let acquire_result = state_guard
-                    .debouncer
-                    .acquire(&subrequest.index_id, &subrequest.source_id);
+                let acquire_result = state_guard.debouncer.acquire(&index_id, &source_id);
 
                 match acquire_result {
                     Ok(permit) => {
                         let subrequest = GetOrCreateOpenShardsSubrequest {
-                            subrequest_id: subrequest.subrequest_id,
-                            index_id: subrequest.index_id.clone(),
-                            source_id: subrequest.source_id.clone(),
+                            subrequest_id,
+                            index_id,
+                            source_id,
                         };
-                        debounced_request.push_subrequest(subrequest, permit);
+                        acquired_subrequests.push((subrequest, permit, source_unavailable_leaders));
                     }
                     Err(barrier) => {
                         debounced_request.push_barrier(barrier);
@@ -200,20 +221,28 @@ impl IngestRouter {
         }
         drop(state_guard);
 
+        let global_unavailable_leaders = workbench.unavailable_leaders.clone();
+        for (subrequest, permit, source_unavailable_leaders) in acquired_subrequests {
+            let mut unavailable_leaders = global_unavailable_leaders.clone();
+            unavailable_leaders.extend(source_unavailable_leaders);
+            debounced_request.push_subrequest(
+                subrequest,
+                permit,
+                unavailable_leaders
+                    .into_iter()
+                    .map(|leader_id| leader_id.to_string())
+                    .collect(),
+            );
+        }
+
         if !debounced_request.is_empty() && !workbench.closed_shards.is_empty() {
             info!(closed_shards=?workbench.closed_shards, "reporting closed shard(s) to control plane");
             debounced_request
                 .closed_shards
                 .append(&mut workbench.closed_shards);
         }
-        if !debounced_request.is_empty() && !unavailable_leaders.is_empty() {
-            info!(unavailable_leaders=?unavailable_leaders, "reporting unavailable leader(s) to control plane");
-
-            for unavailable_leader in unavailable_leaders.iter() {
-                debounced_request
-                    .unavailable_leaders
-                    .push(unavailable_leader.to_string());
-            }
+        if !debounced_request.is_empty() && !global_unavailable_leaders.is_empty() {
+            info!(unavailable_leaders=?global_unavailable_leaders, "reporting unavailable leader(s) to control plane");
         }
         debounced_request
     }
@@ -223,9 +252,9 @@ impl IngestRouter {
         workbench: &mut IngestWorkbench,
         debounced_request: DebouncedGetOrCreateOpenShardsRequest,
     ) {
-        let (request_opt, rendezvous) = debounced_request.take();
+        let (requests, rendezvous) = debounced_request.take();
 
-        if let Some(request) = request_opt {
+        for request in requests {
             self.populate_routing_table(workbench, request).await;
         }
         rendezvous.wait().await;
@@ -285,7 +314,18 @@ impl IngestRouter {
         while let Some((persist_summary, persist_result)) = persist_futures.next().await {
             match persist_result {
                 Ok(persist_response) => {
-                    let leader_id = NodeId::from_str(&persist_response.leader_id);
+                    // Route bookkeeping must be attributed to the node we called, not to an
+                    // untrusted/malformed leader ID echoed by the response.
+                    let leader_id = persist_summary.leader_id.clone();
+                    let response_leader_id = NodeId::from_str(&persist_response.leader_id);
+                    if response_leader_id != leader_id {
+                        warn!(
+                            expected_leader_id = %leader_id,
+                            actual_leader_id = %response_leader_id,
+                            "persist response leader ID does not match request leader ID"
+                        );
+                    }
+                    let mut no_shards_entries: Vec<(IndexUid, SourceId)> = Vec::new();
 
                     for persist_success in persist_response.successes {
                         workbench.record_persist_success(persist_success);
@@ -295,9 +335,14 @@ impl IngestRouter {
 
                         match persist_failure.reason() {
                             PersistFailureReason::NoShardsAvailable => {
-                                // For non-critical failures, we don't mark the nodes unavailable;
-                                // a routing update is piggybacked on PersistResponses, so shard
-                                // counts and capacity scores will be fresh on the next try.
+                                // The ingester has no reachable shard for this source. A
+                                // piggybacked routing update only contains sources that still
+                                // exist, so an omitted source would
+                                // otherwise leave this stale entry
+                                // routable forever.
+                                let index_uid = persist_failure.index_uid().clone();
+                                let source_id = persist_failure.source_id.clone();
+                                no_shards_entries.push((index_uid, source_id));
                             }
                             PersistFailureReason::NodeUnavailable
                             | PersistFailureReason::WalFull
@@ -308,22 +353,33 @@ impl IngestRouter {
                         }
                     }
 
-                    if let Some(routing_update) = persist_response.routing_update {
+                    if !no_shards_entries.is_empty() || persist_response.routing_update.is_some() {
                         // Since we just talked to the node, we take advantage and use the
                         // opportunity to get a fresh routing update.
                         let mut state_guard = self.state.lock().await;
-                        for shard_update in routing_update.source_shard_updates {
-                            state_guard.routing_table.apply_capacity_update(
-                                leader_id.clone(),
-                                shard_update.index_uid().clone(),
-                                shard_update.source_id,
-                                routing_update.capacity_score as usize,
-                                shard_update.open_shard_count as usize,
-                            );
-                        }
-                        drop(state_guard);
 
-                        workbench.closed_shards.extend(routing_update.closed_shards);
+                        // Clear stale entries first. A fresh update for the same source, when
+                        // present, is applied below and deliberately takes precedence.
+                        for (index_uid, source_id) in no_shards_entries {
+                            state_guard
+                                .routing_table
+                                .mark_source_unavailable(&leader_id, &index_uid, &source_id);
+                        }
+
+                        if let Some(routing_update) = persist_response.routing_update {
+                            for shard_update in routing_update.source_shard_updates {
+                                let index_uid = shard_update.index_uid().clone();
+                                let source_id = shard_update.source_id;
+                                state_guard.routing_table.apply_capacity_update(
+                                    leader_id.clone(),
+                                    index_uid,
+                                    source_id,
+                                    routing_update.capacity_score as usize,
+                                    shard_update.open_shard_count as usize,
+                                );
+                            }
+                            workbench.closed_shards.extend(routing_update.closed_shards);
+                        }
                     }
                 }
                 Err(persist_error) => {
@@ -356,7 +412,6 @@ impl IngestRouter {
         self.populate_routing_table_debounced(workbench, debounced_request)
             .await;
 
-        let unavailable_leaders = &workbench.unavailable_leaders;
         let mut no_shards_available_subrequest_ids: Vec<SubrequestId> = Vec::new();
         let mut per_leader_persist_subrequests: HashMap<&NodeId, Vec<PersistSubrequest>> =
             HashMap::new();
@@ -368,7 +423,7 @@ impl IngestRouter {
                 &subrequest.index_id,
                 &subrequest.source_id,
                 &self.ingester_pool,
-                unavailable_leaders,
+                &workbench.unavailable_leaders,
             );
 
             let ingester_node = match ingester_node {
@@ -621,7 +676,7 @@ pub(super) struct PersistRequestSummary {
 #[cfg(test)]
 mod tests {
     use quickwit_proto::control_plane::{
-        GetOrCreateOpenShardsFailure, GetOrCreateOpenShardsFailureReason,
+        ControlPlaneError, GetOrCreateOpenShardsFailure, GetOrCreateOpenShardsFailureReason,
         GetOrCreateOpenShardsResponse, GetOrCreateOpenShardsSuccess, MockControlPlaneService,
     };
     use quickwit_proto::ingest::ingester::{
@@ -630,7 +685,7 @@ mod tests {
     };
     use quickwit_proto::ingest::router::IngestSubrequest;
     use quickwit_proto::ingest::{
-        CommitTypeV2, DocBatchV2, ParseFailure, ParseFailureReason, Shard, ShardState,
+        CommitTypeV2, DocBatchV2, ParseFailure, ParseFailureReason, Shard, ShardIds, ShardState,
     };
     use quickwit_proto::types::{DocUid, IndexUid, Position, ShardId, SourceUid};
 
@@ -654,11 +709,11 @@ mod tests {
             Some("test-az".to_string()),
         );
         let mut workbench = IngestWorkbench::default();
-        let (get_or_create_open_shard_request_opt, rendezvous) = router
+        let (get_or_create_open_shard_requests, rendezvous) = router
             .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
             .await
             .take();
-        assert!(get_or_create_open_shard_request_opt.is_none());
+        assert!(get_or_create_open_shard_requests.is_empty());
         assert!(rendezvous.is_empty());
 
         {
@@ -692,12 +747,13 @@ mod tests {
             },
         ];
         let mut workbench = IngestWorkbench::new(ingest_subrequests.clone(), 3);
-        let (get_or_create_open_shard_request_opt, rendezvous_1) = router
+        let (get_or_create_open_shard_requests, rendezvous_1) = router
             .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
             .await
             .take();
 
-        let get_or_create_open_shard_request = get_or_create_open_shard_request_opt.unwrap();
+        assert_eq!(get_or_create_open_shard_requests.len(), 1);
+        let get_or_create_open_shard_request = &get_or_create_open_shard_requests[0];
         assert_eq!(get_or_create_open_shard_request.subrequests.len(), 2);
 
         assert_eq!(rendezvous_1.num_permits(), 2);
@@ -724,12 +780,12 @@ mod tests {
 
         workbench.unavailable_leaders.clear();
 
-        let (get_or_create_open_shard_request_opt, rendezvous_2) = router
+        let (get_or_create_open_shard_requests, rendezvous_2) = router
             .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
             .await
             .take();
 
-        assert!(get_or_create_open_shard_request_opt.is_none());
+        assert!(get_or_create_open_shard_requests.is_empty());
 
         assert_eq!(rendezvous_2.num_permits(), 0);
         assert_eq!(rendezvous_2.num_barriers(), 2);
@@ -748,11 +804,12 @@ mod tests {
             workbench
                 .unavailable_leaders
                 .insert(NodeId::from_str("test-ingester-0"));
-            let (get_or_create_open_shard_request_opt, _rendezvous) = router
+            let (get_or_create_open_shard_requests, _rendezvous) = router
                 .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
                 .await
                 .take();
-            let get_or_create_open_shard_request = get_or_create_open_shard_request_opt.unwrap();
+            assert_eq!(get_or_create_open_shard_requests.len(), 1);
+            let get_or_create_open_shard_request = &get_or_create_open_shard_requests[0];
             assert_eq!(get_or_create_open_shard_request.subrequests.len(), 2);
             assert_eq!(
                 get_or_create_open_shard_request.unavailable_leaders.len(),
@@ -763,11 +820,12 @@ mod tests {
             // Fresh workbench: ingester-0 is in pool, in table, and NOT unavailable.
             // has_any_routing_candidate returns true for index-0 → only index-1 triggers request.
             let mut workbench = IngestWorkbench::new(ingest_subrequests, 3);
-            let (get_or_create_open_shard_request_opt, _rendezvous) = router
+            let (get_or_create_open_shard_requests, _rendezvous) = router
                 .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
                 .await
                 .take();
-            let get_or_create_open_shard_request = get_or_create_open_shard_request_opt.unwrap();
+            assert_eq!(get_or_create_open_shard_requests.len(), 1);
+            let get_or_create_open_shard_request = &get_or_create_open_shard_requests[0];
             assert_eq!(get_or_create_open_shard_request.subrequests.len(), 1);
 
             let subrequest = &get_or_create_open_shard_request.subrequests[0];
@@ -780,6 +838,161 @@ mod tests {
                     .is_empty()
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_router_populate_routing_table_debounced_splits_source_exclusions() {
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let captured_requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let mut mock_control_plane = MockControlPlaneService::new();
+        let captured_requests_clone = captured_requests.clone();
+        let index_uid_clone = index_uid.clone();
+        mock_control_plane
+            .expect_get_or_create_open_shards()
+            .times(3)
+            .returning(move |request| {
+                assert_eq!(request.subrequests.len(), 1);
+                let subrequest = &request.subrequests[0];
+                let subrequest_id = subrequest.subrequest_id;
+                let source_id = subrequest.source_id.clone();
+                captured_requests_clone.lock().unwrap().push(request);
+
+                // The requests are ordered by their unavailable-leader set. Failing the middle
+                // group must not prevent the router from processing the final group.
+                if source_id == "source-b" {
+                    return Err(ControlPlaneError::Unavailable(
+                        "control plane unavailable for source-b".to_string(),
+                    ));
+                }
+                let replacement_leader_id = format!("replacement-{source_id}");
+                Ok(GetOrCreateOpenShardsResponse {
+                    successes: vec![GetOrCreateOpenShardsSuccess {
+                        subrequest_id,
+                        index_uid: Some(index_uid_clone.clone()),
+                        source_id: source_id.clone(),
+                        open_shards: vec![Shard {
+                            index_uid: Some(index_uid_clone.clone()),
+                            source_id,
+                            shard_id: Some(ShardId::from(u64::from(subrequest_id) + 1)),
+                            shard_state: ShardState::Open as i32,
+                            leader_id: replacement_leader_id,
+                            ..Default::default()
+                        }],
+                    }],
+                    ..Default::default()
+                })
+            });
+
+        let ingester_pool = IngesterPool::default();
+        for leader_id in ["replacement-source-a", "replacement-source-c"] {
+            ingester_pool.insert(
+                NodeId::from_str(leader_id),
+                IngesterPoolEntry::mocked_ingester(),
+            );
+        }
+        let router = IngestRouter::new(
+            NodeId::from_str("test-router"),
+            ControlPlaneServiceClient::from_mock(mock_control_plane),
+            ingester_pool.clone(),
+            1,
+            EventBroker::default(),
+            Some("test-az".to_string()),
+        );
+        {
+            let mut state_guard = router.state.lock().await;
+            for (source_id, leader_id) in [
+                ("source-a", "leader-a"),
+                ("source-b", "leader-b"),
+                ("source-c", "leader-c"),
+            ] {
+                state_guard.routing_table.mark_source_unavailable(
+                    &NodeId::from_str(leader_id),
+                    &index_uid,
+                    source_id,
+                );
+            }
+        }
+
+        let ingest_subrequests = ["source-a", "source-b", "source-c"]
+            .into_iter()
+            .enumerate()
+            .map(|(subrequest_id, source_id)| IngestSubrequest {
+                subrequest_id: subrequest_id as SubrequestId,
+                index_id: "test-index".to_string(),
+                source_id: source_id.to_string(),
+                ..Default::default()
+            })
+            .collect();
+        let closed_shards = ShardIds {
+            index_uid: Some(index_uid.clone()),
+            source_id: "source-a".to_string(),
+            shard_ids: vec![ShardId::from(42)],
+        };
+        let mut workbench = IngestWorkbench::new(ingest_subrequests, 3);
+        workbench.closed_shards.push(closed_shards.clone());
+
+        let debounced_request = router
+            .make_get_or_create_open_shard_request(&mut workbench, &ingester_pool)
+            .await;
+        assert!(workbench.closed_shards.is_empty());
+        router
+            .populate_routing_table_debounced(&mut workbench, debounced_request)
+            .await;
+
+        {
+            let captured_requests = captured_requests.lock().unwrap();
+            assert_eq!(captured_requests.len(), 3);
+            for (request, (source_id, unavailable_leader)) in captured_requests.iter().zip([
+                ("source-a", "leader-a"),
+                ("source-b", "leader-b"),
+                ("source-c", "leader-c"),
+            ]) {
+                assert_eq!(request.subrequests[0].source_id, source_id);
+                assert_eq!(request.unavailable_leaders, [unavailable_leader]);
+            }
+            assert_eq!(captured_requests[0].closed_shards, [closed_shards]);
+            assert!(captured_requests[1].closed_shards.is_empty());
+            assert!(captured_requests[2].closed_shards.is_empty());
+        }
+
+        let state_guard = router.state.lock().await;
+        let unavailable_leaders = HashSet::new();
+        assert_eq!(
+            state_guard
+                .routing_table
+                .pick_node(
+                    "test-index",
+                    "source-a",
+                    &ingester_pool,
+                    &unavailable_leaders,
+                )
+                .unwrap()
+                .node_id,
+            NodeId::from_str("replacement-source-a")
+        );
+        assert!(
+            !state_guard.routing_table.has_any_routing_candidate(
+                "test-index",
+                "source-b",
+                &ingester_pool,
+                &mut HashSet::new(),
+            ),
+            "the failed source group should remain unresolved"
+        );
+        assert_eq!(
+            state_guard
+                .routing_table
+                .pick_node(
+                    "test-index",
+                    "source-c",
+                    &ingester_pool,
+                    &unavailable_leaders,
+                )
+                .unwrap()
+                .node_id,
+            NodeId::from_str("replacement-source-c")
+        );
     }
 
     #[tokio::test]
@@ -1859,5 +2072,356 @@ mod tests {
             .pick_node("test-index", "test-source", &ingester_pool, &HashSet::new())
             .unwrap();
         assert_eq!(node.node_id, NodeId::from_str("test-ingester-0"));
+    }
+
+    #[tokio::test]
+    async fn test_no_shards_available_uses_request_leader_and_clears_omitted_stale_entry() {
+        let ingester_pool = IngesterPool::default();
+        let router = IngestRouter::new(
+            NodeId::from_str("test-router"),
+            ControlPlaneServiceClient::from_mock(MockControlPlaneService::new()),
+            ingester_pool.clone(),
+            1,
+            EventBroker::default(),
+            Some("test-az".to_string()),
+        );
+        let index_uid = IndexUid::for_test("test-index", 0);
+        {
+            let mut state_guard = router.state.lock().await;
+            state_guard.routing_table.merge_from_shards(
+                index_uid.clone(),
+                "test-source".to_string(),
+                vec![Shard {
+                    index_uid: Some(index_uid.clone()),
+                    source_id: "test-source".to_string(),
+                    shard_id: Some(ShardId::from(1)),
+                    shard_state: ShardState::Open as i32,
+                    leader_id: "test-ingester-0".to_string(),
+                    ..Default::default()
+                }],
+            );
+            state_guard.routing_table.merge_from_shards(
+                index_uid.clone(),
+                "healthy-source".to_string(),
+                vec![Shard {
+                    index_uid: Some(index_uid.clone()),
+                    source_id: "healthy-source".to_string(),
+                    shard_id: Some(ShardId::from(2)),
+                    shard_state: ShardState::Open as i32,
+                    leader_id: "test-ingester-0".to_string(),
+                    ..Default::default()
+                }],
+            );
+        }
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester-0"),
+            IngesterPoolEntry::mocked_ingester(),
+        );
+
+        let mut workbench = IngestWorkbench::new(
+            vec![IngestSubrequest {
+                subrequest_id: 0,
+                index_id: "test-index".to_string(),
+                source_id: "test-source".to_string(),
+                ..Default::default()
+            }],
+            2,
+        );
+        let persist_futures = FuturesUnordered::new();
+        let index_uid_clone = index_uid.clone();
+        persist_futures.push(async move {
+            let summary = PersistRequestSummary {
+                leader_id: NodeId::from_str("test-ingester-0"),
+                subrequest_ids: vec![0],
+            };
+            let result = Ok::<_, IngestV2Error>(PersistResponse {
+                // The response's echoed leader ID is not authoritative. Routing state must be
+                // updated for the actual RPC target recorded in `PersistRequestSummary`.
+                leader_id: "incorrect-response-leader".to_string(),
+                successes: Vec::new(),
+                failures: vec![PersistFailure {
+                    subrequest_id: 0,
+                    index_uid: Some(index_uid_clone),
+                    source_id: "test-source".to_string(),
+                    reason: PersistFailureReason::NoShardsAvailable as i32,
+                }],
+                // The source is omitted because the ingester no longer has it.
+                routing_update: Some(RoutingUpdate {
+                    capacity_score: 6,
+                    source_shard_updates: Vec::new(),
+                    ..Default::default()
+                }),
+            });
+            (summary, result)
+        });
+
+        router
+            .process_persist_results(&mut workbench, persist_futures)
+            .await;
+
+        let state_guard = router.state.lock().await;
+        let mut unavailable_leaders = HashSet::new();
+        assert_eq!(
+            state_guard
+                .routing_table
+                .source_unavailable_leaders("test-index", "test-source"),
+            HashSet::from([NodeId::from_str("test-ingester-0")])
+        );
+        assert!(
+            !state_guard.routing_table.has_any_routing_candidate(
+                "test-index",
+                "test-source",
+                &ingester_pool,
+                &mut unavailable_leaders,
+            ),
+            "NoShardsAvailable must invalidate an omitted stale routing entry"
+        );
+        assert!(
+            unavailable_leaders.is_empty(),
+            "a source-specific failure must not mark the leader unavailable"
+        );
+        assert!(
+            state_guard
+                .routing_table
+                .pick_node(
+                    "test-index",
+                    "healthy-source",
+                    &ingester_pool,
+                    &unavailable_leaders,
+                )
+                .is_some(),
+            "another source on the same leader must remain routable"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_shards_available_recovers_via_source_scoped_leader_exclusion() {
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let stale_leader_id = NodeId::from_str("test-ingester-0");
+        let replacement_leader_id = NodeId::from_str("test-ingester-1");
+
+        let mut mock_control_plane = MockControlPlaneService::new();
+        let index_uid_clone = index_uid.clone();
+        let stale_leader_id_clone = stale_leader_id.clone();
+        let replacement_leader_id_clone = replacement_leader_id.clone();
+        mock_control_plane
+            .expect_get_or_create_open_shards()
+            .once()
+            .return_once(move |request| {
+                assert_eq!(request.subrequests.len(), 1);
+                assert_eq!(request.subrequests[0].subrequest_id, 0);
+                assert_eq!(request.subrequests[0].source_id, "stale-source");
+                assert_eq!(
+                    request.unavailable_leaders,
+                    [stale_leader_id_clone.to_string()],
+                    "the stale leader must be excluded only from this source's CP request"
+                );
+                Ok(GetOrCreateOpenShardsResponse {
+                    successes: vec![GetOrCreateOpenShardsSuccess {
+                        subrequest_id: 0,
+                        index_uid: Some(index_uid_clone.clone()),
+                        source_id: "stale-source".to_string(),
+                        // Include the stale shard to simulate an eventually-consistent CP snapshot.
+                        // The router tombstone must survive this merge and select the replacement.
+                        open_shards: vec![
+                            Shard {
+                                index_uid: Some(index_uid_clone.clone()),
+                                source_id: "stale-source".to_string(),
+                                shard_id: Some(ShardId::from(1)),
+                                shard_state: ShardState::Open as i32,
+                                leader_id: stale_leader_id_clone.to_string(),
+                                ..Default::default()
+                            },
+                            Shard {
+                                index_uid: Some(index_uid_clone.clone()),
+                                source_id: "stale-source".to_string(),
+                                shard_id: Some(ShardId::from(3)),
+                                shard_state: ShardState::Open as i32,
+                                leader_id: replacement_leader_id_clone.to_string(),
+                                ..Default::default()
+                            },
+                        ],
+                    }],
+                    ..Default::default()
+                })
+            });
+
+        let ingester_pool = IngesterPool::default();
+        let mut mock_stale_ingester = MockIngesterService::new();
+        let index_uid_clone = index_uid.clone();
+        mock_stale_ingester
+            .expect_persist()
+            .once()
+            .return_once(move |request| {
+                assert_eq!(request.subrequests.len(), 2);
+                Ok(PersistResponse {
+                    leader_id: request.leader_id,
+                    successes: vec![PersistSuccess {
+                        subrequest_id: 1,
+                        index_uid: Some(index_uid_clone.clone()),
+                        source_id: "healthy-source".to_string(),
+                        shard_id: Some(ShardId::from(2)),
+                        replication_position_inclusive: Some(Position::offset(0u64)),
+                        num_persisted_docs: 1,
+                        parse_failures: Vec::new(),
+                    }],
+                    failures: vec![PersistFailure {
+                        subrequest_id: 0,
+                        index_uid: Some(index_uid_clone.clone()),
+                        source_id: "stale-source".to_string(),
+                        reason: PersistFailureReason::NoShardsAvailable as i32,
+                    }],
+                    routing_update: Some(RoutingUpdate {
+                        capacity_score: 6,
+                        // The failed source is omitted, while the unrelated source remains healthy.
+                        source_shard_updates: vec![SourceShardUpdate {
+                            index_uid: Some(index_uid_clone),
+                            source_id: "healthy-source".to_string(),
+                            open_shard_count: 1,
+                        }],
+                        ..Default::default()
+                    }),
+                })
+            });
+        ingester_pool.insert(
+            stale_leader_id.clone(),
+            IngesterPoolEntry {
+                client: IngesterServiceClient::from_mock(mock_stale_ingester),
+                status: IngesterStatus::Ready,
+                availability_zone: None,
+            },
+        );
+
+        let mut mock_replacement_ingester = MockIngesterService::new();
+        let index_uid_clone = index_uid.clone();
+        mock_replacement_ingester
+            .expect_persist()
+            .times(2)
+            .returning(move |request| {
+                assert_eq!(request.subrequests.len(), 1);
+                let subrequest = &request.subrequests[0];
+                assert_eq!(subrequest.source_id, "stale-source");
+                Ok(PersistResponse {
+                    leader_id: request.leader_id,
+                    successes: vec![PersistSuccess {
+                        subrequest_id: subrequest.subrequest_id,
+                        index_uid: Some(index_uid_clone.clone()),
+                        source_id: subrequest.source_id.clone(),
+                        shard_id: Some(ShardId::from(3)),
+                        replication_position_inclusive: Some(Position::offset(0u64)),
+                        num_persisted_docs: 1,
+                        parse_failures: Vec::new(),
+                    }],
+                    failures: Vec::new(),
+                    routing_update: Some(RoutingUpdate {
+                        capacity_score: 6,
+                        source_shard_updates: vec![SourceShardUpdate {
+                            index_uid: Some(index_uid_clone.clone()),
+                            source_id: "stale-source".to_string(),
+                            open_shard_count: 1,
+                        }],
+                        ..Default::default()
+                    }),
+                })
+            });
+        ingester_pool.insert(
+            replacement_leader_id,
+            IngesterPoolEntry {
+                client: IngesterServiceClient::from_mock(mock_replacement_ingester),
+                status: IngesterStatus::Ready,
+                availability_zone: None,
+            },
+        );
+
+        let router = IngestRouter::new(
+            NodeId::from_str("test-router"),
+            ControlPlaneServiceClient::from_mock(mock_control_plane),
+            ingester_pool.clone(),
+            1,
+            EventBroker::default(),
+            None,
+        );
+        {
+            let mut state_guard = router.state.lock().await;
+            state_guard.routing_table.merge_from_shards(
+                index_uid.clone(),
+                "stale-source".to_string(),
+                vec![Shard {
+                    index_uid: Some(index_uid.clone()),
+                    source_id: "stale-source".to_string(),
+                    shard_id: Some(ShardId::from(1)),
+                    shard_state: ShardState::Open as i32,
+                    leader_id: stale_leader_id.to_string(),
+                    ..Default::default()
+                }],
+            );
+            state_guard.routing_table.merge_from_shards(
+                index_uid,
+                "healthy-source".to_string(),
+                vec![Shard {
+                    index_uid: Some(IndexUid::for_test("test-index", 0)),
+                    source_id: "healthy-source".to_string(),
+                    shard_id: Some(ShardId::from(2)),
+                    shard_state: ShardState::Open as i32,
+                    leader_id: stale_leader_id.to_string(),
+                    ..Default::default()
+                }],
+            );
+            // Make the stale leader strictly preferable to the replacement returned by the CP.
+            // If the source tombstone is accidentally lost, power-of-two routing will therefore
+            // deterministically choose the stale node and violate its `.once()` expectation.
+            state_guard.routing_table.apply_capacity_update(
+                stale_leader_id.clone(),
+                IndexUid::for_test("test-index", 0),
+                "stale-source".to_string(),
+                10,
+                1,
+            );
+        }
+
+        let response = router
+            .retry_batch_persist(
+                IngestRequestV2 {
+                    subrequests: vec![
+                        IngestSubrequest {
+                            subrequest_id: 0,
+                            index_id: "test-index".to_string(),
+                            source_id: "stale-source".to_string(),
+                            doc_batch: Some(DocBatchV2::for_test(["stale"])),
+                        },
+                        IngestSubrequest {
+                            subrequest_id: 1,
+                            index_id: "test-index".to_string(),
+                            source_id: "healthy-source".to_string(),
+                            doc_batch: Some(DocBatchV2::for_test(["healthy"])),
+                        },
+                    ],
+                    commit_type: CommitTypeV2::Auto as i32,
+                },
+                3,
+            )
+            .await;
+        assert_eq!(response.successes.len(), 2);
+        assert!(response.failures.is_empty());
+
+        // The tombstone is routing-table state, not request-local state. A fresh workbench must go
+        // directly to the replacement rather than paying the stale-leader failure/CP round trip
+        // again.
+        let response = router
+            .retry_batch_persist(
+                IngestRequestV2 {
+                    subrequests: vec![IngestSubrequest {
+                        subrequest_id: 2,
+                        index_id: "test-index".to_string(),
+                        source_id: "stale-source".to_string(),
+                        doc_batch: Some(DocBatchV2::for_test(["next-request"])),
+                    }],
+                    commit_type: CommitTypeV2::Auto as i32,
+                },
+                2,
+            )
+            .await;
+        assert_eq!(response.successes.len(), 1);
+        assert!(response.failures.is_empty());
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/routing_table.rs
@@ -43,10 +43,20 @@ impl IngesterNode {
         ingester_pool: &IngesterPool,
         unavailable_leaders: &mut HashSet<NodeId>,
     ) -> bool {
-        if self.capacity_score == 0 || self.open_shard_count == 0 {
+        if unavailable_leaders.contains(&self.node_id) {
             return false;
         }
-        if unavailable_leaders.contains(&self.node_id) {
+        // A zero capacity score is a node-wide signal: the ingester cannot accept writes for any
+        // source. Report it to the control plane so it can exclude the leader and open replacement
+        // shards elsewhere. If we merely return `false`, the control plane can return the same
+        // nominally-open shards and the router makes no progress.
+        if self.capacity_score == 0 {
+            unavailable_leaders.insert(self.node_id.clone());
+            return false;
+        }
+        // Unlike capacity, the open-shard count is source-specific. It is not sufficient evidence
+        // to mark the entire ingester unavailable.
+        if self.open_shard_count == 0 {
             return false;
         }
         let is_ready = ingester_pool
@@ -65,6 +75,10 @@ impl IngesterNode {
 pub(super) struct RoutingEntry {
     pub index_uid: IndexUid,
     pub nodes: HashMap<NodeId, IngesterNode>,
+    /// Leaders that authoritatively reported `NoShardsAvailable` for this source. Control-plane
+    /// shard snapshots are eventually consistent and must not make these leaders routable again;
+    /// only a positive update from the ingester or a new index incarnation clears the tombstone.
+    source_unavailable_leaders: HashSet<NodeId>,
     /// Whether this entry has been seeded from a control plane response. During a rolling
     /// deployment, Chitchat broadcasts from already-upgraded nodes may populate the table
     /// before the router ever asks the CP, causing it to miss old-version nodes. This flag
@@ -77,6 +91,7 @@ impl RoutingEntry {
         Self {
             index_uid,
             nodes: HashMap::new(),
+            source_unavailable_leaders: HashSet::new(),
             seeded_from_cp: false,
         }
     }
@@ -125,6 +140,7 @@ impl RoutingEntry {
                         .map(|entry| entry.status.is_ready())
                         .unwrap_or(false)
                     && !unavailable_leaders.contains(&node.node_id)
+                    && !self.source_unavailable_leaders.contains(&node.node_id)
             })
             .partition(|node| {
                 let node_az = ingester_pool
@@ -201,6 +217,7 @@ impl RoutingTable {
                         "node_id": node_id,
                         "capacity_score": node.capacity_score,
                         "open_shard_count": node.open_shard_count,
+                        "source_unavailable": entry.source_unavailable_leaders.contains(node_id),
                         "availability_zone": az,
                     }));
             }
@@ -232,6 +249,9 @@ impl RoutingTable {
         let mut has_any_candidate = false;
 
         for node in entry.nodes.values() {
+            if entry.source_unavailable_leaders.contains(&node.node_id) {
+                continue;
+            }
             has_any_candidate |= node.is_routing_candidate(ingester_pool, unavailable_leaders);
         }
         has_any_candidate
@@ -258,6 +278,7 @@ impl RoutingTable {
             Ordering::Less => {
                 entry.index_uid = index_uid.clone();
                 entry.nodes.clear();
+                entry.source_unavailable_leaders.clear();
                 entry.seeded_from_cp = false;
             }
             // If we receive an update for a previous incarnation of the index, then we ignore it.
@@ -270,7 +291,47 @@ impl RoutingTable {
             capacity_score,
             open_shard_count,
         };
+        if open_shard_count > 0 {
+            entry.source_unavailable_leaders.remove(&node_id);
+        }
         entry.nodes.insert(node_id, ingester_node);
+    }
+
+    pub fn source_unavailable_leaders(&self, index_id: &str, source_id: &str) -> HashSet<NodeId> {
+        self.table
+            .get(&(index_id.to_string(), source_id.to_string()))
+            .map(|entry| entry.source_unavailable_leaders.clone())
+            .unwrap_or_default()
+    }
+
+    /// Marks one node as having no open shard for a specific source while preserving its
+    /// node-wide capacity score. `NoShardsAvailable` is source-specific and must not make the
+    /// ingester unavailable to other sources in the same request.
+    pub fn mark_source_unavailable(
+        &mut self,
+        node_id: &NodeId,
+        index_uid: &IndexUid,
+        source_id: &str,
+    ) {
+        let key = (index_uid.index_id.to_string(), source_id.to_string());
+        let entry = self
+            .table
+            .entry(key)
+            .or_insert_with(|| RoutingEntry::new(index_uid.clone()));
+        match entry.index_uid.cmp(index_uid) {
+            Ordering::Less => {
+                entry.index_uid = index_uid.clone();
+                entry.nodes.clear();
+                entry.source_unavailable_leaders.clear();
+                entry.seeded_from_cp = false;
+            }
+            Ordering::Greater => return,
+            Ordering::Equal => {}
+        }
+        entry.source_unavailable_leaders.insert(node_id.clone());
+        if let Some(node) = entry.nodes.get_mut(node_id) {
+            node.open_shard_count = 0;
+        }
     }
 
     /// Merges routing updates from a GetOrCreateOpenShards control plane response into the
@@ -293,6 +354,7 @@ impl RoutingTable {
             Ordering::Less => {
                 entry.index_uid = index_uid.clone();
                 entry.nodes.clear();
+                entry.source_unavailable_leaders.clear();
             }
             // If we receive an update for a previous incarnation of the index, then we ignore it.
             Ordering::Greater => return,
@@ -360,11 +422,20 @@ mod tests {
         let pool = IngesterPool::default();
         pool.insert(NodeId::from_str("node-1"), mocked_ingester(None));
 
-        // No capacity or no open shards: not a routing candidate, not reported as unavailable.
+        // No capacity: not a routing candidate and reported as unavailable so the control plane
+        // does not return the same exhausted leader.
         let mut unavailable_leaders = HashSet::new();
         assert!(
             !ingester_node("node-1", 0, 3).is_routing_candidate(&pool, &mut unavailable_leaders)
         );
+        assert_eq!(
+            unavailable_leaders,
+            HashSet::from([NodeId::from_str("node-1")])
+        );
+
+        // No open shards is source-specific: it is not a routing candidate, but does not make the
+        // entire ingester unavailable.
+        unavailable_leaders.clear();
         assert!(
             !ingester_node("node-1", 5, 0).is_routing_candidate(&pool, &mut unavailable_leaders)
         );
@@ -530,7 +601,8 @@ mod tests {
             &mut unavailable_leaders
         ));
 
-        // Node with capacity_score=0 is not eligible and is not reported as unavailable.
+        // Node with capacity_score=0 is not eligible and is reported as unavailable, otherwise the
+        // control plane can return the same exhausted leader forever.
         table.apply_capacity_update(
             NodeId::from_str("node-2"),
             index_uid.clone(),
@@ -547,7 +619,7 @@ mod tests {
         ));
         assert_eq!(
             unavailable_leaders,
-            HashSet::from([NodeId::from_str("node-1")])
+            HashSet::from([NodeId::from_str("node-1"), NodeId::from_str("node-2")])
         );
     }
 
@@ -761,6 +833,56 @@ mod tests {
         assert!(entry.nodes.contains_key("node-2"));
         assert!(entry.nodes.contains_key("node-3"));
         assert!(entry.nodes.contains_key("node-4"));
+    }
+
+    #[test]
+    fn test_source_unavailable_tombstone_survives_stale_cp_merge() {
+        let mut table = RoutingTable::default();
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let node_id = NodeId::from_str("node-1");
+        let shard = Shard {
+            index_uid: Some(index_uid.clone()),
+            source_id: "test-source".to_string(),
+            shard_id: Some(ShardId::from(1)),
+            shard_state: ShardState::Open as i32,
+            leader_id: node_id.to_string(),
+            ..Default::default()
+        };
+        table.merge_from_shards(
+            index_uid.clone(),
+            "test-source".to_string(),
+            vec![shard.clone()],
+        );
+        let pool = IngesterPool::default();
+        pool.insert(node_id.clone(), mocked_ingester(None));
+
+        table.mark_source_unavailable(&node_id, &index_uid, "test-source");
+        assert!(
+            table
+                .pick_node("test-index", "test-source", &pool, &HashSet::new())
+                .is_none()
+        );
+
+        // The control plane can lag the ingester and return the same nominally-open shard. This is
+        // not authoritative enough to make the failed leader routable again.
+        table.merge_from_shards(index_uid.clone(), "test-source".to_string(), vec![shard]);
+        assert!(
+            table
+                .pick_node("test-index", "test-source", &pool, &HashSet::new())
+                .is_none()
+        );
+        assert_eq!(
+            table.source_unavailable_leaders("test-index", "test-source"),
+            HashSet::from([node_id.clone()])
+        );
+
+        // A positive update from the ingester is authoritative and clears the tombstone.
+        table.apply_capacity_update(node_id, index_uid, "test-source".to_string(), 5, 1);
+        assert!(
+            table
+                .pick_node("test-index", "test-source", &pool, &HashSet::new())
+                .is_some()
+        );
     }
 
     #[test]

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -80,7 +80,7 @@ use quickwit_compaction::{
     wait_for_compactor_decommission,
 };
 use quickwit_config::service::QuickwitService;
-use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig};
+use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig, PostgresMetastoreConfig};
 use quickwit_control_plane::control_plane::{ControlPlane, ControlPlaneEventSubscriber};
 use quickwit_control_plane::{IndexerNodeInfo, IndexerPool};
 use quickwit_index_management::{IndexService as IndexManager, IndexServiceError};
@@ -575,45 +575,41 @@ pub async fn serve_quickwit(
     let grpc_config = node_config.grpc_config.clone();
 
     // Instantiate a metastore "server" if the `metastore` role is enabled on the node.
-    let metastore_server_opt: Option<MetastoreServiceClient> =
-        if node_config.is_service_enabled(QuickwitService::Metastore) {
-            let metastore: MetastoreServiceClient = metastore_resolver
-                .resolve(&node_config.metastore_uri)
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to resolve metastore uri `{}`",
-                        node_config.metastore_uri
-                    )
-                })?;
-            let max_in_flight_requests = if node_config.metastore_uri.protocol().is_database() {
-                node_config
-                    .metastore_configs
-                    .find_postgres()
-                    .map(|config| config.max_connections.get() * 2)
-                    .unwrap_or_default()
-                    .max(100)
-            } else {
-                100
-            };
-            // These layers apply to all the RPCs of the metastore.
-            let shared_layer = ServiceBuilder::new()
-                .layer(METASTORE_GRPC_SERVER_METRICS_LAYER.clone())
-                .layer(LoadShedLayer::new(max_in_flight_requests))
-                .into_inner();
-            let broker_layer = EventListenerLayer::new(event_broker.clone());
-            let metastore = MetastoreServiceClient::tower()
-                .stack_layer(shared_layer)
-                .stack_create_index_layer(broker_layer.clone())
-                .stack_delete_index_layer(broker_layer.clone())
-                .stack_add_source_layer(broker_layer.clone())
-                .stack_delete_source_layer(broker_layer.clone())
-                .stack_toggle_source_layer(broker_layer)
-                .build(metastore);
-            Some(metastore)
+    let metastore_server_opt: Option<MetastoreServiceClient> = if node_config
+        .is_service_enabled(QuickwitService::Metastore)
+    {
+        let metastore: MetastoreServiceClient = metastore_resolver
+            .resolve(&node_config.metastore_uri)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to resolve metastore uri `{}`",
+                    node_config.metastore_uri
+                )
+            })?;
+        let max_in_flight_requests = if node_config.metastore_uri.protocol().is_database() {
+            postgres_metastore_max_in_flight_requests(node_config.metastore_configs.find_postgres())
         } else {
-            None
+            100
         };
+        // These layers apply to all the RPCs of the metastore.
+        let shared_layer = ServiceBuilder::new()
+            .layer(METASTORE_GRPC_SERVER_METRICS_LAYER.clone())
+            .layer(LoadShedLayer::new_shared(max_in_flight_requests))
+            .into_inner();
+        let broker_layer = EventListenerLayer::new(event_broker.clone());
+        let metastore = MetastoreServiceClient::tower()
+            .stack_layer(shared_layer)
+            .stack_create_index_layer(broker_layer.clone())
+            .stack_delete_index_layer(broker_layer.clone())
+            .stack_add_source_layer(broker_layer.clone())
+            .stack_delete_source_layer(broker_layer.clone())
+            .stack_toggle_source_layer(broker_layer)
+            .build(metastore);
+        Some(metastore)
+    } else {
+        None
+    };
     // Instantiate a metastore client, either local if available or remote otherwise.
     let metastore_client: MetastoreServiceClient =
         if let Some(metastore_server) = &metastore_server_opt {
@@ -1108,6 +1104,25 @@ pub async fn serve_quickwit(
         .await
         .context("failed to gracefully shutdown services")?;
     Ok(actor_exit_statuses)
+}
+
+/// Limits PostgreSQL-backed metastore RPCs to fewer than the number of database connections
+/// available to execute them. Admitting more requests would only move the overload into SQLx's
+/// acquisition queue, where requests can hold server capacity until the pool acquisition timeout
+/// expires.
+///
+/// When the pool contains at least two connections, one slot is left as headroom for operations
+/// such as `check_connectivity`. This is not a hard reservation: streaming RPCs release their
+/// admission permit when they return the stream, and direct pool users bypass this layer entirely.
+fn postgres_metastore_max_in_flight_requests(
+    postgres_config_opt: Option<&PostgresMetastoreConfig>,
+) -> usize {
+    let max_connections = postgres_config_opt
+        .cloned()
+        .unwrap_or_default()
+        .max_connections
+        .get();
+    max_connections.saturating_sub(1).max(1)
 }
 
 #[derive(Clone, Copy)]
@@ -1742,6 +1757,7 @@ async fn check_cluster_configuration(
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
     use std::sync::{Arc, Mutex};
 
     use anyhow::bail;
@@ -1752,16 +1768,98 @@ mod tests {
     use quickwit_metastore::{IndexMetadata, metastore_for_test};
     use quickwit_proto::indexing::IndexingTask;
     use quickwit_proto::ingest::ingester::{MockIngesterService, ObservationMessage};
-    use quickwit_proto::metastore::{ListIndexesMetadataResponse, MockMetastoreService};
+    use quickwit_proto::metastore::{
+        IndexMetadataRequest, IndexMetadataResponse, ListIndexesMetadataResponse,
+        MockMetastoreService,
+    };
     use quickwit_proto::types::{IndexUid, PipelineUid};
     use quickwit_search::Job;
-    use tokio::sync::watch;
+    use tokio::sync::{Notify, watch};
     use tonic::transport::{Channel, Server};
     use tonic_health::pb::HealthCheckRequest;
     use tonic_health::pb::health_client::HealthClient;
     use tonic_health::server::health_reporter;
 
     use super::*;
+
+    #[test]
+    fn test_postgres_metastore_admission_matches_connection_pool_capacity() {
+        for (max_connections, expected_admission) in [(1, 1), (2, 1), (10, 9), (128, 127)] {
+            let postgres_config = PostgresMetastoreConfig {
+                max_connections: NonZeroUsize::new(max_connections).unwrap(),
+                ..Default::default()
+            };
+
+            assert_eq!(
+                postgres_metastore_max_in_flight_requests(Some(&postgres_config)),
+                expected_admission
+            );
+        }
+
+        let default_max_connections = PostgresMetastoreConfig::default().max_connections.get();
+        assert_eq!(
+            postgres_metastore_max_in_flight_requests(None),
+            default_max_connections.saturating_sub(1).max(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_metastore_admission_is_shared_across_rpc_methods() {
+        let mut mock_metastore = MockMetastoreService::new();
+        mock_metastore
+            .expect_list_indexes_metadata()
+            .once()
+            .return_once(|_| Ok(ListIndexesMetadataResponse::default()));
+
+        let request_started = Arc::new(Notify::new());
+        let release_request = Arc::new(Notify::new());
+        let request_started_clone = request_started.clone();
+        let release_request_clone = release_request.clone();
+        let index_metadata_layer = tower::layer::layer_fn(move |_| {
+            let request_started = request_started_clone.clone();
+            let release_request = release_request_clone.clone();
+            tower::service_fn(move |_: IndexMetadataRequest| {
+                let request_started = request_started.clone();
+                let release_request = release_request.clone();
+                async move {
+                    request_started.notify_one();
+                    // Hold the first RPC's load-shed permit while the test invokes another method.
+                    release_request.notified().await;
+                    Ok::<_, MetastoreError>(IndexMetadataResponse::default())
+                }
+            })
+        });
+        let inner_metastore = MetastoreServiceClient::tower()
+            .stack_index_metadata_layer(index_metadata_layer)
+            .build_from_mock(mock_metastore);
+        let metastore = MetastoreServiceClient::tower()
+            .stack_layer(LoadShedLayer::new_shared(1))
+            .build(inner_metastore);
+        let first_metastore = metastore.clone();
+        let first_request_handle = tokio::spawn(async move {
+            first_metastore
+                .index_metadata(IndexMetadataRequest::default())
+                .await
+        });
+        request_started.notified().await;
+
+        let second_result = metastore
+            .list_indexes_metadata(ListIndexesMetadataRequest::default())
+            .await;
+        // Always release the first request before asserting so a failure cannot strand its task.
+        release_request.notify_one();
+        first_request_handle.await.unwrap().unwrap();
+
+        assert!(
+            matches!(second_result, Err(MetastoreError::TooManyRequests)),
+            "a different RPC method should be shed by the aggregate metastore limit: \
+             {second_result:?}"
+        );
+        metastore
+            .list_indexes_metadata(ListIndexesMetadataRequest::default())
+            .await
+            .expect("the second RPC method should succeed after the shared permit is released");
+    }
 
     #[tokio::test]
     async fn test_check_cluster_configuration() {


### PR DESCRIPTION
### Description

A production metastore overload exposed several recovery paths that could keep a cluster degraded long after the initial database pressure had subsided.

See [Metastore overload and cluster recovery](https://github.com/quickwit-oss/quickwit/blob/codex/fix-cloudprem-outage-recovery-oss/docs/internals/metastore-overload-recovery.md) for the trigger, the fix-by-fix outage mechanics, regression coverage, and remaining limitations.

This change hardens recovery across the control plane, indexing scheduler, ingest router, and metastore server:

- Scope periodic control-plane work, watchers, and delayed shard rebalances to a supervisor generation; clear readiness before teardown and ignore stale callbacks.
- Reschedule the control loop after pre-dispatch `TooManyRequests` errors instead of respawning the control plane.
- Replay unchanged indexing plans to a new node generation, bound plan-application waits, and preserve draining-node plans safely.
- Track unavailable shard leaders per index source, split control-plane requests by their source-specific exclusion sets, and clear stale routes after `NoShardsAvailable` responses.
- Share one load-shed semaphore across all generated metastore RPC methods. For PostgreSQL, admit at most `max_connections - 1` unary RPCs when possible so readiness and control work retain connection-pool headroom during lock convoys.

The PostgreSQL admission limit is intentionally best-effort rather than a hard reservation: streaming responses and direct pool users do not hold this generic RPC permit for their entire database lifetime. SQLx pool-acquisition timeouts remain conservatively classified as uncertain database errors.

### How was this PR tested?

- `cargo test -p quickwit-common --lib` (132 passed)
- `cargo test -p quickwit-ingest --lib -- --skip test_ingester_persist_replicate_grpc` (174 passed, 1 ignored)
- `cargo test -p quickwit-control-plane --lib` (128 passed)
- `SSL_CERT_FILE=/etc/ssl/cert.pem cargo test -p quickwit-serve --lib` (165 passed)
- `cargo clippy -p quickwit-common -p quickwit-ingest -p quickwit-control-plane -p quickwit-serve --lib --tests -- -D warnings`
- Nightly `rustfmt --check` on all eight changed Rust files

Regression coverage includes generation-owned task cancellation, readiness transitions, stale callback rejection, recoverable overload handling, generation-aware plan replay, source-scoped routing recovery, closed-shard feedback sent exactly once across grouped requests, and shared cross-method metastore admission with permit release after cancellation.
