### PR TITLE
fix(config): apply --service override before validation

### DIFF
--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -230,14 +230,25 @@ pub fn start_actor_runtimes(
 }
 
 /// Loads a node config located at `config_uri` with the default storage configuration.
-async fn load_node_config(config_uri: &Uri) -> anyhow::Result<NodeConfig> {
+///
+/// When `service_override` is provided, it is applied before config validation so that
+/// service-dependent validation (e.g. the disk-usage check) reflects the actual runtime service
+/// set (e.g. `--service searcher`).
+async fn load_node_config(
+    config_uri: &Uri,
+    service_override: Option<&HashSet<QuickwitService>>,
+) -> anyhow::Result<NodeConfig> {
     let config_content = load_file(&StorageResolver::unconfigured(), config_uri)
         .await
         .context("failed to load node config")?;
     let config_format = ConfigFormat::sniff_from_uri(config_uri)?;
-    let config = NodeConfig::load(config_format, config_content.as_slice())
-        .await
-        .with_context(|| format!("failed to parse node config `{config_uri}`"))?;
+    let config = NodeConfig::load_with_service_override(
+        config_format,
+        config_content.as_slice(),
+        service_override,
+    )
+    .await
+    .with_context(|| format!("failed to parse node config `{config_uri}`"))?;
     info!(config_uri=%config_uri, config=?config, "loaded node config");
     Ok(config)
 }

--- a/quickwit/quickwit-cli/src/lib.rs
+++ b/quickwit/quickwit-cli/src/lib.rs
@@ -232,8 +232,8 @@ pub fn start_actor_runtimes(
 /// Loads a node config located at `config_uri` with the default storage configuration.
 ///
 /// When `service_override` is provided, it is applied before config validation so that
-/// service-dependent validation (e.g. the disk-usage check) reflects the actual runtime service
-/// set (e.g. `--service searcher`).
+/// service-dependent validation reflects the actual runtime service set (e.g. `--service
+/// searcher`).
 async fn load_node_config(
     config_uri: &Uri,
     service_override: Option<&HashSet<QuickwitService>>,

--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -22,6 +22,7 @@ use futures::future::select;
 use itertools::Itertools;
 use quickwit_common::runtimes::RuntimesConfig;
 use quickwit_common::uri::Uri;
+use quickwit_config::NodeConfig;
 use quickwit_config::service::QuickwitService;
 use quickwit_serve::tcp_listener::DefaultTcpListenerResolver;
 use quickwit_serve::{BuildInfo, EnvFilterReloadFn, reload_tls_cert, serve_quickwit};
@@ -92,6 +93,10 @@ async fn listen_sighup() {
 }
 
 impl RunCliCommand {
+    async fn load_node_config(&self) -> anyhow::Result<NodeConfig> {
+        load_node_config(&self.config_uri, self.services.as_ref()).await
+    }
+
     pub fn parse_cli_args(mut matches: ArgMatches) -> anyhow::Result<Self> {
         let config_uri = matches
             .remove_one::<String>("config")
@@ -117,7 +122,7 @@ impl RunCliCommand {
         debug!(args = ?self, "run-service");
         let version_text = BuildInfo::get_version_text();
         info!("quickwit version: {version_text}");
-        let node_config = load_node_config(&self.config_uri, self.services.as_ref()).await?;
+        let node_config = self.load_node_config().await?;
         if let Some(services) = &self.services {
             info!(services = %services.iter().join(", "), "services set from CLI override");
         }
@@ -150,8 +155,38 @@ impl RunCliCommand {
 #[cfg(test)]
 mod tests {
 
+    use tempfile::tempdir;
+
     use super::*;
     use crate::cli::{CliCommand, build_cli};
+
+    #[tokio::test]
+    async fn test_run_command_forwards_service_override_before_validation() -> anyhow::Result<()> {
+        let temp_dir = tempdir()?;
+        let config_path = temp_dir.path().join("quickwit.yaml");
+        let config = format!(
+            r#"
+            version: 0.8
+            data_dir: "{}"
+            enabled_services:
+              - compactor
+            "#,
+            temp_dir.path().display()
+        );
+        std::fs::write(&config_path, config)?;
+        let run_command = RunCliCommand {
+            config_uri: Uri::from_str(&format!("file://{}", config_path.display()))?,
+            services: Some(HashSet::from([QuickwitService::Searcher])),
+        };
+
+        let node_config = run_command.load_node_config().await?;
+
+        assert_eq!(
+            node_config.enabled_services,
+            HashSet::from([QuickwitService::Searcher])
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_parse_service_run_args_all_services() -> anyhow::Result<()> {

--- a/quickwit/quickwit-cli/src/service.rs
+++ b/quickwit/quickwit-cli/src/service.rs
@@ -117,15 +117,13 @@ impl RunCliCommand {
         debug!(args = ?self, "run-service");
         let version_text = BuildInfo::get_version_text();
         info!("quickwit version: {version_text}");
-        let mut node_config = load_node_config(&self.config_uri).await?;
+        let node_config = load_node_config(&self.config_uri, self.services.as_ref()).await?;
+        if let Some(services) = &self.services {
+            info!(services = %services.iter().join(", "), "services set from CLI override");
+        }
         let (storage_resolver, metastore_resolver) =
             get_resolvers(&node_config.storage_configs, &node_config.metastore_configs);
         crate::busy_detector::set_enabled(true);
-
-        if let Some(services) = &self.services {
-            info!(services = %services.iter().join(", "), "setting services from override");
-            node_config.enabled_services.clone_from(services);
-        }
         // TODO move in serve quickwit?
         let runtimes_config = RuntimesConfig::default();
         start_actor_runtimes(runtimes_config, &node_config.enabled_services)?;

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -402,7 +402,7 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
     debug!(args=?args, "local-ingest-docs");
     println!("❯ Ingesting documents locally...");
 
-    let config = load_node_config(&args.config_uri).await?;
+    let config = load_node_config(&args.config_uri, None).await?;
     let (storage_resolver, metastore_resolver) =
         get_resolvers(&config.storage_configs, &config.metastore_configs);
     let mut metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
@@ -536,7 +536,7 @@ pub async fn local_ingest_docs_cli(args: LocalIngestDocsArgs) -> anyhow::Result<
 pub async fn local_search_cli(args: LocalSearchArgs) -> anyhow::Result<()> {
     debug!(args=?args, "local-search");
     println!("❯ Searching directly on the index storage (without calling REST API)...");
-    let config = load_node_config(&args.config_uri).await?;
+    let config = load_node_config(&args.config_uri, None).await?;
     let (storage_resolver, metastore_resolver) =
         get_resolvers(&config.storage_configs, &config.metastore_configs);
     let metastore: MetastoreServiceClient =
@@ -574,7 +574,7 @@ pub async fn local_search_cli(args: LocalSearchArgs) -> anyhow::Result<()> {
 pub async fn merge_cli(args: MergeArgs) -> anyhow::Result<()> {
     debug!(args=?args, "run-merge-operations");
     println!("❯ Merging splits locally...");
-    let config = load_node_config(&args.config_uri).await?;
+    let config = load_node_config(&args.config_uri, None).await?;
     let (storage_resolver, metastore_resolver) =
         get_resolvers(&config.storage_configs, &config.metastore_configs);
     let mut metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
@@ -662,7 +662,7 @@ pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow:
     debug!(args=?args, "garbage-collect-index");
     println!("❯ Garbage collecting index...");
 
-    let config = load_node_config(&args.config_uri).await?;
+    let config = load_node_config(&args.config_uri, None).await?;
     let (storage_resolver, metastore_resolver) =
         get_resolvers(&config.storage_configs, &config.metastore_configs);
     let metastore = metastore_resolver.resolve(&config.metastore_uri).await?;
@@ -792,7 +792,7 @@ async fn extract_split_cli(args: ExtractSplitArgs) -> anyhow::Result<()> {
     debug!(args=?args, "extract-split");
     println!("❯ Extracting split...");
 
-    let config = load_node_config(&args.config_uri).await?;
+    let config = load_node_config(&args.config_uri, None).await?;
     let (storage_resolver, metastore_resolver) =
         get_resolvers(&config.storage_configs, &config.metastore_configs);
     let metastore = metastore_resolver.resolve(&config.metastore_uri).await?;

--- a/quickwit/quickwit-cli/tests/helpers.rs
+++ b/quickwit/quickwit-cli/tests/helpers.rs
@@ -24,7 +24,6 @@ use quickwit_cli::service::RunCliCommand;
 use quickwit_common::net::find_available_tcp_port;
 use quickwit_common::test_utils::wait_for_server_ready;
 use quickwit_common::uri::Uri;
-use quickwit_config::service::QuickwitService;
 use quickwit_metastore::{IndexMetadata, IndexMetadataResponseExt, MetastoreResolver};
 use quickwit_proto::metastore::{IndexMetadataRequest, MetastoreService, MetastoreServiceClient};
 use quickwit_proto::types::IndexId;
@@ -155,9 +154,12 @@ impl TestEnv {
     }
 
     pub async fn start_server(&self) -> anyhow::Result<()> {
+        // Use the default all-in-one service set, which excludes the standalone compactor.
+        // `QuickwitService::supported_services()` includes the compactor and would make this
+        // config invalid unless `enable_standalone_compactors` was explicitly enabled.
         let run_command = RunCliCommand {
             config_uri: self.resource_files.config.clone(),
-            services: Some(QuickwitService::supported_services()),
+            services: None,
         };
         let server_handle = tokio::spawn(async move {
             if let Err(error) = run_command

--- a/quickwit/quickwit-common/src/fs.rs
+++ b/quickwit/quickwit-common/src/fs.rs
@@ -36,9 +36,20 @@ pub fn get_cache_directory_path(data_dir_path: &Path) -> PathBuf {
     data_dir_path.join("indexer-split-cache").join("splits")
 }
 
-/// Get the total size of the disk containing the given directory, or `None` if
-/// it couldn't be determined.
-pub fn get_disk_size(dir_path: &Path) -> Option<ByteSize> {
+/// Information about the disk containing a directory.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiskInfo {
+    /// Name reported by the operating system for the backing device.
+    pub device_name: String,
+    /// Canonical mount point of the backing device.
+    pub mount_point: PathBuf,
+    /// Total capacity of the backing device.
+    pub total_space: ByteSize,
+}
+
+/// Returns information about the disk containing the given directory, or `None` if it couldn't be
+/// determined.
+pub fn get_disk_info(dir_path: &Path) -> Option<DiskInfo> {
     let disks = sysinfo::Disks::new_with_refreshed_list_specifics(
         DiskRefreshKind::nothing().with_storage(),
     );
@@ -65,7 +76,11 @@ pub fn get_disk_size(dir_path: &Path) -> Option<ByteSize> {
             return None;
         }
     }
-    best_match.map(|(disk, _)| ByteSize::b(disk.total_space()))
+    best_match.map(|(disk, mount_point)| DiskInfo {
+        device_name: disk.name().to_string_lossy().into_owned(),
+        mount_point,
+        total_space: ByteSize::b(disk.total_space()),
+    })
 }
 
 #[cfg(test)]

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -915,9 +915,8 @@ impl NodeConfig {
     }
 
     /// Parses and validates a [`NodeConfig`], applying `service_override` before validation so
-    /// service-dependent validation (e.g. the disk-usage check) uses the actual runtime service
-    /// set rather than the pre-override default (e.g. when `--service searcher` is passed via the
-    /// CLI).
+    /// service-dependent validation uses the actual runtime service set rather than the
+    /// pre-override default (e.g. when `--service searcher` is passed via the CLI).
     pub async fn load_with_service_override(
         config_format: ConfigFormat,
         config_content: &[u8],

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -911,8 +911,22 @@ impl NodeConfig {
 
     /// Parses and validates a [`NodeConfig`] from a given URI and config content.
     pub async fn load(config_format: ConfigFormat, config_content: &[u8]) -> anyhow::Result<Self> {
+        Self::load_with_service_override(config_format, config_content, None).await
+    }
+
+    /// Parses and validates a [`NodeConfig`], applying `service_override` before validation so
+    /// service-dependent validation (e.g. the disk-usage check) uses the actual runtime service
+    /// set rather than the pre-override default (e.g. when `--service searcher` is passed via the
+    /// CLI).
+    pub async fn load_with_service_override(
+        config_format: ConfigFormat,
+        config_content: &[u8],
+        service_override: Option<&HashSet<QuickwitService>>,
+    ) -> anyhow::Result<Self> {
         let env_vars = env::vars().collect::<HashMap<_, _>>();
-        let config = load_node_config_with_env(config_format, config_content, &env_vars).await?;
+        let config =
+            load_node_config_with_env(config_format, config_content, service_override, &env_vars)
+                .await?;
         if !config.data_dir_path.try_exists()? {
             bail!(
                 "data dir `{}` does not exist",

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -1597,4 +1597,29 @@ mod tests {
         assert_eq!(config.enabled_services, services_override);
         std::fs::remove_dir_all(data_dir).unwrap();
     }
+
+    #[tokio::test]
+    async fn test_service_override_takes_precedence_over_env() {
+        let config_yaml = r#"
+            version: 0.8
+            enabled_services:
+              - indexer
+        "#;
+        let env_vars = HashMap::from([(
+            "QW_ENABLED_SERVICES".to_string(),
+            "not-a-service".to_string(),
+        )]);
+        let services_override = HashSet::from([QuickwitService::Searcher]);
+
+        let config = load_node_config_with_env(
+            ConfigFormat::Yaml,
+            config_yaml.as_bytes(),
+            Some(&services_override),
+            &env_vars,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(config.enabled_services, services_override);
+    }
 }

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -18,9 +18,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context, bail, ensure};
-use bytesize::ByteSize;
 use http::HeaderMap;
-use quickwit_common::fs::get_disk_size;
 use quickwit_common::net::{Host, find_private_ip, get_short_hostname};
 use quickwit_common::new_coolid;
 use quickwit_common::uri::Uri;
@@ -394,59 +392,7 @@ fn validate(node_config: &NodeConfig) -> anyhow::Result<()> {
              merge pipeline, the compactor service must not be enabled."
         );
     }
-    validate_disk_usage(node_config);
     Ok(())
-}
-
-/// A list of all the known disk budgets
-///
-/// External disk usage and unbounded disk usages, e.g the indexing workbench
-/// (indexing/) and the delete task workbench (delete_task_service/) are not included.
-#[derive(Default, Debug)]
-struct ExpectedDiskUsage {
-    // indexer / ingester
-    split_store_max_num_bytes: Option<ByteSize>,
-    max_queue_disk_usage: Option<ByteSize>,
-    // searcher
-    split_cache: Option<ByteSize>,
-}
-
-impl ExpectedDiskUsage {
-    fn from_config(node_config: &NodeConfig) -> Self {
-        let mut expected = Self::default();
-        if node_config.is_service_enabled(QuickwitService::Indexer) {
-            expected.max_queue_disk_usage =
-                Some(node_config.ingest_api_config.max_queue_disk_usage);
-            expected.split_store_max_num_bytes =
-                Some(node_config.indexer_config.split_store_max_num_bytes);
-        }
-        if node_config.is_service_enabled(QuickwitService::Searcher) {
-            expected.split_cache = node_config
-                .searcher_config
-                .split_cache
-                .map(|limits| limits.max_num_bytes);
-        }
-        expected
-    }
-
-    fn total(&self) -> ByteSize {
-        self.split_store_max_num_bytes.unwrap_or_default()
-            + self.max_queue_disk_usage.unwrap_or_default()
-            + self.split_cache.unwrap_or_default()
-    }
-}
-
-fn validate_disk_usage(node_config: &NodeConfig) {
-    if let Some(volume_size) = get_disk_size(&node_config.data_dir_path) {
-        let expected_disk_usage = ExpectedDiskUsage::from_config(node_config);
-        if expected_disk_usage.total() > volume_size {
-            warn!(
-                ?volume_size,
-                ?expected_disk_usage,
-                "data dir volume too small"
-            );
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1626,9 +1572,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_service_override_applied_before_validation() {
-        // A searcher started with `--service searcher` must not warn about indexer split-store or
-        // ingest queue disk budgets. The service override has to be applied before validation so
-        // the disk-usage check runs against the real runtime service set, not the default set.
+        // The config's compactor service is invalid without `enable_standalone_compactors`. A CLI
+        // searcher override must replace it before service-dependent validation runs.
         let data_dir = env::temp_dir().join(new_coolid("node-config"));
         std::fs::create_dir_all(&data_dir).unwrap();
         let config_yaml = format!(
@@ -1636,12 +1581,7 @@ mod tests {
             version: 0.8
             data_dir: "{}"
             enabled_services:
-              - indexer
-              - searcher
-            indexer:
-              split_store_max_num_bytes: 100GiB
-            ingest_api:
-              max_queue_disk_usage: 24GiB
+              - compactor
         "#,
             data_dir.display()
         );
@@ -1655,11 +1595,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.enabled_services, services_override);
-
-        // With only the searcher enabled and no split_cache configured, the expected disk usage
-        // must be zero: no indexer/ingest budgets are counted.
-        let expected_disk_usage = ExpectedDiskUsage::from_config(&config);
-        assert_eq!(expected_disk_usage.total(), ByteSize::default());
         std::fs::remove_dir_all(data_dir).unwrap();
     }
 }

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -142,13 +142,16 @@ fn default_index_root_uri(data_dir_uri: &Uri) -> Uri {
 pub async fn load_node_config_with_env(
     config_format: ConfigFormat,
     config_content: &[u8],
+    service_override: Option<&HashSet<QuickwitService>>,
     env_vars: &HashMap<String, String>,
 ) -> anyhow::Result<NodeConfig> {
     let rendered_config_content = render_config(config_content)?;
     let versioned_node_config: VersionedNodeConfig =
         config_format.parse(rendered_config_content.as_bytes())?;
     let node_config_builder: NodeConfigBuilder = versioned_node_config.into();
-    let config = node_config_builder.build_and_validate(env_vars).await?;
+    let config = node_config_builder
+        .build_and_validate(service_override, env_vars)
+        .await?;
     Ok(config)
 }
 
@@ -233,6 +236,7 @@ struct NodeConfigBuilder {
 impl NodeConfigBuilder {
     pub async fn build_and_validate(
         mut self,
+        service_override: Option<&HashSet<QuickwitService>>,
         env_vars: &HashMap<String, String>,
     ) -> anyhow::Result<NodeConfig> {
         let node_id = self
@@ -243,13 +247,24 @@ impl NodeConfigBuilder {
 
         let enable_standalone_compactors = self.enable_standalone_compactors.resolve(env_vars)?;
 
-        let enabled_services: HashSet<QuickwitService> = self
-            .enabled_services
-            .resolve(env_vars)?
-            .0
-            .into_iter()
-            .map(|service| service.parse())
-            .collect::<Result<_, _>>()?;
+        // A service override (e.g. the CLI `--service` flag) takes precedence over the config file
+        // and env vars, so that service-dependent validation runs against the real runtime set.
+        //
+        // It is applied here, on the resolved service set, rather than on the builder's
+        // `enabled_services` field. That field goes through `ConfigValue::resolve`, where a
+        // `QW_ENABLED_SERVICES` env var wins over the field value, so setting the field could let
+        // the env var silently override the CLI `--service` flag. Overriding the resolved set
+        // keeps the CLI flag authoritative.
+        let enabled_services: HashSet<QuickwitService> = if let Some(services) = service_override {
+            services.clone()
+        } else {
+            self.enabled_services
+                .resolve(env_vars)?
+                .0
+                .into_iter()
+                .map(|service| service.parse())
+                .collect::<Result<_, _>>()?
+        };
 
         let listen_address = self.listen_address.resolve(env_vars)?;
         let listen_host = listen_address.parse::<Host>()?;
@@ -642,7 +657,8 @@ mod tests {
             get_config_filepath(&format!("quickwit.{config_format:?}").to_lowercase());
         let file = std::fs::read_to_string(&config_filepath).unwrap();
         let env_vars = HashMap::default();
-        let config = load_node_config_with_env(config_format, file.as_bytes(), &env_vars).await?;
+        let config =
+            load_node_config_with_env(config_format, file.as_bytes(), None, &env_vars).await?;
         assert_eq!(config.cluster_id, "quickwit-cluster");
         assert_eq!(config.enabled_services.len(), 2);
 
@@ -872,6 +888,7 @@ mod tests {
         let parsing_error = super::load_node_config_with_env(
             ConfigFormat::Yaml,
             config_str.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -888,6 +905,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -970,7 +988,7 @@ mod tests {
             "s3://quickwit-indexes/prod".to_string(),
         );
         let config =
-            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), &env_vars)
+            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), None, &env_vars)
                 .await
                 .unwrap();
         assert_eq!(config.cluster_id, "test-cluster");
@@ -1040,6 +1058,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1062,6 +1081,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1087,7 +1107,7 @@ mod tests {
             "QW_DATA_DIR".to_string(),
             data_dir_path.to_string_lossy().to_string(),
         );
-        load_node_config_with_env(ConfigFormat::Toml, file_content.as_bytes(), &env_vars)
+        load_node_config_with_env(ConfigFormat::Toml, file_content.as_bytes(), None, &env_vars)
             .await
             .unwrap();
     }
@@ -1104,7 +1124,7 @@ mod tests {
             ])),
             ..Default::default()
         }
-        .build_and_validate(&HashMap::new())
+        .build_and_validate(None, &HashMap::new())
         .await
         .unwrap_err();
         assert!(
@@ -1129,7 +1149,7 @@ mod tests {
             enable_standalone_compactors: ConfigValue::for_test(true),
             ..Default::default()
         }
-        .build_and_validate(&HashMap::new())
+        .build_and_validate(None, &HashMap::new())
         .await
         .unwrap();
         assert!(node_config.is_service_enabled(QuickwitService::Compactor));
@@ -1141,7 +1161,7 @@ mod tests {
             let node_config = NodeConfigBuilder {
                 ..Default::default()
             }
-            .build_and_validate(&HashMap::new())
+            .build_and_validate(None, &HashMap::new())
             .await
             .unwrap();
             assert!(node_config.peer_seed_addrs().await.unwrap().is_empty());
@@ -1161,7 +1181,7 @@ mod tests {
                 ])),
                 ..Default::default()
             }
-            .build_and_validate(&HashMap::new())
+            .build_and_validate(None, &HashMap::new())
             .await
             .unwrap();
             assert_eq!(
@@ -1184,7 +1204,7 @@ mod tests {
                 listen_address: default_listen_address(),
                 ..Default::default()
             }
-            .build_and_validate(&HashMap::new())
+            .build_and_validate(None, &HashMap::new())
             .await
             .unwrap();
             assert_eq!(
@@ -1203,7 +1223,7 @@ mod tests {
                 },
                 ..Default::default()
             }
-            .build_and_validate(&HashMap::new())
+            .build_and_validate(None, &HashMap::new())
             .await
             .unwrap();
             assert_eq!(
@@ -1224,7 +1244,7 @@ mod tests {
                 },
                 ..Default::default()
             }
-            .build_and_validate(&HashMap::new())
+            .build_and_validate(None, &HashMap::new())
             .await
             .unwrap();
             assert_eq!(
@@ -1248,7 +1268,7 @@ mod tests {
             },
             ..Default::default()
         }
-        .build_and_validate(&HashMap::new())
+        .build_and_validate(None, &HashMap::new())
         .await
         .unwrap();
         assert_eq!(
@@ -1281,6 +1301,7 @@ mod tests {
                 load_node_config_with_env(
                     ConfigFormat::Yaml,
                     config_yaml.as_bytes(),
+                    None,
                     &Default::default()
                 )
                 .await
@@ -1298,6 +1319,7 @@ mod tests {
                 load_node_config_with_env(
                     ConfigFormat::Yaml,
                     config_yaml.as_bytes(),
+                    None,
                     &Default::default()
                 )
                 .await
@@ -1316,6 +1338,7 @@ mod tests {
             let config = load_node_config_with_env(
                 ConfigFormat::Yaml,
                 config_yaml.as_bytes(),
+                None,
                 &HashMap::default(),
             )
             .await
@@ -1330,6 +1353,7 @@ mod tests {
             let config = load_node_config_with_env(
                 ConfigFormat::Yaml,
                 config_yaml.as_bytes(),
+                None,
                 &HashMap::default(),
             )
             .await
@@ -1344,6 +1368,7 @@ mod tests {
             let error = load_node_config_with_env(
                 ConfigFormat::Yaml,
                 config_yaml.as_bytes(),
+                None,
                 &HashMap::default(),
             )
             .await
@@ -1363,6 +1388,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             config_yaml.as_bytes(),
+            None,
             &HashMap::default(),
         )
         .await
@@ -1399,6 +1425,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             rest_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1417,6 +1444,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             rest_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1434,6 +1462,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             rest_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1455,6 +1484,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             rest_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1474,6 +1504,7 @@ mod tests {
         let config = load_node_config_with_env(
             ConfigFormat::Yaml,
             rest_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1494,6 +1525,7 @@ mod tests {
         load_node_config_with_env(
             ConfigFormat::Yaml,
             rest_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1508,6 +1540,7 @@ mod tests {
         load_node_config_with_env(
             ConfigFormat::Yaml,
             rest_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1538,6 +1571,7 @@ mod tests {
         let error_message = load_node_config_with_env(
             ConfigFormat::Yaml,
             node_config_yaml.as_bytes(),
+            None,
             &Default::default(),
         )
         .await
@@ -1557,7 +1591,7 @@ mod tests {
             "true".to_string(),
         )]);
         let config =
-            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), &env_vars)
+            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), None, &env_vars)
                 .await
                 .unwrap();
         assert!(config.enabled_services.contains(&QuickwitService::Indexer));
@@ -1579,7 +1613,7 @@ mod tests {
             enabled_services: [indexer]
         "#;
         let config =
-            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), &env_vars)
+            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), None, &env_vars)
                 .await
                 .unwrap();
         assert!(config.enabled_services.contains(&QuickwitService::Indexer));
@@ -1588,5 +1622,44 @@ mod tests {
                 .enabled_services
                 .contains(&QuickwitService::Compactor)
         );
+    }
+
+    #[tokio::test]
+    async fn test_service_override_applied_before_validation() {
+        // A searcher started with `--service searcher` must not warn about indexer split-store or
+        // ingest queue disk budgets. The service override has to be applied before validation so
+        // the disk-usage check runs against the real runtime service set, not the default set.
+        let data_dir = env::temp_dir().join(new_coolid("node-config"));
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let config_yaml = format!(
+            r#"
+            version: 0.8
+            data_dir: "{}"
+            enabled_services:
+              - indexer
+              - searcher
+            indexer:
+              split_store_max_num_bytes: 100GiB
+            ingest_api:
+              max_queue_disk_usage: 24GiB
+        "#,
+            data_dir.display()
+        );
+        let services_override = HashSet::from([QuickwitService::Searcher]);
+        let config = NodeConfig::load_with_service_override(
+            ConfigFormat::Yaml,
+            config_yaml.as_bytes(),
+            Some(&services_override),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(config.enabled_services, services_override);
+
+        // With only the searcher enabled and no split_cache configured, the expected disk usage
+        // must be zero: no indexer/ingest budgets are counted.
+        let expected_disk_usage = ExpectedDiskUsage::from_config(&config);
+        assert_eq!(expected_disk_usage.total(), ByteSize::default());
+        std::fs::remove_dir_all(data_dir).unwrap();
     }
 }

--- a/quickwit/quickwit-serve/src/disk_usage.rs
+++ b/quickwit/quickwit-serve/src/disk_usage.rs
@@ -1,0 +1,110 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytesize::ByteSize;
+use quickwit_common::fs::get_disk_info;
+use quickwit_config::NodeConfig;
+use quickwit_config::service::QuickwitService;
+use tracing::warn;
+
+/// A list of all the known disk budgets.
+///
+/// External and unbounded disk usage, e.g. the indexing workbench (`indexing/`) and the delete
+/// task workbench (`delete_task_service/`), are not included.
+#[derive(Default, Debug, Eq, PartialEq)]
+struct ExpectedDiskUsage {
+    // indexer / ingester
+    split_store_max_num_bytes: Option<ByteSize>,
+    max_queue_disk_usage: Option<ByteSize>,
+    // searcher
+    split_cache: Option<ByteSize>,
+}
+
+impl ExpectedDiskUsage {
+    fn from_config(node_config: &NodeConfig) -> Self {
+        let mut expected = Self::default();
+        if node_config.is_service_enabled(QuickwitService::Indexer) {
+            expected.max_queue_disk_usage =
+                Some(node_config.ingest_api_config.max_queue_disk_usage);
+            expected.split_store_max_num_bytes =
+                Some(node_config.indexer_config.split_store_max_num_bytes);
+        }
+        if node_config.is_service_enabled(QuickwitService::Searcher) {
+            expected.split_cache = node_config
+                .searcher_config
+                .split_cache
+                .map(|limits| limits.max_num_bytes);
+        }
+        expected
+    }
+
+    fn total(&self) -> ByteSize {
+        self.split_store_max_num_bytes.unwrap_or_default()
+            + self.max_queue_disk_usage.unwrap_or_default()
+            + self.split_cache.unwrap_or_default()
+    }
+}
+
+pub(super) fn check_data_dir_disk_usage(node_config: &NodeConfig) {
+    let Some(disk_info) = get_disk_info(&node_config.data_dir_path) else {
+        return;
+    };
+    let expected_disk_usage = ExpectedDiskUsage::from_config(node_config);
+    if expected_disk_usage.total() > disk_info.total_space {
+        warn!(
+            data_dir = %node_config.data_dir_path.display(),
+            device = %disk_info.device_name,
+            mount_point = %disk_info.mount_point.display(),
+            volume_size = ?disk_info.total_space,
+            ?expected_disk_usage,
+            "data dir volume too small"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn test_searcher_without_split_cache_has_no_expected_disk_usage() {
+        let mut node_config = NodeConfig::for_test();
+        node_config.enabled_services = HashSet::from([QuickwitService::Searcher]);
+        node_config.searcher_config.split_cache = None;
+
+        let expected_disk_usage = ExpectedDiskUsage::from_config(&node_config);
+
+        assert_eq!(expected_disk_usage, ExpectedDiskUsage::default());
+    }
+
+    #[test]
+    fn test_expected_disk_usage_aggregates_enabled_service_budgets() {
+        let mut node_config = NodeConfig::for_test();
+        node_config.enabled_services =
+            HashSet::from([QuickwitService::Indexer, QuickwitService::Searcher]);
+
+        let expected_disk_usage = ExpectedDiskUsage::from_config(&node_config);
+        let expected_total = node_config.indexer_config.split_store_max_num_bytes
+            + node_config.ingest_api_config.max_queue_disk_usage
+            + node_config
+                .searcher_config
+                .split_cache
+                .map(|limits| limits.max_num_bytes)
+                .unwrap_or_default();
+
+        assert_eq!(expected_disk_usage.total(), expected_total);
+    }
+}

--- a/quickwit/quickwit-serve/src/disk_usage.rs
+++ b/quickwit/quickwit-serve/src/disk_usage.rs
@@ -22,6 +22,9 @@ use tracing::warn;
 ///
 /// External and unbounded disk usage, e.g. the indexing workbench (`indexing/`) and the delete
 /// task workbench (`delete_task_service/`), are not included.
+///
+/// The budgets are aggregated because enabled services share the data-dir volume. Checking each
+/// service independently could miss a combined overcommit even when every individual budget fits.
 #[derive(Default, Debug, Eq, PartialEq)]
 struct ExpectedDiskUsage {
     // indexer / ingester

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -21,6 +21,7 @@ mod datafusion_api;
 mod decompression;
 mod delete_task_api;
 mod developer_api;
+mod disk_usage;
 mod elasticsearch_api;
 mod format;
 mod grpc;
@@ -564,6 +565,8 @@ pub async fn serve_quickwit(
     shutdown_signal: BoxFutureInfaillible<()>,
     env_filter_reload_fn: EnvFilterReloadFn,
 ) -> anyhow::Result<HashMap<String, ActorExitStatus>> {
+    disk_usage::check_data_dir_disk_usage(&node_config);
+
     let cluster = start_cluster_service(&node_config)
         .await
         .context("failed to start cluster service")?;


### PR DESCRIPTION
A searcher node started with `--service searcher` could log a misleading "data dir volume too small" warning at startup, comparing its volume against the indexer split-store and ingest queue disk budgets. A searcher does not use those budgets, so the warning was wrong and misleading.

There were two related design issues:

1. the CLI `--service` override was applied after `load_node_config()` had already run service-dependent validation;
2. the disk-capacity check lived in config validation even though it inspects runtime host state.

### What changed

- thread the typed service override from the CLI through node-config loading;
- apply it to the resolved service set before validation, keeping the effective services in `NodeConfig`;
- keep CLI precedence over both `QW_ENABLED_SERVICES` and the config file, matching the previous post-load behavior;
- move the disk-capacity warning from `quickwit-config` to `quickwit-serve` startup;
- measure the data directory's backing disk once and compare it with the aggregate budgets of the effective enabled services;
- include `data_dir`, backing `device`, canonical `mount_point`, and `volume_size` in the warning;
- leave config loading unchanged when no CLI override is supplied;
- cover both CLI-to-config forwarding and CLI precedence over an invalid
  `QW_ENABLED_SERVICES` value with dedicated regression tests.

The budgets remain aggregated because all enabled services share the data-dir volume: budgets that fit individually can still exceed the disk together. A searcher without a configured split cache has zero expected disk usage and does not warn.

### Integration-test follow-up

Applying overrides before validation exposed an invalid setup in the CLI integration-test helper. It passed `QuickwitService::supported_services()`, which includes the standalone `compactor`, while its config left `enable_standalone_compactors` disabled. That only appeared to work previously because the override was applied after validation.

The helper now uses the normal default all-in-one service set, which intentionally excludes the standalone compactor. A code comment documents why `supported_services()` must not be used there.

### How was this PR tested?

- `cargo test -p quickwit-common fs`
- `cargo test -p quickwit-config` (104 passed)
- `cargo test -p quickwit-cli test_run_command_forwards_service_override_before_validation`
- `cargo test -p quickwit-serve disk_usage` (2 passed)
- `cargo test -p quickwit-cli --test cli --features=metrics -- --test-threads=1` (18 passed, 1 ignored)
- `cargo clippy -p quickwit-common -p quickwit-config -p quickwit-serve -p quickwit-cli --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `bash scripts/check_log_format.sh`
- `git diff --check`
