### PR TITLE
docs: clarify 0.9 metrics status and downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metastore format: new `maturity` field and compaction columns on splits; PostgreSQL metastore migrates automatically on first start.
 - Building from source now requires Rust 1.92 (#6432, #6545).
 
+### Prototype work (not included in release artifacts)
+
+The Parquet metrics and DataFusion work below is an early prototype. It is not built into the v0.9.0 binaries or Docker images and is not a supported 0.9.0 feature.
+
+- Add experimental DataFusion query layer for Parquet metrics with SQL/Substrait execution, Arrow IPC streaming, and distributed workers (#6276)
+- Extend the Parquet metrics pipeline with DDSketch, sorted-series and row-key metadata, zone-map pruning, partitioning, sketch split pagination, and Substrait execution metadata (#6248, #6257, #6290, #6292, #6295, #6340, #6347, #6348, #6349, #6363, #6364, #6368)
+
 ### Added
 - Add Ingest V2 — now the default (#5600, #5566, #5463, #5375, #5350, #5252, #5202, #6078, #6185, #6203, #6207, #6217, #6249)
 - Offload leaf-search work to AWS Lambda functions — searchers can farm out part of their workload to Lambda (#6157, #5c1e60f)
-- Add experimental DataFusion query layer for Parquet metrics with SQL/Substrait execution, Arrow IPC streaming, and distributed workers (#6276)
-- Extend the Parquet metrics pipeline with DDSketch, sorted-series and row-key metadata, zone-map pruning, partitioning, sketch split pagination, and Substrait execution metadata (#6248, #6257, #6290, #6292, #6295, #6340, #6347, #6348, #6349, #6363, #6364, #6368)
 - Add column-major and streaming Parquet merge primitives, merge scheduler wiring, and a rollout flag for routing regular merges through the streaming engine (#6335, #6362, #6367, #6377, #6384, #6386, #6406, #6407, #6408, #6409, #6423, #6424, #6425, #6426, #6428, #6441)
 - Add optional mTLS validation to the REST API and an optional dedicated health-check HTTP server for deployments that put the REST API behind mTLS (#6467, #6528)
 - Add SQS source (#5374, #5335, #5148)

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -41,16 +41,16 @@ Downloads `.tar.gz`:
 
 </RenderIf>
 
-<!-- Bellow is the set of links to edit when a new version is released -->
+<!-- Below is the set of links to edit when a new version is released -->
 <RenderIf condition={useDocsVersion().version != 'current'}>
 
-version: 0.8.1 - [Release notes](https://github.com/quickwit-oss/quickwit/releases/tag/v0.8.1) - [Changelog](https://github.com/quickwit-oss/quickwit/blob/main/CHANGELOG.md)
+Version: 0.9.0 - [Release notes](https://github.com/quickwit-oss/quickwit/releases/tag/v0.9.0) - [Changelog](https://github.com/quickwit-oss/quickwit/blob/main/CHANGELOG.md#090)
 License: [Apache 2.0](https://github.com/quickwit-oss/quickwit/blob/main/LICENSE)
 Downloads `.tar.gz`:
-- [Linux ARM64](https://github.com/quickwit-oss/quickwit/releases/download/v0.8.1/quickwit-v0.8.1-aarch64-unknown-linux-gnu.tar.gz)
-- [Linux x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.8.1/quickwit-v0.8.1-x86_64-unknown-linux-gnu.tar.gz)
-- [macOS aarch64](https://github.com/quickwit-oss/quickwit/releases/download/v0.8.1/quickwit-v0.8.1-aarch64-apple-darwin.tar.gz)
-- [macOS x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.8.1/quickwit-v0.8.1-x86_64-apple-darwin.tar.gz)
+- [Linux ARM64](https://github.com/quickwit-oss/quickwit/releases/download/v0.9.0/quickwit-v0.9.0-aarch64-unknown-linux-gnu.tar.gz)
+- [Linux x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.9.0/quickwit-v0.9.0-x86_64-unknown-linux-gnu.tar.gz)
+- [macOS aarch64](https://github.com/quickwit-oss/quickwit/releases/download/v0.9.0/quickwit-v0.9.0-aarch64-apple-darwin.tar.gz)
+- [macOS x86_64](https://github.com/quickwit-oss/quickwit/releases/download/v0.9.0/quickwit-v0.9.0-x86_64-apple-darwin.tar.gz)
 
 </RenderIf>
 

--- a/docs/get-started/upgrade.md
+++ b/docs/get-started/upgrade.md
@@ -11,6 +11,10 @@ This page documents breaking changes and migration steps when upgrading Quickwit
 2. **Back up your index data (optional).** The on-disk split format and object-storage layout are unchanged, so no re-indexing is needed. A backup is still recommended if your storage is not already versioned.
 3. **Stop all 0.8.x nodes before starting any 0.9 node.** Mixed-version clusters are not supported during the migration.
 
+### Metrics prototype
+
+The Parquet metrics pipeline and DataFusion query layer in the source tree are early prototype work. They are not built into the official v0.9.0 binaries or Docker images and are not supported in this release.
+
 ### Ingest V2
 
 In 0.8.x, ingest V2 was opt-in via `QW_ENABLE_INGEST_V2=true` and was served from a dedicated route `POST /api/v1/{index}/ingest-v2`.


### PR DESCRIPTION
## Summary

- identify the Parquet metrics and DataFusion work as prototype-only and absent from official v0.9.0 binaries and Docker images
- add the same clarification to the 0.9 upgrade guide
- update the versioned installation page to the exact v0.9.0 release assets

## Validation

- verified all four archive names against the published v0.9.0 release assets
- ran `yarn clear && yarn build` in the quickwit.io repository; the Docusaurus production build passed
- checked the generated 0.9 installation and upgrade pages for the corrected downloads and warning