### PR TITLE
Use predicate cache for all non-timestamp predicates

### DIFF
--- a/quickwit/quickwit-query/src/elastic_query_dsl/terms_query.rs
+++ b/quickwit/quickwit-query/src/elastic_query_dsl/terms_query.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Deserialize;
 
@@ -87,7 +87,7 @@ impl TryFrom<TermsQueryForSerialization> for TermsQuery {
 
 impl ConvertibleToQueryAst for TermsQuery {
     fn convert_to_query_ast(self) -> anyhow::Result<QueryAst> {
-        let mut terms_per_field = HashMap::new();
+        let mut terms_per_field = BTreeMap::new();
         let values_set: BTreeSet<String> = self.values.into_iter().collect();
         terms_per_field.insert(self.field, values_set);
 

--- a/quickwit/quickwit-query/src/query_ast/cache_node.rs
+++ b/quickwit/quickwit-query/src/query_ast/cache_node.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use bitpacking::{BitPacker, BitPacker1x};
@@ -105,14 +106,18 @@ impl BuildTantivyAst for CacheNode {
             }
             .into()),
             CacheState::CacheMiss(cache_filler) => {
-                let tantivy_query: Box<dyn Query> = self
-                    .inner
-                    .build_tantivy_ast_call(context)?
-                    .simplify()
-                    .into();
+                let tantivy_query_ast = self.inner.build_tantivy_ast_call(context)?.simplify();
+                let mut required_terms = HashSet::new();
+                super::required_terms::collect_required_terms(
+                    &tantivy_query_ast,
+                    context.schema,
+                    &mut required_terms,
+                );
+                let tantivy_query: Box<dyn Query> = tantivy_query_ast.into();
                 Ok(CacheFillerQuery {
                     inner_query: Box::new(tantivy_query),
                     cache_filler: cache_filler.clone(),
+                    required_terms,
                 }
                 .into())
             }
@@ -123,7 +128,7 @@ impl BuildTantivyAst for CacheNode {
 use tantivy::directory::OwnedBytes;
 use tantivy::index::SegmentId;
 use tantivy::query::{EnableScoring, Explanation, Query, Scorer, Weight};
-use tantivy::{DocId, DocSet, Score, SegmentReader, TantivyError};
+use tantivy::{DocId, DocSet, Score, SegmentReader, TantivyError, Term};
 
 #[derive(Clone, Debug)]
 pub struct CacheHitQuery {
@@ -397,6 +402,7 @@ impl CacheFiller {
 pub struct CacheFillerQuery {
     inner_query: Box<dyn Query>,
     cache_filler: CacheFiller,
+    required_terms: HashSet<Term>,
 }
 
 impl Clone for CacheFillerQuery {
@@ -404,7 +410,14 @@ impl Clone for CacheFillerQuery {
         Self {
             inner_query: self.inner_query.box_clone(),
             cache_filler: self.cache_filler.clone(),
+            required_terms: self.required_terms.clone(),
         }
+    }
+}
+
+impl CacheFillerQuery {
+    pub(crate) fn required_terms(&self) -> &HashSet<Term> {
+        &self.required_terms
     }
 }
 
@@ -714,6 +727,56 @@ mod tests {
             visitor.transform(ast).unwrap();
             assert!(visitor.0);
         }
+    }
+
+    #[test]
+    fn test_cache_filler_preserves_required_terms() {
+        let mut schema_builder = Schema::builder();
+        let body_field = schema_builder.add_text_field("body", TEXT);
+        let schema = schema_builder.build();
+        let context = BuildTantivyAstContext::for_test(&schema);
+        let term_query: QueryAst = TermQuery {
+            field: "body".to_string(),
+            value: "val".to_string(),
+        }
+        .into();
+        let cache_node = CacheNode::new(term_query);
+        let query_json = serde_json::to_string(&cache_node.inner).unwrap();
+        let ast: QueryAst = cache_node.into();
+        let cache = Arc::new(Mutex::new(HashMap::new()));
+
+        let cache_miss_ast = PredicateCacheInjector {
+            cache: cache.clone(),
+            split_id: "split".to_string(),
+        }
+        .transform(ast.clone())
+        .unwrap()
+        .unwrap();
+        let (_query, required_terms) = cache_miss_ast
+            .build_tantivy_query_and_required_terms(&context)
+            .unwrap();
+        assert_eq!(
+            required_terms,
+            HashSet::from([Term::from_field_text(body_field, "val")])
+        );
+
+        cache.put(
+            "split".to_string(),
+            query_json,
+            SegmentId::from_uuid_string("1686a000d4f7a91939d0e71df1646d7a").unwrap(),
+            HitSet::empty(),
+        );
+        let cache_hit_ast = PredicateCacheInjector {
+            cache,
+            split_id: "split".to_string(),
+        }
+        .transform(ast)
+        .unwrap()
+        .unwrap();
+        let (_query, required_terms) = cache_hit_ast
+            .build_tantivy_query_and_required_terms(&context)
+            .unwrap();
+        assert!(required_terms.is_empty());
     }
 
     #[test]

--- a/quickwit/quickwit-query/src/query_ast/required_terms.rs
+++ b/quickwit/quickwit-query/src/query_ast/required_terms.rs
@@ -37,6 +37,7 @@ use tantivy::Term;
 use tantivy::query::TermQuery as TantivyTermQuery;
 use tantivy::schema::Schema;
 
+use crate::query_ast::cache_node::CacheFillerQuery;
 use crate::query_ast::tantivy_query_ast::{TantivyBoolQuery, TantivyQueryAst};
 
 /// Collects the terms that must be present for the (already simplified) query to
@@ -48,12 +49,15 @@ pub(crate) fn collect_required_terms(
 ) {
     match ast {
         TantivyQueryAst::Leaf(query) => {
-            let Some(term_query) = query.downcast_ref::<TantivyTermQuery>() else {
+            if let Some(term_query) = query.downcast_ref::<TantivyTermQuery>() {
+                let term = term_query.term();
+                if schema.get_field_entry(term.field()).is_indexed() {
+                    required_terms.insert(term.clone());
+                }
                 return;
-            };
-            let term = term_query.term();
-            if schema.get_field_entry(term.field()).is_indexed() {
-                required_terms.insert(term.clone());
+            }
+            if let Some(cache_filler_query) = query.downcast_ref::<CacheFillerQuery>() {
+                required_terms.extend(cache_filler_query.required_terms().iter().cloned());
             }
         }
         TantivyQueryAst::Bool(bool_query) => {

--- a/quickwit/quickwit-query/src/query_ast/term_set_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/term_set_query.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use serde::{Deserialize, Serialize};
 use tantivy::Term;
@@ -28,7 +28,7 @@ use crate::query_ast::{
 /// The text will be used as is, untokenized.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct TermSetQuery {
-    pub terms_per_field: HashMap<String, BTreeSet<String>>,
+    pub terms_per_field: BTreeMap<String, BTreeSet<String>>,
 }
 
 impl TermSetQuery {
@@ -130,7 +130,7 @@ impl From<TermSetQuery> for QueryAst {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::{BTreeMap, BTreeSet};
 
     use tantivy::schema::{FAST, INDEXED, Schema};
 
@@ -143,7 +143,7 @@ mod tests {
         schema_builder.add_u64_field("fast_field", FAST);
         let schema = schema_builder.build();
 
-        let terms_per_field = HashMap::from([(
+        let terms_per_field = BTreeMap::from([(
             "fast_field".to_string(),
             BTreeSet::from(["1".to_string(), "2".to_string()]),
         )]);
@@ -168,7 +168,7 @@ mod tests {
         schema_builder.add_u64_field("indexed_field", FAST | INDEXED);
         let schema = schema_builder.build();
 
-        let terms_per_field = HashMap::from([(
+        let terms_per_field = BTreeMap::from([(
             "indexed_field".to_string(),
             BTreeSet::from(["1".to_string(), "2".to_string()]),
         )]);

--- a/quickwit/quickwit-query/src/query_ast/user_input_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/user_input_query.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Bound;
 
 use anyhow::bail;
@@ -164,7 +164,7 @@ fn convert_user_input_ast_to_query_ast(
                 if field_names.is_empty() {
                     anyhow::bail!("set query need to target a specific field");
                 }
-                let mut terms_per_field: HashMap<String, BTreeSet<String>> = Default::default();
+                let mut terms_per_field: BTreeMap<String, BTreeSet<String>> = Default::default();
                 let terms: BTreeSet<String> = elements.into_iter().collect();
                 for field in field_names {
                     terms_per_field.insert(field.to_string(), terms.clone());

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -729,22 +729,18 @@ async fn leaf_search_single_split(
         agg_context_params,
     )?;
 
-    let predicate_cache = if collector.requires_scoring() {
-        // at the moment the predicate cache doesn't support scoring
-        None
-    } else {
-        Some((
-            ctx.searcher_context.predicate_cache.clone() as _,
-            split.split_id.clone(),
-        ))
-    };
-    let split_schema = index.schema();
-    let (query, mut warmup_info) = ctx.doc_mapper.query(
-        split_schema.clone(),
-        query_ast.clone(),
-        false,
-        predicate_cache,
-    )?;
+    let predicate_cache =
+        if collector.requires_scoring() || !ctx.searcher_context.predicate_cache.is_enabled() {
+            None
+        } else {
+            Some((
+                ctx.searcher_context.predicate_cache.clone() as Arc<dyn PredicateCache>,
+                split.split_id.clone(),
+            ))
+        };
+    let (query, mut warmup_info) =
+        ctx.doc_mapper
+            .query(index.schema(), query_ast.clone(), false, predicate_cache)?;
 
     let collector_warmup_info = collector.warmup_info();
     warmup_info.merge(collector_warmup_info);
@@ -974,7 +970,7 @@ async fn leaf_search_single_split(
 ///
 /// This include things such as sorting result by a field or _score when no document is requested,
 /// or applying date range when the range covers the entire split.
-fn rewrite_request(
+pub(crate) fn rewrite_request(
     search_request: &mut SearchRequest,
     split: &SplitIdAndFooterOffsets,
     timestamp_field: Option<&str>,
@@ -983,7 +979,7 @@ fn rewrite_request(
         search_request.sort_fields = Vec::new();
     }
     if let Some(timestamp_field) = timestamp_field {
-        remove_redundant_timestamp_range(search_request, split, timestamp_field);
+        normalize_timestamp_range(search_request, split, timestamp_field);
     }
     rewrite_aggregation(search_request);
     // we add a top level cache node when search_after is set, this won't help for this query (which
@@ -1099,11 +1095,7 @@ fn min_bound<T: Ord + Copy>(left: Bound<T>, right: Bound<T>) -> Bound<T> {
     }
 }
 
-/// remove timestamp range that would be present both in QueryAst and SearchRequest
-///
-/// this can save us from doing double the work in some cases, and help with the partial request
-/// cache.
-fn remove_redundant_timestamp_range(
+fn normalize_timestamp_range(
     search_request: &mut SearchRequest,
     split: &SplitIdAndFooterOffsets,
     timestamp_field: &str,
@@ -1133,6 +1125,8 @@ fn remove_redundant_timestamp_range(
         .transform(query_ast)
         .expect("can't fail unwrapping Infallible")
         .unwrap_or(QueryAst::MatchAll);
+    let is_time_bounded =
+        visitor.start_timestamp != Bound::Unbounded || visitor.end_timestamp != Bound::Unbounded;
 
     let final_start_timestamp = match (
         visitor.start_timestamp,
@@ -1172,12 +1166,22 @@ fn remove_redundant_timestamp_range(
         (Bound::Unbounded, Some(_)) => Bound::Unbounded,
         (query_bound, None) => query_bound,
     };
+    if is_time_bounded && !matches!(&new_ast, QueryAst::MatchAll | QueryAst::MatchNone) {
+        // CacheFillerWeight exhausts the predicate when creating its scorer, before the outer
+        // timestamp filter is applied. No separate execution is needed to populate the cache.
+        new_ast = BoolQuery {
+            must: vec![QueryAst::from(CacheNode::new(new_ast))],
+            ..Default::default()
+        }
+        .into();
+    }
+
     if final_start_timestamp != Bound::Unbounded || final_end_timestamp != Bound::Unbounded {
-        let range = RangeQuery {
+        let time_range = QueryAst::from(RangeQuery {
             field: timestamp_field.to_string(),
             lower_bound: final_start_timestamp.map(|bound| bound.into_timestamp_nanos().into()),
             upper_bound: final_end_timestamp.map(|bound| bound.into_timestamp_nanos().into()),
-        };
+        });
         new_ast = if let QueryAst::Bool(mut bool_query) = new_ast {
             if bool_query.must.is_empty()
                 && bool_query.filter.is_empty()
@@ -1187,22 +1191,22 @@ fn remove_redundant_timestamp_range(
                 // add a new layer of bool query
                 BoolQuery {
                     must: vec![bool_query.into()],
-                    filter: vec![range.into()],
+                    filter: vec![time_range],
                     ..Default::default()
                 }
                 .into()
             } else {
-                bool_query.filter.push(range.into());
+                bool_query.filter.push(time_range);
                 QueryAst::Bool(bool_query)
             }
         } else {
             BoolQuery {
                 must: vec![new_ast],
-                filter: vec![range.into()],
+                filter: vec![time_range],
                 ..Default::default()
             }
             .into()
-        }
+        };
     }
 
     search_request.query_ast = serde_json::to_string(&new_ast).unwrap();
@@ -2327,8 +2331,6 @@ async fn leaf_search_single_split_wrapper(
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Bound;
-
     use async_trait::async_trait;
     use bytes::BufMut;
     use quickwit_config::{LambdaConfig, SearcherConfig};
@@ -2378,302 +2380,6 @@ mod tests {
         assert_eq!(counters.error_tantivy_search.get(), 0);
         assert_eq!(counters.error_panic.get(), 0);
         assert_eq!(counters.cancel_warmup.get(), 1);
-    }
-
-    fn bool_filter(ast: impl Into<QueryAst>) -> QueryAst {
-        BoolQuery {
-            must: vec![QueryAst::MatchAll],
-            filter: vec![ast.into()],
-            ..Default::default()
-        }
-        .into()
-    }
-
-    #[track_caller]
-    fn assert_ast_eq(got: &SearchRequest, expected: &QueryAst) {
-        let got_ast: QueryAst = serde_json::from_str(&got.query_ast).unwrap();
-        assert_eq!(&got_ast, expected);
-        assert!(got.start_timestamp.is_none());
-        assert!(got.end_timestamp.is_none());
-    }
-
-    #[track_caller]
-    fn remove_timestamp_test_case(
-        request: &SearchRequest,
-        split: &SplitIdAndFooterOffsets,
-        expected: Option<RangeQuery>,
-    ) {
-        let timestamp_field = "timestamp";
-
-        // test the query directly
-        let mut request_direct = request.clone();
-        remove_redundant_timestamp_range(&mut request_direct, split, timestamp_field);
-        let expected_direct = expected
-            .clone()
-            .map(bool_filter)
-            .unwrap_or(QueryAst::MatchAll);
-        assert_ast_eq(&request_direct, &expected_direct);
-    }
-
-    #[test]
-    fn test_remove_timestamp_range() {
-        const S_TO_NS: i64 = 1_000_000_000;
-        let time1 = 1700001000;
-        let time2 = 1700002000;
-        let time3 = 1700003000;
-        let time4 = 1700004000;
-
-        let timestamp_field = "timestamp".to_string();
-
-        // cases where the bounds are larger than the split: no bound is emitted
-        let split = SplitIdAndFooterOffsets {
-            timestamp_start: Some(time2),
-            timestamp_end: Some(time3),
-            ..SplitIdAndFooterOffsets::default()
-        };
-
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Included(time1.into()),
-                // *1000 has no impact, we detect timestamp in ms instead of s
-                upper_bound: Bound::Included((time4 * 1000).into()),
-            }))
-            .unwrap(),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(&search_request, &split, None);
-
-        let expected_upper_inclusive = RangeQuery {
-            field: timestamp_field.to_string(),
-            lower_bound: Bound::Unbounded,
-            upper_bound: Bound::Included((time3 * S_TO_NS).into()),
-        };
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Included(time1.into()),
-                upper_bound: Bound::Included(time3.into()),
-            }))
-            .unwrap(),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(&search_request, &split, Some(expected_upper_inclusive));
-
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::MatchAll).unwrap(),
-            start_timestamp: Some(time1),
-            end_timestamp: Some(time4),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(&search_request, &split, None);
-
-        // request bound that are exclusive are treated properly
-        let expected_upper_exclusive = RangeQuery {
-            field: timestamp_field.to_string(),
-            lower_bound: Bound::Unbounded,
-            upper_bound: Bound::Excluded((time3 * S_TO_NS).into()),
-        };
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Included(time1.into()),
-                upper_bound: Bound::Excluded(time3.into()),
-            }))
-            .unwrap(),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(
-            &search_request,
-            &split,
-            Some(expected_upper_exclusive.clone()),
-        );
-
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::MatchAll).unwrap(),
-            start_timestamp: Some(time1),
-            end_timestamp: Some(time3),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(
-            &search_request,
-            &split,
-            Some(expected_upper_exclusive.clone()),
-        );
-
-        let expected_lower_excl_upper_incl = RangeQuery {
-            field: timestamp_field.to_string(),
-            lower_bound: Bound::Excluded((time2 * S_TO_NS).into()),
-            upper_bound: Bound::Included((time3 * S_TO_NS).into()),
-        };
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Excluded(time2.into()),
-                upper_bound: Bound::Included(time3.into()),
-            }))
-            .unwrap(),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(
-            &search_request,
-            &split,
-            Some(expected_lower_excl_upper_incl.clone()),
-        );
-    }
-
-    #[test]
-    fn test_remove_timestamp_range_multiple_bounds() {
-        // When bounds are defined both in the AST and in the search request,
-        // make sure we take the most restrictive ones.
-        const S_TO_NS: i64 = 1_000_000_000;
-        let time1 = 1700001000;
-        let time2 = 1700002000;
-        let time3 = 1700003000;
-        let time4 = 1700004000;
-
-        let timestamp_field = "timestamp".to_string();
-
-        let split = SplitIdAndFooterOffsets {
-            timestamp_start: Some(time1),
-            timestamp_end: Some(time4),
-            ..SplitIdAndFooterOffsets::default()
-        };
-
-        let expected_upper_2_ex = RangeQuery {
-            field: timestamp_field.to_string(),
-            lower_bound: Bound::Unbounded,
-            upper_bound: Bound::Excluded((time2 * S_TO_NS).into()),
-        };
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Included(time1.into()),
-                upper_bound: Bound::Included(time3.into()),
-            }))
-            .unwrap(),
-            start_timestamp: Some(time1),
-            end_timestamp: Some(time2),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(&search_request, &split, Some(expected_upper_2_ex));
-
-        let expected_upper_2_inc = RangeQuery {
-            field: timestamp_field.to_string(),
-            lower_bound: Bound::Unbounded,
-            upper_bound: Bound::Included((time2 * S_TO_NS).into()),
-        };
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Included(time1.into()),
-                upper_bound: Bound::Included(time2.into()),
-            }))
-            .unwrap(),
-            start_timestamp: Some(time1),
-            end_timestamp: Some(time3),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(&search_request, &split, Some(expected_upper_2_inc));
-
-        let expected_lower_3_upper_4 = RangeQuery {
-            field: timestamp_field.to_string(),
-            lower_bound: Bound::Included((time3 * S_TO_NS).into()),
-            upper_bound: Bound::Included((time4 * S_TO_NS).into()),
-        };
-
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Included(time2.into()),
-                upper_bound: Bound::Included(time4.into()),
-            }))
-            .unwrap(),
-            start_timestamp: Some(time3),
-            end_timestamp: Some(time4 + 1),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(
-            &search_request,
-            &split,
-            Some(expected_lower_3_upper_4.clone()),
-        );
-
-        let search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Range(RangeQuery {
-                field: timestamp_field.to_string(),
-                lower_bound: Bound::Included(time3.into()),
-                upper_bound: Bound::Included(time4.into()),
-            }))
-            .unwrap(),
-            start_timestamp: Some(time2),
-            end_timestamp: Some(time4 + 1),
-            ..SearchRequest::default()
-        };
-        remove_timestamp_test_case(&search_request, &split, Some(expected_lower_3_upper_4));
-
-        let mut search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::MatchAll).unwrap(),
-            start_timestamp: Some(time1),
-            end_timestamp: Some(time4),
-            ..SearchRequest::default()
-        };
-        let split = SplitIdAndFooterOffsets {
-            timestamp_start: Some(time2),
-            timestamp_end: Some(time3),
-            ..SplitIdAndFooterOffsets::default()
-        };
-        remove_redundant_timestamp_range(&mut search_request, &split, &timestamp_field);
-        assert_ast_eq(&search_request, &QueryAst::MatchAll);
-    }
-
-    // regression test for #4935
-    #[test]
-    fn test_remove_timestamp_range_keep_should() {
-        let time1 = 1700001000;
-        let time2 = 1700002000;
-        let time3 = 1700003000;
-
-        let timestamp_field = "timestamp".to_string();
-
-        // cases where the bounds are larger than the split: no bound is emitted
-        let split = SplitIdAndFooterOffsets {
-            timestamp_start: Some(time1),
-            timestamp_end: Some(time3),
-            ..SplitIdAndFooterOffsets::default()
-        };
-
-        let mut search_request = SearchRequest {
-            query_ast: serde_json::to_string(&QueryAst::Bool(BoolQuery {
-                should: vec![QueryAst::MatchAll],
-                ..BoolQuery::default()
-            }))
-            .unwrap(),
-            start_timestamp: Some(time2),
-            end_timestamp: None,
-            ..SearchRequest::default()
-        };
-        remove_redundant_timestamp_range(&mut search_request, &split, &timestamp_field);
-        assert_ast_eq(
-            &search_request,
-            &QueryAst::Bool(BoolQuery {
-                // original request
-                must: vec![QueryAst::Bool(BoolQuery {
-                    should: vec![QueryAst::MatchAll],
-                    ..BoolQuery::default()
-                })],
-                // time bound
-                filter: vec![
-                    RangeQuery {
-                        field: "timestamp".to_string(),
-                        lower_bound: Bound::Included(1_700_002_000_000_000_000u64.into()),
-                        upper_bound: Bound::Unbounded,
-                    }
-                    .into(),
-                ],
-                ..BoolQuery::default()
-            }),
-        );
     }
 
     #[test]

--- a/quickwit/quickwit-search/src/leaf.rs
+++ b/quickwit/quickwit-search/src/leaf.rs
@@ -1167,8 +1167,6 @@ fn normalize_timestamp_range(
         (query_bound, None) => query_bound,
     };
     if is_time_bounded && !matches!(&new_ast, QueryAst::MatchAll | QueryAst::MatchNone) {
-        // CacheFillerWeight exhausts the predicate when creating its scorer, before the outer
-        // timestamp filter is applied. No separate execution is needed to populate the cache.
         new_ast = BoolQuery {
             must: vec![QueryAst::from(CacheNode::new(new_ast))],
             ..Default::default()
@@ -1275,6 +1273,27 @@ impl QueryAstTransformer for RemoveTimestampRange<'_> {
             .into_iter()
             .filter_map(|query_ast| self.transform(query_ast).transpose())
             .collect::<Result<Vec<_>, _>>()?;
+
+        if bool_query
+            .must
+            .iter()
+            .chain(&bool_query.filter)
+            .any(|query_ast| matches!(query_ast, QueryAst::MatchNone))
+        {
+            return Ok(Some(QueryAst::MatchNone));
+        }
+        let only_matches_all = bool_query
+            .must
+            .iter()
+            .chain(&bool_query.filter)
+            .all(|query_ast| matches!(query_ast, QueryAst::MatchAll));
+        if only_matches_all
+            && bool_query.should.is_empty()
+            && bool_query.must_not.is_empty()
+            && bool_query.minimum_should_match.unwrap_or(0) == 0
+        {
+            return Ok(Some(QueryAst::MatchAll));
+        }
 
         Ok(Some(QueryAst::Bool(bool_query)))
     }

--- a/quickwit/quickwit-search/src/leaf_cache.rs
+++ b/quickwit/quickwit-search/src/leaf_cache.rs
@@ -237,6 +237,7 @@ impl RangeBounds<i64> for HalfOpenRange {
 pub struct PredicateCacheImpl {
     content: MemorySizedCache<CacheKeyHash>,
     key_hasher: CacheKeyHasher,
+    enabled: bool,
 }
 
 impl PredicateCacheImpl {
@@ -247,7 +248,12 @@ impl PredicateCacheImpl {
                 &quickwit_storage::metrics::PREDICATE_CACHE,
             ),
             key_hasher: CacheKeyHasher::random(),
+            enabled: config.capacity().as_u64() > 0,
         }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
     }
 }
 
@@ -257,6 +263,9 @@ impl quickwit_query::query_ast::PredicateCache for PredicateCacheImpl {
         split_id: String,
         query_ast_json: String,
     ) -> Option<(SegmentId, quickwit_query::query_ast::HitSet)> {
+        if !self.enabled {
+            return None;
+        }
         let key = self
             .key_hasher
             .hash(&(split_id.as_str(), query_ast_json.as_str()));
@@ -275,6 +284,9 @@ impl quickwit_query::query_ast::PredicateCache for PredicateCacheImpl {
         segment: SegmentId,
         hits: quickwit_query::query_ast::HitSet,
     ) {
+        if !self.enabled {
+            return;
+        }
         let hits_buffer = hits.into_buffer();
         let mut buffer = Vec::with_capacity(32 + hits_buffer.len());
         buffer.extend_from_slice(segment.uuid_string().as_bytes());
@@ -282,7 +294,15 @@ impl quickwit_query::query_ast::PredicateCache for PredicateCacheImpl {
         let key = self
             .key_hasher
             .hash(&(split_id.as_str(), query_ast_json.as_str()));
-        self.content.put(key, OwnedBytes::new(buffer));
+        let entry_num_bytes = buffer.len();
+        if !self.content.put(key, OwnedBytes::new(buffer)) {
+            quickwit_common::rate_limited_warn!(
+                limit_per_min = 10,
+                split_id,
+                entry_num_bytes,
+                "predicate cache rejected an entry"
+            );
+        }
     }
 }
 

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -2240,6 +2240,38 @@ fn test_time_bounded_predicate_cache_eligibility_after_split_normalization() {
         assert!(time_bounded_cached_predicate(&time_only_ast, "ts").is_none());
     }
 
+    let bool_wrapped_time_range = QueryAst::from(BoolQuery {
+        filter: vec![QueryAst::from(RangeQuery {
+            field: "ts".to_string(),
+            lower_bound: Bound::Included(120i64.into()),
+            upper_bound: Bound::Excluded(180i64.into()),
+        })],
+        ..Default::default()
+    });
+    let mut bool_wrapped_time_only_request = SearchRequest {
+        query_ast: serde_json::to_string(&bool_wrapped_time_range).unwrap(),
+        ..Default::default()
+    };
+    leaf::rewrite_request(&mut bool_wrapped_time_only_request, &split, Some("ts"));
+    let bool_wrapped_time_only_ast: QueryAst =
+        serde_json::from_str(&bool_wrapped_time_only_request.query_ast).unwrap();
+    assert!(time_bounded_cached_predicate(&bool_wrapped_time_only_ast, "ts").is_none());
+
+    let mut bool_wrapped_match_none_request = SearchRequest {
+        query_ast: serde_json::to_string(&QueryAst::from(BoolQuery {
+            must: vec![QueryAst::MatchNone],
+            ..Default::default()
+        }))
+        .unwrap(),
+        start_timestamp: Some(120),
+        end_timestamp: Some(180),
+        ..Default::default()
+    };
+    leaf::rewrite_request(&mut bool_wrapped_match_none_request, &split, Some("ts"));
+    let bool_wrapped_match_none_ast: QueryAst =
+        serde_json::from_str(&bool_wrapped_match_none_request.query_ast).unwrap();
+    assert!(time_bounded_cached_predicate(&bool_wrapped_match_none_ast, "ts").is_none());
+
     let user_semantic_time_range = QueryAst::from(RangeQuery {
         field: "ts".to_string(),
         lower_bound: Bound::Included(130i64.into()),

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -2185,6 +2185,17 @@ fn test_time_bounded_predicate_cache_eligibility_after_split_normalization() {
     };
     leaf::rewrite_request(&mut partial_request, &split, Some("ts"));
     let partial_ast: QueryAst = serde_json::from_str(&partial_request.query_ast).unwrap();
+    let QueryAst::Bool(partial_bool_query) = &partial_ast else {
+        panic!("expected a bool combining the cached predicate and timestamp range");
+    };
+    assert_eq!(
+        partial_bool_query.filter,
+        vec![QueryAst::from(RangeQuery {
+            field: "ts".to_string(),
+            lower_bound: Bound::Included(120_000_000_000i64.into()),
+            upper_bound: Bound::Excluded(180_000_000_000i64.into()),
+        })]
+    );
     let partial_predicate = time_bounded_cached_predicate(&partial_ast, "ts")
         .expect("a partial range should install a cached predicate");
 

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -14,6 +14,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Bound;
 
 use assert_json_diff::{assert_json_eq, assert_json_include};
 use quickwit_config::SearcherConfig;
@@ -25,12 +26,13 @@ use quickwit_proto::search::{
     SortValue, TraceId,
 };
 use quickwit_query::query_ast::{
-    HitSet, PredicateCache, QueryAst, qast_helper, qast_json_helper, query_ast_from_user_text,
+    BoolQuery, HitSet, PredicateCache, QueryAst, RangeQuery, qast_helper, qast_json_helper,
+    query_ast_from_user_text,
 };
 use serde_json::{Value as JsonValue, json};
-use tantivy::Term;
 use tantivy::schema::OwnedValue as TantivyValue;
 use tantivy::time::OffsetDateTime;
+use tantivy::{DocSet, Term};
 
 use self::leaf::single_doc_mapping_leaf_search;
 use super::*;
@@ -2135,6 +2137,269 @@ async fn negative_cache_ts_test_setup() -> (
         doc_mapper,
         start_timestamp,
     )
+}
+
+// Inspects the normalized AST shape for cache-placement assertions only.
+fn time_bounded_cached_predicate(query_ast: &QueryAst, timestamp_field: &str) -> Option<QueryAst> {
+    match query_ast {
+        QueryAst::Cache(cache_node) => {
+            time_bounded_cached_predicate(&cache_node.inner, timestamp_field)
+        }
+        QueryAst::Bool(bool_query)
+            if bool_query.must.len() == 1
+                && bool_query.filter.len() <= 1
+                && bool_query.must_not.is_empty()
+                && bool_query.should.is_empty() =>
+        {
+            let QueryAst::Cache(cache_node) = &bool_query.must[0] else {
+                return None;
+            };
+            if let Some(time_filter) = bool_query.filter.first() {
+                let QueryAst::Range(time_range) = time_filter else {
+                    return None;
+                };
+                if time_range.field != timestamp_field {
+                    return None;
+                }
+            }
+            Some((*cache_node.inner).clone())
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn test_time_bounded_predicate_cache_eligibility_after_split_normalization() {
+    let split = SplitIdAndFooterOffsets {
+        timestamp_start: Some(100),
+        timestamp_end: Some(199),
+        ..Default::default()
+    };
+    let predicate_ast = qast_helper("info", &["body"]);
+
+    let mut partial_request = SearchRequest {
+        query_ast: serde_json::to_string(&predicate_ast).unwrap(),
+        start_timestamp: Some(120),
+        end_timestamp: Some(180),
+        ..Default::default()
+    };
+    leaf::rewrite_request(&mut partial_request, &split, Some("ts"));
+    let partial_ast: QueryAst = serde_json::from_str(&partial_request.query_ast).unwrap();
+    let partial_predicate = time_bounded_cached_predicate(&partial_ast, "ts")
+        .expect("a partial range should install a cached predicate");
+
+    let mut full_split_request = SearchRequest {
+        query_ast: serde_json::to_string(&predicate_ast).unwrap(),
+        start_timestamp: Some(50),
+        end_timestamp: Some(250),
+        ..Default::default()
+    };
+    leaf::rewrite_request(&mut full_split_request, &split, Some("ts"));
+    let full_split_ast: QueryAst = serde_json::from_str(&full_split_request.query_ast).unwrap();
+    let full_split_predicate = time_bounded_cached_predicate(&full_split_ast, "ts")
+        .expect("a full-split range should install a cached predicate");
+    assert_eq!(full_split_predicate, partial_predicate);
+
+    let mut full_split_search_after_request = SearchRequest {
+        query_ast: serde_json::to_string(&predicate_ast).unwrap(),
+        start_timestamp: Some(50),
+        end_timestamp: Some(250),
+        search_after: Some(Default::default()),
+        ..Default::default()
+    };
+    leaf::rewrite_request(&mut full_split_search_after_request, &split, Some("ts"));
+    let full_split_search_after_ast: QueryAst =
+        serde_json::from_str(&full_split_search_after_request.query_ast).unwrap();
+    assert_eq!(
+        time_bounded_cached_predicate(&full_split_search_after_ast, "ts"),
+        Some(partial_predicate.clone())
+    );
+
+    let mut timeless_search_after_request = SearchRequest {
+        query_ast: serde_json::to_string(&predicate_ast).unwrap(),
+        search_after: Some(Default::default()),
+        ..Default::default()
+    };
+    leaf::rewrite_request(&mut timeless_search_after_request, &split, Some("ts"));
+    let timeless_search_after_ast: QueryAst =
+        serde_json::from_str(&timeless_search_after_request.query_ast).unwrap();
+    assert!(
+        time_bounded_cached_predicate(&timeless_search_after_ast, "ts").is_none(),
+        "the search-after cache node should not be treated as a predicate cache node"
+    );
+
+    for trivial_predicate in [QueryAst::MatchAll, QueryAst::MatchNone] {
+        let mut time_only_request = SearchRequest {
+            query_ast: serde_json::to_string(&trivial_predicate).unwrap(),
+            start_timestamp: Some(120),
+            end_timestamp: Some(180),
+            ..Default::default()
+        };
+        leaf::rewrite_request(&mut time_only_request, &split, Some("ts"));
+        let time_only_ast: QueryAst = serde_json::from_str(&time_only_request.query_ast).unwrap();
+        assert!(time_bounded_cached_predicate(&time_only_ast, "ts").is_none());
+    }
+
+    let user_semantic_time_range = QueryAst::from(RangeQuery {
+        field: "ts".to_string(),
+        lower_bound: Bound::Included(130i64.into()),
+        upper_bound: Bound::Unbounded,
+    });
+    let nested_semantic_ast = QueryAst::from(BoolQuery {
+        must: vec![predicate_ast],
+        should: vec![user_semantic_time_range.clone()],
+        ..Default::default()
+    });
+    let mut nested_semantic_request = SearchRequest {
+        query_ast: serde_json::to_string(&nested_semantic_ast).unwrap(),
+        start_timestamp: Some(120),
+        end_timestamp: Some(180),
+        ..Default::default()
+    };
+    leaf::rewrite_request(&mut nested_semantic_request, &split, Some("ts"));
+    let nested_rewritten_ast: QueryAst =
+        serde_json::from_str(&nested_semantic_request.query_ast).unwrap();
+    let cached_predicate = time_bounded_cached_predicate(&nested_rewritten_ast, "ts")
+        .expect("the non-time predicate should be cached");
+    let QueryAst::Bool(cached_bool) = cached_predicate else {
+        panic!("expected normalized bool predicate");
+    };
+    assert_eq!(cached_bool.should, vec![user_semantic_time_range]);
+}
+
+#[tokio::test]
+async fn test_time_bounded_query_populates_and_reuses_complete_predicate_cache() {
+    let (test_sandbox, searcher_context, storage, splits, doc_mapper, start_timestamp) =
+        negative_cache_ts_test_setup().await;
+    let split_id = splits[0].split_id.clone();
+
+    let first_window_request = SearchRequest {
+        index_id_patterns: vec!["negative-cache-ts-index".to_string()],
+        query_ast: qast_json_helper("info", &["body"]),
+        start_timestamp: Some(start_timestamp),
+        end_timestamp: Some(start_timestamp + 3),
+        max_hits: 10,
+        ..Default::default()
+    };
+    let mut rewritten_request = first_window_request.clone();
+    leaf::rewrite_request(
+        &mut rewritten_request,
+        &splits[0],
+        doc_mapper.timestamp_field_name(),
+    );
+    let rewritten_ast: QueryAst = serde_json::from_str(&rewritten_request.query_ast).unwrap();
+    let predicate_ast = time_bounded_cached_predicate(&rewritten_ast, "ts")
+        .expect("a partial time range should install a cached predicate");
+    let predicate_key = serde_json::to_string(&predicate_ast).unwrap();
+
+    let first_response = single_doc_mapping_leaf_search(
+        searcher_context.clone(),
+        std::sync::Arc::new(first_window_request),
+        storage.clone(),
+        splits.clone(),
+        doc_mapper.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(first_response.num_hits, 3);
+    let first_input_memory_bytes = first_response
+        .resource_stats
+        .as_ref()
+        .and_then(|stats| stats.split_resources_sum)
+        .expect("the split should report resource stats")
+        .input_memory_bytes;
+
+    let (_segment_id, complete_hits) = searcher_context
+        .predicate_cache
+        .get(split_id.clone(), predicate_key)
+        .expect("the first window should populate the predicate cache");
+    assert_eq!(complete_hits.size_hint(), 10);
+
+    let full_split_window_request = SearchRequest {
+        index_id_patterns: vec!["negative-cache-ts-index".to_string()],
+        query_ast: qast_json_helper("info", &["body"]),
+        start_timestamp: Some(start_timestamp - 10),
+        end_timestamp: Some(start_timestamp + 20),
+        max_hits: 10,
+        ..Default::default()
+    };
+    let full_split_response = single_doc_mapping_leaf_search(
+        searcher_context.clone(),
+        std::sync::Arc::new(full_split_window_request),
+        storage.clone(),
+        splits.clone(),
+        doc_mapper.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(full_split_response.num_hits, 10);
+    let full_split_input_memory_bytes = full_split_response
+        .resource_stats
+        .as_ref()
+        .and_then(|stats| stats.split_resources_sum)
+        .expect("the split should report resource stats")
+        .input_memory_bytes;
+    assert!(
+        full_split_input_memory_bytes < first_input_memory_bytes,
+        "a full-split predicate-cache hit should not warm the predicate posting lists"
+    );
+
+    let different_predicate_request = SearchRequest {
+        index_id_patterns: vec!["negative-cache-ts-index".to_string()],
+        query_ast: qast_json_helper("0", &["body"]),
+        start_timestamp: Some(start_timestamp - 10),
+        end_timestamp: Some(start_timestamp + 20),
+        max_hits: 10,
+        ..Default::default()
+    };
+    let mut different_rewritten_request = different_predicate_request.clone();
+    leaf::rewrite_request(
+        &mut different_rewritten_request,
+        &splits[0],
+        doc_mapper.timestamp_field_name(),
+    );
+    let different_rewritten_ast: QueryAst =
+        serde_json::from_str(&different_rewritten_request.query_ast).unwrap();
+    let different_predicate_ast = time_bounded_cached_predicate(&different_rewritten_ast, "ts")
+        .expect("a full-split time range should install a cached predicate");
+    let different_predicate_key = serde_json::to_string(&different_predicate_ast).unwrap();
+
+    let different_predicate_response = single_doc_mapping_leaf_search(
+        searcher_context.clone(),
+        std::sync::Arc::new(different_predicate_request),
+        test_sandbox.storage(),
+        splits.clone(),
+        doc_mapper.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(different_predicate_response.num_hits, 1);
+    let (_segment_id, different_hits) = searcher_context
+        .predicate_cache
+        .get(split_id, different_predicate_key)
+        .expect("a different predicate should populate a separate entry");
+    assert_eq!(different_hits.size_hint(), 1);
+
+    let different_partial_request = SearchRequest {
+        index_id_patterns: vec!["negative-cache-ts-index".to_string()],
+        query_ast: qast_json_helper("0", &["body"]),
+        start_timestamp: Some(start_timestamp),
+        end_timestamp: Some(start_timestamp + 2),
+        max_hits: 10,
+        ..Default::default()
+    };
+    let different_partial_response = single_doc_mapping_leaf_search(
+        searcher_context,
+        std::sync::Arc::new(different_partial_request),
+        storage,
+        splits,
+        doc_mapper,
+    )
+    .await
+    .unwrap();
+    assert_eq!(different_partial_response.num_hits, 1);
+
+    test_sandbox.assert_quit().await;
 }
 
 #[tokio::test]

--- a/quickwit/quickwit-storage/src/cache/base_cache.rs
+++ b/quickwit/quickwit-storage/src/cache/base_cache.rs
@@ -113,7 +113,7 @@ impl<K: Hash + Eq + Send + Sync + 'static, V: ValueLen + Clone + Send + Sync + '
             AnyCache::TinyLfu(tiny_lfu) => tiny_lfu.get(cache_key),
         }
     }
-    pub fn put(&mut self, key: K, value: V) {
+    pub fn put(&mut self, key: K, value: V) -> bool {
         match self {
             AnyCache::Lru(lru) => lru.put(key, value),
             AnyCache::S3Fifo(s3fifo) => s3fifo.put(key, value),
@@ -196,7 +196,7 @@ impl<K: Hash + Eq, V: ValueLen + Clone> Lru<K, V> {
     /// Attempt to put the given amount of data in the cache.
     /// This may fail silently if the owned_bytes slice is larger than the cache
     /// capacity.
-    fn put(&mut self, key: K, bytes: V) {
+    fn put(&mut self, key: K, bytes: V) -> bool {
         if self.capacity.exceeds_capacity(bytes.len()) {
             // The value does not fit in the cache. We simply don't store it.
             if self.capacity != Capacity::InBytes(0) {
@@ -206,7 +206,7 @@ impl<K: Hash + Eq, V: ValueLen + Clone> Lru<K, V> {
                     "Downloaded a byte slice larger than the cache capacity."
                 );
             }
-            return;
+            return false;
         }
         if let Some(previous_data) = self.lru_cache.pop(&key) {
             self.drop_item(previous_data.len() as u64);
@@ -224,7 +224,7 @@ impl<K: Hash + Eq, V: ValueLen + Clone> Lru<K, V> {
                     // It is not worth doing an eviction.
                     // TODO: It is sub-optimal that we might have needlessly evicted items in this
                     // loop before just returning.
-                    return;
+                    return false;
                 }
             }
             if let Some((_, bytes)) = self.lru_cache.pop_lru() {
@@ -235,11 +235,12 @@ impl<K: Hash + Eq, V: ValueLen + Clone> Lru<K, V> {
                      capacity is insufficient. This case is guarded against and should never \
                      happen."
                 );
-                return;
+                return false;
             }
         }
         self.record_item(bytes.len() as u64);
         self.lru_cache.put(key, StoredItem::new(bytes, now));
+        true
     }
 }
 
@@ -322,7 +323,7 @@ impl<K: Hash + Eq, V: ValueLen + Clone> S3Fifo<K, V> {
     /// Attempt to put the given amount of data in the cache.
     /// This may fail silently if the owned_bytes slice is larger than the cache
     /// capacity.
-    fn put(&mut self, key: K, value: V) {
+    fn put(&mut self, key: K, value: V) -> bool {
         if self.capacity < value.len() as u64 {
             // The value does not fit in the cache. We simply don't store it.
             if self.capacity != 0 {
@@ -332,7 +333,7 @@ impl<K: Hash + Eq, V: ValueLen + Clone> S3Fifo<K, V> {
                     "Downloaded a byte slice larger than the cache capacity."
                 );
             }
-            return;
+            return false;
         }
 
         self.cache_metrics.in_cache_count.inc();
@@ -349,6 +350,7 @@ impl<K: Hash + Eq, V: ValueLen + Clone> S3Fifo<K, V> {
             .dec_by(evicted.bytes as f64);
         self.cache_metrics.evict_num_items.inc_by(evicted.count);
         self.cache_metrics.evict_num_bytes.inc_by(evicted.bytes);
+        true
     }
 }
 
@@ -433,7 +435,7 @@ impl<K: Hash + Eq + Send + Sync + 'static, V: ValueLen + Clone + Send + Sync + '
     /// Attempt to put the given amount of data in the cache.
     /// This may fail silently if the owned_bytes slice is larger than the cache
     /// capacity.
-    fn put(&mut self, key: K, value: V) {
+    fn put(&mut self, key: K, value: V) -> bool {
         if self.capacity < value.len() as u64 {
             // The value does not fit in the cache. We simply don't store it.
             if self.capacity != 0 {
@@ -443,7 +445,7 @@ impl<K: Hash + Eq + Send + Sync + 'static, V: ValueLen + Clone + Send + Sync + '
                     "Downloaded a byte slice larger than the cache capacity."
                 );
             }
-            return;
+            return false;
         }
 
         self.cache_metrics.in_cache_count.inc();
@@ -458,5 +460,6 @@ impl<K: Hash + Eq + Send + Sync + 'static, V: ValueLen + Clone + Send + Sync + '
             }
             .into(),
         );
+        true
     }
 }

--- a/quickwit/quickwit-storage/src/cache/memory_sized_cache.rs
+++ b/quickwit/quickwit-storage/src/cache/memory_sized_cache.rs
@@ -76,7 +76,7 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> CacheState<K> {
         self.cache.get(cache_key)
     }
 
-    fn put(&mut self, key: K, bytes: OwnedBytes) {
+    fn put(&mut self, key: K, bytes: OwnedBytes) -> bool {
         for virtual_cache in &mut self.virtual_caches {
             // we simulate an access on all virtual caches
             virtual_cache.put(key.clone(), FakeCacheEntry(bytes.len()));
@@ -116,11 +116,9 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> MemorySizedCache<K> {
         self.inner.lock().unwrap().get(cache_key)
     }
 
-    /// Attempt to put the given amount of data in the cache.
-    /// This may fail silently if the owned_bytes slice is larger than the cache
-    /// capacity.
-    pub fn put(&self, val: K, bytes: OwnedBytes) {
-        self.inner.lock().unwrap().put(val, bytes);
+    /// Attempts to put the data in the cache and returns whether it was admitted.
+    pub fn put(&self, val: K, bytes: OwnedBytes) -> bool {
+        self.inner.lock().unwrap().put(val, bytes)
     }
 }
 
@@ -169,14 +167,14 @@ mod tests {
         }
         {
             let data = OwnedBytes::new(&b"fghij"[..]);
-            cache.put("5".to_string(), data);
+            assert!(!cache.put("5".to_string(), data));
             // Eviction should not happen, because all items in cache are too young.
             assert!(cache.get(&"5".to_string()).is_none());
         }
         tokio::time::advance(LRU_MIN_TIME_SINCE_LAST_ACCESS.mul_f32(1.1f32)).await;
         {
             let data = OwnedBytes::new(&b"fghij"[..]);
-            cache.put("5".to_string(), data);
+            assert!(cache.put("5".to_string(), data));
             assert_eq!(cache.get(&"5".to_string()).unwrap(), &b"fghij"[..]);
             // our two first entries should have be removed from the cache
             assert!(cache.get(&"2".to_string()).is_none());
@@ -185,7 +183,7 @@ mod tests {
         tokio::time::advance(LRU_MIN_TIME_SINCE_LAST_ACCESS.mul_f32(1.1f32)).await;
         {
             let data = OwnedBytes::new(&b"klmnop"[..]);
-            cache.put("6".to_string(), data);
+            assert!(!cache.put("6".to_string(), data));
             // The entry put should have been dismissed as it is too large for the cache
             assert!(cache.get(&"6".to_string()).is_none());
             // The previous entry should however be remaining.
@@ -225,7 +223,7 @@ mod tests {
             MemorySizedCache::from_config(&CacheConfig::no_cache(), &CACHE_METRICS_FOR_TESTS);
         assert!(cache.get(&"hello.seg").is_none());
         let data = OwnedBytes::new(&b"werwer"[..]);
-        cache.put("hello.seg", data);
+        assert!(!cache.put("hello.seg", data));
         assert!(cache.get(&"hello.seg").is_none());
     }
 }


### PR DESCRIPTION
This is done to better support monitor queries which shift their timerange.

## Summary

- separate timestamp constraints from cacheable predicates during per-split request rewriting
- populate predicate-cache entries across the complete split and reuse them for partial and fully covered time windows
- avoid caching timestamp-only and other trivial `match_all`/`match_none` boolean predicates
- skip posting-list warmup on predicate-cache hits and bypass predicate-cache processing when disabled
- use deterministic term-set serialization and preserve required-term metadata through cache fillers
- report rejected cache admission and warn when a computed entry cannot be retained

## Implementation

Timestamp ranges are extracted from strict positive clauses and intersected with request and split bounds. The remaining non-timestamp predicate is cached, while any residual timestamp range is applied outside the cache node. Boolean predicates made trivial by timestamp extraction are simplified before cache-node insertion.

<img width="1500" height="1532" alt="image" src="https://github.com/user-attachments/assets/83284f7d-02dc-44f0-8928-39ee4f391a0d" />

<img width="2189" height="2188" alt="image" src="https://github.com/user-attachments/assets/b82337f2-1e52-41e7-9785-1d7d61c2c019" />
