### PR TITLE
fix(control-plane): Avoid spawning a new control plan loop on every single actor restart.

### DIFF
--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -65,11 +65,6 @@ impl Stream for ClusterChangeStream {
     }
 }
 
-/// A factory for creating cluster change streams.
-pub trait ClusterChangeStreamFactory: Clone + Send + 'static {
-    fn create(&self) -> ClusterChangeStream;
-}
-
 /// Compares the digests of the previous and new set of lives nodes, identifies the changes that
 /// occurred in the cluster, and emits the corresponding events, focusing on ready nodes only.
 pub(crate) async fn compute_cluster_change_events(
@@ -332,8 +327,6 @@ async fn try_new_node(
 
 #[cfg(any(test, feature = "testsuite"))]
 pub mod for_test {
-    use std::sync::{Arc, Mutex};
-
     use quickwit_config::GrpcConfig;
     use tokio::sync::mpsc;
 
@@ -345,22 +338,18 @@ pub mod for_test {
             .expect("plaintext channel factory should build")
     }
 
-    #[derive(Clone, Default)]
-    pub struct ClusterChangeStreamFactoryForTest {
-        inner: Arc<Mutex<Option<mpsc::UnboundedSender<ClusterChange>>>>,
+    pub struct ClusterChangeStreamForTest {
+        pub cluster_change_rx: ClusterChangeStream,
+        pub cluster_change_tx: mpsc::UnboundedSender<ClusterChange>,
     }
 
-    impl ClusterChangeStreamFactoryForTest {
-        pub fn change_stream_tx(&self) -> mpsc::UnboundedSender<ClusterChange> {
-            self.inner.lock().unwrap().take().unwrap()
-        }
-    }
-
-    impl ClusterChangeStreamFactory for ClusterChangeStreamFactoryForTest {
-        fn create(&self) -> ClusterChangeStream {
-            let (change_stream, change_stream_tx) = ClusterChangeStream::new_unbounded();
-            *self.inner.lock().unwrap() = Some(change_stream_tx);
-            change_stream
+    impl Default for ClusterChangeStreamForTest {
+        fn default() -> Self {
+            let (cluster_change_rx, cluster_change_tx) = ClusterChangeStream::new_unbounded();
+            Self {
+                cluster_change_rx,
+                cluster_change_tx,
+            }
         }
     }
 }

--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -328,7 +328,6 @@ async fn try_new_node(
 #[cfg(any(test, feature = "testsuite"))]
 pub mod for_test {
     use quickwit_config::GrpcConfig;
-    use tokio::sync::mpsc;
 
     use super::*;
 
@@ -336,21 +335,6 @@ pub mod for_test {
     pub fn channel_factory_for_test() -> ChannelFactory {
         ChannelFactory::for_grpc(&GrpcConfig::default())
             .expect("plaintext channel factory should build")
-    }
-
-    pub struct ClusterChangeStreamForTest {
-        pub cluster_change_rx: ClusterChangeStream,
-        pub cluster_change_tx: mpsc::UnboundedSender<ClusterChange>,
-    }
-
-    impl Default for ClusterChangeStreamForTest {
-        fn default() -> Self {
-            let (cluster_change_rx, cluster_change_tx) = ClusterChangeStream::new_unbounded();
-            Self {
-                cluster_change_rx,
-                cluster_change_tx,
-            }
-        }
     }
 }
 

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -37,7 +37,7 @@ use tokio::time::timeout;
 use tokio_stream::StreamExt;
 use tracing::{info, warn};
 
-use crate::change::{ClusterChange, ClusterChangeStreamFactory, compute_cluster_change_events};
+use crate::change::{ClusterChange, compute_cluster_change_events};
 use crate::grpc_gossip::spawn_catchup_callback_task;
 use crate::member::{
     AVAILABILITY_ZONE_KEY, ClusterMember, ENABLED_SERVICES_KEY, GRPC_ADVERTISE_ADDR_KEY,
@@ -513,12 +513,6 @@ impl Cluster {
             .await
             .chitchat_handle
             .termination_watcher()
-    }
-}
-
-impl ClusterChangeStreamFactory for Cluster {
-    fn create(&self) -> ClusterChangeStream {
-        self.change_stream()
     }
 }
 

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -40,7 +40,7 @@ use time::OffsetDateTime;
 
 #[cfg(any(test, feature = "testsuite"))]
 pub use crate::change::for_test::*;
-pub use crate::change::{ClusterChange, ClusterChangeStream, ClusterChangeStreamFactory};
+pub use crate::change::{ClusterChange, ClusterChangeStream};
 pub use crate::cluster::{Cluster, ClusterSnapshot, NodeIdSchema};
 #[cfg(any(test, feature = "testsuite"))]
 pub use crate::cluster::{

--- a/quickwit/quickwit-common/src/tower/pool.rs
+++ b/quickwit/quickwit-common/src/tower/pool.rs
@@ -21,7 +21,6 @@ use std::hash::Hash;
 use std::sync::{Arc, RwLock};
 
 use futures::{Stream, StreamExt};
-use tokio::sync::watch;
 
 use super::Change;
 
@@ -29,10 +28,6 @@ use super::Change;
 /// `add/remove` methods or by listening to a stream of changes.
 pub struct Pool<K, V> {
     pool: Arc<RwLock<HashMap<K, V>>>,
-    /// Publishes a notification after each mutation.
-    changes_tx: watch::Sender<()>,
-    /// Receives pool change notifications.
-    pub changes_rx: watch::Receiver<()>,
 }
 
 impl<K, V> fmt::Debug for Pool<K, V>
@@ -49,8 +44,6 @@ impl<K, V> Clone for Pool<K, V> {
     fn clone(&self) -> Self {
         Self {
             pool: self.pool.clone(),
-            changes_tx: self.changes_tx.clone(),
-            changes_rx: self.changes_rx.clone(),
         }
     }
 }
@@ -59,11 +52,8 @@ impl<K, V> Default for Pool<K, V>
 where K: Eq + PartialEq + Hash
 {
     fn default() -> Self {
-        let (changes_tx, changes_rx) = watch::channel(());
         Self {
             pool: Arc::new(RwLock::new(HashMap::default())),
-            changes_tx,
-            changes_rx,
         }
     }
 }
@@ -94,10 +84,6 @@ where
                 .await;
         };
         tokio::spawn(future);
-    }
-
-    fn notify_change(&self) {
-        self.changes_tx.send_replace(());
     }
 
     /// Returns whether the pool is empty.
@@ -194,19 +180,14 @@ where
             .write()
             .expect("lock should not be poisoned")
             .insert(key, service);
-        self.notify_change();
     }
 
     /// Removes a value from the pool.
     fn remove(&self, key: &K) {
-        let removed = self
-            .pool
+        self.pool
             .write()
             .expect("lock should not be poisoned")
             .remove(key);
-        if removed.is_some() {
-            self.notify_change();
-        }
     }
 }
 
@@ -215,11 +196,8 @@ where K: Eq + PartialEq + Hash
 {
     fn from_iter<I>(iter: I) -> Self
     where I: IntoIterator<Item = (K, V)> {
-        let (changes_tx, changes_rx) = watch::channel(());
         Self {
             pool: Arc::new(RwLock::new(HashMap::from_iter(iter))),
-            changes_tx,
-            changes_rx,
         }
     }
 }
@@ -231,26 +209,6 @@ mod tests {
     use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
-
-    #[tokio::test]
-    async fn test_pool_change_notifications() {
-        let pool = Pool::default();
-        let mut changes_rx = pool.changes_rx.clone();
-
-        pool.insert(1, 11);
-        changes_rx.changed().await.unwrap();
-        assert_eq!(pool.get(&1), Some(11));
-
-        pool.insert(1, 12);
-        changes_rx.changed().await.unwrap();
-        assert_eq!(pool.get(&1), Some(12));
-
-        pool.remove(&2);
-
-        pool.remove(&1);
-        changes_rx.changed().await.unwrap();
-        assert!(!pool.contains_key(&1));
-    }
 
     #[tokio::test]
     async fn test_pool() {

--- a/quickwit/quickwit-common/src/tower/pool.rs
+++ b/quickwit/quickwit-common/src/tower/pool.rs
@@ -30,7 +30,7 @@ use super::Change;
 pub struct Pool<K, V> {
     pool: Arc<RwLock<HashMap<K, V>>>,
     /// Publishes a notification after each mutation.
-    pub changes_tx: watch::Sender<()>,
+    changes_tx: watch::Sender<()>,
     /// Receives pool change notifications.
     pub changes_rx: watch::Receiver<()>,
 }
@@ -40,7 +40,7 @@ where
     K: 'static,
     V: 'static,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Pool<{:?}, {:?}>", TypeId::of::<K>(), TypeId::of::<V>())
     }
 }

--- a/quickwit/quickwit-common/src/tower/pool.rs
+++ b/quickwit/quickwit-common/src/tower/pool.rs
@@ -21,6 +21,7 @@ use std::hash::Hash;
 use std::sync::{Arc, RwLock};
 
 use futures::{Stream, StreamExt};
+use tokio::sync::watch;
 
 use super::Change;
 
@@ -28,6 +29,10 @@ use super::Change;
 /// `add/remove` methods or by listening to a stream of changes.
 pub struct Pool<K, V> {
     pool: Arc<RwLock<HashMap<K, V>>>,
+    /// Publishes the pool generation after each mutation.
+    pub generation_tx: watch::Sender<u64>,
+    /// Receives pool generation changes.
+    pub generation_rx: watch::Receiver<u64>,
 }
 
 impl<K, V> fmt::Debug for Pool<K, V>
@@ -44,6 +49,8 @@ impl<K, V> Clone for Pool<K, V> {
     fn clone(&self) -> Self {
         Self {
             pool: self.pool.clone(),
+            generation_tx: self.generation_tx.clone(),
+            generation_rx: self.generation_rx.clone(),
         }
     }
 }
@@ -52,8 +59,11 @@ impl<K, V> Default for Pool<K, V>
 where K: Eq + PartialEq + Hash
 {
     fn default() -> Self {
+        let (generation_tx, generation_rx) = watch::channel(1);
         Self {
             pool: Arc::new(RwLock::new(HashMap::default())),
+            generation_tx,
+            generation_rx,
         }
     }
 }
@@ -84,6 +94,19 @@ where
                 .await;
         };
         tokio::spawn(future);
+    }
+
+    /// Returns the current pool generation.
+    pub fn generation(&self) -> u64 {
+        *self.generation_rx.borrow()
+    }
+
+    fn increment_generation(&self) {
+        self.generation_tx.send_modify(|generation| {
+            *generation = generation
+                .checked_add(1)
+                .expect("pool generation should not overflow")
+        });
     }
 
     /// Returns whether the pool is empty.
@@ -165,12 +188,12 @@ where
     }
 
     /// Finds a key in the pool that satisfies the given predicate.
-    pub fn find(&self, func: impl Fn(&K, &V) -> bool) -> Option<(K, V)> {
+    pub fn find(&self, predicate_fn: impl Fn(&K, &V) -> bool) -> Option<(K, V)> {
         self.pool
             .read()
             .expect("lock should not be poisoned")
             .iter()
-            .find(|(key, value)| func(key, value))
+            .find(|(key, value)| predicate_fn(key, value))
             .map(|(key, value)| (key.clone(), value.clone()))
     }
 
@@ -180,14 +203,19 @@ where
             .write()
             .expect("lock should not be poisoned")
             .insert(key, service);
+        self.increment_generation();
     }
 
     /// Removes a value from the pool.
     fn remove(&self, key: &K) {
-        self.pool
+        let removed = self
+            .pool
             .write()
             .expect("lock should not be poisoned")
             .remove(key);
+        if removed.is_some() {
+            self.increment_generation();
+        }
     }
 }
 
@@ -196,8 +224,11 @@ where K: Eq + PartialEq + Hash
 {
     fn from_iter<I>(iter: I) -> Self
     where I: IntoIterator<Item = (K, V)> {
+        let (generation_tx, generation_rx) = watch::channel(0);
         Self {
             pool: Arc::new(RwLock::new(HashMap::from_iter(iter))),
+            generation_tx,
+            generation_rx,
         }
     }
 }
@@ -209,6 +240,32 @@ mod tests {
     use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
+
+    #[tokio::test]
+    async fn test_pool_generation() {
+        let pool = Pool::default();
+        let mut generation_rx = pool.generation_rx.clone();
+
+        assert_eq!(pool.generation(), 1);
+
+        pool.insert(1, 11);
+        generation_rx.changed().await.unwrap();
+        assert_eq!(*generation_rx.borrow_and_update(), 2);
+        assert_eq!(pool.get(&1), Some(11));
+
+        pool.insert(1, 12);
+        generation_rx.changed().await.unwrap();
+        assert_eq!(*generation_rx.borrow_and_update(), 3);
+        assert_eq!(pool.get(&1), Some(12));
+
+        pool.remove(&2);
+        assert_eq!(pool.generation(), 3);
+
+        pool.remove(&1);
+        generation_rx.changed().await.unwrap();
+        assert_eq!(*generation_rx.borrow_and_update(), 4);
+        assert!(!pool.contains_key(&1));
+    }
 
     #[tokio::test]
     async fn test_pool() {

--- a/quickwit/quickwit-common/src/tower/pool.rs
+++ b/quickwit/quickwit-common/src/tower/pool.rs
@@ -29,10 +29,10 @@ use super::Change;
 /// `add/remove` methods or by listening to a stream of changes.
 pub struct Pool<K, V> {
     pool: Arc<RwLock<HashMap<K, V>>>,
-    /// Publishes the pool generation after each mutation.
-    pub generation_tx: watch::Sender<u64>,
-    /// Receives pool generation changes.
-    pub generation_rx: watch::Receiver<u64>,
+    /// Publishes a notification after each mutation.
+    pub changes_tx: watch::Sender<()>,
+    /// Receives pool change notifications.
+    pub changes_rx: watch::Receiver<()>,
 }
 
 impl<K, V> fmt::Debug for Pool<K, V>
@@ -49,8 +49,8 @@ impl<K, V> Clone for Pool<K, V> {
     fn clone(&self) -> Self {
         Self {
             pool: self.pool.clone(),
-            generation_tx: self.generation_tx.clone(),
-            generation_rx: self.generation_rx.clone(),
+            changes_tx: self.changes_tx.clone(),
+            changes_rx: self.changes_rx.clone(),
         }
     }
 }
@@ -59,11 +59,11 @@ impl<K, V> Default for Pool<K, V>
 where K: Eq + PartialEq + Hash
 {
     fn default() -> Self {
-        let (generation_tx, generation_rx) = watch::channel(1);
+        let (changes_tx, changes_rx) = watch::channel(());
         Self {
             pool: Arc::new(RwLock::new(HashMap::default())),
-            generation_tx,
-            generation_rx,
+            changes_tx,
+            changes_rx,
         }
     }
 }
@@ -96,17 +96,8 @@ where
         tokio::spawn(future);
     }
 
-    /// Returns the current pool generation.
-    pub fn generation(&self) -> u64 {
-        *self.generation_rx.borrow()
-    }
-
-    fn increment_generation(&self) {
-        self.generation_tx.send_modify(|generation| {
-            *generation = generation
-                .checked_add(1)
-                .expect("pool generation should not overflow")
-        });
+    fn notify_change(&self) {
+        self.changes_tx.send_replace(());
     }
 
     /// Returns whether the pool is empty.
@@ -203,7 +194,7 @@ where
             .write()
             .expect("lock should not be poisoned")
             .insert(key, service);
-        self.increment_generation();
+        self.notify_change();
     }
 
     /// Removes a value from the pool.
@@ -214,7 +205,7 @@ where
             .expect("lock should not be poisoned")
             .remove(key);
         if removed.is_some() {
-            self.increment_generation();
+            self.notify_change();
         }
     }
 }
@@ -224,11 +215,11 @@ where K: Eq + PartialEq + Hash
 {
     fn from_iter<I>(iter: I) -> Self
     where I: IntoIterator<Item = (K, V)> {
-        let (generation_tx, generation_rx) = watch::channel(0);
+        let (changes_tx, changes_rx) = watch::channel(());
         Self {
             pool: Arc::new(RwLock::new(HashMap::from_iter(iter))),
-            generation_tx,
-            generation_rx,
+            changes_tx,
+            changes_rx,
         }
     }
 }
@@ -242,28 +233,22 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_pool_generation() {
+    async fn test_pool_change_notifications() {
         let pool = Pool::default();
-        let mut generation_rx = pool.generation_rx.clone();
-
-        assert_eq!(pool.generation(), 1);
+        let mut changes_rx = pool.changes_rx.clone();
 
         pool.insert(1, 11);
-        generation_rx.changed().await.unwrap();
-        assert_eq!(*generation_rx.borrow_and_update(), 2);
+        changes_rx.changed().await.unwrap();
         assert_eq!(pool.get(&1), Some(11));
 
         pool.insert(1, 12);
-        generation_rx.changed().await.unwrap();
-        assert_eq!(*generation_rx.borrow_and_update(), 3);
+        changes_rx.changed().await.unwrap();
         assert_eq!(pool.get(&1), Some(12));
 
         pool.remove(&2);
-        assert_eq!(pool.generation(), 3);
 
         pool.remove(&1);
-        generation_rx.changed().await.unwrap();
-        assert_eq!(*generation_rx.borrow_and_update(), 4);
+        changes_rx.changed().await.unwrap();
         assert!(!pool.contains_key(&1));
     }
 

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -77,7 +77,7 @@ const PRUNE_SHARDS_DEFAULT_COOLDOWN_PERIOD: Duration = Duration::from_secs(120);
 const REBUILD_PLAN_COOLDOWN_PERIOD: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]
-struct ControlPlanLoop;
+struct ControlPlaneLoop;
 
 #[derive(Debug, Default, Clone, Copy)]
 struct RebuildPlan;
@@ -98,8 +98,6 @@ pub struct ControlPlane {
     prune_shard_cooldown: CooldownMap<(IndexId, SourceId)>,
     rebuild_plan_debouncer: Debouncer,
     readiness_tx: watch::Sender<bool>,
-    // Disables the control loop. This is useful for unit testing.
-    disable_control_loop: bool,
 }
 
 impl fmt::Debug for ControlPlane {
@@ -121,36 +119,8 @@ impl ControlPlane {
         ActorHandle<Supervisor<Self>>,
         watch::Receiver<bool>,
     ) {
-        let disable_control_loop = false;
-        Self::spawn_inner(
-            universe,
-            cluster_config,
-            self_node_id,
-            indexer_pool,
-            ingester_pool,
-            metastore,
-            disable_control_loop,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn spawn_inner(
-        universe: &Universe,
-        cluster_config: ClusterConfig,
-        self_node_id: NodeId,
-        indexer_pool: IndexerPool,
-        ingester_pool: IngesterPool,
-        metastore: MetastoreServiceClient,
-        disable_control_loop: bool,
-    ) -> (
-        Mailbox<Self>,
-        ActorHandle<Supervisor<Self>>,
-        watch::Receiver<bool>,
-    ) {
         info!("starting control plane");
-
         let (readiness_tx, readiness_rx) = watch::channel(false);
-        let ingester_pool_changes_rx = ingester_pool.changes_rx.clone();
         let (control_plane_mailbox, control_plane_handle) =
             universe.spawn_builder().supervise_fn(move || {
                 let cluster_id = cluster_config.cluster_id.clone();
@@ -180,10 +150,8 @@ impl ControlPlane {
                     prune_shard_cooldown: CooldownMap::new(NonZeroUsize::new(1024).unwrap()),
                     rebuild_plan_debouncer: Debouncer::new(REBUILD_PLAN_COOLDOWN_PERIOD),
                     readiness_tx,
-                    disable_control_loop,
                 }
             });
-        spawn_watch_ingester_pool(control_plane_mailbox.downgrade(), ingester_pool_changes_rx);
         (control_plane_mailbox, control_plane_handle, readiness_rx)
     }
 }
@@ -227,7 +195,7 @@ impl Actor for ControlPlane {
 
         self.ingest_controller.sync_with_all_ingesters(&self.model);
 
-        ctx.schedule_self_msg(CONTROL_PLAN_LOOP_INTERVAL, ControlPlanLoop);
+        ctx.schedule_self_msg(CONTROL_PLAN_LOOP_INTERVAL, ControlPlaneLoop);
 
         let _ = self.readiness_tx.send(true);
         Ok(())
@@ -511,18 +479,15 @@ impl Handler<ShardPositionsUpdate> for ControlPlane {
 }
 
 #[async_trait]
-impl Handler<ControlPlanLoop> for ControlPlane {
+impl Handler<ControlPlaneLoop> for ControlPlane {
     type Reply = ();
 
     #[allow(clippy::collapsible_if, clippy::question_mark)]
     async fn handle(
         &mut self,
-        _message: ControlPlanLoop,
+        _message: ControlPlaneLoop,
         ctx: &ActorContext<Self>,
     ) -> Result<(), ActorExitStatus> {
-        if self.disable_control_loop {
-            return Ok(());
-        }
         if let Err(metastore_error) = self
             .ingest_controller
             .rebalance_shards(&mut self.model, ctx.mailbox(), ctx.progress())
@@ -540,7 +505,7 @@ impl Handler<ControlPlanLoop> for ControlPlane {
             }
         }
         self.indexing_scheduler.control_running_plan(&self.model);
-        ctx.schedule_self_msg(CONTROL_PLAN_LOOP_INTERVAL, ControlPlanLoop);
+        ctx.schedule_self_msg(CONTROL_PLAN_LOOP_INTERVAL, ControlPlaneLoop);
         Ok(())
     }
 }
@@ -1060,31 +1025,6 @@ fn apply_index_template_match(
     Ok(index_config)
 }
 
-#[derive(Debug)]
-struct IngesterPoolHasChanged;
-
-#[async_trait]
-impl Handler<IngesterPoolHasChanged> for ControlPlane {
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        _message: IngesterPoolHasChanged,
-        ctx: &ActorContext<Self>,
-    ) -> Result<Self::Reply, ActorExitStatus> {
-        info!("triggering rebalance shards and rebuild plan due to a change in the ingester pool");
-        if let Err(error) = self
-            .ingest_controller
-            .rebalance_shards(&mut self.model, ctx.mailbox(), ctx.progress())
-            .await
-        {
-            return convert_metastore_error::<()>(error).map(|_| ());
-        };
-        let _ = self.rebuild_plan_debounced(ctx);
-        Ok(())
-    }
-}
-
 #[async_trait]
 impl Handler<RebalanceShardsCallback> for ControlPlane {
     type Reply = ();
@@ -1110,22 +1050,6 @@ impl Handler<RebalanceShardsCallback> for ControlPlane {
         drop(message.rebalance_guard);
         Ok(())
     }
-}
-
-fn spawn_watch_ingester_pool(
-    weak_mailbox: WeakMailbox<ControlPlane>,
-    mut ingester_pool_changes_rx: watch::Receiver<()>,
-) {
-    tokio::spawn(async move {
-        while ingester_pool_changes_rx.changed().await.is_ok() {
-            let Some(mailbox) = weak_mailbox.upgrade() else {
-                return;
-            };
-            if mailbox.send_message(IngesterPoolHasChanged).await.is_err() {
-                return;
-            }
-        }
-    });
 }
 
 #[cfg(test)]
@@ -1760,7 +1684,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_control_plan_loop_continues_after_too_many_requests() {
-        let universe = Universe::default();
+        let universe = Universe::with_accelerated_time();
         let index_uid = IndexUid::for_test("test-index", 0);
         let retiring_ingester_id = NodeId::from_str("retiring-ingester");
         let ready_ingester_id = NodeId::from_str("ready-ingester");
@@ -1869,12 +1793,10 @@ mod tests {
             )),
         );
 
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
         let (control_plane_mailbox, control_plane_handle, mut readiness_rx) = ControlPlane::spawn(
             &universe,
             ClusterConfig::for_test(),
             NodeId::from_str("test-control-plane"),
-            cluster_change_stream_factory,
             IndexerPool::default(),
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2533,24 +2455,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_watch_ingester_pool() {
-        let universe = Universe::with_accelerated_time();
-        let (control_plane_mailbox, control_plane_inbox) = universe.create_test_mailbox();
-        let weak_control_plane_mailbox = control_plane_mailbox.downgrade();
-        let ingester_pool = IngesterPool::default();
-
-        spawn_watch_ingester_pool(weak_control_plane_mailbox, ingester_pool.changes_rx.clone());
-
-        ingester_pool.insert(
-            NodeId::from_str("test-ingester"),
-            IngesterPoolEntry::mocked_ingester(),
-        );
-        let IngesterPoolHasChanged = control_plane_inbox.recv_typed_message().await.unwrap();
-
-        universe.assert_quit().await;
-    }
-
-    #[tokio::test]
     async fn test_control_plane_rebuilds_plan_on_indexer_joins_or_leaves_the_cluster() {
         let universe = Universe::with_accelerated_time();
 
@@ -2565,25 +2469,39 @@ mod tests {
         let mut mock_metastore = MockMetastoreService::new();
         mock_metastore
             .expect_list_indexes_metadata()
-            .return_once(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
+            .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
         let metastore = MetastoreServiceClient::from_mock(mock_metastore);
-        let disable_control_loop = true;
-        let (_control_plane_mailbox, control_plane_handle, _readiness_rx) =
-            ControlPlane::spawn_inner(
-                &universe,
-                cluster_config,
-                node_id,
-                indexer_pool.clone(),
-                ingester_pool.clone(),
-                metastore,
-                disable_control_loop,
-            );
+        let (_control_plane_mailbox, control_plane_handle, _readiness_rx) = ControlPlane::spawn(
+            &universe,
+            cluster_config,
+            node_id,
+            indexer_pool.clone(),
+            ingester_pool.clone(),
+            metastore,
+        );
 
+        let mut mock_ingester = MockIngesterService::new();
+        mock_ingester
+            .expect_retain_shards()
+            .returning(|_| Ok(RetainShardsResponse {}));
+        mock_ingester.expect_init_shards().return_once(|request| {
+            let shard = request.subrequests[0].shard().clone();
+            let response = InitShardsResponse {
+                successes: vec![InitShardSuccess {
+                    subrequest_id: 0,
+                    shard: Some(shard),
+                }],
+                failures: Vec::new(),
+            };
+            Ok(response)
+        });
         let indexer_id = NodeId::from_str("test-indexer");
         ingester_pool_change_tx
             .unbounded_send(Change::Insert(
                 indexer_id.clone(),
-                IngesterPoolEntry::mocked_ingester(),
+                IngesterPoolEntry::ready_with_client(IngesterServiceClient::from_mock(
+                    mock_ingester,
+                )),
             ))
             .unwrap();
 
@@ -2596,7 +2514,8 @@ mod tests {
             .as_ref()
             .unwrap()
             .ingest_controller;
-        assert_eq!(ingest_controller_stats.num_rebalance_shards_ops, 1);
+        let num_rebalance_1 = ingest_controller_stats.num_rebalance_shards_ops;
+        assert!(num_rebalance_1 >= 1);
 
         ingester_pool_change_tx
             .unbounded_send(Change::Remove(indexer_id))
@@ -2611,7 +2530,9 @@ mod tests {
             .as_ref()
             .unwrap()
             .ingest_controller;
-        assert_eq!(ingest_controller_stats.num_rebalance_shards_ops, 2);
+
+        let num_rebalance_2 = ingest_controller_stats.num_rebalance_shards_ops;
+        assert!(num_rebalance_2 > num_rebalance_1);
 
         universe.assert_quit().await;
     }

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -28,7 +28,7 @@ use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorHandle, DeferableReplyHandler, Handler, Mailbox,
     Supervisor, Universe, WeakMailbox,
 };
-use quickwit_cluster::{ClusterChange, ClusterChangeStream, ClusterChangeStreamFactory};
+use quickwit_cluster::{ClusterChange, ClusterChangeStream};
 use quickwit_common::pretty::PrettyDisplay;
 use quickwit_common::pubsub::EventSubscriber;
 use quickwit_common::uri::Uri;
@@ -85,7 +85,6 @@ struct RebuildPlan;
 
 pub struct ControlPlane {
     cluster_config: ClusterConfig,
-    cluster_change_stream_opt: Option<ClusterChangeStream>,
     // The control plane state is split into to independent functions, that we naturally isolated
     // code wise and state wise.
     //
@@ -115,7 +114,7 @@ impl ControlPlane {
         universe: &Universe,
         cluster_config: ClusterConfig,
         self_node_id: NodeId,
-        cluster_change_stream_factory: impl ClusterChangeStreamFactory,
+        cluster_change_stream: ClusterChangeStream,
         indexer_pool: IndexerPool,
         ingester_pool: IngesterPool,
         metastore: MetastoreServiceClient,
@@ -129,7 +128,7 @@ impl ControlPlane {
             universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream,
             indexer_pool,
             ingester_pool,
             metastore,
@@ -142,7 +141,7 @@ impl ControlPlane {
         universe: &Universe,
         cluster_config: ClusterConfig,
         self_node_id: NodeId,
-        cluster_change_stream_factory: impl ClusterChangeStreamFactory,
+        cluster_change_stream: ClusterChangeStream,
         indexer_pool: IndexerPool,
         ingester_pool: IngesterPool,
         metastore: MetastoreServiceClient,
@@ -177,7 +176,6 @@ impl ControlPlane {
 
                 ControlPlane {
                     cluster_config: cluster_config.clone(),
-                    cluster_change_stream_opt: Some(cluster_change_stream_factory.create()),
                     indexing_scheduler,
                     ingest_controller,
                     metastore: metastore.clone(),
@@ -188,6 +186,9 @@ impl ControlPlane {
                     disable_control_loop,
                 }
             });
+        // The mailbox is preserved by the supervisor across actor restarts, so this watcher must
+        // be spawned once for the mailbox rather than once for each actor instance.
+        spawn_watch_indexers_task(control_plane_mailbox.downgrade(), cluster_change_stream);
         (control_plane_mailbox, control_plane_handle, readiness_rx)
     }
 }
@@ -233,12 +234,6 @@ impl Actor for ControlPlane {
 
         ctx.schedule_self_msg(CONTROL_PLAN_LOOP_INTERVAL, ControlPlanLoop);
 
-        let weak_mailbox = ctx.mailbox().downgrade();
-        let cluster_change_stream = self
-            .cluster_change_stream_opt
-            .take()
-            .expect("`initialize` should be called only once");
-        spawn_watch_indexers_task(weak_mailbox, cluster_change_stream);
         let _ = self.readiness_tx.send(true);
         Ok(())
     }
@@ -1188,7 +1183,7 @@ mod tests {
 
     use mockall::Sequence;
     use quickwit_actors::{AskError, Observe, SupervisorMetrics};
-    use quickwit_cluster::{ClusterChangeStreamFactoryForTest, ClusterNode};
+    use quickwit_cluster::{ClusterChangeStreamForTest, ClusterNode};
     use quickwit_config::{
         CLI_SOURCE_ID, INGEST_V2_SOURCE_ID, IndexConfig, KafkaSourceParams, SourceParams,
     };
@@ -1253,12 +1248,12 @@ mod tests {
             .expect_list_indexes_metadata()
             .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1296,12 +1291,12 @@ mod tests {
             .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1355,12 +1350,12 @@ mod tests {
             .return_once(move |_| Ok(ListShardsResponse::default()));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1457,12 +1452,12 @@ mod tests {
             .return_once(move |_| Ok(ListShardsResponse::default()));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1526,12 +1521,12 @@ mod tests {
             });
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1582,12 +1577,12 @@ mod tests {
             .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1656,12 +1651,12 @@ mod tests {
             });
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1748,12 +1743,12 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, control_plane_handle, mut readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2056,12 +2051,12 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2189,12 +2184,12 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2275,12 +2270,12 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2395,12 +2390,12 @@ mod tests {
         ingester_pool.insert(NodeId::from_str("node1"), ingester);
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2492,12 +2487,12 @@ mod tests {
             },
         );
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2523,7 +2518,7 @@ mod tests {
         cluster_config.auto_create_indexes = true;
 
         let node_id = NodeId::from_str("test-node");
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
 
@@ -2580,7 +2575,7 @@ mod tests {
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory,
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2619,11 +2614,11 @@ mod tests {
         let (control_plane_mailbox, control_plane_inbox) = universe.create_test_mailbox();
         let weak_control_plane_mailbox = control_plane_mailbox.downgrade();
 
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
-        let cluster_change_stream = cluster_change_stream_factory.create();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
+        let cluster_change_stream = cluster_change_stream_for_test.cluster_change_rx;
         spawn_watch_indexers_task(weak_control_plane_mailbox, cluster_change_stream);
 
-        let cluster_change_stream_tx = cluster_change_stream_factory.change_stream_tx();
+        let cluster_change_stream_tx = cluster_change_stream_for_test.cluster_change_tx;
 
         // a non-indexer node status change doesn't trigger a shard rebalancing.
         let metastore_node = ClusterNode::for_test(
@@ -2725,7 +2720,7 @@ mod tests {
 
         let cluster_config = ClusterConfig::for_test();
         let node_id = NodeId::from_str("test-control-plane");
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
 
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
@@ -2740,13 +2735,13 @@ mod tests {
                 &universe,
                 cluster_config,
                 node_id,
-                cluster_change_stream_factory.clone(),
+                cluster_change_stream_for_test.cluster_change_rx,
                 indexer_pool.clone(),
                 ingester_pool,
                 metastore,
                 disable_control_loop,
             );
-        let cluster_change_stream_tx = cluster_change_stream_factory.change_stream_tx();
+        let cluster_change_stream_tx = cluster_change_stream_for_test.cluster_change_tx;
         let indexer_node: ClusterNode = ClusterNode::for_test(
             "test-indexer",
             1515,
@@ -2793,7 +2788,7 @@ mod tests {
 
         let cluster_config = ClusterConfig::for_test();
         let node_id = NodeId::from_str("test-control-plane");
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
 
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
@@ -2864,7 +2859,7 @@ mod tests {
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory.clone(),
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool.clone(),
             ingester_pool,
             metastore,
@@ -2932,7 +2927,7 @@ mod tests {
 
         let cluster_config = ClusterConfig::for_test();
         let node_id = NodeId::from_str("test-control-plane");
-        let cluster_change_stream_factory = ClusterChangeStreamFactoryForTest::default();
+        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
 
         let indexer_pool = IndexerPool::default();
         let ingester_id = NodeId::from_str("test-ingester");
@@ -3020,7 +3015,7 @@ mod tests {
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_factory.clone(),
+            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool.clone(),
             ingester_pool,
             metastore,

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -28,7 +28,6 @@ use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorHandle, DeferableReplyHandler, Handler, Mailbox,
     Supervisor, Universe, WeakMailbox,
 };
-use quickwit_cluster::{ClusterChange, ClusterChangeStream};
 use quickwit_common::pretty::PrettyDisplay;
 use quickwit_common::pubsub::EventSubscriber;
 use quickwit_common::uri::Uri;
@@ -114,7 +113,6 @@ impl ControlPlane {
         universe: &Universe,
         cluster_config: ClusterConfig,
         self_node_id: NodeId,
-        cluster_change_stream: ClusterChangeStream,
         indexer_pool: IndexerPool,
         ingester_pool: IngesterPool,
         metastore: MetastoreServiceClient,
@@ -128,7 +126,6 @@ impl ControlPlane {
             universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream,
             indexer_pool,
             ingester_pool,
             metastore,
@@ -141,7 +138,6 @@ impl ControlPlane {
         universe: &Universe,
         cluster_config: ClusterConfig,
         self_node_id: NodeId,
-        cluster_change_stream: ClusterChangeStream,
         indexer_pool: IndexerPool,
         ingester_pool: IngesterPool,
         metastore: MetastoreServiceClient,
@@ -154,6 +150,7 @@ impl ControlPlane {
         info!("starting control plane");
 
         let (readiness_tx, readiness_rx) = watch::channel(false);
+        let ingester_pool_generation_rx = ingester_pool.generation_rx.clone();
         let (control_plane_mailbox, control_plane_handle) =
             universe.spawn_builder().supervise_fn(move || {
                 let cluster_id = cluster_config.cluster_id.clone();
@@ -186,9 +183,10 @@ impl ControlPlane {
                     disable_control_loop,
                 }
             });
-        // The mailbox is preserved by the supervisor across actor restarts, so this watcher must
-        // be spawned once for the mailbox rather than once for each actor instance.
-        spawn_watch_indexers_task(control_plane_mailbox.downgrade(), cluster_change_stream);
+        spawn_watch_ingester_pool(
+            control_plane_mailbox.downgrade(),
+            ingester_pool_generation_rx,
+        );
         (control_plane_mailbox, control_plane_handle, readiness_rx)
     }
 }
@@ -1065,24 +1063,40 @@ fn apply_index_template_match(
 }
 
 #[derive(Debug)]
-struct RebalanceShards;
+struct IngesterPoolHasChanged;
 
 #[async_trait]
-impl Handler<RebalanceShards> for ControlPlane {
+impl Handler<IngesterPoolHasChanged> for ControlPlane {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _message: RebalanceShards,
+        _message: IngesterPoolHasChanged,
         ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        if let Err(error) = self
+        let observed_pool_generation = self.ingest_controller.ingester_pool.generation();
+        if observed_pool_generation
+            <= self
+                .ingest_controller
+                .last_rebalanced_ingester_pool_generation
+        {
+            debug!(
+                pool_generation = observed_pool_generation,
+                "skipping rebalance: ingester pool is unchanged"
+            );
+            return Ok(());
+        }
+        let rebalance_performed = match self
             .ingest_controller
-            .rebalance_shards(&mut self.model, ctx.mailbox(), ctx.progress())
+            .rebalance_shards_inner(&mut self.model, ctx.mailbox(), ctx.progress())
             .await
         {
-            return convert_metastore_error::<()>(error).map(|_| ());
+            Ok(num_opened_shards_opt) => num_opened_shards_opt.is_some(),
+            Err(error) => return convert_metastore_error::<()>(error).map(|_| ()),
         };
+        if !rebalance_performed {
+            return Ok(());
+        }
         self.indexing_scheduler.rebuild_plan(&self.model);
         Ok(())
     }
@@ -1115,65 +1129,20 @@ impl Handler<RebalanceShardsCallback> for ControlPlane {
     }
 }
 
-fn spawn_watch_indexers_task(
+fn spawn_watch_ingester_pool(
     weak_mailbox: WeakMailbox<ControlPlane>,
-    cluster_change_stream: ClusterChangeStream,
+    mut ingester_pool_generation_rx: watch::Receiver<u64>,
 ) {
-    tokio::spawn(watcher_indexers(weak_mailbox, cluster_change_stream));
-}
-
-async fn watcher_indexers(
-    weak_mailbox: WeakMailbox<ControlPlane>,
-    mut cluster_change_stream: ClusterChangeStream,
-) {
-    while let Some(cluster_change) = cluster_change_stream.next().await {
-        let Some(mailbox) = weak_mailbox.upgrade() else {
-            return;
-        };
-
-        // Ingesters have two readiness levels:
-        // 1. Cluster connectivity: node is up and can reach the metastore (similar to other nodes)
-        // 2. Shard readiness: IngesterStatus::Ready indicates the ingester can accept new shards
-        // We rebalance shards when either readiness level changes.
-        let mut trigger_rebalance = false;
-        match cluster_change {
-            ClusterChange::Add(node) if node.is_indexer() && node.ingester_status.is_ready() => {
-                info!(
-                    "indexer `{}` with status `{}` joined the cluster: rebalancing shards and \
-                     rebuilding indexing plan",
-                    node.node_id,
-                    node.ingester_status.as_json_str_name()
-                );
-                trigger_rebalance = true;
+    tokio::spawn(async move {
+        while ingester_pool_generation_rx.changed().await.is_ok() {
+            let Some(mailbox) = weak_mailbox.upgrade() else {
+                return;
+            };
+            if mailbox.send_message(IngesterPoolHasChanged).await.is_err() {
+                return;
             }
-            ClusterChange::Remove(node) if node.is_indexer() => {
-                info!(
-                    "indexer `{}` left the cluster: rebalancing shards and rebuilding indexing \
-                     plan",
-                    node.node_id
-                );
-                trigger_rebalance = true
-            }
-            ClusterChange::Update { previous, updated } if updated.is_indexer() => {
-                let was_ready = previous.ingester_status.is_ready();
-                let is_ready = updated.ingester_status.is_ready();
-
-                if was_ready ^ is_ready {
-                    info!(
-                        "indexer `{}` status changed to `{}`: rebalancing shards and rebuilding \
-                         indexing plan",
-                        updated.node_id,
-                        updated.ingester_status.as_json_str_name()
-                    );
-                    trigger_rebalance = true;
-                }
-            }
-            _ => {}
         }
-        if trigger_rebalance && mailbox.send_message(RebalanceShards).await.is_err() {
-            return;
-        }
-    }
+    });
 }
 
 #[cfg(test)]
@@ -1183,7 +1152,6 @@ mod tests {
 
     use mockall::Sequence;
     use quickwit_actors::{AskError, Observe, SupervisorMetrics};
-    use quickwit_cluster::{ClusterChangeStreamForTest, ClusterNode};
     use quickwit_config::{
         CLI_SOURCE_ID, INGEST_V2_SOURCE_ID, IndexConfig, KafkaSourceParams, SourceParams,
     };
@@ -1248,12 +1216,10 @@ mod tests {
             .expect_list_indexes_metadata()
             .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1291,12 +1257,10 @@ mod tests {
             .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1350,12 +1314,10 @@ mod tests {
             .return_once(move |_| Ok(ListShardsResponse::default()));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1452,12 +1414,10 @@ mod tests {
             .return_once(move |_| Ok(ListShardsResponse::default()));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1521,12 +1481,10 @@ mod tests {
             });
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1577,12 +1535,10 @@ mod tests {
             .returning(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1651,12 +1607,10 @@ mod tests {
             });
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             self_node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -1743,12 +1697,10 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, control_plane_handle, mut readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2051,12 +2003,10 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2184,12 +2134,10 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2270,12 +2218,10 @@ mod tests {
         );
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2390,12 +2336,10 @@ mod tests {
         ingester_pool.insert(NodeId::from_str("node1"), ingester);
 
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2487,12 +2431,10 @@ mod tests {
             },
         );
         let cluster_config = ClusterConfig::for_test();
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2518,7 +2460,6 @@ mod tests {
         cluster_config.auto_create_indexes = true;
 
         let node_id = NodeId::from_str("test-node");
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
 
@@ -2575,7 +2516,6 @@ mod tests {
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool,
             ingester_pool,
             MetastoreServiceClient::from_mock(mock_metastore),
@@ -2609,118 +2549,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_watch_indexers() {
+    async fn test_watch_ingester_pool() {
         let universe = Universe::with_accelerated_time();
         let (control_plane_mailbox, control_plane_inbox) = universe.create_test_mailbox();
         let weak_control_plane_mailbox = control_plane_mailbox.downgrade();
+        let ingester_pool = IngesterPool::default();
 
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
-        let cluster_change_stream = cluster_change_stream_for_test.cluster_change_rx;
-        spawn_watch_indexers_task(weak_control_plane_mailbox, cluster_change_stream);
-
-        let cluster_change_stream_tx = cluster_change_stream_for_test.cluster_change_tx;
-
-        // a non-indexer node status change doesn't trigger a shard rebalancing.
-        let metastore_node = ClusterNode::for_test(
-            "test-metastore",
-            1515,
-            false,
-            &["metastore"],
-            &[],
-            IngesterStatus::Unspecified,
-        )
-        .await;
-        let cluster_change = ClusterChange::Add(metastore_node);
-        cluster_change_stream_tx.send(cluster_change).unwrap();
-
-        tokio::time::sleep(Duration::from_millis(1)).await;
-        assert!(
-            control_plane_inbox
-                .drain_for_test_typed::<RebalanceShards>()
-                .is_empty()
+        spawn_watch_ingester_pool(
+            weak_control_plane_mailbox,
+            ingester_pool.generation_rx.clone(),
         );
 
-        // an indexer initializing doesn't trigger a shard rebalancing.
-        let indexer_node_initializing: ClusterNode = ClusterNode::for_test(
-            "test-indexer",
-            1515,
-            false,
-            &["indexer"],
-            &[],
-            IngesterStatus::Initializing,
-        )
-        .await;
-        let cluster_change = ClusterChange::Add(indexer_node_initializing);
-        cluster_change_stream_tx.send(cluster_change).unwrap();
-
-        tokio::time::sleep(Duration::from_millis(1)).await;
-        assert!(
-            control_plane_inbox
-                .drain_for_test_typed::<RebalanceShards>()
-                .is_empty()
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester"),
+            IngesterPoolEntry::mocked_ingester(),
         );
-
-        // an indexer ready triggers a shard rebalancing.
-        let indexer_node: ClusterNode = ClusterNode::for_test(
-            "test-indexer",
-            1515,
-            false,
-            &["indexer"],
-            &[],
-            IngesterStatus::Ready,
-        )
-        .await;
-        let cluster_change = ClusterChange::Add(indexer_node.clone());
-        cluster_change_stream_tx.send(cluster_change).unwrap();
-
-        tokio::time::sleep(Duration::from_millis(1)).await;
-        let RebalanceShards = control_plane_inbox.recv_typed_message().await.unwrap();
-
-        // removing an indexer node triggers a shard rebalancing.
-        let cluster_change = ClusterChange::Remove(indexer_node.clone());
-        cluster_change_stream_tx.send(cluster_change).unwrap();
-
-        tokio::time::sleep(Duration::from_millis(1)).await;
-        let RebalanceShards = control_plane_inbox.recv_typed_message().await.unwrap();
-
-        // a change in IngesterStatus readiness triggers a shard rebalancing.
-        let node_ready = ClusterNode::for_test(
-            "test-indexer",
-            1515,
-            false,
-            &["indexer"],
-            &[],
-            IngesterStatus::Ready,
-        )
-        .await;
-        let node_retiring = ClusterNode::for_test(
-            "test-indexer",
-            1515,
-            false,
-            &["indexer"],
-            &[],
-            IngesterStatus::Retiring,
-        )
-        .await;
-        let cluster_change = ClusterChange::Update {
-            previous: node_ready,
-            updated: node_retiring,
-        };
-        cluster_change_stream_tx.send(cluster_change).unwrap();
-
-        tokio::time::sleep(Duration::from_millis(1)).await;
-        let RebalanceShards = control_plane_inbox.recv_typed_message().await.unwrap();
+        let IngesterPoolHasChanged = control_plane_inbox.recv_typed_message().await.unwrap();
 
         universe.assert_quit().await;
     }
 
     #[tokio::test]
-    async fn test_control_plane_rebuilds_plan_on_indexer_joins_or_leaves_the_cluster() {
+    async fn test_control_plane_debounces_ingester_pool_changes() {
         let universe = Universe::with_accelerated_time();
 
         let cluster_config = ClusterConfig::for_test();
         let node_id = NodeId::from_str("test-control-plane");
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
 
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
@@ -2730,29 +2584,33 @@ mod tests {
             .return_once(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
         let metastore = MetastoreServiceClient::from_mock(mock_metastore);
         let disable_control_loop = true;
-        let (_control_plane_mailbox, control_plane_handle, _readiness_rx) =
+        let (control_plane_mailbox, control_plane_handle, _readiness_rx) =
             ControlPlane::spawn_inner(
                 &universe,
                 cluster_config,
                 node_id,
-                cluster_change_stream_for_test.cluster_change_rx,
                 indexer_pool.clone(),
-                ingester_pool,
+                ingester_pool.clone(),
                 metastore,
                 disable_control_loop,
             );
-        let cluster_change_stream_tx = cluster_change_stream_for_test.cluster_change_tx;
-        let indexer_node: ClusterNode = ClusterNode::for_test(
-            "test-indexer",
-            1515,
-            false,
-            &["indexer"],
-            &[],
-            IngesterStatus::Ready,
-        )
-        .await;
-        let cluster_change = ClusterChange::Add(indexer_node.clone());
-        cluster_change_stream_tx.send(cluster_change).unwrap();
+
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester-0"),
+            IngesterPoolEntry::mocked_ingester(),
+        );
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester-1"),
+            IngesterPoolEntry::mocked_ingester(),
+        );
+        control_plane_mailbox
+            .send_message(IngesterPoolHasChanged)
+            .await
+            .unwrap();
+        control_plane_mailbox
+            .send_message(IngesterPoolHasChanged)
+            .await
+            .unwrap();
 
         universe.sleep(Duration::from_secs(10)).await;
 
@@ -2765,8 +2623,10 @@ mod tests {
             .ingest_controller;
         assert_eq!(ingest_controller_stats.num_rebalance_shards_ops, 1);
 
-        let cluster_change = ClusterChange::Remove(indexer_node);
-        cluster_change_stream_tx.send(cluster_change).unwrap();
+        ingester_pool.insert(
+            NodeId::from_str("test-ingester-1"),
+            IngesterPoolEntry::mocked_ingester(),
+        );
 
         universe.sleep(Duration::from_secs(10)).await;
 
@@ -2788,7 +2648,6 @@ mod tests {
 
         let cluster_config = ClusterConfig::for_test();
         let node_id = NodeId::from_str("test-control-plane");
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
 
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
@@ -2859,7 +2718,6 @@ mod tests {
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool.clone(),
             ingester_pool,
             metastore,
@@ -2927,7 +2785,6 @@ mod tests {
 
         let cluster_config = ClusterConfig::for_test();
         let node_id = NodeId::from_str("test-control-plane");
-        let cluster_change_stream_for_test = ClusterChangeStreamForTest::default();
 
         let indexer_pool = IndexerPool::default();
         let ingester_id = NodeId::from_str("test-ingester");
@@ -3015,7 +2872,6 @@ mod tests {
             &universe,
             cluster_config,
             node_id,
-            cluster_change_stream_for_test.cluster_change_rx,
             indexer_pool.clone(),
             ingester_pool,
             metastore,

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -417,6 +417,7 @@ impl ControlPlane {
     ///
     /// This method returns a future that can be awaited to ensure that the relevant rebuild plan
     /// operation has been executed.
+    /// Regardless of whether that future is awaited for or not, the future will be scheduled.
     fn rebuild_plan_debounced(
         &mut self,
         ctx: &ActorContext<Self>,
@@ -1071,6 +1072,7 @@ impl Handler<IngesterPoolHasChanged> for ControlPlane {
         _message: IngesterPoolHasChanged,
         ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
+        info!("triggering rebalance shards and rebuild plan due to a change in the ingester pool");
         if let Err(error) = self
             .ingest_controller
             .rebalance_shards(&mut self.model, ctx.mailbox(), ctx.progress())
@@ -1078,7 +1080,7 @@ impl Handler<IngesterPoolHasChanged> for ControlPlane {
         {
             return convert_metastore_error::<()>(error).map(|_| ());
         };
-        self.indexing_scheduler.rebuild_plan(&self.model);
+        let _ = self.rebuild_plan_debounced(ctx);
         Ok(())
     }
 }

--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -150,7 +150,7 @@ impl ControlPlane {
         info!("starting control plane");
 
         let (readiness_tx, readiness_rx) = watch::channel(false);
-        let ingester_pool_generation_rx = ingester_pool.generation_rx.clone();
+        let ingester_pool_changes_rx = ingester_pool.changes_rx.clone();
         let (control_plane_mailbox, control_plane_handle) =
             universe.spawn_builder().supervise_fn(move || {
                 let cluster_id = cluster_config.cluster_id.clone();
@@ -183,10 +183,7 @@ impl ControlPlane {
                     disable_control_loop,
                 }
             });
-        spawn_watch_ingester_pool(
-            control_plane_mailbox.downgrade(),
-            ingester_pool_generation_rx,
-        );
+        spawn_watch_ingester_pool(control_plane_mailbox.downgrade(), ingester_pool_changes_rx);
         (control_plane_mailbox, control_plane_handle, readiness_rx)
     }
 }
@@ -1074,29 +1071,13 @@ impl Handler<IngesterPoolHasChanged> for ControlPlane {
         _message: IngesterPoolHasChanged,
         ctx: &ActorContext<Self>,
     ) -> Result<Self::Reply, ActorExitStatus> {
-        let observed_pool_generation = self.ingest_controller.ingester_pool.generation();
-        if observed_pool_generation
-            <= self
-                .ingest_controller
-                .last_rebalanced_ingester_pool_generation
-        {
-            debug!(
-                pool_generation = observed_pool_generation,
-                "skipping rebalance: ingester pool is unchanged"
-            );
-            return Ok(());
-        }
-        let rebalance_performed = match self
+        if let Err(error) = self
             .ingest_controller
-            .rebalance_shards_inner(&mut self.model, ctx.mailbox(), ctx.progress())
+            .rebalance_shards(&mut self.model, ctx.mailbox(), ctx.progress())
             .await
         {
-            Ok(num_opened_shards_opt) => num_opened_shards_opt.is_some(),
-            Err(error) => return convert_metastore_error::<()>(error).map(|_| ()),
+            return convert_metastore_error::<()>(error).map(|_| ());
         };
-        if !rebalance_performed {
-            return Ok(());
-        }
         self.indexing_scheduler.rebuild_plan(&self.model);
         Ok(())
     }
@@ -1131,10 +1112,10 @@ impl Handler<RebalanceShardsCallback> for ControlPlane {
 
 fn spawn_watch_ingester_pool(
     weak_mailbox: WeakMailbox<ControlPlane>,
-    mut ingester_pool_generation_rx: watch::Receiver<u64>,
+    mut ingester_pool_changes_rx: watch::Receiver<()>,
 ) {
     tokio::spawn(async move {
-        while ingester_pool_generation_rx.changed().await.is_ok() {
+        while ingester_pool_changes_rx.changed().await.is_ok() {
             let Some(mailbox) = weak_mailbox.upgrade() else {
                 return;
             };
@@ -1152,6 +1133,7 @@ mod tests {
 
     use mockall::Sequence;
     use quickwit_actors::{AskError, Observe, SupervisorMetrics};
+    use quickwit_common::tower::Change;
     use quickwit_config::{
         CLI_SOURCE_ID, INGEST_V2_SOURCE_ID, IndexConfig, KafkaSourceParams, SourceParams,
     };
@@ -2555,10 +2537,7 @@ mod tests {
         let weak_control_plane_mailbox = control_plane_mailbox.downgrade();
         let ingester_pool = IngesterPool::default();
 
-        spawn_watch_ingester_pool(
-            weak_control_plane_mailbox,
-            ingester_pool.generation_rx.clone(),
-        );
+        spawn_watch_ingester_pool(weak_control_plane_mailbox, ingester_pool.changes_rx.clone());
 
         ingester_pool.insert(
             NodeId::from_str("test-ingester"),
@@ -2570,7 +2549,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_control_plane_debounces_ingester_pool_changes() {
+    async fn test_control_plane_rebuilds_plan_on_indexer_joins_or_leaves_the_cluster() {
         let universe = Universe::with_accelerated_time();
 
         let cluster_config = ClusterConfig::for_test();
@@ -2578,13 +2557,16 @@ mod tests {
 
         let indexer_pool = IndexerPool::default();
         let ingester_pool = IngesterPool::default();
+        let (ingester_pool_change_tx, ingester_pool_change_rx) =
+            futures::channel::mpsc::unbounded();
+        ingester_pool.listen_for_changes(ingester_pool_change_rx);
         let mut mock_metastore = MockMetastoreService::new();
         mock_metastore
             .expect_list_indexes_metadata()
             .return_once(|_| Ok(ListIndexesMetadataResponse::for_test(Vec::new())));
         let metastore = MetastoreServiceClient::from_mock(mock_metastore);
         let disable_control_loop = true;
-        let (control_plane_mailbox, control_plane_handle, _readiness_rx) =
+        let (_control_plane_mailbox, control_plane_handle, _readiness_rx) =
             ControlPlane::spawn_inner(
                 &universe,
                 cluster_config,
@@ -2595,21 +2577,12 @@ mod tests {
                 disable_control_loop,
             );
 
-        ingester_pool.insert(
-            NodeId::from_str("test-ingester-0"),
-            IngesterPoolEntry::mocked_ingester(),
-        );
-        ingester_pool.insert(
-            NodeId::from_str("test-ingester-1"),
-            IngesterPoolEntry::mocked_ingester(),
-        );
-        control_plane_mailbox
-            .send_message(IngesterPoolHasChanged)
-            .await
-            .unwrap();
-        control_plane_mailbox
-            .send_message(IngesterPoolHasChanged)
-            .await
+        let indexer_id = NodeId::from_str("test-indexer");
+        ingester_pool_change_tx
+            .unbounded_send(Change::Insert(
+                indexer_id.clone(),
+                IngesterPoolEntry::mocked_ingester(),
+            ))
             .unwrap();
 
         universe.sleep(Duration::from_secs(10)).await;
@@ -2623,10 +2596,9 @@ mod tests {
             .ingest_controller;
         assert_eq!(ingest_controller_stats.num_rebalance_shards_ops, 1);
 
-        ingester_pool.insert(
-            NodeId::from_str("test-ingester-1"),
-            IngesterPoolEntry::mocked_ingester(),
-        );
+        ingester_pool_change_tx
+            .unbounded_send(Change::Remove(indexer_id))
+            .unwrap();
 
         universe.sleep(Duration::from_secs(10)).await;
 

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -204,7 +204,6 @@ pub struct IngestControllerStats {
 pub struct IngestController {
     pub(crate) ingester_pool: IngesterPool,
     pub(crate) stats: IngestControllerStats,
-    pub(crate) last_rebalanced_ingester_pool_generation: u64,
     metastore: MetastoreServiceClient,
     replication_factor: usize,
     // This lock ensures that only one rebalance operation is performed at a time.
@@ -310,7 +309,6 @@ impl IngestController {
             replication_factor,
             rebalance_lock: Arc::new(Mutex::new(())),
             stats: IngestControllerStats::default(),
-            last_rebalanced_ingester_pool_generation: 0,
             scaling_arbiter: ScalingArbiter::with_max_shard_ingestion_throughput_mib_per_sec(
                 max_shard_ingestion_throughput_mib_per_sec,
                 shard_scale_up_factor,
@@ -1036,23 +1034,10 @@ impl IngestController {
         mailbox: &Mailbox<ControlPlane>,
         progress: &Progress,
     ) -> MetastoreResult<usize> {
-        Ok(self
-            .rebalance_shards_inner(model, mailbox, progress)
-            .await?
-            .unwrap_or_default())
-    }
-
-    pub(crate) async fn rebalance_shards_inner(
-        &mut self,
-        model: &mut ControlPlaneModel,
-        mailbox: &Mailbox<ControlPlane>,
-        progress: &Progress,
-    ) -> MetastoreResult<Option<usize>> {
         let Ok(rebalance_guard) = self.rebalance_lock.clone().try_lock_owned() else {
             debug!("skipping rebalance: another rebalance is already in progress");
-            return Ok(None);
+            return Ok(0);
         };
-        let ingester_pool_generation = self.ingester_pool.generation();
         self.stats.num_rebalance_shards_ops += 1;
 
         let shards_to_rebalance: Vec<Shard> = self.compute_shards_to_rebalance(model);
@@ -1061,8 +1046,7 @@ impl IngestController {
 
         if shards_to_rebalance.is_empty() {
             debug!("skipping rebalance: no shards to rebalance");
-            self.last_rebalanced_ingester_pool_generation = ingester_pool_generation;
-            return Ok(Some(0));
+            return Ok(0);
         }
         let mut per_source_num_shards_to_open: HashMap<SourceUid, usize> = HashMap::new();
 
@@ -1133,8 +1117,7 @@ impl IngestController {
         if num_opened_shards > 0 {
             info!("rebalance opened {num_opened_shards} new shards");
         }
-        self.last_rebalanced_ingester_pool_generation = ingester_pool_generation;
-        Ok(Some(num_opened_shards))
+        Ok(num_opened_shards)
     }
 
     /// Computes shards that need to be rebalanced.

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -204,6 +204,7 @@ pub struct IngestControllerStats {
 pub struct IngestController {
     pub(crate) ingester_pool: IngesterPool,
     pub(crate) stats: IngestControllerStats,
+    pub(crate) last_rebalanced_ingester_pool_generation: u64,
     metastore: MetastoreServiceClient,
     replication_factor: usize,
     // This lock ensures that only one rebalance operation is performed at a time.
@@ -309,6 +310,7 @@ impl IngestController {
             replication_factor,
             rebalance_lock: Arc::new(Mutex::new(())),
             stats: IngestControllerStats::default(),
+            last_rebalanced_ingester_pool_generation: 0,
             scaling_arbiter: ScalingArbiter::with_max_shard_ingestion_throughput_mib_per_sec(
                 max_shard_ingestion_throughput_mib_per_sec,
                 shard_scale_up_factor,
@@ -1034,10 +1036,23 @@ impl IngestController {
         mailbox: &Mailbox<ControlPlane>,
         progress: &Progress,
     ) -> MetastoreResult<usize> {
+        Ok(self
+            .rebalance_shards_inner(model, mailbox, progress)
+            .await?
+            .unwrap_or_default())
+    }
+
+    pub(crate) async fn rebalance_shards_inner(
+        &mut self,
+        model: &mut ControlPlaneModel,
+        mailbox: &Mailbox<ControlPlane>,
+        progress: &Progress,
+    ) -> MetastoreResult<Option<usize>> {
         let Ok(rebalance_guard) = self.rebalance_lock.clone().try_lock_owned() else {
             debug!("skipping rebalance: another rebalance is already in progress");
-            return Ok(0);
+            return Ok(None);
         };
+        let ingester_pool_generation = self.ingester_pool.generation();
         self.stats.num_rebalance_shards_ops += 1;
 
         let shards_to_rebalance: Vec<Shard> = self.compute_shards_to_rebalance(model);
@@ -1046,7 +1061,8 @@ impl IngestController {
 
         if shards_to_rebalance.is_empty() {
             debug!("skipping rebalance: no shards to rebalance");
-            return Ok(0);
+            self.last_rebalanced_ingester_pool_generation = ingester_pool_generation;
+            return Ok(Some(0));
         }
         let mut per_source_num_shards_to_open: HashMap<SourceUid, usize> = HashMap::new();
 
@@ -1117,7 +1133,8 @@ impl IngestController {
         if num_opened_shards > 0 {
             info!("rebalance opened {num_opened_shards} new shards");
         }
-        Ok(num_opened_shards)
+        self.last_rebalanced_ingester_pool_generation = ingester_pool_generation;
+        Ok(Some(num_opened_shards))
     }
 
     /// Computes shards that need to be rebalanced.

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -144,7 +144,6 @@ async fn start_control_plane(
         universe,
         cluster_config,
         self_node_id,
-        cluster.change_stream(),
         indexer_pool,
         ingester_pool,
         MetastoreServiceClient::from_mock(mock_metastore),

--- a/quickwit/quickwit-control-plane/src/tests.rs
+++ b/quickwit/quickwit-control-plane/src/tests.rs
@@ -144,7 +144,7 @@ async fn start_control_plane(
         universe,
         cluster_config,
         self_node_id,
-        cluster,
+        cluster.change_stream(),
         indexer_pool,
         ingester_pool,
         MetastoreServiceClient::from_mock(mock_metastore),

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1460,7 +1460,7 @@ async fn setup_control_plane(
         universe,
         cluster_config,
         self_node_id,
-        cluster.clone(),
+        cluster.change_stream(),
         indexer_pool,
         ingester_pool,
         metastore,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -1460,7 +1460,6 @@ async fn setup_control_plane(
         universe,
         cluster_config,
         self_node_id,
-        cluster.change_stream(),
         indexer_pool,
         ingester_pool,
         metastore,


### PR DESCRIPTION
### Description

Bugfix: before a failure of the control plane actor (due to connectivity with the metastore for instance) would trigger a restart of the control plane actor. A chitchat watching task is monitoring for node membership changes and triggering rebalance shards on this change. That task was spawned in initialized, on a recycled mailbox. As a result, every single restart would start a new watching loop.

This PR starts a loop once and for all.

Also, instead of looking for changes in the cluster membership, it looks for change in the ingester pool itself.

Each pool owns a monotonic generation sender that is updated after mutations are applied. The control plane subscribes once for the lifetime of its supervised mailbox, and the ingest controller tracks the last successfully rebalanced generation so bulk or duplicate notifications are coalesced. Periodic control-loop rebalances remain unconditional.

This also removes the obsolete cluster change stream factory and test stream abstractions from the control-plane API.

### How was this PR tested?

- `cargo test -p quickwit-common tower::pool --lib`
- `cargo test -p quickwit-control-plane --lib`
- `cargo check -p quickwit-serve --lib`
- `cargo +nightly fmt --all -- --check`