### PR TITLE
Shorten decommissioned/dead node grace periods to prevent digest overflow

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1984,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "chitchat"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1cfd5d16c6fc43487006ab5b5c910f295cc53cf07d90491fb36c8dc479c754"
+checksum = "b364e0923b5cff38b15d6eed267dea5e984eb1933a8a6e34bb87eb3a833a5d1c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2189,7 +2189,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6614,7 +6614,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",
@@ -7041,7 +7041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13375,7 +13375,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -114,7 +114,7 @@ bitpacking = "0.9"
 bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "2.4", features = ["serde"] }
 bytestring = "1.5"
-chitchat = "0.11.1"
+chitchat = "0.11.2"
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -50,7 +50,7 @@ use crate::{ClusterChangeStream, ClusterNode};
 const MARKED_FOR_DELETION_GRACE_PERIOD: Duration = if cfg!(any(test, feature = "testsuite")) {
     Duration::from_millis(2_500) // 2.5 secs
 } else {
-    Duration::from_secs(3_600 * 2) // 2 hours.
+    Duration::from_mins(15)
 };
 
 // An indexing task key is formatted as

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -133,7 +133,7 @@ pub async fn start_cluster_service(node_config: &NodeConfig) -> anyhow::Result<C
         enable_standalone_compactors: node_config.enable_standalone_compactors,
     };
     let failure_detector_config = FailureDetectorConfig {
-        dead_node_grace_period: Duration::from_secs(2 * 60 * 60), // 2 hours
+        dead_node_grace_period: Duration::from_mins(15),
         ..Default::default()
     };
     let channel_factory = ChannelFactory::for_grpc(&node_config.grpc_config)?;


### PR DESCRIPTION
## Summary
When a cluster is unstable for a long period of time, nodes accumulate in the marked-for-deletion and failure-detector state without being garbage collected, since both grace periods were set to 2 hours. This let the chitchat digest grow past 500 nodes after a gossip round, exceeding the largest transmittable digest size and causing nodes to fail.

- Shortens `MARKED_FOR_DELETION_GRACE_PERIOD` from 2 hours to 15 minutes
- Shortens `dead_node_grace_period` from 2 hours to 15 minutes

## Test plan
- [ ] `cargo clippy --workspace --all-features --tests` (blocked locally: `chitchat = "0.11.2"` isn't published on crates.io yet)
- [ ] `cargo nextest run -p quickwit-cluster --all-features`