### PR TITLE
chore(dependabot): Group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,7 @@ updates:
 
   # NPM dependencies
   - package-ecosystem: npm
-    directory: "/"
+    directory: "/quickwit/quickwit-ui"
     schedule:
       interval: "monthly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+      rust-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "*"
@@ -34,6 +38,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 2
@@ -45,6 +53,10 @@ updates:
       interval: "monthly"
     groups:
       npm-dependencies:
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
         patterns:
           - "*"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- group Cargo security updates into a single PR
- group npm security updates into a single PR
- group GitHub Actions security updates into a single PR
- leave Docker update handling unchanged

Each security group is scoped to its own package ecosystem and does not affect the existing version-update groups.

## Testing

- `make fmt`
- parsed `.github/dependabot.yml` with Ruby's YAML parser
- `git diff --check`