### PR TITLE
Log generation ID consistently as string

### DIFF
--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -178,7 +178,7 @@ impl Cluster {
         info!(
             cluster_id=%cluster_id,
             node_id=%self_node.node_id,
-            generation_id=self_node.generation_id.as_u64(),
+            generation_id=%self_node.generation_id.as_u64(),
             enabled_services=?self_node.enabled_services,
             gossip_listen_addr=%gossip_listen_addr,
             gossip_advertise_addr=%self_node.gossip_advertise_addr,

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -480,14 +480,14 @@ impl IndexingScheduler {
                         warn!(
                             %error,
                             node_id=%indexer.node_id,
-                            generation_id=indexer.generation_id,
+                            generation_id=%indexer.generation_id,
                             "failed to apply indexing plan to indexer"
                         );
                     }
                     Err(_elapsed) => {
                         warn!(
                             node_id=%indexer.node_id,
-                            generation_id=indexer.generation_id,
+                            generation_id=%indexer.generation_id,
                             "timed out applying indexing plan to indexer"
                         );
                     }

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -242,7 +242,7 @@ async fn balance_channel_for_service(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` to {} pool",
                         chitchat_id.node_id,
                         service.as_str().replace('_', " "),
@@ -253,7 +253,7 @@ async fn balance_channel_for_service(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "removing node `{}` from {} pool",
                         chitchat_id.node_id,
                         service.as_str().replace('_', " "),
@@ -1226,7 +1226,7 @@ fn setup_ingester_pool(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` with ingester status `{}` to ingester pool",
                         chitchat_id.node_id,
                         node.ingester_status,
@@ -1289,7 +1289,7 @@ fn build_ingester_remove_change(node: &ClusterNode) -> Change<NodeId, IngesterPo
     let chitchat_id = node.chitchat_id();
     info!(
         node_id = %chitchat_id.node_id,
-        generation_id = chitchat_id.generation_id,
+        generation_id = %chitchat_id.generation_id,
         "removing node `{}` from ingester pool",
         chitchat_id.node_id,
     );
@@ -1353,7 +1353,7 @@ async fn setup_searcher(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` to searcher pool",
                         chitchat_id.node_id,
                     );
@@ -1377,7 +1377,7 @@ async fn setup_searcher(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "removing node `{}` from searcher pool",
                         chitchat_id.node_id,
                     );
@@ -1458,7 +1458,7 @@ fn setup_indexer_pool(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` with ingester status `{}` to indexer pool",
                         chitchat_id.node_id,
                         node.ingester_status
@@ -1523,7 +1523,7 @@ fn build_indexer_remove_change(node: &ClusterNode) -> Change<NodeId, IndexerNode
     let chitchat_id = node.chitchat_id();
     info!(
         node_id = %chitchat_id.node_id,
-        generation_id = chitchat_id.generation_id,
+        generation_id = %chitchat_id.generation_id,
         "removing node `{}` from indexer pool",
         chitchat_id.node_id,
     );


### PR DESCRIPTION
### Description
When logged this way, `generation_id = chitchat_id.generation_id`, log sites serialize as u64, and those nanosecond timestamps exceed JSON’s exact integer limit of `2^53 - 1`... Other log sites use `Display` so we end up with confusing logs, for instance `1786461916535218400` vs `1786461916535218310`.

