### PR TITLE
Add configurable S3 download throughput limits

### DIFF
--- a/docs/configuration/storage-config.md
+++ b/docs/configuration/storage-config.md
@@ -56,6 +56,7 @@ This section contains one configuration subsection per storage provider. If a st
 | `force_path_style_access` | Disables [virtual-hosted–style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) requests. Required by some S3-compatible providers (Ceph, MinIO). | `false` |
 | `disable_multi_object_delete` | Disables [Multi-Object Delete](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) requests. Required by some S3-compatible providers (GCS). | `false` |
 | `disable_multipart_upload` | Disables [multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html) of objects. Required by some S3-compatible providers (GCS). | `false` |
+| `max_download_bytes_per_sec` | Maximum aggregate S3 download throughput for the Quickwit process. Accepts byte-size values such as `500MB`. | Unlimited |
 | `checksum_algorithm` | Upload [checksum](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html) algorithm. Allowed values: `crc32c` (computed and validated by the AWS SDK), `md5` (sent client-side via `Content-MD5`; useful for S3-compatible providers that predate `x-amz-checksum-*`), or `disabled`.  | `crc32c` |
 | `disable_checksums` | **Deprecated.** Previously a boolean that disabled all request/response checksums. Equivalent to setting `checksum_algorithm: disabled`. | `false` |
 

--- a/quickwit/quickwit-common/src/io.rs
+++ b/quickwit/quickwit-common/src/io.rs
@@ -34,7 +34,7 @@ use async_speed_limit::limiter::Consume;
 use bytesize::ByteSize;
 use pin_project::pin_project;
 use quickwit_metrics::{Counter, LazyCounter, counter, lazy_counter};
-use tokio::io::AsyncWrite;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::{KillSwitch, Progress, ProtectedZoneGuard};
 
@@ -236,6 +236,58 @@ fn quirky_truncate_slices<'a, 'b>(bufs: &'b [IoSlice<'a>], max_len: usize) -> &'
     bufs
 }
 
+#[pin_project]
+pub struct ControlledRead<A: IoControlsAccess, R> {
+    #[pin]
+    underlying_read: R,
+    waiter: Option<Consume<StandardClock, ()>>,
+    io_controls_access: A,
+}
+
+impl<A: IoControlsAccess, R: AsyncRead> AsyncRead for ControlledRead<A, R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.project();
+
+        let _protect_guard = match this
+            .io_controls_access
+            .apply(|io_controls| io_controls.check_if_alive())
+        {
+            Ok(protect_guard) => protect_guard,
+            Err(io_error) => return Poll::Ready(Err(io_error)),
+        };
+
+        if let Some(waiter) = this.waiter {
+            if Pin::new(waiter).poll(cx).is_pending() {
+                return Poll::Pending;
+            }
+            *this.waiter = None;
+        }
+
+        let max_num_bytes = buf.remaining().min(MAX_NUM_BYTES_WRITTEN_AT_ONCE);
+        let mut limited_buf = buf.take(max_num_bytes);
+        let poll_result = this.underlying_read.poll_read(cx, &mut limited_buf);
+        if poll_result.is_ready() {
+            let num_bytes_read = limited_buf.filled().len();
+            drop(limited_buf);
+            buf.advance(num_bytes_read);
+            if num_bytes_read > 0 {
+                *this.waiter = this.io_controls_access.apply(|io_controls| {
+                    io_controls.bytes_counter.inc_by(num_bytes_read as u64);
+                    io_controls
+                        .throughput_limiter_opt
+                        .as_ref()
+                        .map(|limiter| limiter.consume(num_bytes_read))
+                });
+            }
+        }
+        poll_result
+    }
+}
+
 impl<A: IoControlsAccess, W: AsyncWrite> AsyncWrite for ControlledWrite<A, W> {
     fn poll_write(
         self: Pin<&mut Self>,
@@ -270,6 +322,14 @@ impl<A: IoControlsAccess, W: AsyncWrite> AsyncWrite for ControlledWrite<A, W> {
 }
 
 pub trait IoControlsAccess: Sized {
+    fn wrap_read<R>(self, read: R) -> ControlledRead<Self, R> {
+        ControlledRead {
+            underlying_read: read,
+            waiter: None,
+            io_controls_access: self,
+        }
+    }
+
     fn wrap_write<W>(self, wrt: W) -> ControlledWrite<Self, W> {
         ControlledWrite {
             underlying_wrt: wrt,
@@ -328,10 +388,23 @@ mod tests {
     use std::time::Duration;
 
     use bytesize::ByteSize;
-    use tokio::io::{AsyncWriteExt, sink};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, repeat, sink};
     use tokio::time::Instant;
 
     use crate::io::{IoControls, IoControlsAccess};
+
+    #[tokio::test]
+    async fn test_controlled_reader_limited_async() {
+        let io_controls = IoControls::default().set_throughput_limit(ByteSize::mb(2));
+        let mut controlled_read = io_controls.clone().wrap_read(repeat(0));
+        let mut buf = vec![0; 2_000_000];
+        let start = Instant::now();
+        controlled_read.read_exact(&mut buf).await.unwrap();
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(400));
+        assert!(elapsed <= Duration::from_millis(700));
+        assert_eq!(io_controls.num_bytes(), 2_000_000u64);
+    }
 
     #[tokio::test]
     async fn test_controlled_writer_limited_async() {

--- a/quickwit/quickwit-config/src/storage_config.rs
+++ b/quickwit/quickwit-config/src/storage_config.rs
@@ -17,6 +17,7 @@ use std::sync::OnceLock;
 use std::{env, fmt};
 
 use anyhow::ensure;
+use bytesize::ByteSize;
 use itertools::Itertools;
 use quickwit_common::{get_bool_from_env, get_from_env_opt};
 use serde::{Deserialize, Serialize};
@@ -119,6 +120,15 @@ impl StorageConfigs {
             ensure!(
                 left != right,
                 "{left:?} storage config is defined multiple times",
+            );
+        }
+        if let Some(max_download_bytes_per_sec) = self
+            .find_s3()
+            .and_then(|s3_config| s3_config.max_download_bytes_per_sec)
+        {
+            ensure!(
+                max_download_bytes_per_sec.as_u64() > 0,
+                "storage.s3.max_download_bytes_per_sec must be greater than zero"
             );
         }
         Ok(())
@@ -399,6 +409,9 @@ pub struct S3StorageConfig {
     pub disable_stalled_stream_protection_upload: bool,
     #[serde(default)]
     pub disable_stalled_stream_protection_download: bool,
+    /// Maximum aggregate S3 download throughput for this process. Unlimited by default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_download_bytes_per_sec: Option<ByteSize>,
 }
 
 impl S3StorageConfig {
@@ -478,6 +491,10 @@ impl fmt::Debug for S3StorageConfig {
             .field(
                 "disable_stalled_stream_protection_download",
                 &self.disable_stalled_stream_protection_download,
+            )
+            .field(
+                "max_download_bytes_per_sec",
+                &self.max_download_bytes_per_sec,
             )
             .finish()
     }
@@ -603,6 +620,16 @@ mod tests {
             .into(),
         ]);
         storage_configs.validate().unwrap_err();
+
+        let storage_configs = StorageConfigs(vec![
+            S3StorageConfig {
+                max_download_bytes_per_sec: Some(ByteSize::b(0)),
+                ..Default::default()
+            }
+            .into(),
+        ]);
+        let error = storage_configs.validate().unwrap_err();
+        assert!(error.to_string().contains("must be greater than zero"));
     }
 
     #[test]
@@ -769,6 +796,7 @@ mod tests {
                 checksum_algorithm: disabled
                 disable_stalled_stream_protection_upload: true
                 disable_stalled_stream_protection_download: true
+                max_download_bytes_per_sec: 500MB
             "#;
             let s3_storage_config: S3StorageConfig =
                 serde_yaml::from_str(s3_storage_config_yaml).unwrap();
@@ -782,6 +810,7 @@ mod tests {
                 checksum_algorithm: ChecksumAlgorithm::Disabled,
                 disable_stalled_stream_protection_upload: true,
                 disable_stalled_stream_protection_download: true,
+                max_download_bytes_per_sec: Some(ByteSize::mb(500)),
                 ..Default::default()
             };
             assert_eq!(s3_storage_config, expected_s3_config);

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -47,6 +47,7 @@ use futures::{StreamExt, stream};
 use percent_encoding::percent_decode_str;
 use quickwit_aws::retry::{AwsRetryable, aws_retry};
 use quickwit_aws::{aws_behavior_version, get_aws_config};
+use quickwit_common::io::{IoControls, IoControlsAccess};
 use quickwit_common::retry::{Retry, RetryParams};
 use quickwit_common::thread_pool::run_cpu_intensive;
 use quickwit_common::uri::Uri;
@@ -104,6 +105,7 @@ pub struct S3CompatibleObjectStorage {
     disable_multi_object_delete: bool,
     disable_multipart_upload: bool,
     checksum_algorithm: quickwit_config::ChecksumAlgorithm,
+    download_io_controls_opt: Option<IoControls>,
 }
 
 impl fmt::Debug for S3CompatibleObjectStorage {
@@ -179,6 +181,12 @@ pub async fn create_s3_client(s3_storage_config: &S3StorageConfig) -> S3Client {
     S3Client::from_conf(s3_config.build())
 }
 
+pub(crate) fn download_io_controls(s3_storage_config: &S3StorageConfig) -> Option<IoControls> {
+    s3_storage_config
+        .max_download_bytes_per_sec
+        .map(|throughput| IoControls::default().set_throughput_limit(throughput))
+}
+
 impl S3CompatibleObjectStorage {
     /// Creates an object storage given a region and an uri.
     pub async fn from_uri(
@@ -194,6 +202,22 @@ impl S3CompatibleObjectStorage {
         s3_storage_config: &S3StorageConfig,
         uri: &Uri,
         s3_client: S3Client,
+    ) -> Result<Self, StorageResolverError> {
+        let download_io_controls_opt = download_io_controls(s3_storage_config);
+        Self::from_uri_client_and_download_controls(
+            s3_storage_config,
+            uri,
+            s3_client,
+            download_io_controls_opt,
+        )
+        .await
+    }
+
+    pub(crate) async fn from_uri_client_and_download_controls(
+        s3_storage_config: &S3StorageConfig,
+        uri: &Uri,
+        s3_client: S3Client,
+        download_io_controls_opt: Option<IoControls>,
     ) -> Result<Self, StorageResolverError> {
         let (bucket, prefix) = parse_s3_uri(uri).ok_or_else(|| {
             let message = format!("failed to extract bucket name from S3 URI: {uri}");
@@ -212,6 +236,7 @@ impl S3CompatibleObjectStorage {
             disable_multi_object_delete,
             disable_multipart_upload,
             checksum_algorithm: s3_storage_config.checksum_algorithm,
+            download_io_controls_opt,
         })
     }
 
@@ -230,6 +255,7 @@ impl S3CompatibleObjectStorage {
             disable_multi_object_delete: self.disable_multi_object_delete,
             disable_multipart_upload: self.disable_multipart_upload,
             checksum_algorithm: self.checksum_algorithm,
+            download_io_controls_opt: self.download_io_controls_opt,
         }
     }
 
@@ -735,7 +761,11 @@ impl S3CompatibleObjectStorage {
         // only record ranged get request as being in flight
         let _in_flight_guards =
             range_opt.map(|range| object_storage_get_slice_in_flight_guards(range.len()));
-        download_all(get_object_output.body).await
+        download_all(
+            get_object_output.body,
+            self.download_io_controls_opt.as_ref(),
+        )
+        .await
     }
 
     /// Bulk delete implementation based on the DeleteObject API:
@@ -874,14 +904,26 @@ impl S3CompatibleObjectStorage {
     }
 }
 
-async fn download_all(byte_stream: ByteStream) -> StorageResult<Bytes> {
-    let aggregated: AggregatedBytes = byte_stream
-        .collect()
-        .await
-        .map_err(byte_stream_to_storage_error)?;
-    // `AggregatedBytes::into_bytes` returns the underlying `Bytes` without copying when the body
-    // was received as a single segment, and concatenates into a fresh `Bytes` otherwise.
-    let bytes = aggregated.into_bytes();
+async fn download_all(
+    byte_stream: ByteStream,
+    download_io_controls_opt: Option<&IoControls>,
+) -> StorageResult<Bytes> {
+    let bytes = if let Some(download_io_controls) = download_io_controls_opt {
+        let mut controlled_read = download_io_controls
+            .clone()
+            .wrap_read(byte_stream.into_async_read());
+        let mut bytes = Vec::new();
+        controlled_read.read_to_end(&mut bytes).await?;
+        Bytes::from(bytes)
+    } else {
+        let aggregated: AggregatedBytes = byte_stream
+            .collect()
+            .await
+            .map_err(byte_stream_to_storage_error)?;
+        // `AggregatedBytes::into_bytes` returns the underlying `Bytes` without copying when the
+        // body was received as a single segment, and concatenates otherwise.
+        aggregated.into_bytes()
+    };
     crate::metrics::OBJECT_STORAGE_DOWNLOAD_NUM_BYTES.inc_by(bytes.len() as u64);
     Ok(bytes)
 }
@@ -946,7 +988,15 @@ impl Storage for S3CompatibleObjectStorage {
         let get_object_output =
             aws_retry(&self.retry_params, || self.get_object(path, None)).await?;
         let mut body_read = BufReader::new(get_object_output.body.into_async_read());
-        let num_bytes_copied = tokio::io::copy_buf(&mut body_read, output).await?;
+        let num_bytes_copied = if let Some(download_io_controls) = &self.download_io_controls_opt {
+            tokio::io::copy(
+                &mut download_io_controls.clone().wrap_read(body_read),
+                output,
+            )
+            .await?
+        } else {
+            tokio::io::copy_buf(&mut body_read, output).await?
+        };
         crate::metrics::OBJECT_STORAGE_DOWNLOAD_NUM_BYTES.inc_by(num_bytes_copied);
         output.flush().await?;
         Ok(())
@@ -1110,10 +1160,15 @@ impl Storage for S3CompatibleObjectStorage {
             self.get_object(path, Some(range.clone()))
         })
         .await?;
-        Ok(Box::new(S3AsyncRead {
+        let read = S3AsyncRead {
             read: get_object_output.body.into_async_read(),
             _permit: permit,
-        }))
+        };
+        if let Some(download_io_controls) = &self.download_io_controls_opt {
+            Ok(Box::new(download_io_controls.clone().wrap_read(read)))
+        } else {
+            Ok(Box::new(read))
+        }
     }
 
     #[instrument(
@@ -1332,6 +1387,7 @@ mod tests {
             disable_multi_object_delete: false,
             disable_multipart_upload: false,
             checksum_algorithm: quickwit_config::ChecksumAlgorithm::Crc32c,
+            download_io_controls_opt: None,
         };
         assert_eq!(
             s3_storage.relative_path("indexes/foo"),
@@ -1449,6 +1505,7 @@ mod tests {
             disable_multi_object_delete: false,
             disable_multipart_upload: false,
             checksum_algorithm: quickwit_config::ChecksumAlgorithm::Crc32c,
+            download_io_controls_opt: None,
         });
 
         let pages: Vec<Vec<ObjectMetadata>> =
@@ -1506,6 +1563,7 @@ mod tests {
             disable_multi_object_delete: true,
             disable_multipart_upload: false,
             checksum_algorithm: quickwit_config::ChecksumAlgorithm::Crc32c,
+            download_io_controls_opt: None,
         };
         let _ = s3_storage
             .bulk_delete(&[Path::new("foo"), Path::new("bar")])
@@ -1544,6 +1602,7 @@ mod tests {
             disable_multi_object_delete: false,
             disable_multipart_upload: false,
             checksum_algorithm: quickwit_config::ChecksumAlgorithm::Crc32c,
+            download_io_controls_opt: None,
         };
         let _ = s3_storage
             .bulk_delete(&[Path::new("foo"), Path::new("bar")])
@@ -1627,6 +1686,7 @@ mod tests {
             disable_multi_object_delete: false,
             disable_multipart_upload: false,
             checksum_algorithm: quickwit_config::ChecksumAlgorithm::Crc32c,
+            download_io_controls_opt: None,
         };
         let bulk_delete_error = s3_storage
             .bulk_delete(&[
@@ -1719,6 +1779,7 @@ mod tests {
             disable_multi_object_delete: false,
             disable_multipart_upload: false,
             checksum_algorithm: quickwit_config::ChecksumAlgorithm::Crc32c,
+            download_io_controls_opt: None,
         };
         s3_storage
             .put(Path::new("my-path"), Box::new(vec![1, 2, 3]))
@@ -1748,6 +1809,7 @@ mod tests {
             disable_multi_object_delete: false,
             disable_multipart_upload: true,
             checksum_algorithm,
+            download_io_controls_opt: None,
         }
     }
 

--- a/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage_resolver.rs
+++ b/quickwit/quickwit-storage/src/object_storage/s3_compatible_storage_resolver.rs
@@ -20,7 +20,7 @@ use quickwit_common::uri::Uri;
 use quickwit_config::{S3StorageConfig, StorageBackend};
 use tokio::sync::OnceCell;
 
-use super::s3_compatible_storage::create_s3_client;
+use super::s3_compatible_storage::{create_s3_client, download_io_controls};
 use crate::{
     DebouncedStorage, S3CompatibleObjectStorage, Storage, StorageFactory, StorageResolverError,
 };
@@ -34,14 +34,19 @@ pub struct S3CompatibleObjectStorageFactory {
     // end up being used, or if something like azure, gcs, or even local files, will be used
     // instead.
     s3_client: OnceCell<S3Client>,
+    // Shared by every storage resolved by this factory, making the configured throughput limit
+    // aggregate across buckets and search requests in this process.
+    download_io_controls_opt: Option<quickwit_common::io::IoControls>,
 }
 
 impl S3CompatibleObjectStorageFactory {
     /// Creates a new S3-compatible storage factory.
     pub fn new(storage_config: S3StorageConfig) -> Self {
+        let download_io_controls_opt = download_io_controls(&storage_config);
         Self {
             storage_config,
             s3_client: OnceCell::new(),
+            download_io_controls_opt,
         }
     }
 }
@@ -58,9 +63,13 @@ impl StorageFactory for S3CompatibleObjectStorageFactory {
             .get_or_init(|| create_s3_client(&self.storage_config))
             .await
             .clone();
-        let storage =
-            S3CompatibleObjectStorage::from_uri_and_client(&self.storage_config, uri, s3_client)
-                .await?;
+        let storage = S3CompatibleObjectStorage::from_uri_client_and_download_controls(
+            &self.storage_config,
+            uri,
+            s3_client,
+            self.download_io_controls_opt.clone(),
+        )
+        .await?;
         Ok(Arc::new(DebouncedStorage::new(storage)))
     }
 }


### PR DESCRIPTION
## Summary
- Add `storage.s3.max_download_bytes_per_sec` to bound S3 download bandwidth, with unlimited throughput by default.
- Share rate-limited read controls across storage instances resolved by the same factory and apply them to buffered and streaming downloads.
- Reject zero limits, add controlled-reader and configuration tests, and document the setting.

## Testing
- Not run locally.