### PR TITLE
limit tag pruning to where it works

### DIFF
--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/doc_mapper_impl.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/doc_mapper_impl.rs
@@ -1943,7 +1943,7 @@ mod tests {
             }"#,
             "concat",
             r#"{"some_text": "this is a text", "other_text": "this is a text too"}"#,
-            vec!["this is a text".into(), "this is a text too".into()],
+            vec!["this is a text too".into(), "this is a text".into()],
         );
     }
 

--- a/quickwit/quickwit-doc-mapper/src/doc_mapper/doc_mapper_impl.rs
+++ b/quickwit/quickwit-doc-mapper/src/doc_mapper/doc_mapper_impl.rs
@@ -1943,7 +1943,7 @@ mod tests {
             }"#,
             "concat",
             r#"{"some_text": "this is a text", "other_text": "this is a text too"}"#,
-            vec!["this is a text too".into(), "this is a text".into()],
+            vec!["this is a text".into(), "this is a text too".into()],
         );
     }
 

--- a/quickwit/quickwit-doc-mapper/src/tag_pruning.rs
+++ b/quickwit/quickwit-doc-mapper/src/tag_pruning.rs
@@ -92,22 +92,11 @@ fn extract_unsimplified_tags_filter_ast(query_ast: QueryAst) -> UnsimplifiedTagF
                 value: full_text_query.text,
             }
         }
-        QueryAst::PhrasePrefix(phrase_prefix_query) => {
-            // TODO same as FullText above.
-            UnsimplifiedTagFilterAst::Tag {
-                is_present: true,
-                field: phrase_prefix_query.field,
-                value: phrase_prefix_query.phrase,
-            }
-        }
-        QueryAst::Wildcard(wildcard_query) => {
-            // TODO same as FullText above.
-            UnsimplifiedTagFilterAst::Tag {
-                is_present: true,
-                field: wildcard_query.field,
-                value: wildcard_query.value,
-            }
-        }
+        // TODO this is somewhat informative, but we need tokenization and glob-like metastore
+        // semantic
+        QueryAst::PhrasePrefix(_) => UnsimplifiedTagFilterAst::Uninformative,
+        // TODO this is somewhat informative, but we need glob-like metastore semantic
+        QueryAst::Wildcard(_) => UnsimplifiedTagFilterAst::Uninformative,
         QueryAst::Boost { underlying, .. } => extract_unsimplified_tags_filter_ast(*underlying),
         QueryAst::UserInput(_user_text_query) => {
             panic!("Extract unsimplified should only be called on AST without UserInputQuery.");

--- a/quickwit/quickwit-doc-mapper/src/tag_pruning.rs
+++ b/quickwit/quickwit-doc-mapper/src/tag_pruning.rs
@@ -32,10 +32,10 @@ pub fn match_tag_field_name(field_name: &str, tag: &str) -> bool {
 /// If the predicate evaluates to false for a given set of tags
 /// associated with a split, we are guaranteed that no documents
 /// in the split matches the query.
-pub fn extract_tags_from_query(query_ast: QueryAst) -> Option<TagFilterAst> {
+pub fn extract_tags_from_query(query_ast: QueryAst) -> MaybeAst<TagFilterAst> {
     let unsimplified_tag_filter_ast = extract_unsimplified_tags_filter_ast(query_ast);
-    let term_filters_ast = simplify_ast(unsimplified_tag_filter_ast)?;
-    Some(expand_to_tag_ast(term_filters_ast))
+    let term_filters_ast = simplify_ast(unsimplified_tag_filter_ast);
+    term_filters_ast.map(expand_to_tag_ast)
 }
 
 fn extract_unsimplified_tags_filter_ast(query_ast: QueryAst) -> UnsimplifiedTagFilterAst {
@@ -61,7 +61,8 @@ fn extract_unsimplified_tags_filter_ast(query_ast: QueryAst) -> UnsimplifiedTagF
             field: term_query.field,
             value: term_query.value,
         },
-        QueryAst::MatchAll | QueryAst::MatchNone => UnsimplifiedTagFilterAst::Uninformative,
+        QueryAst::MatchAll => UnsimplifiedTagFilterAst::Uninformative,
+        QueryAst::MatchNone => UnsimplifiedTagFilterAst::NoMatch,
         QueryAst::Range(_) => {
             // We could technically add support for range over some quantitive tag value (like we do
             // for timestamps). This is not supported at this point.
@@ -124,6 +125,35 @@ enum UnsimplifiedTagFilterAst {
     /// Any subnode of the `UserInputAST` can be
     /// replaced by `Uninformative` while still being correct.
     Uninformative,
+    NoMatch,
+}
+
+/// Result of simplifying a tag filter AST, once uninformative
+/// and always-true/always-false leaves have been pruned away.
+#[derive(Debug, PartialEq, Clone)]
+pub enum MaybeAst<T> {
+    /// A simplified, informative AST remains.
+    Ast(T),
+    /// The predicate carries no information: the split may or may not match.
+    MaybeMatch,
+    /// The predicate can never be satisfied: the split cannot match.
+    NoMatch,
+}
+
+impl<T> MaybeAst<T> {
+    fn map<U>(self, f: impl FnOnce(T) -> U) -> MaybeAst<U> {
+        match self {
+            MaybeAst::Ast(ast) => MaybeAst::Ast(f(ast)),
+            MaybeAst::MaybeMatch => MaybeAst::MaybeMatch,
+            MaybeAst::NoMatch => MaybeAst::NoMatch,
+        }
+    }
+}
+
+impl<T> From<T> for MaybeAst<T> {
+    fn from(ast: T) -> Self {
+        Self::Ast(ast)
+    }
 }
 
 /// Represents a tag filter used for split pruning.
@@ -220,28 +250,46 @@ impl TagFilterAst {
 // The resulting AST does not contain any uninformative leaves.
 //
 // Returning None here, is to be interpreted as returning `True`.
-fn simplify_ast(ast: UnsimplifiedTagFilterAst) -> Option<TermFilterAst> {
+fn simplify_ast(ast: UnsimplifiedTagFilterAst) -> MaybeAst<TermFilterAst> {
     match ast {
         UnsimplifiedTagFilterAst::And(conditions) => {
-            let mut pruned_conditions: Vec<TermFilterAst> =
-                conditions.into_iter().filter_map(simplify_ast).collect();
-            match pruned_conditions.len() {
-                0 => None,
-                1 => pruned_conditions.pop().unwrap().into(),
-                _ => TermFilterAst::And(pruned_conditions).into(),
+            let simplified_conditions: Vec<MaybeAst<TermFilterAst>> =
+                conditions.into_iter().map(simplify_ast).collect();
+            // an empty And before MaybeMatch filtering matches nothing
+            if simplified_conditions.is_empty() {
+                return MaybeAst::NoMatch;
+            }
+            let mut prunned_conditions: Vec<TermFilterAst> =
+                Vec::with_capacity(simplified_conditions.len());
+            for condition in simplified_conditions {
+                match condition {
+                    MaybeAst::NoMatch => return MaybeAst::NoMatch,
+                    MaybeAst::MaybeMatch => continue,
+                    MaybeAst::Ast(ast) => prunned_conditions.push(ast),
+                }
+            }
+            match prunned_conditions.len() {
+                0 => MaybeAst::MaybeMatch,
+                1 => prunned_conditions.pop().unwrap().into(),
+                _ => TermFilterAst::And(prunned_conditions).into(),
             }
         }
         UnsimplifiedTagFilterAst::Or(conditions) => {
-            let mut pruned_conditions: Vec<TermFilterAst> = Vec::new();
-            for condition in conditions {
-                // If we get None as part of the condition here, we return None
-                // directly. (Remember None means True).
-                pruned_conditions.push(simplify_ast(condition)?);
+            let simplified_conditions: Vec<MaybeAst<TermFilterAst>> =
+                conditions.into_iter().map(simplify_ast).collect();
+            let mut prunned_conditions: Vec<TermFilterAst> =
+                Vec::with_capacity(simplified_conditions.len());
+            for condition in simplified_conditions {
+                match condition {
+                    MaybeAst::NoMatch => continue,
+                    MaybeAst::MaybeMatch => return MaybeAst::MaybeMatch,
+                    MaybeAst::Ast(ast) => prunned_conditions.push(ast),
+                }
             }
-            match pruned_conditions.len() {
-                0 => None,
-                1 => pruned_conditions.pop().unwrap().into(),
-                _ => TermFilterAst::Or(pruned_conditions).into(),
+            match prunned_conditions.len() {
+                0 => MaybeAst::NoMatch,
+                1 => prunned_conditions.pop().unwrap().into(),
+                _ => TermFilterAst::Or(prunned_conditions).into(),
             }
         }
         UnsimplifiedTagFilterAst::Tag {
@@ -250,17 +298,18 @@ fn simplify_ast(ast: UnsimplifiedTagFilterAst) -> Option<TermFilterAst> {
             value,
         } => {
             if is_present {
-                Some(TermFilterAst::Term { field, value })
+                TermFilterAst::Term { field, value }.into()
             } else {
                 // we can't do tag pruning on negative filters. If `field` can be one of 1 or 2,
                 // and we search for not(1), we don't want to remove a split where
                 // tags=[1,2] (which is_present: false does). It's even more problematic if some
                 // documents have `field` unset, because we don't record that at all, so can't
                 // even reject a split based on it having tags=[1].
-                None
+                MaybeAst::MaybeMatch
             }
         }
-        UnsimplifiedTagFilterAst::Uninformative => None,
+        UnsimplifiedTagFilterAst::Uninformative => MaybeAst::MaybeMatch,
+        UnsimplifiedTagFilterAst::NoMatch => MaybeAst::NoMatch,
     }
 }
 
@@ -353,6 +402,10 @@ fn negate_ast(clause: UnsimplifiedTagFilterAst) -> UnsimplifiedTagFilterAst {
             value,
         },
         UnsimplifiedTagFilterAst::Uninformative => UnsimplifiedTagFilterAst::Uninformative,
+        // TODO we could convert into an "Always Match". This could make some query lighter on the
+        // metastore we'd need a query with a double negation to actually prune more splits with
+        // that
+        UnsimplifiedTagFilterAst::NoMatch => UnsimplifiedTagFilterAst::Uninformative,
     }
 }
 
@@ -377,9 +430,9 @@ mod test {
     use quickwit_query::query_ast::{QueryAst, UserInputQuery};
 
     use super::extract_tags_from_query;
-    use crate::tag_pruning::TagFilterAst;
+    use crate::tag_pruning::{MaybeAst, TagFilterAst};
 
-    fn extract_tags_from_query_helper(user_query: &str) -> Option<TagFilterAst> {
+    fn extract_tags_from_query_helper(user_query: &str) -> MaybeAst<TagFilterAst> {
         let query_ast: QueryAst = UserInputQuery {
             user_text: user_query.to_string(),
             default_fields: None,
@@ -391,22 +444,39 @@ mod test {
         extract_tags_from_query(parsed_query_ast)
     }
 
+    fn unwrap_ast(maybe_ast: MaybeAst<TagFilterAst>) -> TagFilterAst {
+        match maybe_ast {
+            MaybeAst::Ast(ast) => ast,
+            MaybeAst::MaybeMatch => panic!("expected an Ast, got MaybeMatch"),
+            MaybeAst::NoMatch => panic!("expected an Ast, got NoMatch"),
+        }
+    }
+
     #[test]
     fn test_extract_tags_from_query_all() {
-        assert_eq!(extract_tags_from_query_helper("*"), None);
+        assert_eq!(extract_tags_from_query_helper("*"), MaybeAst::MaybeMatch);
+    }
+
+    #[test]
+    fn test_extract_tags_from_query_none() {
+        assert_eq!(
+            extract_tags_from_query(QueryAst::MatchNone),
+            MaybeAst::NoMatch
+        );
     }
 
     #[test]
     fn test_extract_tags_from_query_range_query() {
-        assert_eq!(extract_tags_from_query_helper("title:>foo lang:fr"), None);
+        assert_eq!(
+            extract_tags_from_query_helper("title:>foo lang:fr"),
+            MaybeAst::MaybeMatch
+        );
     }
 
     #[test]
     fn test_extract_tags_from_query_range_query_conjunction() {
         assert_eq!(
-            &extract_tags_from_query_helper("title:>foo AND lang:fr")
-                .unwrap()
-                .to_string(),
+            &unwrap_ast(extract_tags_from_query_helper("title:>foo AND lang:fr")).to_string(),
             "(¬lang! ∨ lang:fr)"
         );
     }
@@ -414,9 +484,10 @@ mod test {
     #[test]
     fn test_extract_tags_from_query_mixed_disjunction() -> anyhow::Result<()> {
         assert_eq!(
-            &extract_tags_from_query_helper("title:foo user:bart lang:fr")
-                .unwrap()
-                .to_string(),
+            &unwrap_ast(extract_tags_from_query_helper(
+                "title:foo user:bart lang:fr"
+            ))
+            .to_string(),
             "((¬title! ∨ title:foo) ∨ (¬user! ∨ user:bart) ∨ (¬lang! ∨ lang:fr))"
         );
         Ok(())
@@ -425,9 +496,10 @@ mod test {
     #[test]
     fn test_extract_tags_from_query_and_or() -> anyhow::Result<()> {
         assert_eq!(
-            &extract_tags_from_query_helper("title:foo AND (user:bart OR lang:fr)")
-                .unwrap()
-                .to_string(),
+            &unwrap_ast(extract_tags_from_query_helper(
+                "title:foo AND (user:bart OR lang:fr)"
+            ))
+            .to_string(),
             "(¬title! ∨ title:foo) ∧ ((¬user! ∨ user:bart) ∨ (¬lang! ∨ lang:fr))"
         );
         Ok(())
@@ -436,9 +508,7 @@ mod test {
     #[test]
     fn test_conjunction_of_tags() {
         assert_eq!(
-            &extract_tags_from_query_helper("(user:bart AND lang:fr)")
-                .unwrap()
-                .to_string(),
+            &unwrap_ast(extract_tags_from_query_helper("(user:bart AND lang:fr)")).to_string(),
             "(¬user! ∨ user:bart) ∧ (¬lang! ∨ lang:fr)"
         );
     }
@@ -446,9 +516,7 @@ mod test {
     #[test]
     fn test_disjunction_of_tags() {
         assert_eq!(
-            &extract_tags_from_query_helper("(user:bart OR lang:fr)")
-                .unwrap()
-                .to_string(),
+            &unwrap_ast(extract_tags_from_query_helper("(user:bart OR lang:fr)")).to_string(),
             "((¬user! ∨ user:bart) ∨ (¬lang! ∨ lang:fr))"
         );
     }
@@ -456,16 +524,17 @@ mod test {
     #[test]
     fn test_disjunction_of_tag_disjunction_with_not_clause() {
         // ORed negative tags make the result inconclusive. See simplify_ast() for details
-        assert!(extract_tags_from_query_helper("(user:bart -lang:fr)").is_none());
+        assert_eq!(
+            extract_tags_from_query_helper("(user:bart -lang:fr)"),
+            MaybeAst::MaybeMatch
+        );
     }
 
     #[test]
     fn test_disjunction_of_tag_conjunction_with_not_clause() {
         // negative tags are removed from AND clauses. See simplify_ast() for details
         assert_eq!(
-            &extract_tags_from_query_helper("user:bart AND NOT lang:fr")
-                .unwrap()
-                .to_string(),
+            &unwrap_ast(extract_tags_from_query_helper("user:bart AND NOT lang:fr")).to_string(),
             "(¬user! ∨ user:bart)"
         );
     }
@@ -473,9 +542,7 @@ mod test {
     #[test]
     fn test_disjunction_of_tag_must_should() {
         assert_eq!(
-            &extract_tags_from_query_helper("(+user:bart lang:fr)")
-                .unwrap()
-                .to_string(),
+            &unwrap_ast(extract_tags_from_query_helper("(+user:bart lang:fr)")).to_string(),
             "(¬user! ∨ user:bart)"
         );
     }

--- a/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
+++ b/quickwit/quickwit-janitor/src/actors/delete_task_planner.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, Handler, Mailbox, QueueCapacity};
 use quickwit_common::extract_time_range;
 use quickwit_common::uri::Uri;
-use quickwit_doc_mapper::tag_pruning::extract_tags_from_query;
+use quickwit_doc_mapper::tag_pruning::{MaybeAst, extract_tags_from_query};
 use quickwit_indexing::actors::{MergeSchedulerService, MergeSplitDownloader, schedule_merge};
 use quickwit_indexing::merge_policy::MergeOperation;
 use quickwit_metastore::{ListSplitsResponseExt, Split, split_tag_filter, split_time_range_filter};
@@ -254,7 +254,11 @@ impl DeleteTaskPlanner {
                     // TODO: validate the query at the beginning and return an appropriate error.
                     let delete_query_ast = serde_json::from_str(&delete_query.query_ast)
                         .expect("Failed to deserialize query_ast json");
-                    let tags_filter = extract_tags_from_query(delete_query_ast);
+                    let tags_filter = match extract_tags_from_query(delete_query_ast) {
+                        MaybeAst::NoMatch => return false,
+                        MaybeAst::MaybeMatch => None,
+                        MaybeAst::Ast(ast) => Some(ast),
+                    };
                     split_time_range_filter(&stale_split.split_metadata, time_range.as_ref())
                         && split_tag_filter(&stale_split.split_metadata, tags_filter.as_ref())
                 })

--- a/quickwit/quickwit-search/src/list_fields/root.rs
+++ b/quickwit/quickwit-search/src/list_fields/root.rs
@@ -20,7 +20,7 @@ use futures::future::try_join_all;
 use quickwit_common::rate_limited_warn;
 use quickwit_common::uri::Uri;
 use quickwit_config::build_doc_mapper;
-use quickwit_doc_mapper::tag_pruning::extract_tags_from_query;
+use quickwit_doc_mapper::tag_pruning::{MaybeAst, extract_tags_from_query};
 use quickwit_metastore::SplitMetadata;
 use quickwit_proto::metastore::MetastoreServiceClient;
 use quickwit_proto::search::{
@@ -106,7 +106,11 @@ pub async fn root_list_fields(
                 &mut end_timestamp,
             );
         }
-        extract_tags_from_query(query_ast)
+        match extract_tags_from_query(query_ast) {
+            MaybeAst::Ast(ast) => Some(ast),
+            MaybeAst::MaybeMatch => None,
+            MaybeAst::NoMatch => return Ok(ListFieldsResponse::default()), // nothing matches
+        }
     } else {
         None
     };

--- a/quickwit/quickwit-search/src/root.rs
+++ b/quickwit/quickwit-search/src/root.rs
@@ -26,7 +26,7 @@ use quickwit_common::thread_pool::with_priority::Priority;
 use quickwit_common::uri::Uri;
 use quickwit_config::build_doc_mapper;
 use quickwit_doc_mapper::DYNAMIC_FIELD_NAME;
-use quickwit_doc_mapper::tag_pruning::extract_tags_from_query;
+use quickwit_doc_mapper::tag_pruning::{MaybeAst, extract_tags_from_query};
 use quickwit_metastore::{IndexMetadata, ListIndexesMetadataResponseExt, SplitMetadata};
 use quickwit_proto::metastore::{
     ListIndexesMetadataRequest, MetastoreService, MetastoreServiceClient,
@@ -1235,7 +1235,11 @@ async fn refine_and_list_matches(
             &mut search_request.end_timestamp,
         );
     }
-    let tag_filter_ast = extract_tags_from_query(query_ast_resolved);
+    let tag_filter_ast = match extract_tags_from_query(query_ast_resolved) {
+        MaybeAst::Ast(ast) => Some(ast),
+        MaybeAst::MaybeMatch => None,
+        MaybeAst::NoMatch => return Ok(Vec::new()), // nothing matches
+    };
 
     // TODO if search after is set, we sort by timestamp and we don't want to count all results,
     // we can refine more here. Same if we sort by _shard_doc

--- a/quickwit/quickwit-search/src/tests.rs
+++ b/quickwit/quickwit-search/src/tests.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use assert_json_diff::{assert_json_eq, assert_json_include};
 use quickwit_config::SearcherConfig;
 use quickwit_doc_mapper::DocMapper;
-use quickwit_doc_mapper::tag_pruning::extract_tags_from_query;
+use quickwit_doc_mapper::tag_pruning::{MaybeAst, extract_tags_from_query};
 use quickwit_indexing::TestSandbox;
 use quickwit_proto::search::{
     LeafListTermsResponse, ListTermsRequest, SearchRequest, SortByValue, SortField, SortOrder,
@@ -38,6 +38,16 @@ use crate::find_trace_ids_collector::Span;
 use crate::list_terms::leaf_list_terms;
 use crate::service::SearcherContext;
 use crate::single_node_search;
+
+fn extract_tags_filter_opt(
+    query_ast: QueryAst,
+) -> Option<quickwit_doc_mapper::tag_pruning::TagFilterAst> {
+    match extract_tags_from_query(query_ast) {
+        MaybeAst::Ast(ast) => Some(ast),
+        MaybeAst::MaybeMatch => None,
+        MaybeAst::NoMatch => panic!("test query unexpectedly matches no document"),
+    }
+}
 
 #[tokio::test]
 async fn test_single_node_simple() -> anyhow::Result<()> {
@@ -965,7 +975,7 @@ async fn test_single_node_split_pruning_by_tags() -> anyhow::Result<()> {
         vec![index_uid.clone()],
         None,
         None,
-        extract_tags_from_query(query_ast),
+        extract_tags_filter_opt(query_ast),
         &test_sandbox.metastore(),
     )
     .await?;
@@ -977,7 +987,7 @@ async fn test_single_node_split_pruning_by_tags() -> anyhow::Result<()> {
         vec![index_uid.clone()],
         None,
         None,
-        extract_tags_from_query(query_ast),
+        extract_tags_filter_opt(query_ast),
         &test_sandbox.metastore(),
     )
     .await?;
@@ -989,7 +999,7 @@ async fn test_single_node_split_pruning_by_tags() -> anyhow::Result<()> {
         vec![index_uid.clone()],
         None,
         None,
-        extract_tags_from_query(query_ast),
+        extract_tags_filter_opt(query_ast),
         &test_sandbox.metastore(),
     )
     .await?;


### PR DESCRIPTION
`service:quickwit*` searches for the literal `quickwit*` in the metastore, which it ain't gonna find, so no split matches and this query searches through zero split, despite some splits possibly containing `quickwit-searcher`, or even `quickwit`