### PR TITLE
use macro with cache to load env

### DIFF
--- a/quickwit/quickwit-cli/src/main.rs
+++ b/quickwit/quickwit-cli/src/main.rs
@@ -34,10 +34,10 @@ const QW_ENABLE_TOKIO_CONSOLE_ENV_KEY: &str = "QW_ENABLE_TOKIO_CONSOLE";
 /// The main tokio runtime takes num_cores / 3 threads by default, and can be overridden by the
 /// QW_RUNTIME_NUM_THREADS environment variable.
 fn get_main_runtime_num_threads() -> usize {
-    let default_num_runtime_threads: usize = quickwit_common::num_cpus().div_ceil(3);
-    quickwit_common::get_from_env(
+    quickwit_common::get_from_env_cached!(
+        usize,
         "QW_TOKIO_RUNTIME_NUM_THREADS",
-        default_num_runtime_threads,
+        quickwit_common::num_cpus().div_ceil(3),
         false,
     )
 }
@@ -92,7 +92,7 @@ fn init_telemetry(
 )> {
     #[cfg(feature = "tokio-console")]
     {
-        if quickwit_common::get_bool_from_env(QW_ENABLE_TOKIO_CONSOLE_ENV_KEY, false) {
+        if quickwit_common::get_bool_from_env_cached!(QW_ENABLE_TOKIO_CONSOLE_ENV_KEY, false) {
             let telemetry_handle =
                 quickwit_telemetry_exporters::init_meter_provider_only(service_version)?;
             console_subscriber::init();

--- a/quickwit/quickwit-common/src/env.rs
+++ b/quickwit/quickwit-common/src/env.rs
@@ -78,14 +78,14 @@ pub fn parse_bool_lenient(bool_str: &str) -> Option<bool> {
 }
 
 /// Reads and parses an environment variable exactly once, caching the result for the lifetime of
-/// the process via a per-call-site [`std::sync::LazyLock`].
+/// the process via a per-call-site [`std::sync::OnceLock`].
 ///
 /// Prefer this over [`get_from_env`](crate::get_from_env) on paths that may run repeatedly (e.g.
 /// constructors that are re-invoked): it avoids re-reading and, more importantly, re-logging the
 /// same variable on every call.
 ///
 /// The type is required because the backing `static` needs a concrete type. The key and default
-/// must be `const` expressions or literals — a `static` initializer cannot capture locals.
+/// are evaluated only on the first invocation and may reference local values.
 ///
 /// ```no_run
 /// # use quickwit_common::get_from_env_cached;
@@ -94,12 +94,13 @@ pub fn parse_bool_lenient(bool_str: &str) -> Option<bool> {
 #[macro_export]
 macro_rules! get_from_env_cached {
     ($ty:ty, $key:expr, $default:expr, $sensitive:expr $(,)?) => {{
-        static CACHED: ::std::sync::LazyLock<$ty> =
-            ::std::sync::LazyLock::new(|| $crate::get_from_env::<$ty>($key, $default, $sensitive));
-        // `LazyLock<T>` derefs to `T`; clone so callers receive an owned value, matching
-        // `get_from_env`'s return type (a no-op copy for the common `Copy` cases).
+        static CACHED: ::std::sync::OnceLock<$ty> = ::std::sync::OnceLock::new();
+        // Clone so callers receive an owned value, matching `get_from_env`'s return type (a no-op
+        // copy for the common `Copy` cases).
         #[allow(clippy::clone_on_copy)]
-        let value = (*CACHED).clone();
+        let value = CACHED
+            .get_or_init(|| $crate::get_from_env::<$ty>($key, $default, $sensitive))
+            .clone();
         value
     }};
 }
@@ -115,9 +116,8 @@ macro_rules! get_from_env_cached {
 #[macro_export]
 macro_rules! get_bool_from_env_cached {
     ($key:expr, $default:expr $(,)?) => {{
-        static CACHED: ::std::sync::LazyLock<bool> =
-            ::std::sync::LazyLock::new(|| $crate::get_bool_from_env($key, $default));
-        *CACHED
+        static CACHED: ::std::sync::OnceLock<bool> = ::std::sync::OnceLock::new();
+        *CACHED.get_or_init(|| $crate::get_bool_from_env($key, $default))
     }};
 }
 

--- a/quickwit/quickwit-common/src/runtimes.rs
+++ b/quickwit/quickwit-common/src/runtimes.rs
@@ -121,7 +121,7 @@ impl Default for RuntimesConfig {
 fn start_runtimes(config: RuntimesConfig) -> HashMap<RuntimeType, Runtime> {
     let mut runtimes = HashMap::with_capacity(2);
 
-    let disable_lifo_slot = crate::get_bool_from_env("QW_DISABLE_TOKIO_LIFO_SLOT", true);
+    let disable_lifo_slot = crate::get_bool_from_env_cached!("QW_DISABLE_TOKIO_LIFO_SLOT", true);
 
     let mut blocking_runtime_builder = tokio::runtime::Builder::new_multi_thread();
     if disable_lifo_slot {

--- a/quickwit/quickwit-common/src/shared_consts.rs
+++ b/quickwit/quickwit-common/src/shared_consts.rs
@@ -36,7 +36,8 @@ pub fn split_deletion_grace_period() -> Duration {
     const DEFAULT_DELETION_GRACE_PERIOD: Duration = Duration::from_secs(60 * 32); // 32 min
 
     static SPLIT_DELETION_GRACE_PERIOD_SECS_LOCK: LazyLock<Duration> = LazyLock::new(|| {
-        let deletion_grace_period_secs: u64 = crate::get_from_env(
+        let deletion_grace_period_secs: u64 = crate::get_from_env_cached!(
+            u64,
             "QW_SPLIT_DELETION_GRACE_PERIOD_SECS",
             DEFAULT_DELETION_GRACE_PERIOD.as_secs(),
             false,

--- a/quickwit/quickwit-config/src/storage_config.rs
+++ b/quickwit/quickwit-config/src/storage_config.rs
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 use std::ops::Deref;
-use std::sync::OnceLock;
 use std::{env, fmt};
 
 use anyhow::ensure;
 use itertools::Itertools;
-use quickwit_common::get_bool_from_env;
 use serde::{Deserialize, Serialize};
 use serde_with::{EnumMap, serde_as};
 
@@ -406,14 +404,10 @@ impl S3StorageConfig {
     }
 
     pub fn force_path_style_access(&self) -> Option<bool> {
-        static FORCE_PATH_STYLE: OnceLock<Option<bool>> = OnceLock::new();
-        *FORCE_PATH_STYLE.get_or_init(|| {
-            let force_path_style_access = get_bool_from_env(
-                "QW_S3_FORCE_PATH_STYLE_ACCESS",
-                self.force_path_style_access,
-            );
-            Some(force_path_style_access)
-        })
+        Some(quickwit_common::get_bool_from_env_cached!(
+            "QW_S3_FORCE_PATH_STYLE_ACCESS",
+            self.force_path_style_access,
+        ))
     }
 }
 

--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -743,7 +743,7 @@ impl IndexingService {
             merge_scheduler_service,
             max_concurrent_split_uploads: self.max_concurrent_split_uploads,
             event_broker: self.event_broker.clone(),
-            skip_initial_seed: quickwit_common::get_bool_from_env(
+            skip_initial_seed: quickwit_common::get_bool_from_env_cached!(
                 super::parquet_pipeline::PARQUET_MERGE_SKIP_INITIAL_SEED_ENV_KEY,
                 false,
             ),

--- a/quickwit/quickwit-ingest/src/ingest_v2/router.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/router.rs
@@ -67,7 +67,8 @@ fn ingest_request_timeout() -> Duration {
         Duration::from_secs(35)
     };
     static TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
-        let duration_ms = quickwit_common::get_from_env(
+        let duration_ms = quickwit_common::get_from_env_cached!(
+            u64,
             "QW_INGEST_REQUEST_TIMEOUT_MS",
             DEFAULT_INGEST_REQUEST_TIMEOUT.as_millis() as u64,
             false,

--- a/quickwit/quickwit-metastore/src/metastore/postgres/migrator.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/migrator.rs
@@ -14,7 +14,6 @@
 
 use std::collections::BTreeMap;
 
-use quickwit_common::get_bool_from_env;
 use quickwit_metrics::{counter, labels};
 use quickwit_proto::metastore::{MetastoreError, MetastoreResult};
 use sqlx::migrate::{Migrate, Migrator};
@@ -63,9 +62,18 @@ impl Migrations {
     pub(super) fn from_env(connection_pool: TrackedPool<Postgres>) -> Self {
         Self {
             connection_pool,
-            skip_migrations: get_bool_from_env(QW_POSTGRES_SKIP_MIGRATIONS_ENV_KEY, false),
-            skip_locking: get_bool_from_env(QW_POSTGRES_SKIP_MIGRATION_LOCKING_ENV_KEY, false),
-            skip_deferred: get_bool_from_env(QW_POSTGRES_SKIP_DEFERRED_MIGRATIONS_ENV_KEY, false),
+            skip_migrations: quickwit_common::get_bool_from_env_cached!(
+                QW_POSTGRES_SKIP_MIGRATIONS_ENV_KEY,
+                false
+            ),
+            skip_locking: quickwit_common::get_bool_from_env_cached!(
+                QW_POSTGRES_SKIP_MIGRATION_LOCKING_ENV_KEY,
+                false
+            ),
+            skip_deferred: quickwit_common::get_bool_from_env_cached!(
+                QW_POSTGRES_SKIP_DEFERRED_MIGRATIONS_ENV_KEY,
+                false
+            ),
         }
     }
 

--- a/quickwit/quickwit-proto/src/types/split_id.rs
+++ b/quickwit/quickwit-proto/src/types/split_id.rs
@@ -50,10 +50,9 @@ impl SplitId {
     /// Layout with prefix enabled: `<4 random chars>_<22 remaining ULID chars>`
     /// (27 chars total vs the usual 26).
     pub fn new() -> Self {
-        static RANDOM_PREFIX_ENABLED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-            quickwit_common::get_bool_from_env("QW_RANDOM_SPLIT_PREFIX", false)
-        });
-        Self::from_ulid(ulid::Ulid::new(), *RANDOM_PREFIX_ENABLED)
+        let random_prefix_enabled =
+            quickwit_common::get_bool_from_env_cached!("QW_RANDOM_SPLIT_PREFIX", false);
+        Self::from_ulid(ulid::Ulid::new(), random_prefix_enabled)
     }
 
     /// Constructs a `SplitId` from a `Ulid`, optionally prepending a random prefix.

--- a/quickwit/quickwit-serve/src/datafusion_api/setup.rs
+++ b/quickwit/quickwit-serve/src/datafusion_api/setup.rs
@@ -72,7 +72,7 @@ pub(crate) fn build_datafusion_session_builder(
     if !node_config.is_service_enabled(QuickwitService::Searcher) {
         return Ok(None);
     }
-    if !quickwit_common::get_bool_from_env("QW_ENABLE_DATAFUSION_ENDPOINT", false) {
+    if !quickwit_common::get_bool_from_env_cached!("QW_ENABLE_DATAFUSION_ENDPOINT", false) {
         return Ok(None);
     }
 

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -67,13 +67,13 @@ use quickwit_common::pubsub::{EventBroker, EventSubscriptionHandle};
 use quickwit_common::rate_limiter::RateLimiterSettings;
 use quickwit_common::retry::RetryParams;
 use quickwit_common::runtimes::RuntimesConfig;
+use quickwit_common::spawn_named_task;
 use quickwit_common::tower::{
     BalanceChannel, BoxFutureInfaillible, BufferLayer, Change, CircuitBreakerEvaluator,
     ConstantRate, EstimateRateLayer, EventListenerLayer, GrpcMetricsLayer, LoadShedLayer,
     RateLimitLayer, RetryLayer, RetryPolicy, SmaRateEstimator, TimeoutLayer,
 };
 use quickwit_common::uri::Uri;
-use quickwit_common::{get_bool_from_env, spawn_named_task};
 use quickwit_compaction::planner::CompactionPlanner;
 use quickwit_compaction::{
     CompactorSupervisor, notify_compactor_decommission, start_compactor_service,
@@ -159,7 +159,8 @@ const DEFAULT_METASTORE_CLIENT_MAX_CONCURRENCY: usize = 6;
 const DISABLE_DELETE_TASK_SERVICE_ENV_KEY: &str = "QW_DISABLE_DELETE_TASK_SERVICE";
 
 fn get_metastore_client_max_concurrency() -> usize {
-    quickwit_common::get_from_env(
+    quickwit_common::get_from_env_cached!(
+        usize,
         METASTORE_CLIENT_MAX_CONCURRENCY_ENV_KEY,
         DEFAULT_METASTORE_CLIENT_MAX_CONCURRENCY,
         false,
@@ -882,7 +883,7 @@ pub async fn serve_quickwit(
             search_job_placer,
             storage_resolver.clone(),
             event_broker.clone(),
-            !get_bool_from_env(DISABLE_DELETE_TASK_SERVICE_ENV_KEY, false),
+            !quickwit_common::get_bool_from_env_cached!(DISABLE_DELETE_TASK_SERVICE_ENV_KEY, false),
             compaction_planner_handle_opt,
         )
         .await

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -66,7 +66,7 @@ use crate::{
 /// (R2, SeaweedFs...) return errors when too many concurrent requests are emitted.
 static REQUEST_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| {
     let num_permits: usize =
-        quickwit_common::get_from_env("QW_S3_MAX_CONCURRENCY", 10_000usize, false);
+        quickwit_common::get_from_env_cached!(usize, "QW_S3_MAX_CONCURRENCY", 10_000usize, false);
     Semaphore::new(num_permits)
 });
 

--- a/quickwit/quickwit-telemetry-exporters/src/otlp/config.rs
+++ b/quickwit/quickwit-telemetry-exporters/src/otlp/config.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use anyhow::Context;
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::Resource;
-use quickwit_common::{get_bool_from_env, get_from_env, get_from_env_opt};
+use quickwit_common::get_from_env_opt;
 
 pub const QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER_ENV_KEY: &str =
     "QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER";
@@ -66,8 +66,12 @@ pub(crate) struct OtlpExporterConfig {
 impl OtlpExporterConfig {
     pub(crate) fn load_from_env() -> Self {
         OtlpExporterConfig {
-            enabled: get_bool_from_env(QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER_ENV_KEY, false),
-            default_protocol: get_from_env(
+            enabled: quickwit_common::get_bool_from_env_cached!(
+                QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER_ENV_KEY,
+                false
+            ),
+            default_protocol: quickwit_common::get_from_env_cached!(
+                String,
                 OTEL_EXPORTER_OTLP_PROTOCOL_ENV_KEY,
                 "grpc".to_string(),
                 false,


### PR DESCRIPTION
switch more usage to `get_from_env_cached` to enforce they are read (and logged) only once