### PR TITLE
docs: fix typos in upgrades and query-language docs

### DIFF
--- a/docs/operating/upgrades.md
+++ b/docs/operating/upgrades.md
@@ -21,7 +21,7 @@ No migration is done if `otel-traces-v0_7` already exists. If you want `service_
 
 ## Migration from 0.8 to 0.9
 
-Quickwit 0.9 introduces a new ingestion service to to power the ingest and bulk APIs (v2). The new ingest is enabled and used by default, even though the legacy one (v1) remains enabled to finish indexing residual data in the legacy write ahead logs. Note that `ingest_api.max_queue_disk_usage` is enforced on both ingest versions separately, which means that the cumulated disk usage might be up to twice this limit.
+Quickwit 0.9 introduces a new ingestion service to power the ingest and bulk APIs (v2). The new ingest is enabled and used by default, even though the legacy one (v1) remains enabled to finish indexing residual data in the legacy write ahead logs. Note that `ingest_api.max_queue_disk_usage` is enforced on both ingest versions separately, which means that the cumulated disk usage might be up to twice this limit.
 
 When upgrading to 0.9, we recommend to perform a full cluster restart.
 

--- a/docs/reference/query-language.md
+++ b/docs/reference/query-language.md
@@ -27,7 +27,7 @@ defaultable_clause = term | term_prefix | term_set | phrase | phrase_prefix
 ## Writing Queries
 ### Escaping Special Characters
 
-Some characters need to be escaped in non quoted terms because they are syntactically significant otherwise: special reserved characters are: `+` , `^`, `` ` ``, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `*`, `SPACE`. If such such characters appear in query terms, they need to be escaped by prefixing them with an anti-slash `\`.
+Some characters need to be escaped in non quoted terms because they are syntactically significant otherwise: special reserved characters are: `+` , `^`, `` ` ``, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `*`, `SPACE`. If such characters appear in query terms, they need to be escaped by prefixing them with an anti-slash `\`.
 
 In quoted terms, the quote character in use `'` or `"` needs to be escaped.
 
@@ -128,7 +128,7 @@ The field must have been configured with `record: position` when indexing.
 :::
 
 ###### Slop operator
-Is is also possible to add a slop, which allow matching a sequence with some distance. For instance `"looks to me"~1` will match "looks good to me", but not "looks very good to me".
+It is also possible to add a slop, which allow matching a sequence with some distance. For instance `"looks to me"~1` will match "looks good to me", but not "looks very good to me".
 Transposition costs 2, e.g. `"A B"~1` will not match `"B A"` but it would with `"A B"~2`.
 Transposition is not a special case, in the example above A is moved 1 position and B is moved 1 position, so the slop is 2.
 


### PR DESCRIPTION
A few small typos in the docs:

- `docs/operating/upgrades.md`: "ingestion service to to power" -> "to power".
- `docs/reference/query-language.md`: "If such such characters" -> "If such characters"; and "Is is also possible to add a slop" -> "It is also possible".

Documentation only.
