### PR TITLE
fix(indexing): align sequencer capacity with upload concurrency

### DIFF
--- a/quickwit/quickwit-indexing/README.md
+++ b/quickwit/quickwit-indexing/README.md
@@ -8,7 +8,7 @@ flowchart LR
         indexer[Indexer] --1--> serializer
         serializer[IndexSerializer] --1--> packager
         packager[Packager] --0--> uploader
-        uploader[Uploader] --2--> sequencer
+        uploader[Uploader] --upload concurrency--> sequencer
         sequencer[Sequencer] --1--> publisher
     end
     subgraph Merge pipeline

--- a/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -321,7 +321,10 @@ impl IndexingPipeline {
             .set_backpressure_micros_counter(counter!(parent: BACKPRESSURE_MICROS, labels: [label_values!(ACTOR_NAME => "publisher")]))
             .spawn(publisher);
 
-        let sequencer = Sequencer::new(publisher_mailbox);
+        let sequencer = Sequencer::new(
+            publisher_mailbox,
+            QueueCapacity::Bounded(self.params.max_concurrent_split_uploads_index),
+        );
         let (sequencer_mailbox, sequencer_handle) = ctx
             .spawn_actor()
             .set_backpressure_micros_counter(counter!(parent: BACKPRESSURE_MICROS, labels: [label_values!(ACTOR_NAME => "sequencer")]))

--- a/quickwit/quickwit-indexing/src/actors/parquet_pipeline/mod.rs
+++ b/quickwit/quickwit-indexing/src/actors/parquet_pipeline/mod.rs
@@ -89,7 +89,10 @@ pub(crate) fn spawn_sequencer_for_test(
     universe: &quickwit_actors::Universe,
     publisher_mailbox: quickwit_actors::Mailbox<crate::actors::Publisher>,
 ) -> quickwit_actors::Mailbox<crate::actors::Sequencer<crate::actors::Publisher>> {
-    let sequencer = crate::actors::Sequencer::new(publisher_mailbox);
+    let sequencer = crate::actors::Sequencer::new(
+        publisher_mailbox,
+        quickwit_actors::QueueCapacity::Bounded(2),
+    );
     let (sequencer_mailbox, _sequencer_handle) = universe.spawn_builder().spawn(sequencer);
     sequencer_mailbox
 }

--- a/quickwit/quickwit-indexing/src/actors/parquet_pipeline/parquet_e2e_test.rs
+++ b/quickwit/quickwit-indexing/src/actors/parquet_pipeline/parquet_e2e_test.rs
@@ -521,7 +521,7 @@ async fn test_sketch_pipeline_e2e() {
     );
     let (publisher_mailbox, publisher_handle) = universe.spawn_builder().spawn(publisher);
 
-    let sequencer = Sequencer::new(publisher_mailbox);
+    let sequencer = Sequencer::new(publisher_mailbox, QueueCapacity::Bounded(4));
     let (sequencer_mailbox, _sequencer_handle) = universe.spawn_builder().spawn(sequencer);
 
     let uploader = ParquetUploader::new(

--- a/quickwit/quickwit-indexing/src/actors/parquet_pipeline/parquet_merge_pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/parquet_pipeline/parquet_merge_pipeline.rs
@@ -313,7 +313,10 @@ impl ParquetMergePipeline {
 
         // 2. Sequencer — ensures merged splits are published in the order they were uploaded, even
         //    if uploads complete out of order.
-        let sequencer = Sequencer::new(merge_publisher_mailbox.clone());
+        let sequencer = Sequencer::new(
+            merge_publisher_mailbox.clone(),
+            QueueCapacity::Bounded(self.params.max_concurrent_split_uploads),
+        );
         let (sequencer_mailbox, _sequencer_handle) = ctx
             .spawn_actor()
             .set_kill_switch(self.kill_switch.clone())

--- a/quickwit/quickwit-indexing/src/actors/parquet_pipeline/parquet_uploader.rs
+++ b/quickwit/quickwit-indexing/src/actors/parquet_pipeline/parquet_uploader.rs
@@ -705,7 +705,7 @@ mod tests {
         let (publisher_mailbox, publisher_inbox) = universe.create_test_mailbox::<Publisher>();
 
         // Create sequencer that forwards to publisher
-        let sequencer = Sequencer::new(publisher_mailbox);
+        let sequencer = Sequencer::new(publisher_mailbox, QueueCapacity::Bounded(4));
         let (sequencer_mailbox, _sequencer_handle) = universe.spawn_builder().spawn(sequencer);
 
         let mut mock_metastore = MockMetastoreService::new();

--- a/quickwit/quickwit-indexing/src/actors/parquet_pipeline/pipeline.rs
+++ b/quickwit/quickwit-indexing/src/actors/parquet_pipeline/pipeline.rs
@@ -349,7 +349,10 @@ impl MetricsPipeline {
             .spawn(publisher);
 
         // Sequencer
-        let sequencer = Sequencer::new(publisher_mailbox);
+        let sequencer = Sequencer::new(
+            publisher_mailbox,
+            QueueCapacity::Bounded(self.params.max_concurrent_split_uploads),
+        );
         let (sequencer_mailbox, sequencer_handle) = ctx
             .spawn_actor()
             .set_kill_switch(self.kill_switch.clone())

--- a/quickwit/quickwit-indexing/src/actors/sequencer.rs
+++ b/quickwit/quickwit-indexing/src/actors/sequencer.rs
@@ -32,11 +32,18 @@ use tokio::sync::oneshot;
 /// ensures that publish message are send in the right order.
 pub struct Sequencer<A: Actor> {
     mailbox: Mailbox<A>,
+    queue_capacity: QueueCapacity,
 }
 
 impl<A: Actor> Sequencer<A> {
-    pub fn new(mailbox: Mailbox<A>) -> Self {
-        Sequencer { mailbox }
+    /// The queue must be large enough to hold the reservations for all concurrent producers.
+    /// Otherwise, its backpressure becomes a lower concurrency limit than the producer's own
+    /// semaphore.
+    pub fn new(mailbox: Mailbox<A>, queue_capacity: QueueCapacity) -> Self {
+        Sequencer {
+            mailbox,
+            queue_capacity,
+        }
     }
 }
 
@@ -45,7 +52,7 @@ impl<A: Actor> Actor for Sequencer<A> {
     type ObservableState = ();
 
     fn queue_capacity(&self) -> QueueCapacity {
-        QueueCapacity::Bounded(2)
+        self.queue_capacity
     }
 
     fn observable_state(&self) {}
@@ -124,10 +131,8 @@ mod tests {
         let universe = Universe::with_accelerated_time();
         let test_actor = SequencerTestActor::default();
         let (test_mailbox, test_handle) = universe.spawn_builder().spawn(test_actor);
-        let sequencer = Sequencer::new(test_mailbox);
+        let sequencer = Sequencer::new(test_mailbox, QueueCapacity::Bounded(2));
         let (sequencer_mailbox, sequencer_handle) = universe.spawn_builder().spawn(sequencer);
-        // The sequencer has a capacity of 2.
-        // This is the maximum we can do without provoking a deadlock.
         let (fut_tx_1, fut_rx_1) = oneshot::channel();
         let (fut_tx_2, fut_rx_2) = oneshot::channel();
         let (fut_tx_3, fut_rx_3) = oneshot::channel();


### PR DESCRIPTION
Closes #6312

### Description

Makes the sequencer mailbox capacity configurable and sizes it according to each pipeline’s configured concurrent upload limit.

Previously, every sequencer used a fixed mailbox capacity of two. Because uploaders reserve a position in the sequencer before starting an upload, this unintentionally limited each pipeline to three concurrent uploads, regardless of the configured upload concurrency.

The change covers the standard indexing pipeline, Parquet indexing pipeline, and Parquet merge pipeline. It also updates the indexing pipeline diagram to document the new relationship.

### How was this PR tested?

- Ran the `quickwit-indexing` unit tests successfully with a single test thread.
- Ran the relevant sequencer, uploader, and Parquet ordering tests.
- Ran `cargo clippy` with warnings treated as errors.
- Ran `make fmt`.