### PR TITLE
feat(api): indices as alias for indexes

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -175,6 +175,11 @@ The parse failure objects contain the following fields:
 
 ## Index API
 
+All index API endpoints accept `indices` as an alias for `indexes`. For example,
+`GET api/v1/indices/<index id>` is equivalent to
+`GET api/v1/indexes/<index id>`. The examples below use the canonical `indexes`
+spelling.
+
 ### Create an index
 
 ```

--- a/quickwit/quickwit-serve/src/index_api/index_resource.rs
+++ b/quickwit/quickwit-serve/src/index_api/index_resource.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 use warp::{Filter, Rejection};
 
+use super::indexes_path_segment;
 use super::rest_handler::log_failure;
 use crate::format::{extract_config_format, extract_format_from_qs};
 use crate::rest_api_response::into_rest_api_response;
@@ -42,7 +43,8 @@ use crate::with_arg;
 pub fn get_index_metadata_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String)
+    indexes_path_segment()
+        .and(warp::path!(String))
         .and(warp::get())
         .and(with_arg(metastore))
         .then(get_index_metadata)
@@ -78,7 +80,8 @@ pub struct ListIndexesQueryParams {
 pub fn list_indexes_metadata_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes")
+    indexes_path_segment()
+        .and(warp::path::end())
         .and(warp::get())
         .and(warp::query())
         .and(with_arg(metastore))
@@ -177,7 +180,8 @@ pub async fn describe_index(
 pub fn describe_index_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "describe")
+    indexes_path_segment()
+        .and(warp::path!(String / "describe"))
         .and(warp::get())
         .and(with_arg(metastore))
         .then(describe_index)
@@ -235,7 +239,8 @@ pub fn create_index_handler(
     index_service: IndexService,
     node_config: Arc<NodeConfig>,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes")
+    indexes_path_segment()
+        .and(warp::path::end())
         .and(warp::post())
         .and(warp::query())
         .and(extract_config_format())
@@ -300,7 +305,8 @@ pub fn update_index_handler(
     index_service: IndexService,
     node_config: Arc<NodeConfig>,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String)
+    indexes_path_segment()
+        .and(warp::path!(String))
         .and(warp::put())
         .and(extract_config_format())
         .and(update_index_qp())
@@ -400,7 +406,8 @@ pub async fn update_index(
 pub fn clear_index_handler(
     index_service: IndexService,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "clear")
+    indexes_path_segment()
+        .and(warp::path!(String / "clear"))
         .and(warp::put())
         .and(with_arg(index_service))
         .then(clear_index)
@@ -440,7 +447,8 @@ pub struct DeleteIndexQueryParam {
 pub fn delete_index_handler(
     index_service: IndexService,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String)
+    indexes_path_segment()
+        .and(warp::path!(String))
         .and(warp::delete())
         .and(warp::query())
         .and(with_arg(index_service))

--- a/quickwit/quickwit-serve/src/index_api/mod.rs
+++ b/quickwit/quickwit-serve/src/index_api/mod.rs
@@ -17,6 +17,44 @@ mod rest_handler;
 mod source_resource;
 mod split_resource;
 
+use warp::{Filter, Rejection};
+
 pub use self::index_resource::get_index_metadata_handler;
 pub use self::rest_handler::{IndexApi, index_management_handlers};
 pub use self::split_resource::{ListSplitsQueryParams, ListSplitsResponse};
+
+fn indexes_path_segment() -> impl Filter<Extract = (), Error = Rejection> + Clone {
+    warp::path("indexes").or(warp::path("indices")).unify()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_indexes_path_segment() {
+        let index_api_root = indexes_path_segment().and(warp::path::end());
+
+        assert!(
+            warp::test::request()
+                .path("/indexes")
+                .filter(&index_api_root)
+                .await
+                .is_ok()
+        );
+        assert!(
+            warp::test::request()
+                .path("/indices")
+                .filter(&index_api_root)
+                .await
+                .is_ok()
+        );
+        assert!(
+            warp::test::request()
+                .path("/index")
+                .filter(&index_api_root)
+                .await
+                .is_err()
+        );
+    }
+}

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -255,7 +255,7 @@ mod tests {
             super::index_management_handlers(index_service, Arc::new(NodeConfig::for_test()))
                 .recover(recover_fn);
         let resp = warp::test::request()
-            .path("/indexes/test-index")
+            .path("/indices/test-index")
             .reply(&index_management_handler)
             .await;
         assert_eq!(resp.status(), 200);
@@ -332,7 +332,7 @@ mod tests {
         {
             let resp = warp::test::request()
                 .path(
-                    "/indexes/quickwit-demo-index/splits?split_states=Published,Staged&\
+                    "/indices/quickwit-demo-index/splits?split_states=Published,Staged&\
                      start_timestamp=10&end_timestamp=20&end_create_timestamp=2",
                 )
                 .reply(&index_management_handler)
@@ -550,7 +550,7 @@ mod tests {
             super::index_management_handlers(index_service, Arc::new(NodeConfig::for_test()))
                 .recover(recover_fn);
         let resp = warp::test::request()
-            .path("/indexes?index_id_patterns=test-index-*")
+            .path("/indices?index_id_patterns=test-index-*")
             .reply(&index_management_handler)
             .await;
         assert_eq!(resp.status(), 200);
@@ -744,7 +744,7 @@ mod tests {
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(node_config));
         let resp = warp::test::request()
-            .path("/indexes")
+            .path("/indices")
             .method("POST")
             .json(&true)
             .body(r#"{"version": "0.7", "index_id": "hdfs-logs", "doc_mapping": {"field_mappings":[{"name": "timestamp", "type": "i64", "fast": true, "indexed": true}]}}"#)
@@ -763,7 +763,7 @@ mod tests {
         // Create source.
         let source_config_body = r#"{"version": "0.7", "source_id": "vec-source", "source_type": "vec", "params": {"docs": [], "batch_num_docs": 10}}"#;
         let resp = warp::test::request()
-            .path("/indexes/hdfs-logs/sources")
+            .path("/indices/hdfs-logs/sources")
             .method("POST")
             .json(&true)
             .body(source_config_body)
@@ -773,7 +773,7 @@ mod tests {
 
         // Get source.
         let resp = warp::test::request()
-            .path("/indexes/hdfs-logs/sources/vec-source")
+            .path("/indices/hdfs-logs/sources/vec-source")
             .method("GET")
             .reply(&index_management_handler)
             .await;
@@ -800,7 +800,7 @@ mod tests {
 
         // Check delete source.
         let resp = warp::test::request()
-            .path("/indexes/hdfs-logs/sources/vec-source")
+            .path("/indices/hdfs-logs/sources/vec-source")
             .method("DELETE")
             .body(source_config_body)
             .reply(&index_management_handler)
@@ -842,7 +842,7 @@ mod tests {
 
         // Check delete index.
         let resp = warp::test::request()
-            .path("/indexes/hdfs-logs")
+            .path("/indices/hdfs-logs")
             .method("DELETE")
             .body(source_config_body)
             .reply(&index_management_handler)

--- a/quickwit/quickwit-serve/src/index_api/rest_handler.rs
+++ b/quickwit/quickwit-serve/src/index_api/rest_handler.rs
@@ -533,7 +533,7 @@ mod tests {
         let mut mock_metastore = MockMetastoreService::new();
         mock_metastore
             .expect_list_indexes_metadata()
-            .return_once(|list_indexes_request| {
+            .returning(|list_indexes_request| {
                 assert_eq!(
                     list_indexes_request.index_id_patterns,
                     vec!["test-index-*".to_string()]
@@ -541,7 +541,8 @@ mod tests {
                 let index_metadata =
                     IndexMetadata::for_test("test-index", "ram:///indexes/test-index");
                 Ok(ListIndexesMetadataResponse::for_test(vec![index_metadata]))
-            });
+            })
+            .times(2);
         let index_service = IndexService::new(
             MetastoreServiceClient::from_mock(mock_metastore),
             StorageResolver::unconfigured(),
@@ -549,23 +550,28 @@ mod tests {
         let index_management_handler =
             super::index_management_handlers(index_service, Arc::new(NodeConfig::for_test()))
                 .recover(recover_fn);
-        let resp = warp::test::request()
-            .path("/indices?index_id_patterns=test-index-*")
-            .reply(&index_management_handler)
-            .await;
-        assert_eq!(resp.status(), 200);
-        let actual_response_json: JsonValue = serde_json::from_slice(resp.body())?;
-        let actual_response_arr: &Vec<JsonValue> = actual_response_json.as_array().unwrap();
-        assert_eq!(actual_response_arr.len(), 1);
-        let actual_index_metadata_json: &JsonValue = &actual_response_arr[0];
-        let expected_response_json = serde_json::json!({
-            "index_id": "test-index",
-            "index_uri": "ram:///indexes/test-index",
-        });
-        assert_json_include!(
-            actual: actual_index_metadata_json.get("index_config").unwrap(),
-            expected: expected_response_json
-        );
+        for path in [
+            "/indexes?index_id_patterns=test-index-*",
+            "/indices?index_id_patterns=test-index-*",
+        ] {
+            let resp = warp::test::request()
+                .path(path)
+                .reply(&index_management_handler)
+                .await;
+            assert_eq!(resp.status(), 200);
+            let actual_response_json: JsonValue = serde_json::from_slice(resp.body())?;
+            let actual_response_arr: &Vec<JsonValue> = actual_response_json.as_array().unwrap();
+            assert_eq!(actual_response_arr.len(), 1);
+            let actual_index_metadata_json: &JsonValue = &actual_response_arr[0];
+            let expected_response_json = serde_json::json!({
+                "index_id": "test-index",
+                "index_uri": "ram:///indexes/test-index",
+            });
+            assert_json_include!(
+                actual: actual_index_metadata_json.get("index_config").unwrap(),
+                expected: expected_response_json
+            );
+        }
         Ok(())
     }
 

--- a/quickwit/quickwit-serve/src/index_api/source_resource.rs
+++ b/quickwit/quickwit-serve/src/index_api/source_resource.rs
@@ -30,6 +30,7 @@ use serde::Deserialize;
 use tracing::info;
 use warp::{Filter, Rejection};
 
+use super::indexes_path_segment;
 use super::rest_handler::{json_body, log_failure};
 use crate::format::{extract_config_format, extract_format_from_qs};
 use crate::rest_api_response::into_rest_api_response;
@@ -38,7 +39,8 @@ use crate::with_arg;
 pub fn create_source_handler(
     index_service: IndexService,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "sources")
+    indexes_path_segment()
+        .and(warp::path!(String / "sources"))
         .and(warp::post())
         .and(extract_config_format())
         .and(warp::body::content_length_limit(1024 * 1024))
@@ -117,7 +119,8 @@ fn update_source_qp() -> impl Filter<Extract = (UpdateQueryParams,), Error = Rej
 pub fn update_source_handler(
     index_service: IndexService,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "sources" / String)
+    indexes_path_segment()
+        .and(warp::path!(String / "sources" / String))
         .and(warp::put())
         .and(extract_config_format())
         .and(update_source_qp())
@@ -201,7 +204,8 @@ pub async fn update_source(
 pub fn get_source_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "sources" / String)
+    indexes_path_segment()
+        .and(warp::path!(String / "sources" / String))
         .and(warp::get())
         .and(with_arg(metastore))
         .then(get_source)
@@ -235,7 +239,10 @@ pub async fn get_source(
 pub fn reset_source_checkpoint_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "sources" / String / "reset-checkpoint")
+    indexes_path_segment()
+        .and(warp::path!(
+            String / "sources" / String / "reset-checkpoint"
+        ))
         .and(warp::put())
         .and(with_arg(metastore))
         .then(reset_source_checkpoint)
@@ -282,7 +289,8 @@ pub async fn reset_source_checkpoint(
 pub fn toggle_source_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "sources" / String / "toggle")
+    indexes_path_segment()
+        .and(warp::path!(String / "sources" / String / "toggle"))
         .and(warp::put())
         .and(json_body())
         .and(with_arg(metastore))
@@ -343,7 +351,8 @@ pub async fn toggle_source(
 pub fn delete_source_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "sources" / String)
+    indexes_path_segment()
+        .and(warp::path!(String / "sources" / String))
         .and(warp::delete())
         .and(with_arg(metastore))
         .then(delete_source)
@@ -394,7 +403,8 @@ pub async fn delete_source(
 pub fn get_source_shards_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "sources" / String / "shards")
+    indexes_path_segment()
+        .and(warp::path!(String / "sources" / String / "shards"))
         .and(warp::get())
         .and(with_arg(metastore))
         .then(get_source_shards)

--- a/quickwit/quickwit-serve/src/index_api/split_resource.rs
+++ b/quickwit/quickwit-serve/src/index_api/split_resource.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 use warp::{Filter, Rejection};
 
+use super::indexes_path_segment;
 use super::rest_handler::json_body;
 use crate::format::extract_format_from_qs;
 use crate::rest_api_response::into_rest_api_response;
@@ -139,7 +140,8 @@ pub async fn list_splits(
 pub fn list_splits_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "splits")
+    indexes_path_segment()
+        .and(warp::path!(String / "splits"))
         .and(warp::get())
         .and(warp::query())
         .and(with_arg(metastore))
@@ -196,7 +198,8 @@ pub async fn mark_splits_for_deletion(
 pub fn mark_splits_for_deletion_handler(
     metastore: MetastoreServiceClient,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = Rejection> + Clone {
-    warp::path!("indexes" / String / "splits" / "mark-for-deletion")
+    indexes_path_segment()
+        .and(warp::path!(String / "splits" / "mark-for-deletion"))
         .and(warp::put())
         .and(json_body())
         .and(with_arg(metastore))


### PR DESCRIPTION
Resolves #3540

### Description

  Adds indices as an alias for indexes across all index management REST API routes, including index, split, source, and source-shard endpoints. indexes remains the canonical spelling in OpenAPI and documentation examples.

  The alias uses a shared path-segment filter, avoiding duplicated handlers or business logic. A redirect was not used because these routes include methods such as POST, PUT, and DELETE with request bodies; redirect handling may not
  reliably preserve the method and body across clients and would add an unnecessary round trip.

  The REST API documentation was updated accordingly.

  ### How was this PR tested?

  - Ran make fmt.
  - Ran cargo check -p quickwit-serve --tests.
  - Ran the focused index API test suite: 25 tests passed.
  - Ran the full quickwit-serve test suite: 165 tests passed.
  - Added tests covering both /indexes and /indices, including collection, individual index, split, and source routes.