### PR TITLE
Reject empty document clustering configurations

### DIFF
--- a/quickwit/quickwit-config/src/docs_clustering.rs
+++ b/quickwit/quickwit-config/src/docs_clustering.rs
@@ -94,6 +94,10 @@ impl DocsClusteringConfigBuilder {
 
 impl DocsClusteringConfig {
     pub fn validate(&self) -> anyhow::Result<()> {
+        ensure!(
+            !self.policies.is_empty(),
+            "document clustering policies must contain at least one policy"
+        );
         for policy in &self.policies {
             policy.validate()?;
         }
@@ -373,6 +377,19 @@ mod tests {
                 "expected `{expected_error}`, got: {error:?}"
             );
         }
+    }
+
+    #[test]
+    fn config_validation_rejects_empty_policies() {
+        let json_value = serde_json::json!([]);
+        let expected_error = "document clustering policies must contain at least one policy";
+
+        let config: DocsClusteringConfig = serde_json::from_value(json_value).unwrap();
+        let error = config.validate().unwrap_err();
+        assert!(
+            error.to_string().contains(expected_error),
+            "expected `{expected_error}`, got: {error:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject `docs_clustering: []` during node configuration validation
- prevent no-op clustering from triggering document-store rewrites
- add regression coverage for empty policy lists

## Test plan
- [x] `cargo test -p quickwit-config docs_clustering`
- [x] `make fmt`