### PR TITLE
Fix possible control-plane panic caused by race condition between reporting shard load and deleting index

### DIFF
--- a/quickwit/quickwit-control-plane/src/control_plane.rs
+++ b/quickwit/quickwit-control-plane/src/control_plane.rs
@@ -1063,7 +1063,7 @@ mod tests {
         CLI_SOURCE_ID, INGEST_V2_SOURCE_ID, IndexConfig, KafkaSourceParams, SourceParams,
     };
     use quickwit_indexing::IndexingService;
-    use quickwit_ingest::IngesterPoolEntry;
+    use quickwit_ingest::{IngesterPoolEntry, RateMibPerSec, ShardInfo};
     use quickwit_metastore::{
         CreateIndexRequestExt, IndexMetadata, ListIndexesMetadataResponseExt,
     };
@@ -2252,6 +2252,95 @@ mod tests {
             .ask(DeleteIndexRequest {
                 index_uid: Some(index_0.index_uid),
             })
+            .await
+            .unwrap()
+            .unwrap();
+
+        universe.assert_quit().await;
+    }
+
+    // Same race as `test_ingest_controller_handle_local_shards_update_for_deleted_index`, but
+    // going through the real delete handler, so that the state the unit test builds by hand is
+    // proven reachable. When the stale update panics the control plane, its supervisor only
+    // respawns it at the next health check, and every ingest that needs a shard opened in the
+    // meantime hangs or returns 503.
+    #[tokio::test]
+    async fn test_control_plane_survives_local_shards_update_for_deleted_index() {
+        quickwit_common::setup_logging_for_tests();
+        // Real time on purpose: with accelerated time, the supervisor could respawn a panicked
+        // control plane and hide the failure.
+        let universe = Universe::default();
+        let node_id = NodeId::from_str("test-control-plane");
+        let indexer_pool = IndexerPool::default();
+        // The ingester is left out of the pool: the control plane merely logs that it cannot sync
+        // with it.
+        let ingester_pool = IngesterPool::default();
+
+        let mut index = IndexMetadata::for_test("test-index-0", "ram:///test-index-0");
+        let mut source = SourceConfig::ingest_v2();
+        source.enabled = true;
+        index.add_source(source).unwrap();
+        let index_uid = index.index_uid.clone();
+
+        let mut mock_metastore = MockMetastoreService::new();
+        // The startup calls are not bounded with `times(1)`: a panicked control plane is
+        // respawned and reloads its state, which would fail the mock instead of the assertions.
+        let index_clone = index.clone();
+        mock_metastore
+            .expect_list_indexes_metadata()
+            .returning(move |_| {
+                Ok(ListIndexesMetadataResponse::for_test(vec![
+                    index_clone.clone(),
+                ]))
+            });
+        mock_metastore.expect_list_shards().returning(|_| {
+            Ok(ListShardsResponse {
+                subresponses: Vec::new(),
+            })
+        });
+        let index_uid_clone = index_uid.clone();
+        mock_metastore.expect_delete_index().times(1).returning(
+            move |delete_index_request: DeleteIndexRequest| {
+                assert_eq!(delete_index_request.index_uid(), &index_uid_clone);
+                Ok(EmptyResponse {})
+            },
+        );
+
+        let cluster_config = ClusterConfig::for_test();
+        let (control_plane_mailbox, _control_plane_handle, _readiness_rx) = ControlPlane::spawn(
+            &universe,
+            cluster_config,
+            node_id,
+            indexer_pool,
+            ingester_pool,
+            MetastoreServiceClient::from_mock(mock_metastore),
+        );
+        control_plane_mailbox
+            .ask(DeleteIndexRequest {
+                index_uid: Some(index_uid.clone()),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        // The stale shard update lands after the deletion.
+        let local_shards_update = LocalShardsUpdate {
+            ingester_id: NodeId::from_str("test-ingester"),
+            source_uid: SourceUid {
+                index_uid,
+                source_id: INGEST_V2_SOURCE_ID.to_string(),
+            },
+            shard_infos: BTreeSet::from_iter([ShardInfo {
+                shard_id: ShardId::from(15),
+                shard_state: ShardState::Open,
+                short_term_ingestion_rate: RateMibPerSec(10),
+                long_term_ingestion_rate: RateMibPerSec(10),
+            }]),
+        };
+        // A panicking handler kills the actor mid-message and drops the reply channel, so this
+        // `ask` fails with `AskError::ProcessMessageError`.
+        control_plane_mailbox
+            .ask(local_shards_update)
             .await
             .unwrap()
             .unwrap();

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -348,12 +348,18 @@ impl IngestController {
             &local_shards_update.source_uid,
             &local_shards_update.shard_infos,
         );
-        let min_shards = model
+        // The index may have been deleted between the ingester emitting this update and the
+        // control plane handling it. The update is stale, there is nothing left to scale.
+        let Some(min_shards) = model
             .index_metadata(&local_shards_update.source_uid.index_uid)
-            .expect("index should exist")
-            .index_config
-            .ingest_settings
-            .min_shards;
+            .map(|index_metadata| index_metadata.index_config.ingest_settings.min_shards)
+        else {
+            warn!(
+                index_uid=%local_shards_update.source_uid.index_uid,
+                "ignoring local shards update for a deleted index"
+            );
+            return Ok(());
+        };
 
         let Some(scaling_mode) = self.scaling_arbiter.should_scale(shard_stats, min_shards) else {
             return Ok(());

--- a/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
+++ b/quickwit/quickwit-control-plane/src/ingest/ingest_controller.rs
@@ -2338,6 +2338,67 @@ mod tests {
             .unwrap();
     }
 
+    // A shard update sent by an ingester can reach the control plane after the index it refers
+    // to was deleted. The update is stale, and must not panic the control plane.
+    #[tokio::test]
+    async fn test_ingest_controller_handle_local_shards_update_for_deleted_index() {
+        // No metastore expectation: the mock fails the test if the handler attempts to scale the
+        // deleted index.
+        let metastore = MetastoreServiceClient::from_mock(MockMetastoreService::new());
+        let ingester_pool = IngesterPool::default();
+
+        let mut controller = IngestController::new(
+            metastore,
+            ingester_pool,
+            TEST_SHARD_THROUGHPUT_LIMIT_MIB,
+            1.001,
+        );
+
+        let index_uid = IndexUid::for_test("test-index", 0);
+        let source_id: SourceId = "test-source".to_string();
+        let mut index_metadata = IndexMetadata::for_test("test-index", "ram://indexes/test-index");
+        index_metadata.sources.insert(
+            source_id.clone(),
+            SourceConfig::for_test(&source_id, quickwit_config::SourceParams::void()),
+        );
+        let source_uid = SourceUid {
+            index_uid: index_uid.clone(),
+            source_id: source_id.clone(),
+        };
+        let mut model = ControlPlaneModel::default();
+        model.add_index(index_metadata);
+
+        let shards = vec![Shard {
+            index_uid: Some(index_uid.clone()),
+            source_id: source_id.clone(),
+            shard_id: Some(ShardId::from(1)),
+            ingester_id: "test-ingester".to_string(),
+            shard_state: ShardState::Open as i32,
+            ..Default::default()
+        }];
+        model.insert_shards(&index_uid, &source_id, shards);
+
+        // The control plane handles the index deletion first, see `Handler<DeleteIndexRequest>`.
+        model.delete_index(&index_uid);
+
+        // The ingestion rates are above the scale up threshold on purpose.
+        let shard_infos = BTreeSet::from_iter([ShardInfo {
+            shard_id: ShardId::from(1),
+            shard_state: ShardState::Open,
+            short_term_ingestion_rate: RateMibPerSec(10),
+            long_term_ingestion_rate: RateMibPerSec(10),
+        }]);
+        let local_shards_update = LocalShardsUpdate {
+            ingester_id: NodeId::from_str("test-ingester"),
+            source_uid,
+            shard_infos,
+        };
+        controller
+            .handle_local_shards_update(local_shards_update, &mut model, &Progress::default())
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn test_ingest_controller_disable_validation_when_vrl() {
         let mut mock_metastore = MockMetastoreService::new();


### PR DESCRIPTION
### Description

On a test environment which uses Quickwit as a sidecar, and where I'm creating/deleting indices repeatedly, I think there is a possible race condition between reporting the shard load and deleting index, causing the control-plane actor to panic and to stay dead for ~30 seconds

This PR add 2 tests to show the problem, and fixes the `.expect("index should exist")` that causes the panic.

### How was this PR tested?

Unit tests only
