### PR TITLE
Log root search requests and partial resource stats on cancellation

### DIFF
--- a/docs/internals/root-resource-stats.md
+++ b/docs/internals/root-resource-stats.md
@@ -1,0 +1,32 @@
+# Root search resource logging
+
+Each `root_search` invocation emits a `root_resource_stats` event when its guard
+is dropped, including planning errors, execution errors, and cancellation of the
+search future (for example, by a timeout). As with other drop-based logging, this
+cannot guarantee delivery on process abort or termination.
+
+The guard records resource stats from each returned leaf response before joining
+all responses. A later leaf error or cancellation therefore does not discard
+stats already received. Hits and aggregation payloads are not retained for logging.
+
+- `status`: `success`, `error`, or `cancelled`.
+- `root_wall_time_microsecs`: elapsed time across planning and execution.
+- `leaf_num_calls`, `leaf_num_calls_including_retries`: dispatched leaf batches
+  and attempts, respectively.
+- `leaf_num_responses`, `leaf_num_responses_with_stats`: response coverage.
+- `resource_stats_available`: whether any leaf returned resource stats.
+- `resource_stats_partial`: true on error/cancellation, missing leaf stats, or
+  reported split failures. A successful metadata-only count can have no leaf calls
+  and no resource stats without being partial.
+- `sleaf_ssplit_cpu_search_microsecs`, `sleaf_ssplit_warmup_microsecs`, and the
+  corresponding wait fields: sums over received leaf resource stats, not wall time.
+- `leaf_resources_sum` and `leaf_resources_worst`: debug representations of the
+  full received leaf stats for inspection.
+
+A root cannot report work still running remotely, or stats lost with a failed
+RPC. Missing CPU timings are omitted, **not reported as zero**. Partial sums must
+not be treated as total resource usage for the request. Leaf-local metrics remain
+necessary for work whose response never reaches the root.
+
+This guard covers `root_search`; subsequent scroll-page execution that calls the
+partial-hits phase directly does not emit an additional root event.

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod resource_stats_logging;
+
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
@@ -41,6 +43,7 @@ use quickwit_proto::types::{IndexUid, SplitId};
 use quickwit_query::query_ast::{
     BoolQuery, QueryAst, QueryAstVisitor, RangeQuery, TermQuery, TermSetQuery,
 };
+use resource_stats_logging::RootResourceStatsLogGuard;
 use serde::{Deserialize, Serialize};
 use tantivy::TantivyError;
 use tantivy::aggregation::agg_result::AggregationResults;
@@ -573,6 +576,7 @@ async fn search_partial_hits_phase_with_scroll(
     mut search_request: SearchRequest,
     split_metadatas: &[SplitMetadata],
     cluster_client: &ClusterClient,
+    resource_log: &RootResourceStatsLogGuard,
 ) -> crate::Result<(
     LeafSearchResponse,
     Option<ScrollKeyAndStartOffset>,
@@ -595,6 +599,7 @@ async fn search_partial_hits_phase_with_scroll(
             &search_request,
             split_metadatas,
             cluster_client,
+            Some(resource_log),
         )
         .await?;
         let cached_partial_hits = leaf_search_resp.partial_hits.clone();
@@ -644,6 +649,7 @@ async fn search_partial_hits_phase_with_scroll(
             &search_request,
             split_metadatas,
             cluster_client,
+            Some(resource_log),
         )
         .await?;
         Ok((leaf_search_resp, None, root_resource_stats))
@@ -798,11 +804,14 @@ pub(crate) async fn search_partial_hits_phase(
     search_request: &SearchRequest,
     split_metadatas: &[SplitMetadata],
     cluster_client: &ClusterClient,
+    resource_log: Option<&RootResourceStatsLogGuard>,
 ) -> crate::Result<(LeafSearchResponse, Option<RootResourceStats>)> {
     // Each entry is (leaf response, number of leaf attempts made to obtain it).
     // Metadata-count responses are synthesised locally and contribute 0 attempts.
     let mut leaf_num_calls = 0u64;
-    let leaf_num_calls_including_retries_arc: Arc<AtomicU64> = Default::default();
+    let leaf_num_calls_including_retries_arc: Arc<AtomicU64> = resource_log
+        .map(|log| log.leaf_num_calls_including_retries.clone())
+        .unwrap_or_default();
     let leaf_search_responses: Vec<LeafSearchResponse> =
         if is_metadata_count_request(search_request) {
             get_count_from_metadata(split_metadatas)
@@ -826,7 +835,19 @@ pub(crate) async fn search_partial_hits_phase(
                 ));
             }
             leaf_num_calls = leaf_request_tasks.len() as u64;
-            try_join_all(leaf_request_tasks).await?
+            if let Some(log) = resource_log {
+                log.leaf_num_calls.store(leaf_num_calls, Ordering::Relaxed);
+            }
+            // Capture each response before try_join_all can discard it on another leaf's error
+            // or cancellation. Only returned resource stats, not payloads, are retained.
+            try_join_all(leaf_request_tasks.into_iter().map(|task| async move {
+                let response = task.await?;
+                if let Some(log) = resource_log {
+                    log.record_response(&response);
+                }
+                Ok::<_, crate::SearchError>(response)
+            }))
+            .await?
         };
 
     let num_failed_splits: u64 = leaf_search_responses
@@ -1057,9 +1078,10 @@ fn get_sort_field_datetime_format(
 async fn root_search_aux(
     searcher_context: &SearcherContext,
     indexes_metas_for_leaf_search: &IndexesMetasForLeafSearch,
-    search_request: SearchRequest,
+    search_request: &SearchRequest,
     split_metadatas: Vec<SplitMetadata>,
     cluster_client: &ClusterClient,
+    resource_log: &RootResourceStatsLogGuard,
 ) -> crate::Result<SearchResponse> {
     debug!(split_metadatas = ?PrettySample::new(&split_metadatas, 5));
     let start = Instant::now();
@@ -1073,6 +1095,7 @@ async fn root_search_aux(
         search_request.clone(),
         &split_metadatas[..],
         cluster_client,
+        resource_log,
     )
     .await?;
 
@@ -1085,13 +1108,13 @@ async fn root_search_aux(
         indexes_metas_for_leaf_search,
         &first_phase_result.partial_hits,
         &split_metadatas[..],
-        &search_request,
+        search_request,
         cluster_client,
     )
     .await?;
 
     let mut aggregation_result_postcard_opt = finalize_aggregation_if_any(
-        &search_request,
+        search_request,
         first_phase_result.intermediate_aggregation_result,
         searcher_context,
     )?;
@@ -1289,6 +1312,35 @@ async fn plan_splits_for_root_search(
     ))
 }
 
+/// Logs root-search details on completion, including when the search future is cancelled.
+struct RootSearchLogGuard<'a> {
+    start_instant: Instant,
+    search_request: &'a SearchRequest,
+    num_docs: usize,
+    num_splits: usize,
+    status: &'static str,
+}
+
+impl Drop for RootSearchLogGuard<'_> {
+    fn drop(&mut self) {
+        info!(
+            query_ast = self.search_request.query_ast.as_str(),
+            agg = self.search_request.aggregation_request(),
+            start_ts = ?(
+                self.search_request.start_timestamp()..self.search_request.end_timestamp()
+            ),
+            count_required = self.search_request.count_hits().as_str_name(),
+            max_hits = self.search_request.max_hits,
+            num_docs = self.num_docs,
+            num_splits = self.num_splits,
+            priority = self.search_request.priority,
+            elapsed_time_micros = self.start_instant.elapsed().as_micros() as u64,
+            status = self.status,
+            "root_search"
+        );
+    }
+}
+
 /// Performs a distributed search.
 /// 1. Sends leaf requests over gRPC to multiple leaf nodes.
 /// 2. Merges the search results.
@@ -1302,29 +1354,32 @@ pub async fn root_search(
     cluster_client: &ClusterClient,
 ) -> crate::Result<SearchResponse> {
     let start_instant = Instant::now();
+    let mut resource_log = RootResourceStatsLogGuard::new();
 
-    let (split_metadatas, indexes_meta_for_leaf_search) = RootSearchMetricsFuture {
+    let plan_result = RootSearchMetricsFuture {
         start: start_instant,
         tracked: plan_splits_for_root_search(&mut search_request, metastore),
         is_success: None,
         step: RootSearchMetricsStep::Plan,
     }
-    .await?;
+    .await;
+    let (split_metadatas, indexes_meta_for_leaf_search) = match plan_result {
+        Ok(plan) => plan,
+        Err(error) => {
+            resource_log.status = "error";
+            return Err(error);
+        }
+    };
 
     let num_docs: usize = split_metadatas.iter().map(|split| split.num_docs).sum();
     let num_splits = split_metadatas.len();
-
-    info!(
-        query_ast = search_request.query_ast.as_str(),
-        agg = search_request.aggregation_request(),
-        start_ts = ?(search_request.start_timestamp()..search_request.end_timestamp()),
-        count_required = search_request.count_hits().as_str_name(),
-        max_hits = search_request.max_hits,
-        num_docs = num_docs,
-        num_splits = num_splits,
-        priority = search_request.priority,
-        "root_search"
-    );
+    let mut log_guard = RootSearchLogGuard {
+        start_instant,
+        search_request: &search_request,
+        num_docs,
+        num_splits,
+        status: "cancelled",
+    };
 
     // set attributes directly on the trace so it doesn't make logs too verbose
     Span::current().set_attribute("query_ast", search_request.query_ast.clone());
@@ -1347,6 +1402,8 @@ pub async fn root_search(
             query=%search_request.query_ast,
             "max total splits exceeded"
         );
+        log_guard.status = "error";
+        resource_log.status = "error";
         return Err(SearchError::InvalidArgument(format!(
             "Number of targeted splits {num_splits} exceeds the limit {max_total_split_searches}"
         )));
@@ -1357,9 +1414,10 @@ pub async fn root_search(
         tracked: root_search_aux(
             searcher_context,
             &indexes_meta_for_leaf_search,
-            search_request,
+            &search_request,
             split_metadatas,
             cluster_client,
+            &resource_log,
         ),
         is_success: None,
         step: RootSearchMetricsStep::Exec {
@@ -1370,7 +1428,11 @@ pub async fn root_search(
 
     if let Ok(search_response) = &mut search_response_result {
         search_response.elapsed_time_micros = start_instant.elapsed().as_micros() as u64;
+        log_guard.status = "success";
+    } else {
+        log_guard.status = "error";
     }
+    resource_log.status = log_guard.status;
 
     search_response_result
 }

--- a/quickwit/quickwit-search/src/root/resource_stats_logging.rs
+++ b/quickwit/quickwit-search/src/root/resource_stats_logging.rs
@@ -1,0 +1,270 @@
+// Copyright 2021-Present Datadog, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use quickwit_proto::search::{LeafSearchResponse, RootResourceStats};
+use tracing::info;
+
+#[derive(Default)]
+struct ReceivedStats {
+    // Only resource stats are retained, never hits or aggregation payloads.
+    responses: Vec<LeafSearchResponse>,
+    num_failed_splits: u64,
+}
+
+/// Lives outside the search future so cancellation logs the stats already received.
+/// In-flight leaves and failed RPCs cannot contribute CPU stats: their work is unknown,
+/// not zero. The log explicitly reports coverage and keeps missing timings absent.
+pub(crate) struct RootResourceStatsLogGuard {
+    start: Instant,
+    pub status: &'static str,
+    pub leaf_num_calls: AtomicU64,
+    pub leaf_num_calls_including_retries: Arc<AtomicU64>,
+    received: Mutex<ReceivedStats>,
+}
+
+impl RootResourceStatsLogGuard {
+    pub fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            status: "cancelled",
+            leaf_num_calls: AtomicU64::new(0),
+            leaf_num_calls_including_retries: Arc::default(),
+            received: Mutex::default(),
+        }
+    }
+
+    pub fn record_response(&self, response: &LeafSearchResponse) {
+        let mut received = self.received.lock().expect("resource stats lock poisoned");
+        received.num_failed_splits += response.failed_splits.len() as u64;
+        received.responses.push(LeafSearchResponse {
+            resource_stats: response.resource_stats.clone(),
+            ..Default::default()
+        });
+    }
+
+    fn snapshot(&self) -> (Option<RootResourceStats>, usize, usize) {
+        let received = self.received.lock().expect("resource stats lock poisoned");
+        let num_with_stats = received
+            .responses
+            .iter()
+            .filter(|resp| resp.resource_stats.is_some())
+            .count();
+        let stats = super::compute_root_resource_stats(
+            &received.responses,
+            self.leaf_num_calls.load(Ordering::Relaxed),
+            self.leaf_num_calls_including_retries
+                .load(Ordering::Relaxed),
+            received.num_failed_splits,
+        );
+        (stats, received.responses.len(), num_with_stats)
+    }
+}
+
+impl Drop for RootResourceStatsLogGuard {
+    fn drop(&mut self) {
+        let (stats, num_responses, num_with_stats) = self.snapshot();
+        let leaf_num_calls = self.leaf_num_calls.load(Ordering::Relaxed);
+        let leaf_sum = stats
+            .as_ref()
+            .and_then(|stats| stats.leaf_resources_sum.as_ref());
+        let split_sum = leaf_sum.and_then(|stats| stats.split_resources_sum.as_ref());
+        let leaf_worst = stats
+            .as_ref()
+            .and_then(|stats| stats.leaf_resources_worst.as_ref());
+        info!(
+            status = self.status,
+            root_wall_time_microsecs = self.start.elapsed().as_micros() as u64,
+            leaf_num_calls,
+            leaf_num_calls_including_retries = self.leaf_num_calls_including_retries.load(Ordering::Relaxed),
+            leaf_num_responses = num_responses,
+            leaf_num_responses_with_stats = num_with_stats,
+            resource_stats_available = stats.is_some(),
+            resource_stats_partial = self.status != "success"
+                || num_with_stats as u64 != leaf_num_calls
+                || stats.as_ref().is_some_and(|stats| stats.num_failed_splits != 0),
+            num_failed_splits = stats.as_ref().map(|stats| stats.num_failed_splits),
+            sleaf_wall_time_microsecs = leaf_sum.map(|stats| stats.wall_time_microsecs),
+            wleaf_wall_time_microsecs = leaf_worst.map(|stats| stats.wall_time_microsecs),
+            sleaf_localexec_num_splits = leaf_sum.map(|stats| stats.localexec_num_splits),
+            sleaf_ssplit_cpu_search_microsecs = split_sum.map(|stats| stats.cpu_search_microsecs),
+            sleaf_ssplit_warmup_microsecs = split_sum.map(|stats| stats.warmup_microsecs),
+            sleaf_ssplit_wait_for_cpu_pool_microsecs = split_sum.map(|stats| stats.wait_for_cpu_pool_microsecs),
+            sleaf_ssplit_wait_for_search_permit_microsecs = split_sum.map(|stats| stats.wait_for_search_permit_microsecs),
+            leaf_resources_sum = ?leaf_sum,
+            leaf_resources_worst = ?leaf_worst,
+            "root_resource_stats"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quickwit_proto::search::{LeafResourceStats, SplitResourceStats};
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct LogCapture(Arc<Mutex<Vec<std::collections::BTreeMap<String, String>>>>);
+
+    impl tracing::Subscriber for LogCapture {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            struct Fields(std::collections::BTreeMap<String, String>);
+            impl tracing::field::Visit for Fields {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    self.0
+                        .insert(field.name().to_string(), format!("{value:?}"));
+                }
+            }
+            let mut fields = Fields(Default::default());
+            event.record(&mut fields);
+            self.0.lock().unwrap().push(fields.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn timeout_logs_partial_stats_once() {
+        use tracing::instrument::WithSubscriber;
+
+        let capture = LogCapture::default();
+        let search = async {
+            let mut guard = RootResourceStatsLogGuard::new();
+            guard.leaf_num_calls.store(2, Ordering::Relaxed);
+            guard.record_response(&LeafSearchResponse {
+                resource_stats: Some(LeafResourceStats {
+                    split_resources_sum: Some(SplitResourceStats {
+                        cpu_search_microsecs: 123,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            std::future::pending::<()>().await;
+            guard.status = "success";
+        };
+        async {
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(1), search)
+                    .await
+                    .is_err()
+            );
+        }
+        .with_subscriber(capture.clone())
+        .await;
+        let events = capture.0.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        let fields = &events[0];
+        assert!(fields["message"].contains("root_resource_stats"));
+        assert_eq!(fields["status"], "\"cancelled\"");
+        assert_eq!(fields["resource_stats_partial"], "true");
+        assert_eq!(fields["leaf_num_responses"], "1");
+        assert_eq!(fields["sleaf_ssplit_cpu_search_microsecs"], "123");
+    }
+
+    #[test]
+    fn success_logs_complete_stats_once() {
+        let capture = LogCapture::default();
+        tracing::subscriber::with_default(capture.clone(), || {
+            let mut guard = RootResourceStatsLogGuard::new();
+            guard.leaf_num_calls.store(1, Ordering::Relaxed);
+            guard.record_response(&LeafSearchResponse {
+                resource_stats: Some(LeafResourceStats::default()),
+                ..Default::default()
+            });
+            guard.status = "success";
+        });
+        let events = capture.0.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["status"], "\"success\"");
+        assert_eq!(events[0]["resource_stats_partial"], "false");
+        assert_eq!(events[0]["resource_stats_available"], "true");
+    }
+
+    #[test]
+    fn error_without_responses_logs_missing_cpu_once() {
+        let capture = LogCapture::default();
+        tracing::subscriber::with_default(capture.clone(), || {
+            let mut guard = RootResourceStatsLogGuard::new();
+            guard.status = "error";
+        });
+        let events = capture.0.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["status"], "\"error\"");
+        assert_eq!(events[0]["resource_stats_partial"], "true");
+        assert!(!events[0].contains_key("sleaf_ssplit_cpu_search_microsecs"));
+    }
+
+    #[test]
+    fn missing_leaf_responses_do_not_report_zero_cpu() {
+        let guard = RootResourceStatsLogGuard::new();
+        guard.leaf_num_calls.store(4, Ordering::Relaxed);
+        let (stats, num_responses, num_with_stats) = guard.snapshot();
+        assert!(stats.is_none());
+        assert_eq!((num_responses, num_with_stats), (0, 0));
+        assert_eq!(guard.status, "cancelled");
+    }
+
+    #[test]
+    fn partial_leaf_stats_survive_failure() {
+        let mut guard = RootResourceStatsLogGuard::new();
+        guard.leaf_num_calls.store(4, Ordering::Relaxed);
+        guard
+            .leaf_num_calls_including_retries
+            .store(5, Ordering::Relaxed);
+        guard.record_response(&LeafSearchResponse {
+            resource_stats: Some(LeafResourceStats {
+                split_resources_sum: Some(SplitResourceStats {
+                    cpu_search_microsecs: 123,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        guard.record_response(&LeafSearchResponse::default());
+        guard.status = "error";
+        let (stats, num_responses, num_with_stats) = guard.snapshot();
+        let stats = stats.unwrap();
+        assert_eq!((num_responses, num_with_stats), (2, 1));
+        assert_eq!(stats.leaf_num_calls, 4);
+        assert_eq!(stats.leaf_num_calls_including_retries, 5);
+        assert_eq!(
+            stats
+                .leaf_resources_sum
+                .unwrap()
+                .split_resources_sum
+                .unwrap()
+                .cpu_search_microsecs,
+            123
+        );
+    }
+}

--- a/quickwit/quickwit-search/src/scroll_context.rs
+++ b/quickwit/quickwit-search/src/scroll_context.rs
@@ -122,6 +122,7 @@ impl ScrollContext {
             &self.search_request,
             &self.split_metadatas[..],
             cluster_client,
+            None,
         )
         .await?;
         self.cached_partial_hits_start_offset = start_offset;


### PR DESCRIPTION
## Summary
- Log root search requests on drop, including elapsed time and success/error/cancelled status.
- Emit root_resource_stats on success, planning/execution errors, and timeout cancellation.
- Retain resource stats as individual leaf responses arrive, before a subsequent error or cancellation can discard them.
- Report response coverage and partial/unavailable stats explicitly; omit unknown CPU timings rather than reporting zero.
- Document scope and limitations: in-flight/failed RPC work is unknown, and subsequent scroll pages do not emit this root event.

## Validation
- make fmt
- git diff --check
- cargo nextest run -p quickwit-search: 214 tests passed
- Added tests for success, errors, timeout cancellation, and partial/missing stats.