### PR TITLE
Emit metastore max connections metric

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -67,6 +67,7 @@ PostgreSQL-backed metastores also expose connection pool gauges:
 | `quickwit_metastore` | `active_connections` | Number of active PostgreSQL pool connections, including used and idle connections | `gauge` |
 | `quickwit_metastore` | `idle_connections` | Number of idle PostgreSQL pool connections | `gauge` |
 | `quickwit_metastore` | `acquire_connections` | Number of requests currently waiting to acquire a PostgreSQL pool connection | `gauge` |
+| `quickwit_metastore` | `max_connections` | Maximum number of PostgreSQL pool connections configured per metastore node | `gauge` |
 
 ## Rest API Metrics
 

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metrics.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metrics.rs
@@ -52,3 +52,9 @@ pub(super) static IDLE_CONNECTIONS: LazyGauge = lazy_gauge!(
         description: "Number of idle connections.",
         subsystem: "metastore",
 );
+
+pub(super) static MAX_CONNECTIONS: LazyGauge = lazy_gauge!(
+        name: "max_connections",
+        description: "Maximum number of connections configured for the pool.",
+        subsystem: "metastore",
+);

--- a/quickwit/quickwit-metastore/src/metastore/postgres/pool.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/pool.rs
@@ -21,13 +21,16 @@ use sqlx::{
     Acquire, Database, Describe, Either, Error, Execute, Executor, Pool, Postgres, Transaction,
 };
 
-use super::metrics::{ACQUIRE_CONNECTIONS, ACTIVE_CONNECTIONS, IDLE_CONNECTIONS, MetastoreKind};
+use super::metrics::{
+    ACQUIRE_CONNECTIONS, ACTIVE_CONNECTIONS, IDLE_CONNECTIONS, MAX_CONNECTIONS, MetastoreKind,
+};
 
 #[derive(Clone, Debug)]
 struct TrackedPoolMetrics {
     acquire_connections: Gauge,
     active_connections: Gauge,
     idle_connections: Gauge,
+    max_connections: Gauge,
 }
 
 impl TrackedPoolMetrics {
@@ -37,6 +40,7 @@ impl TrackedPoolMetrics {
             acquire_connections: gauge!(parent: ACQUIRE_CONNECTIONS, labels: [kind_label]),
             active_connections: gauge!(parent: ACTIVE_CONNECTIONS, labels: [kind_label]),
             idle_connections: gauge!(parent: IDLE_CONNECTIONS, labels: [kind_label]),
+            max_connections: gauge!(parent: MAX_CONNECTIONS, labels: [kind_label]),
         }
     }
 }
@@ -49,9 +53,13 @@ pub(super) struct TrackedPool<DB: Database> {
 
 impl TrackedPool<Postgres> {
     pub fn new(inner_pool: Pool<Postgres>, kind: MetastoreKind) -> Self {
+        let metrics = TrackedPoolMetrics::new(kind);
+        metrics
+            .max_connections
+            .set(inner_pool.options().get_max_connections() as f64);
         Self {
             inner_pool,
-            metrics: TrackedPoolMetrics::new(kind),
+            metrics,
         }
     }
 }


### PR DESCRIPTION
## Summary

- emit the configured PostgreSQL connection pool maximum as `quickwit_metastore_max_connections`
- expose the gauge with the existing `metastore_kind` label
- document the metric alongside the active, idle, and acquire connection gauges

This makes it possible to display pool utilization directly in dashboards, for example `(active_connections - idle_connections) / max_connections`.

## Validation

- `cargo check -p quickwit-metastore`
- `git diff --check`