### PR TITLE
improvements to our gcs storage

### DIFF
--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -199,7 +199,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -679,6 +679,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "asyncband"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d85fd3d291fabcc40c7232c92c280ec1754fd7b5d7ea769f143222143e179a"
 
 [[package]]
 name = "atoi"
@@ -4041,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5454,7 +5460,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6453,7 +6459,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8365,6 +8371,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9491,6 +9507,8 @@ dependencies = [
  "quickwit-metrics",
  "quickwit-proto",
  "regex",
+ "reqsign-core",
+ "reqsign-google",
  "reqwest 0.12.28",
  "reqwest 0.13.4",
  "rustc-hash",
@@ -9607,7 +9625,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10014,9 +10032,8 @@ dependencies = [
 
 [[package]]
 name = "reqsign-aws-core"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4af084e1f3cbf3e67e0c972765399bce54ecec804cceba46b39a8331f3c1bff"
+version = "3.1.1"
+source = "git+https://github.com/apache/opendal-reqsign?rev=29f3a9a529f21a5ae0ae32cc9c0967045569d96d#29f3a9a529f21a5ae0ae32cc9c0967045569d96d"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -10024,7 +10041,7 @@ dependencies = [
  "http 1.4.2",
  "log",
  "percent-encoding",
- "quick-xml 0.41.0",
+ "quick-xml 0.42.0",
  "reqsign-core",
  "rust-ini",
  "serde",
@@ -10035,14 +10052,13 @@ dependencies = [
 
 [[package]]
 name = "reqsign-aws-v4"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac5b3b7cefa28933792b439186459f77f19f9b6edbeab41b8b187150361a206"
+version = "3.3.0"
+source = "git+https://github.com/apache/opendal-reqsign?rev=29f3a9a529f21a5ae0ae32cc9c0967045569d96d#29f3a9a529f21a5ae0ae32cc9c0967045569d96d"
 dependencies = [
  "bytes",
  "http 1.4.2",
  "log",
- "quick-xml 0.41.0",
+ "quick-xml 0.42.0",
  "reqsign-aws-core",
  "reqsign-core",
  "serde",
@@ -10050,14 +10066,13 @@ dependencies = [
 
 [[package]]
 name = "reqsign-core"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07dd510b1e1b9b241883e483358147fb2ed2d497a7b39b065ba61eb93deceb0"
+version = "3.3.1"
+source = "git+https://github.com/apache/opendal-reqsign?rev=29f3a9a529f21a5ae0ae32cc9c0967045569d96d#29f3a9a529f21a5ae0ae32cc9c0967045569d96d"
 dependencies = [
  "anyhow",
+ "asyncband",
  "base64 0.23.0",
  "bytes",
- "futures",
  "hex",
  "hmac 0.13.0",
  "http 1.4.2",
@@ -10085,10 +10100,10 @@ dependencies = [
 
 [[package]]
 name = "reqsign-google"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4080a227f82a09f68540ecd028622065d7ac4c0bcb8727a25bdcfc0526235792"
+version = "3.1.1"
+source = "git+https://github.com/apache/opendal-reqsign?rev=29f3a9a529f21a5ae0ae32cc9c0967045569d96d#29f3a9a529f21a5ae0ae32cc9c0967045569d96d"
 dependencies = [
+ "bytes",
  "form_urlencoded",
  "http 1.4.2",
  "log",
@@ -10386,7 +10401,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10399,7 +10414,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10479,7 +10494,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10744,7 +10759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11312,7 +11327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11584,7 +11599,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12011,7 +12026,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12020,7 +12035,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/quickwit/Cargo.lock
+++ b/quickwit/Cargo.lock
@@ -6790,6 +6790,7 @@ dependencies = [
  "opendal-http-transport-reqwest",
  "opendal-layer-concurrent-limit",
  "opendal-layer-retry",
+ "opendal-layer-timeout",
  "opendal-service-gcs",
 ]
 
@@ -6854,6 +6855,16 @@ dependencies = [
  "backon",
  "log",
  "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a704141924500f3803c05ed871b53305d2a2f11cb5ef20160c3ee688a1857f66"
+dependencies = [
+ "opendal-core",
+ "tokio",
 ]
 
 [[package]]

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -390,7 +390,8 @@ opendal = { version = "0.58", default-features = false, features = [
   "layers-concurrent-limit",
   "layers-timeout",
 ] }
-reqsign = { version = "0.18", default-features = false, features = ["google", "default-context"] }
+reqsign-core = { version = "3.2", default-features = false }
+reqsign-google = { version = "3.0", default-features = false }
 
 quickwit-actors = { path = "quickwit-actors" }
 quickwit-aws = { path = "quickwit-aws" }
@@ -446,6 +447,10 @@ encoding_rs = "=0.8.35"
 
 [patch.crates-io]
 sasl2-sys = { git = "https://github.com/quickwit-oss/rust-sasl/", rev = "085a4c7" }
+# ServiceAccountTokenCredentialProvider isn't released yet, temporarily depend on a git release
+# to get it
+reqsign-core = { git = "https://github.com/apache/opendal-reqsign", rev = "29f3a9a529f21a5ae0ae32cc9c0967045569d96d" }
+reqsign-google = { git = "https://github.com/apache/opendal-reqsign", rev = "29f3a9a529f21a5ae0ae32cc9c0967045569d96d" }
 
 ## this patched version of tracing helps better understand what happens inside futures (when are
 ## they polled, how long does poll take...)

--- a/quickwit/Cargo.toml
+++ b/quickwit/Cargo.toml
@@ -388,6 +388,7 @@ opendal = { version = "0.58", default-features = false, features = [
   "http-transport-reqwest",
   "layers-retry",
   "layers-concurrent-limit",
+  "layers-timeout",
 ] }
 reqsign = { version = "0.18", default-features = false, features = ["google", "default-context"] }
 

--- a/quickwit/quickwit-storage/Cargo.toml
+++ b/quickwit/quickwit-storage/Cargo.toml
@@ -58,6 +58,8 @@ quickwit-config = { workspace = true }
 quickwit-proto = { workspace = true }
 
 opendal = { workspace = true, optional = true }
+reqsign-core = { workspace = true, optional = true }
+reqsign-google = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -93,7 +95,7 @@ azure = [
   "azure_storage/enable_reqwest_rustls",
   "azure_storage_blobs/enable_reqwest_rustls",
 ]
-gcs = ["dep:opendal", "opendal/services-gcs"]
+gcs = ["dep:opendal", "opendal/services-gcs", "dep:reqsign-core", "dep:reqsign-google"]
 ci-test = []
 integration-testsuite = [
   "azure",

--- a/quickwit/quickwit-storage/src/opendal_storage/base.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/base.rs
@@ -279,7 +279,7 @@ impl Storage for OpendalStorage {
         // Let's fallback to delete one by one in this case.
         #[cfg(feature = "integration-testsuite")]
         {
-            let storage_info = self.op.info();
+            let storage_info = self.op_read.info();
             if storage_info.name().starts_with("sample-bucket") && storage_info.scheme() == "gcs" {
                 let mut bulk_error = BulkDeleteError::default();
                 for (index, path) in paths.iter().enumerate() {
@@ -287,7 +287,10 @@ impl Storage for OpendalStorage {
                     let _timer = HistogramTimer::new(
                         &crate::metrics::OBJECT_STORAGE_BULK_DELETE_REQUEST_DURATION,
                     );
-                    let result = self.op.delete(&path.as_os_str().to_string_lossy()).await;
+                    let result = self
+                        .op_read
+                        .delete(&path.as_os_str().to_string_lossy())
+                        .await;
                     if let Err(err) = result {
                         let storage_error_kind = err.kind();
                         let storage_error: StorageError = err.into();

--- a/quickwit/quickwit-storage/src/opendal_storage/base.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/base.rs
@@ -20,7 +20,7 @@ use std::{fmt, io};
 
 use async_trait::async_trait;
 use futures::AsyncWriteExt as FuturesAsyncWriteExt;
-use opendal::layers::{ConcurrentLimitLayer, RetryLayer};
+use opendal::layers::{ConcurrentLimitLayer, RetryLayer, TimeoutLayer};
 use opendal::{DeleteInput, IntoDeleteInput, Operator};
 use quickwit_common::get_from_env_cached;
 use quickwit_common::uri::Uri;
@@ -37,14 +37,22 @@ use crate::{
     StorageErrorKind, StorageResolverError, StorageResult,
 };
 
+const GCS_CONTROL_OP_TIMEOUT: Duration = Duration::from_secs(3);
+const GCS_READ_IO_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// OpenDAL based storage implementation.
 /// # TODO
 ///
-/// - Implement REQUEST_SEMAPHORE to control the concurrency.
 /// - Implement object storage metrics.
 pub struct OpendalStorage {
     uri: Uri,
-    op: Operator,
+    // this operator carries a timeout, which is not suitable for uploading large chunks at
+    // once (if we provide a 1GB contiguous buffer, it must be written in one timeout period
+    // or gets killed. Large reads end up in many non-contiguous buffers and so don't suffer
+    // from this issue)
+    op_read: Operator,
+    // same as op, but without any timeout, which makes it suitable to upload large bodies
+    op_write: Operator,
     multipart_policy: MultiPartPolicy,
 }
 
@@ -52,7 +60,8 @@ impl fmt::Debug for OpendalStorage {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
             .debug_struct("OpendalStorage")
-            .field("operator", &self.op.info())
+            .field("op_read", &self.op_read.info())
+            .field("op_write", &self.op_write.info())
             .finish()
     }
 }
@@ -64,16 +73,23 @@ impl OpendalStorage {
         cfg: opendal::services::Gcs,
     ) -> Result<Self, StorageResolverError> {
         opendal::install_default();
-        let op = Operator::new(cfg)?
+        let base = Operator::new(cfg)?;
+        let op_write = base
+            .clone()
             .layer(gcs_retry_layer())
             .layer(GCS_CONCURRENT_LIMIT_LAYER.clone());
-        Ok(Self::from_operator(uri, op))
+        let op_read = base
+            .layer(gcs_timeout_layer())
+            .layer(gcs_retry_layer())
+            .layer(GCS_CONCURRENT_LIMIT_LAYER.clone());
+        Ok(Self::from_operators(uri, op_read, op_write))
     }
 
-    fn from_operator(uri: Uri, op: Operator) -> Self {
+    fn from_operators(uri: Uri, op_read: Operator, op_write: Operator) -> Self {
         Self {
             uri,
-            op,
+            op_read,
+            op_write,
             // limits are the same as on S3
             multipart_policy: MultiPartPolicy::default(),
         }
@@ -87,11 +103,17 @@ impl OpendalStorage {
         cfg: opendal::services::Gcs,
         http_transport: opendal::HttpTransporter,
     ) -> Result<Self, StorageResolverError> {
-        let op = Operator::new(cfg)?
-            .with_context(opendal::OperationContext::new().with_http_transport(http_transport))
+        let ctx = opendal::OperationContext::new().with_http_transport(http_transport);
+        let base = Operator::new(cfg)?.with_context(ctx);
+        let op_write = base
+            .clone()
             .layer(gcs_retry_layer())
             .layer(GCS_CONCURRENT_LIMIT_LAYER.clone());
-        Ok(Self::from_operator(uri, op))
+        let op = base
+            .layer(gcs_timeout_layer())
+            .layer(gcs_retry_layer())
+            .layer(GCS_CONCURRENT_LIMIT_LAYER.clone());
+        Ok(Self::from_operators(uri, op, op_write))
     }
 
     #[cfg(feature = "integration-testsuite")]
@@ -118,6 +140,12 @@ static GCS_CONCURRENT_LIMIT_LAYER: LazyLock<ConcurrentLimitLayer> = LazyLock::ne
         get_from_env_cached!(usize, "QW_S3_MAX_CONCURRENCY", 10_000, false);
     ConcurrentLimitLayer::new(max_concurrency)
 });
+
+fn gcs_timeout_layer() -> TimeoutLayer {
+    TimeoutLayer::new()
+        .with_timeout(GCS_CONTROL_OP_TIMEOUT)
+        .with_io_timeout(GCS_READ_IO_TIMEOUT)
+}
 
 /// We spotted a ever growing usage of RAM in the opendal GCS implementation.
 /// We are using the same fix as
@@ -153,7 +181,7 @@ where
 #[async_trait]
 impl Storage for OpendalStorage {
     async fn check_connectivity(&self) -> anyhow::Result<()> {
-        self.op.check().await?;
+        self.op_read.check().await?;
         Ok(())
     }
 
@@ -165,7 +193,7 @@ impl Storage for OpendalStorage {
         let mut payload_reader = payload.byte_stream().await?.into_async_read();
 
         let mut storage_writer = self
-            .op
+            .op_write
             .writer_with(&path)
             .chunk(self.multipart_policy.part_num_bytes(payload.len()) as usize)
             .await?
@@ -182,7 +210,7 @@ impl Storage for OpendalStorage {
     async fn copy_to(&self, path: &Path, output: &mut dyn SendableAsync) -> StorageResult<()> {
         let path = path.as_os_str().to_string_lossy();
         let mut storage_reader = self
-            .op
+            .op_read
             .reader(&path)
             .await?
             .into_futures_async_read(..)
@@ -207,7 +235,7 @@ impl Storage for OpendalStorage {
         // `Buffer::to_bytes` is zero-copy when the underlying buffer is contiguous, and coalesces
         // into a single `Bytes` otherwise — avoiding the extra `Vec<u8>` round-trip `to_vec` would
         // perform.
-        let storage_content = self.op.read_with(&path).range(range).await?.to_bytes();
+        let storage_content = self.op_read.read_with(&path).range(range).await?.to_bytes();
         Ok(into_owned_bytes(storage_content))
     }
 
@@ -220,7 +248,7 @@ impl Storage for OpendalStorage {
         let path = path.as_os_str().to_string_lossy();
         let range = range.start as u64..range.end as u64;
         let storage_reader = self
-            .op
+            .op_read
             .reader_with(&path)
             .await?
             .into_futures_async_read(range)
@@ -232,7 +260,7 @@ impl Storage for OpendalStorage {
     #[instrument(name = "storage.gcs.get_all", level = "debug", skip(self))]
     async fn get_all(&self, path: &Path) -> StorageResult<OwnedBytes> {
         let path = path.as_os_str().to_string_lossy();
-        let storage_content = self.op.read(&path).await?.to_bytes();
+        let storage_content = self.op_read.read(&path).await?.to_bytes();
         Ok(into_owned_bytes(storage_content))
     }
 
@@ -241,7 +269,7 @@ impl Storage for OpendalStorage {
         let path = path.as_os_str().to_string_lossy();
         crate::metrics::OBJECT_STORAGE_DELETE_REQUESTS_TOTAL.inc();
         let _timer = HistogramTimer::new(&crate::metrics::OBJECT_STORAGE_DELETE_REQUEST_DURATION);
-        self.op.delete(&path).await?;
+        self.op_read.delete(&path).await?;
         Ok(())
     }
 
@@ -293,7 +321,7 @@ impl Storage for OpendalStorage {
             .map(|path| path.as_os_str().to_string_lossy().into_delete_input())
             .collect();
 
-        self.op
+        self.op_read
             .delete_iter(delete_inputs)
             .await
             .map_err(|error| BulkDeleteError {
@@ -306,7 +334,7 @@ impl Storage for OpendalStorage {
     #[instrument(name = "storage.gcs.file_num_bytes", level = "debug", skip(self))]
     async fn file_num_bytes(&self, path: &Path) -> StorageResult<u64> {
         let path = path.as_os_str().to_string_lossy();
-        let meta = self.op.stat(&path).await?;
+        let meta = self.op_read.stat(&path).await?;
         Ok(meta.content_length())
     }
 
@@ -321,6 +349,11 @@ impl From<opendal::Error> for StorageError {
             opendal::ErrorKind::NotFound => StorageErrorKind::NotFound.with_error(err),
             opendal::ErrorKind::PermissionDenied => StorageErrorKind::Unauthorized.with_error(err),
             opendal::ErrorKind::ConfigInvalid => StorageErrorKind::Service.with_error(err),
+            opendal::ErrorKind::Unexpected
+                if err.is_temporary() && err.message().contains("timeout") =>
+            {
+                StorageErrorKind::Timeout.with_error(err)
+            }
             _ => StorageErrorKind::Io.with_error(err),
         }
     }

--- a/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
@@ -20,11 +20,20 @@ use async_trait::async_trait;
 use quickwit_common::uri::Uri;
 use quickwit_config::{GoogleCloudStorageConfig, StorageBackend};
 use regex::Regex;
+use reqsign_core::{Context, ProvideCredential, ProvideCredentialChain};
+use reqsign_google::{
+    Credential, DefaultCredentialProvider, FileCredentialProvider,
+    ServiceAccountTokenCredentialProvider,
+};
 use tracing::info;
 
 use super::OpendalStorage;
 use crate::debouncer::DebouncedStorage;
 use crate::{Storage, StorageFactory, StorageResolverError};
+
+// Matches opendal's DEFAULT_GCS_SCOPE, which is more restrictive than `cloud-platform` used by
+// default in reqsign_google
+const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
 
 /// Google cloud storage resolver.
 pub struct GoogleCloudStorageFactory {
@@ -89,6 +98,54 @@ pub mod test_config_helpers {
     }
 }
 
+// this struct implements a ProvideCredential which calls the usual chain of credential providers.
+// if that chain returns service-account details, but no token, we lower ourselves the
+// service-account to a token, which can get cached by our caller
+//
+// before this, our caller would cache the service-account details, but SA to token conversion would
+// happen per-request instead of once every hour
+#[derive(Debug)]
+struct ServiceAccountTokenExchanger {
+    inner: ProvideCredentialChain<Credential>,
+    scope: String,
+}
+
+impl ServiceAccountTokenExchanger {
+    fn new(credential_path: Option<String>, scope: String) -> Self {
+        let mut chain = ProvideCredentialChain::new().push(DefaultCredentialProvider::new());
+        if let Some(path) = credential_path {
+            chain = chain.push_front(FileCredentialProvider::new(path).with_scope(&scope));
+        }
+        Self {
+            inner: chain,
+            scope,
+        }
+    }
+}
+
+impl ProvideCredential for ServiceAccountTokenExchanger {
+    type Credential = Credential;
+
+    async fn provide_credential(
+        &self,
+        ctx: &Context,
+    ) -> reqsign_core::Result<Option<Self::Credential>> {
+        let Some(cred) = self.inner.provide_credential(ctx).await? else {
+            return Ok(None);
+        };
+        match (&cred.service_account, &cred.token) {
+            (Some(sa), None) => {
+                // service account but no token: fetch a token
+                ServiceAccountTokenCredentialProvider::new(sa.clone())
+                    .with_scope(&self.scope)
+                    .provide_credential(ctx)
+                    .await
+            }
+            _ => Ok(Some(cred)),
+        }
+    }
+}
+
 fn from_uri(
     google_cloud_storage_config: &GoogleCloudStorageConfig,
     uri: &Uri,
@@ -102,10 +159,16 @@ fn from_uri(
         .bucket(&bucket_name)
         .root(&prefix.to_string_lossy());
 
-    if let Some(credential_path) = google_cloud_storage_config.resolve_credential_path() {
+    let credential_path = google_cloud_storage_config.resolve_credential_path();
+    if let Some(credential_path) = credential_path.as_ref() {
         info!(path=%credential_path, "fetching google cloud storage credentials from path");
-        cfg = cfg.credential_path(&credential_path);
     }
+
+    cfg = cfg.credential_provider(ServiceAccountTokenExchanger::new(
+        credential_path,
+        GCS_SCOPE.to_string(),
+    ));
+
     let store = OpendalStorage::new_google_cloud_storage(uri.clone(), cfg)?;
     Ok(store)
 }

--- a/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
+++ b/quickwit/quickwit-storage/src/opendal_storage/google_cloud_storage.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use async_trait::async_trait;
 use quickwit_common::uri::Uri;
@@ -28,12 +29,18 @@ use crate::{Storage, StorageFactory, StorageResolverError};
 /// Google cloud storage resolver.
 pub struct GoogleCloudStorageFactory {
     storage_config: GoogleCloudStorageConfig,
+    // this is technically an unbounded cache, the bound is the number of indexes that have existed
+    // since node start, which should be low enough this isn't catastrophic
+    storage_cache: Mutex<HashMap<Uri, Arc<DebouncedStorage<OpendalStorage>>>>,
 }
 
 impl GoogleCloudStorageFactory {
     /// Create a new google cloud storage factory via config.
     pub fn new(storage_config: GoogleCloudStorageConfig) -> Self {
-        Self { storage_config }
+        Self {
+            storage_config,
+            storage_cache: Mutex::new(HashMap::new()),
+        }
     }
 }
 
@@ -44,8 +51,17 @@ impl StorageFactory for GoogleCloudStorageFactory {
     }
 
     async fn resolve(&self, uri: &Uri) -> Result<Arc<dyn Storage>, StorageResolverError> {
-        let storage = from_uri(&self.storage_config, uri)?;
-        Ok(Arc::new(DebouncedStorage::new(storage)))
+        let storage = {
+            let mut cache = self.storage_cache.lock().expect("lock poisoned");
+            if let Some(storage) = cache.get(uri) {
+                storage.clone()
+            } else {
+                let storage = Arc::new(DebouncedStorage::new(from_uri(&self.storage_config, uri)?));
+                cache.insert(uri.clone(), storage.clone());
+                storage
+            }
+        };
+        Ok(storage)
     }
 }
 


### PR DESCRIPTION
### Description

- add timeout and stalled-stream-protection like behaviour to individual calls
  - separate read and write operator, we send big chunks and that doesn't work well with the SSP-like timeout of opendal (it wants one chunk send by the deadline, but our chunks can be too big for that to happen, especially on compactors)
- share underlying operator between calls to storage factory, to share the underlying connection pool
- use proper caching of credential when doing service-account based authentication
  - opendal always cache authentication, but for gcs S-A auth, it only caches the service account keys (usually read from file) as they are enough to sign presigned requests. For non-presigned request, it perform au oauth flow per query *outside* the caching machinery, so there is effectively no caching of authentication
  - for other auth kinds, it seems to do the right thing
  - implement a ProvideCredential which calls the main credential chain, and if it gets a service account and no token, calls into a ServiceAccountTokenCredentialProvider (not included in any tagged release yet) to let the caching machinery work with the token

### How was this PR tested?

deployed on a test cluster, with good improvement in search reliability and latency