### PR TITLE
Add create-only split staging mode

### DIFF
--- a/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/file_backed_index/mod.rs
@@ -333,6 +333,17 @@ impl FileBackedIndex {
         Ok(())
     }
 
+    /// Stages a split only when its ID is absent, preserving any concurrent writer's row.
+    pub(crate) fn stage_split_create_only(
+        &mut self,
+        split_metadata: SplitMetadata,
+    ) -> Result<(), MetastoreError> {
+        if self.splits.contains_key(split_metadata.split_id()) {
+            return Ok(());
+        }
+        self.stage_split(split_metadata)
+    }
+
     /// Marks the splits for deletion. Returns whether a mutation occurred.
     pub(crate) fn mark_splits_for_deletion(
         &mut self,

--- a/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/file_backed/mod.rs
@@ -656,13 +656,19 @@ impl MetastoreService for FileBackedMetastore {
     #[instrument(name = "metastore.file_backed.stage_splits", skip_all, fields(index_uid = %request.index_uid()))]
     async fn stage_splits(&self, request: StageSplitsRequest) -> MetastoreResult<EmptyResponse> {
         let index_uid = request.index_uid().clone();
+        let create_only = request.create_only;
         let splits_metadata = request.deserialize_splits_metadata()?;
 
         self.mutate(&index_uid, |index| {
             let mut failed_split_ids = Vec::new();
 
             for split_metadata in splits_metadata {
-                match index.stage_split(split_metadata) {
+                let stage_result = if create_only {
+                    index.stage_split_create_only(split_metadata)
+                } else {
+                    index.stage_split(split_metadata)
+                };
+                match stage_result {
                     Ok(()) => {}
                     Err(MetastoreError::FailedPrecondition {
                         entity: EntityKind::Split { split_id },

--- a/quickwit/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit/quickwit-metastore/src/metastore/mod.rs
@@ -650,6 +650,7 @@ impl StageSplitsRequestExt for StageSplitsRequest {
         let request = Self {
             index_uid: Some(index_uid.into()),
             split_metadata_list_serialized_json,
+            create_only: false,
         };
         Ok(request)
     }
@@ -663,6 +664,7 @@ impl StageSplitsRequestExt for StageSplitsRequest {
         let request = Self {
             index_uid: Some(index_uid.into()),
             split_metadata_list_serialized_json,
+            create_only: false,
         };
         Ok(request)
     }

--- a/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
+++ b/quickwit/quickwit-metastore/src/metastore/postgres/metastore.rs
@@ -679,6 +679,7 @@ impl MetastoreService for PostgresqlMetastore {
     #[instrument(name = "metastore.postgres.stage_splits", skip_all, fields(split_ids))]
     async fn stage_splits(&self, request: StageSplitsRequest) -> MetastoreResult<EmptyResponse> {
         let index_uid: IndexUid = request.index_uid().clone();
+        let create_only = request.create_only;
         let splits_metadata = request.deserialize_splits_metadata()?;
 
         if splits_metadata.is_empty() {
@@ -745,7 +746,9 @@ impl MetastoreService for PostgresqlMetastore {
                         node_id = excluded.node_id,
                         update_timestamp = CURRENT_TIMESTAMP,
                         create_timestamp = CURRENT_TIMESTAMP
-                    WHERE splits.split_id = excluded.split_id AND splits.split_state = 'Staged'
+                    WHERE splits.split_id = excluded.split_id
+                      AND splits.split_state = 'Staged'
+                      AND NOT $11
                 RETURNING split_id;
                 "#)
                 .bind(&split_ids)
@@ -758,11 +761,12 @@ impl MetastoreService for PostgresqlMetastore {
                 .bind(&node_ids)
                 .bind(SplitState::Staged.as_str())
                 .bind(&index_uid)
+                .bind(create_only)
                 .fetch_all(tx.as_mut())
                 .await
                 .map_err(|sqlx_error| convert_sqlx_err(&index_uid.index_id, sqlx_error))?;
 
-            if upserted_split_ids.len() != split_ids.len() {
+            if !create_only && upserted_split_ids.len() != split_ids.len() {
                 let failed_split_ids: Vec<String> = split_ids
                     .into_iter()
                     .filter(|split_id| !upserted_split_ids.contains(split_id))

--- a/quickwit/quickwit-metastore/src/tests/split.rs
+++ b/quickwit/quickwit-metastore/src/tests/split.rs
@@ -1621,6 +1621,43 @@ pub async fn test_metastore_stage_splits<MetastoreToTest: MetastoreServiceExt + 
         .await
         .expect("Pre-existing staged splits should be updated.");
 
+    // Recovery staging inserts missing rows but must not overwrite an existing writer's staged row.
+    let mut conflicting_split_metadata = split_metadata_1.clone();
+    conflicting_split_metadata.node_id = "recovery".to_string();
+    let split_metadata_3 = SplitMetadata {
+        split_id: format!("{index_id}--split-3").into(),
+        index_uid: index_uid.clone(),
+        node_id: "recovery".to_string(),
+        ..Default::default()
+    };
+    let mut stage_splits_request = StageSplitsRequest::try_from_splits_metadata(
+        index_uid.clone(),
+        [conflicting_split_metadata, split_metadata_3.clone()],
+    )
+    .unwrap();
+    stage_splits_request.create_only = true;
+    metastore.stage_splits(stage_splits_request).await.unwrap();
+
+    let query = ListSplitsQuery::for_index(index_uid.clone()).with_split_state(SplitState::Staged);
+    let splits = metastore
+        .list_splits(ListSplitsRequest::try_from_list_splits_query(&query).unwrap())
+        .await
+        .unwrap()
+        .collect_splits()
+        .await
+        .unwrap();
+    assert_eq!(splits.len(), 3);
+    let existing_split = splits
+        .iter()
+        .find(|split| split.split_id().as_str() == split_id_1)
+        .unwrap();
+    assert_eq!(existing_split.split_metadata.node_id, "node-1");
+    assert!(
+        splits
+            .iter()
+            .any(|split| split.split_id() == split_metadata_3.split_id())
+    );
+
     let publish_splits_request = PublishSplitsRequest {
         index_uid: Some(index_uid.clone()),
         staged_split_ids: vec![split_id_1.clone(), split_id_2.clone()],

--- a/quickwit/quickwit-proto/protos/quickwit/metastore.proto
+++ b/quickwit/quickwit-proto/protos/quickwit/metastore.proto
@@ -388,6 +388,8 @@ message ListSplitsResponse {
 message StageSplitsRequest {
   quickwit.common.IndexUid index_uid = 1;
   string split_metadata_list_serialized_json = 2;
+  // Create-only mode: insert missing rows without upserting an existing split row.
+  bool create_only = 3;
 }
 
 message PublishSplitsRequest {

--- a/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
+++ b/quickwit/quickwit-proto/src/codegen/quickwit/quickwit.metastore.rs
@@ -215,6 +215,9 @@ pub struct StageSplitsRequest {
     pub index_uid: ::core::option::Option<crate::types::IndexUid>,
     #[prost(string, tag = "2")]
     pub split_metadata_list_serialized_json: ::prost::alloc::string::String,
+    /// Create-only mode: insert missing rows without upserting an existing split row.
+    #[prost(bool, tag = "3")]
+    pub create_only: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]


### PR DESCRIPTION
## Context
Reconciliation may re-stage a split after a retry or while another reconciliation worker is handling the same split. The existing `stage_splits` semantics upsert an already-staged row, so a later request can overwrite metadata written by the first worker. In particular, this can replace the row that represents the currently authoritative recovery candidate.

## What this changes
Adds a `create_only` flag to `StageSplitsRequest`. When enabled, staging inserts only missing split rows and leaves any existing row unchanged. This makes recovery staging idempotent and prevents retries or concurrent reconciliation writers from clobbering an existing split.

The default remains unchanged (`create_only: false`), preserving the normal upsert behavior for existing callers. The behavior is implemented for both file-backed and PostgreSQL metastores, with coverage for create-only staging.

## Testing
- `cargo test -p quickwit-metastore --lib --tests`