### PR TITLE
Fix docs clustering log message

### DIFF
--- a/quickwit/quickwit-indexing/src/actors/indexing_service.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_service.rs
@@ -404,7 +404,7 @@ impl IndexingService {
             info!(
                 index_id = indexing_pipeline_id.index_uid.index_id,
                 source_id = indexing_pipeline_id.source_id,
-                sorting_config=?fingerprinter.config(),
+                clustering_config=?fingerprinter.config(),
                 "document clustering enabled",
             );
         }


### PR DESCRIPTION
Update the log message when docs clustering is enabled from `sorting_enabled` to `clustering_enabled`.
