### PR TITLE
ui(deps): remove unused dep @testing-library/user-event

### DIFF
--- a/quickwit/quickwit-ui/package.json
+++ b/quickwit/quickwit-ui/package.json
@@ -21,7 +21,6 @@
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
-    "@testing-library/user-event": "14.6.1",
     "@types/jest": "30.0.0",
     "@types/node": "24.10.9",
     "@types/react": "19.2.14",

--- a/quickwit/quickwit-ui/yarn.lock
+++ b/quickwit/quickwit-ui/yarn.lock
@@ -2997,11 +2997,6 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@testing-library/user-event@14.6.1":
-  version "14.6.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
-  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
-
 "@tree-sitter-grammars/tree-sitter-yaml@=0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz#9fcf9c56c7b4adb19097f869ada29c2d7a62c93d"


### PR DESCRIPTION
Description

Removes the unused @testing-library/user-event dependency from quickwit-ui.

The package was declared in quickwit/quickwit-ui/package.json but never imported anywhere:

- No references in any source or test file (src/, e2e/, mocks/, jest/) — the 7 existing Jest suites use @testing-library/react and @testing-library/jest-dom only.
- Not pulled in by test setup: jest.config.js loads react-app-polyfill/jsdom, jest/setup.js, and @testing-library/jest-dom.
- Not required transitively — it appeared in yarn.lock solely as a top-level entry, and it is an optional peer of @testing-library/react.

Changes:
- quickwit/quickwit-ui/package.json: drop "@testing-library/user-event": "14.6.1"
- quickwit/quickwit-ui/yarn.lock: regenerated via yarn install; only the orphaned entry was removed (5 lines), no other packages changed.

How was this PR tested?

- Repo-wide grep for user-event / userEvent across .ts, .tsx, .js, .jsx, .json, and .md (excluding node_modules and lockfiles) confirmed package.json was the only reference.
- yarn install — lockfile updated cleanly, no other dependency resolutions affected.
- yarn test — all 7 test suites / 7 tests pass.