### PR TITLE
chore(CI): Run the full test suite automatically on every PR commit

### DIFF
--- a/.github/workflows/full-tests-trigger.yml
+++ b/.github/workflows/full-tests-trigger.yml
@@ -1,112 +1,28 @@
 name: Full test suite trigger
 
-# Maintainers trigger this workflow with `/ci-run-all-tests`.
-# `issue_comment` uses the trusted default-branch workflow and supports statuses
-# for fork PRs.
+# Fires on every commit pushed to a PR. The job is a no-op signal that wakes
+# the trusted `full-tests.yml` dispatcher, which runs the suite from the
+# default-branch workflow definition. This file runs from the PR revision, so
+# a PR author can only decide whether the dispatcher wakes, never what it
+# does.
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
 
+concurrency:
+  # One run per PR. New pushes cancel superseded runs.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  authorize:
-    name: Authorize and resolve target
-    if: >-
-      ${{ github.event.issue.pull_request != null &&
-      github.event.comment.body == '/ci-run-all-tests' }}
+  request:
+    name: request
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      head_sha: ${{ steps.resolve.outputs.head_sha }}
-      merge_sha: ${{ steps.resolve.outputs.merge_sha }}
+    timeout-minutes: 2
+    permissions: {}
     steps:
-      # Authorize the original commenter; `github.actor` changes on retries.
-      - name: Check commenter has write access or above
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        env:
-          COMMENTER: ${{ github.event.comment.user.login }}
-        with:
-          script: |
-            const commenter = process.env.COMMENTER;
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: commenter,
-            });
-            core.info(`${commenter}: permission=${data.permission} role=${data.role_name}`);
-
-            // The coarse permission field reports the maintain role as write.
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(
-                `@${commenter} has '${data.role_name}' access to this repo, but ` +
-                'triggering the full test suite requires write access or above.'
-              );
-            }
-
-      # Resolve immutable head and merge SHAs when the command is received.
-      # Mergeability is computed asynchronously, so poll until it is available.
-      - name: Resolve PR head and merge commit
-        id: resolve
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const pull_number = context.issue.number;
-            let pr;
-            for (let attempt = 1; attempt <= 10; attempt += 1) {
-              ({ data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number,
-              }));
-              if (pr.state !== 'open') {
-                core.setFailed(`PR #${pull_number} is ${pr.state}, not open.`);
-                return;
-              }
-              if (pr.mergeable !== null) {
-                break;
-              }
-              core.info(`Mergeability not computed yet (attempt ${attempt}/10); retrying in 3s.`);
-              await new Promise((resolve) => { setTimeout(resolve, 3000); });
-            }
-
-            if (pr.mergeable === null) {
-              core.setFailed(
-                `GitHub did not finish computing mergeability for PR #${pull_number}. ` +
-                'Comment /ci-run-all-tests again in a moment.'
-              );
-              return;
-            }
-            if (pr.mergeable === false) {
-              core.setFailed(
-                `PR #${pull_number} conflicts with ${pr.base.ref}. Merge or rebase ` +
-                `${pr.base.ref} before running the full suite.`
-              );
-              return;
-            }
-            if (!pr.merge_commit_sha) {
-              core.setFailed(`PR #${pull_number} has no test merge commit to test.`);
-              return;
-            }
-
-            core.info(`Testing merge commit ${pr.merge_commit_sha} (head ${pr.head.sha}).`);
-            core.setOutput('head_sha', pr.head.sha);
-            core.setOutput('merge_sha', pr.merge_commit_sha);
-
-  full-tests:
-    name: Run full test suite
-    needs: authorize
-    uses: ./.github/workflows/full-tests.yml
-    permissions:
-      contents: read
-      statuses: write
-    with:
-      head_sha: ${{ needs.authorize.outputs.head_sha }}
-      merge_sha: ${{ needs.authorize.outputs.merge_sha }}
-      pr_number: ${{ github.event.issue.number }}
-    secrets:
-      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Request the full test suite
+        run: echo "Requesting the full test suite for commit ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -1,39 +1,28 @@
 name: Full test suite
 
-# Runs `make test-all` against a PR merge commit and reports status on its head.
+# Trusted dispatcher for the full test suite. `workflow_run` executes the
+# default-branch workflow definition, so PR authors cannot weaken the suite or
+# forge its result by editing it in the PR. It runs `make test-all` against the
+# PR merge commit whenever the trigger workflow completes, skips docs- and
+# UI-only changes, and publishes the `full-test-suite` commit status on the
+# PR head.
 on:
-  workflow_call:
-    inputs:
-      head_sha:
-        description: "PR head SHA -- the commit the status is reported on"
-        required: true
-        type: string
-      merge_sha:
-        description: "PR test merge commit SHA -- this is what gets tested"
-        required: true
-        type: string
-      pr_number:
-        description: "PR number being tested"
-        required: true
-        type: string
-    secrets:
-      DISCORD_WEBHOOK:
-        required: false
+  workflow_run:
+    workflows: [Full test suite trigger]
+    types: [completed]
 
 permissions:
   contents: read
 
-env:
-  # Must match the required status context in branch protection.
-  STATUS_CONTEXT: "full-test-suite"
-
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.pr_number }}
+  # One run per PR. New pushes cancel superseded runs.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
   prepare:
     name: Set pending status
+    if: github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-24.04
     timeout-minutes: 3
     permissions:
@@ -41,7 +30,7 @@ jobs:
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
-          STATUS_SHA: ${{ inputs.head_sha }}
+          STATUS_SHA: ${{ github.event.workflow_run.head_sha }}
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -49,7 +38,7 @@ jobs:
               repo: context.repo.repo,
               sha: process.env.STATUS_SHA,
               state: 'pending',
-              context: process.env.STATUS_CONTEXT,
+              context: 'full-test-suite',
               description: 'Running full test suite...',
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
@@ -59,19 +48,145 @@ jobs:
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    # PR-authored code runs only in this job. It has no secrets or write access,
-    # checkout does not persist credentials, and cache writes are disabled. Jobs
-    # with write access never execute PR code. This isolation mitigates CodeQL's
-    # `actions/untrusted-checkout` finding.
+    # PR-authored code runs only in this job, with no secrets or write access
+    # (CodeQL `actions/untrusted-checkout` mitigation).
     permissions:
       contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      merge_sha: ${{ steps.resolve.outputs.merge_sha }}
+      affects_suite: ${{ steps.changes.outputs.affects_suite }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Resolve the PR by head and a fresh merge SHA. Mergeability is computed
+      # asynchronously, so poll until it is available.
+      - name: Resolve PR and merge commit
+        id: resolve
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
-          ref: ${{ inputs.merge_sha }}
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}`,
+              state: 'open',
+            });
+            const pull = prs.find((pr) => pr.head.sha === process.env.HEAD_SHA);
+            if (!pull) {
+              core.setFailed(
+                `No open PR has head ${process.env.HEAD_SHA}. ` +
+                'The branch may have been force pushed. Push again to retrigger.'
+              );
+              return;
+            }
+            core.setOutput('pr_number', String(pull.number));
+
+            let pr;
+            for (let attempt = 1; attempt <= 10; attempt += 1) {
+              ({ data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pull.number,
+              }));
+              if (pr.state !== 'open') {
+                core.setFailed(`PR #${pull.number} is ${pr.state}, not open.`);
+                return;
+              }
+              if (pr.mergeable !== null) {
+                break;
+              }
+              core.info(`Mergeability not computed yet (attempt ${attempt}/10), retrying in 3s.`);
+              await new Promise((resolve) => { setTimeout(resolve, 3000); });
+            }
+
+            if (pr.mergeable === null) {
+              core.setFailed(
+                `GitHub did not finish computing mergeability for PR #${pull.number}. ` +
+                'Re-run the workflow in a moment.'
+              );
+              return;
+            }
+            if (pr.mergeable === false) {
+              core.setFailed(
+                `PR #${pull.number} conflicts with ${pr.base.ref}. Merge or rebase ` +
+                `${pr.base.ref} for the full test suite to run.`
+              );
+              return;
+            }
+            if (!pr.merge_commit_sha) {
+              core.setFailed(`PR #${pull.number} has no test merge commit to test.`);
+              return;
+            }
+
+            core.info(`Testing merge commit ${pr.merge_commit_sha} (head ${pr.head.sha}).`);
+            core.setOutput('merge_sha', pr.merge_commit_sha);
+
+      # Skip only when every changed file is docs or UI (the UI has its own
+      # ui-ci.yml). Everything else runs the suite. Renames count on both
+      # sides.
+      - name: Detect changes that can affect the test suite
+        id: changes
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const pull_number = Number(process.env.PR_NUMBER);
+            const isSafe = (path) =>
+              path.endsWith('.md') ||
+              path.startsWith('docs/') ||
+              path.startsWith('quickwit/quickwit-ui/');
+
+            let allSafe = true;
+            let unsafe = '';
+            for (let page = 1; allSafe; page += 1) {
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number,
+                per_page: 100,
+                page,
+              });
+              if (files.length === 0) {
+                break;
+              }
+              for (const file of files) {
+                const paths = [file.filename];
+                if (file.previous_filename) {
+                  paths.push(file.previous_filename);
+                }
+                for (const path of paths) {
+                  if (!isSafe(path)) {
+                    allSafe = false;
+                    unsafe = path;
+                    break;
+                  }
+                }
+                if (!allSafe) {
+                  break;
+                }
+              }
+            }
+
+            core.info(
+              allSafe
+                ? 'All changed files are docs or UI, skipping the full test suite.'
+                : `Changed file ${unsafe} can affect the test suite, running it.`
+            );
+            core.setOutput('affects_suite', allSafe ? 'false' : 'true');
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.changes.outputs.affects_suite == 'true'
+        with:
+          ref: ${{ steps.resolve.outputs.merge_sha }}
           persist-credentials: false
 
       - name: Install Ubuntu packages
+        if: steps.changes.outputs.affects_suite == 'true'
         run: |
           sudo apt-get update
           sudo apt-get -y install libsasl2-dev libcurl4-openssl-dev
@@ -79,19 +194,22 @@ jobs:
       # apt's protobuf-compiler is too old for proto3 optional fields required
       # by the substrait crate enabled through the datafusion feature.
       - name: Install protoc
+        if: steps.changes.outputs.affects_suite == 'true'
         uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1
         with:
           tool: protoc
 
       - name: Setup stable Rust Toolchain
+        if: steps.changes.outputs.affects_suite == 'true'
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
-      # Do not save caches from PR code: `issue_comment` runs use the default-
-      # branch cache scope, so writes could poison trusted workflows. Reuse the
-      # trusted `quickwit-cargo` key read-only.
+      # workflow_run runs use the default-branch cache scope, so writes would
+      # let PR-authored code poison trusted caches. Reuse the trusted
+      # `quickwit-cargo` key read-only.
       - name: Setup cache (read-only)
+        if: steps.changes.outputs.affects_suite == 'true'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "./quickwit -> target"
@@ -99,17 +217,19 @@ jobs:
           save-if: false
 
       - name: Install cargo-nextest
+        if: steps.changes.outputs.affects_suite == 'true'
         uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1
         with:
           tool: cargo-nextest
 
       - name: Run full test suite
+        if: steps.changes.outputs.affects_suite == 'true'
         run: make test-all
 
   report-status:
     name: Report final status
     needs: [prepare, full-tests]
-    if: ${{ always() && needs.prepare.result == 'success' }}
+    if: always() && needs.prepare.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 3
     permissions:
@@ -117,24 +237,31 @@ jobs:
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
-          TEST_SHA: ${{ inputs.merge_sha }}
-          STATUS_SHA: ${{ inputs.head_sha }}
+          STATUS_SHA: ${{ github.event.workflow_run.head_sha }}
           RESULT: ${{ needs.full-tests.result }}
+          AFFECTS_SUITE: ${{ needs.full-tests.outputs.affects_suite }}
+          MERGE_SHA: ${{ needs.full-tests.outputs.merge_sha }}
         with:
           script: |
+            const skipped = process.env.AFFECTS_SUITE === 'false';
             const state = process.env.RESULT === 'success' ? 'success' : 'failure';
-            const testSha = process.env.TEST_SHA;
+            const mergeSha = process.env.MERGE_SHA;
             const statusSha = process.env.STATUS_SHA;
-
-            const suffix = testSha === statusSha ? '' : ` (merge commit ${testSha.slice(0, 7)})`;
+            const suffix =
+              !skipped && mergeSha && mergeSha !== statusSha
+                ? ` (merge commit ${mergeSha.slice(0, 7)})`
+                : '';
+            const description = skipped
+              ? 'Full test suite skipped (docs/UI only)'
+              : (state === 'success' ? 'Full test suite passed' : 'Full test suite failed') + suffix;
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: statusSha,
               state,
-              context: process.env.STATUS_CONTEXT,
-              description: (state === 'success' ? 'Full test suite passed' : 'Full test suite failed') + suffix,
+              context: 'full-test-suite',
+              description,
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
 
@@ -147,11 +274,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     permissions: {}
-    # Job-level env is required by the step condition. This job does not check
+    # Job-level env is required by the step condition. This job never checks
     # out PR code.
     env:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-      TARGET: "PR #${{ inputs.pr_number }}"
+      TARGET: "PR #${{ needs.full-tests.outputs.pr_number }}"
     steps:
       - name: Send message
         if: env.DISCORD_WEBHOOK != ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Feel free to send your contribution in an unfinished state to get early feedback
 In that case, simply mark the PR with the tag [WIP] (standing for work in progress).
 
 ## PR verification checks
-When you submit a pull request to the project, the CI system runs several verification checks. A collaborator with write access or above can run the full test suite by commenting `/ci-run-all-tests` on the pull request. This runs `make test-all` (all features, failpoints, and all broker backends) against the pull request merged with its base branch and publishes the `full-test-suite` commit status. It takes approximately 22 minutes. If you push new commits afterwards, the command must be run again. Maintainers should run the full test suite before merging a pull request.
+When you submit a pull request to the project, the CI system runs several verification checks. On every commit pushed to the pull request, the CI also runs the full test suite: `make test-all` (all features, failpoints, and all broker backends) against the pull request merged with its base branch. Changes that only touch documentation or the UI skip the run. It takes approximately 22 minutes, and superseded runs are cancelled automatically when you push new commits.
 
 You will be notified by email from the CI system if any issues are discovered, but if you want to run these checks locally before submitting PR or in order to verify changes you can use the following commands in the root directory:
 1. To verify that all tests are passing, run `make test-all`.


### PR DESCRIPTION
### Description

Runs make test-all on every commit pushed to any PR, from any author including forks. The only exception is a commit that touches nothing but markdown, docs/, or quickwit/quickwit-ui/, which is skipped. Everything else, including dependency bumps and any file type it doesn't recognize, runs the full suite.

This will be a required check.