### PR TITLE
Update Quickwit security policy with current vulnerability reporting guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,15 +1,23 @@
 # Security Policy
 
-## Supported Versions
+## Vulnerability Reporting
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.3.1   | :white_check_mark: |
-| < 0.3.1   | :x:                |
+We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
 
-## Reporting a Vulnerability
+### Quickwit CI
 
-To disclose a vulnerability in our code, please notify us by email at security@quickwit.io or private message _@fulmicoton_ or _@guilload_ on our Discord 
-server ([discord.quickwit.io](https://discord.quickwit.io)). We will open a draft security advisory on our repository and grant you access so you can
-share with us more details about the vulnerability. After releasing a fix, we will publish the security advisory to publicly disclose the security vulnerability
-to the project's community.
+If you would like to report a vulnerability in Quickwit's CI or have security concerns with other Datadog products, please email [security@datadoghq.com](mailto:security@datadoghq.com).
+
+We take all disclosures seriously and will do our best to respond promptly, verify the vulnerability, and take the necessary steps to fix it. After our initial reply, we will periodically update you on the status of the fix.
+
+### Other Reports
+
+Quickwit is an open source project designed to be self-hosted, so users are responsible for managing their deployments. Vulnerabilities in Quickwit deployments could potentially be exploited by malicious actors who already have access to the user's infrastructure. We encourage responsible disclosure by [opening a GitHub issue](https://github.com/quickwit-oss/quickwit/issues/new) so that risks can be properly assessed and mitigated.
+
+To help us investigate your report, please include any of the following:
+
+- A proof of concept
+- Any tools used, including their versions
+- Any relevant output
+
+Do not include credentials, secrets, or other sensitive information in a public GitHub issue.


### PR DESCRIPTION
Replace the outdated security policy with updated information.

### Description

- Direct Quickwit CI and Datadog security concerns to `security@datadoghq.com`
- Direct other Quickwit reports to GitHub Issues
- List useful details to include in reports
- Warn reporters not to disclose secrets or credentials publicly
- Remove the obsolete `0.3.1` support table and old contact information

### How was this PR tested?

- Formatting check passed
- Clippy passed