### PR TITLE
fix(storage): initialize OpenDAL's default HTTP transport

### DIFF
--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -384,7 +384,7 @@ azure_storage_blobs = { version = "0.21", default-features = false, features = [
   "enable_reqwest_rustls",
 ] }
 
-opendal = { version = "0.58", default-features = false, features = ["reqwest-rustls-tls"] }
+opendal = { version = "0.58", default-features = false, features = ["http-transport-reqwest"] }
 reqsign = { version = "0.18", default-features = false, features = ["google", "default-context"] }
 
 quickwit-actors = { path = "quickwit-actors" }

--- a/quickwit/quickwit-storage/src/opendal_storage/base.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/base.rs
@@ -59,6 +59,7 @@ impl OpendalStorage {
         uri: Uri,
         cfg: opendal::services::Gcs,
     ) -> Result<Self, StorageResolverError> {
+        opendal::install_default();
         let op = Operator::new(cfg)?;
         Ok(Self::from_operator(uri, op))
     }


### PR DESCRIPTION
### Description

OpenDAL 0.58 moved HTTP handling behind a process-wide transport. Quickwit disables OpenDAL's default features, including `auto-register-services`, so the migration in #6656 left normal GCS operators with a lazy default transport but no installed implementation. The first GCS request therefore failed with `ConfigInvalid: default HTTP transport is not installed`.

This PR:

- Calls `opendal::install_default()` at the shared GCS constructor so the compiled Reqwest transport is registered as OpenDAL's process-wide default before the first GCS request
- Replaces the deprecated `reqwest-rustls-tls` alias with the canonical `http-transport-reqwest` feature. Both select the same Reqwest/Rustls transport in OpenDAL 0.58 but `reqwest-rustls-tls` will be deleted in 0.59

### How was this PR tested?

This issue was discovered while following the local development instructions in `CONTRIBUTING.md` and running `make test-all`. Before the fix, the GCS integration test consistently failed with `ConfigInvalid: default HTTP transport is not installed`.

After the fix:

- The GCS integration test passed both in isolation and as part of the
full suite.
- `make test-all` passed 3,030 tests with 17 skipped; the 10 failpoint
tests also passed.
- The Clippy, nightly rustfmt, and license-header checks passed.

Closes #6677
