### PR TITLE
Handle non-advertisable shards in idle task and during decommissioning

### DIFF
--- a/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/ingester.rs
@@ -3872,6 +3872,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_check_decommissioning_status_with_empty_orphan_shard() {
+        // A non-advertisable shard is invisible to gossip/RPC-driven cleanup and will never be
+        // deleted, so the ingester must not wait for its removal to consider itself
+        // decommissioned as long as it is empty.
+        let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
+        let mut state_guard = ingester.state.lock_fully("test").await.unwrap();
+
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let source_id = SourceId::from("test-source");
+
+        let empty_orphan_shard =
+            IngesterShard::new_solo(index_uid.clone(), source_id, ShardId::from(1))
+                .with_state(ShardState::Closed)
+                .build();
+        let queue_id = empty_orphan_shard.queue_id();
+        state_guard
+            .shards
+            .insert(queue_id.clone(), empty_orphan_shard);
+
+        state_guard
+            .set_status(IngesterStatus::Decommissioning)
+            .await;
+        state_guard.check_decommissioning_status().await;
+
+        assert_eq!(state_guard.status(), IngesterStatus::Decommissioned);
+        assert!(state_guard.shards.contains_key(&queue_id));
+    }
+
+    #[tokio::test]
     async fn test_decommission_completes_when_empty_shard_deleted_via_gossip() {
         let (_ingester_ctx, ingester) = IngesterForTest::default().build().await;
 

--- a/quickwit/quickwit-ingest/src/ingest_v2/models.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/models.rs
@@ -20,6 +20,7 @@ use quickwit_doc_mapper::DocMapper;
 use quickwit_proto::ingest::ShardState;
 use quickwit_proto::types::{IndexUid, NodeId, Position, QueueId, ShardId, SourceId, queue_id};
 use tokio::sync::watch;
+use tracing::error;
 
 use crate::ingest_v2::rate_meter::RateMeter;
 
@@ -267,6 +268,29 @@ impl IngesterShard {
         now.duration_since(self.last_write_instant) >= idle_timeout
     }
 
+    /// Returns `true` if the shard is unreachable to the control plane and empty.
+    // A non-advertisable shard means the control plane never got confirmation that this
+    // shard was initialized on this ingester (e.g. it lost the `init_shards` response),
+    // so it never recorded the shard in the metastore or handed it out to any router or
+    // indexer. Such a shard can never become advertisable (that requires a persist/fetch
+    // request, which requires the control plane to know about it) and is invisible to
+    // the other RPC or gossip-driven cleanup mechanisms. It's safe to delete: never
+    // having been advertised, it can't have received any writes.
+    pub fn is_empty_orphan(&self) -> bool {
+        if self.is_advertisable {
+            return false;
+        }
+        let is_empty = self.replication_position_inclusive.is_beginning();
+        if !is_empty {
+            error!(
+                "shard `{}` is not advertisable but is not empty, this should never happen, \
+                 please report",
+                self.queue_id()
+            );
+        }
+        is_empty
+    }
+
     pub fn is_replica(&self) -> bool {
         matches!(self.shard_type, IngesterShardType::Replica { .. })
     }
@@ -438,5 +462,37 @@ mod tests {
             Position::Beginning
         );
         assert!(!solo_shard.is_advertisable);
+    }
+
+    #[test]
+    fn test_is_empty_orphan() {
+        let non_advertisable_empty_shard = IngesterShard::new_solo(
+            IndexUid::for_test("test-index", 0),
+            SourceId::from("test-source"),
+            ShardId::from(1),
+        )
+        .with_state(ShardState::Closed)
+        .build();
+        assert!(non_advertisable_empty_shard.is_empty_orphan());
+
+        let advertisable_empty_shard = IngesterShard::new_solo(
+            IndexUid::for_test("test-index", 0),
+            SourceId::from("test-source"),
+            ShardId::from(2),
+        )
+        .with_state(ShardState::Closed)
+        .advertisable()
+        .build();
+        assert!(!advertisable_empty_shard.is_empty_orphan());
+
+        let non_advertisable_non_empty_shard = IngesterShard::new_solo(
+            IndexUid::for_test("test-index", 0),
+            SourceId::from("test-source"),
+            ShardId::from(3),
+        )
+        .with_state(ShardState::Closed)
+        .with_replication_position_inclusive(Position::offset(42u64))
+        .build();
+        assert!(!non_advertisable_non_empty_shard.is_empty_orphan());
     }
 }

--- a/quickwit/quickwit-ingest/src/ingest_v2/state.rs
+++ b/quickwit/quickwit-ingest/src/ingest_v2/state.rs
@@ -85,7 +85,15 @@ impl InnerIngesterState {
         if self.status() != IngesterStatus::Decommissioning {
             return;
         }
-        if self.shards.is_empty() {
+        // An ingester is decommissioned if:
+        // - `self.shards` is empty OR
+        // - all shards are non-advertisable and empty
+        //
+        // see `IngesterShard::is_empty_orphan` for why the latter are never going to be deleted
+        // by any other cleanup mechanism, so we must not wait on them here.
+        let is_decommissioned = self.shards.values().all(|shard| shard.is_empty_orphan());
+
+        if is_decommissioned {
             self.set_status(IngesterStatus::Decommissioned).await;
         }
     }


### PR DESCRIPTION
### Description
A non-advertisable shard is a shard that was created by an ingester but is unknown to the control plane. This can happen when the control plane performs a successful init shards RPC on ingester but somehow the RPC response did not make it to the control plane (network issue?). For a shard to become advertisable, it needs to receive a persist or fetch RPC, which only happens if a router or an indexer knows about it, which means the control plane knows about.

~~If a shard has been non-advertisable, idle for a while, and empty, it is safe to delete. That's commit 6be93316e2c8b67f841041355c3d79a3450d07c6~~

If a shard is non-advertisable and empty, it should not prevent ingesters from decommissioning. That's commit 6b38a79f4284038eae7f0f57a21dd0c4ecb2698d

### How was this PR tested?
Added / updated unit tests
