### PR TITLE
fix issues with some structured logs

### DIFF
--- a/quickwit/quickwit-cluster/src/change.rs
+++ b/quickwit/quickwit-cluster/src/change.rs
@@ -149,7 +149,7 @@ async fn compute_cluster_change_events_on_added(
 
         if previous_node_ref.chitchat_id().generation_id > new_chitchat_id.generation_id {
             warn!(
-                node_id=%new_chitchat_id.node_id,
+                remote_node_id=%new_chitchat_id.node_id,
                 generation_id=%new_chitchat_id.generation_id,
                 "ignoring node `{}` rejoining the cluster with a lower generation ID",
                 new_chitchat_id.node_id
@@ -175,7 +175,7 @@ async fn compute_cluster_change_events_on_added(
         return events;
     };
     info!(
-        node_id=%new_chitchat_id.node_id,
+        remote_node_id=%new_chitchat_id.node_id,
         generation_id=%new_chitchat_id.generation_id,
         "node `{}` has {verb} the cluster",
         new_chitchat_id.node_id,
@@ -185,7 +185,7 @@ async fn compute_cluster_change_events_on_added(
 
     if new_node.is_ready {
         info!(
-            node_id=%new_chitchat_id.node_id,
+            remote_node_id=%new_chitchat_id.node_id,
             generation_id=%new_chitchat_id.generation_id,
             "node `{}` has transitioned to ready state",
             new_chitchat_id.node_id
@@ -207,7 +207,7 @@ async fn compute_cluster_change_events_on_updated(
 
     if previous_node.chitchat_id().generation_id > updated_chitchat_id.generation_id {
         warn!(
-            node_id=%updated_chitchat_id.node_id,
+            remote_node_id=%updated_chitchat_id.node_id,
             generation_id=%updated_chitchat_id.generation_id,
             "ignoring node `{}` update with a lower generation ID",
             updated_chitchat_id.node_id
@@ -230,7 +230,7 @@ async fn compute_cluster_change_events_on_updated(
         warmup_channel(updated_node.channel()).await;
 
         info!(
-            node_id=%updated_chitchat_id.node_id,
+            remote_node_id=%updated_chitchat_id.node_id,
             generation_id=%updated_chitchat_id.generation_id,
             "node `{}` has transitioned to ready state",
             updated_chitchat_id.node_id
@@ -238,7 +238,7 @@ async fn compute_cluster_change_events_on_updated(
         Some(ClusterChange::Add(updated_node))
     } else if previous_node.is_ready && !updated_node.is_ready {
         info!(
-            node_id=%updated_chitchat_id.node_id,
+            remote_node_id=%updated_chitchat_id.node_id,
             generation_id=%updated_chitchat_id.generation_id,
             "node `{}` has transitioned out of ready state",
             updated_chitchat_id.node_id
@@ -265,7 +265,7 @@ fn compute_cluster_change_events_on_removed(
 
         if previous_node_ref.chitchat_id().generation_id == removed_chitchat_id.generation_id {
             info!(
-                node_id=%removed_chitchat_id.node_id,
+                remote_node_id=%removed_chitchat_id.node_id,
                 generation_id=%removed_chitchat_id.generation_id,
                 "node `{}` has left the cluster",
                 removed_chitchat_id.node_id
@@ -292,7 +292,7 @@ fn try_new_node_with_channel(
         Err(error) => {
             warn!(
                 cluster_id=%cluster_id,
-                node_id=%chitchat_id.node_id,
+                remote_node_id=%chitchat_id.node_id,
                 error=%error,
                 "failed to create cluster node from Chitchat node state"
             );
@@ -316,7 +316,7 @@ async fn try_new_node(
         Err(error) => {
             warn!(
                 cluster_id=%cluster_id,
-                node_id=%chitchat_id.node_id,
+                remote_node_id=%chitchat_id.node_id,
                 error=%error,
                 "failed to read or parse gRPC advertise address"
             );

--- a/quickwit/quickwit-cluster/src/cluster.rs
+++ b/quickwit/quickwit-cluster/src/cluster.rs
@@ -178,7 +178,7 @@ impl Cluster {
         info!(
             cluster_id=%cluster_id,
             node_id=%self_node.node_id,
-            generation_id=self_node.generation_id.as_u64(),
+            generation_id=%self_node.generation_id.as_u64(),
             enabled_services=?self_node.enabled_services,
             gossip_listen_addr=%gossip_listen_addr,
             gossip_advertise_addr=%self_node.gossip_advertise_addr,

--- a/quickwit/quickwit-cluster/src/member.rs
+++ b/quickwit/quickwit-cluster/src/member.rs
@@ -233,7 +233,7 @@ fn parse_enabled_services_str(
             Ok(service) => Some(service),
             Err(_) => {
                 warn!(
-                    node_id=%node_id,
+                    remote_node_id=%node_id,
                     service=%service_str,
                     "Found unknown service enabled on node."
                 );
@@ -243,7 +243,7 @@ fn parse_enabled_services_str(
         .collect();
     if enabled_services.is_empty() {
         warn!(
-            node_id=%node_id,
+            remote_node_id=%node_id,
             "Node has no enabled services."
         )
     }

--- a/quickwit/quickwit-compaction/src/planner/compaction_state.rs
+++ b/quickwit/quickwit-compaction/src/planner/compaction_state.rs
@@ -192,7 +192,7 @@ impl CompactionState {
 
         for task_id in timed_out_task_ids {
             if let Some(inflight) = self.in_flight.remove(&task_id) {
-                error!(%task_id, node_id=%inflight.node_id, "compaction task timed out");
+                error!(%task_id, remote_node_id=%inflight.node_id, "compaction task timed out");
                 TIMED_OUT_OPERATIONS.inc();
                 for split_id in &inflight.split_ids {
                     // these splits will be picked up again on the next metastore scan.

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -480,14 +480,14 @@ impl IndexingScheduler {
                         warn!(
                             %error,
                             node_id=%indexer.node_id,
-                            generation_id=indexer.generation_id,
+                            generation_id=%indexer.generation_id,
                             "failed to apply indexing plan to indexer"
                         );
                     }
                     Err(_elapsed) => {
                         warn!(
                             node_id=%indexer.node_id,
-                            generation_id=indexer.generation_id,
+                            generation_id=%indexer.generation_id,
                             "timed out applying indexing plan to indexer"
                         );
                     }

--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/mod.rs
@@ -479,14 +479,14 @@ impl IndexingScheduler {
                     Ok(Err(error)) => {
                         warn!(
                             %error,
-                            node_id=%indexer.node_id,
+                            remote_node_id=%indexer.node_id,
                             generation_id=%indexer.generation_id,
                             "failed to apply indexing plan to indexer"
                         );
                     }
                     Err(_elapsed) => {
                         warn!(
-                            node_id=%indexer.node_id,
+                            remote_node_id=%indexer.node_id,
                             generation_id=%indexer.generation_id,
                             "timed out applying indexing plan to indexer"
                         );

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -241,7 +241,7 @@ async fn balance_channel_for_service(
                 ClusterChange::Add(node) if node.is_service_enabled(service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = %chitchat_id.node_id,
+                        remote_node_id = %chitchat_id.node_id,
                         generation_id = %chitchat_id.generation_id,
                         "adding node `{}` to {} pool",
                         chitchat_id.node_id,
@@ -252,7 +252,7 @@ async fn balance_channel_for_service(
                 ClusterChange::Remove(node) if node.is_service_enabled(service) => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = %chitchat_id.node_id,
+                        remote_node_id = %chitchat_id.node_id,
                         generation_id = %chitchat_id.generation_id,
                         "removing node `{}` from {} pool",
                         chitchat_id.node_id,
@@ -1225,7 +1225,7 @@ fn setup_ingester_pool(
                 ClusterChange::Add(node) if node.is_indexer() => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = %chitchat_id.node_id,
+                        remote_node_id = %chitchat_id.node_id,
                         generation_id = %chitchat_id.generation_id,
                         "adding node `{}` with ingester status `{}` to ingester pool",
                         chitchat_id.node_id,
@@ -1288,7 +1288,7 @@ fn build_ingester_insert_change(
 fn build_ingester_remove_change(node: &ClusterNode) -> Change<NodeId, IngesterPoolEntry> {
     let chitchat_id = node.chitchat_id();
     info!(
-        node_id = %chitchat_id.node_id,
+        remote_node_id = %chitchat_id.node_id,
         generation_id = %chitchat_id.generation_id,
         "removing node `{}` from ingester pool",
         chitchat_id.node_id,
@@ -1352,7 +1352,7 @@ async fn setup_searcher(
                 ClusterChange::Add(node) if node.is_searcher() => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = %chitchat_id.node_id,
+                        remote_node_id = %chitchat_id.node_id,
                         generation_id = %chitchat_id.generation_id,
                         "adding node `{}` to searcher pool",
                         chitchat_id.node_id,
@@ -1376,7 +1376,7 @@ async fn setup_searcher(
                 ClusterChange::Remove(node) if node.is_searcher() => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = %chitchat_id.node_id,
+                        remote_node_id = %chitchat_id.node_id,
                         generation_id = %chitchat_id.generation_id,
                         "removing node `{}` from searcher pool",
                         chitchat_id.node_id,
@@ -1457,7 +1457,7 @@ fn setup_indexer_pool(
                 ClusterChange::Add(node) if node.is_indexer() => {
                     let chitchat_id = node.chitchat_id();
                     info!(
-                        node_id = %chitchat_id.node_id,
+                        remote_node_id = %chitchat_id.node_id,
                         generation_id = %chitchat_id.generation_id,
                         "adding node `{}` with ingester status `{}` to indexer pool",
                         chitchat_id.node_id,
@@ -1522,7 +1522,7 @@ fn build_indexer_insert_change(
 fn build_indexer_remove_change(node: &ClusterNode) -> Change<NodeId, IndexerNodeInfo> {
     let chitchat_id = node.chitchat_id();
     info!(
-        node_id = %chitchat_id.node_id,
+        remote_node_id = %chitchat_id.node_id,
         generation_id = %chitchat_id.generation_id,
         "removing node `{}` from indexer pool",
         chitchat_id.node_id,

--- a/quickwit/quickwit-serve/src/lib.rs
+++ b/quickwit/quickwit-serve/src/lib.rs
@@ -242,7 +242,7 @@ async fn balance_channel_for_service(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` to {} pool",
                         chitchat_id.node_id,
                         service.as_str().replace('_', " "),
@@ -253,7 +253,7 @@ async fn balance_channel_for_service(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "removing node `{}` from {} pool",
                         chitchat_id.node_id,
                         service.as_str().replace('_', " "),
@@ -1226,7 +1226,7 @@ fn setup_ingester_pool(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` with ingester status `{}` to ingester pool",
                         chitchat_id.node_id,
                         node.ingester_status,
@@ -1289,7 +1289,7 @@ fn build_ingester_remove_change(node: &ClusterNode) -> Change<NodeId, IngesterPo
     let chitchat_id = node.chitchat_id();
     info!(
         node_id = %chitchat_id.node_id,
-        generation_id = chitchat_id.generation_id,
+        generation_id = %chitchat_id.generation_id,
         "removing node `{}` from ingester pool",
         chitchat_id.node_id,
     );
@@ -1353,7 +1353,7 @@ async fn setup_searcher(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` to searcher pool",
                         chitchat_id.node_id,
                     );
@@ -1377,7 +1377,7 @@ async fn setup_searcher(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "removing node `{}` from searcher pool",
                         chitchat_id.node_id,
                     );
@@ -1458,7 +1458,7 @@ fn setup_indexer_pool(
                     let chitchat_id = node.chitchat_id();
                     info!(
                         node_id = %chitchat_id.node_id,
-                        generation_id = chitchat_id.generation_id,
+                        generation_id = %chitchat_id.generation_id,
                         "adding node `{}` with ingester status `{}` to indexer pool",
                         chitchat_id.node_id,
                         node.ingester_status
@@ -1523,7 +1523,7 @@ fn build_indexer_remove_change(node: &ClusterNode) -> Change<NodeId, IndexerNode
     let chitchat_id = node.chitchat_id();
     info!(
         node_id = %chitchat_id.node_id,
-        generation_id = chitchat_id.generation_id,
+        generation_id = %chitchat_id.generation_id,
         "removing node `{}` from indexer pool",
         chitchat_id.node_id,
     );


### PR DESCRIPTION
our generation_id was sometime emitted as string, and other as integers. Some web UI round these integers because js only has floating point numbers, always emit generation_id as string so those UI always show the correct value

node_id is often added to each event by collectors, but we set it in some logs. This causes confusing situations where a log looks like it comes from a node, but it comes from a different one, taking about that 1st node. Rename the field to `remote_node_id` so there is no ambiguity