### PR TITLE
add a timeout layer to our gcp connector

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -540,6 +540,7 @@ opendal-core,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@op
 opendal-http-transport-reqwest,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
 opendal-layer-concurrent-limit,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
 opendal-layer-retry,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
+opendal-layer-timeout,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
 opendal-service-gcs,https://github.com/apache/opendal,Apache-2.0,Apache OpenDAL <dev@opendal.apache.org>
 openidconnect,https://github.com/ramosbugs/openidconnect-rs,MIT,David A. Ramos <ramos@cs.stanford.edu>
 openssl,https://github.com/rust-openssl/rust-openssl,Apache-2.0,Steven Fackler <sfackler@gmail.com>

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -6790,6 +6790,7 @@ dependencies = [
  "opendal-http-transport-reqwest",
  "opendal-layer-concurrent-limit",
  "opendal-layer-retry",
+ "opendal-layer-timeout",
  "opendal-service-gcs",
 ]
 
@@ -6854,6 +6855,16 @@ dependencies = [
  "backon",
  "log",
  "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a704141924500f3803c05ed871b53305d2a2f11cb5ef20160c3ee688a1857f66"
+dependencies = [
+ "opendal-core",
+ "tokio",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -388,6 +388,7 @@ opendal = { version = "0.58", default-features = false, features = [
   "http-transport-reqwest",
   "layers-retry",
   "layers-concurrent-limit",
+  "layers-timeout",
 ] }
 reqsign = { version = "0.18", default-features = false, features = ["google", "default-context"] }
 

--- a/quickwit/quickwit-storage/src/opendal_storage/base.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/base.rs
@@ -20,7 +20,7 @@ use std::{fmt, io};
 
 use async_trait::async_trait;
 use futures::AsyncWriteExt as FuturesAsyncWriteExt;
-use opendal::layers::{ConcurrentLimitLayer, RetryLayer};
+use opendal::layers::{ConcurrentLimitLayer, RetryLayer, TimeoutLayer};
 use opendal::{DeleteInput, IntoDeleteInput, Operator};
 use quickwit_common::get_from_env_cached;
 use quickwit_common::uri::Uri;
@@ -65,6 +65,7 @@ impl OpendalStorage {
     ) -> Result<Self, StorageResolverError> {
         opendal::install_default();
         let op = Operator::new(cfg)?
+            .layer(gcs_timeout_layer())
             .layer(gcs_retry_layer())
             .layer(GCS_CONCURRENT_LIMIT_LAYER.clone());
         Ok(Self::from_operator(uri, op))
@@ -87,8 +88,26 @@ impl OpendalStorage {
         cfg: opendal::services::Gcs,
         http_transport: opendal::HttpTransporter,
     ) -> Result<Self, StorageResolverError> {
+        Self::new_google_cloud_storage_with_http_transport_and_io_timeout_for_test(
+            uri,
+            cfg,
+            http_transport,
+            GCS_IO_TIMEOUT,
+        )
+    }
+
+    // same as `new_google_cloud_storage_with_http_transport_for_test` but let pick a custom
+    // timeout for testing purpose
+    #[cfg(test)]
+    pub(super) fn new_google_cloud_storage_with_http_transport_and_io_timeout_for_test(
+        uri: Uri,
+        cfg: opendal::services::Gcs,
+        http_transport: opendal::HttpTransporter,
+        io_timeout: Duration,
+    ) -> Result<Self, StorageResolverError> {
         let op = Operator::new(cfg)?
             .with_context(opendal::OperationContext::new().with_http_transport(http_transport))
+            .layer(gcs_timeout_layer_with(io_timeout))
             .layer(gcs_retry_layer())
             .layer(GCS_CONCURRENT_LIMIT_LAYER.clone());
         Ok(Self::from_operator(uri, op))
@@ -98,6 +117,21 @@ impl OpendalStorage {
     pub fn set_policy(&mut self, multipart_policy: MultiPartPolicy) {
         self.multipart_policy = multipart_policy;
     }
+}
+
+const GCS_CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
+const GCS_IO_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn gcs_timeout_layer() -> TimeoutLayer {
+    gcs_timeout_layer_with(GCS_IO_TIMEOUT)
+}
+
+// io_timeout is similar to s3 stalled stream protection. it also covers connect() timeout (though
+// we use a different connect and stalled stream timeout in our s3 connector)
+fn gcs_timeout_layer_with(io_timeout: Duration) -> TimeoutLayer {
+    TimeoutLayer::default()
+        .with_timeout(GCS_CONTROL_TIMEOUT)
+        .with_io_timeout(io_timeout)
 }
 
 /// Builds the retry layer applied to the GCS operator.

--- a/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
@@ -253,7 +253,8 @@ mod tests {
             )?;
 
         let result = tokio::time::timeout(
-            Duration::from_secs(5),
+            // high because we have arround 7s of retries in total
+            Duration::from_secs(15),
             storage.get_slice(Path::new("stalled.txt"), 0..1),
         )
         .await

--- a/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
@@ -116,6 +116,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::Path;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use base64::Engine;
     use opendal::HttpTransporter;
@@ -213,6 +214,57 @@ mod tests {
         let bytes = storage.get_slice(Path::new("hello.txt"), 0..2).await?;
         assert_eq!(bytes.as_slice(), b"ok");
         server_task.await??;
+        Ok(())
+    }
+
+    /// A TCP server that accepts connections but never writes a response
+    async fn start_stalling_gcs_server() -> anyhow::Result<(String, JoinHandle<()>)> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+        let endpoint = format!("http://127.0.0.1:{}", listener.local_addr()?.port());
+        let server_task = tokio::spawn(async move {
+            let mut held_streams = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held_streams.push(stream);
+            }
+            drop(held_streams);
+        });
+        Ok((endpoint, server_task))
+    }
+
+    #[tokio::test]
+    async fn test_gcs_storage_get_slice_errors_on_stalled_connection() -> anyhow::Result<()> {
+        let (endpoint, server_task) = start_stalling_gcs_server().await?;
+
+        let reqwest_client = reqwest_013::Client::builder().no_proxy().build()?;
+        let cfg = opendal::services::Gcs::default()
+            .bucket("quickwit-test-bucket")
+            .endpoint(&endpoint)
+            .skip_signature()
+            .disable_config_load()
+            .disable_vm_metadata();
+        let storage =
+            OpendalStorage::new_google_cloud_storage_with_http_transport_and_io_timeout_for_test(
+                Uri::for_test("gs://quickwit-test-bucket"),
+                cfg,
+                HttpTransporter::new(ReqwestTransport::new(reqwest_client)),
+                // Tight IO timeout so the test resolves in well under a second
+                // per attempt rather than the production 5s budget.
+                Duration::from_millis(200),
+            )?;
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            storage.get_slice(Path::new("stalled.txt"), 0..1),
+        )
+        .await
+        .expect("get_slice on a stalled GCS connection must not hang indefinitely");
+
+        assert!(
+            result.is_err(),
+            "a stalled GCS connection should surface as a storage error, not succeed"
+        );
+
+        server_task.abort();
         Ok(())
     }
 


### PR DESCRIPTION
currently on the query path, the timeout hitting is the leaf search one, at 30s, which causes a bunch of work to be loss because of one flaky connection