### PR TITLE
split search failures in outcome metrics

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -79,7 +79,7 @@ PostgreSQL-backed metastores also expose connection pool gauges:
 
 | Namespace | Metric Name | Description | Type |
 | --------- | ----------- | ----------- | ---- |
-| `quickwit_search` | `leaf_searches_splits_total` | Number of leaf searches (count of splits) started | `counter` |
+| `quickwit_search` | `split_search_outcome` | Number of local leaf split search outcomes by `category` (`success`, operational `error`, cache/pruning, or cancellation phase). Retries are counted separately | `counter` |
 | `quickwit_search` | `leaf_search_split_duration_secs` | Number of seconds required to run a leaf search over a single split. The timer starts after the semaphore is obtained | `histogram` |
 | `quickwit_search` | `active_search_threads_count` | Number of threads in use in the CPU thread pool | `gauge` |
 

--- a/monitoring/grafana/dashboards/searchers.json
+++ b/monitoring/grafana/dashboards/searchers.json
@@ -108,11 +108,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "quickwit_search_leaf_searches_splits_total{instance=~\"$instance\"}",
+          "expr": "quickwit_search_split_search_outcome{instance=~\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{instance}} / {{category}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -857,7 +857,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(quickwit_search_leaf_searches_splits_total,instance)",
+        "definition": "label_values(quickwit_search_split_search_outcome,instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Instance",
@@ -865,7 +865,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(quickwit_search_leaf_searches_splits_total,instance)",
+          "query": "label_values(quickwit_search_split_search_outcome,instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -700,7 +700,8 @@ async fn leaf_search_single_split(
         Some(ctx.doc_mapper.tokenizer_manager()),
         Some(byte_range_cache.clone()),
     )
-    .await?;
+    .await
+    .inspect_err(|_| leaf_search_state_guard.set_state(SplitSearchState::Error))?;
 
     let index_size = compute_index_size(&hot_directory);
     if index_size < search_permit.memory_allocation() {
@@ -797,7 +798,8 @@ async fn leaf_search_single_split(
         );
         let provably_empty = warmup(&searcher, &warmup_info, &record_absence)
             .instrument(warmup_span.clone())
-            .await?;
+            .await
+            .inspect_err(|_| leaf_search_state_guard.set_state(SplitSearchState::Error))?;
         warmup_span.record(
             "downloaded_mb",
             download_counters
@@ -909,10 +911,14 @@ async fn leaf_search_single_split(
                     if is_metadata_count_request_with_ast(&query_ast, &simplified_search_request) {
                         get_leaf_resp_from_count(searcher.num_docs())
                     } else if collector.is_count_only() {
-                        let count = query.count(&searcher)? as u64;
+                        let count = query.count(&searcher).inspect_err(|_| {
+                            leaf_search_state_guard.set_state(SplitSearchState::Error)
+                        })? as u64;
                         get_leaf_resp_from_count(count)
                     } else {
-                        searcher.search(&query, &collector)?
+                        searcher.search(&query, &collector).inspect_err(|_| {
+                            leaf_search_state_guard.set_state(SplitSearchState::Error)
+                        })?
                     };
                 let (download_num_bytes, download_num_requests) =
                     download_counters_clone.snapshot();
@@ -2170,6 +2176,8 @@ enum SplitSearchState {
     PrunedAfterWarmup,
     CpuQueue,
     Cpu,
+    // Reserved for infrastructure and search-execution failures, not invalid user requests.
+    Error,
     Success,
 }
 
@@ -2184,6 +2192,7 @@ impl SplitSearchState {
             SplitSearchState::PrunedAfterWarmup => counters.pruned_after_warmup.inc(),
             SplitSearchState::CpuQueue => counters.cancel_cpu_queue.inc(),
             SplitSearchState::Cpu => counters.cancel_cpu.inc(),
+            SplitSearchState::Error => counters.error.inc(),
             SplitSearchState::Success => counters.success.inc(),
         }
     }
@@ -2191,9 +2200,13 @@ impl SplitSearchState {
 
 impl Drop for SplitSearchStateGuard {
     fn drop(&mut self) {
-        self.state.increment(&SPLIT_SEARCH_OUTCOME_TOTAL);
-        self.state
-            .increment(&self.local_split_search_outcome_counters);
+        let state = if std::thread::panicking() {
+            SplitSearchState::Error
+        } else {
+            self.state
+        };
+        state.increment(&SPLIT_SEARCH_OUTCOME_TOTAL);
+        state.increment(&self.local_split_search_outcome_counters);
     }
 }
 
@@ -2295,6 +2308,30 @@ mod tests {
 
     use super::*;
     use crate::LambdaLeafSearchInvoker;
+
+    #[test]
+    fn test_split_search_state_guard_records_error() {
+        let counters = Arc::new(SplitSearchOutcomeCounters::default());
+        let mut leaf_guard = SplitSearchStateGuard::new(counters.clone());
+        leaf_guard.set_state(SplitSearchState::Error);
+
+        drop(leaf_guard);
+
+        assert_eq!(counters.error.get(), 1);
+        assert_eq!(counters.cancel_warmup.get(), 0);
+    }
+
+    #[test]
+    fn test_split_search_state_guard_preserves_cancellation_state() {
+        let counters = Arc::new(SplitSearchOutcomeCounters::default());
+        let mut leaf_guard = SplitSearchStateGuard::new(counters.clone());
+        leaf_guard.set_state(SplitSearchState::WarmUp);
+
+        drop(leaf_guard);
+
+        assert_eq!(counters.error.get(), 0);
+        assert_eq!(counters.cancel_warmup.get(), 1);
+    }
 
     fn bool_filter(ast: impl Into<QueryAst>) -> QueryAst {
         BoolQuery {

--- a/quickwit/quickwit-search/src/metrics.rs
+++ b/quickwit/quickwit-search/src/metrics.rs
@@ -47,6 +47,7 @@ pub struct SplitSearchOutcomeCounters {
     pub pruned_after_warmup: Counter,
     pub cancel_cpu_queue: Counter,
     pub cancel_cpu: Counter,
+    pub error: Counter,
     pub success: Counter,
 }
 
@@ -61,6 +62,7 @@ impl Default for SplitSearchOutcomeCounters {
             pruned_after_warmup: Counter::local(),
             cancel_cpu_queue: Counter::local(),
             cancel_cpu: Counter::local(),
+            error: Counter::local(),
             success: Counter::local(),
         }
     }
@@ -76,6 +78,7 @@ impl fmt::Display for SplitSearchOutcomeCounters {
         print_if_not_null("pruned_after_warmup", &self.pruned_after_warmup, f)?;
         print_if_not_null("cancel_cpu_queue", &self.cancel_cpu_queue, f)?;
         print_if_not_null("cancel_cpu", &self.cancel_cpu, f)?;
+        print_if_not_null("error", &self.error, f)?;
         print_if_not_null("success", &self.success, f)?;
         Ok(())
     }
@@ -99,6 +102,7 @@ impl SplitSearchOutcomeCounters {
             pruned_after_warmup: counter("pruned_after_warmup"),
             cancel_cpu_queue: counter("cancel_cpu_queue"),
             cancel_cpu: counter("cancel_cpu"),
+            error: counter("error"),
             success: counter("success"),
         }
     }


### PR DESCRIPTION
Record storage, warmup, Tantivy execution failures, and panics as `category="error"` in `quickwit_search_split_search_outcome` metric