### PR TITLE
Clean up add/remove node from pool logs

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -25,7 +25,9 @@ use fnv::{FnvHashMap, FnvHashSet};
 use itertools::Itertools;
 use quickwit_common::is_parquet_pipeline_index;
 use quickwit_common::pretty::PrettySample;
-use quickwit_config::{FileSourceParams, SourceParams, indexing_pipeline_params_fingerprint};
+use quickwit_config::{
+    FileSourceParams, SourceParams, disable_ingest_v1, indexing_pipeline_params_fingerprint,
+};
 use quickwit_proto::indexing::{
     ApplyIndexingPlanRequest, CpuCapacity, IndexingService, IndexingTask, PIPELINE_FULL_CAPACITY,
     PIPELINE_THROUGHPUT,
@@ -200,7 +202,13 @@ fn get_default_load_per_shard() -> NonZeroU32 {
     *DEFAULT_LOAD_PER_SHARD
 }
 
-fn get_sources_to_schedule(model: &ControlPlaneModel) -> Vec<SourceToSchedule> {
+fn get_sources_to_schedule(
+    model: &ControlPlaneModel,
+    disable_ingest_v1: bool,
+) -> Vec<SourceToSchedule> {
+    if disable_ingest_v1 {
+        debug!("skipping scheduling of ingest API sources because ingest v1 is disabled");
+    }
     let mut sources = Vec::new();
 
     for (source_uid, source_config) in model.source_configs() {
@@ -222,6 +230,9 @@ fn get_sources_to_schedule(model: &ControlPlaneModel) -> Vec<SourceToSchedule> {
             }
 
             SourceParams::IngestApi => {
+                if disable_ingest_v1 {
+                    continue;
+                }
                 // Metrics indexes should use IngestV2 only, not IngestV1.
                 // The ParquetSourceLoader doesn't support IngestV1.
                 if is_parquet_pipeline_index(&source_uid.index_uid.index_id) {
@@ -306,7 +317,7 @@ impl IndexingScheduler {
 
         let notify_on_drop = self.next_rebuild_tracker.start_rebuild();
 
-        let sources = get_sources_to_schedule(model);
+        let sources = get_sources_to_schedule(model, disable_ingest_v1());
 
         let indexers: Vec<IndexerNodeInfo> = self.select_available_indexers_for_scheduling();
 
@@ -1020,8 +1031,19 @@ mod tests {
             ..Default::default()
         };
         model.insert_shards(&index_uid, &"ingest_v2".to_string(), vec![shard]);
-        let shards: Vec<SourceToSchedule> = get_sources_to_schedule(&model);
-        assert_eq!(shards.len(), 3);
+
+        let disable_ingest_v1 = false;
+        let sources: Vec<SourceToSchedule> = get_sources_to_schedule(&model, disable_ingest_v1);
+        assert_eq!(sources.len(), 3);
+
+        let disable_ingest_v1 = true;
+        let sources: Vec<SourceToSchedule> = get_sources_to_schedule(&model, disable_ingest_v1);
+        assert_eq!(sources.len(), 2);
+
+        let contains_any_ingest_v1_source = sources
+            .iter()
+            .any(|source| matches!(source.source_type, SourceToScheduleType::IngestV1));
+        assert!(!contains_any_ingest_v1_source);
     }
 
     #[test]
@@ -1126,7 +1148,7 @@ mod tests {
                 model.add_source(index_uid, source_config.clone()).unwrap();
             }
 
-            let sources: Vec<SourceToSchedule> = get_sources_to_schedule(&model);
+            let sources: Vec<SourceToSchedule> = get_sources_to_schedule(&model, false);
             let mut indexer_max_loads = FnvHashMap::default();
             for i in 0..num_indexers {
                 let indexer_id = format!("indexer-{i}");

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -29,8 +29,8 @@ use quickwit_cluster::Cluster;
 use quickwit_common::pubsub::EventBroker;
 use quickwit_common::{io, temp_dir};
 use quickwit_config::{
-    INGEST_API_SOURCE_ID, IndexConfig, IndexerConfig, SourceConfig, build_doc_mapper,
-    indexing_pipeline_params_fingerprint,
+    INGEST_API_SOURCE_ID, IndexConfig, IndexerConfig, SourceConfig, SourceParams, build_doc_mapper,
+    disable_ingest_v1, indexing_pipeline_params_fingerprint,
 };
 use quickwit_ingest::{
     DropQueueRequest, GetPartitionId, IngestApiService, IngesterPool, ListQueuesRequest,
@@ -885,6 +885,16 @@ impl IndexingService {
                 per_index_uid_indexes_metadata.get(task_to_spawn.index_uid())
             {
                 if let Some(source_config) = index_metadata.sources.get(&task_to_spawn.source_id) {
+                    if disable_ingest_v1()
+                        && matches!(source_config.source_params, SourceParams::IngestApi)
+                    {
+                        debug!(
+                            "skipping spawn of ingest API pipeline for index `{}` because ingest \
+                             v1 is disabled",
+                            id_to_spawn.index_uid.index_id
+                        );
+                        continue;
+                    }
                     let merge_pipeline_id = id_to_spawn.merge_pipeline_id();
                     let immature_splits_opt =
                         per_merge_pipeline_immature_splits.remove(&merge_pipeline_id);

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -80,7 +80,7 @@ use quickwit_compaction::{
     wait_for_compactor_decommission,
 };
 use quickwit_config::service::QuickwitService;
-use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig};
+use quickwit_config::{ClusterConfig, IngestApiConfig, NodeConfig, disable_ingest_v1};
 use quickwit_control_plane::control_plane::{ControlPlane, ControlPlaneEventSubscriber};
 use quickwit_control_plane::{IndexerNodeInfo, IndexerPool};
 use quickwit_index_management::{IndexService as IndexManager, IndexServiceError};
@@ -373,6 +373,16 @@ async fn start_ingest_client_if_needed(
     universe: &Universe,
     cluster: &Cluster,
 ) -> anyhow::Result<IngestServiceClient> {
+    if disable_ingest_v1() {
+        debug!("returning no-op ingest service because ingest v1 is disabled");
+        let (balance_channel, _change_tx) = BalanceChannel::new();
+        let ingest_service = IngestServiceClient::from_balance_channel(
+            balance_channel,
+            node_config.grpc_config.max_message_size,
+            node_config.ingest_api_config.grpc_compression_encoding(),
+        );
+        return Ok(ingest_service);
+    }
     if node_config.is_service_enabled(QuickwitService::Indexer) {
         let ingest_api_service = start_ingest_api_service(
             universe,
@@ -1253,6 +1263,14 @@ fn setup_ingester_pool(
         Box::pin(async move {
             match cluster_change {
                 ClusterChange::Add(node) if node.is_indexer() => {
+                    let chitchat_id = node.chitchat_id();
+                    info!(
+                        node_id = %chitchat_id.node_id,
+                        generation_id = chitchat_id.generation_id,
+                        "adding node `{}` with ingester status `{}` to ingester pool",
+                        chitchat_id.node_id,
+                        node.ingester_status,
+                    );
                     let change = build_ingester_insert_change(
                         &node,
                         ingester_opt_clone,
@@ -1292,14 +1310,6 @@ fn build_ingester_insert_change(
     grpc_max_message_size: ByteSize,
     grpc_compression_encoding_opt: Option<CompressionEncoding>,
 ) -> Change<NodeId, IngesterPoolEntry> {
-    let chitchat_id = node.chitchat_id();
-    info!(
-        node_id = %chitchat_id.node_id,
-        generation_id = chitchat_id.generation_id,
-        "adding/updating node `{}` with ingester status `{}` to ingester pool",
-        chitchat_id.node_id,
-        node.ingester_status,
-    );
     let node_id: NodeId = node.node_id.clone();
     let ingester_service = build_ingester_service(
         node,
@@ -1486,6 +1496,14 @@ fn setup_indexer_pool(
         Box::pin(async move {
             match cluster_change {
                 ClusterChange::Add(node) if node.is_indexer() => {
+                    let chitchat_id = node.chitchat_id();
+                    info!(
+                        node_id = %chitchat_id.node_id,
+                        generation_id = chitchat_id.generation_id,
+                        "adding node `{}` with ingester status `{}` to indexer pool",
+                        chitchat_id.node_id,
+                        node.ingester_status
+                    );
                     let change = build_indexer_insert_change(
                         &node,
                         indexing_service_clone_opt,
@@ -1527,13 +1545,6 @@ fn build_indexer_insert_change(
     grpc_max_message_size: ByteSize,
 ) -> Change<NodeId, IndexerNodeInfo> {
     let chitchat_id = node.chitchat_id();
-    info!(
-        node_id = %chitchat_id.node_id,
-        generation_id = chitchat_id.generation_id,
-        "adding node `{}` with ingester status `{}` to indexer pool",
-        chitchat_id.node_id,
-        node.ingester_status
-    );
     let node_id: NodeId = node.node_id.clone();
     let client = build_indexing_service(node, indexing_service_opt, grpc_max_message_size);
     Change::Insert(


### PR DESCRIPTION
### Description
Clean up add/remove node from pool logs:
- remove noisy ingest v1 logs when ingest v1 is disabled
- remove noisy on update logs

To do so properly wire disable ingest v1 logic.

### How was this PR tested?
Updated unit tests and test locally with multiple nodes.
