### PR TITLE
Filter lexical siblings from prefixed listings

### DIFF
--- a/quickwit/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit/quickwit-storage/src/prefix_storage.rs
@@ -125,21 +125,19 @@ impl Storage for PrefixStorage {
                         object.path = relative_path.to_path_buf();
                         relative_objects.push(object);
                     }
-                    Err(_)
-                        if object
+                    Err(error) => {
+                        let is_under_prefix = object
                             .path
                             .as_os_str()
                             .as_encoded_bytes()
-                            .starts_with(prefix_bytes) =>
-                    {
-                        // Byte-prefix backends may return lexical siblings of the storage root.
-                    }
-                    Err(error) => {
-                        return Err(StorageErrorKind::Internal.with_error(anyhow::anyhow!(
-                            "listed object `{}` is not under storage prefix `{}`: {error}",
-                            object.path.display(),
-                            prefix.display()
-                        )));
+                            .starts_with(prefix_bytes);
+                        if !is_under_prefix {
+                            return Err(StorageErrorKind::Internal.with_error(anyhow::anyhow!(
+                                "listed object `{}` is not under storage prefix `{}`: {error}",
+                                object.path.display(),
+                                prefix.display()
+                            )));
+                        }
                     }
                 }
             }

--- a/quickwit/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit/quickwit-storage/src/prefix_storage.rs
@@ -23,10 +23,7 @@ use quickwit_common::uri::Uri;
 use tokio::io::AsyncRead;
 
 use crate::storage::SendableAsync;
-use crate::{
-    BulkDeleteError, ListObjectsStream, ObjectMetadata, OwnedBytes, Storage, StorageErrorKind,
-    StorageResult,
-};
+use crate::{BulkDeleteError, ListObjectsStream, ObjectMetadata, OwnedBytes, Storage};
 
 /// This storage acts as a proxy to another storage that simply modifies each API call
 /// by preceding each path with a given a prefix.
@@ -111,23 +108,22 @@ impl Storage for PrefixStorage {
         /// Makes listed paths relative to this storage root again, undoing the prefix added by
         /// [`PrefixStorage::list`].
         fn strip_prefix_from_objects(
-            mut objects: Vec<ObjectMetadata>,
+            objects: Vec<ObjectMetadata>,
             prefix: &Path,
-        ) -> StorageResult<Vec<ObjectMetadata>> {
+        ) -> Vec<ObjectMetadata> {
             if prefix == Path::new("") {
-                return Ok(objects);
+                return objects;
             }
-            for object in &mut objects {
-                let relative_path = object.path.strip_prefix(prefix).map_err(|error| {
-                    StorageErrorKind::Internal.with_error(anyhow::anyhow!(
-                        "listed object `{}` is not under storage prefix `{}`: {error}",
-                        object.path.display(),
-                        prefix.display()
-                    ))
-                })?;
+            let mut relative_objects = Vec::with_capacity(objects.len());
+            for mut object in objects {
+                let Ok(relative_path) = object.path.strip_prefix(prefix) else {
+                    // Some backends use byte-prefix semantics and may return lexical siblings.
+                    continue;
+                };
                 object.path = relative_path.to_path_buf();
+                relative_objects.push(object);
             }
-            Ok(objects)
+            relative_objects
         }
 
         let storage_prefix = self.prefix.clone();
@@ -135,7 +131,7 @@ impl Storage for PrefixStorage {
             .list(&self.prefix.join(prefix))
             .map(move |objects_res| {
                 let objects = objects_res?;
-                strip_prefix_from_objects(objects, &storage_prefix)
+                Ok(strip_prefix_from_objects(objects, &storage_prefix))
             })
             .boxed()
     }
@@ -255,6 +251,38 @@ mod tests {
         assert_eq!(pages[0].len(), 1);
         assert_eq!(pages[0][0].path, Path::new("splits/foo.split"));
         assert_eq!(pages[0][0].size, bytesize::ByteSize(11));
+    }
+
+    #[tokio::test]
+    async fn test_prefix_storage_list_filters_lexical_siblings() {
+        let mut mock_storage = MockStorage::default();
+        mock_storage.expect_list().times(1).returning(|prefix| {
+            assert_eq!(prefix, Path::new("ram:///indexes"));
+            let objects = vec![
+                ObjectMetadata {
+                    path: PathBuf::from("ram:///indexes/foo.split"),
+                    size: bytesize::ByteSize(11),
+                    last_modified: SystemTime::UNIX_EPOCH,
+                },
+                ObjectMetadata {
+                    path: PathBuf::from("ram:///indexes-old/unrelated.split"),
+                    size: bytesize::ByteSize(13),
+                    last_modified: SystemTime::UNIX_EPOCH,
+                },
+            ];
+            stream::once(async move { Ok(objects) }).boxed()
+        });
+        let storage = add_prefix_to_storage(
+            Arc::new(mock_storage),
+            PathBuf::from("ram:///indexes"),
+            Uri::for_test("ram:///indexes"),
+        );
+        let pages: Vec<Vec<ObjectMetadata>> =
+            storage.list(Path::new("")).try_collect().await.unwrap();
+
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].len(), 1);
+        assert_eq!(pages[0][0].path, Path::new("foo.split"));
     }
 
     #[test]

--- a/quickwit/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit/quickwit-storage/src/prefix_storage.rs
@@ -23,7 +23,10 @@ use quickwit_common::uri::Uri;
 use tokio::io::AsyncRead;
 
 use crate::storage::SendableAsync;
-use crate::{BulkDeleteError, ListObjectsStream, ObjectMetadata, OwnedBytes, Storage};
+use crate::{
+    BulkDeleteError, ListObjectsStream, ObjectMetadata, OwnedBytes, Storage, StorageErrorKind,
+    StorageResult,
+};
 
 /// This storage acts as a proxy to another storage that simply modifies each API call
 /// by preceding each path with a given a prefix.
@@ -110,20 +113,37 @@ impl Storage for PrefixStorage {
         fn strip_prefix_from_objects(
             objects: Vec<ObjectMetadata>,
             prefix: &Path,
-        ) -> Vec<ObjectMetadata> {
+        ) -> StorageResult<Vec<ObjectMetadata>> {
             if prefix == Path::new("") {
-                return objects;
+                return Ok(objects);
             }
+            let prefix_bytes = prefix.as_os_str().as_encoded_bytes();
             let mut relative_objects = Vec::with_capacity(objects.len());
             for mut object in objects {
-                let Ok(relative_path) = object.path.strip_prefix(prefix) else {
-                    // Some backends use byte-prefix semantics and may return lexical siblings.
-                    continue;
-                };
-                object.path = relative_path.to_path_buf();
-                relative_objects.push(object);
+                match object.path.strip_prefix(prefix) {
+                    Ok(relative_path) => {
+                        object.path = relative_path.to_path_buf();
+                        relative_objects.push(object);
+                    }
+                    Err(_)
+                        if object
+                            .path
+                            .as_os_str()
+                            .as_encoded_bytes()
+                            .starts_with(prefix_bytes) =>
+                    {
+                        // Byte-prefix backends may return lexical siblings of the storage root.
+                    }
+                    Err(error) => {
+                        return Err(StorageErrorKind::Internal.with_error(anyhow::anyhow!(
+                            "listed object `{}` is not under storage prefix `{}`: {error}",
+                            object.path.display(),
+                            prefix.display()
+                        )));
+                    }
+                }
             }
-            relative_objects
+            Ok(relative_objects)
         }
 
         let storage_prefix = self.prefix.clone();
@@ -131,7 +151,7 @@ impl Storage for PrefixStorage {
             .list(&self.prefix.join(prefix))
             .map(move |objects_res| {
                 let objects = objects_res?;
-                Ok(strip_prefix_from_objects(objects, &storage_prefix))
+                strip_prefix_from_objects(objects, &storage_prefix)
             })
             .boxed()
     }
@@ -283,6 +303,32 @@ mod tests {
         assert_eq!(pages.len(), 1);
         assert_eq!(pages[0].len(), 1);
         assert_eq!(pages[0][0].path, Path::new("foo.split"));
+    }
+
+    #[tokio::test]
+    async fn test_prefix_storage_list_rejects_unrelated_paths() {
+        let mut mock_storage = MockStorage::default();
+        mock_storage.expect_list().times(1).returning(|prefix| {
+            assert_eq!(prefix, Path::new("ram:///indexes"));
+            let objects = vec![ObjectMetadata {
+                path: PathBuf::from("ram:///unrelated/foo.split"),
+                size: bytesize::ByteSize(11),
+                last_modified: SystemTime::UNIX_EPOCH,
+            }];
+            stream::once(async move { Ok(objects) }).boxed()
+        });
+        let storage = add_prefix_to_storage(
+            Arc::new(mock_storage),
+            PathBuf::from("ram:///indexes"),
+            Uri::for_test("ram:///indexes"),
+        );
+        let error = storage
+            .list(Path::new(""))
+            .try_collect::<Vec<Vec<ObjectMetadata>>>()
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), StorageErrorKind::Internal);
     }
 
     #[test]


### PR DESCRIPTION
### Description

From an independent codex CI:
> Skip lexical siblings when stripping the storage prefix
>
> When `list("")` wraps an implementation with byte-prefix semantics, the underlying call may validly return a lexical sibling such as indexes-old/object for the requested prefix indexes (the S3 implementation explicitly handles this case). Path::strip_prefix rejects that object and turns the entire page into an internal error, so listing the prefixed storage can fail because of an unrelated sibling object. Filter objects outside the component-level storage root instead of returning an error for the batch.

`PrefixStorage::list` now filters lexical siblings outside its component-level storage root before stripping the prefix. This prevents byte-prefix backends such as S3 from failing an entire listing page when they return a lexical sibling (for example, `indexes-old/object` while listing `indexes`). Unrelated out-of-prefix paths still produce an internal error so backend contract violations are not hidden.

Adds regression tests for both lexical siblings and unrelated paths.

Follow-up to #6705.

### How was this PR tested?

- `make fmt`
- `cargo check -p quickwit-storage --lib`
- Attempted `cargo nextest run -p quickwit-storage prefix_storage --retries 1`; test compilation is currently blocked on `main` by `aws-smithy-http-client` enabling `serde_json/preserve_order`, which triggers the existing compile-time assertion in `quickwit-storage/src/lib.rs`.
