### PR TITLE
feat(ui): create index

### DIFF
--- a/quickwit/quickwit-ui/src/components/CreateIndexDialog.tsx
+++ b/quickwit/quickwit-ui/src/components/CreateIndexDialog.tsx
@@ -1,0 +1,146 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+import { useMemo, useState } from "react";
+import { Client } from "../services/client";
+import { ResponseError } from "../utils/models";
+import { YamlEditor } from "./YamlEditor";
+
+// Starter config offered when the dialog opens. It mirrors the index config
+// files accepted by `quickwit index create --index-config`.
+export const DEFAULT_INDEX_CONFIG_YAML = `version: 0.9
+
+index_id: my-index
+
+doc_mapping:
+  field_mappings:
+    - name: timestamp
+      type: datetime
+      fast: true
+      input_formats:
+        - rfc3339
+      fast_precision: seconds
+    - name: body
+      type: text
+      tokenizer: default
+      record: position
+      stored: true
+  timestamp_field: timestamp
+
+search_settings:
+  default_search_fields:
+    - body
+
+indexing_settings:
+  commit_timeout_secs: 30
+`;
+
+const EDITOR_HEIGHT_PX = 420;
+
+export default function CreateIndexDialog({
+  open,
+  onClose,
+  onIndexCreated,
+}: Readonly<{
+  open: boolean;
+  onClose: () => void;
+  onIndexCreated: () => void;
+}>) {
+  const [indexConfig, setIndexConfig] = useState(DEFAULT_INDEX_CONFIG_YAML);
+  const [submitting, setSubmitting] = useState(false);
+  const [responseError, setResponseError] = useState<ResponseError | null>(
+    null,
+  );
+  const quickwitClient = useMemo(() => new Client(), []);
+
+  const handleClose = () => {
+    // Closing mid-flight would leave the dialog unable to report the outcome.
+    if (submitting) {
+      return;
+    }
+    setResponseError(null);
+    onClose();
+  };
+
+  const handleCreate = () => {
+    setSubmitting(true);
+    setResponseError(null);
+    quickwitClient.createIndex(indexConfig).then(
+      () => {
+        setSubmitting(false);
+        setResponseError(null);
+        setIndexConfig(DEFAULT_INDEX_CONFIG_YAML);
+        onIndexCreated();
+      },
+      (error) => {
+        // Keep the dialog open so the config can be fixed and resubmitted.
+        setSubmitting(false);
+        setResponseError(error);
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+      <DialogTitle>Create index</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ fontSize: 14, pb: 1 }}>
+          Paste an index config in YAML.
+        </DialogContentText>
+        <Box
+          sx={{
+            height: `${EDITOR_HEIGHT_PX}px`,
+            border: "1px solid rgba(0, 0, 0, 0.12)",
+            borderRadius: 1,
+            overflow: "hidden",
+          }}
+        >
+          <YamlEditor value={indexConfig} onChange={setIndexConfig} />
+        </Box>
+        {responseError !== null && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {responseError.message}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          disableElevation
+          onClick={handleCreate}
+          disabled={submitting || indexConfig.trim().length === 0}
+          startIcon={
+            submitting ? <CircularProgress size={16} color="inherit" /> : null
+          }
+        >
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/quickwit/quickwit-ui/src/components/YamlEditor.tsx
+++ b/quickwit/quickwit-ui/src/components/YamlEditor.tsx
@@ -1,0 +1,58 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { BeforeMount, Editor } from "@monaco-editor/react";
+import { EDITOR_THEME } from "../utils/theme";
+
+// Editable YAML editor. Unlike `JsonEditor`, it works on a raw string and lets
+// the caller own the value, and it does not size itself: the caller must give
+// it a container with a definite height.
+export function YamlEditor({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const beforeMount: BeforeMount = (monaco) => {
+    monaco.editor.defineTheme("quickwit-light", EDITOR_THEME);
+  };
+
+  return (
+    <Editor
+      language="yaml"
+      value={value}
+      onChange={(newValue) => onChange(newValue ?? "")}
+      beforeMount={beforeMount}
+      options={{
+        fontFamily: "monospace",
+        overviewRulerBorder: false,
+        overviewRulerLanes: 0,
+        minimap: {
+          enabled: false,
+        },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+        },
+        renderLineHighlight: "gutter",
+        fontSize: 12,
+        fixedOverflowWidgets: true,
+        scrollBeyondLastLine: false,
+        automaticLayout: true,
+        tabSize: 2,
+      }}
+      theme="quickwit-light"
+    />
+  );
+}

--- a/quickwit/quickwit-ui/src/components/YamlEditor.tsx
+++ b/quickwit/quickwit-ui/src/components/YamlEditor.tsx
@@ -15,9 +15,6 @@
 import { BeforeMount, Editor } from "@monaco-editor/react";
 import { EDITOR_THEME } from "../utils/theme";
 
-// Editable YAML editor. Unlike `JsonEditor`, it works on a raw string and lets
-// the caller own the value, and it does not size itself: the caller must give
-// it a container with a definite height.
 export function YamlEditor({
   value,
   onChange,

--- a/quickwit/quickwit-ui/src/services/client.test.ts
+++ b/quickwit/quickwit-ui/src/services/client.test.ts
@@ -52,4 +52,62 @@ describe("Client unit test", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
   });
+
+  it("Should post the index config as YAML when creating an index", async () => {
+    const mockFetch = jest.fn((_url: string, _options?: unknown) =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    );
+    (global as any).fetch = mockFetch;
+
+    const indexConfigYaml = "version: 0.9\nindex_id: my-index\n";
+    const client = new Client();
+    await client.createIndex(indexConfigYaml);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, params] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${client.apiRoot()}indexes`);
+    expect(params.method).toBe("POST");
+    // The config must be sent verbatim, not JSON-encoded.
+    expect(params.body).toBe(indexConfigYaml);
+    expect((params.headers as Record<string, string>)["content-type"]).toBe(
+      "application/yaml",
+    );
+  });
+
+  it("Should unwrap the message of a JSON error envelope", async () => {
+    const mockFetch = jest.fn((_url: string, _options?: unknown) =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        text: () =>
+          Promise.resolve(
+            '{"message":"field `timestamp` has an unknown type"}',
+          ),
+      }),
+    );
+    (global as any).fetch = mockFetch;
+
+    const client = new Client();
+    await expect(client.createIndex("version: 0.9\n")).rejects.toEqual({
+      message: "field `timestamp` has an unknown type",
+      status: 400,
+    });
+  });
+
+  it("Should surface a non-JSON error body verbatim", async () => {
+    const mockFetch = jest.fn((_url: string, _options?: unknown) =>
+      Promise.resolve({
+        ok: false,
+        status: 502,
+        text: () => Promise.resolve("<html>Bad Gateway</html>"),
+      }),
+    );
+    (global as any).fetch = mockFetch;
+
+    const client = new Client();
+    await expect(client.createIndex("version: 0.9\n")).rejects.toEqual({
+      message: "<html>Bad Gateway</html>",
+      status: 502,
+    });
+  });
 });

--- a/quickwit/quickwit-ui/src/services/client.ts
+++ b/quickwit/quickwit-ui/src/services/client.ts
@@ -106,6 +106,23 @@ export class Client {
     return this.fetch(`${this.apiRoot()}indexes`, {});
   }
 
+  // Creates an index from a raw index config expressed in YAML. The config is
+  // sent as-is: the server selects its parser from the `content-type` subtype
+  // and reports validation errors, so no client-side YAML parsing is done here.
+  async createIndex(indexConfigYaml: string): Promise<IndexMetadata> {
+    return this.fetch(
+      `${this.apiRoot()}indexes`,
+      {
+        headers: {
+          "content-type": "application/yaml",
+          Accept: "application/json",
+        },
+        mode: "cors",
+      },
+      indexConfigYaml,
+    );
+  }
+
   async fetch<T>(
     url: string,
     params: RequestInit,
@@ -114,20 +131,37 @@ export class Client {
     if (body !== null) {
       params.method = "POST";
       params.body = body;
+      // The caller's `content-type` wins: callers that do not set one default
+      // to JSON.
       params.headers = {
-        ...params.headers,
         "content-type": "application/json",
+        ...params.headers,
       };
     }
     const response = await fetch(url, params);
     if (response.ok) {
       return response.json() as Promise<T>;
     }
-    const message = await response.text();
     return await Promise.reject({
-      message: message,
+      message: await this.extractErrorMessage(response),
       status: response.status,
     });
+  }
+
+  // Quickwit reports errors as a `{"message": "..."}` JSON envelope. Anything
+  // else (a proxy error page, for instance) is surfaced verbatim so failures
+  // are never hidden.
+  private async extractErrorMessage(response: Response): Promise<string> {
+    const rawBody = await response.text();
+    try {
+      const parsedBody = JSON.parse(rawBody);
+      if (typeof parsedBody?.message === "string") {
+        return parsedBody.message;
+      }
+    } catch {
+      // Not a JSON error envelope.
+    }
+    return rawBody;
   }
 
   private defaultGetRequestParams(): RequestInit {

--- a/quickwit/quickwit-ui/src/services/client.ts
+++ b/quickwit/quickwit-ui/src/services/client.ts
@@ -106,9 +106,6 @@ export class Client {
     return this.fetch(`${this.apiRoot()}indexes`, {});
   }
 
-  // Creates an index from a raw index config expressed in YAML. The config is
-  // sent as-is: the server selects its parser from the `content-type` subtype
-  // and reports validation errors, so no client-side YAML parsing is done here.
   async createIndex(indexConfigYaml: string): Promise<IndexMetadata> {
     return this.fetch(
       `${this.apiRoot()}indexes`,
@@ -148,9 +145,6 @@ export class Client {
     });
   }
 
-  // Quickwit reports errors as a `{"message": "..."}` JSON envelope. Anything
-  // else (a proxy error page, for instance) is surfaced verbatim so failures
-  // are never hidden.
   private async extractErrorMessage(response: Response): Promise<string> {
     const rawBody = await response.text();
     try {

--- a/quickwit/quickwit-ui/src/views/IndexesView.test.jsx
+++ b/quickwit/quickwit-ui/src/views/IndexesView.test.jsx
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
+import { DEFAULT_INDEX_CONFIG_YAML } from "../components/CreateIndexDialog";
 import { Client } from "../services/client";
 import IndexesView from "./IndexesView";
 
@@ -37,29 +38,30 @@ afterEach(() => {
   container = null;
 });
 
-test("renders IndexesView", async () => {
-  const indexes = [
-    {
-      index_config: {
-        index_id: "my-new-fresh-index",
-        index_uri: "my-uri",
-        indexing_settings: {
-          timestamp_field: "timestamp",
-        },
-        search_settings: {},
-        doc_mapping: {
-          store: false,
-          field_mappings: [],
-          tag_fields: [],
-          dynamic_mapping: false,
-        },
+const indexes = [
+  {
+    index_config: {
+      index_id: "my-new-fresh-index",
+      index_uri: "my-uri",
+      indexing_settings: {
+        timestamp_field: "timestamp",
       },
-      sources: [],
-      create_timestamp: 1000,
-      update_timestamp: 1000,
+      search_settings: {},
+      doc_mapping: {
+        store: false,
+        field_mappings: [],
+        tag_fields: [],
+        dynamic_mapping: false,
+      },
     },
-  ];
-  Client.prototype.listIndexes.mockResolvedValueOnce(() => indexes);
+    sources: [],
+    create_timestamp: 1000,
+    update_timestamp: 1000,
+  },
+];
+
+test("renders IndexesView", async () => {
+  Client.prototype.listIndexes.mockResolvedValue(indexes);
 
   await act(async () => {
     render(<IndexesView />, container);
@@ -68,4 +70,73 @@ test("renders IndexesView", async () => {
   expect(
     screen.getByText(indexes[0].index_config.index_id),
   ).toBeInTheDocument();
+});
+
+test("opens the create index dialog with the default config", async () => {
+  Client.prototype.listIndexes.mockResolvedValue(indexes);
+
+  await act(async () => {
+    render(<IndexesView />, container);
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /create index/i }));
+  });
+
+  // The Monaco editor is mocked and renders its value as plain text. Compare
+  // raw `textContent`: `toHaveTextContent` collapses the YAML indentation.
+  expect(screen.getByRole("dialog").textContent).toContain(
+    DEFAULT_INDEX_CONFIG_YAML,
+  );
+});
+
+test("creates an index and refetches the index list", async () => {
+  Client.prototype.listIndexes.mockResolvedValue(indexes);
+  Client.prototype.createIndex.mockResolvedValue(indexes[0]);
+
+  await act(async () => {
+    render(<IndexesView />, container);
+  });
+  expect(Client.prototype.listIndexes).toHaveBeenCalledTimes(1);
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /create index/i }));
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+  });
+
+  expect(Client.prototype.createIndex).toHaveBeenCalledWith(
+    DEFAULT_INDEX_CONFIG_YAML,
+  );
+  expect(Client.prototype.listIndexes).toHaveBeenCalledTimes(2);
+  // The dialog fades out, so it only leaves the DOM once the transition ends.
+  await waitFor(() =>
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+  );
+});
+
+test("keeps the dialog open and displays the error when creation fails", async () => {
+  Client.prototype.listIndexes.mockResolvedValue(indexes);
+  Client.prototype.createIndex.mockRejectedValue({
+    status: 400,
+    message: "index `my-index` already exists",
+  });
+
+  await act(async () => {
+    render(<IndexesView />, container);
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /create index/i }));
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+  });
+
+  expect(
+    screen.getByText("index `my-index` already exists"),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("dialog")).toBeInTheDocument();
+  expect(Client.prototype.listIndexes).toHaveBeenCalledTimes(1);
 });

--- a/quickwit/quickwit-ui/src/views/IndexesView.tsx
+++ b/quickwit/quickwit-ui/src/views/IndexesView.tsx
@@ -89,6 +89,7 @@ function IndexesView() {
           <Button
             variant="contained"
             disableElevation
+            disabled={loading}
             startIcon={<AddIcon />}
             onClick={() => setCreateDialogOpen(true)}
           >

--- a/quickwit/quickwit-ui/src/views/IndexesView.tsx
+++ b/quickwit/quickwit-ui/src/views/IndexesView.tsx
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Typography } from "@mui/material";
-import { useEffect, useMemo, useState } from "react";
+import AddIcon from "@mui/icons-material/Add";
+import { Box, Button, Typography } from "@mui/material";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ApiUrlFooter from "../components/ApiUrlFooter";
+import CreateIndexDialog from "../components/CreateIndexDialog";
 import IndexesTable from "../components/IndexesTable";
 import {
   FullBoxContainer,
@@ -32,6 +34,7 @@ function IndexesView() {
     null,
   );
   const [indexesMetadata, setIndexesMetadata] = useState<IndexMetadata[]>();
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const quickwitClient = useMemo(() => new Client(), []);
 
   const renderFetchIndexesResult = () => {
@@ -51,7 +54,7 @@ function IndexesView() {
     return <Box>You have no index registered in your metastore.</Box>;
   };
 
-  useEffect(() => {
+  const fetchIndexes = useCallback(() => {
     setLoading(true);
     quickwitClient.listIndexes().then(
       (indexesMetadata) => {
@@ -66,14 +69,42 @@ function IndexesView() {
     );
   }, [quickwitClient]);
 
+  useEffect(() => {
+    fetchIndexes();
+  }, [fetchIndexes]);
+
   return (
     <ViewUnderAppBarBox>
       <FullBoxContainer>
-        <QBreadcrumbs aria-label="breadcrumb">
-          <Typography color="text.primary">Indexes</Typography>
-        </QBreadcrumbs>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <QBreadcrumbs aria-label="breadcrumb">
+            <Typography color="text.primary">Indexes</Typography>
+          </QBreadcrumbs>
+          <Button
+            variant="contained"
+            disableElevation
+            startIcon={<AddIcon />}
+            onClick={() => setCreateDialogOpen(true)}
+          >
+            Create index
+          </Button>
+        </Box>
         {renderFetchIndexesResult()}
       </FullBoxContainer>
+      <CreateIndexDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        onIndexCreated={() => {
+          setCreateDialogOpen(false);
+          fetchIndexes();
+        }}
+      />
       {ApiUrlFooter("api/v1/indexes")}
     </ViewUnderAppBarBox>
   );


### PR DESCRIPTION
### Description

Adds a **Create index** action to the Indexes page in the web UI. Until now an index could only be created from the CLI (`quickwit index create --index-config`) or by calling the REST API directly.

A button in the page header opens a dialog with a Monaco YAML editor, pre-filled with a starter index config. Submitting POSTs the config verbatim to `/api/v1/indexes` with `content-type: application/yaml` — the same format the CLI accepts — and the index table refetches on success. Validation errors from the server are shown inline in the dialog, which stays open so the config can be corrected and resubmitted.

No backend changes: `POST /api/v1/indexes` already selects its parser from the `content-type` subtype.

Changes, all under `quickwit/quickwit-ui/`:

- `src/components/CreateIndexDialog.tsx` (new) — the dialog, plus the `DEFAULT_INDEX_CONFIG_YAML` template.
- `src/components/YamlEditor.tsx` (new) — editable Monaco editor, `language="yaml"`, reusing the existing `quickwit-light` theme. Modeled on `JsonEditor.tsx`, which is read-only and JSON-only. No new dependency — Monaco bundles the YAML basic language.
- `src/views/IndexesView.tsx` — header row with the Create button, kept outside the result renderer so it is available in the loading, error, and empty-metastore states. The fetch moves into a `fetchIndexes` `useCallback` so the table can be refreshed after a create.
- `src/services/client.ts` — new `createIndex(indexConfigYaml)`. Two supporting changes to the shared `fetch` helper: the caller's `content-type` now wins (callers that set none still default to JSON, so `search` is unchanged), and Quickwit's `{"message": "..."}` error envelope is unwrapped so views display the message instead of raw JSON. A body that is not that envelope is surfaced verbatim rather than swallowed.

Scope is limited to creation — no delete, no update, no `?overwrite=` toggle.

### How was this PR tested?

**Automated** — from `quickwit/quickwit-ui/`:

- `yarn test` — 13 tests / 7 suites pass. New coverage: `createIndex` posts the raw YAML with the right URL, method, and content-type; a JSON error envelope is unwrapped while a non-JSON body passes through verbatim; the dialog opens with the template; a successful create refetches the list and closes the dialog; a failed create renders the message and leaves the dialog open.
- `yarn type` (tsc, strict) and `biome check src` are clean.

Also corrected an existing mock in `IndexesView.test.jsx`: `mockResolvedValueOnce(() => indexes)` resolved a *function* rather than the array, so the assertion was not exercising the table.

**Manual** — ran a server from this tree on an isolated port and data dir, and issued the exact request the client sends:

| Case | Result |
| --- | --- |
| Default template, `content-type: application/yaml` | 200, index created |
| Same config again | 400 — ``metastore error `index `my-index` already exist(s)` `` |
| Field mapping with `type: unknown` | 400 — ``field `timestamp` has an unknown type: `unknown` `` |
| `stackoverflow` config from the CLI docs, verbatim | 200 — confirms parity with `quickwit index create --index-config` |

Both 400s come back as `{"message": ...}`, which is what the dialog renders.

<img width="1894" height="474" alt="image" src="https://github.com/user-attachments/assets/ce1ea97a-a4dd-42e6-9373-5334b93b0bc0" />

<img width="943" height="603" alt="image" src="https://github.com/user-attachments/assets/a8f43752-a28c-403b-81cc-7e47aca3cf4a" />

<img width="914" height="651" alt="image" src="https://github.com/user-attachments/assets/9afb5970-a08e-4c15-bdbc-247323f311f9" />
