### PR TITLE
Prevent search workers from starving network requests

### DIFF
--- a/quickwit/quickwit-search/src/lib.rs
+++ b/quickwit/quickwit-search/src/lib.rs
@@ -138,7 +138,7 @@ pub type SearcherPool = Pool<SocketAddr, SearcherNode>;
 
 fn search_thread_pool() -> &'static ThreadPoolWithPriority {
     static SEARCH_THREAD_POOL: LazyLock<ThreadPoolWithPriority> =
-        LazyLock::new(|| ThreadPoolWithPriority::new("search", None));
+        LazyLock::new(|| ThreadPoolWithPriority::new("search", Some(quickwit_common::num_cpus())));
     &SEARCH_THREAD_POOL
 }
 


### PR DESCRIPTION
## Summary
- size the search Rayon pool from Quickwit's configured CPU capacity
- prevent search work from using every CPU visible on Kubernetes nodes when `QW_NUM_CPUS` is lower
- preserve CPU capacity for networking and runtime tasks such as load-reporting RPCs

## Context
Kubernetes searcher pods can request fewer CPUs than their nodes expose. The Tokio runtimes respect `QW_NUM_CPUS`, but the Rayon search pool previously used Rayon's default available parallelism and therefore created a worker for every visible node CPU. CPU-heavy searches could saturate the node and delay load-reporting RPCs, causing healthy searchers to be treated as unreachable.

## Validation
- `make fmt`
- `cargo check -p quickwit-search`