### PR TITLE
Lower severity of routine scheduling rescaling

### DIFF
--- a/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
+++ b/quickwit/quickwit-control-plane/src/indexing_scheduler/scheduling/scheduling_logic.rs
@@ -38,6 +38,10 @@ fn check_contract_conditions(problem: &SchedulingProblem, solution: &SchedulingS
 /// 1.2^30 is about 240. If we reach 30 attempts we are certain to have a logical bug.
 const MAX_INFLATION_ATTEMPTS: u32 = 30;
 
+/// One inflation attempt is expected from normal bin-packing fragmentation. Two attempts increase
+/// the virtual capacity by 44%, which warrants operator attention.
+const MIN_INFLATION_ATTEMPT_FOR_WARNING: u32 = 2;
+
 pub fn solve(
     mut problem: SchedulingProblem,
     previous_solution: SchedulingSolution,
@@ -88,9 +92,13 @@ pub fn solve(
         }
     }
 
-    if best_attempt > 0 {
-        // the higher the attempt number, the more unbalanced the solution
+    if best_attempt >= MIN_INFLATION_ATTEMPT_FOR_WARNING {
         tracing::warn!(
+            attempt_number = best_attempt,
+            "capacity re-scaled, scheduling solution likely unbalanced"
+        );
+    } else if best_attempt > 0 {
+        tracing::info!(
             attempt_number = best_attempt,
             "capacity re-scaled, scheduling solution likely unbalanced"
         );


### PR DESCRIPTION
## Summary
- log the first scheduling capacity inflation at info level
- retain warning severity from the second inflation attempt onward
- document the threshold: two 20% inflations increase virtual capacity by 44%

## Tests
- `cargo test -p quickwit-control-plane`
- `cargo clippy -p quickwit-control-plane --all-features --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `bash scripts/check_log_format.sh`