### PR TITLE
prune intermediate results at leaf

### DIFF
--- a/quickwit/quickwit-search/src/collector.rs
+++ b/quickwit/quickwit-search/src/collector.rs
@@ -26,7 +26,7 @@ use quickwit_proto::search::{
 use quickwit_proto::types::SplitId;
 use serde::Deserialize;
 use tantivy::aggregation::agg_req::{Aggregations, get_fast_field_names};
-use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
+use tantivy::aggregation::intermediate_agg_result::{IntermediateAggregationResults, PruneMode};
 use tantivy::aggregation::{AggContextParams, AggregationLimitsGuard, AggregationSegmentCollector};
 use tantivy::collector::{Collector, SegmentCollector};
 use tantivy::columnar::{ColumnType, MonotonicallyMappableToU64};
@@ -884,7 +884,7 @@ fn merge_intermediate_aggregation_result<'a>(
             let serialized = postcard::to_allocvec(&merged_fruit).map_err(map_error)?;
             Some(serialized)
         }
-        Some(QuickwitAggregations::TantivyAggregations(_)) => {
+        Some(QuickwitAggregations::TantivyAggregations(aggregations)) => {
             let merged_opt = intermediate_aggregation_results
                 .map(|bytes| postcard::from_bytes(bytes).map_err(map_error))
                 .try_fold::<_, _, Result<_, TantivyError>>(
@@ -900,8 +900,11 @@ fn merge_intermediate_aggregation_result<'a>(
                         }
                     },
                 )?;
-            let serialized =
-                postcard::to_allocvec(&merged_opt.unwrap_or_default()).map_err(map_error)?;
+            let mut merged = merged_opt.unwrap_or_default();
+            // Leaf results can be merged again at the root or by a federated query. Keep the
+            // intermediate candidate set (`segment_size`) rather than applying final pruning.
+            merged.prune_intermediate_results(aggregations, PruneMode::Intermediate)?;
+            let serialized = postcard::to_allocvec(&merged).map_err(map_error)?;
             Some(serialized)
         }
         None => None,
@@ -2075,5 +2078,73 @@ mod tests {
                 .unwrap();
         let _merged: IntermediateAggregationResults = postcard::from_bytes(&serialized).unwrap();
         // Hopefully `_merged` is empty but the API does not allow us to assert that.
+    }
+
+    #[test]
+    fn test_merge_intermediate_terms_prunes_to_segment_size() {
+        use tantivy::Index;
+        use tantivy::aggregation::DistributedAggregationCollector;
+        use tantivy::aggregation::intermediate_agg_result::{
+            IntermediateAggregationResult, IntermediateBucketResult,
+        };
+        use tantivy::query::AllQuery;
+        use tantivy::schema::{FAST, STRING, Schema};
+
+        let aggregations: Aggregations = serde_json::from_str(
+            r#"{
+                "terms": {
+                    "terms": {
+                        "field": "term",
+                        "size": 2,
+                        "segment_size": 4
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let make_fruit = |fruit_ord: usize| {
+            let mut schema_builder = Schema::builder();
+            let term_field = schema_builder.add_text_field("term", STRING | FAST);
+            let index = Index::create_in_ram(schema_builder.build());
+            let mut writer = index.writer(15_000_000).unwrap();
+            for term_ord in 0..3 {
+                let mut document = TantivyDocument::new();
+                document.add_text(term_field, format!("term-{fruit_ord}-{term_ord}"));
+                writer.add_document(document).unwrap();
+            }
+            writer.commit().unwrap();
+
+            let reader = index.reader().unwrap();
+            let searcher = reader.searcher();
+            let collector = DistributedAggregationCollector::from_aggs(
+                aggregations.clone(),
+                Default::default(),
+            );
+            searcher.search(&AllQuery, &collector).unwrap()
+        };
+
+        // Each fruit is below segment_size, but their disjoint union is not.
+        let serialized_fruits: Vec<Vec<u8>> = (0..3)
+            .map(make_fruit)
+            .map(|fruit| postcard::to_allocvec(&fruit).unwrap())
+            .collect();
+        let quickwit_aggregations = QuickwitAggregations::TantivyAggregations(aggregations.clone());
+        let serialized = merge_intermediate_aggregation_result(
+            &Some(quickwit_aggregations),
+            serialized_fruits.iter().map(Vec::as_slice),
+        )
+        .unwrap()
+        .unwrap();
+        let merged: IntermediateAggregationResults = postcard::from_bytes(&serialized).unwrap();
+
+        let IntermediateAggregationResult::Bucket(IntermediateBucketResult::Terms { buckets }) =
+            merged.get("terms").unwrap()
+        else {
+            panic!("expected terms aggregation result");
+        };
+        // Intermediate mode preserves more candidates than the final size (2), while bounding the
+        // merged response to segment_size (4).
+        assert_eq!(buckets.entries().len(), 4);
     }
 }

--- a/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
+++ b/quickwit/rest-api-tests/scenarii/aggregations/0001-aggregations.yaml
@@ -170,13 +170,12 @@ expected:
   aggregations:
     names:
       buckets:
-        # There are 3 documents with name "Fritz" but we only get 2. One does not get passed to the
-        # root node, because it gets cut off due to the split_size parameter set to 1.
-        # We also get doc_count_error_upper_bound: 2, which signals that the result is approximate.
+        # There are 3 documents with name "Fritz", but split-level pruning omits one of them.
+        # The two split cutoffs and the merged leaf cutoff each contribute 1 to the error bound.
       - doc_count: 2
         key: "Fritz"
       sum_other_doc_count: 8
-      doc_count_error_upper_bound: 2
+      doc_count_error_upper_bound: 3
 ---
 # Test term aggs with shard_size
 # segment_size is an alias to shard_size
@@ -196,13 +195,12 @@ expected:
   aggregations:
     names:
       buckets:
-        # There are 3 documents with name "Fritz" but we only get 2. One does not get passed to the
-        # root node, because it gets cut off due to the split_size parameter set to 1.
-        # We also get doc_count_error_upper_bound: 2, which signals that the result is approximate.
+        # There are 3 documents with name "Fritz", but split-level pruning omits one of them.
+        # The two split cutoffs and the merged leaf cutoff each contribute 1 to the error bound.
       - doc_count: 2
         key: "Fritz"
       sum_other_doc_count: 8
-      doc_count_error_upper_bound: 2
+      doc_count_error_upper_bound: 3
 ---
 # Test term aggs with shard_size
 method: [GET]
@@ -221,13 +219,12 @@ expected:
   aggregations:
     names:
       buckets:
-        # There are 3 documents with name "Fritz" but we only get 2. One does not get passed to the
-        # root node, because it gets cut off due to the split_size parameter set to 1.
-        # We also get doc_count_error_upper_bound: 2, which signals that the result is approximate.
+        # There are 3 documents with name "Fritz", but split-level pruning omits one of them.
+        # The two split cutoffs and the merged leaf cutoff each contribute 1 to the error bound.
       - doc_count: 2
         key: "Fritz"
       sum_other_doc_count: 8
-      doc_count_error_upper_bound: 2
+      doc_count_error_upper_bound: 3
 ---
 # Test term aggs with split_size
 # Here we increase split_size to 5, so we will get the 3 documents with name "Fritz"
@@ -247,12 +244,12 @@ expected:
   aggregations:
     names:
       buckets:
-        # We get all 3 documents with name "Fritz"
-        # We also get doc_count_error_upper_bound: 0, to the result is exact.
+        # We get all 3 documents with name "Fritz". Merging the split results creates 8 unique
+        # terms, so pruning the merged leaf result to 5 contributes 1 to the error bound.
       - doc_count: 3
         key: "Fritz"
       sum_other_doc_count: 7
-      doc_count_error_upper_bound: 0
+      doc_count_error_upper_bound: 1
 ---
 # Test date histogram + percentiles sub-aggregation
 method: [GET]


### PR DESCRIPTION
prune intermediate aggregation results before sending back from leaf to root node.

Otherwise a term aggregation on a high cardinality field over many splits will exceed the grpc payload.
