### PR TITLE
build(deps): upgrade opendal from 0.57 to 0.58

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -535,6 +535,7 @@ oorandom,https://hg.sr.ht/~icefox/oorandom,MIT,Simon Heath <icefox@dreamquest.io
 opaque-debug,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 opendal,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
 opendal-core,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
+opendal-http-transport-reqwest,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
 opendal-service-gcs,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
 openidconnect,https://github.com/ramosbugs/openidconnect-rs,MIT,David A. Ramos <ramos@cs.stanford.edu>
 openssl,https://github.com/rust-openssl/rust-openssl,Apache-2.0,Steven Fackler <sfackler@gmail.com>
@@ -683,6 +684,7 @@ regex-lite,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Projec
 regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regress,https://github.com/ridiculousfish/regress,MIT OR Apache-2.0,ridiculousfish <corydoras@ridiculousfish.com>
 relative-path,https://github.com/udoprog/relative-path,MIT OR Apache-2.0,John-John Tedro <udoprog@tedro.se>
+reqsign-aws-core,https://github.com/apache/opendal-reqsign,Apache-2.0,The reqsign-aws-core Authors
 reqsign-aws-v4,https://github.com/apache/opendal-reqsign,Apache-2.0,The reqsign-aws-v4 Authors
 reqsign-core,https://github.com/apache/opendal-reqsign,Apache-2.0,The reqsign-core Authors
 reqsign-file-read-tokio,https://github.com/apache/opendal-reqsign,Apache-2.0,The reqsign-file-read-tokio Authors

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1507,6 +1507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6762,34 +6768,33 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendal"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
+checksum = "4f20562cc7447fcc915fc5c23df305a412ea80a733c9f2fd9e2d267e2815be6d"
 dependencies = [
  "opendal-core",
+ "opendal-http-transport-reqwest",
  "opendal-service-gcs",
 ]
 
 [[package]]
 name = "opendal-core"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f8607c90e2c963a91467f50fb49fbc7fb3d573f88cea219ca59ccd3740b309"
+checksum = "ec75551ff4cf3e57da98979f6a937aaa9ddb3915bf68cc17d03df733be6646ed"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "futures",
  "http 1.4.2",
- "http-body 1.0.1",
  "jiff",
  "log",
  "md-5 0.11.0",
  "mea",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "reqsign-core",
- "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -6799,10 +6804,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-service-gcs"
-version = "0.57.0"
+name = "opendal-http-transport-reqwest"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48de101aac565ed06af4b47903c24eafd249075553ec1fb18256751c45148d47"
+checksum = "ad4d4f19c3ce01126a30611f8e544eaa217104a278c889ac17c9374fe4f9e4ef"
+dependencies = [
+ "bytes",
+ "futures",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "opendal-core",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opendal-service-gcs"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007f3fba63c21e516c956b891e96ff9892d8175662bfb781cdada9d3766a11e6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6810,7 +6829,7 @@ dependencies = [
  "log",
  "opendal-core",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "reqsign-google",
@@ -8287,19 +8306,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -9418,6 +9427,7 @@ dependencies = [
  "mini-moka",
  "mockall",
  "opendal",
+ "opendal-http-transport-reqwest",
  "pin-project",
  "proptest",
  "quick_cache",
@@ -9948,19 +9958,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqsign-aws-v4"
-version = "3.0.1"
+name = "reqsign-aws-core"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75624bd8a466e37ddc0a7b6c33ac859a85347c153a916e1dd9d0b68338f74a"
+checksum = "e4af084e1f3cbf3e67e0c972765399bce54ecec804cceba46b39a8331f3c1bff"
 dependencies = [
- "anyhow",
  "bytes",
  "form_urlencoded",
  "hex",
  "http 1.4.2",
  "log",
  "percent-encoding",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "reqsign-core",
  "rust-ini",
  "serde",
@@ -9970,15 +9979,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqsign-core"
-version = "3.0.1"
+name = "reqsign-aws-v4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fa5cb48808693614d1701fcd3db0b30fa292e0f18e122ae068b6d32eaeed3f"
+checksum = "4ac5b3b7cefa28933792b439186459f77f19f9b6edbeab41b8b187150361a206"
+dependencies = [
+ "bytes",
+ "http 1.4.2",
+ "log",
+ "quick-xml 0.41.0",
+ "reqsign-aws-core",
+ "reqsign-core",
+ "serde",
+]
+
+[[package]]
+name = "reqsign-core"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07dd510b1e1b9b241883e483358147fb2ed2d497a7b39b065ba61eb93deceb0"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
- "form_urlencoded",
  "futures",
  "hex",
  "hmac 0.13.0",
@@ -9996,9 +10019,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-file-read-tokio"
-version = "3.0.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4b6f3a3fd29ffcc99a90aec585a65217783badfd73acddf847b63ae683bda9"
+checksum = "663d9d55abd0df0830ef0ae43708297cc1371cf4e8ca91f3ac813c309cca8c98"
 dependencies = [
  "anyhow",
  "reqsign-core",
@@ -10007,9 +10030,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-google"
-version = "3.0.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb215d0876a18b6bd9cdd380b589e5292aaa638ca15266de794b1122d898b6b2"
+checksum = "4080a227f82a09f68540ecd028622065d7ac4c0bcb8727a25bdcfc0526235792"
 dependencies = [
  "form_urlencoded",
  "http 1.4.2",

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -384,7 +384,7 @@ azure_storage_blobs = { version = "0.21", default-features = false, features = [
   "enable_reqwest_rustls",
 ] }
 
-opendal = { version = "0.57", default-features = false, features = ["reqwest-rustls-tls"] }
+opendal = { version = "0.58", default-features = false, features = ["reqwest-rustls-tls"] }
 reqsign = { version = "0.18", default-features = false, features = ["google", "default-context"] }
 
 quickwit-actors = { path = "quickwit-actors" }

--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -66,6 +66,9 @@ proptest = { workspace = true }
 # intentional: the HTTPS regression test should get TLS only from OpenDAL's
 # `reqwest-rustls-tls` feature, not from this dev-dependency.
 reqwest-013 = { package = "reqwest", version = "0.13", default-features = false }
+# Used by the HTTPS TLS regression test to inject a custom reqwest client via
+# OpenDAL's HttpTransporter API (split out of opendal in 0.58).
+opendal-http-transport-reqwest = "0.58"
 rustls = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }

--- a/quickwit/quickwit-storage/src/opendal_storage/base.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/base.rs
@@ -59,7 +59,7 @@ impl OpendalStorage {
         uri: Uri,
         cfg: opendal::services::Gcs,
     ) -> Result<Self, StorageResolverError> {
-        let op = Operator::new(cfg)?.finish();
+        let op = Operator::new(cfg)?;
         Ok(Self::from_operator(uri, op))
     }
 
@@ -75,14 +75,14 @@ impl OpendalStorage {
     #[cfg(test)]
     // Lets local HTTPS tests trust a private CA without changing global trust,
     // while still using Quickwit's GCS storage construction and read path.
-    pub(super) fn new_google_cloud_storage_with_http_client_for_test(
+    pub(super) fn new_google_cloud_storage_with_http_transport_for_test(
         uri: Uri,
         cfg: opendal::services::Gcs,
-        http_client: opendal::raw::HttpClient,
+        http_transport: opendal::HttpTransporter,
     ) -> Result<Self, StorageResolverError> {
-        let op = Operator::new(cfg)?
-            .layer(opendal::layers::HttpClientLayer::new(http_client))
-            .finish();
+        let op = Operator::new(cfg)?.with_context(
+            opendal::OperationContext::new().with_http_transport(http_transport),
+        );
         Ok(Self::from_operator(uri, op))
     }
 

--- a/quickwit/quickwit-storage/src/opendal_storage/base.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/base.rs
@@ -80,9 +80,8 @@ impl OpendalStorage {
         cfg: opendal::services::Gcs,
         http_transport: opendal::HttpTransporter,
     ) -> Result<Self, StorageResolverError> {
-        let op = Operator::new(cfg)?.with_context(
-            opendal::OperationContext::new().with_http_transport(http_transport),
-        );
+        let op = Operator::new(cfg)?
+            .with_context(opendal::OperationContext::new().with_http_transport(http_transport));
         Ok(Self::from_operator(uri, op))
     }
 

--- a/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
@@ -118,7 +118,8 @@ mod tests {
     use std::sync::Arc;
 
     use base64::Engine;
-    use opendal::raw::HttpClient;
+    use opendal::HttpTransporter;
+    use opendal_http_transport_reqwest::ReqwestTransport;
     use quickwit_common::uri::Uri;
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivateSec1KeyDer};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -203,10 +204,10 @@ mod tests {
             .skip_signature()
             .disable_config_load()
             .disable_vm_metadata();
-        let storage = OpendalStorage::new_google_cloud_storage_with_http_client_for_test(
+        let storage = OpendalStorage::new_google_cloud_storage_with_http_transport_for_test(
             Uri::for_test("gs://quickwit-test-bucket"),
             cfg,
-            HttpClient::with(reqwest_client),
+            HttpTransporter::new(ReqwestTransport::new(reqwest_client)),
         )?;
 
         let bytes = storage.get_slice(Path::new("hello.txt"), 0..2).await?;


### PR DESCRIPTION
### Description

Upgrade Apache OpenDAL from 0.57 to 0.58.1 so Quickwit stays on the latest storage layer release (including GCS path encoding and HTTP transport fixes).

OpenDAL 0.58 has a few API changes that this PR adapts to:

- `Operator::new(...)` now returns `Result<Operator>` directly; the old `.finish()` step is gone.
- Custom HTTP clients no longer use `HttpClientLayer` / `raw::HttpClient`. The HTTPS TLS regression test now injects a reqwest client through `OperationContext` + `HttpTransporter` / `ReqwestTransport`.

### How was this PR tested?

- `cargo check -p quickwit-storage --features gcs`
- `cargo test -p quickwit-storage --features gcs --lib` (71 tests, including `test_gcs_storage_get_slice_over_https_with_verified_tls`)
- `dd-rust-license-tool --config quickwit/license-tool.toml --manifest-path quickwit/Cargo.toml check`
