### PR TITLE
Upgrade chichat to 0.13.0

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -199,7 +199,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1700,7 +1700,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1984,15 +1984,15 @@ dependencies = [
 
 [[package]]
 name = "chitchat"
-version = "0.11.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b364e0923b5cff38b15d6eed267dea5e984eb1933a8a6e34bb87eb3a833a5d1c"
+checksum = "473eddded9fefd4df26abdf2aebd8b0c352fc5cb77fe12b4d3cf2f84fcc686bb"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "itertools 0.14.0",
- "lru 0.17.0",
+ "itertools 0.15.0",
+ "lru 0.18.0",
  "rand 0.10.2",
  "serde",
  "tokio",
@@ -2189,7 +2189,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2702,7 +2702,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.118",
 ]
 
@@ -4025,7 +4024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5426,7 +5425,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5975,15 +5974,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
-dependencies = [
- "hashbrown 0.17.1",
-]
-
-[[package]]
-name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
@@ -6434,7 +6424,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6615,7 +6605,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",
@@ -7042,7 +7032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8052,7 +8042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -8072,7 +8062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -8093,7 +8083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -8106,7 +8096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -9544,7 +9534,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10310,7 +10300,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10323,7 +10313,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10403,7 +10393,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10668,7 +10658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11226,7 +11216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11498,7 +11488,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11913,7 +11903,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11922,7 +11912,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12146,9 +12136,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -13378,7 +13368,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -114,7 +114,7 @@ bitpacking = "0.9"
 bytes = { version = "1", features = ["serde"] }
 bytesize = { version = "2.4", features = ["serde"] }
 bytestring = "1.5"
-chitchat = "0.11.2"
+chitchat = "0.13.0"
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",

--- a/quickwit/quickwit-cli/src/tool.rs
+++ b/quickwit/quickwit-cli/src/tool.rs
@@ -1033,6 +1033,7 @@ async fn create_empty_cluster(config: &NodeConfig) -> anyhow::Result<Cluster> {
         config.gossip_advertise_addr,
         Vec::new(),
         config.gossip_interval,
+        config.gossip_protocol_version,
         FailureDetectorConfig::default(),
         &ChitchatTransport::default(),
         channel_factory,

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -19,12 +19,12 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[cfg(any(test, feature = "testsuite"))]
 use anyhow::Context;
 use chitchat::transport::Transport;
 use chitchat::{
     Chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, ClusterStateSnapshot,
-    FailureDetectorConfig, KeyChangeEvent, ListenerHandle, NodeState, spawn_chitchat,
+    FailureDetectorConfig, KeyChangeEvent, ListenerHandle, NodeState, ProtocolVersion,
+    spawn_chitchat,
 };
 use itertools::Itertools;
 use quickwit_proto::indexing::{IndexingPipelineId, IndexingTask, PipelineMetrics};
@@ -170,6 +170,7 @@ impl Cluster {
         gossip_listen_addr: SocketAddr,
         peer_seed_addrs: Vec<String>,
         gossip_interval: Duration,
+        gossip_protocol_version: u8,
         failure_detector_config: FailureDetectorConfig,
         transport: &dyn Transport,
         channel_factory: ChannelFactory,
@@ -195,6 +196,10 @@ impl Cluster {
                 .iter()
                 .all(|key| node_state.contains_key(key))
         };
+        let gossip_protocol_version = ProtocolVersion::from_code(gossip_protocol_version)
+            .with_context(|| {
+                format!("invalid gossip protocol version `{gossip_protocol_version}`")
+            })?;
         let chitchat_config = ChitchatConfig {
             cluster_id: cluster_id.clone(),
             chitchat_id: self_node.chitchat_id(),
@@ -205,6 +210,7 @@ impl Cluster {
             marked_for_deletion_grace_period: MARKED_FOR_DELETION_GRACE_PERIOD,
             catchup_callback: Some(Box::new(catchup_callback)),
             extra_liveness_predicate: Some(Box::new(extra_liveness_predicate)),
+            protocol_version: gossip_protocol_version,
         };
         let mut initial_key_values = vec![
             (
@@ -744,6 +750,7 @@ pub async fn create_cluster_for_test_with_id(
         gossip_advertise_addr,
         peer_seed_addrs,
         Duration::from_millis(25),
+        ProtocolVersion::V0.to_code(),
         failure_detector_config,
         transport,
         crate::change::for_test::channel_factory_for_test(),
@@ -804,6 +811,7 @@ mod tests {
 
     use itertools::Itertools;
     use quickwit_common::test_utils::wait_until_predicate;
+    use quickwit_config::MAX_GOSSIP_PROTOCOL_VERSION;
     use quickwit_config::service::QuickwitService;
     use quickwit_proto::indexing::IndexingTask;
     use quickwit_proto::types::IndexUid;
@@ -811,6 +819,22 @@ mod tests {
 
     use super::*;
     use crate::ChitchatTransport;
+
+    #[test]
+    fn test_max_gossip_protocol_version_matches_chitchat() {
+        // Keep this match exhaustive: when Chitchat adds a protocol version, compilation should
+        // fail until `MAX_GOSSIP_PROTOCOL_VERSION` is reviewed and updated.
+        fn protocol_version_code(protocol_version: ProtocolVersion) -> u8 {
+            match protocol_version {
+                ProtocolVersion::V0 | ProtocolVersion::V1 => protocol_version.to_code(),
+            }
+        }
+
+        assert_eq!(
+            MAX_GOSSIP_PROTOCOL_VERSION,
+            protocol_version_code(ProtocolVersion::V1)
+        );
+    }
 
     #[tokio::test]
     async fn test_single_node_cluster_readiness() {

--- a/quickwit/quickwit-cluster/src/lib.rs
+++ b/quickwit/quickwit-cluster/src/lib.rs
@@ -26,9 +26,9 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chitchat::ChitchatEnvelope;
 pub use chitchat::transport::ChannelTransport as ChitchatTransport;
-use chitchat::transport::{Socket, Transport, UdpSocket};
-use chitchat::{ChitchatMessage, Serializable};
+use chitchat::transport::{RecvOutcome, SendOutcome, Socket, Transport, UdpSocket};
 pub use chitchat::{FailureDetectorConfig, KeyChangeEvent, ListenerHandle};
 pub use grpc_service::cluster_grpc_server;
 use quickwit_config::NodeConfig;
@@ -80,20 +80,26 @@ struct CountingUdpSocket {
 
 #[async_trait]
 impl Socket for CountingUdpSocket {
-    async fn send(&mut self, to: SocketAddr, msg: ChitchatMessage) -> anyhow::Result<()> {
-        let msg_len = msg.serialized_len() as u64;
-        self.socket.send(to, msg).await?;
-        GOSSIP_SENT_MESSAGES_TOTAL.inc();
-        GOSSIP_SENT_BYTES_TOTAL.inc_by(msg_len);
-        Ok(())
+    fn local_addr(&self) -> anyhow::Result<SocketAddr> {
+        self.socket.local_addr()
     }
 
-    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)> {
-        let (socket_addr, msg) = self.socket.recv().await?;
+    async fn send(
+        &mut self,
+        to: SocketAddr,
+        envelope: ChitchatEnvelope,
+    ) -> anyhow::Result<SendOutcome> {
+        let outcome = self.socket.send(to, envelope).await?;
+        GOSSIP_SENT_MESSAGES_TOTAL.inc();
+        GOSSIP_SENT_BYTES_TOTAL.inc_by(outcome.num_bytes_sent as u64);
+        Ok(outcome)
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<RecvOutcome> {
+        let outcome = self.socket.recv().await?;
         GOSSIP_RECV_MESSAGES_TOTAL.inc();
-        let msg_len = msg.serialized_len() as u64;
-        GOSSIP_RECV_BYTES_TOTAL.inc_by(msg_len);
-        Ok((socket_addr, msg))
+        GOSSIP_RECV_BYTES_TOTAL.inc_by(outcome.num_bytes_received as u64);
+        Ok(outcome)
     }
 }
 
@@ -143,6 +149,7 @@ pub async fn start_cluster_service(node_config: &NodeConfig) -> anyhow::Result<C
         gossip_listen_addr,
         peer_seed_addrs,
         node_config.gossip_interval,
+        node_config.gossip_protocol_version,
         failure_detector_config,
         &CountingUdpTransport,
         channel_factory,

--- a/quickwit/quickwit-config/resources/tests/node_config/quickwit.json
+++ b/quickwit/quickwit-config/resources/tests/node_config/quickwit.json
@@ -11,6 +11,7 @@
     "listen_address": "0.0.0.0",
     "advertise_address": "172.0.0.12",
     "gossip_listen_port": 2222,
+    "gossip_protocol_version": 1,
     "grpc_listen_port": 3333,
     "peer_seeds": [
         "quickwit-searcher-0.local",

--- a/quickwit/quickwit-config/resources/tests/node_config/quickwit.toml
+++ b/quickwit/quickwit-config/resources/tests/node_config/quickwit.toml
@@ -7,6 +7,7 @@ enabled_services = [ "janitor", "metastore" ]
 listen_address = "0.0.0.0"
 advertise_address = "172.0.0.12"
 gossip_listen_port = 2222
+gossip_protocol_version = 1
 grpc_listen_port = 3333
 peer_seeds = [ "quickwit-searcher-0.local", "quickwit-searcher-1.local" ]
 data_dir = "/opt/quickwit/data"

--- a/quickwit/quickwit-config/resources/tests/node_config/quickwit.yaml
+++ b/quickwit/quickwit-config/resources/tests/node_config/quickwit.yaml
@@ -9,6 +9,7 @@ enabled_services:
 listen_address: 0.0.0.0
 advertise_address: 172.0.0.12
 gossip_listen_port: 2222
+gossip_protocol_version: 1
 grpc_listen_port: 3333
 peer_seeds:
   - quickwit-searcher-0.local

--- a/quickwit/quickwit-config/src/lib.rs
+++ b/quickwit/quickwit-config/src/lib.rs
@@ -79,8 +79,8 @@ pub use crate::metastore_config::{
 pub use crate::node_config::{
     CacheConfig, CachePolicy, CompactorConfig, DEFAULT_QW_CONFIG_PATH, GrpcConfig, HealthConfig,
     IndexerConfig, IngestApiConfig, JaegerConfig, KeepAliveConfig, LambdaConfig,
-    LambdaDeployConfig, NodeConfig, RestConfig, SearcherConfig, SplitCacheLimits,
-    StorageTimeoutPolicy, TlsConfig,
+    LambdaDeployConfig, MAX_GOSSIP_PROTOCOL_VERSION, NodeConfig, RestConfig, SearcherConfig,
+    SplitCacheLimits, StorageTimeoutPolicy, TlsConfig,
 };
 pub use crate::serde_utils::HumanDuration;
 use crate::source_config::serialize::{SourceConfigV0_7, SourceConfigV0_8, VersionedSourceConfig};

--- a/quickwit/quickwit-config/src/node_config/mod.rs
+++ b/quickwit/quickwit-config/src/node_config/mod.rs
@@ -44,6 +44,9 @@ use crate::{ConfigFormat, MetastoreConfigs};
 
 pub const DEFAULT_QW_CONFIG_PATH: &str = "config/quickwit.yaml";
 
+/// Highest Chitchat protocol version accepted by Quickwit configuration.
+pub const MAX_GOSSIP_PROTOCOL_VERSION: u8 = 1;
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RestConfig {
@@ -927,6 +930,7 @@ pub struct NodeConfig {
     pub gossip_advertise_addr: SocketAddr,
     pub grpc_advertise_addr: SocketAddr,
     pub gossip_interval: Duration,
+    pub gossip_protocol_version: u8,
     pub peer_seeds: Vec<String>,
     pub data_dir_path: PathBuf,
     pub metastore_uri: Uri,

--- a/quickwit/quickwit-config/src/node_config/serialize.rs
+++ b/quickwit/quickwit-config/src/node_config/serialize.rs
@@ -28,7 +28,7 @@ use quickwit_proto::types::NodeId;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use super::{GrpcConfig, HealthConfig, RestConfig};
+use super::{GrpcConfig, HealthConfig, MAX_GOSSIP_PROTOCOL_VERSION, RestConfig};
 use crate::config_value::ConfigValue;
 use crate::docs_clustering::DocsClusteringConfigBuilder;
 use crate::qw_env_vars::*;
@@ -50,6 +50,8 @@ pub const DEFAULT_GOSSIP_INTERVAL: Duration = if cfg!(any(test, feature = "tests
 } else {
     Duration::from_secs(1)
 };
+
+const DEFAULT_GOSSIP_PROTOCOL_VERSION: u8 = 0;
 
 // Default config values in the order they appear in [`NodeConfigBuilder`].
 fn default_cluster_id() -> ConfigValue<String, QW_CLUSTER_ID> {
@@ -195,6 +197,8 @@ struct NodeConfigBuilder {
     gossip_listen_port: ConfigValue<u16, QW_GOSSIP_LISTEN_PORT>,
     grpc_listen_port: ConfigValue<u16, QW_GRPC_LISTEN_PORT>,
     gossip_interval_ms: ConfigValue<u32, QW_GOSSIP_INTERVAL_MS>,
+    #[serde(default)]
+    gossip_protocol_version: ConfigValue<u8, QW_GOSSIP_PROTOCOL_VERSION>,
     #[serde(default)]
     peer_seeds: ConfigValue<List, QW_PEER_SEEDS>,
     #[serde(rename = "data_dir")]
@@ -348,6 +352,15 @@ impl NodeConfigBuilder {
             .resolve_optional(env_vars)?
             .map(|gossip_interval_ms| Duration::from_millis(gossip_interval_ms as u64))
             .unwrap_or(DEFAULT_GOSSIP_INTERVAL);
+        let gossip_protocol_version = self
+            .gossip_protocol_version
+            .resolve_optional(env_vars)?
+            .unwrap_or(DEFAULT_GOSSIP_PROTOCOL_VERSION);
+        ensure!(
+            gossip_protocol_version <= MAX_GOSSIP_PROTOCOL_VERSION,
+            "gossip protocol version must be between 0 and {MAX_GOSSIP_PROTOCOL_VERSION}, got \
+             `{gossip_protocol_version}`"
+        );
 
         let node_config = NodeConfig {
             cluster_id: self.cluster_id.resolve(env_vars)?,
@@ -359,6 +372,7 @@ impl NodeConfigBuilder {
             gossip_advertise_addr,
             grpc_advertise_addr,
             gossip_interval,
+            gossip_protocol_version,
             peer_seeds: self.peer_seeds.resolve(env_vars)?.0,
             data_dir_path,
             metastore_uri,
@@ -502,6 +516,7 @@ impl Default for NodeConfigBuilder {
             gossip_listen_port: ConfigValue::none(),
             grpc_listen_port: ConfigValue::none(),
             gossip_interval_ms: ConfigValue::none(),
+            gossip_protocol_version: ConfigValue::none(),
             advertise_address: ConfigValue::none(),
             peer_seeds: ConfigValue::with_default(List::default()),
             data_dir_uri: default_data_dir_uri(),
@@ -654,6 +669,7 @@ pub fn node_config_for_tests_from_ports(
         gossip_listen_addr,
         grpc_listen_addr,
         gossip_interval: Duration::from_millis(25u64),
+        gossip_protocol_version: DEFAULT_GOSSIP_PROTOCOL_VERSION,
         peer_seeds: Vec::new(),
         data_dir_path,
         metastore_uri,
@@ -774,6 +790,7 @@ mod tests {
             config.gossip_listen_addr,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 2222)
         );
+        assert_eq!(config.gossip_protocol_version, 1);
         assert_eq!(
             config.grpc_listen_addr,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 3333)
@@ -1013,6 +1030,7 @@ mod tests {
         env_vars.insert("QW_REST_LISTEN_PORT".to_string(), "1234".to_string());
         env_vars.insert("QW_HEALTH_LISTEN_PORT".to_string(), "3456".to_string());
         env_vars.insert("QW_GOSSIP_LISTEN_PORT".to_string(), "5678".to_string());
+        env_vars.insert("QW_GOSSIP_PROTOCOL_VERSION".to_string(), "1".to_string());
         env_vars.insert("QW_GRPC_LISTEN_PORT".to_string(), "9012".to_string());
         env_vars.insert(
             "QW_PEER_SEEDS".to_string(),
@@ -1074,6 +1092,7 @@ mod tests {
             config.grpc_advertise_addr,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(172, 0, 0, 13)), 9012)
         );
+        assert_eq!(config.gossip_protocol_version, 1);
         assert_eq!(
             config.peer_seeds,
             vec![
@@ -1090,6 +1109,41 @@ mod tests {
             "postgresql://test-user:test-password@test-host:4321/test-db"
         );
         assert_eq!(config.default_index_root_uri, "s3://quickwit-indexes/prod");
+    }
+
+    #[tokio::test]
+    async fn test_node_config_rejects_malformed_gossip_protocol_version() {
+        let config_yaml = "version: 0.8";
+        let env_vars = HashMap::from([(
+            "QW_GOSSIP_PROTOCOL_VERSION".to_string(),
+            "invalid".to_string(),
+        )]);
+        let error =
+            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), &env_vars, None)
+                .await
+                .unwrap_err();
+        assert!(
+            error.to_string().contains("QW_GOSSIP_PROTOCOL_VERSION"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_node_config_rejects_unsupported_gossip_protocol_version() {
+        let config_yaml = "version: 0.8";
+        let unsupported_protocol_version = MAX_GOSSIP_PROTOCOL_VERSION + 1;
+        let env_vars = HashMap::from([(
+            "QW_GOSSIP_PROTOCOL_VERSION".to_string(),
+            unsupported_protocol_version.to_string(),
+        )]);
+        let error =
+            load_node_config_with_env(ConfigFormat::Yaml, config_yaml.as_bytes(), &env_vars, None)
+                .await
+                .unwrap_err();
+        assert!(
+            error.to_string().contains("gossip protocol version"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/quickwit/quickwit-config/src/qw_env_vars.rs
+++ b/quickwit/quickwit-config/src/qw_env_vars.rs
@@ -51,6 +51,7 @@ qw_env_vars!(
     QW_ENABLED_SERVICES,
     QW_GOSSIP_INTERVAL_MS,
     QW_GOSSIP_LISTEN_PORT,
+    QW_GOSSIP_PROTOCOL_VERSION,
     QW_GRPC_LISTEN_PORT,
     QW_HEALTH_LISTEN_PORT,
     QW_LISTEN_ADDRESS,
@@ -78,9 +79,9 @@ mod tests {
             QW_ENV_VARS.get(&QW_METASTORE_READ_REPLICA_URI).unwrap(),
             &"QW_METASTORE_READ_REPLICA_URI"
         );
-        assert_eq!(QW_METASTORE_READ_REPLICA_URI, 14);
+        assert_eq!(QW_METASTORE_READ_REPLICA_URI, 15);
 
         assert_eq!(QW_ENV_VARS.get(&QW_NODE_ID).unwrap(), &"QW_NODE_ID");
-        assert_eq!(QW_NODE_ID, 15);
+        assert_eq!(QW_NODE_ID, 16);
     }
 }


### PR DESCRIPTION
Upgrade chichat to 0.13.0. Using protocol version 0 does nothing but using the existing protocol. V1 enables digest compression but needs to enabled once all nodes in the cluster have picked up this change first.