### PR TITLE
Update Tantivy to main at 1020eba2

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -740,6 +740,7 @@ semver,https://github.com/dtolnay/semver,MIT OR Apache-2.0,David Tolnay <dtolnay
 separator,https://github.com/saghm/rust-separator,MIT,Saghm Rossi <saghmrossi@gmail.com>
 seq-macro,https://github.com/dtolnay/seq-macro,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+serde-tuple-vec-map,https://github.com/daboross/serde-tuple-vec-map,MIT,David Ross <daboross@daboross.net>
 serde-value,https://github.com/arcnmx/serde-value,MIT,arcnmx
 serde_core,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_derive,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "itertools 0.15.0",
- "lru 0.18.0",
+ "lru 0.18.4",
  "rand 0.10.2",
  "serde",
  "tokio",
@@ -5980,9 +5980,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -7087,7 +7087,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -8597,7 +8597,7 @@ dependencies = [
  "fnv",
  "futures",
  "itertools 0.15.0",
- "lru 0.18.0",
+ "lru 0.18.4",
  "mockall",
  "proptest",
  "quickwit-actors",
@@ -9416,7 +9416,7 @@ dependencies = [
  "http 1.4.2",
  "http-body-util",
  "hyper 1.11.1",
- "lru 0.18.0",
+ "lru 0.18.4",
  "md5",
  "mini-moka",
  "mockall",
@@ -10721,6 +10721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-tuple-vec-map"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04d0ebe0de77d7d445bb729a895dcb0a288854b267ca85f030ce51cdc578c82"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11778,11 +11787,11 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bitpacking",
  "bon",
  "byteorder",
@@ -11800,7 +11809,7 @@ dependencies = [
  "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru 0.16.4",
+ "lru 0.18.4",
  "lz4_flex 0.14.0",
  "measure_time",
  "memmap2",
@@ -11810,6 +11819,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "serde",
+ "serde-tuple-vec-map",
  "serde_json",
  "sketches-ddsketch 0.4.0",
  "smallvec",
@@ -11817,7 +11827,7 @@ dependencies = [
  "tantivy-columnar",
  "tantivy-common",
  "tantivy-fst",
- "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=86641f7)",
+ "tantivy-query-grammar 0.26.0 (git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0)",
  "tantivy-sstable",
  "tantivy-stacker",
  "tantivy-tokenizer-api",
@@ -11834,7 +11844,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "bitpacking",
 ]
@@ -11842,7 +11852,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -11857,7 +11867,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11893,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -11905,7 +11915,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -11918,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -11927,7 +11937,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/quickwit-oss/tantivy/?rev=86641f7#86641f72df7f79867486aa4645b66767a80cc4e8"
+source = "git+https://github.com/quickwit-oss/tantivy/?rev=1020eba2b9c20c422c6d061528f08aeda3e5a3e0#1020eba2b9c20c422c6d061528f08aeda3e5a3e0"
 dependencies = [
  "serde",
 ]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -426,7 +426,7 @@ quickwit-storage = { path = "quickwit-storage" }
 quickwit-telemetry-exporters = { path = "quickwit-telemetry-exporters" }
 quickwit-transport = { path = "quickwit-transport" }
 
-tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "86641f7", default-features = false, features = [
+tantivy = { git = "https://github.com/quickwit-oss/tantivy/", rev = "1020eba2b9c20c422c6d061528f08aeda3e5a3e0", default-features = false, features = [
   "lz4-compression",
   "mmap",
   "quickwit",

--- a/quickwit/quickwit-directories/src/hot_directory.rs
+++ b/quickwit/quickwit-directories/src/hot_directory.rs
@@ -459,11 +459,7 @@ impl Directory for HotDirectory {
 
 fn list_index_files(index: &Index) -> tantivy::Result<HashSet<PathBuf>> {
     let index_meta = index.load_metas()?;
-    let mut files: HashSet<PathBuf> = index_meta
-        .segments
-        .into_iter()
-        .flat_map(|segment_meta| segment_meta.list_files())
-        .collect();
+    let mut files = index_meta.list_segment_files();
     files.insert(Path::new("meta.json").to_path_buf());
     files.insert(Path::new(".managed.json").to_path_buf());
     Ok(files)

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_entry.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_entry.rs
@@ -772,6 +772,7 @@ fn deserialize_mapping_type(
             Ok(FieldMappingType::DateTime(date_time_options, cardinality))
         }
         Type::Facet => unimplemented!("Facet are not supported in quickwit yet."),
+        Type::Custom => bail!("custom fields are not supported in Quickwit"),
         Type::Bytes => {
             let numeric_options: QuickwitBytesOptions = serde_json::from_value(json)?;
             if numeric_options.fast && cardinality == Cardinality::MultiValued {

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_type.rs
@@ -138,6 +138,8 @@ fn primitive_type_to_str(primitive_type: &Type) -> &'static str {
         Type::Facet => {
             unimplemented!("Facets are not supported by quickwit at the moment.")
         }
+        // Quickwit mappings cannot construct custom field types.
+        Type::Custom => unreachable!("custom fields are not supported in Quickwit"),
     }
 }
 

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_type.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/field_mapping_type.rs
@@ -139,7 +139,7 @@ fn primitive_type_to_str(primitive_type: &Type) -> &'static str {
             unimplemented!("Facets are not supported by quickwit at the moment.")
         }
         // Quickwit mappings cannot construct custom field types.
-        Type::Custom => unreachable!("custom fields are not supported in Quickwit"),
+        Type::Custom => unimplemented!("custom fields are not supported in Quickwit"),
     }
 }
 

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/tantivy_val_to_json.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/tantivy_val_to_json.rs
@@ -216,7 +216,7 @@ pub fn tantivy_value_to_json(value: TantivyValue) -> JsonValue {
         TantivyValue::Facet(facet) => JsonValue::String(facet.to_string()),
         TantivyValue::Bytes(bytes) => BinaryFormat::Base64.format_to_json(&bytes),
         TantivyValue::Custom(_) => {
-            unreachable!("custom values cannot originate from a Quickwit-supported schema")
+            unimplemented!("custom values cannot originate from a Quickwit-supported schema")
         }
         TantivyValue::IpAddr(ip_v6) => {
             let ip_str = if let Some(ip_v4) = ip_v6.to_ipv4_mapped() {

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/tantivy_val_to_json.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/tantivy_val_to_json.rs
@@ -191,6 +191,9 @@ pub fn tantivy_object_to_json_value(object: Vec<(String, TantivyValue)>) -> Json
 /// Converts Tantivy::Value into Json Value.
 ///
 /// Formatting by defaults, e.g. Rfc3339 for dates.
+///
+/// Values must originate from a Quickwit-supported schema: custom plugin values have no
+/// supported JSON representation and violate this invariant.
 pub fn tantivy_value_to_json(value: TantivyValue) -> JsonValue {
     match value {
         TantivyValue::Null => JsonValue::Null,
@@ -212,6 +215,9 @@ pub fn tantivy_value_to_json(value: TantivyValue) -> JsonValue {
             .expect("Invalid datetime is not allowed."),
         TantivyValue::Facet(facet) => JsonValue::String(facet.to_string()),
         TantivyValue::Bytes(bytes) => BinaryFormat::Base64.format_to_json(&bytes),
+        TantivyValue::Custom(_) => {
+            unreachable!("custom values cannot originate from a Quickwit-supported schema")
+        }
         TantivyValue::IpAddr(ip_v6) => {
             let ip_str = if let Some(ip_v4) = ip_v6.to_ipv4_mapped() {
                 ip_v4.to_string()

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -357,7 +357,7 @@ fn tantivy_type_to_list_field_type(typ: Type) -> ListFieldsType {
         Type::Str => ListFieldsType::Str,
         Type::U64 => ListFieldsType::U64,
         // Packaged fields originate from Quickwit mappings, which cannot define custom types.
-        Type::Custom => unreachable!("custom fields are not supported in Quickwit"),
+        Type::Custom => unimplemented!("custom fields are not supported in Quickwit"),
     }
 }
 

--- a/quickwit/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit/quickwit-indexing/src/actors/packager.rs
@@ -30,7 +30,7 @@ use quickwit_doc_mapper::tag_pruning::append_to_tag_set;
 use quickwit_proto::search::{ListFieldsEntry, ListFieldsMetadata, ListFieldsType};
 use tantivy::index::FieldMetadata;
 use tantivy::schema::{FieldType, Type};
-use tantivy::{InvertedIndexReader, ReloadPolicy, SegmentMeta};
+use tantivy::{IndexMeta, InvertedIndexReader, ReloadPolicy};
 use tokio::runtime::Handle;
 use tracing::{debug, info, instrument, warn};
 
@@ -83,10 +83,9 @@ impl Packager {
         split: IndexedSplit,
         ctx: &ActorContext<Self>,
     ) -> anyhow::Result<PackagedSplit> {
-        let segment_metas = split.index.searchable_segment_metas()?;
-        assert_eq!(segment_metas.len(), 1);
-        let packaged_split =
-            create_packaged_split(&segment_metas[..], split, &self.tag_fields, ctx)?;
+        let index_meta = split.index.load_metas()?;
+        assert_eq!(index_meta.segments.len(), 1);
+        let packaged_split = create_packaged_split(&index_meta, split, &self.tag_fields, ctx)?;
         Ok(packaged_split)
     }
 }
@@ -183,21 +182,17 @@ impl Handler<EmptySplit> for Packager {
 }
 
 fn list_split_files(
-    segment_metas: &[SegmentMeta],
+    index_meta: &IndexMeta,
     scratch_directory: &TempDirectory,
 ) -> io::Result<Vec<PathBuf>> {
     let mut split_files = vec![scratch_directory.path().join("meta.json")];
 
-    // list the segment files
-    for segment_meta in segment_metas {
-        for relative_path in segment_meta.list_files() {
-            let filepath = scratch_directory.path().join(relative_path);
-            if filepath.try_exists()? {
-                // If the file is missing, this is fine.
-                // segment_meta.list_files() may actually returns files that
-                // may not exist.
-                split_files.push(filepath);
-            }
+    for relative_path in index_meta.list_segment_files() {
+        let filepath = scratch_directory.path().join(relative_path);
+        // Tantivy lists candidate component paths, including optional files
+        // that may not exist.
+        if filepath.try_exists()? {
+            split_files.push(filepath);
         }
     }
     split_files.sort();
@@ -266,13 +261,13 @@ fn try_extract_terms(
 }
 
 fn create_packaged_split(
-    segment_metas: &[SegmentMeta],
+    index_meta: &IndexMeta,
     split: IndexedSplit,
     tag_fields: &[NamedField],
     ctx: &ActorContext<Packager>,
 ) -> anyhow::Result<PackagedSplit> {
     debug!(split_id = %split.split_id(), "create-packaged-split");
-    let split_files = list_split_files(segment_metas, &split.split_scratch_directory)?;
+    let split_files = list_split_files(index_meta, &split.split_scratch_directory)?;
 
     // Extracts tag values from inverted indexes only when a field cardinality is less
     // than `MAX_VALUES_PER_TAG_FIELD`.
@@ -361,6 +356,8 @@ fn tantivy_type_to_list_field_type(typ: Type) -> ListFieldsType {
         Type::Json => ListFieldsType::Json,
         Type::Str => ListFieldsType::Str,
         Type::U64 => ListFieldsType::U64,
+        // Packaged fields originate from Quickwit mappings, which cannot define custom types.
+        Type::Custom => unreachable!("custom fields are not supported in Quickwit"),
     }
 }
 

--- a/quickwit/quickwit-query/src/query_ast/range_query.rs
+++ b/quickwit/quickwit-query/src/query_ast/range_query.rs
@@ -195,6 +195,12 @@ impl BuildTantivyAst for RangeQuery {
                     field_name: field_entry.name().to_string(),
                 });
             }
+            tantivy::schema::FieldType::Custom(_) => {
+                return Err(InvalidQuery::RangeQueryNotSupportedForField {
+                    value_type: "custom",
+                    field_name: field_entry.name().to_string(),
+                });
+            }
             tantivy::schema::FieldType::Bytes(_) => todo!(),
             tantivy::schema::FieldType::JsonObject(options) => {
                 let mut sub_queries: Vec<TantivyQueryAst> = Vec::new();

--- a/quickwit/quickwit-query/src/query_ast/utils.rs
+++ b/quickwit/quickwit-query/src/query_ast/utils.rs
@@ -187,6 +187,9 @@ fn compute_query_with_field(
         FieldType::Facet(_) => Err(InvalidQuery::SchemaError(
             "facets are not supported in Quickwit".to_string(),
         )),
+        FieldType::Custom(_) => Err(InvalidQuery::SchemaError(
+            "custom fields are not supported in Quickwit".to_string(),
+        )),
         FieldType::Bytes(_) => {
             let buffer: Vec<u8> = parse_value_from_user_text(value, field_entry.name())?;
             let term = Term::from_field_bytes(field, &buffer[..]);


### PR DESCRIPTION
## Summary

- Update Tantivy from `86641f7` to upstream main revision `1020eba2b9c20c422c6d061528f08aeda3e5a3e0`, including the public `IndexMeta::list_segment_files()` API from https://github.com/quickwit-oss/tantivy/pull/3080.
- Use metadata-level file enumeration in split packaging and hot-cache construction, retaining separate handling for `meta.json` and `.managed.json`.
- Handle the new custom field/type/value variants explicitly; custom fields remain unsupported in Quickwit.
- Refresh the lockfile and third-party license inventory.

## Validation

- `cargo check --locked -p quickwit-cli` — passed.
- `make fmt`, `make update-licenses`, and `git diff --check` — passed.
- `cargo nextest run --locked --no-fail-fast -p quickwit-query -p quickwit-doc-mapper -p quickwit-directories` — 400 passed, 1 failed.
- `cargo nextest run --locked --no-fail-fast -p quickwit-indexing -p quickwit-search -E 'package(quickwit-search) | test(actors::packager::) | test(actors::index_serializer::) | test(actors::merge_executor::) | test(actors::indexer::)'` — 232 passed.

### Pre-existing test failure

`doc_mapper::doc_mapper_impl::tests::test_concatenate_multiple_field` fails on a string ordering assertion. The same failure was reproduced in an untouched worktree at Quickwit `893410182` with the original Tantivy `86641f7` pin and the same package selection. It is not introduced by this update. Existing unit tests are unchanged.
