### PR TITLE
restrict bounds on cardinality test

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -904,6 +904,7 @@ unit-prefix,https://codeberg.org/commons-rs/unit-prefix,MIT,"Fabio Valentini <de
 universal-hash,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtolnay@gmail.com>
 untrusted,https://github.com/briansmith/untrusted,ISC,Brian Smith <brian@briansmith.org>
+unwrap-infallible,https://github.com/mzabaluev/unwrap-infallible,MIT OR Apache-2.0,Mikhail Zabaluev <mikhail.zabaluev@gmail.com>
 ureq-proto,https://github.com/algesten/ureq-proto,MIT OR Apache-2.0,Martin Algesten <martin@algesten.se>
 url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 urlencoding,https://github.com/kornelski/rust_urlencoding,MIT,"Kornel <kornel@geekhood.net>, Bertram Truong <b@bertramtruong.com>"

--- a/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
@@ -356,14 +356,11 @@ json:
 expected:
   aggregations:
     unique_names:
-      value:
-        $expect: 'abs(val - 8) <= 2'
+      value: 8.0
     unique_response:
-      value:
-        $expect: 'abs(val - 6) <= 2' # TODO: Check. The correct number is 6
+      value: 5.0
     unique_dates:
-      value:
-        $expect: 'abs(val - 6) <= 3'
+      value: 6.0
 ---
 # Test extended stats aggregation
 method: [GET]


### PR DESCRIPTION
the underlying issue has been fixed when upgrading to datasketch 0.3

fix https://github.com/quickwit-oss/quickwit/issues/6294