### PR TITLE
Deduplicate published shard positions by keeping the max per shard

### DIFF
--- a/quickwit/quickwit-indexing/src/models/shard_positions.rs
+++ b/quickwit/quickwit-indexing/src/models/shard_positions.rs
@@ -293,12 +293,26 @@ impl ShardPositionsService {
             warn!("received an empty publish shard positions update");
             return Vec::new();
         }
+        // Deduplicate the incoming positions by only keeping the max position for each shard.
+        // Downstream consumers only care about the highest published position per shard.
+        let mut max_positions_per_shard: FnvHashMap<ShardId, Position> = FnvHashMap::default();
+        for (shard, new_position) in published_positions_per_shard {
+            max_positions_per_shard
+                .entry(shard)
+                .and_modify(|current_position| {
+                    if new_position > *current_position {
+                        *current_position = new_position.clone();
+                    }
+                })
+                .or_insert(new_position);
+        }
+
         let current_shard_positions = self
             .shard_positions_per_source
             .entry(source_uid.clone())
             .or_default();
 
-        let updated_positions_per_shard = published_positions_per_shard
+        let updated_positions_per_shard = max_positions_per_shard
             .into_iter()
             .filter(|(shard, new_position)| {
                 let Some(position) = current_shard_positions.get(shard) else {

--- a/quickwit/quickwit-indexing/src/models/shard_positions.rs
+++ b/quickwit/quickwit-indexing/src/models/shard_positions.rs
@@ -566,4 +566,54 @@ mod tests {
         }
         universe.assert_quit().await;
     }
+
+    #[tokio::test]
+    async fn test_shard_positions_apply_update_deduplicates_same_batch() {
+        let transport = ChitchatTransport::default();
+        let cluster = create_cluster_for_test(Vec::new(), &[], &transport, true)
+            .await
+            .unwrap();
+        let mut shard_positions_service =
+            ShardPositionsService::new(EventBroker::default(), cluster);
+
+        let index_uid = IndexUid::new_with_random_ulid("index-test");
+        let source_id = "test-source".to_string();
+        let source_uid = SourceUid {
+            index_uid,
+            source_id,
+        };
+        let shard_id = ShardId::from(1);
+
+        // The batch contains several positions for the same shard, out of order.
+        // Only the max position should be kept.
+        let update_to_42 = shard_positions_service.apply_update(
+            &source_uid,
+            vec![
+                (shard_id.clone(), Position::offset(10u64)),
+                (shard_id.clone(), Position::offset(42u64)),
+                (shard_id.clone(), Position::offset(5u64)),
+            ],
+        );
+        assert_eq!(
+            &update_to_42,
+            &[(shard_id.clone(), Position::offset(42u64))]
+        );
+
+        // We only update on a strictly greater position
+        let no_updates: Vec<_> = shard_positions_service.apply_update(
+            &source_uid,
+            vec![(shard_id.clone(), Position::offset(42u64))],
+        );
+        assert!(no_updates.is_empty());
+
+        // We only update when there is a strictly greater position
+        let update_to_43: Vec<_> = shard_positions_service.apply_update(
+            &source_uid,
+            vec![(shard_id.clone(), Position::offset(43u64))],
+        );
+        assert_eq!(
+            &update_to_43,
+            &[(shard_id.clone(), Position::offset(43u64))]
+        );
+    }
 }

--- a/quickwit/quickwit-proto/src/types/position.rs
+++ b/quickwit/quickwit-proto/src/types/position.rs
@@ -308,6 +308,10 @@ mod tests {
 
         assert!(Position::offset(0u64) < Position::offset(1u64));
 
+        assert!(Position::offset(0u64) < Position::Eof(None));
+        assert!(Position::offset(1u64) < Position::eof(1u64));
+        assert!(Position::offset(1u64) < Position::eof(0u64)); //< this should not happen, but let's test it still.
+
         assert!(Position::Eof(None) < Position::eof(0u64));
         assert!(Position::eof(0u64) < Position::eof(1u64));
     }


### PR DESCRIPTION
## Summary
- When a single publish batch contains multiple position updates for the same shard, keep only the max position per shard before merging into `current_shard_positions`, instead of letting later entries in the batch clobber earlier (possibly higher) ones.

## Test plan
- [x] Added assertions to `Position` ordering tests covering `Eof`/`offset` comparisons
- [x] `cargo clippy -p quickwit-indexing -p quickwit-proto --all-features --tests`
- [x] `cargo +nightly fmt --all -- --check`