### PR TITLE
Add S3 PUT failure metrics

### DIFF
--- a/quickwit/quickwit-storage/src/metrics.rs
+++ b/quickwit/quickwit-storage/src/metrics.rs
@@ -33,6 +33,7 @@ const OUTCOME_NAME: LabelNames<1> = label_names!("outcome");
 const COMPONENT_NAME: LabelNames<1> = label_names!("component_name");
 const COMPONENT_CAPACITY_POLICY: LabelNames<3> =
     label_names!("component_name", "capacity", "policy");
+pub(crate) const ERROR_CLASS: LabelNames<1> = label_names!("class");
 
 static GET_SLICE_TIMEOUT_OUTCOME_TOTAL: LazyCounter = lazy_counter!(
         name: "get_slice_timeout_outcome",
@@ -128,6 +129,18 @@ pub(crate) static OBJECT_STORAGE_PUT_TOTAL: LazyCounter = lazy_counter!(
         name: "object_storage_puts_total",
         description: "Number of objects uploaded. May differ from object_storage_requests_parts due to multipart upload.",
         subsystem: "storage",
+);
+
+pub(crate) static OBJECT_STORAGE_PUT_ERRORS_TOTAL: LazyCounter = lazy_counter!(
+    name: "object_storage_put_errors_total",
+        description: "Number of S3 object uploads that failed after retries were exhausted.",
+    subsystem: "storage",
+);
+
+pub(crate) static OBJECT_STORAGE_PUT_ATTEMPT_ERRORS_TOTAL: LazyCounter = lazy_counter!(
+    name: "object_storage_put_attempt_errors_total",
+        description: "Number of failed S3 PutObject and UploadPart attempts, counted per attempt (retried attempts included), labeled by error class. Use class=\"throttling\" to measure S3 rate limiting.",
+    subsystem: "storage",
 );
 
 pub(crate) static OBJECT_STORAGE_PUT_PARTS: LazyCounter = lazy_counter!(

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -271,9 +271,7 @@ fn aws_checksum_algorithm(
 /// Coarse classification of an SDK error, used as a counter label.
 /// timeout, io, throttling, transient, or other.
 fn classify_sdk_error<E>(error: &SdkError<E>) -> &'static str
-where
-    E: ProvideErrorMetadata,
-{
+where E: ProvideErrorMetadata {
     match error {
         SdkError::TimeoutError(_) => "timeout",
         SdkError::DispatchFailure(failure) => {

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -400,10 +400,9 @@ impl S3CompatibleObjectStorage {
             .send()
             .await
             .inspect_err(|error| {
-                let error_class: &'static str = classify_sdk_error(error);
                 counter!(
                     parent: crate::metrics::OBJECT_STORAGE_PUT_ATTEMPT_ERRORS_TOTAL,
-                    labels: [label_values!(ERROR_CLASS => error_class)],
+                    labels: [label_values!(ERROR_CLASS => classify_sdk_error(error))],
                 )
                 .inc();
             })
@@ -558,10 +557,9 @@ impl S3CompatibleObjectStorage {
             .send()
             .await
             .inspect_err(|error| {
-                let error_class: &'static str = classify_sdk_error(error);
                 counter!(
                     parent: crate::metrics::OBJECT_STORAGE_PUT_ATTEMPT_ERRORS_TOTAL,
-                    labels: [label_values!(ERROR_CLASS => error_class)],
+                    labels: [label_values!(ERROR_CLASS => classify_sdk_error(error))],
                 )
                 .inc();
             })
@@ -689,10 +687,9 @@ impl S3CompatibleObjectStorage {
             // retry), labeled by error class so rate limiting (class="throttled") can be measured
             // independently of other transient failures.
             .inspect_err(|error| {
-                let error_class: &'static str = classify_sdk_error(error);
                 counter!(
                     parent: crate::metrics::OBJECT_STORAGE_GET_ATTEMPT_ERRORS_TOTAL,
-                    labels: [label_values!(ERROR_CLASS => error_class)],
+                    labels: [label_values!(ERROR_CLASS => classify_sdk_error(error))],
                 )
                 .inc();
             })

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -47,13 +47,13 @@ use quickwit_common::thread_pool::run_cpu_intensive;
 use quickwit_common::uri::Uri;
 use quickwit_common::{chunk_range, into_u64_range};
 use quickwit_config::S3StorageConfig;
-use quickwit_metrics::{HistogramTimer, counter};
+use quickwit_metrics::{HistogramTimer, counter, label_values};
 use regex::Regex;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, ReadBuf};
 use tokio::sync::Semaphore;
 use tracing::{info, instrument, warn};
 
-use crate::metrics::object_storage_get_slice_in_flight_guards;
+use crate::metrics::{ERROR_CLASS, object_storage_get_slice_in_flight_guards};
 use crate::object_storage::MultiPartPolicy;
 use crate::stable_deref_bytes::into_owned_bytes;
 use crate::storage::SendableAsync;
@@ -271,7 +271,9 @@ fn aws_checksum_algorithm(
 /// Coarse classification of an SDK error, used as a counter label.
 /// timeout, io, throttling, transient, or other.
 fn classify_sdk_error<E>(error: &SdkError<E>) -> &'static str
-where E: ProvideErrorMetadata {
+where
+    E: ProvideErrorMetadata,
+{
     match error {
         SdkError::TimeoutError(_) => "timeout",
         SdkError::DispatchFailure(failure) => {
@@ -399,6 +401,14 @@ impl S3CompatibleObjectStorage {
             .set_content_md5(content_md5)
             .send()
             .await
+            .inspect_err(|error| {
+                let error_class: &'static str = classify_sdk_error(error);
+                counter!(
+                    parent: crate::metrics::OBJECT_STORAGE_PUT_ATTEMPT_ERRORS_TOTAL,
+                    labels: [label_values!(ERROR_CLASS => error_class)],
+                )
+                .inc();
+            })
             .map_err(|sdk_error| {
                 if sdk_error.is_retryable() {
                     Retry::Transient(StorageError::from(sdk_error))
@@ -549,6 +559,14 @@ impl S3CompatibleObjectStorage {
             .upload_id(upload_id.0)
             .send()
             .await
+            .inspect_err(|error| {
+                let error_class: &'static str = classify_sdk_error(error);
+                counter!(
+                    parent: crate::metrics::OBJECT_STORAGE_PUT_ATTEMPT_ERRORS_TOTAL,
+                    labels: [label_values!(ERROR_CLASS => error_class)],
+                )
+                .inc();
+            })
             .map_err(|s3_err| {
                 if s3_err.is_retryable() {
                     Retry::Transient(StorageError::from(s3_err))
@@ -676,7 +694,7 @@ impl S3CompatibleObjectStorage {
                 let error_class: &'static str = classify_sdk_error(error);
                 counter!(
                     parent: crate::metrics::OBJECT_STORAGE_GET_ATTEMPT_ERRORS_TOTAL,
-                    "class" => error_class,
+                    labels: [label_values!(ERROR_CLASS => error_class)],
                 )
                 .inc();
             })
@@ -887,13 +905,16 @@ impl Storage for S3CompatibleObjectStorage {
         let key = self.key(path);
         let total_len = payload.len();
         let part_num_bytes = self.multipart_policy.part_num_bytes(total_len);
-        if self.disable_multipart_upload || part_num_bytes >= total_len {
-            self.put_single_part(&key, payload, total_len).await?;
+        let put_result = if self.disable_multipart_upload || part_num_bytes >= total_len {
+            self.put_single_part(&key, payload, total_len).await
         } else {
             self.put_multipart(&key, payload, part_num_bytes, total_len)
-                .await?;
+                .await
+        };
+        if put_result.is_err() {
+            crate::metrics::OBJECT_STORAGE_PUT_ERRORS_TOTAL.inc();
         }
-        Ok(())
+        put_result
     }
 
     #[instrument(name = "storage.s3.copy_to", level = "debug", skip(self, output))]


### PR DESCRIPTION
## Summary
Quickwit already tracks errors for S3 GET requests, but does not expose equivalent error metrics for S3 PUT requests. This PR adds the same level of visibility for PUT errors as currently exists for GET errors by:

- tracking S3 object uploads that fail after retries are exhausted
- counting failed `PutObject` and `UploadPart` attempts by error class
- sharing the typed error-class label definition with the existing GET attempt metric

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo check -p quickwit-storage`
- [ ] `cargo test -p quickwit-storage test_s3_compatible_storage_retry_put` (blocked by the workspace `serde_json/preserve_order` compile-time guard)

Made with [Cursor](https://cursor.com)