### PR TITLE
chore(codeowners): drop byoc-metrics required reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,6 @@
 # CODEOWNERS — see https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
-# Last matching rule per file wins. Multiple owners listed on the same line
-# means approval from ANY ONE of them satisfies the requirement.
+# Last matching rule per file wins.
 
 # Default: quickwit-core owns everything
 *                                                        @quickwit-oss/quickwit-core
-
-# byoc-metrics paths — owned by byoc-metrics
-/quickwit/quickwit-parquet-engine/                       @quickwit-oss/byoc-metrics
-/quickwit/quickwit-datafusion/                           @quickwit-oss/byoc-metrics
-/quickwit/quickwit-df-core/                              @quickwit-oss/byoc-metrics
-/quickwit/quickwit-dst/                                  @quickwit-oss/byoc-metrics
-/quickwit/quickwit-indexing/src/actors/parquet_pipeline/ @quickwit-oss/byoc-metrics
-
-# Shared paths — either team can approve. `docs/internals/` is shared
-# architecture + verification docs that any team working on the codebase
-# may need to update. `Cargo.lock` churns on routine dependency bumps
-# and doesn't carry domain-specific review value.
-/docs/internals/                                         @quickwit-oss/quickwit-core @quickwit-oss/byoc-metrics
-/quickwit/Cargo.lock                                     @quickwit-oss/quickwit-core @quickwit-oss/byoc-metrics


### PR DESCRIPTION
## Summary

- Remove `@quickwit-oss/byoc-metrics` from `.github/CODEOWNERS`. Every path now falls under `@quickwit-oss/quickwit-core`.
- Exclusive byoc-metrics paths (`quickwit-parquet-engine`, `quickwit-datafusion`, `quickwit-df-core`, `quickwit-dst`, parquet pipeline) and the shared `docs/internals` / `Cargo.lock` lines are gone; they were only there to require that second team.



## Test plan

- [ ] Confirm GitHub code-owner required reviews on this PR list only `@quickwit-oss/quickwit-core`
- [ ] After merge, confirm #6711 no longer requests `@quickwit-oss/byoc-metrics`


Made with [Cursor](https://cursor.com)