### PR TITLE
ui: refactor dev deps into correct section

### DIFF
--- a/quickwit/quickwit-ui/Makefile
+++ b/quickwit/quickwit-ui/Makefile
@@ -4,7 +4,7 @@ build:
 	yarn build
 
 install:
-	yarn install --frozen-lockfile --network-timeout 300000
+	yarn install --production=false --frozen-lockfile --network-timeout 300000
 
 start:
 	yarn start

--- a/quickwit/quickwit-ui/package.json
+++ b/quickwit/quickwit-ui/package.json
@@ -5,10 +5,6 @@
   "private": true,
   "packageManager": "yarn@1.22.22",
   "dependencies": {
-    "@babel/core": "7.29.0",
-    "@babel/runtime": "7.28.6",
-    "@biomejs/biome": "2.4.4",
-    "@dr.pogodin/babel-plugin-transform-assets": "1.2.6",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@monaco-editor/react": "4.7.0",
@@ -18,6 +14,22 @@
     "@mui/system": "7.3.8",
     "@mui/x-charts": "8.27.0",
     "@mui/x-date-pickers": "8.27.2",
+    "dayjs": "1.11.19",
+    "monaco-editor": "0.55.1",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "react-number-format": "5.4.4",
+    "react-router": "7.13.1",
+    "styled-components": "6.1.19",
+    "styled-icons": "10.47.1",
+    "swagger-ui-react": "5.32.0"
+  },
+  "devDependencies": {
+    "@babel/core": "7.29.0",
+    "@babel/runtime": "7.28.6",
+    "@biomejs/biome": "2.4.4",
+    "@dr.pogodin/babel-plugin-transform-assets": "1.2.6",
+    "@playwright/test": "^1.58.2",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
@@ -29,18 +41,9 @@
     "@types/swagger-ui-react": "5.18.0",
     "babel-jest": "30.2.0",
     "babel-preset-react-app": "10.1.0",
-    "dayjs": "1.11.19",
     "jest": "30.2.0",
     "jest-environment-jsdom": "30.2.0",
-    "monaco-editor": "0.55.1",
-    "react": "19.2.4",
     "react-app-polyfill": "3.0.0",
-    "react-dom": "19.2.4",
-    "react-number-format": "5.4.4",
-    "react-router": "7.13.1",
-    "styled-components": "6.1.19",
-    "styled-icons": "10.47.1",
-    "swagger-ui-react": "5.32.0",
     "typescript": "5.9.3",
     "vite": "7.3.1"
   },
@@ -60,8 +63,5 @@
     "format": "biome check --write",
     "type": "tsc",
     "e2e-test": "playwright test"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.58.2"
   }
 }


### PR DESCRIPTION
### Description

Split `quickwit/quickwit-ui/package.json` dependencies into `dependencies` and
`devDependencies`. Everything that is only used by the build, test, lint, or
type-check tooling moved to `devDependencies`; only packages that end up in the
shipped bundle remain in `dependencies`.

Moved to `devDependencies` (21):

- Build/tooling: `vite`, `typescript`, `@biomejs/biome`
- Jest transform: `@babel/core` (peer of `babel-jest`), `@babel/runtime`,
  `babel-jest`, `babel-preset-react-app`,
  `@dr.pogodin/babel-plugin-transform-assets`
- Test runtime: `jest`, `jest-environment-jsdom`, `react-app-polyfill`
  (only referenced from `jest.config.js` setupFiles),
  `@testing-library/{dom,jest-dom,react,user-event}`
- Types: `@types/{jest,node,react,react-dom,swagger-ui-react}`

Kept in `dependencies` — including three that are not imported directly from
`src/` but are required peer dependencies:

- `styled-components`: hard peer of `@styled-icons/styled-icon` (`>=4.1.0`) and
  verified present in the built bundle.
- `@mui/system`: peer of `@mui/x-charts` and `@mui/x-date-pickers`.
- `@emotion/react`: peer of `@mui/material`.

No version changes, and `yarn.lock` is unchanged: this is a classification-only
change, so resolution is identical.

### How was this PR tested?

Clean install and full UI check pipeline from `quickwit/quickwit-ui`:

- `yarn install --frozen-lockfile` — passes, lockfile unmodified, no new
  peer-dependency warnings compared to before the change.
- `yarn type` (`tsc`) — passes.
- `yarn lint` (`biome check`) — passes, 55 files, no fixes applied.
- `yarn build` (`vite build`) — succeeds.
- `yarn test` (`jest`) — 7/7 suites, 7/7 tests pass.

Additionally grepped the bundle output to confirm `styled-components` is still
linked in, justifying keeping it as a runtime dependency.