### PR TITLE
Bump tantivy dependency to latest main

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -7071,7 +7071,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -11737,7 +11737,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -11776,7 +11776,7 @@ dependencies = [
  "tantivy-columnar",
  "tantivy-common",
  "tantivy-fst",
- "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b)",
+ "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=057458b)",
  "tantivy-sstable",
  "tantivy-stacker",
  "tantivy-tokenizer-api",
@@ -11792,7 +11792,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "bitpacking",
 ]
@@ -11800,7 +11800,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -11815,7 +11815,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11851,7 +11851,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -11863,7 +11863,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -11876,7 +11876,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -11885,7 +11885,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=6b8bd7b#6b8bd7b8847c87686117a0e3a400bd6377afb8fd"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=057458b#057458bf14d6973c9c97594c1d99580b6af4c49d"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -426,7 +426,7 @@ quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry-exporters = { path = "quickwit-telemetry-exporters" }
 quickwit-transport = { path = "quickwit-transport" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "6b8bd7b", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "057458b", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",


### PR DESCRIPTION
## Summary
- Bumps the `tantivy` git dependency from `6b8bd7b` to `057458b` (tantivy's `main` HEAD).
- Notably pulls in a correctness fix for aggregation cache flushing: quickwit-oss/tantivy@6169313 (fixes tantivy#2992).

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --tests`
- [x] `cargo +nightly fmt --all -- --check`