### PR TITLE
Split Cargo Dependabot version updates by dependency family

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,28 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      rust-dependencies:
+      arrow-datafusion:
+        applies-to: version-updates
         patterns:
-          - "*"
+          - "arrow"
+          - "datafusion"
+          - "datafusion-*"
+          - "object_store"
+          - "parquet"
+          - "thrift"
+      aws:
+        applies-to: version-updates
+        patterns:
+          - "aws-*"
+      google-cloud:
+        applies-to: version-updates
+        patterns:
+          - "google-cloud-*"
+      reqwest:
+        applies-to: version-updates
+        patterns:
+          - "reqwest"
+          - "reqwest-*"
       rust-security:
         applies-to: security-updates
         patterns:


### PR DESCRIPTION
## Summary

- replace the catch-all Cargo version-update group with focused groups for coupled dependency families
- keep Arrow/DataFusion, AWS, Google Cloud, and Reqwest family updates together
- let unrelated Cargo version updates fall through to individual PRs
- leave the catch-all `rust-security` group and the existing patch-update suppression unchanged

This follows up on #6730, which combined 36 unrelated updates and failed compilation and several CI lanes.

## Testing

- `make fmt`
- parsed `.github/dependabot.yml` with Ruby's YAML parser and asserted the expected group scopes
- `git diff --check`